### PR TITLE
refactor: duplicate-logic consolidation (9 clusters)

### DIFF
--- a/Compilation/AsyncArrowStateMachineBuilder.cs
+++ b/Compilation/AsyncArrowStateMachineBuilder.cs
@@ -92,8 +92,7 @@ public class AsyncArrowStateMachineBuilder : AsyncBuilderBase
     // The stub method that returns Task<object>
     public MethodBuilder StubMethod { get; private set; } = null!;
 
-    // Builder type. AwaiterType lives in AsyncBuilderBase (#1125).
-    public Type BuilderType { get; private set; } = null!;
+    // BuilderType and AwaiterType live in AsyncBuilderBase (#1125).
 
     public AsyncArrowStateMachineBuilder(
         ModuleBuilder moduleBuilder,
@@ -563,51 +562,20 @@ public class AsyncArrowStateMachineBuilder : AsyncBuilderBase
         return CapturedFieldMap.ContainsKey(name) || (name == "this" && Captures.Contains("this"));
     }
 
-    /// <summary>
-    /// Finalizes the type after MoveNext body has been emitted.
-    /// </summary>
-    public override Type CreateType()
-    {
-        ILLabelValidator.SweepAllTypes(new[] { _stateMachineType });
-        ILLabelValidator.SweepConstructors(new[] { _stateMachineType });
-        return _stateMachineType.CreateType()!;
-    }
+    // CreateType and the common builder accessors (Create/Task/Start/SetException/
+    // AwaitUnsafeOnCompleted) live in AsyncBuilderBase; only SetResult differs per builder.
 
     #region Helper Methods for IL Emission
 
-    public MethodInfo GetBuilderCreateMethod()
-    {
-        return BuilderType.GetMethod("Create", BindingFlags.Public | BindingFlags.Static)!;
-    }
-
-    public MethodInfo GetBuilderTaskGetter()
-    {
-        return BuilderType.GetProperty("Task", BindingFlags.Public | BindingFlags.Instance)!.GetGetMethod()!;
-    }
-
-    public MethodInfo GetBuilderStartMethod()
-    {
-        var methods = BuilderType.GetMethods(BindingFlags.Public | BindingFlags.Instance);
-        var startMethod = methods.First(m => m.Name == "Start" && m.IsGenericMethod);
-        return startMethod.MakeGenericMethod(_stateMachineType);
-    }
-
+    /// <summary>
+    /// Gets the SetResult method for the specific builder type. Specialized here (not in
+    /// AsyncBuilderBase): the arrow builder is always the generic AsyncTaskMethodBuilder&lt;object&gt;,
+    /// whose SetResult takes the result value.
+    /// </summary>
     public MethodInfo GetBuilderSetResultMethod()
     {
         var innerType = BuilderType.GetGenericArguments()[0];
         return BuilderType.GetMethod("SetResult", BindingFlags.Public | BindingFlags.Instance, null, [innerType], null)!;
-    }
-
-    public MethodInfo GetBuilderSetExceptionMethod()
-    {
-        return BuilderType.GetMethod("SetException", BindingFlags.Public | BindingFlags.Instance)!;
-    }
-
-    public MethodInfo GetBuilderAwaitUnsafeOnCompletedMethod()
-    {
-        var methods = BuilderType.GetMethods(BindingFlags.Public | BindingFlags.Instance);
-        var awaitMethod = methods.First(m => m.Name == "AwaitUnsafeOnCompleted" && m.IsGenericMethod);
-        return awaitMethod.MakeGenericMethod(AwaiterType, _stateMachineType);
     }
 
     // GetAwaiterIsCompletedGetter / GetAwaiterGetResultMethod / GetTaskGetAwaiterMethod moved to the

--- a/Compilation/AsyncBuilderBase.cs
+++ b/Compilation/AsyncBuilderBase.cs
@@ -18,6 +18,12 @@ public abstract class AsyncBuilderBase : StateMachineBuilderBase
     /// <summary>The <c>TaskAwaiter&lt;object&gt;</c> type stored at every await point.</summary>
     public Type AwaiterType { get; protected set; } = null!;
 
+    /// <summary>
+    /// The <c>AsyncTaskMethodBuilder</c> variant driving this state machine. Set by the subclass
+    /// (constructor or DefineStateMachine) before any builder accessor below is used.
+    /// </summary>
+    public Type BuilderType { get; protected set; } = null!;
+
     /// <summary>Gets the IsCompleted property getter for the awaiter.</summary>
     public MethodInfo GetAwaiterIsCompletedGetter()
     {
@@ -34,5 +40,57 @@ public abstract class AsyncBuilderBase : StateMachineBuilderBase
     public MethodInfo GetTaskGetAwaiterMethod()
     {
         return Types.GetMethodNoParams(Types.TaskOfObject, "GetAwaiter");
+    }
+
+    /// <summary>Gets the static Create method for the specific builder type.</summary>
+    public MethodInfo GetBuilderCreateMethod()
+    {
+        return BuilderType.GetMethod("Create", BindingFlags.Public | BindingFlags.Static)!;
+    }
+
+    /// <summary>Gets the Task property getter for the specific builder type.</summary>
+    public MethodInfo GetBuilderTaskGetter()
+    {
+        return BuilderType.GetProperty("Task", BindingFlags.Public | BindingFlags.Instance)!.GetGetMethod()!;
+    }
+
+    /// <summary>Gets Start&lt;TStateMachine&gt;(ref TStateMachine) instantiated for this state machine.</summary>
+    public MethodInfo GetBuilderStartMethod()
+    {
+        var methods = BuilderType.GetMethods(BindingFlags.Public | BindingFlags.Instance);
+        var startMethod = methods.First(m => m.Name == "Start" && m.IsGenericMethod);
+        return startMethod.MakeGenericMethod(StateMachineType);
+    }
+
+    /// <summary>Gets the SetException method for the specific builder type.</summary>
+    public MethodInfo GetBuilderSetExceptionMethod()
+    {
+        return BuilderType.GetMethod("SetException", BindingFlags.Public | BindingFlags.Instance)!;
+    }
+
+    /// <summary>
+    /// Gets AwaitUnsafeOnCompleted&lt;TAwaiter, TStateMachine&gt;(ref TAwaiter, ref TStateMachine)
+    /// instantiated for this state machine's awaiter and struct.
+    /// </summary>
+    public MethodInfo GetBuilderAwaitUnsafeOnCompletedMethod()
+    {
+        var methods = BuilderType.GetMethods(BindingFlags.Public | BindingFlags.Instance);
+        var awaitMethod = methods.First(m => m.Name == "AwaitUnsafeOnCompleted" && m.IsGenericMethod);
+        return awaitMethod.MakeGenericMethod(AwaiterType, StateMachineType);
+    }
+
+    // GetBuilderSetResultMethod stays specialized in each subclass: the non-generic
+    // AsyncTaskMethodBuilder has a parameterless SetResult, the generic builders take the value.
+
+    /// <summary>
+    /// Finalizes the type after the MoveNext body has been emitted. Validates labels on every
+    /// method in this state-machine type first — CreateType() clears the ILGenerator control-flow
+    /// state, so a post-finalize sweep cannot see unmarked branched labels.
+    /// </summary>
+    public override Type CreateType()
+    {
+        ILLabelValidator.SweepAllTypes(new[] { StateMachineType });
+        ILLabelValidator.SweepConstructors(new[] { StateMachineType });
+        return StateMachineType.CreateType()!;
     }
 }

--- a/Compilation/AsyncStateMachineBuilder.cs
+++ b/Compilation/AsyncStateMachineBuilder.cs
@@ -59,8 +59,7 @@ public class AsyncStateMachineBuilder : AsyncBuilderBase
     public MethodBuilder MoveNextMethod { get; private set; } = null!;
     public MethodBuilder SetStateMachineMethod { get; private set; } = null!;
 
-    // Builder type (Task vs Task<T>). AwaiterType lives in AsyncBuilderBase (#1125).
-    public Type BuilderType { get; private set; } = null!;
+    // BuilderType (Task vs Task<T>) and AwaiterType live in AsyncBuilderBase (#1125).
 
     public AsyncStateMachineBuilder(ModuleBuilder moduleBuilder, TypeProvider types, int counter = 0)
     {
@@ -278,50 +277,15 @@ public class AsyncStateMachineBuilder : AsyncBuilderBase
     /// </summary>
     public override FieldBuilder? GetVariableField(string name) => _hoisting.GetVariableField(name);
 
-    /// <summary>
-    /// Finalizes the type after MoveNext body has been emitted.
-    /// </summary>
-    public override Type CreateType()
-    {
-        // Validate labels on every method in this state-machine type before finalization —
-        // CreateType() clears the ILGenerator control-flow state, so a post-finalize sweep
-        // cannot see unmarked branched labels.
-        ILLabelValidator.SweepAllTypes(new[] { _stateMachineType });
-        ILLabelValidator.SweepConstructors(new[] { _stateMachineType });
-        return _stateMachineType.CreateType()!;
-    }
+    // CreateType and the common builder accessors (Create/Task/Start/SetException/
+    // AwaitUnsafeOnCompleted) live in AsyncBuilderBase; only SetResult differs per builder.
 
     #region Helper Methods for IL Emission
 
     /// <summary>
-    /// Gets the Create method for the specific builder type.
-    /// </summary>
-    public MethodInfo GetBuilderCreateMethod()
-    {
-        return BuilderType.GetMethod("Create", BindingFlags.Public | BindingFlags.Static)!;
-    }
-
-    /// <summary>
-    /// Gets the Task property getter for the specific builder type.
-    /// </summary>
-    public MethodInfo GetBuilderTaskGetter()
-    {
-        return BuilderType.GetProperty("Task", BindingFlags.Public | BindingFlags.Instance)!.GetGetMethod()!;
-    }
-
-    /// <summary>
-    /// Gets the Start method for the specific builder type.
-    /// </summary>
-    public MethodInfo GetBuilderStartMethod()
-    {
-        // Start<TStateMachine>(ref TStateMachine)
-        var methods = BuilderType.GetMethods(BindingFlags.Public | BindingFlags.Instance);
-        var startMethod = methods.First(m => m.Name == "Start" && m.IsGenericMethod);
-        return startMethod.MakeGenericMethod(_stateMachineType);
-    }
-
-    /// <summary>
-    /// Gets the SetResult method for the specific builder type.
+    /// Gets the SetResult method for the specific builder type. Specialized here (not in
+    /// AsyncBuilderBase): the non-generic AsyncTaskMethodBuilder has a parameterless SetResult,
+    /// the generic builder takes the result value.
     /// </summary>
     public MethodInfo GetBuilderSetResultMethod()
     {
@@ -334,25 +298,6 @@ public class AsyncStateMachineBuilder : AsyncBuilderBase
             var innerType = BuilderType.GetGenericArguments()[0];
             return BuilderType.GetMethod("SetResult", BindingFlags.Public | BindingFlags.Instance, null, [innerType], null)!;
         }
-    }
-
-    /// <summary>
-    /// Gets the SetException method for the specific builder type.
-    /// </summary>
-    public MethodInfo GetBuilderSetExceptionMethod()
-    {
-        return BuilderType.GetMethod("SetException", BindingFlags.Public | BindingFlags.Instance)!;
-    }
-
-    /// <summary>
-    /// Gets the AwaitUnsafeOnCompleted method for the specific builder type.
-    /// </summary>
-    public MethodInfo GetBuilderAwaitUnsafeOnCompletedMethod()
-    {
-        // AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter, ref TStateMachine)
-        var methods = BuilderType.GetMethods(BindingFlags.Public | BindingFlags.Instance);
-        var awaitMethod = methods.First(m => m.Name == "AwaitUnsafeOnCompleted" && m.IsGenericMethod);
-        return awaitMethod.MakeGenericMethod(AwaiterType, _stateMachineType);
     }
 
     // GetAwaiterIsCompletedGetter / GetAwaiterGetResultMethod / GetTaskGetAwaiterMethod moved to the

--- a/Compilation/Emitters/ArrayEmitter.cs
+++ b/Compilation/Emitters/ArrayEmitter.cs
@@ -232,7 +232,7 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
                 break;
 
             case "join":
-                EmitSingleArgOrNull(emitter, arguments, argLocals);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayJoin);
                 break;
 
@@ -264,24 +264,24 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
                 break;
 
             case "flat":
-                EmitSingleArgOrNull(emitter, arguments, argLocals);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayFlat);
                 break;
 
             case "flatMap":
-                EmitSingleArgOrNull(emitter, arguments, argLocals);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayFlatMap);
                 break;
 
             case "includes":
-                EmitSingleArgOrNull(emitter, arguments, argLocals);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayIncludes);
                 break;
 
             case "indexOf":
             case "lastIndexOf":
                 // searchElement (arg 0) + optional fromIndex (arg 1).
-                EmitSingleArgOrNull(emitter, arguments, argLocals);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0, argLocals);
                 if (arguments.Count >= 2)
                 {
                     if (argLocals != null)
@@ -303,12 +303,12 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
                 break;
 
             case "sort":
-                EmitSingleArgOrNull(emitter, arguments, argLocals);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArraySort);
                 break;
 
             case "toSorted":
-                EmitSingleArgOrNull(emitter, arguments, argLocals);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayToSorted);
                 break;
 
@@ -355,7 +355,7 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
                 break;
 
             case "at":
-                EmitSingleArgOrNull(emitter, arguments, argLocals);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0, argLocals);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ArrayAt);
                 break;
 
@@ -730,7 +730,7 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
 
     /// <summary>
     /// Array methods that evaluate plain-expression arguments (via <see cref="EmitVariadicListMutation"/>,
-    /// <see cref="IEmitterContext.EmitArgsArray"/>, <see cref="EmitSingleArgOrNull"/>, or inline) rather than dispatching
+    /// <see cref="IEmitterContext.EmitArgsArray"/>, <see cref="EmitterArgumentHelpers.EmitBoxedArgumentOrNull"/>, or inline) rather than dispatching
     /// a callback arrow from the AST. Only these can hit the #850 stack-spill bug when an argument
     /// contains <c>await</c>/<c>yield</c>, so only these get await-safe argument pre-spilling. The
     /// callback methods (map/filter/forEach/find/findIndex/some/every/findLast/findLastIndex) are
@@ -741,34 +741,6 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         "push" or "unshift" or "slice" or "reduce" or "reduceRight" or "join" or "concat" or
         "flat" or "flatMap" or "includes" or "indexOf" or "lastIndexOf" or "sort" or "toSorted" or
         "splice" or "toSpliced" or "with" or "at" or "fill" or "copyWithin";
-
-    /// <summary>
-    /// Emits a single argument or null if no arguments provided. When <paramref name="argLocals"/> is
-    /// supplied (await-safe pre-spilled args, #850) the value is loaded from the local rather than
-    /// re-evaluated.
-    /// </summary>
-    private static void EmitSingleArgOrNull(IEmitterContext emitter, List<Expr> arguments, LocalBuilder[]? argLocals = null)
-    {
-        var ctx = emitter.Context;
-        var il = ctx.IL;
-
-        if (arguments.Count > 0)
-        {
-            if (argLocals != null)
-            {
-                il.Emit(OpCodes.Ldloc, argLocals[0]);
-            }
-            else
-            {
-                emitter.EmitExpression(arguments[0]);
-                emitter.EmitBoxIfNeeded(arguments[0]);
-            }
-        }
-        else
-        {
-            il.Emit(OpCodes.Ldnull);
-        }
-    }
 
     /// <summary>
     /// Emits the callback (arg 0) and stashes optional thisArg (arg 1) into

--- a/Compilation/Emitters/EmitterArgumentHelpers.cs
+++ b/Compilation/Emitters/EmitterArgumentHelpers.cs
@@ -1,0 +1,49 @@
+using System.Reflection.Emit;
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation.Emitters;
+
+/// <summary>
+/// Shared argument-emission helpers for strategy emitters. Consolidates the
+/// EmitSingleArgOrNull / EmitSecondArgOrNull / EmitBoxedArg copies that were repeated across
+/// Map, Set, WeakMap, WeakSet, Iterator, Array, and Process emitters.
+/// </summary>
+/// <remarks>
+/// The emitted default is <c>null</c> (Ldnull) — NOT the <c>$Undefined</c> sentinel. Call sites
+/// whose omitted argument must observe <c>undefined</c> semantics use <c>EmitOmittedArgument</c>
+/// instead; the two are not interchangeable. Helpers with other defaults (e.g. a string-coerced
+/// argument defaulting to <c>""</c>) stay separately named at their call sites.
+/// </remarks>
+internal static class EmitterArgumentHelpers
+{
+    /// <summary>
+    /// Emits the argument at <paramref name="index"/> boxed, or <c>null</c> when absent.
+    /// When <paramref name="preEvaluated"/> is supplied (await-safe pre-spilled args, #850) the
+    /// value is loaded from the local rather than re-evaluated, preserving evaluation order.
+    /// </summary>
+    public static void EmitBoxedArgumentOrNull(
+        IEmitterContext emitter,
+        List<Expr> arguments,
+        int index,
+        LocalBuilder[]? preEvaluated = null)
+    {
+        var il = emitter.Context.IL;
+
+        if (index < arguments.Count)
+        {
+            if (preEvaluated != null)
+            {
+                il.Emit(OpCodes.Ldloc, preEvaluated[index]);
+            }
+            else
+            {
+                emitter.EmitExpression(arguments[index]);
+                emitter.EmitBoxIfNeeded(arguments[index]);
+            }
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldnull);
+        }
+    }
+}

--- a/Compilation/Emitters/IteratorEmitter.cs
+++ b/Compilation/Emitters/IteratorEmitter.cs
@@ -20,14 +20,14 @@ public sealed class IteratorEmitter : ITypeEmitterStrategy
             case "map":
                 emitter.EmitExpression(receiver);
                 emitter.EmitBoxIfNeeded(receiver);
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.IteratorMap);
                 return true;
 
             case "filter":
                 emitter.EmitExpression(receiver);
                 emitter.EmitBoxIfNeeded(receiver);
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.IteratorFilter);
                 return true;
 
@@ -48,7 +48,7 @@ public sealed class IteratorEmitter : ITypeEmitterStrategy
             case "flatMap":
                 emitter.EmitExpression(receiver);
                 emitter.EmitBoxIfNeeded(receiver);
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.IteratorFlatMap);
                 return true;
 
@@ -56,7 +56,7 @@ public sealed class IteratorEmitter : ITypeEmitterStrategy
                 emitter.EmitExpression(receiver);
                 emitter.EmitBoxIfNeeded(receiver);
                 // callback
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 // initial value (or null)
                 if (arguments.Count > 1)
                 {
@@ -81,28 +81,28 @@ public sealed class IteratorEmitter : ITypeEmitterStrategy
             case "forEach":
                 emitter.EmitExpression(receiver);
                 emitter.EmitBoxIfNeeded(receiver);
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.IteratorForEach);
                 return true;
 
             case "some":
                 emitter.EmitExpression(receiver);
                 emitter.EmitBoxIfNeeded(receiver);
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.IteratorSome);
                 return true;
 
             case "every":
                 emitter.EmitExpression(receiver);
                 emitter.EmitBoxIfNeeded(receiver);
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.IteratorEvery);
                 return true;
 
             case "find":
                 emitter.EmitExpression(receiver);
                 emitter.EmitBoxIfNeeded(receiver);
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.IteratorFind);
                 return true;
 
@@ -137,19 +137,6 @@ public sealed class IteratorEmitter : ITypeEmitterStrategy
     public bool TryEmitPropertySet(IEmitterContext emitter, Expr receiver, string propertyName, Expr value)
     {
         return false;
-    }
-
-    private static void EmitSingleArgOrNull(IEmitterContext emitter, List<Expr> arguments)
-    {
-        if (arguments.Count > 0)
-        {
-            emitter.EmitExpression(arguments[0]);
-            emitter.EmitBoxIfNeeded(arguments[0]);
-        }
-        else
-        {
-            emitter.Context.IL.Emit(OpCodes.Ldnull);
-        }
     }
 
     private static void EmitIntArg(IEmitterContext emitter, List<Expr> arguments)

--- a/Compilation/Emitters/MapEmitter.cs
+++ b/Compilation/Emitters/MapEmitter.cs
@@ -24,24 +24,24 @@ public sealed class MapEmitter : ITypeEmitterStrategy
         switch (methodName)
         {
             case "get":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.MapGet);
                 return true;
 
             case "set":
-                EmitSingleArgOrNull(emitter, arguments);
-                EmitSecondArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 1);
                 il.Emit(OpCodes.Call, ctx.Runtime!.MapSet);
                 return true;
 
             case "has":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.MapHas);
                 il.Emit(OpCodes.Box, ctx.Types.Boolean);
                 return true;
 
             case "delete":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.MapDelete);
                 il.Emit(OpCodes.Box, ctx.Types.Boolean);
                 return true;
@@ -64,7 +64,7 @@ public sealed class MapEmitter : ITypeEmitterStrategy
                 return true;
 
             case "forEach":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.MapForEach);
                 il.Emit(OpCodes.Ldsfld, ctx.Runtime!.UndefinedInstance);
                 return true;
@@ -103,39 +103,4 @@ public sealed class MapEmitter : ITypeEmitterStrategy
         return false;
     }
 
-    #region Helper Methods
-
-    private static void EmitSingleArgOrNull(IEmitterContext emitter, List<Expr> arguments)
-    {
-        var ctx = emitter.Context;
-        var il = ctx.IL;
-
-        if (arguments.Count > 0)
-        {
-            emitter.EmitExpression(arguments[0]);
-            emitter.EmitBoxIfNeeded(arguments[0]);
-        }
-        else
-        {
-            il.Emit(OpCodes.Ldnull);
-        }
-    }
-
-    private static void EmitSecondArgOrNull(IEmitterContext emitter, List<Expr> arguments)
-    {
-        var ctx = emitter.Context;
-        var il = ctx.IL;
-
-        if (arguments.Count > 1)
-        {
-            emitter.EmitExpression(arguments[1]);
-            emitter.EmitBoxIfNeeded(arguments[1]);
-        }
-        else
-        {
-            il.Emit(OpCodes.Ldnull);
-        }
-    }
-
-    #endregion
 }

--- a/Compilation/Emitters/Modules/ProcessModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/ProcessModuleEmitter.cs
@@ -50,8 +50,8 @@ public sealed class ProcessModuleEmitter : IBuiltInModuleEmitter
             case "nextTick": return EmitNextTick(emitter, arguments);
 
             case "kill":
-                EmitBoxedArgument(emitter, arguments, 0);
-                EmitBoxedArgument(emitter, arguments, 1);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 1);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ProcessKill);
                 return true;
 
@@ -62,12 +62,12 @@ public sealed class ProcessModuleEmitter : IBuiltInModuleEmitter
                 return true;
 
             case "umask":
-                EmitBoxedArgument(emitter, arguments, 0);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ProcessUmask);
                 return true;
 
             case "cpuUsage":
-                EmitBoxedArgument(emitter, arguments, 0);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ProcessCpuUsage);
                 return true;
 
@@ -89,17 +89,17 @@ public sealed class ProcessModuleEmitter : IBuiltInModuleEmitter
                 return true;
 
             case "emitWarning":
-                EmitBoxedArgument(emitter, arguments, 0);
-                EmitBoxedArgument(emitter, arguments, 1);
-                EmitBoxedArgument(emitter, arguments, 2);
-                EmitBoxedArgument(emitter, arguments, 3);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 1);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 2);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 3);
                 il.Emit(OpCodes.Call, ctx.Runtime!.ProcessEmitWarning);
                 return true;
 
             case "setSourceMapsEnabled":
                 il.Emit(OpCodes.Call, ctx.Runtime!.GetProcessObject);
                 il.Emit(OpCodes.Ldstr, "sourceMapsEnabled");
-                EmitBoxedArgument(emitter, arguments, 0);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.SetProperty);
                 il.Emit(OpCodes.Ldnull);
                 return true;
@@ -235,23 +235,6 @@ public sealed class ProcessModuleEmitter : IBuiltInModuleEmitter
 
             default:
                 return false;
-        }
-    }
-
-    /// <summary>
-    /// Emits arguments[index] boxed, or null when absent — the object-arg
-    /// convention of the $Runtime process helpers.
-    /// </summary>
-    private static void EmitBoxedArgument(IEmitterContext emitter, List<Expr> arguments, int index)
-    {
-        if (index < arguments.Count)
-        {
-            emitter.EmitExpression(arguments[index]);
-            emitter.EmitBoxIfNeeded(arguments[index]);
-        }
-        else
-        {
-            emitter.Context.IL.Emit(OpCodes.Ldnull);
         }
     }
 

--- a/Compilation/Emitters/ProcessStaticEmitter.cs
+++ b/Compilation/Emitters/ProcessStaticEmitter.cs
@@ -113,7 +113,7 @@ public sealed class ProcessStaticEmitter : IStaticTypeEmitterStrategy
                 // live object (SetProperty handles the bool coercion).
                 il.Emit(OpCodes.Call, ctx.Runtime!.GetProcessObject);
                 il.Emit(OpCodes.Ldstr, "sourceMapsEnabled");
-                EmitBoxedArg(emitter, arguments, 0);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.SetProperty);
                 il.Emit(OpCodes.Ldnull);
                 return true;
@@ -314,25 +314,25 @@ public sealed class ProcessStaticEmitter : IStaticTypeEmitterStrategy
     /// <summary>Emits a call to a one-object-arg $Runtime helper (missing arg → null).</summary>
     private static void EmitOneArgHelperCall(IEmitterContext emitter, List<Expr> arguments, System.Reflection.Emit.MethodBuilder helper)
     {
-        EmitBoxedArg(emitter, arguments, 0);
+        EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
         emitter.Context.IL.Emit(OpCodes.Call, helper);
     }
 
     /// <summary>Emits a call to a two-object-arg $Runtime helper (missing args → null).</summary>
     private static void EmitTwoArgHelperCall(IEmitterContext emitter, List<Expr> arguments, System.Reflection.Emit.MethodBuilder helper)
     {
-        EmitBoxedArg(emitter, arguments, 0);
-        EmitBoxedArg(emitter, arguments, 1);
+        EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
+        EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 1);
         emitter.Context.IL.Emit(OpCodes.Call, helper);
     }
 
     /// <summary>Emits a call to a four-object-arg $Runtime helper (missing args → null).</summary>
     private static void EmitFourArgHelperCall(IEmitterContext emitter, List<Expr> arguments, System.Reflection.Emit.MethodBuilder helper)
     {
-        EmitBoxedArg(emitter, arguments, 0);
-        EmitBoxedArg(emitter, arguments, 1);
-        EmitBoxedArg(emitter, arguments, 2);
-        EmitBoxedArg(emitter, arguments, 3);
+        EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
+        EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 1);
+        EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 2);
+        EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 3);
         emitter.Context.IL.Emit(OpCodes.Call, helper);
     }
 
@@ -483,14 +483,14 @@ public sealed class ProcessStaticEmitter : IStaticTypeEmitterStrategy
                 // On(string eventName, object listener) -> $EventEmitter
                 il.Emit(OpCodes.Call, runtime.GetProcessEventEmitter);
                 EmitStringArg(emitter, arguments, 0);
-                EmitBoxedArg(emitter, arguments, 1);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 1);
                 il.Emit(OpCodes.Callvirt, runtime.TSEventEmitterOn);
                 break;
 
             case "once":
                 il.Emit(OpCodes.Call, runtime.GetProcessEventEmitter);
                 EmitStringArg(emitter, arguments, 0);
-                EmitBoxedArg(emitter, arguments, 1);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 1);
                 il.Emit(OpCodes.Callvirt, runtime.TSEventEmitterOnce);
                 break;
 
@@ -498,7 +498,7 @@ public sealed class ProcessStaticEmitter : IStaticTypeEmitterStrategy
             case "removeListener":
                 il.Emit(OpCodes.Call, runtime.GetProcessEventEmitter);
                 EmitStringArg(emitter, arguments, 0);
-                EmitBoxedArg(emitter, arguments, 1);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 1);
                 il.Emit(OpCodes.Callvirt, runtime.TSEventEmitterOff);
                 break;
 
@@ -545,14 +545,14 @@ public sealed class ProcessStaticEmitter : IStaticTypeEmitterStrategy
             case "prependListener":
                 il.Emit(OpCodes.Call, runtime.GetProcessEventEmitter);
                 EmitStringArg(emitter, arguments, 0);
-                EmitBoxedArg(emitter, arguments, 1);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 1);
                 il.Emit(OpCodes.Callvirt, runtime.TSEventEmitterPrependListener);
                 break;
 
             case "prependOnceListener":
                 il.Emit(OpCodes.Call, runtime.GetProcessEventEmitter);
                 EmitStringArg(emitter, arguments, 0);
-                EmitBoxedArg(emitter, arguments, 1);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 1);
                 il.Emit(OpCodes.Callvirt, runtime.TSEventEmitterPrependOnceListener);
                 break;
 
@@ -589,20 +589,6 @@ public sealed class ProcessStaticEmitter : IStaticTypeEmitterStrategy
         else
         {
             il.Emit(OpCodes.Ldstr, "");
-        }
-    }
-
-    private static void EmitBoxedArg(IEmitterContext emitter, List<Expr> arguments, int index)
-    {
-        var il = emitter.Context.IL;
-        if (index < arguments.Count)
-        {
-            emitter.EmitExpression(arguments[index]);
-            emitter.EmitBoxIfNeeded(arguments[index]);
-        }
-        else
-        {
-            il.Emit(OpCodes.Ldnull);
         }
     }
 

--- a/Compilation/Emitters/SetEmitter.cs
+++ b/Compilation/Emitters/SetEmitter.cs
@@ -24,18 +24,18 @@ public sealed class SetEmitter : ITypeEmitterStrategy
         switch (methodName)
         {
             case "add":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.SetAdd);
                 return true;
 
             case "has":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.SetHas);
                 il.Emit(OpCodes.Box, ctx.Types.Boolean);
                 return true;
 
             case "delete":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.SetDelete);
                 il.Emit(OpCodes.Box, ctx.Types.Boolean);
                 return true;
@@ -58,46 +58,46 @@ public sealed class SetEmitter : ITypeEmitterStrategy
                 return true;
 
             case "forEach":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.SetForEach);
                 il.Emit(OpCodes.Ldsfld, ctx.Runtime!.UndefinedInstance);
                 return true;
 
             // ES2025 Set Operations
             case "union":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.SetUnion);
                 return true;
 
             case "intersection":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.SetIntersection);
                 return true;
 
             case "difference":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.SetDifference);
                 return true;
 
             case "symmetricDifference":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.SetSymmetricDifference);
                 return true;
 
             case "isSubsetOf":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.SetIsSubsetOf);
                 il.Emit(OpCodes.Box, ctx.Types.Boolean);
                 return true;
 
             case "isSupersetOf":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.SetIsSupersetOf);
                 il.Emit(OpCodes.Box, ctx.Types.Boolean);
                 return true;
 
             case "isDisjointFrom":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.SetIsDisjointFrom);
                 il.Emit(OpCodes.Box, ctx.Types.Boolean);
                 return true;
@@ -136,23 +136,4 @@ public sealed class SetEmitter : ITypeEmitterStrategy
         return false;
     }
 
-    #region Helper Methods
-
-    private static void EmitSingleArgOrNull(IEmitterContext emitter, List<Expr> arguments)
-    {
-        var ctx = emitter.Context;
-        var il = ctx.IL;
-
-        if (arguments.Count > 0)
-        {
-            emitter.EmitExpression(arguments[0]);
-            emitter.EmitBoxIfNeeded(arguments[0]);
-        }
-        else
-        {
-            il.Emit(OpCodes.Ldnull);
-        }
-    }
-
-    #endregion
 }

--- a/Compilation/Emitters/WeakMapEmitter.cs
+++ b/Compilation/Emitters/WeakMapEmitter.cs
@@ -24,24 +24,24 @@ public sealed class WeakMapEmitter : ITypeEmitterStrategy
         switch (methodName)
         {
             case "get":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.WeakMapGet);
                 return true;
 
             case "set":
-                EmitSingleArgOrNull(emitter, arguments);
-                EmitSecondArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 1);
                 il.Emit(OpCodes.Call, ctx.Runtime!.WeakMapSet);
                 return true;
 
             case "has":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.WeakMapHas);
                 il.Emit(OpCodes.Box, ctx.Types.Boolean);
                 return true;
 
             case "delete":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.WeakMapDelete);
                 il.Emit(OpCodes.Box, ctx.Types.Boolean);
                 return true;
@@ -70,39 +70,4 @@ public sealed class WeakMapEmitter : ITypeEmitterStrategy
         return false;
     }
 
-    #region Helper Methods
-
-    private static void EmitSingleArgOrNull(IEmitterContext emitter, List<Expr> arguments)
-    {
-        var ctx = emitter.Context;
-        var il = ctx.IL;
-
-        if (arguments.Count > 0)
-        {
-            emitter.EmitExpression(arguments[0]);
-            emitter.EmitBoxIfNeeded(arguments[0]);
-        }
-        else
-        {
-            il.Emit(OpCodes.Ldnull);
-        }
-    }
-
-    private static void EmitSecondArgOrNull(IEmitterContext emitter, List<Expr> arguments)
-    {
-        var ctx = emitter.Context;
-        var il = ctx.IL;
-
-        if (arguments.Count > 1)
-        {
-            emitter.EmitExpression(arguments[1]);
-            emitter.EmitBoxIfNeeded(arguments[1]);
-        }
-        else
-        {
-            il.Emit(OpCodes.Ldnull);
-        }
-    }
-
-    #endregion
 }

--- a/Compilation/Emitters/WeakSetEmitter.cs
+++ b/Compilation/Emitters/WeakSetEmitter.cs
@@ -24,18 +24,18 @@ public sealed class WeakSetEmitter : ITypeEmitterStrategy
         switch (methodName)
         {
             case "add":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.WeakSetAdd);
                 return true;
 
             case "has":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.WeakSetHas);
                 il.Emit(OpCodes.Box, ctx.Types.Boolean);
                 return true;
 
             case "delete":
-                EmitSingleArgOrNull(emitter, arguments);
+                EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
                 il.Emit(OpCodes.Call, ctx.Runtime!.WeakSetDelete);
                 il.Emit(OpCodes.Box, ctx.Types.Boolean);
                 return true;
@@ -64,23 +64,4 @@ public sealed class WeakSetEmitter : ITypeEmitterStrategy
         return false;
     }
 
-    #region Helper Methods
-
-    private static void EmitSingleArgOrNull(IEmitterContext emitter, List<Expr> arguments)
-    {
-        var ctx = emitter.Context;
-        var il = ctx.IL;
-
-        if (arguments.Count > 0)
-        {
-            emitter.EmitExpression(arguments[0]);
-            emitter.EmitBoxIfNeeded(arguments[0]);
-        }
-        else
-        {
-            il.Emit(OpCodes.Ldnull);
-        }
-    }
-
-    #endregion
 }

--- a/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/Compilation/ILCompiler.ArrowFunctions.cs
@@ -1307,102 +1307,47 @@ public partial class ILCompiler
         _closures.ArrowReturnTypes.TryGetValue(arrow, out var arrowReturnType);
         arrowReturnType ??= _types.Object;
 
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            FunctionRestParams = _functions.RestParams,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            AsyncArrowBuilders = _async.ArrowBuilders.Count > 0 ? _async.ArrowBuilders : null,
-            // Top-level variables for module-level access
-            TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
-            // Module support for multi-module compilation
-            CurrentModulePath = _modules.CurrentPath,
-            CurrentNamespacePath = _currentNamespacePath,
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            ClassExprBuilders = _classExprs.Builders,
-            // A function expression / arrow with its own "use strict" prologue is
-            // strict even when the enclosing code is sloppy. Detect it here (not
-            // just inherit the parent) so `this` resolution honors it — otherwise a
-            // strict `function(){ "use strict"; … }` callback is misclassified
-            // sloppy and LoadThis's undefined→globalThis coercion wrongly fires
-            // (Test262 String/prototype/replace/S15.5.4.11_A12: a strict replace
-            // callback must see `this === undefined`). Function-expression/arrow
-            // bodies are parsed with Block() and no directive prologue, so their
-            // "use strict" is an ordinary string expression statement rather than a
-            // Stmt.Directive — BodyDeclaresUseStrict handles both forms (plain
-            // CheckForUseStrict only matches Directive).
-            IsStrictMode = _isStrictMode || BodyDeclaresUseStrict(arrow.BlockBody),
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Propagate the enclosing class name so private-member dispatch (#field / #method
-            // access, `super` lookups) works inside arrow bodies nested in class methods.
-            // Without this, `this.#parseGlob()` inside an arrow throws "class context not
-            // available" at runtime.
-            CurrentClassName = _async.ArrowEnclosingClassNames.TryGetValue(arrow, out var enclosingClassName)
-                ? enclosingClassName
-                : null,
-            // Entry-point display class for accessing captured top-level variables
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-            // Function-level display class for nested arrow functions
-            ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null,
-            // Arrow scope display class for nested arrow functions
-            ArrowScopeDCFields = _closures.ArrowScopeDCFields.Count > 0 ? _closures.ArrowScopeDCFields : null,
-            ArrowScopeDCExtraFieldsByArrow = _arrowScopeDCExtraFields.Count > 0 ? _arrowScopeDCExtraFields : null,
-            // Inner function metadata — required for any `function X() {}` declared INSIDE this
-            // arrow body to be reachable from sibling statements. Without this, IIFE-style
-            // wrappers that declare nested functions (lodash's `(function() { function basePropertyOf() {...} }())`)
-            // crash at runtime with "Undefined variable" when earlier statements reference them.
-            InnerFunctionMethods = _innerFunctionMethods,
-            InnerFunctionDisplayClasses = _innerFunctionDisplayClasses,
-            InnerFunctionDCFields = _innerFunctionDCFields,
-            InnerFunctionDCCtors = _innerFunctionDCCtors,
-            InnerFunctionEntryPointDCFields = _innerFunctionEntryPointDCFields,
-            InnerFunctionFunctionDCFields = _innerFunctionFunctionDCFields,
-            // CJS-context propagation — arrow bodies nested in a CJS module must see the
-            // same `exports` binding and require() resolution as the enclosing module init.
-            // Without this, bare `exports` inside an IIFE resolves to null and the lodash-
-            // style feature detection `typeof exports == 'object' && exports && ...` fails.
-            CurrentCjsExportsField = _modules.CurrentPath != null
-                && _modules.CommonJsExportFields.TryGetValue(_modules.CurrentPath, out var cjsArrowExports)
-                ? cjsArrowExports
-                : null,
-            ModuleResolver = _modules.Resolver,
-            ModuleExportFields = _modules.ExportFields,
-            ModuleInitMethods = _modules.InitMethods,
-            ModuleImportFields = _modules.ImportFields,
-            ModuleTypes = _modules.Types,
-            CommonJsExportFields = _modules.CommonJsExportFields,
-            CommonJsGetExportsMethods = _modules.CommonJsGetExportsMethods,
-            // Typed return optimization - set return type so EmitReturn knows whether to box
-            CurrentMethodReturnType = arrowReturnType
-        };
+        var ctx = CreateModuleMemberContext(il);
+        ctx.AsyncArrowBuilders = _async.ArrowBuilders.Count > 0 ? _async.ArrowBuilders : null;
+        // A function expression / arrow with its own "use strict" prologue is
+        // strict even when the enclosing code is sloppy. Detect it here (not
+        // just inherit the parent) so `this` resolution honors it — otherwise a
+        // strict `function(){ "use strict"; … }` callback is misclassified
+        // sloppy and LoadThis's undefined→globalThis coercion wrongly fires
+        // (Test262 String/prototype/replace/S15.5.4.11_A12: a strict replace
+        // callback must see `this === undefined`). Function-expression/arrow
+        // bodies are parsed with Block() and no directive prologue, so their
+        // "use strict" is an ordinary string expression statement rather than a
+        // Stmt.Directive — BodyDeclaresUseStrict handles both forms (plain
+        // CheckForUseStrict only matches Directive).
+        ctx.IsStrictMode = _isStrictMode || BodyDeclaresUseStrict(arrow.BlockBody);
+        // Propagate the enclosing class name so private-member dispatch (#field / #method
+        // access, `super` lookups) works inside arrow bodies nested in class methods.
+        // Without this, `this.#parseGlob()` inside an arrow throws "class context not
+        // available" at runtime.
+        ctx.CurrentClassName = _async.ArrowEnclosingClassNames.TryGetValue(arrow, out var enclosingClassName)
+            ? enclosingClassName
+            : null;
+        // Entry-point display class for accessing captured top-level variables
+        ApplyCapturedTopLevelVariableAccess(ctx);
+        ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;
+        // Function-level display class for nested arrow functions
+        ctx.ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null;
+        // Arrow scope display class for nested arrow functions
+        ctx.ArrowScopeDCFields = _closures.ArrowScopeDCFields.Count > 0 ? _closures.ArrowScopeDCFields : null;
+        ctx.ArrowScopeDCExtraFieldsByArrow = _arrowScopeDCExtraFields.Count > 0 ? _arrowScopeDCExtraFields : null;
+        // Inner function metadata — required for any `function X() {}` declared INSIDE this
+        // arrow body to be reachable from sibling statements. Without this, IIFE-style
+        // wrappers that declare nested functions (lodash's `(function() { function basePropertyOf() {...} }())`)
+        // crash at runtime with "Undefined variable" when earlier statements reference them.
+        ApplyInnerFunctionSupport(ctx);
+        // CJS-context propagation — arrow bodies nested in a CJS module must see the
+        // same `exports` binding and require() resolution as the enclosing module init.
+        // Without this, bare `exports` inside an IIFE resolves to null and the lodash-
+        // style feature detection `typeof exports == 'object' && exports && ...` fails.
+        ApplyCommonJsModuleAccess(ctx);
+        // Typed return optimization - set return type so EmitReturn knows whether to box
+        ctx.CurrentMethodReturnType = arrowReturnType;
 
         if (displayClass != null)
         {

--- a/Compilation/ILCompiler.Async.cs
+++ b/Compilation/ILCompiler.Async.cs
@@ -712,59 +712,21 @@ public partial class ILCompiler
 
             // Create context for MoveNext emission
             var il = smBuilder.MoveNextMethod.GetILGenerator();
-            var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-            {
-                Runtime = _runtime,
-                ClosureAnalyzer = _closures.Analyzer,
-                ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-                DisplayClasses = _closures.DisplayClasses,
-                DisplayClassFields = _closures.DisplayClassFields,
-                DisplayClassConstructors = _closures.DisplayClassConstructors,
-                EnumMembers = _enums.Members,
-                EnumReverse = _enums.Reverse,
-                EnumKinds = _enums.Kinds,
-                TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
-                FunctionRestParams = _functions.RestParams,
-                FunctionsCapturingArguments = _functions.CapturingArguments,
-                FunctionGenericParams = _functions.GenericParams,
-                IsGenericFunction = _functions.IsGeneric,
-                TypeMap = _typeMap,
-                DeadCode = _deadCodeInfo,
-                AsyncMethods = null,
-                AsyncArrowBuilders = _async.ArrowBuilders,
-                AsyncArrowOuterBuilders = _async.ArrowOuterBuilders,
-                AsyncArrowParentBuilders = _async.ArrowParentBuilders,
-                // Module support for multi-module compilation
-                CurrentModulePath = _modules.CurrentPath,
-                CurrentNamespacePath = _currentNamespacePath,
-                ModuleResolver = _modules.Resolver,
-                CommonJsExportFields = _modules.CommonJsExportFields,
-                CommonJsGetExportsMethods = _modules.CommonJsGetExportsMethods,
-                ClassToModule = _modules.ClassToModule,
-                FunctionToModule = _modules.FunctionToModule,
-                EnumToModule = _modules.EnumToModule,
-                DotNetNamespace = _modules.CurrentDotNetNamespace,
-                TypeEmitterRegistry = _typeEmitterRegistry,
-                BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-                BuiltInModuleNamespaces = _builtInModuleNamespaces,
-                BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-                ImportedNames = _importedNames,
-                ClassExprBuilders = _classExprs.Builders,
-                // Check for function-level "use strict" directive
-                IsStrictMode = _isStrictMode || CheckForUseStrict(func.Body),
-                // Registry services
-                ClassRegistry = GetClassRegistry(),
-                // Entry-point display class for captured top-level variables
-                EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-                CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-                ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-                EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-                // Function display class for captured locals (closure mutation sharing with arrows)
-                ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null,
-            };
+            var ctx = CreateModuleMemberContext(il);
+            ctx.AsyncArrowBuilders = _async.ArrowBuilders;
+            ctx.AsyncArrowOuterBuilders = _async.ArrowOuterBuilders;
+            ctx.AsyncArrowParentBuilders = _async.ArrowParentBuilders;
+            // CJS resolution (partial — this state-machine body only needs require()/exports reads)
+            ctx.ModuleResolver = _modules.Resolver;
+            ctx.CommonJsExportFields = _modules.CommonJsExportFields;
+            ctx.CommonJsGetExportsMethods = _modules.CommonJsGetExportsMethods;
+            // Check for function-level "use strict" directive
+            ctx.IsStrictMode = _isStrictMode || CheckForUseStrict(func.Body);
+            // Entry-point display class for captured top-level variables
+            ApplyCapturedTopLevelVariableAccess(ctx);
+            ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;
+            // Function display class for captured locals (closure mutation sharing with arrows)
+            ctx.ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null;
 
             // Set function DC info if this async function has captured locals.
             // funcName is already the module-qualified registry key (#418) — and the
@@ -839,56 +801,7 @@ public partial class ILCompiler
         );
 
         // Create a new context for arrow MoveNext emission
-        var ctx = new CompilationContext(il, parentCtx.TypeMapper, parentCtx.Functions, parentCtx.Classes, parentCtx.NamespaceFields, parentCtx.NamespaceVarFields, parentCtx.Types)
-        {
-            Runtime = parentCtx.Runtime,
-            ClosureAnalyzer = parentCtx.ClosureAnalyzer,
-            ArrowMethods = parentCtx.ArrowMethods,
-            ConstArrowBindings = parentCtx.ConstArrowBindings,
-            DirectCallArrowBindings = parentCtx.DirectCallArrowBindings,
-            DisplayClasses = parentCtx.DisplayClasses,
-            DisplayClassFields = parentCtx.DisplayClassFields,
-            DisplayClassConstructors = parentCtx.DisplayClassConstructors,
-            EnumMembers = parentCtx.EnumMembers,
-            EnumReverse = parentCtx.EnumReverse,
-            EnumKinds = parentCtx.EnumKinds,
-            TopLevelStaticVars = parentCtx.TopLevelStaticVars,
-            FunctionRestParams = parentCtx.FunctionRestParams,
-            FunctionGenericParams = parentCtx.FunctionGenericParams,
-            IsGenericFunction = parentCtx.IsGenericFunction,
-            TypeMap = parentCtx.TypeMap,
-            DeadCode = parentCtx.DeadCode,
-            AsyncMethods = null,
-            AsyncArrowBuilders = _async.ArrowBuilders,
-            AsyncArrowOuterBuilders = _async.ArrowOuterBuilders,
-            AsyncArrowParentBuilders = _async.ArrowParentBuilders,
-            // Inherit module support from parent context
-            CurrentModulePath = parentCtx.CurrentModulePath,
-            ClassToModule = parentCtx.ClassToModule,
-            FunctionToModule = parentCtx.FunctionToModule,
-            EnumToModule = parentCtx.EnumToModule,
-            TypeEmitterRegistry = parentCtx.TypeEmitterRegistry,
-            ClassExprBuilders = parentCtx.ClassExprBuilders,
-            IsStrictMode = parentCtx.IsStrictMode,
-            // ES2022 Private Class Elements support - inherit from parent context
-            CurrentClassName = parentCtx.CurrentClassName,
-            CurrentClassBuilder = parentCtx.CurrentClassBuilder,
-            // Registry services
-            ClassRegistry = parentCtx.ClassRegistry,
-            // Entry-point display class for captured top-level variables
-            EntryPointDisplayClassFields = parentCtx.EntryPointDisplayClassFields,
-            CapturedTopLevelVars = parentCtx.CapturedTopLevelVars,
-            EntryPointDisplayClassStaticField = parentCtx.EntryPointDisplayClassStaticField,
-            // Captured locals promoted into the enclosing function's display class (#625): the
-            // arrow reads/writes them through `outer.functionDC.field` rather than mutating the
-            // boxed value-type state machine in place (unverifiable). Only fields the function
-            // actually placed in its DC are listed here, so a name present means "route via DC".
-            FunctionDisplayClassFields = parentCtx.FunctionDisplayClassFields,
-            OuterFunctionDCField = parentCtx.OuterFunctionDCField,
-            // Follow-up to #838: lets this nested async arrow's MoveNext populate a nested sync arrow's
-            // $functionDC from this arrow's OWN DC (EmitCapturingArrowInAsyncArrow).
-            ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null,
-        };
+        var ctx = CreateNestedAsyncArrowContext(il, parentCtx);
 
         // Create arrow-specific emitter
         var arrowEmitter = new AsyncArrowMoveNextEmitter(arrowBuilder, analysis, _types);
@@ -1129,67 +1042,21 @@ public partial class ILCompiler
 
         // Create context for MoveNext emission
         var il = smBuilder.MoveNextMethod.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            FieldsField = fieldsField,
-            IsInstanceMethod = isInstanceMethod,
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            FunctionRestParams = _functions.RestParams,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            AsyncArrowBuilders = _async.ArrowBuilders,
-            AsyncArrowOuterBuilders = _async.ArrowOuterBuilders,
-            AsyncArrowParentBuilders = _async.ArrowParentBuilders,
-            // Module support for multi-module compilation
-            CurrentModulePath = _modules.CurrentPath,
-            CurrentNamespacePath = _currentNamespacePath,
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            // @lock decorator support
-            SyncLockFields = _locks.SyncLockFields,
-            AsyncLockFields = _locks.AsyncLockFields,
-            LockReentrancyFields = _locks.ReentrancyFields,
-            StaticSyncLockFields = _locks.StaticSyncLockFields,
-            StaticAsyncLockFields = _locks.StaticAsyncLockFields,
-            StaticLockReentrancyFields = _locks.StaticReentrancyFields,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-                BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-                ImportedNames = _importedNames,
-            ClassExprBuilders = _classExprs.Builders,
-            IsStrictMode = _isStrictMode,
-            // ES2022 Private Class Elements support for async methods. currentClassName lets a private
-            // method pass its QUALIFIED class name (the ClassRegistry keys private members by it), so
-            // nested private member access inside the async body resolves under module compilation.
-            CurrentClassName = currentClassName ?? methodBuilder.DeclaringType?.Name,
-            CurrentClassBuilder = methodBuilder.DeclaringType as TypeBuilder,
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Entry-point display class for captured top-level variables
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField
-        };
+        var ctx = CreateModuleMemberContext(il);
+        ctx.FieldsField = fieldsField;
+        ctx.IsInstanceMethod = isInstanceMethod;
+        ctx.AsyncArrowBuilders = _async.ArrowBuilders;
+        ctx.AsyncArrowOuterBuilders = _async.ArrowOuterBuilders;
+        ctx.AsyncArrowParentBuilders = _async.ArrowParentBuilders;
+        ApplyLockDecoratorFields(ctx);
+        // ES2022 Private Class Elements support for async methods. currentClassName lets a private
+        // method pass its QUALIFIED class name (the ClassRegistry keys private members by it), so
+        // nested private member access inside the async body resolves under module compilation.
+        ctx.CurrentClassName = currentClassName ?? methodBuilder.DeclaringType?.Name;
+        ctx.CurrentClassBuilder = methodBuilder.DeclaringType as TypeBuilder;
+        // Entry-point display class for captured top-level variables
+        ApplyCapturedTopLevelVariableAccess(ctx);
+        ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;
 
         // #682: route promoted captures through the method's function display class (shared by the
         // method body and its nested async arrows via this ctx).
@@ -1364,60 +1231,22 @@ public partial class ILCompiler
             }
 
             // Create context for MoveNext emission
-            var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-            {
-                Runtime = _runtime,
-                ClosureAnalyzer = _closures.Analyzer,
-                ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-                DisplayClasses = _closures.DisplayClasses,
-                DisplayClassFields = _closures.DisplayClassFields,
-                DisplayClassConstructors = _closures.DisplayClassConstructors,
-                EnumMembers = _enums.Members,
-                EnumReverse = _enums.Reverse,
-                EnumKinds = _enums.Kinds,
-                TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
-                FunctionRestParams = _functions.RestParams,
-                FunctionsCapturingArguments = _functions.CapturingArguments,
-                FunctionGenericParams = _functions.GenericParams,
-                IsGenericFunction = _functions.IsGeneric,
-                TypeMap = _typeMap,
-                DeadCode = _deadCodeInfo,
-                AsyncMethods = null,
-                AsyncArrowBuilders = _async.ArrowBuilders,
-                AsyncArrowOuterBuilders = _async.ArrowOuterBuilders,
-                AsyncArrowParentBuilders = _async.ArrowParentBuilders,
-                CurrentModulePath = _modules.CurrentPath,
-                CurrentNamespacePath = _currentNamespacePath,
-                ClassToModule = _modules.ClassToModule,
-                FunctionToModule = _modules.FunctionToModule,
-                EnumToModule = _modules.EnumToModule,
-                DotNetNamespace = _modules.CurrentDotNetNamespace,
-                TypeEmitterRegistry = _typeEmitterRegistry,
-                BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-                BuiltInModuleNamespaces = _builtInModuleNamespaces,
-                BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-                ImportedNames = _importedNames,
-                ClassExprBuilders = _classExprs.Builders,
-                IsStrictMode = _isStrictMode,
-                // ES2022 Private Class Elements support
-                CurrentClassName = enclosingClassName,
-                CurrentClassBuilder = enclosingClassBuilder,
-                ClassRegistry = GetClassRegistry(),
-                EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-                CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-                // #1222: lets the shadow-capture check distinguish a #1201-lifted binding
-                // (home = entry-DC field, must stay live) from a block-scoped shadow
-                // (by-value standalone capture) — see TryGetShadowedTopLevelCaptureField.
-                LiftedBlockScopedTopLevelVars = BuildLiftedBlockScopedTopLevelVarsForModule(_modules.CurrentPath),
-                ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-                EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-                // Follow-up to #838: lets this standalone async arrow's MoveNext populate a nested sync
-                // arrow's $functionDC from this arrow's OWN DC (EmitCapturingArrowInAsyncArrow).
-                ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null
-            };
+            var ctx = CreateModuleMemberContext(il);
+            ctx.AsyncArrowBuilders = _async.ArrowBuilders;
+            ctx.AsyncArrowOuterBuilders = _async.ArrowOuterBuilders;
+            ctx.AsyncArrowParentBuilders = _async.ArrowParentBuilders;
+            // ES2022 Private Class Elements support
+            ctx.CurrentClassName = enclosingClassName;
+            ctx.CurrentClassBuilder = enclosingClassBuilder;
+            ApplyCapturedTopLevelVariableAccess(ctx);
+            // #1222: lets the shadow-capture check distinguish a #1201-lifted binding
+            // (home = entry-DC field, must stay live) from a block-scoped shadow
+            // (by-value standalone capture) — see TryGetShadowedTopLevelCaptureField.
+            ctx.LiftedBlockScopedTopLevelVars = BuildLiftedBlockScopedTopLevelVarsForModule(_modules.CurrentPath);
+            ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;
+            // Follow-up to #838: lets this standalone async arrow's MoveNext populate a nested sync
+            // arrow's $functionDC from this arrow's OWN DC (EmitCapturingArrowInAsyncArrow).
+            ctx.ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null;
 
             // Create arrow-specific emitter
             var arrowEmitter = new AsyncArrowMoveNextEmitter(arrowBuilder, analysis, _types);

--- a/Compilation/ILCompiler.AsyncGenerators.cs
+++ b/Compilation/ILCompiler.AsyncGenerators.cs
@@ -141,52 +141,12 @@ public partial class ILCompiler
 
         // Create a compilation context for the state machine
         var il = smBuilder.MoveNextAsyncMethod.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            FunctionRestParams = _functions.RestParams,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            // Module support for multi-module compilation
-            CurrentModulePath = _modules.CurrentPath,
-            CurrentNamespacePath = _currentNamespacePath,
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            ClassExprBuilders = _classExprs.Builders,
-            IsStrictMode = _isStrictMode,
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Captured top-level variables (entry-point display class)
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-            // Per-arrow $entryPointDC field map so a capturing arrow nested in the async generator body
-            // gets the entry-point display class threaded in (#725 / async analog of #732).
-            ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-            TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath)
-        };
+        var ctx = CreateModuleMemberContext(il);
+        // Captured top-level variables (entry-point display class)
+        ApplyCapturedTopLevelVariableAccess(ctx);
+        // Per-arrow $entryPointDC field map so a capturing arrow nested in the async generator body
+        // gets the entry-point display class threaded in (#725 / async analog of #732).
+        ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;
 
         // Route reads/writes of captured-and-mutated locals through the shared function display class
         // (#725) and let capturing arrows thread it in. Only set when this async generator has a
@@ -241,58 +201,19 @@ public partial class ILCompiler
 
         // Create context for MoveNextAsync emission
         var il = smBuilder.MoveNextAsyncMethod.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            FieldsField = fieldsField,
-            IsInstanceMethod = isInstanceMethod,
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            FunctionRestParams = _functions.RestParams,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            // Module support for multi-module compilation
-            CurrentModulePath = _modules.CurrentPath,
-            CurrentNamespacePath = _currentNamespacePath,
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            ClassExprBuilders = _classExprs.Builders,
-            IsStrictMode = _isStrictMode || CheckForUseStrict(method.Body),
-            // ES2022 Private Class Elements support for async generator methods (a private async
-            // generator threads its QUALIFIED class name so nested private member access resolves — #720).
-            CurrentClassName = currentClassName ?? methodBuilder.DeclaringType?.Name,
-            CurrentClassBuilder = methodBuilder.DeclaringType as TypeBuilder,
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Entry-point display class for captured top-level variables
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-            // Per-arrow $entryPointDC field map so a capturing arrow nested in this instance async
-            // generator method's body gets the entry-point display class threaded in (#725).
-            ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-            TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath)
-        };
+        var ctx = CreateModuleMemberContext(il);
+        ctx.FieldsField = fieldsField;
+        ctx.IsInstanceMethod = isInstanceMethod;
+        ctx.IsStrictMode = _isStrictMode || CheckForUseStrict(method.Body);
+        // ES2022 Private Class Elements support for async generator methods (a private async
+        // generator threads its QUALIFIED class name so nested private member access resolves — #720).
+        ctx.CurrentClassName = currentClassName ?? methodBuilder.DeclaringType?.Name;
+        ctx.CurrentClassBuilder = methodBuilder.DeclaringType as TypeBuilder;
+        // Entry-point display class for captured top-level variables
+        ApplyCapturedTopLevelVariableAccess(ctx);
+        // Per-arrow $entryPointDC field map so a capturing arrow nested in this instance async
+        // generator method's body gets the entry-point display class threaded in (#725).
+        ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;
 
         // #725: route reads/writes of captured-and-mutated method locals through the shared function
         // display class so the arrow's write and the generator body observe the same storage. Only set

--- a/Compilation/ILCompiler.Classes.Accessors.cs
+++ b/Compilation/ILCompiler.Classes.Accessors.cs
@@ -165,58 +165,18 @@ public partial class ILCompiler
         }
 
         var il = methodBuilder.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            FieldsField = fieldsField,
-            IsInstanceMethod = !accessor.IsStatic,
-            CurrentClassName = className,
-            CurrentClassBuilder = typeBuilder,
-            EmittingTypeBuilder = typeBuilder,
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            FunctionRestParams = _functions.RestParams,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            // Module support for multi-module compilation
-            CurrentModulePath = _modules.CurrentPath,
-            CurrentNamespacePath = _currentNamespacePath,
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            ClassExprBuilders = _classExprs.Builders,
-            IsStrictMode = _isStrictMode,
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Module-level / captured top-level variable access. Without these an
-            // accessor body that references a top-level binding (a captured `let`,
-            // a same-module export, an import) throws ReferenceError at runtime —
-            // every other body-emission context (methods, ctors, functions, …)
-            // sets them; the accessor path was the lone omission. (#300)
-            TopLevelStaticVars = BuildClassMethodTopLevelStaticVarsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField
-        };
+        var ctx = CreateModuleMemberContext(il);
+        ctx.FieldsField = fieldsField;
+        ctx.IsInstanceMethod = !accessor.IsStatic;
+        ctx.CurrentClassName = className;
+        ctx.CurrentClassBuilder = typeBuilder;
+        ctx.EmittingTypeBuilder = typeBuilder;
+        // Module-level / captured top-level variable access. Without these an
+        // accessor body that references a top-level binding (a captured `let`,
+        // a same-module export, an import) throws ReferenceError at runtime —
+        // every other body-emission context (methods, ctors, functions, …)
+        // sets them; the accessor path was the lone omission. (#300)
+        ApplyCapturedTopLevelVariableAccess(ctx, classMethodExports: true);
 
         // Add class generic type parameters to context
         if (_classes.GenericParams.TryGetValue(typeBuilder.Name, out var classGenericParams))

--- a/Compilation/ILCompiler.Classes.ClassExpressions.cs
+++ b/Compilation/ILCompiler.Classes.ClassExpressions.cs
@@ -492,74 +492,37 @@ public partial class ILCompiler
     {
         string className = _classExprs.Names[classExpr];
 
-        return new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            FieldsField = fieldsField,
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            CurrentClassBuilder = typeBuilder,
-            FunctionRestParams = _functions.RestParams,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            CurrentModulePath = _modules.CurrentPath,
-            CurrentNamespacePath = _currentNamespacePath,
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            PropertyBackingFields = _typedInterop.PropertyBackingFields,
-            ClassProperties = _typedInterop.ClassProperties,
-            DeclaredPropertyNames = _typedInterop.DeclaredPropertyNames,
-            ReadonlyPropertyNames = _typedInterop.ReadonlyPropertyNames,
-            PropertyTypes = _typedInterop.PropertyTypes,
-            ExtrasFields = _typedInterop.ExtrasFields,
-            UnionGenerator = _unionGenerator,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            ClassExprBuilders = _classExprs.Builders,
-            ClassExprBackingFields = _classExprs.BackingFields,
-            ClassExprProperties = _classExprs.Properties,
-            ClassExprPropertyTypes = _classExprs.PropertyTypes,
-            ClassExprDeclaredProperties = _classExprs.DeclaredProperties,
-            ClassExprReadonlyProperties = _classExprs.ReadonlyProperties,
-            ClassExprStaticFields = _classExprs.StaticFields,
-            ClassExprStaticMethods = _classExprs.StaticMethods,
-            ClassExprInstanceMethods = _classExprs.InstanceMethods,
-            ClassExprGetters = _classExprs.Getters,
-            ClassExprSetters = _classExprs.Setters,
-            ClassExprConstructors = _classExprs.Constructors,
-            ClassExprGenericParams = _classExprs.GenericParams,
-            ClassExprSuperclass = _classExprs.Superclass,
-            CurrentClassExpr = classExpr,
-            VarToClassExpr = _classExprs.VarToClassExpr,
-            IsStrictMode = _isStrictMode,
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Module-level / captured top-level variable access — without these a
-            // class-expression method or accessor body referencing a top-level
-            // binding throws ReferenceError at runtime (same omission #300 fixed
-            // for class-declaration accessor bodies).
-            TopLevelStaticVars = BuildClassMethodTopLevelStaticVarsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField
-        };
+        var ctx = CreateModuleMemberContext(il);
+        ctx.FieldsField = fieldsField;
+        ctx.CurrentClassBuilder = typeBuilder;
+        ctx.PropertyBackingFields = _typedInterop.PropertyBackingFields;
+        ctx.ClassProperties = _typedInterop.ClassProperties;
+        ctx.DeclaredPropertyNames = _typedInterop.DeclaredPropertyNames;
+        ctx.ReadonlyPropertyNames = _typedInterop.ReadonlyPropertyNames;
+        ctx.PropertyTypes = _typedInterop.PropertyTypes;
+        ctx.ExtrasFields = _typedInterop.ExtrasFields;
+        ctx.UnionGenerator = _unionGenerator;
+        ctx.ClassExprBackingFields = _classExprs.BackingFields;
+        ctx.ClassExprProperties = _classExprs.Properties;
+        ctx.ClassExprPropertyTypes = _classExprs.PropertyTypes;
+        ctx.ClassExprDeclaredProperties = _classExprs.DeclaredProperties;
+        ctx.ClassExprReadonlyProperties = _classExprs.ReadonlyProperties;
+        ctx.ClassExprStaticFields = _classExprs.StaticFields;
+        ctx.ClassExprStaticMethods = _classExprs.StaticMethods;
+        ctx.ClassExprInstanceMethods = _classExprs.InstanceMethods;
+        ctx.ClassExprGetters = _classExprs.Getters;
+        ctx.ClassExprSetters = _classExprs.Setters;
+        ctx.ClassExprConstructors = _classExprs.Constructors;
+        ctx.ClassExprGenericParams = _classExprs.GenericParams;
+        ctx.ClassExprSuperclass = _classExprs.Superclass;
+        ctx.CurrentClassExpr = classExpr;
+        ctx.VarToClassExpr = _classExprs.VarToClassExpr;
+        // Module-level / captured top-level variable access — without these a
+        // class-expression method or accessor body referencing a top-level
+        // binding throws ReferenceError at runtime (same omission #300 fixed
+        // for class-declaration accessor bodies).
+        ApplyCapturedTopLevelVariableAccess(ctx, classMethodExports: true);
+        return ctx;
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.Classes.Constructors.cs
+++ b/Compilation/ILCompiler.Classes.Constructors.cs
@@ -45,76 +45,34 @@ public partial class ILCompiler
         }
 
         var il = ctorBuilder.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            FunctionRestParams = _functions.RestParams,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            Runtime = _runtime,
-            CurrentSuperclassName = Expr.GetSuperclassLeafName(classStmt.SuperclassExpr),
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            // Typed interop support
-            PropertyBackingFields = _typedInterop.PropertyBackingFields,
-            ClassProperties = _typedInterop.ClassProperties,
-            DeclaredPropertyNames = _typedInterop.DeclaredPropertyNames,
-            ReadonlyPropertyNames = _typedInterop.ReadonlyPropertyNames,
-            PropertyTypes = _typedInterop.PropertyTypes,
-            ExtrasFields = _typedInterop.ExtrasFields,
-            UnionGenerator = _unionGenerator,
-            // Module support for multi-module compilation
-            CurrentModulePath = _modules.CurrentPath,
-            CurrentNamespacePath = _currentNamespacePath,
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            // .NET namespace support
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            ClassExprBuilders = _classExprs.Builders,
-            IsStrictMode = _isStrictMode,
-            // ES2022 Private Class Elements support
-            CurrentClassName = className,
-            CurrentClassBuilder = typeBuilder,
-            EmittingTypeBuilder = typeBuilder,
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Module-level variable access
-            TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-            // Arrow-closure DC field maps — without these, arrow closures created inside
-            // the constructor (e.g. `arr.map(v => v < MAX)` referencing a module-level
-            // captured var) won't populate their `$entryPointDC`/`$functionDC`/`$arrowDC`
-            // fields on the newobj'd display class, and the arrow body's `ldfld $entryPointDC`
-            // dereferences null at runtime.
-            ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-            ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null,
-            ArrowScopeDCFields = _closures.ArrowScopeDCFields.Count > 0 ? _closures.ArrowScopeDCFields : null,
-            ArrowScopeDCExtraFieldsByArrow = _arrowScopeDCExtraFields.Count > 0 ? _arrowScopeDCExtraFields : null,
-            // Constructors have a void signature; without this the `return;`
-            // inside a ctor body defaults to object and emits `ldnull` before
-            // the `ret`, producing an invalid method.
-            CurrentMethodReturnType = typeof(void),
-        };
+        var ctx = CreateModuleMemberContext(il);
+        ctx.CurrentSuperclassName = Expr.GetSuperclassLeafName(classStmt.SuperclassExpr);
+        // Typed interop support
+        ctx.PropertyBackingFields = _typedInterop.PropertyBackingFields;
+        ctx.ClassProperties = _typedInterop.ClassProperties;
+        ctx.DeclaredPropertyNames = _typedInterop.DeclaredPropertyNames;
+        ctx.ReadonlyPropertyNames = _typedInterop.ReadonlyPropertyNames;
+        ctx.PropertyTypes = _typedInterop.PropertyTypes;
+        ctx.ExtrasFields = _typedInterop.ExtrasFields;
+        ctx.UnionGenerator = _unionGenerator;
+        // ES2022 Private Class Elements support
+        ctx.CurrentClassName = className;
+        ctx.CurrentClassBuilder = typeBuilder;
+        ctx.EmittingTypeBuilder = typeBuilder;
+        ApplyCapturedTopLevelVariableAccess(ctx);
+        // Arrow-closure DC field maps — without these, arrow closures created inside
+        // the constructor (e.g. `arr.map(v => v < MAX)` referencing a module-level
+        // captured var) won't populate their `$entryPointDC`/`$functionDC`/`$arrowDC`
+        // fields on the newobj'd display class, and the arrow body's `ldfld $entryPointDC`
+        // dereferences null at runtime.
+        ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;
+        ctx.ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null;
+        ctx.ArrowScopeDCFields = _closures.ArrowScopeDCFields.Count > 0 ? _closures.ArrowScopeDCFields : null;
+        ctx.ArrowScopeDCExtraFieldsByArrow = _arrowScopeDCExtraFields.Count > 0 ? _arrowScopeDCExtraFields : null;
+        // Constructors have a void signature; without this the `return;`
+        // inside a ctor body defaults to object and emits `ldnull` before
+        // the `ret`, producing an invalid method.
+        ctx.CurrentMethodReturnType = typeof(void);
 
         // Add class generic type parameters to context
         if (_classes.GenericParams.TryGetValue(className, out var classGenericParams))

--- a/Compilation/ILCompiler.Classes.Methods.cs
+++ b/Compilation/ILCompiler.Classes.Methods.cs
@@ -717,73 +717,23 @@ public partial class ILCompiler
         // "Yield not supported" (the public static async-generator gap, #761), not invalid IL.
 
         var il = methodBuilder.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            FieldsField = isStatic ? null : fieldsField,
-            IsInstanceMethod = !isStatic,
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            CurrentClassBuilder = typeBuilder,
-            EmittingTypeBuilder = typeBuilder,
-            FunctionRestParams = _functions.RestParams,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            CurrentModulePath = _modules.CurrentPath,
-            CurrentNamespacePath = _currentNamespacePath,
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            ClassExprBuilders = _classExprs.Builders,
-            IsStrictMode = _isStrictMode,
-            // ES2022 Private Class Elements support
-            CurrentClassName = qualifiedClassName,
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Module-level variable access
-            TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-            // Arrow-closure DC field maps — required so arrow closures created inside
-            // this method populate their captured-DC fields at newobj time.
-            ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-            ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null,
-            ArrowScopeDCFields = _closures.ArrowScopeDCFields.Count > 0 ? _closures.ArrowScopeDCFields : null,
-            ArrowScopeDCExtraFieldsByArrow = _arrowScopeDCExtraFields.Count > 0 ? _arrowScopeDCExtraFields : null,
-            // CJS resolution — needed so `exports`, `module.exports`, and `require(...)`
-            // work inside class method bodies nested in a CJS module.
-            ModuleResolver = _modules.Resolver,
-            ModuleExportFields = _modules.ExportFields,
-            ModuleInitMethods = _modules.InitMethods,
-            ModuleImportFields = _modules.ImportFields,
-            ModuleTypes = _modules.Types,
-            CommonJsExportFields = _modules.CommonJsExportFields,
-            CommonJsGetExportsMethods = _modules.CommonJsGetExportsMethods,
-            CurrentCjsExportsField = _modules.CurrentPath != null
-                && _modules.CommonJsExportFields.TryGetValue(_modules.CurrentPath, out var cjsExportsStatic)
-                ? cjsExportsStatic
-                : null,
-        };
+        var ctx = CreateModuleMemberContext(il);
+        ctx.FieldsField = isStatic ? null : fieldsField;
+        ctx.IsInstanceMethod = !isStatic;
+        ctx.CurrentClassBuilder = typeBuilder;
+        ctx.EmittingTypeBuilder = typeBuilder;
+        // ES2022 Private Class Elements support
+        ctx.CurrentClassName = qualifiedClassName;
+        ApplyCapturedTopLevelVariableAccess(ctx);
+        // Arrow-closure DC field maps — required so arrow closures created inside
+        // this method populate their captured-DC fields at newobj time.
+        ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;
+        ctx.ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null;
+        ctx.ArrowScopeDCFields = _closures.ArrowScopeDCFields.Count > 0 ? _closures.ArrowScopeDCFields : null;
+        ctx.ArrowScopeDCExtraFieldsByArrow = _arrowScopeDCExtraFields.Count > 0 ? _arrowScopeDCExtraFields : null;
+        // CJS resolution — needed so `exports`, `module.exports`, and `require(...)`
+        // work inside class method bodies nested in a CJS module.
+        ApplyCommonJsModuleAccess(ctx);
 
         // Define parameters with typed parameter types from method signature
         var methodParams = methodBuilder.GetParameters();
@@ -1014,84 +964,29 @@ public partial class ILCompiler
         bool hasLock = HasLockDecorator(method);
 
         var il = methodBuilder.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            FieldsField = fieldsField,
-            IsInstanceMethod = true,
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            FunctionRestParams = _functions.RestParams,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            // Async arrow support (for async arrows inside non-async methods)
-            AsyncArrowBuilders = _async.ArrowBuilders.Count > 0 ? _async.ArrowBuilders : null,
-            AsyncArrowOuterBuilders = _async.ArrowOuterBuilders,
-            AsyncArrowParentBuilders = _async.ArrowParentBuilders,
-            // Module support for multi-module compilation
-            CurrentModulePath = _modules.CurrentPath,
-            CurrentNamespacePath = _currentNamespacePath,
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            // @lock decorator support
-            SyncLockFields = _locks.SyncLockFields,
-            AsyncLockFields = _locks.AsyncLockFields,
-            LockReentrancyFields = _locks.ReentrancyFields,
-            StaticSyncLockFields = _locks.StaticSyncLockFields,
-            StaticAsyncLockFields = _locks.StaticAsyncLockFields,
-            StaticLockReentrancyFields = _locks.StaticReentrancyFields,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            ClassExprBuilders = _classExprs.Builders,
-            // Check for method-level "use strict" directive
-            IsStrictMode = _isStrictMode || CheckForUseStrict(method.Body),
-            // ES2022 Private Class Elements support
-            CurrentClassName = typeBuilder.Name,
-            CurrentClassBuilder = typeBuilder,
-            EmittingTypeBuilder = typeBuilder,
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Module-level variable access. For class method bodies we augment
-            // TopLevelStaticVars with this module's ESM export fields so bare
-            // identifiers like `braceExpand` inside a class method resolve to
-            // the module-level `export const braceExpand = ...`. Scoped to the
-            // class-method context to avoid perturbing imports/module-init paths.
-            TopLevelStaticVars = BuildClassMethodTopLevelStaticVarsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-            // CJS resolution — needed so `exports`, `module.exports`, and `require(...)`
-            // work inside class method bodies nested in a CJS module.
-            ModuleResolver = _modules.Resolver,
-            ModuleExportFields = _modules.ExportFields,
-            ModuleInitMethods = _modules.InitMethods,
-            ModuleImportFields = _modules.ImportFields,
-            ModuleTypes = _modules.Types,
-            CommonJsExportFields = _modules.CommonJsExportFields,
-            CommonJsGetExportsMethods = _modules.CommonJsGetExportsMethods,
-            CurrentCjsExportsField = _modules.CurrentPath != null
-                && _modules.CommonJsExportFields.TryGetValue(_modules.CurrentPath, out var cjsExportsInst)
-                ? cjsExportsInst
-                : null,
-        };
+        var ctx = CreateModuleMemberContext(il);
+        ctx.FieldsField = fieldsField;
+        ctx.IsInstanceMethod = true;
+        // Async arrow support (for async arrows inside non-async methods)
+        ctx.AsyncArrowBuilders = _async.ArrowBuilders.Count > 0 ? _async.ArrowBuilders : null;
+        ctx.AsyncArrowOuterBuilders = _async.ArrowOuterBuilders;
+        ctx.AsyncArrowParentBuilders = _async.ArrowParentBuilders;
+        ApplyLockDecoratorFields(ctx);
+        // Check for method-level "use strict" directive
+        ctx.IsStrictMode = _isStrictMode || CheckForUseStrict(method.Body);
+        // ES2022 Private Class Elements support
+        ctx.CurrentClassName = typeBuilder.Name;
+        ctx.CurrentClassBuilder = typeBuilder;
+        ctx.EmittingTypeBuilder = typeBuilder;
+        // Module-level variable access. For class method bodies we augment
+        // TopLevelStaticVars with this module's ESM export fields so bare
+        // identifiers like `braceExpand` inside a class method resolve to
+        // the module-level `export const braceExpand = ...`. Scoped to the
+        // class-method context to avoid perturbing imports/module-init paths.
+        ApplyCapturedTopLevelVariableAccess(ctx, classMethodExports: true);
+        // CJS resolution — needed so `exports`, `module.exports`, and `require(...)`
+        // work inside class method bodies nested in a CJS module.
+        ApplyCommonJsModuleAccess(ctx);
         // Add class generic type parameters to context
         if (_classes.GenericParams.TryGetValue(typeBuilder.Name, out var classGenericParams))
         {

--- a/Compilation/ILCompiler.Classes.Static.cs
+++ b/Compilation/ILCompiler.Classes.Static.cs
@@ -63,53 +63,12 @@ public partial class ILCompiler
         );
 
         var il = cctor.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            CurrentClassBuilder = typeBuilder,
-            EmittingTypeBuilder = typeBuilder,
-            CurrentClassName = qualifiedClassName, // Required for static member access via 'this'
-            FunctionRestParams = _functions.RestParams,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            // Module support for multi-module compilation
-            CurrentModulePath = _modules.CurrentPath,
-            CurrentNamespacePath = _currentNamespacePath,
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            ClassExprBuilders = _classExprs.Builders,
-            IsStrictMode = _isStrictMode,
-            IsStaticConstructorContext = true,
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Module-level variable access
-            TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-        };
+        var ctx = CreateModuleMemberContext(il);
+        ctx.CurrentClassBuilder = typeBuilder;
+        ctx.EmittingTypeBuilder = typeBuilder;
+        ctx.CurrentClassName = qualifiedClassName; // Required for static member access via 'this'
+        ctx.IsStaticConstructorContext = true;
+        ApplyCapturedTopLevelVariableAccess(ctx);
 
         // Add class generic type parameters to context (required for static blocks in generic classes)
         if (_classes.GenericParams.TryGetValue(qualifiedClassName, out var classGenericParams))
@@ -372,61 +331,13 @@ public partial class ILCompiler
         bool hasLock = HasLockDecorator(method);
 
         var il = methodBuilder.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            IsInstanceMethod = false,
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            CurrentClassBuilder = typeBuilder,
-            EmittingTypeBuilder = typeBuilder,
-            FunctionRestParams = _functions.RestParams,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            // Module support for multi-module compilation
-            CurrentModulePath = _modules.CurrentPath,
-            CurrentNamespacePath = _currentNamespacePath,
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            // @lock decorator support
-            SyncLockFields = _locks.SyncLockFields,
-            AsyncLockFields = _locks.AsyncLockFields,
-            LockReentrancyFields = _locks.ReentrancyFields,
-            StaticSyncLockFields = _locks.StaticSyncLockFields,
-            StaticAsyncLockFields = _locks.StaticAsyncLockFields,
-            StaticLockReentrancyFields = _locks.StaticReentrancyFields,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            ClassExprBuilders = _classExprs.Builders,
-            IsStrictMode = _isStrictMode,
-            // ES2022 Private Class Elements support
-            CurrentClassName = className,
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Module-level variable access
-            TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-        };
+        var ctx = CreateModuleMemberContext(il);
+        ctx.CurrentClassBuilder = typeBuilder;
+        ctx.EmittingTypeBuilder = typeBuilder;
+        ApplyLockDecoratorFields(ctx);
+        // ES2022 Private Class Elements support
+        ctx.CurrentClassName = className;
+        ApplyCapturedTopLevelVariableAccess(ctx);
 
         // Define parameters with types (starting at index 0, not 1 since no 'this')
         var methodParams = methodBuilder.GetParameters();
@@ -620,59 +531,16 @@ public partial class ILCompiler
 
         // Create context for MoveNext emission
         var il = smBuilder.MoveNextMethod.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            IsInstanceMethod = false,  // Static method!
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            CurrentClassBuilder = typeBuilder,
-            EmittingTypeBuilder = typeBuilder,
-            FunctionRestParams = _functions.RestParams,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            AsyncArrowBuilders = _async.ArrowBuilders,
-            AsyncArrowOuterBuilders = _async.ArrowOuterBuilders,
-            AsyncArrowParentBuilders = _async.ArrowParentBuilders,
-            // Module support for multi-module compilation
-            CurrentModulePath = _modules.CurrentPath,
-            CurrentNamespacePath = _currentNamespacePath,
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            // @lock decorator support
-            SyncLockFields = _locks.SyncLockFields,
-            AsyncLockFields = _locks.AsyncLockFields,
-            LockReentrancyFields = _locks.ReentrancyFields,
-            StaticSyncLockFields = _locks.StaticSyncLockFields,
-            StaticAsyncLockFields = _locks.StaticAsyncLockFields,
-            StaticLockReentrancyFields = _locks.StaticReentrancyFields,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            ClassExprBuilders = _classExprs.Builders,
-            IsStrictMode = _isStrictMode,
-            // ES2022 Private Class Elements support
-            CurrentClassName = className,
-            // Registry services
-            ClassRegistry = GetClassRegistry()
-        };
+        var ctx = CreateModuleMemberContext(il);
+        // Static method: IsInstanceMethod stays false (the default).
+        ctx.CurrentClassBuilder = typeBuilder;
+        ctx.EmittingTypeBuilder = typeBuilder;
+        ctx.AsyncArrowBuilders = _async.ArrowBuilders;
+        ctx.AsyncArrowOuterBuilders = _async.ArrowOuterBuilders;
+        ctx.AsyncArrowParentBuilders = _async.ArrowParentBuilders;
+        ApplyLockDecoratorFields(ctx);
+        // ES2022 Private Class Elements support
+        ctx.CurrentClassName = className;
 
         // #682: route promoted captures through the static method's function display class.
         WireAsyncMethodFunctionDC(ctx, smBuilder, methodDCKey);

--- a/Compilation/ILCompiler.CommonJs.cs
+++ b/Compilation/ILCompiler.CommonJs.cs
@@ -171,7 +171,7 @@ public partial class ILCompiler
         // ESM does the same dance.)
         var savedPath = _modules.CurrentPath;
         _modules.CurrentPath = module.Path;
-        var ctx = CreateCompilationContext(il);
+        var ctx = CreateModuleTopLevelContext(il);
         _modules.CurrentPath = savedPath;
         ctx.CurrentModulePath = module.Path;
         ctx.ModuleExportFields = _modules.ExportFields;

--- a/Compilation/ILCompiler.ContextFactories.cs
+++ b/Compilation/ILCompiler.ContextFactories.cs
@@ -1,0 +1,302 @@
+using System.Reflection.Emit;
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Layered CompilationContext factories. Every production emission context is created here;
+/// direct <c>new CompilationContext(...)</c> construction outside this file is prohibited
+/// (enforced by CompilationContextFactoryTests). Call sites take a factory context and apply
+/// short, visible overlays for their scope-specific values.
+/// </summary>
+/// <remarks>
+/// Layering:
+/// <list type="bullet">
+/// <item><see cref="CreateBaseCompilationContext"/> — compilation-wide invariants only: values
+/// assigned identically by every emission context (closure registries, enum tables, runtime,
+/// type maps, emitter registries, class registry, ambient strict mode).</item>
+/// <item><see cref="CreateModuleMemberContext"/> — base plus the current-module scope
+/// (module maps, CurrentModulePath/CurrentNamespacePath) shared by every body emitted inside a
+/// module: functions, methods, accessors, constructors, generators, async bodies, arrows.</item>
+/// <item><see cref="CreateModuleTopLevelContext"/> — the module/CommonJS init context; the ONLY
+/// factory besides <see cref="CreateEntryPointTopLevelContext"/> that sets
+/// <c>IsModuleTopLevel = true</c> (#562). Module-top-level state must never leak into function
+/// or state-machine contexts.</item>
+/// <item><see cref="CreateEntryPointTopLevelContext"/> — the single-file entry-point context
+/// (top-level statements; also <c>IsModuleTopLevel = true</c>).</item>
+/// <item><c>Apply*</c> helpers — recurring overlay groups (captured top-level variable access,
+/// CommonJS resolution, @lock decorator fields, inner-function metadata).</item>
+/// </list>
+/// </remarks>
+public partial class ILCompiler
+{
+    /// <summary>
+    /// Creates a CompilationContext carrying only compilation-wide invariants. Scope-sensitive
+    /// values (current module/namespace/class, strict-mode overrides, captured-variable maps,
+    /// state-machine wiring) are applied by the specialized factories and call-site overlays.
+    /// </summary>
+    private CompilationContext CreateBaseCompilationContext(ILGenerator il)
+    {
+        return new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
+        {
+            // Closure analysis registries
+            ClosureAnalyzer = _closures.Analyzer,
+            ArrowMethods = _closures.ArrowMethods,
+            ConstArrowBindings = _closures.ConstArrowBindings,
+            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
+            ObjectShapes = _closures.ObjectShapes,
+            DisplayClasses = _closures.DisplayClasses,
+            DisplayClassFields = _closures.DisplayClassFields,
+            DisplayClassConstructors = _closures.DisplayClassConstructors,
+            // Function metadata
+            FunctionRestParams = _functions.RestParams,
+            FunctionsCapturingArguments = _functions.CapturingArguments,
+            FunctionGenericParams = _functions.GenericParams,
+            IsGenericFunction = _functions.IsGeneric,
+            // Enum tables
+            EnumMembers = _enums.Members,
+            EnumReverse = _enums.Reverse,
+            EnumKinds = _enums.Kinds,
+            // Compilation-wide services
+            Runtime = _runtime,
+            TypeMap = _typeMap,
+            DeadCode = _deadCodeInfo,
+            TypeEmitterRegistry = _typeEmitterRegistry,
+            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
+            BuiltInModuleNamespaces = _builtInModuleNamespaces,
+            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
+            ImportedNames = _importedNames,
+            ClassExprBuilders = _classExprs.Builders,
+            ClassRegistry = GetClassRegistry(),
+            DotNetNamespace = _modules.CurrentDotNetNamespace,
+            // Ambient strict mode; bodies with their own "use strict" prologue override this.
+            IsStrictMode = _isStrictMode,
+        };
+    }
+
+    /// <summary>
+    /// Creates the context for a body emitted inside the current module (function, class member,
+    /// generator, async body, arrow): base invariants plus module maps and the current
+    /// module/namespace scope. Does NOT set IsModuleTopLevel — declarations in these bodies are
+    /// locals, never module-level bindings.
+    /// </summary>
+    private CompilationContext CreateModuleMemberContext(ILGenerator il)
+    {
+        var ctx = CreateBaseCompilationContext(il);
+        ApplyModuleMaps(ctx);
+        ctx.CurrentModulePath = _modules.CurrentPath;
+        ctx.CurrentNamespacePath = _currentNamespacePath;
+        return ctx;
+    }
+
+    /// <summary>
+    /// Creates the context that emits a module's (ESM or CommonJS) top-level statements.
+    /// </summary>
+    private CompilationContext CreateModuleTopLevelContext(ILGenerator il)
+    {
+        var ctx = CreateBaseCompilationContext(il);
+        ApplyModuleMaps(ctx);
+        ApplyCapturedTopLevelVariableAccess(ctx);
+        ctx.LiftedBlockScopedTopLevelVars = BuildLiftedBlockScopedTopLevelVarsForModule(_modules.CurrentPath);
+        ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;
+        ctx.AsyncArrowBuilders = _async.ArrowBuilders.Count > 0 ? _async.ArrowBuilders : null;
+        ctx.AsyncArrowOuterBuilders = _async.ArrowOuterBuilders;
+        ctx.AsyncArrowParentBuilders = _async.ArrowParentBuilders;
+        ctx.ExportAssignmentClasses = _modules.ExportAssignmentClasses;
+        ctx.ExportedClasses = _modules.ExportedClasses;
+        ctx.DefaultExportClasses = _modules.DefaultExportClasses;
+        // This context emits the module/script top-level statements, so var/let/const
+        // declarations here are genuine module-level bindings (#562).
+        ctx.IsModuleTopLevel = true;
+        return ctx;
+    }
+
+    /// <summary>
+    /// Creates the context that emits the single-file entry point's top-level statements
+    /// (and its CommonJS variant). Like <see cref="CreateModuleTopLevelContext"/> this sets
+    /// IsModuleTopLevel (#562), but carries entry-point display-class construction state and
+    /// class-expression lowering maps instead of per-module export tables.
+    /// </summary>
+    private CompilationContext CreateEntryPointTopLevelContext(ILGenerator il)
+    {
+        var ctx = CreateBaseCompilationContext(il);
+        ApplyCapturedTopLevelVariableAccess(ctx);
+        ctx.LiftedBlockScopedTopLevelVars = BuildLiftedBlockScopedTopLevelVarsForModule(_modules.CurrentPath);
+        ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;
+        ctx.FunctionOverloads = _functions.Overloads;
+        ctx.AsyncArrowBuilders = _async.ArrowBuilders.Count > 0 ? _async.ArrowBuilders : null;
+        // Class expression support
+        ctx.VarToClassExpr = _classExprs.VarToClassExpr;
+        ctx.ClassExprStaticFields = _classExprs.StaticFields;
+        ctx.ClassExprStaticMethods = _classExprs.StaticMethods;
+        ctx.ClassExprConstructors = _classExprs.Constructors;
+        ctx.ClassExprGenericParams = _classExprs.GenericParams;
+        ctx.ClassExprSuperclass = _classExprs.Superclass;
+        ctx.UnionGenerator = _unionGenerator;
+        // Entry-point display class for captured top-level variables
+        ctx.EntryPointDisplayClass = _closures.EntryPointDisplayClass;
+        ctx.EntryPointDisplayClassCtor = _closures.EntryPointDisplayClassCtor;
+        // Top-level statements run here: var/let/const are module-level bindings (#562).
+        ctx.IsModuleTopLevel = true;
+        return ctx;
+    }
+
+    /// <summary>
+    /// Creates the context for a nested async arrow's MoveNext, inheriting scope from the parent
+    /// state machine's context rather than from compiler state (the parent may itself be a
+    /// state-machine context whose maps were already scoped).
+    /// </summary>
+    private CompilationContext CreateNestedAsyncArrowContext(ILGenerator il, CompilationContext parentCtx)
+    {
+        return new CompilationContext(il, parentCtx.TypeMapper, parentCtx.Functions, parentCtx.Classes, parentCtx.NamespaceFields, parentCtx.NamespaceVarFields, parentCtx.Types)
+        {
+            Runtime = parentCtx.Runtime,
+            ClosureAnalyzer = parentCtx.ClosureAnalyzer,
+            ArrowMethods = parentCtx.ArrowMethods,
+            ConstArrowBindings = parentCtx.ConstArrowBindings,
+            DirectCallArrowBindings = parentCtx.DirectCallArrowBindings,
+            DisplayClasses = parentCtx.DisplayClasses,
+            DisplayClassFields = parentCtx.DisplayClassFields,
+            DisplayClassConstructors = parentCtx.DisplayClassConstructors,
+            EnumMembers = parentCtx.EnumMembers,
+            EnumReverse = parentCtx.EnumReverse,
+            EnumKinds = parentCtx.EnumKinds,
+            TopLevelStaticVars = parentCtx.TopLevelStaticVars,
+            FunctionRestParams = parentCtx.FunctionRestParams,
+            FunctionGenericParams = parentCtx.FunctionGenericParams,
+            IsGenericFunction = parentCtx.IsGenericFunction,
+            TypeMap = parentCtx.TypeMap,
+            DeadCode = parentCtx.DeadCode,
+            AsyncMethods = null,
+            AsyncArrowBuilders = _async.ArrowBuilders,
+            AsyncArrowOuterBuilders = _async.ArrowOuterBuilders,
+            AsyncArrowParentBuilders = _async.ArrowParentBuilders,
+            // Inherit module support from parent context
+            CurrentModulePath = parentCtx.CurrentModulePath,
+            ClassToModule = parentCtx.ClassToModule,
+            FunctionToModule = parentCtx.FunctionToModule,
+            EnumToModule = parentCtx.EnumToModule,
+            TypeEmitterRegistry = parentCtx.TypeEmitterRegistry,
+            ClassExprBuilders = parentCtx.ClassExprBuilders,
+            IsStrictMode = parentCtx.IsStrictMode,
+            // ES2022 Private Class Elements support - inherit from parent context
+            CurrentClassName = parentCtx.CurrentClassName,
+            CurrentClassBuilder = parentCtx.CurrentClassBuilder,
+            // Registry services
+            ClassRegistry = parentCtx.ClassRegistry,
+            // Entry-point display class for captured top-level variables
+            EntryPointDisplayClassFields = parentCtx.EntryPointDisplayClassFields,
+            CapturedTopLevelVars = parentCtx.CapturedTopLevelVars,
+            EntryPointDisplayClassStaticField = parentCtx.EntryPointDisplayClassStaticField,
+            // Captured locals promoted into the enclosing function's display class (#625): the
+            // arrow reads/writes them through `outer.functionDC.field` rather than mutating the
+            // boxed value-type state machine in place (unverifiable). Only fields the function
+            // actually placed in its DC are listed here, so a name present means "route via DC".
+            FunctionDisplayClassFields = parentCtx.FunctionDisplayClassFields,
+            OuterFunctionDCField = parentCtx.OuterFunctionDCField,
+            // Follow-up to #838: lets this nested async arrow's MoveNext populate a nested sync arrow's
+            // $functionDC from this arrow's OWN DC (EmitCapturingArrowInAsyncArrow).
+            ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null,
+        };
+    }
+
+    /// <summary>
+    /// Creates the deliberately minimal context used to emit an overload's forwarding body —
+    /// just enough to evaluate default-value expressions (#698). Not a general emission context.
+    /// </summary>
+    private CompilationContext CreateOverloadDefaultsContext(ILGenerator il, bool isStrict)
+    {
+        return new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
+        {
+            ClassRegistry = GetClassRegistry(),
+            Runtime = _runtime,
+            TypeMap = _typeMap,
+            IsStrictMode = isStrict
+        };
+    }
+
+    /// <summary>
+    /// Creates the shared definition-phase context (module name resolution). NOT an emission
+    /// context: it has no ILGenerator, and ClassRegistry is intentionally not set — the
+    /// definition phase uses the raw dictionaries.
+    /// </summary>
+    private CompilationContext CreateDefinitionPhaseContext()
+    {
+        return new CompilationContext(null!, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
+        {
+            ClassToModule = _modules.ClassToModule,
+            FunctionToModule = _modules.FunctionToModule,
+            EnumToModule = _modules.EnumToModule,
+            IsStrictMode = _isStrictMode
+        };
+    }
+
+    /// <summary>Applies the compilation's definition→module maps.</summary>
+    private void ApplyModuleMaps(CompilationContext ctx)
+    {
+        ctx.ClassToModule = _modules.ClassToModule;
+        ctx.FunctionToModule = _modules.FunctionToModule;
+        ctx.EnumToModule = _modules.EnumToModule;
+    }
+
+    /// <summary>
+    /// Applies module-level variable access: the current module's top-level static var map, the
+    /// captured-top-level-var set, and the entry-point display-class field map/static field.
+    /// <paramref name="classMethodExports"/> selects the class-method variant of the static-var
+    /// map, which augments it with this module's ESM export fields so bare identifiers inside
+    /// class bodies resolve to module-level exports.
+    /// </summary>
+    private void ApplyCapturedTopLevelVariableAccess(CompilationContext ctx, bool classMethodExports = false)
+    {
+        ctx.TopLevelStaticVars = classMethodExports
+            ? BuildClassMethodTopLevelStaticVarsForModule(_modules.CurrentPath)
+            : BuildTopLevelStaticVarsForModule(_modules.CurrentPath);
+        ctx.CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath);
+        ctx.EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath);
+        ctx.EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField;
+    }
+
+    /// <summary>
+    /// Applies CJS/ESM resolution state so `exports`, `module.exports`, and `require(...)` work
+    /// inside bodies nested in a CJS module.
+    /// </summary>
+    private void ApplyCommonJsModuleAccess(CompilationContext ctx)
+    {
+        ctx.ModuleResolver = _modules.Resolver;
+        ctx.ModuleExportFields = _modules.ExportFields;
+        ctx.ModuleInitMethods = _modules.InitMethods;
+        ctx.ModuleImportFields = _modules.ImportFields;
+        ctx.ModuleTypes = _modules.Types;
+        ctx.CommonJsExportFields = _modules.CommonJsExportFields;
+        ctx.CommonJsGetExportsMethods = _modules.CommonJsGetExportsMethods;
+        ctx.CurrentCjsExportsField = _modules.CurrentPath != null
+            && _modules.CommonJsExportFields.TryGetValue(_modules.CurrentPath, out var cjsExports)
+            ? cjsExports
+            : null;
+    }
+
+    /// <summary>Applies @lock decorator lock/reentrancy field maps.</summary>
+    private void ApplyLockDecoratorFields(CompilationContext ctx)
+    {
+        ctx.SyncLockFields = _locks.SyncLockFields;
+        ctx.AsyncLockFields = _locks.AsyncLockFields;
+        ctx.LockReentrancyFields = _locks.ReentrancyFields;
+        ctx.StaticSyncLockFields = _locks.StaticSyncLockFields;
+        ctx.StaticAsyncLockFields = _locks.StaticAsyncLockFields;
+        ctx.StaticLockReentrancyFields = _locks.StaticReentrancyFields;
+    }
+
+    /// <summary>
+    /// Applies inner-function metadata — required for any `function X() {}` declared inside the
+    /// body being emitted to be reachable from sibling statements.
+    /// </summary>
+    private void ApplyInnerFunctionSupport(CompilationContext ctx)
+    {
+        ctx.InnerFunctionMethods = _innerFunctionMethods;
+        ctx.InnerFunctionDisplayClasses = _innerFunctionDisplayClasses;
+        ctx.InnerFunctionDCFields = _innerFunctionDCFields;
+        ctx.InnerFunctionDCCtors = _innerFunctionDCCtors;
+        ctx.InnerFunctionEntryPointDCFields = _innerFunctionEntryPointDCFields;
+        ctx.InnerFunctionFunctionDCFields = _innerFunctionFunctionDCFields;
+    }
+}

--- a/Compilation/ILCompiler.Enums.cs
+++ b/Compilation/ILCompiler.Enums.cs
@@ -94,71 +94,12 @@ public partial class ILCompiler
     }
 
     /// <summary>
-    /// Evaluates a constant expression for const enum members during compilation.
+    /// Evaluates a constant expression for const enum members during compilation via the shared
+    /// <see cref="ConstEnumExpressionEvaluator"/>, surfacing failures as CompileExceptions.
     /// </summary>
-    private object EvaluateConstEnumExpression(Expr expr, Dictionary<string, object> resolvedMembers, string enumName)
+    private static object EvaluateConstEnumExpression(Expr expr, Dictionary<string, object> resolvedMembers, string enumName)
     {
-        return expr switch
-        {
-            Expr.Literal lit => lit.Value ?? throw new CompileException($"Const enum expression cannot be null."),
-
-            Expr.Get g when g.Object is Expr.Variable v && v.Name.Lexeme == enumName =>
-                resolvedMembers.TryGetValue(g.Name.Lexeme, out var val)
-                    ? val
-                    : throw new CompileException($"Const enum member '{g.Name.Lexeme}' referenced before definition."),
-
-            Expr.Grouping gr => EvaluateConstEnumExpression(gr.Expression, resolvedMembers, enumName),
-
-            Expr.Unary u => EvaluateConstEnumUnary(u, resolvedMembers, enumName),
-
-            Expr.Binary b => EvaluateConstEnumBinary(b, resolvedMembers, enumName),
-
-            _ => throw new CompileException($"Expression type '{expr.GetType().Name}' is not allowed in const enum initializer.")
-        };
-    }
-
-    private object EvaluateConstEnumUnary(Expr.Unary unary, Dictionary<string, object> resolvedMembers, string enumName)
-    {
-        var operand = EvaluateConstEnumExpression(unary.Right, resolvedMembers, enumName);
-
-        return unary.Operator.Type switch
-        {
-            TokenType.MINUS when operand is double d => -d,
-            TokenType.PLUS when operand is double d => d,
-            TokenType.TILDE when operand is double d => (double)(~(int)d),
-            _ => throw new CompileException($"Operator '{unary.Operator.Lexeme}' is not allowed in const enum expressions.")
-        };
-    }
-
-    private object EvaluateConstEnumBinary(Expr.Binary binary, Dictionary<string, object> resolvedMembers, string enumName)
-    {
-        var left = EvaluateConstEnumExpression(binary.Left, resolvedMembers, enumName);
-        var right = EvaluateConstEnumExpression(binary.Right, resolvedMembers, enumName);
-
-        if (left is double l && right is double r)
-        {
-            return binary.Operator.Type switch
-            {
-                TokenType.PLUS => l + r,
-                TokenType.MINUS => l - r,
-                TokenType.STAR => l * r,
-                TokenType.SLASH => l / r,
-                TokenType.PERCENT => l % r,
-                TokenType.STAR_STAR => Math.Pow(l, r),
-                TokenType.AMPERSAND => (double)((int)l & (int)r),
-                TokenType.PIPE => (double)((int)l | (int)r),
-                TokenType.CARET => (double)((int)l ^ (int)r),
-                TokenType.LESS_LESS => (double)((int)l << (int)r),
-                TokenType.GREATER_GREATER => (double)((int)l >> (int)r),
-                _ => throw new CompileException($"Operator '{binary.Operator.Lexeme}' is not allowed in const enum expressions.")
-            };
-        }
-
-        if (left is string ls && right is string rs && binary.Operator.Type == TokenType.PLUS)
-        {
-            return ls + rs;
-        }
-
-        throw new CompileException($"Invalid operand types for operator '{binary.Operator.Lexeme}' in const enum expression.");
+        return ConstEnumExpressionEvaluator.Evaluate(expr, resolvedMembers, enumName,
+            static e => new CompileException(e.Message));
     }
 }

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -345,83 +345,31 @@ public partial class ILCompiler
         // (state machines, class methods) gets it uniformly, not just this plain-function path.
         Dictionary<string, FieldBuilder>? topLevelVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath);
 
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            FunctionRestParams = _functions.RestParams,
-            FunctionOverloads = _functions.Overloads,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            AsyncArrowBuilders = _async.ArrowBuilders.Count > 0 ? _async.ArrowBuilders : null,
-            TopLevelStaticVars = topLevelVars,
-            // Module support for multi-module compilation
-            CurrentModulePath = _modules.CurrentPath,
-            CurrentNamespacePath = _currentNamespacePath,
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            // CJS/ESM resolution — needed so require('./literal') and module.exports/exports
-            // work inside function bodies nested in a CJS module (e.g. debug's common.js
-            // setup() calls require('ms') from inside the exported function).
-            ModuleResolver = _modules.Resolver,
-            ModuleExportFields = _modules.ExportFields,
-            ModuleInitMethods = _modules.InitMethods,
-            ModuleImportFields = _modules.ImportFields,
-            ModuleTypes = _modules.Types,
-            CommonJsExportFields = _modules.CommonJsExportFields,
-            CommonJsGetExportsMethods = _modules.CommonJsGetExportsMethods,
-            CurrentCjsExportsField = _modules.CurrentPath != null
-                && _modules.CommonJsExportFields.TryGetValue(_modules.CurrentPath, out var cjsExports)
-                ? cjsExports
-                : null,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            ClassExprBuilders = _classExprs.Builders,
-            UnionGenerator = _unionGenerator,
-            // Check for function-level "use strict" directive
-            IsStrictMode = _isStrictMode || CheckForUseStrict(funcStmt.Body),
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Entry-point display class for captured top-level variables
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-            ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-            // Function-level display class for captured function-local variables
-            FunctionDisplayClassFields = hasFunctionDC ? _closures.FunctionDisplayClassFields[qualifiedFunctionName] : null,
-            CapturedFunctionLocals = capturedLocals,
-            ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null,
-            ArrowScopeDCFields = _closures.ArrowScopeDCFields.Count > 0 ? _closures.ArrowScopeDCFields : null,
-            ArrowScopeDCExtraFieldsByArrow = _arrowScopeDCExtraFields.Count > 0 ? _arrowScopeDCExtraFields : null,
-            // Inner function support
-            InnerFunctionMethods = _innerFunctionMethods,
-            InnerFunctionDisplayClasses = _innerFunctionDisplayClasses,
-            InnerFunctionDCFields = _innerFunctionDCFields,
-            InnerFunctionDCCtors = _innerFunctionDCCtors,
-            InnerFunctionEntryPointDCFields = _innerFunctionEntryPointDCFields,
-            InnerFunctionFunctionDCFields = _innerFunctionFunctionDCFields,
-            // Typed return type for unboxed return optimization
-            CurrentMethodReturnType = methodBuilder.ReturnType
-        };
+        var ctx = CreateModuleMemberContext(il);
+        ctx.FunctionOverloads = _functions.Overloads;
+        ctx.AsyncArrowBuilders = _async.ArrowBuilders.Count > 0 ? _async.ArrowBuilders : null;
+        // CJS/ESM resolution — needed so require('./literal') and module.exports/exports
+        // work inside function bodies nested in a CJS module (e.g. debug's common.js
+        // setup() calls require('ms') from inside the exported function).
+        ApplyCommonJsModuleAccess(ctx);
+        ctx.UnionGenerator = _unionGenerator;
+        // Check for function-level "use strict" directive
+        ctx.IsStrictMode = _isStrictMode || CheckForUseStrict(funcStmt.Body);
+        // Entry-point display class for captured top-level variables. TopLevelStaticVars uses
+        // the pre-computed per-function map rather than the module-wide default.
+        ApplyCapturedTopLevelVariableAccess(ctx);
+        ctx.TopLevelStaticVars = topLevelVars;
+        ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;
+        // Function-level display class for captured function-local variables
+        ctx.FunctionDisplayClassFields = hasFunctionDC ? _closures.FunctionDisplayClassFields[qualifiedFunctionName] : null;
+        ctx.CapturedFunctionLocals = capturedLocals;
+        ctx.ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null;
+        ctx.ArrowScopeDCFields = _closures.ArrowScopeDCFields.Count > 0 ? _closures.ArrowScopeDCFields : null;
+        ctx.ArrowScopeDCExtraFieldsByArrow = _arrowScopeDCExtraFields.Count > 0 ? _arrowScopeDCExtraFields : null;
+        // Inner function support
+        ApplyInnerFunctionSupport(ctx);
+        // Typed return type for unboxed return optimization
+        ctx.CurrentMethodReturnType = methodBuilder.ReturnType;
 
         // Create function display class instance if needed
         LocalBuilder? displayLocal = null;
@@ -1002,62 +950,10 @@ public partial class ILCompiler
 
         var il = mainMethod.GetILGenerator();
         EmitInstallEventLoopSyncContext(il);
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            ClassExprBuilders = _classExprs.Builders,
-            FunctionRestParams = _functions.RestParams,
-            FunctionOverloads = _functions.Overloads,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            AsyncArrowBuilders = _async.ArrowBuilders.Count > 0 ? _async.ArrowBuilders : null,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            // Class expression support
-            VarToClassExpr = _classExprs.VarToClassExpr,
-            ClassExprStaticFields = _classExprs.StaticFields,
-            ClassExprStaticMethods = _classExprs.StaticMethods,
-            ClassExprConstructors = _classExprs.Constructors,
-            ClassExprGenericParams = _classExprs.GenericParams,
-            ClassExprSuperclass = _classExprs.Superclass,
-            UnionGenerator = _unionGenerator,
-            PropertyTypes = _typedInterop.PropertyTypes,
-            IsStrictMode = _isStrictMode,
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Entry-point display class for captured top-level variables
-            EntryPointDisplayClass = _closures.EntryPointDisplayClass,
-            EntryPointDisplayClassCtor = _closures.EntryPointDisplayClassCtor,
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            LiftedBlockScopedTopLevelVars = BuildLiftedBlockScopedTopLevelVarsForModule(_modules.CurrentPath),
-            ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-            // Program type for GetMethodFromHandle resolution
-            ProgramType = _programType,
-            // Top-level statements run here: var/let/const are module-level bindings (#562).
-            IsModuleTopLevel = true
-        };
+        var ctx = CreateEntryPointTopLevelContext(il);
+        ctx.PropertyTypes = _typedInterop.PropertyTypes;
+        // Program type for GetMethodFromHandle resolution
+        ctx.ProgramType = _programType;
 
         // Create entry-point display class instance if there are captured top-level variables
         if (_closures.EntryPointDisplayClass != null && _closures.EntryPointDisplayClassCtor != null)
@@ -1183,58 +1079,7 @@ public partial class ILCompiler
 
         var il = mainMethod.GetILGenerator();
         EmitInstallEventLoopSyncContext(il);
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            ClassExprBuilders = _classExprs.Builders,
-            FunctionRestParams = _functions.RestParams,
-            FunctionOverloads = _functions.Overloads,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            AsyncArrowBuilders = _async.ArrowBuilders.Count > 0 ? _async.ArrowBuilders : null,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            VarToClassExpr = _classExprs.VarToClassExpr,
-            ClassExprStaticFields = _classExprs.StaticFields,
-            ClassExprStaticMethods = _classExprs.StaticMethods,
-            ClassExprConstructors = _classExprs.Constructors,
-            ClassExprGenericParams = _classExprs.GenericParams,
-            ClassExprSuperclass = _classExprs.Superclass,
-            UnionGenerator = _unionGenerator,
-            IsStrictMode = _isStrictMode,
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Entry-point display class for captured top-level variables
-            EntryPointDisplayClass = _closures.EntryPointDisplayClass,
-            EntryPointDisplayClassCtor = _closures.EntryPointDisplayClassCtor,
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            LiftedBlockScopedTopLevelVars = BuildLiftedBlockScopedTopLevelVarsForModule(_modules.CurrentPath),
-            ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-            // Top-level statements run here: var/let/const are module-level bindings (#562).
-            IsModuleTopLevel = true
-        };
+        var ctx = CreateEntryPointTopLevelContext(il);
 
         // Create entry-point display class instance if there are captured top-level variables
         if (_closures.EntryPointDisplayClass != null && _closures.EntryPointDisplayClassCtor != null)
@@ -1457,14 +1302,7 @@ public partial class ILCompiler
             var il = overload.GetILGenerator();
 
             // Create a minimal context just for emitting default value expressions
-            var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-            {
-                ClassRegistry = GetClassRegistry(),
-                Runtime = _runtime,
-                TypeMap = _typeMap,
-                // Check for function-level "use strict" directive
-                IsStrictMode = _isStrictMode || CheckForUseStrict(funcStmt.Body)
-            };
+            var ctx = CreateOverloadDefaultsContext(il, _isStrictMode || CheckForUseStrict(funcStmt.Body));
             var emitter = new ILEmitter(ctx);
 
             // Make the provided parameters resolvable so a default value that references an

--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -381,56 +381,17 @@ public partial class ILCompiler
 
         // Create a compilation context for the state machine
         var il = smBuilder.MoveNextMethod.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            FunctionRestParams = _functions.RestParams,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            // Module support for multi-module compilation
-            CurrentModulePath = _modules.CurrentPath,
-            CurrentNamespacePath = _currentNamespacePath,
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            ClassExprBuilders = _classExprs.Builders,
-            // Check for function-level "use strict" directive
-            IsStrictMode = _isStrictMode || CheckForUseStrict(funcStmt.Body),
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Captured outer variables are read live (by reference) rather than snapshotted (#541).
-            // These mirror the async-generator MoveNext context so reads/writes of top-level
-            // variables go straight to their backing storage instead of a stale state-machine field.
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-            // Per-arrow $entryPointDC field map so a capturing arrow nested in the generator body
-            // gets the entry-point display class threaded in (#732). Without this the arrow's
-            // $entryPointDC stays null and reading a captured top-level var NREs.
-            ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-            TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath)
-        };
+        var ctx = CreateModuleMemberContext(il);
+        // Check for function-level "use strict" directive
+        ctx.IsStrictMode = _isStrictMode || CheckForUseStrict(funcStmt.Body);
+        // Captured outer variables are read live (by reference) rather than snapshotted (#541).
+        // These mirror the async-generator MoveNext context so reads/writes of top-level
+        // variables go straight to their backing storage instead of a stale state-machine field.
+        ApplyCapturedTopLevelVariableAccess(ctx);
+        // Per-arrow $entryPointDC field map so a capturing arrow nested in the generator body
+        // gets the entry-point display class threaded in (#732). Without this the arrow's
+        // $entryPointDC stays null and reading a captured top-level var NREs.
+        ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;
 
         // Route reads/writes of captured-and-mutated locals through the shared function display
         // class (#674) and let capturing arrows thread it in. Only set when this generator has a
@@ -487,59 +448,20 @@ public partial class ILCompiler
 
         // Create context for MoveNext emission
         var il = smBuilder.MoveNextMethod.GetILGenerator();
-        var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            FieldsField = fieldsField,
-            IsInstanceMethod = isInstanceMethod,
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            FunctionRestParams = _functions.RestParams,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            // Module support for multi-module compilation
-            CurrentModulePath = _modules.CurrentPath,
-            CurrentNamespacePath = _currentNamespacePath,
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            ClassExprBuilders = _classExprs.Builders,
-            IsStrictMode = _isStrictMode || CheckForUseStrict(method.Body),
-            // ES2022 Private Class Elements support for generator methods (a private generator threads
-            // its QUALIFIED class name so nested private member access resolves under modules — #720).
-            CurrentClassName = currentClassName ?? methodBuilder.DeclaringType?.Name,
-            CurrentClassBuilder = methodBuilder.DeclaringType as TypeBuilder,
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Captured outer variables are read live (by reference), not snapshotted (#541).
-            // TopLevelStaticVars covers module-level vars that aren't in the entry-point display class.
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-            // Per-arrow $entryPointDC field map so a capturing arrow nested in this instance
-            // generator method's body gets the entry-point display class threaded in (#732).
-            ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-            TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath)
-        };
+        var ctx = CreateModuleMemberContext(il);
+        ctx.FieldsField = fieldsField;
+        ctx.IsInstanceMethod = isInstanceMethod;
+        ctx.IsStrictMode = _isStrictMode || CheckForUseStrict(method.Body);
+        // ES2022 Private Class Elements support for generator methods (a private generator threads
+        // its QUALIFIED class name so nested private member access resolves under modules — #720).
+        ctx.CurrentClassName = currentClassName ?? methodBuilder.DeclaringType?.Name;
+        ctx.CurrentClassBuilder = methodBuilder.DeclaringType as TypeBuilder;
+        // Captured outer variables are read live (by reference), not snapshotted (#541).
+        // TopLevelStaticVars covers module-level vars that aren't in the entry-point display class.
+        ApplyCapturedTopLevelVariableAccess(ctx);
+        // Per-arrow $entryPointDC field map so a capturing arrow nested in this instance
+        // generator method's body gets the entry-point display class threaded in (#732).
+        ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;
 
         // #724: route reads/writes of captured-and-mutated method locals through the shared function
         // display class so the arrow's write and the generator body observe the same storage. Only set

--- a/Compilation/ILCompiler.InnerFunctions.cs
+++ b/Compilation/ILCompiler.InnerFunctions.cs
@@ -443,64 +443,22 @@ public partial class ILCompiler
             // Get resolved parameter types for this inner function
             _innerFunctionParamTypes.TryGetValue(func, out var innerParamTypes);
 
-            var ctx = new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
+            var ctx = CreateModuleMemberContext(il);
+            ApplyCapturedTopLevelVariableAccess(ctx);
+            ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;
+            ctx.ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null;
+            ctx.ArrowScopeDCFields = _closures.ArrowScopeDCFields.Count > 0 ? _closures.ArrowScopeDCFields : null;
+            ctx.ArrowScopeDCExtraFieldsByArrow = _arrowScopeDCExtraFields.Count > 0 ? _arrowScopeDCExtraFields : null;
+            ApplyInnerFunctionSupport(ctx);
+            ctx.CurrentMethodReturnType = _types.Object;
+            // Enable self-reference: the function can call itself by name
+            ctx.InnerFunctionMethodsByName = new Dictionary<string, MethodBuilder>
             {
-                ClosureAnalyzer = _closures.Analyzer,
-                ArrowMethods = _closures.ArrowMethods,
-                ConstArrowBindings = _closures.ConstArrowBindings,
-                DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-                ObjectShapes = _closures.ObjectShapes,
-                DisplayClasses = _closures.DisplayClasses,
-                DisplayClassFields = _closures.DisplayClassFields,
-                DisplayClassConstructors = _closures.DisplayClassConstructors,
-                FunctionRestParams = _functions.RestParams,
-                FunctionsCapturingArguments = _functions.CapturingArguments,
-                EnumMembers = _enums.Members,
-                EnumReverse = _enums.Reverse,
-                EnumKinds = _enums.Kinds,
-                Runtime = _runtime,
-                FunctionGenericParams = _functions.GenericParams,
-                IsGenericFunction = _functions.IsGeneric,
-                TypeMap = _typeMap,
-                DeadCode = _deadCodeInfo,
-                TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
-                CurrentModulePath = _modules.CurrentPath,
-                CurrentNamespacePath = _currentNamespacePath,
-                ClassToModule = _modules.ClassToModule,
-                FunctionToModule = _modules.FunctionToModule,
-                EnumToModule = _modules.EnumToModule,
-                DotNetNamespace = _modules.CurrentDotNetNamespace,
-                TypeEmitterRegistry = _typeEmitterRegistry,
-                BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-                BuiltInModuleNamespaces = _builtInModuleNamespaces,
-                BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-                ImportedNames = _importedNames,
-                ClassExprBuilders = _classExprs.Builders,
-                IsStrictMode = _isStrictMode,
-                ClassRegistry = GetClassRegistry(),
-                EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-                CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-                ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-                EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-                ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0 ? _closures.ArrowFunctionDCFields : null,
-                ArrowScopeDCFields = _closures.ArrowScopeDCFields.Count > 0 ? _closures.ArrowScopeDCFields : null,
-            ArrowScopeDCExtraFieldsByArrow = _arrowScopeDCExtraFields.Count > 0 ? _arrowScopeDCExtraFields : null,
-                InnerFunctionMethods = _innerFunctionMethods,
-                InnerFunctionDisplayClasses = _innerFunctionDisplayClasses,
-                InnerFunctionDCFields = _innerFunctionDCFields,
-                InnerFunctionDCCtors = _innerFunctionDCCtors,
-                InnerFunctionEntryPointDCFields = _innerFunctionEntryPointDCFields,
-                InnerFunctionFunctionDCFields = _innerFunctionFunctionDCFields,
-                CurrentMethodReturnType = _types.Object,
-                // Enable self-reference: the function can call itself by name
-                InnerFunctionMethodsByName = new Dictionary<string, MethodBuilder>
-                {
-                    [func.Name.Lexeme] = method
-                },
-                InnerFunctionDisplayClassesByName = hasDisplayClass
-                    ? new Dictionary<string, TypeBuilder> { [func.Name.Lexeme] = displayClass! }
-                    : []
+                [func.Name.Lexeme] = method
             };
+            ctx.InnerFunctionDisplayClassesByName = hasDisplayClass
+                ? new Dictionary<string, TypeBuilder> { [func.Name.Lexeme] = displayClass! }
+                : [];
 
             if (hasDisplayClass)
             {

--- a/Compilation/ILCompiler.Modules.cs
+++ b/Compilation/ILCompiler.Modules.cs
@@ -533,11 +533,11 @@ public partial class ILCompiler
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Stsfld, initializedField);
 
-        // Set _modules.CurrentPath before CreateCompilationContext so
+        // Set _modules.CurrentPath before CreateModuleTopLevelContext so
         // BuildTopLevelStaticVarsForModule can scope to this module.
         var savedPath = _modules.CurrentPath;
         _modules.CurrentPath = module.Path;
-        var ctx = CreateCompilationContext(il);
+        var ctx = CreateModuleTopLevelContext(il);
         _modules.CurrentPath = savedPath;
         ctx.CurrentModulePath = module.Path;
         ctx.ModuleExportFields = _modules.ExportFields;
@@ -549,7 +549,7 @@ public partial class ILCompiler
         ctx.CommonJsGetExportsMethods = _modules.CommonJsGetExportsMethods;
 
         // Note: imports are already merged into ctx.TopLevelStaticVars via
-        // BuildTopLevelStaticVarsForModule in CreateCompilationContext.
+        // BuildTopLevelStaticVarsForModule in CreateModuleTopLevelContext.
 
         var emitter = new ILEmitter(ctx);
 
@@ -615,7 +615,7 @@ public partial class ILCompiler
         // returns the global dict (non-captured field is visible across script-merged files).
         var savedPath = _modules.CurrentPath;
         _modules.CurrentPath = null;
-        var ctx = CreateCompilationContext(il);
+        var ctx = CreateModuleTopLevelContext(il);
         _modules.CurrentPath = savedPath;
         ctx.CurrentModulePath = script.Path;
         ctx.ModuleExportFields = _modules.ExportFields;
@@ -782,67 +782,6 @@ public partial class ILCompiler
 
         // Fall back to filename
         return "./" + Path.GetFileName(targetPath);
-    }
-
-    /// <summary>
-    /// Creates a CompilationContext with common settings.
-    /// </summary>
-    private CompilationContext CreateCompilationContext(ILGenerator il)
-    {
-        return new CompilationContext(il, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            ClosureAnalyzer = _closures.Analyzer,
-            ArrowMethods = _closures.ArrowMethods,
-            ConstArrowBindings = _closures.ConstArrowBindings,
-            DirectCallArrowBindings = _closures.DirectCallArrowBindings,
-            ObjectShapes = _closures.ObjectShapes,
-            DisplayClasses = _closures.DisplayClasses,
-            DisplayClassFields = _closures.DisplayClassFields,
-            DisplayClassConstructors = _closures.DisplayClassConstructors,
-            FunctionRestParams = _functions.RestParams,
-            FunctionsCapturingArguments = _functions.CapturingArguments,
-            EnumMembers = _enums.Members,
-            EnumReverse = _enums.Reverse,
-            EnumKinds = _enums.Kinds,
-            // Scope top-level static vars to the current module to prevent
-            // cross-module name collisions (e.g. `const foo` in main.ts
-            // shadowing `export function foo()` in lib.ts).
-            TopLevelStaticVars = BuildTopLevelStaticVarsForModule(_modules.CurrentPath),
-            Runtime = _runtime,
-            FunctionGenericParams = _functions.GenericParams,
-            IsGenericFunction = _functions.IsGeneric,
-            TypeMap = _typeMap,
-            DeadCode = _deadCodeInfo,
-            AsyncMethods = null,
-            AsyncArrowBuilders = _async.ArrowBuilders.Count > 0 ? _async.ArrowBuilders : null,
-            AsyncArrowOuterBuilders = _async.ArrowOuterBuilders,
-            AsyncArrowParentBuilders = _async.ArrowParentBuilders,
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            ExportAssignmentClasses = _modules.ExportAssignmentClasses,
-            ExportedClasses = _modules.ExportedClasses,
-            DefaultExportClasses = _modules.DefaultExportClasses,
-            DotNetNamespace = _modules.CurrentDotNetNamespace,
-            TypeEmitterRegistry = _typeEmitterRegistry,
-            BuiltInModuleEmitterRegistry = _builtInModuleEmitterRegistry,
-            BuiltInModuleNamespaces = _builtInModuleNamespaces,
-            BuiltInModuleMethodBindings = GetCurrentBuiltInMethodBindings(),
-            ImportedNames = _importedNames,
-            ClassExprBuilders = _classExprs.Builders,
-            IsStrictMode = _isStrictMode,
-            // Registry services
-            ClassRegistry = GetClassRegistry(),
-            // Entry-point display class for captured top-level variables
-            EntryPointDisplayClassFields = BuildEntryPointDisplayClassFieldsForModule(_modules.CurrentPath),
-            CapturedTopLevelVars = BuildCapturedTopLevelVarsForModule(_modules.CurrentPath),
-            LiftedBlockScopedTopLevelVars = BuildLiftedBlockScopedTopLevelVarsForModule(_modules.CurrentPath),
-            ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null,
-            EntryPointDisplayClassStaticField = _closures.EntryPointDisplayClassStaticField,
-            // This context emits the module/script top-level statements, so var/let/const
-            // declarations here are genuine module-level bindings (#562).
-            IsModuleTopLevel = true
-        };
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -330,14 +330,7 @@ public partial class ILCompiler
     /// </summary>
     private CompilationContext GetDefinitionContext()
     {
-        _definitionContext ??= new CompilationContext(null!, _typeMapper, _functions.Builders, _classes.Builders, _namespaceFields, _namespaceVarFields, _types)
-        {
-            ClassToModule = _modules.ClassToModule,
-            FunctionToModule = _modules.FunctionToModule,
-            EnumToModule = _modules.EnumToModule,
-            IsStrictMode = _isStrictMode
-            // Note: ClassRegistry intentionally not set here - definition context uses raw dictionaries
-        };
+        _definitionContext ??= CreateDefinitionPhaseContext();
         _definitionContext.CurrentModulePath = _modules.CurrentPath;
         // Keep the definition context's namespace in sync so GetQualifiedFunctionName produces
         // namespace-qualified keys while a namespace's members are being defined/collected (#657).

--- a/Compilation/RuntimeEmitter.Arrays.cs
+++ b/Compilation/RuntimeEmitter.Arrays.cs
@@ -1659,8 +1659,9 @@ public partial class RuntimeEmitter
         EmitVariadicElementCase("unshift", runtime.ArrayUnshift, reverse: true);
 
         // Single-arg methods (runtime helper takes `object`, not `object[]`).
-        // Aligns with Emitters/ArrayEmitter.cs which also uses EmitSingleArgOrNull
-        // for these methods, so dynamic bound dispatch matches the direct-call path.
+        // Aligns with Emitters/ArrayEmitter.cs which also uses the shared
+        // EmitterArgumentHelpers.EmitBoxedArgumentOrNull for these methods, so
+        // dynamic bound dispatch matches the direct-call path.
         // indexOf/lastIndexOf take searchElement + optional fromIndex.
         EmitSearchCase("indexOf", runtime.ArrayIndexOf);
         EmitSearchCase("lastIndexOf", runtime.ArrayLastIndexOf);

--- a/Compilation/RuntimeEmitter.WeakMaps.cs
+++ b/Compilation/RuntimeEmitter.WeakMaps.cs
@@ -8,95 +8,15 @@ public partial class RuntimeEmitter
 {
     private void EmitWeakMapMethods(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        // Emit validation helper first (shared with WeakSets)
-        EmitValidateWeakMapKey(typeBuilder, runtime);
+        // Emit validation helper first (shared primitive probe: RuntimeEmitter.WeakValidation.cs)
+        runtime.ValidateWeakMapKey = EmitWeakTargetValidator(typeBuilder, "ValidateWeakMapKey",
+            "Runtime Error: Invalid value used as weak map key. WeakMap keys must be objects");
 
         EmitCreateWeakMap(typeBuilder, runtime);
         EmitWeakMapGet(typeBuilder, runtime);
         EmitWeakMapSet(typeBuilder, runtime);
         EmitWeakMapHas(typeBuilder, runtime);
         EmitWeakMapDelete(typeBuilder, runtime);
-    }
-
-    /// <summary>
-    /// Emits the ValidateWeakMapKey helper that throws if key is a primitive type.
-    /// </summary>
-    private void EmitValidateWeakMapKey(TypeBuilder typeBuilder, EmittedRuntime runtime)
-    {
-        var method = typeBuilder.DefineMethod(
-            "ValidateWeakMapKey",
-            MethodAttributes.Private | MethodAttributes.Static,
-            _types.Void,
-            [_types.Object]
-        );
-        runtime.ValidateWeakMapKey = method;
-
-        var il = method.GetILGenerator();
-
-        var stringLabel = il.DefineLabel();
-        var numberLabel = il.DefineLabel();
-        var booleanLabel = il.DefineLabel();
-        var validLabel = il.DefineLabel();
-
-        // Check string
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.String);
-        il.Emit(OpCodes.Brtrue, stringLabel);
-
-        // Check double (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Double);
-        il.Emit(OpCodes.Brtrue, numberLabel);
-
-        // Check int (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Int32);
-        il.Emit(OpCodes.Brtrue, numberLabel);
-
-        // Check long (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Int64);
-        il.Emit(OpCodes.Brtrue, numberLabel);
-
-        // Check float (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Single);
-        il.Emit(OpCodes.Brtrue, numberLabel);
-
-        // Check decimal (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Decimal);
-        il.Emit(OpCodes.Brtrue, numberLabel);
-
-        // Check bool (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Boolean);
-        il.Emit(OpCodes.Brtrue, booleanLabel);
-
-        // Key is valid (not a primitive)
-        il.Emit(OpCodes.Br, validLabel);
-
-        // Throw for string
-        il.MarkLabel(stringLabel);
-        il.Emit(OpCodes.Ldstr, "Runtime Error: Invalid value used as weak map key. WeakMap keys must be objects, not 'string'.");
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
-        il.Emit(OpCodes.Throw);
-
-        // Throw for number
-        il.MarkLabel(numberLabel);
-        il.Emit(OpCodes.Ldstr, "Runtime Error: Invalid value used as weak map key. WeakMap keys must be objects, not 'number'.");
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
-        il.Emit(OpCodes.Throw);
-
-        // Throw for boolean
-        il.MarkLabel(booleanLabel);
-        il.Emit(OpCodes.Ldstr, "Runtime Error: Invalid value used as weak map key. WeakMap keys must be objects, not 'boolean'.");
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
-        il.Emit(OpCodes.Throw);
-
-        // Valid - just return
-        il.MarkLabel(validLabel);
-        il.Emit(OpCodes.Ret);
     }
 
     private void EmitCreateWeakMap(TypeBuilder typeBuilder, EmittedRuntime runtime)

--- a/Compilation/RuntimeEmitter.WeakRefs.cs
+++ b/Compilation/RuntimeEmitter.WeakRefs.cs
@@ -7,90 +7,12 @@ public partial class RuntimeEmitter
 {
     private void EmitWeakRefMethods(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        EmitValidateWeakRefTarget(typeBuilder, runtime);
+        // Shared primitive probe: RuntimeEmitter.WeakValidation.cs
+        runtime.ValidateWeakRefTarget = EmitWeakTargetValidator(typeBuilder, "ValidateWeakRefTarget",
+            "Runtime Error: Invalid value used as weak reference target. WeakRef target must be an object");
+
         EmitCreateWeakRef(typeBuilder, runtime);
         EmitWeakRefDeref(typeBuilder, runtime);
-    }
-
-    /// <summary>
-    /// Emits the ValidateWeakRefTarget helper that throws if target is a primitive type.
-    /// </summary>
-    private void EmitValidateWeakRefTarget(TypeBuilder typeBuilder, EmittedRuntime runtime)
-    {
-        var method = typeBuilder.DefineMethod(
-            "ValidateWeakRefTarget",
-            MethodAttributes.Private | MethodAttributes.Static,
-            _types.Void,
-            [_types.Object]
-        );
-        runtime.ValidateWeakRefTarget = method;
-
-        var il = method.GetILGenerator();
-
-        var stringLabel = il.DefineLabel();
-        var numberLabel = il.DefineLabel();
-        var booleanLabel = il.DefineLabel();
-        var validLabel = il.DefineLabel();
-
-        // Check string
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.String);
-        il.Emit(OpCodes.Brtrue, stringLabel);
-
-        // Check double (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Double);
-        il.Emit(OpCodes.Brtrue, numberLabel);
-
-        // Check int (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Int32);
-        il.Emit(OpCodes.Brtrue, numberLabel);
-
-        // Check long (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Int64);
-        il.Emit(OpCodes.Brtrue, numberLabel);
-
-        // Check float (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Single);
-        il.Emit(OpCodes.Brtrue, numberLabel);
-
-        // Check decimal (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Decimal);
-        il.Emit(OpCodes.Brtrue, numberLabel);
-
-        // Check bool (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Boolean);
-        il.Emit(OpCodes.Brtrue, booleanLabel);
-
-        // Value is valid (not a primitive)
-        il.Emit(OpCodes.Br, validLabel);
-
-        // Throw for string
-        il.MarkLabel(stringLabel);
-        il.Emit(OpCodes.Ldstr, "Runtime Error: Invalid value used as weak reference target. WeakRef target must be an object, not 'string'.");
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
-        il.Emit(OpCodes.Throw);
-
-        // Throw for number
-        il.MarkLabel(numberLabel);
-        il.Emit(OpCodes.Ldstr, "Runtime Error: Invalid value used as weak reference target. WeakRef target must be an object, not 'number'.");
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
-        il.Emit(OpCodes.Throw);
-
-        // Throw for boolean
-        il.MarkLabel(booleanLabel);
-        il.Emit(OpCodes.Ldstr, "Runtime Error: Invalid value used as weak reference target. WeakRef target must be an object, not 'boolean'.");
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
-        il.Emit(OpCodes.Throw);
-
-        // Valid - just return
-        il.MarkLabel(validLabel);
-        il.Emit(OpCodes.Ret);
     }
 
     /// <summary>

--- a/Compilation/RuntimeEmitter.WeakSets.cs
+++ b/Compilation/RuntimeEmitter.WeakSets.cs
@@ -8,94 +8,14 @@ public partial class RuntimeEmitter
 {
     private void EmitWeakSetMethods(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        // Emit validation helper first
-        EmitValidateWeakSetValue(typeBuilder, runtime);
+        // Emit validation helper first (shared primitive probe: RuntimeEmitter.WeakValidation.cs)
+        runtime.ValidateWeakSetValue = EmitWeakTargetValidator(typeBuilder, "ValidateWeakSetValue",
+            "Runtime Error: Invalid value used in weak set. WeakSet values must be objects");
 
         EmitCreateWeakSet(typeBuilder, runtime);
         EmitWeakSetAdd(typeBuilder, runtime);
         EmitWeakSetHas(typeBuilder, runtime);
         EmitWeakSetDelete(typeBuilder, runtime);
-    }
-
-    /// <summary>
-    /// Emits the ValidateWeakSetValue helper that throws if value is a primitive type.
-    /// </summary>
-    private void EmitValidateWeakSetValue(TypeBuilder typeBuilder, EmittedRuntime runtime)
-    {
-        var method = typeBuilder.DefineMethod(
-            "ValidateWeakSetValue",
-            MethodAttributes.Private | MethodAttributes.Static,
-            _types.Void,
-            [_types.Object]
-        );
-        runtime.ValidateWeakSetValue = method;
-
-        var il = method.GetILGenerator();
-
-        var stringLabel = il.DefineLabel();
-        var numberLabel = il.DefineLabel();
-        var booleanLabel = il.DefineLabel();
-        var validLabel = il.DefineLabel();
-
-        // Check string
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.String);
-        il.Emit(OpCodes.Brtrue, stringLabel);
-
-        // Check double (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Double);
-        il.Emit(OpCodes.Brtrue, numberLabel);
-
-        // Check int (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Int32);
-        il.Emit(OpCodes.Brtrue, numberLabel);
-
-        // Check long (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Int64);
-        il.Emit(OpCodes.Brtrue, numberLabel);
-
-        // Check float (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Single);
-        il.Emit(OpCodes.Brtrue, numberLabel);
-
-        // Check decimal (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Decimal);
-        il.Emit(OpCodes.Brtrue, numberLabel);
-
-        // Check bool (boxed)
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, _types.Boolean);
-        il.Emit(OpCodes.Brtrue, booleanLabel);
-
-        // Value is valid (not a primitive)
-        il.Emit(OpCodes.Br, validLabel);
-
-        // Throw for string
-        il.MarkLabel(stringLabel);
-        il.Emit(OpCodes.Ldstr, "Runtime Error: Invalid value used in weak set. WeakSet values must be objects, not 'string'.");
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
-        il.Emit(OpCodes.Throw);
-
-        // Throw for number
-        il.MarkLabel(numberLabel);
-        il.Emit(OpCodes.Ldstr, "Runtime Error: Invalid value used in weak set. WeakSet values must be objects, not 'number'.");
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
-        il.Emit(OpCodes.Throw);
-
-        // Throw for boolean
-        il.MarkLabel(booleanLabel);
-        il.Emit(OpCodes.Ldstr, "Runtime Error: Invalid value used in weak set. WeakSet values must be objects, not 'boolean'.");
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
-        il.Emit(OpCodes.Throw);
-
-        // Valid - just return
-        il.MarkLabel(validLabel);
-        il.Emit(OpCodes.Ret);
     }
 
     private void EmitCreateWeakSet(TypeBuilder typeBuilder, EmittedRuntime runtime)

--- a/Compilation/RuntimeEmitter.WeakValidation.cs
+++ b/Compilation/RuntimeEmitter.WeakValidation.cs
@@ -1,0 +1,76 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    /// <summary>
+    /// Emits a weak-target validation helper — <c>void methodName(object value)</c> — that throws
+    /// when the value is a JS primitive: string, number (boxed double/int/long/float/decimal), or
+    /// boolean. WeakMap keys, WeakSet values, and WeakRef targets share this single primitive-probe
+    /// sequence so future Symbol/BigInt/null conformance fixes cannot drift between the three weak
+    /// constructs; only the method name and the construct-specific error wording differ.
+    /// </summary>
+    /// <param name="errorPrefix">
+    /// Construct-specific message up to (but not including) the <c>, not 'type'.</c> suffix, e.g.
+    /// "Runtime Error: Invalid value used as weak map key. WeakMap keys must be objects".
+    /// </param>
+    private MethodBuilder EmitWeakTargetValidator(TypeBuilder typeBuilder, string methodName, string errorPrefix)
+    {
+        var method = typeBuilder.DefineMethod(
+            methodName,
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.Void,
+            [_types.Object]
+        );
+
+        var il = method.GetILGenerator();
+
+        var stringLabel = il.DefineLabel();
+        var numberLabel = il.DefineLabel();
+        var booleanLabel = il.DefineLabel();
+        var validLabel = il.DefineLabel();
+
+        // Check string
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Brtrue, stringLabel);
+
+        // Check the boxed numeric primitives
+        foreach (var numericType in new[] { _types.Double, _types.Int32, _types.Int64, _types.Single, _types.Decimal })
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, numericType);
+            il.Emit(OpCodes.Brtrue, numberLabel);
+        }
+
+        // Check bool (boxed)
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.Boolean);
+        il.Emit(OpCodes.Brtrue, booleanLabel);
+
+        // Value is valid (not a primitive)
+        il.Emit(OpCodes.Br, validLabel);
+
+        il.MarkLabel(stringLabel);
+        EmitThrow("string");
+        il.MarkLabel(numberLabel);
+        EmitThrow("number");
+        il.MarkLabel(booleanLabel);
+        EmitThrow("boolean");
+
+        // Valid - just return
+        il.MarkLabel(validLabel);
+        il.Emit(OpCodes.Ret);
+
+        return method;
+
+        void EmitThrow(string typeofName)
+        {
+            il.Emit(OpCodes.Ldstr, $"{errorPrefix}, not '{typeofName}'.");
+            il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
+            il.Emit(OpCodes.Throw);
+        }
+    }
+}

--- a/Configuration/FileDiscovery.cs
+++ b/Configuration/FileDiscovery.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+
+namespace SharpTS.Configuration;
+
+/// <summary>
+/// Shared upward config/manifest-file discovery used by <see cref="TsConfigLoader"/>,
+/// <see cref="Packaging.PackageJsonLoader"/>, and <see cref="References.SharpTsManifestLoader"/>,
+/// so all three loaders apply one walk policy.
+/// </summary>
+internal static class FileDiscovery
+{
+    /// <summary>
+    /// The lenient parse options every config/manifest loader uses: case-insensitive keys,
+    /// comments, and trailing commas allowed. Shared read-only instance — never mutate.
+    /// </summary>
+    internal static readonly JsonSerializerOptions LenientJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true
+    };
+
+    /// <summary>
+    /// Returns the full path of the nearest <paramref name="fileName"/> in
+    /// <paramref name="startDirectory"/> or its parents, or null.
+    /// </summary>
+    /// <remarks>
+    /// The upward walk stops (exclusive) at the system temp root and the user profile root — a
+    /// config file sitting there is ambient noise from unrelated tooling, not part of the project
+    /// being run. Each ceiling is still searched when it IS the start directory; the walk only
+    /// stops when it ASCENDS into a ceiling. An explicit <paramref name="stopDirectory"/> is
+    /// always exclusive: neither it nor its parents are searched, even as the start directory.
+    /// Path comparison is case-insensitive (ceilings are OS well-known directories).
+    /// </remarks>
+    internal static string? FindNearestFile(string startDirectory, string fileName, string? stopDirectory = null)
+    {
+        var dir = new DirectoryInfo(startDirectory);
+        var stopDirFullName = stopDirectory != null
+            ? NormalizeDir(new DirectoryInfo(stopDirectory).FullName)
+            : null;
+
+        var ceilings = new[]
+            {
+                Path.GetTempPath(),
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+            }
+            .Where(p => !string.IsNullOrEmpty(p))
+            .Select(p => NormalizeDir(Path.GetFullPath(p)))
+            .ToArray();
+
+        bool isStartDirectory = true;
+        while (dir != null)
+        {
+            var currentPath = NormalizeDir(dir.FullName);
+
+            if (stopDirFullName != null &&
+                string.Equals(currentPath, stopDirFullName, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            if (!isStartDirectory &&
+                ceilings.Any(c => string.Equals(currentPath, c, StringComparison.OrdinalIgnoreCase)))
+            {
+                return null;
+            }
+
+            var candidate = Path.Combine(dir.FullName, fileName);
+            if (File.Exists(candidate))
+                return Path.GetFullPath(candidate);
+
+            isStartDirectory = false;
+            dir = dir.Parent;
+        }
+
+        return null;
+    }
+
+    private static string NormalizeDir(string path) =>
+        path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+}

--- a/Configuration/TsConfigLoader.cs
+++ b/Configuration/TsConfigLoader.cs
@@ -18,12 +18,7 @@ public static class TsConfigLoader
 {
     public const string FileName = "tsconfig.json";
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        ReadCommentHandling = JsonCommentHandling.Skip,
-        AllowTrailingCommas = true
-    };
+    private static JsonSerializerOptions JsonOptions => FileDiscovery.LenientJsonOptions;
 
     /// <summary>
     /// Finds the nearest tsconfig.json in <paramref name="startDirectory"/> or its parents and
@@ -42,40 +37,8 @@ public static class TsConfigLoader
     }
 
     /// <summary>Returns the path of the nearest tsconfig.json, or null.</summary>
-    public static string? Discover(string startDirectory)
-    {
-        var dir = new DirectoryInfo(startDirectory);
-
-        var ceilings = new[]
-            {
-                Path.GetTempPath(),
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
-            }
-            .Where(p => !string.IsNullOrEmpty(p))
-            .Select(p => Path.GetFullPath(p).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
-            .ToArray();
-
-        bool isStartDirectory = true;
-        while (dir != null)
-        {
-            var currentPath = dir.FullName.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-            if (!isStartDirectory &&
-                ceilings.Any(c => string.Equals(currentPath, c, StringComparison.OrdinalIgnoreCase)))
-            {
-                return null;
-            }
-
-            var candidate = Path.Combine(dir.FullName, FileName);
-            if (File.Exists(candidate))
-                return Path.GetFullPath(candidate);
-
-            isStartDirectory = false;
-            dir = dir.Parent;
-        }
-
-        return null;
-    }
+    public static string? Discover(string startDirectory) =>
+        FileDiscovery.FindNearestFile(startDirectory, FileName);
 
     /// <summary>
     /// Resolves a <c>-p</c>/<c>--project</c> argument, which tsc accepts as either a config file

--- a/Execution/Interpreter.Statements.cs
+++ b/Execution/Interpreter.Statements.cs
@@ -145,72 +145,13 @@ public partial class Interpreter
     }
 
     /// <summary>
-    /// Evaluates a constant expression for const enum members.
+    /// Evaluates a constant expression for const enum members via the shared
+    /// <see cref="ConstEnumExpressionEvaluator"/>, surfacing failures as InterpreterExceptions.
     /// </summary>
-    private object EvaluateConstEnumExpression(Expr expr, Dictionary<string, object> resolvedMembers, string enumName)
+    private static object EvaluateConstEnumExpression(Expr expr, Dictionary<string, object> resolvedMembers, string enumName)
     {
-        return expr switch
-        {
-            Expr.Literal lit => lit.Value ?? throw new InterpreterException($"Const enum expression cannot be null."),
-
-            Expr.Get g when g.Object is Expr.Variable v && v.Name.Lexeme == enumName =>
-                resolvedMembers.TryGetValue(g.Name.Lexeme, out var val)
-                    ? val
-                    : throw new InterpreterException($"Const enum member '{g.Name.Lexeme}' referenced before definition."),
-
-            Expr.Grouping gr => EvaluateConstEnumExpression(gr.Expression, resolvedMembers, enumName),
-
-            Expr.Unary u => EvaluateConstEnumUnary(u, resolvedMembers, enumName),
-
-            Expr.Binary b => EvaluateConstEnumBinary(b, resolvedMembers, enumName),
-
-            _ => throw new InterpreterException($"Expression type '{expr.GetType().Name}' is not allowed in const enum initializer.")
-        };
-    }
-
-    private object EvaluateConstEnumUnary(Expr.Unary unary, Dictionary<string, object> resolvedMembers, string enumName)
-    {
-        var operand = EvaluateConstEnumExpression(unary.Right, resolvedMembers, enumName);
-
-        return unary.Operator.Type switch
-        {
-            TokenType.MINUS when operand is double d => -d,
-            TokenType.PLUS when operand is double d => d,
-            TokenType.TILDE when operand is double d => (double)(~(int)d),
-            _ => throw new InterpreterException($"Operator '{unary.Operator.Lexeme}' is not allowed in const enum expressions.")
-        };
-    }
-
-    private object EvaluateConstEnumBinary(Expr.Binary binary, Dictionary<string, object> resolvedMembers, string enumName)
-    {
-        var left = EvaluateConstEnumExpression(binary.Left, resolvedMembers, enumName);
-        var right = EvaluateConstEnumExpression(binary.Right, resolvedMembers, enumName);
-
-        if (left is double l && right is double r)
-        {
-            return binary.Operator.Type switch
-            {
-                TokenType.PLUS => l + r,
-                TokenType.MINUS => l - r,
-                TokenType.STAR => l * r,
-                TokenType.SLASH => l / r,
-                TokenType.PERCENT => l % r,
-                TokenType.STAR_STAR => Math.Pow(l, r),
-                TokenType.AMPERSAND => (double)((int)l & (int)r),
-                TokenType.PIPE => (double)((int)l | (int)r),
-                TokenType.CARET => (double)((int)l ^ (int)r),
-                TokenType.LESS_LESS => (double)((int)l << (int)r),
-                TokenType.GREATER_GREATER => (double)((int)l >> (int)r),
-                _ => throw new InterpreterException($"Operator '{binary.Operator.Lexeme}' is not allowed in const enum expressions.")
-            };
-        }
-
-        if (left is string ls && right is string rs && binary.Operator.Type == TokenType.PLUS)
-        {
-            return ls + rs;
-        }
-
-        throw new InterpreterException($"Invalid operand types for operator '{binary.Operator.Lexeme}' in const enum expression.");
+        return ConstEnumExpressionEvaluator.Evaluate(expr, resolvedMembers, enumName,
+            static e => new InterpreterException(e.Message));
     }
 
     /// <summary>

--- a/Packaging/PackageJsonLoader.cs
+++ b/Packaging/PackageJsonLoader.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using SharpTS.Configuration;
 
 namespace SharpTS.Packaging;
 
@@ -7,70 +8,20 @@ namespace SharpTS.Packaging;
 /// </summary>
 public static class PackageJsonLoader
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        ReadCommentHandling = JsonCommentHandling.Skip,
-        AllowTrailingCommas = true
-    };
+    private static JsonSerializerOptions JsonOptions => FileDiscovery.LenientJsonOptions;
 
     /// <summary>
     /// Attempts to find and load a package.json file in the specified directory or its parents.
+    /// Walk policy (temp/user-profile ceilings, stop-directory exclusivity) is
+    /// <see cref="FileDiscovery.FindNearestFile"/>.
     /// </summary>
     /// <param name="startDirectory">Directory to start searching from.</param>
     /// <param name="stopDirectory">Optional directory to stop searching at (exclusive). If specified, the search will not look in this directory or its parents.</param>
     /// <returns>Loaded PackageJson or null if not found.</returns>
-    /// <remarks>
-    /// The upward walk also stops (exclusive) at the system temp root and the
-    /// user profile root: a package.json sitting in those directories is ambient
-    /// noise from unrelated tooling, not the manifest of the project being
-    /// packed. Each ceiling is still searched when it IS the start directory.
-    /// </remarks>
     public static PackageJson? FindAndLoad(string startDirectory, string? stopDirectory = null)
     {
-        var dir = new DirectoryInfo(startDirectory);
-        var stopDirFullName = stopDirectory != null
-            ? new DirectoryInfo(stopDirectory).FullName.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-            : null;
-
-        var ceilings = new[]
-            {
-                Path.GetTempPath(),
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
-            }
-            .Where(p => !string.IsNullOrEmpty(p))
-            .Select(p => Path.GetFullPath(p).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
-            .ToArray();
-
-        bool isStartDirectory = true;
-        while (dir != null)
-        {
-            // Stop if we've reached the stop directory
-            var currentPath = dir.FullName.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-            if (stopDirFullName != null &&
-                string.Equals(currentPath, stopDirFullName, StringComparison.OrdinalIgnoreCase))
-            {
-                return null;
-            }
-
-            // Stop when the walk ASCENDS into a ceiling directory; only search
-            // a ceiling when the caller started there.
-            if (!isStartDirectory &&
-                ceilings.Any(c => string.Equals(currentPath, c, StringComparison.OrdinalIgnoreCase)))
-            {
-                return null;
-            }
-
-            var packageJsonPath = Path.Combine(dir.FullName, "package.json");
-            if (File.Exists(packageJsonPath))
-            {
-                return Load(packageJsonPath);
-            }
-            isStartDirectory = false;
-            dir = dir.Parent;
-        }
-
-        return null;
+        var path = FileDiscovery.FindNearestFile(startDirectory, "package.json", stopDirectory);
+        return path is null ? null : Load(path);
     }
 
     /// <summary>

--- a/Parsing/ConstEnumExpressionEvaluator.cs
+++ b/Parsing/ConstEnumExpressionEvaluator.cs
@@ -1,0 +1,127 @@
+namespace SharpTS.Parsing;
+
+/// <summary>
+/// Classifies why a const-enum initializer expression failed to evaluate, so each phase can map
+/// the failure onto its own diagnostic (the type checker picks the TS code from this kind).
+/// </summary>
+internal enum ConstEnumErrorKind
+{
+    /// <summary>A literal with a null value (neither number nor string).</summary>
+    NullLiteral,
+    /// <summary>A reference to an enum member that has not been defined yet.</summary>
+    ForwardReference,
+    /// <summary>An expression form that const enum initializers do not allow.</summary>
+    DisallowedExpression,
+    /// <summary>A unary or binary operator that const enum initializers do not allow.</summary>
+    DisallowedOperator,
+    /// <summary>Operand types the operator cannot combine (e.g. string * string).</summary>
+    InvalidOperandTypes,
+}
+
+/// <summary>A structured const-enum evaluation failure: the kind plus a neutral, formatted message.</summary>
+internal readonly record struct ConstEnumError(ConstEnumErrorKind Kind, string Message);
+
+/// <summary>
+/// Phase-neutral evaluation of const-enum member initializer expressions — literals, references
+/// to previously defined members of the same enum, grouping, unary (+ - ~), binary arithmetic /
+/// bitwise / shift, and string concatenation. The single implementation shared by the type
+/// checker, the interpreter, and the IL compiler, which previously each carried an exact copy.
+/// </summary>
+/// <remarks>
+/// Failures are reported through the <c>error</c> factory so each phase throws its own exception
+/// type (TypeCheckException with a TS code / InterpreterException / CompileException) without
+/// this evaluator knowing about any of them. Numeric semantics are preserved exactly: all
+/// arithmetic is double, bitwise/shift operators cast through int and back to double.
+/// </remarks>
+internal static class ConstEnumExpressionEvaluator
+{
+    public static object Evaluate(
+        Expr expression,
+        IReadOnlyDictionary<string, object> resolvedMembers,
+        string enumName,
+        Func<ConstEnumError, Exception> error)
+    {
+        return expression switch
+        {
+            Expr.Literal lit => lit.Value ?? throw error(new(
+                ConstEnumErrorKind.NullLiteral,
+                "Const enum expression cannot be null.")),
+
+            Expr.Get g when g.Object is Expr.Variable v && v.Name.Lexeme == enumName =>
+                resolvedMembers.TryGetValue(g.Name.Lexeme, out var val)
+                    ? val
+                    : throw error(new(
+                        ConstEnumErrorKind.ForwardReference,
+                        $"Const enum member '{g.Name.Lexeme}' referenced before definition.")),
+
+            Expr.Grouping gr => Evaluate(gr.Expression, resolvedMembers, enumName, error),
+
+            Expr.Unary u => EvaluateUnary(u, resolvedMembers, enumName, error),
+
+            Expr.Binary b => EvaluateBinary(b, resolvedMembers, enumName, error),
+
+            _ => throw error(new(
+                ConstEnumErrorKind.DisallowedExpression,
+                $"Expression type '{expression.GetType().Name}' is not allowed in const enum initializer."))
+        };
+    }
+
+    private static object EvaluateUnary(
+        Expr.Unary unary,
+        IReadOnlyDictionary<string, object> resolvedMembers,
+        string enumName,
+        Func<ConstEnumError, Exception> error)
+    {
+        var operand = Evaluate(unary.Right, resolvedMembers, enumName, error);
+
+        return unary.Operator.Type switch
+        {
+            TokenType.MINUS when operand is double d => -d,
+            TokenType.PLUS when operand is double d => d,
+            TokenType.TILDE when operand is double d => (double)(~(int)d),
+            _ => throw error(new(
+                ConstEnumErrorKind.DisallowedOperator,
+                $"Operator '{unary.Operator.Lexeme}' is not allowed in const enum expressions."))
+        };
+    }
+
+    private static object EvaluateBinary(
+        Expr.Binary binary,
+        IReadOnlyDictionary<string, object> resolvedMembers,
+        string enumName,
+        Func<ConstEnumError, Exception> error)
+    {
+        var left = Evaluate(binary.Left, resolvedMembers, enumName, error);
+        var right = Evaluate(binary.Right, resolvedMembers, enumName, error);
+
+        if (left is double l && right is double r)
+        {
+            return binary.Operator.Type switch
+            {
+                TokenType.PLUS => l + r,
+                TokenType.MINUS => l - r,
+                TokenType.STAR => l * r,
+                TokenType.SLASH => l / r,
+                TokenType.PERCENT => l % r,
+                TokenType.STAR_STAR => Math.Pow(l, r),
+                TokenType.AMPERSAND => (double)((int)l & (int)r),
+                TokenType.PIPE => (double)((int)l | (int)r),
+                TokenType.CARET => (double)((int)l ^ (int)r),
+                TokenType.LESS_LESS => (double)((int)l << (int)r),
+                TokenType.GREATER_GREATER => (double)((int)l >> (int)r),
+                _ => throw error(new(
+                    ConstEnumErrorKind.DisallowedOperator,
+                    $"Operator '{binary.Operator.Lexeme}' is not allowed in const enum expressions."))
+            };
+        }
+
+        if (left is string ls && right is string rs && binary.Operator.Type == TokenType.PLUS)
+        {
+            return ls + rs;
+        }
+
+        throw error(new(
+            ConstEnumErrorKind.InvalidOperandTypes,
+            $"Invalid operand types for operator '{binary.Operator.Lexeme}' in const enum expression."));
+    }
+}

--- a/Parsing/Parser.Declarations.cs
+++ b/Parsing/Parser.Declarations.cs
@@ -507,19 +507,8 @@ public partial class Parser
 
                 Token paramName = ConsumeIdentifierName("Expect parameter name.");
 
-                // Check for optional marker
-                bool isOptional = Match(TokenType.QUESTION);
-
-                // Parse type annotation
-                string? paramType = null;
-                TypeNode? paramTypeNode = null;
-                if (Match(TokenType.COLON))
-                {
-                    paramType = ParseTypeAnnotation();
-                    paramTypeNode = TakeTypeNode();
-                }
-
-                parameters.Add(new Stmt.Parameter(paramName, paramType, null, isRest, IsOptional: isOptional, TypeAnnotationNode: paramTypeNode));
+                // Signatures have no bodies, so defaults are not parsed (`=` stays unconsumed).
+                parameters.Add(ParseNamedRuntimeParameterTail(paramName, isRest, allowDefault: false));
 
             } while (Match(TokenType.COMMA));
         }

--- a/Parsing/Parser.Expressions.cs
+++ b/Parsing/Parser.Expressions.cs
@@ -1121,49 +1121,17 @@ public partial class Parser
             {
                 // Destructuring patterns in method parameters
                 // (e.g. yaml's `stringify({source, value}, ctx) {...}`).
-                if (Check(TokenType.LEFT_BRACKET))
+                if (Check(TokenType.LEFT_BRACKET) || Check(TokenType.LEFT_BRACE))
                 {
-                    int line = Peek().Line;
-                    Consume(TokenType.LEFT_BRACKET, "");
-                    var pattern = ParseArrayPattern();
-                    Token synthName = new Token(TokenType.IDENTIFIER, $"_param{parameters.Count}", null, line);
-                    string? pType = Match(TokenType.COLON) ? ParseTypeAnnotation() : null;
-                    TypeNode? pTypeNode = pType is not null ? TakeTypeNode() : null;
-                    Expr? pDefault = Match(TokenType.EQUAL) ? Expression() : null;
-                    parameters.Add(new Stmt.Parameter(synthName, pType, pDefault, TypeAnnotationNode: pTypeNode));
-                    destructuredParams.Add((synthName, pattern));
-                    continue;
-                }
-                if (Check(TokenType.LEFT_BRACE))
-                {
-                    int line = Peek().Line;
-                    Consume(TokenType.LEFT_BRACE, "");
-                    var pattern = ParseObjectPattern();
-                    Token synthName = new Token(TokenType.IDENTIFIER, $"_param{parameters.Count}", null, line);
-                    string? pType = Match(TokenType.COLON) ? ParseTypeAnnotation() : null;
-                    TypeNode? pTypeNode = pType is not null ? TakeTypeNode() : null;
-                    Expr? pDefault = Match(TokenType.EQUAL) ? Expression() : null;
-                    parameters.Add(new Stmt.Parameter(synthName, pType, pDefault, TypeAnnotationNode: pTypeNode));
-                    destructuredParams.Add((synthName, pattern));
+                    var (parameter, pattern) = ParseDestructuredParameter(parameters.Count);
+                    parameters.Add(parameter);
+                    destructuredParams.Add((parameter.Name, pattern));
                     continue;
                 }
 
                 bool isRest = Match(TokenType.DOT_DOT_DOT);
                 Token paramName = ConsumeIdentifierName("Expect parameter name.");
-                bool isOptional = Match(TokenType.QUESTION);
-                string? paramType = null;
-                TypeNode? paramTypeNode = null;
-                if (Match(TokenType.COLON))
-                {
-                    paramType = ParseTypeAnnotation();
-                    paramTypeNode = TakeTypeNode();
-                }
-                Expr? defaultValue = null;
-                if (Match(TokenType.EQUAL))
-                {
-                    defaultValue = Expression();
-                }
-                parameters.Add(new Stmt.Parameter(paramName, paramType, defaultValue, isRest, IsOptional: isOptional, TypeAnnotationNode: paramTypeNode));
+                parameters.Add(ParseNamedRuntimeParameterTail(paramName, isRest));
 
                 if (isRest && Check(TokenType.COMMA))
                 {
@@ -1184,23 +1152,7 @@ public partial class Parser
         Consume(TokenType.LEFT_BRACE, "Expect '{' before method body.");
         List<Stmt> body = Block();
 
-        if (destructuredParams.Count > 0)
-        {
-            var prologue = new List<Stmt>();
-            foreach (var (synthName, pattern) in destructuredParams)
-            {
-                var paramVar = new Expr.Variable(synthName);
-                Stmt desugar = pattern switch
-                {
-                    ArrayPattern ap => DesugarArrayPattern(ap, paramVar),
-                    ObjectPattern op => DesugarObjectPattern(op, paramVar),
-                    _ => throw new Exception("Unknown pattern type")
-                };
-                prologue.Add(desugar);
-            }
-            body = prologue.Concat(body).ToList();
-        }
-
+        body = PrependDestructuringPrologue(destructuredParams, body);
         body = VarHoister.Hoist(body);
 
         return new Expr.ArrowFunction(
@@ -1318,46 +1270,20 @@ public partial class Parser
 
             do
             {
-                if (Check(TokenType.LEFT_BRACKET))
+                if (Check(TokenType.LEFT_BRACKET) || Check(TokenType.LEFT_BRACE))
                 {
-                    // Array destructure parameter: ([a, b]) => ...
-                    int line = Peek().Line;
-                    Consume(TokenType.LEFT_BRACKET, "");
+                    // Destructure parameter: ([a, b]) => ... / ({ x, y }) => ...
+                    // Speculative: an invalid pattern (e.g. it's really an array/object literal
+                    // in a grouping) must BACKTRACK, not throw — the shared component parses,
+                    // this candidate parse owns the failure policy.
                     try
                     {
-                        var pattern = ParseArrayPattern();
-                        Token synthName = new Token(TokenType.IDENTIFIER, $"_param{parameters.Count}", null, line);
-                        string? paramType = Match(TokenType.COLON) ? ParseTypeAnnotation() : null;
-                        TypeNode? paramTypeNode = paramType is not null ? TakeTypeNode() : null;
-                        Expr? defaultValue = Match(TokenType.EQUAL) ? Expression() : null;
-                        parameters.Add(new Stmt.Parameter(synthName, paramType, defaultValue, TypeAnnotationNode: paramTypeNode));
-                        destructuredParams.Add((synthName, pattern));
+                        var (parameter, pattern) = ParseDestructuredParameter(parameters.Count);
+                        parameters.Add(parameter);
+                        destructuredParams.Add((parameter.Name, pattern));
                     }
                     catch
                     {
-                        // Not a valid destructuring pattern, backtrack
-                        _current = savedPosition;
-                        return null;
-                    }
-                }
-                else if (Check(TokenType.LEFT_BRACE))
-                {
-                    // Object destructure parameter: ({ x, y }) => ...
-                    int line = Peek().Line;
-                    Consume(TokenType.LEFT_BRACE, "");
-                    try
-                    {
-                        var pattern = ParseObjectPattern();
-                        Token synthName = new Token(TokenType.IDENTIFIER, $"_param{parameters.Count}", null, line);
-                        string? paramType = Match(TokenType.COLON) ? ParseTypeAnnotation() : null;
-                        TypeNode? paramTypeNode = paramType is not null ? TakeTypeNode() : null;
-                        Expr? defaultValue = Match(TokenType.EQUAL) ? Expression() : null;
-                        parameters.Add(new Stmt.Parameter(synthName, paramType, defaultValue, TypeAnnotationNode: paramTypeNode));
-                        destructuredParams.Add((synthName, pattern));
-                    }
-                    catch
-                    {
-                        // Not a valid destructuring pattern (e.g., it's an object literal), backtrack
                         _current = savedPosition;
                         return null;
                     }
@@ -1377,22 +1303,10 @@ public partial class Parser
                     Token paramName = paramTok.Type == TokenType.IDENTIFIER
                         ? paramTok
                         : new Token(TokenType.IDENTIFIER, paramTok.Lexeme, null, paramTok.Line);
-                    // Optional parameter marker: (x?: T) => ...  (if this isn't an arrow, the
-                    // outer speculative parse backtracks, so consuming '?' here is safe).
-                    bool isOptional = Match(TokenType.QUESTION);
-                    string? paramType = null;
-                    TypeNode? paramTypeNode = null;
-                    if (Match(TokenType.COLON))
-                    {
-                        paramType = ParseTypeAnnotation();
-                        paramTypeNode = TakeTypeNode();
-                    }
-                    Expr? defaultValue = null;
-                    if (Match(TokenType.EQUAL))
-                    {
-                        defaultValue = Expression();
-                    }
-                    parameters.Add(new Stmt.Parameter(paramName, paramType, defaultValue, isRest, IsOptional: isOptional, TypeAnnotationNode: paramTypeNode));
+                    // The shared tail consumes '?'/type/default: (x?: T = v) => ...  (if this
+                    // isn't an arrow, the outer speculative parse backtracks, so consuming here
+                    // is safe).
+                    parameters.Add(ParseNamedRuntimeParameterTail(paramName, isRest));
 
                     // Rest parameter must be last
                     if (isRest && Check(TokenType.COMMA))
@@ -1452,27 +1366,15 @@ public partial class Parser
         // If we have destructured parameters, prepend desugaring to body
         if (destructuredParams.Count > 0)
         {
-            List<Stmt> prologue = [];
-            foreach (var (synthName, pattern) in destructuredParams)
-            {
-                var paramVar = new Expr.Variable(synthName);
-                Stmt desugar = pattern switch
-                {
-                    ArrayPattern ap => DesugarArrayPattern(ap, paramVar),
-                    ObjectPattern op => DesugarObjectPattern(op, paramVar),
-                    _ => throw new Exception("Unknown pattern type")
-                };
-                prologue.Add(desugar);
-            }
-
             if (body != null)
             {
-                body = prologue.Concat(body).ToList();
+                body = PrependDestructuringPrologue(destructuredParams, body);
             }
             else if (exprBody != null)
             {
                 // For expression body, wrap in a block with prologue + return
-                body = prologue.Concat([new Stmt.Return(new Token(TokenType.RETURN, "return", null, 0), exprBody)]).ToList();
+                body = PrependDestructuringPrologue(destructuredParams,
+                    [new Stmt.Return(new Token(TokenType.RETURN, "return", null, 0), exprBody)]);
                 exprBody = null;
             }
         }
@@ -1576,31 +1478,12 @@ public partial class Parser
                 if (Check(TokenType.RIGHT_PAREN)) break;
 
                 // Check for destructuring pattern parameter
-                if (Check(TokenType.LEFT_BRACKET))
+                if (Check(TokenType.LEFT_BRACKET) || Check(TokenType.LEFT_BRACE))
                 {
-                    // Array destructure: function([a, b]) {}
-                    int line = Peek().Line;
-                    Consume(TokenType.LEFT_BRACKET, "");
-                    var pattern = ParseArrayPattern();
-                    Token synthName = new Token(TokenType.IDENTIFIER, $"_param{parameters.Count}", null, line);
-                    string? paramType = Match(TokenType.COLON) ? ParseTypeAnnotation() : null;
-                    TypeNode? paramTypeNode = paramType is not null ? TakeTypeNode() : null;
-                    Expr? defaultValue = Match(TokenType.EQUAL) ? Expression() : null;
-                    parameters.Add(new Stmt.Parameter(synthName, paramType, defaultValue, TypeAnnotationNode: paramTypeNode));
-                    destructuredParams.Add((synthName, pattern));
-                }
-                else if (Check(TokenType.LEFT_BRACE))
-                {
-                    // Object destructure: function({ x, y }) {}
-                    int line = Peek().Line;
-                    Consume(TokenType.LEFT_BRACE, "");
-                    var pattern = ParseObjectPattern();
-                    Token synthName = new Token(TokenType.IDENTIFIER, $"_param{parameters.Count}", null, line);
-                    string? paramType = Match(TokenType.COLON) ? ParseTypeAnnotation() : null;
-                    TypeNode? paramTypeNode = paramType is not null ? TakeTypeNode() : null;
-                    Expr? defaultValue = Match(TokenType.EQUAL) ? Expression() : null;
-                    parameters.Add(new Stmt.Parameter(synthName, paramType, defaultValue, TypeAnnotationNode: paramTypeNode));
-                    destructuredParams.Add((synthName, pattern));
+                    // function([a, b]) {} / function({ x, y }) {}
+                    var (parameter, pattern) = ParseDestructuredParameter(parameters.Count);
+                    parameters.Add(parameter);
+                    destructuredParams.Add((parameter.Name, pattern));
                 }
                 else
                 {
@@ -1608,23 +1491,7 @@ public partial class Parser
                     bool isRest = Match(TokenType.DOT_DOT_DOT);
 
                     Token paramName = ConsumeIdentifierName("Expect parameter name.");
-
-                    // Check for optional parameter marker (?)
-                    bool isOptional = Match(TokenType.QUESTION);
-
-                    string? paramType = null;
-                    TypeNode? paramTypeNode = null;
-                    if (Match(TokenType.COLON))
-                    {
-                        paramType = ParseTypeAnnotation();
-                        paramTypeNode = TakeTypeNode();
-                    }
-                    Expr? defaultValue = null;
-                    if (Match(TokenType.EQUAL))
-                    {
-                        defaultValue = Expression();
-                    }
-                    parameters.Add(new Stmt.Parameter(paramName, paramType, defaultValue, isRest, IsOptional: isOptional, TypeAnnotationNode: paramTypeNode));
+                    parameters.Add(ParseNamedRuntimeParameterTail(paramName, isRest));
 
                     // Rest parameter must be last
                     if (isRest && Check(TokenType.COMMA))
@@ -1648,22 +1515,7 @@ public partial class Parser
         List<Stmt> body = Block();
 
         // Prepend destructuring statements for patterned parameters
-        if (destructuredParams.Count > 0)
-        {
-            List<Stmt> prologue = [];
-            foreach (var (synthName, pattern) in destructuredParams)
-            {
-                var paramVar = new Expr.Variable(synthName);
-                Stmt desugar = pattern switch
-                {
-                    ArrayPattern ap => DesugarArrayPattern(ap, paramVar),
-                    ObjectPattern op => DesugarObjectPattern(op, paramVar),
-                    _ => throw new Exception("Unknown pattern type")
-                };
-                prologue.Add(desugar);
-            }
-            body = prologue.Concat(body).ToList();
-        }
+        body = PrependDestructuringPrologue(destructuredParams, body);
 
         body = VarHoister.Hoist(body);
 

--- a/Parsing/Parser.Functions.cs
+++ b/Parsing/Parser.Functions.cs
@@ -65,31 +65,12 @@ public partial class Parser
                 List<Decorator>? paramDecorators = ParseDecorators();
 
                 // Check for destructuring pattern parameter
-                if (Check(TokenType.LEFT_BRACKET))
+                if (Check(TokenType.LEFT_BRACKET) || Check(TokenType.LEFT_BRACE))
                 {
-                    // Array destructure: function f([a, b]) {}
-                    int line = Peek().Line;
-                    Consume(TokenType.LEFT_BRACKET, "");
-                    var pattern = ParseArrayPattern();
-                    Token synthName = new Token(TokenType.IDENTIFIER, $"_param{parameters.Count}", null, line);
-                    string? paramType = Match(TokenType.COLON) ? ParseTypeAnnotation() : null;
-                    TypeNode? paramTypeNode = paramType is not null ? TakeTypeNode() : null;
-                    Expr? defaultValue = Match(TokenType.EQUAL) ? Expression() : null;
-                    parameters.Add(new Stmt.Parameter(synthName, paramType, defaultValue, Decorators: paramDecorators, TypeAnnotationNode: paramTypeNode));
-                    destructuredParams.Add((synthName, pattern));
-                }
-                else if (Check(TokenType.LEFT_BRACE))
-                {
-                    // Object destructure: function f({ x, y }) {}
-                    int line = Peek().Line;
-                    Consume(TokenType.LEFT_BRACE, "");
-                    var pattern = ParseObjectPattern();
-                    Token synthName = new Token(TokenType.IDENTIFIER, $"_param{parameters.Count}", null, line);
-                    string? paramType = Match(TokenType.COLON) ? ParseTypeAnnotation() : null;
-                    TypeNode? paramTypeNode = paramType is not null ? TakeTypeNode() : null;
-                    Expr? defaultValue = Match(TokenType.EQUAL) ? Expression() : null;
-                    parameters.Add(new Stmt.Parameter(synthName, paramType, defaultValue, Decorators: paramDecorators, TypeAnnotationNode: paramTypeNode));
-                    destructuredParams.Add((synthName, pattern));
+                    // function f([a, b]) {} / function f({ x, y }) {}
+                    var (parameter, pattern) = ParseDestructuredParameter(parameters.Count, paramDecorators);
+                    parameters.Add(parameter);
+                    destructuredParams.Add((parameter.Name, pattern));
                 }
                 else
                 {
@@ -134,23 +115,9 @@ public partial class Parser
                     }
 
                     Token paramName = ConsumeIdentifierName("Expect parameter name.");
-
-                    // Check for optional parameter marker (?)
-                    bool isOptional = Match(TokenType.QUESTION);
-
-                    string? paramType = null;
-                    TypeNode? paramTypeNode = null;
-                    if (Match(TokenType.COLON))
-                    {
-                        paramType = ParseTypeAnnotation();
-                        paramTypeNode = TakeTypeNode();
-                    }
-                    Expr? defaultValue = null;
-                    if (Match(TokenType.EQUAL))
-                    {
-                        defaultValue = Expression();
-                    }
-                    parameters.Add(new Stmt.Parameter(paramName, paramType, defaultValue, isRest, isParameterProperty, access, isReadonly, isOptional, paramDecorators, paramTypeNode));
+                    parameters.Add(ParseNamedRuntimeParameterTail(paramName, isRest,
+                        isParameterProperty: isParameterProperty, access: access,
+                        isReadonly: isReadonly, decorators: paramDecorators));
 
                     // Rest parameter must be last
                     if (isRest && Check(TokenType.COMMA))
@@ -195,22 +162,7 @@ public partial class Parser
         _isStrictMode = previousStrictMode;
 
         // Prepend destructuring statements for patterned parameters
-        if (destructuredParams.Count > 0)
-        {
-            List<Stmt> prologue = [];
-            foreach (var (synthName, pattern) in destructuredParams)
-            {
-                var paramVar = new Expr.Variable(synthName);
-                Stmt desugar = pattern switch
-                {
-                    ArrayPattern ap => DesugarArrayPattern(ap, paramVar),
-                    ObjectPattern op => DesugarObjectPattern(op, paramVar),
-                    _ => throw new Exception("Unknown pattern type")
-                };
-                prologue.Add(desugar);
-            }
-            body = prologue.Concat(body).ToList();
-        }
+        body = PrependDestructuringPrologue(destructuredParams, body);
 
         // Prepend parameter property assignments for constructor: this.x = x
         if (kind == "constructor")
@@ -285,25 +237,9 @@ public partial class Parser
 
                 Token paramName = ConsumeIdentifierName("Expect parameter name.");
 
-                // Check for optional parameter marker (?) — mirrors the main
-                // function-parameter parser so private/abstract methods accept `x?: T`.
-                bool isOptional = Match(TokenType.QUESTION);
-
-                string? paramType = null;
-                TypeNode? paramTypeNode = null;
-                if (Match(TokenType.COLON))
-                {
-                    paramType = ParseTypeAnnotation();
-                    paramTypeNode = TakeTypeNode();
-                }
-                // Abstract methods don't have a body, so no default values make sense
-                // But TypeScript does allow them in the signature, so let's parse them
-                Expr? defaultValue = null;
-                if (Match(TokenType.EQUAL))
-                {
-                    defaultValue = Expression();
-                }
-                parameters.Add(new Stmt.Parameter(paramName, paramType, defaultValue, isRest, IsOptional: isOptional, TypeAnnotationNode: paramTypeNode));
+                // Abstract methods don't have a body, so no default values make sense,
+                // but TypeScript does allow them in the signature — the shared tail parses them.
+                parameters.Add(ParseNamedRuntimeParameterTail(paramName, isRest));
 
                 // Rest parameter must be last
                 if (isRest && Check(TokenType.COMMA))

--- a/Parsing/Parser.Parameters.cs
+++ b/Parsing/Parser.Parameters.cs
@@ -1,0 +1,106 @@
+namespace SharpTS.Parsing;
+
+/// <summary>
+/// Shared runtime-parameter parsing components. The repeated per-parameter units (named-parameter
+/// tail, destructured parameter, destructuring prologue lowering) have one implementation here;
+/// list-loop ownership, trailing-comma handling, rest-last policy, and speculative-arrow
+/// backtracking stay with each caller. Function-TYPE parameter parsing (ParameterTypeNode) is
+/// intentionally not routed through these — its AST output is genuinely different.
+/// </summary>
+public partial class Parser
+{
+    /// <summary>
+    /// Parses the deterministic tail of a named runtime parameter and constructs it. The caller
+    /// has already consumed any leading <c>...</c>, parameter-property modifiers, decorators, and
+    /// the name token itself (so speculative callers control error vs. backtrack on the name).
+    /// Tail: optional <c>?</c>, optional <c>: type</c>, optional <c>= default</c> (only when
+    /// <paramref name="allowDefault"/> — call/constructor signatures leave <c>=</c> unconsumed).
+    /// </summary>
+    private Stmt.Parameter ParseNamedRuntimeParameterTail(
+        Token paramName,
+        bool isRest,
+        bool allowDefault = true,
+        bool isParameterProperty = false,
+        AccessModifier? access = null,
+        bool isReadonly = false,
+        List<Decorator>? decorators = null)
+    {
+        // Check for optional parameter marker (?)
+        bool isOptional = Match(TokenType.QUESTION);
+
+        string? paramType = null;
+        TypeNode? paramTypeNode = null;
+        if (Match(TokenType.COLON))
+        {
+            paramType = ParseTypeAnnotation();
+            paramTypeNode = TakeTypeNode();
+        }
+
+        Expr? defaultValue = null;
+        if (allowDefault && Match(TokenType.EQUAL))
+        {
+            defaultValue = Expression();
+        }
+
+        return new Stmt.Parameter(paramName, paramType, defaultValue, isRest,
+            isParameterProperty, access, isReadonly, isOptional, decorators, paramTypeNode);
+    }
+
+    /// <summary>
+    /// Parses one destructured runtime parameter starting at <c>[</c> or <c>{</c>: the pattern,
+    /// a synthetic <c>_paramN</c> name, an optional type annotation, and an optional default.
+    /// The caller lowers the returned pattern into a body prologue via
+    /// <see cref="PrependDestructuringPrologue"/>; speculative callers wrap this in their own
+    /// try/backtrack.
+    /// </summary>
+    private (Stmt.Parameter Parameter, DestructurePattern Pattern) ParseDestructuredParameter(
+        int parameterIndex, List<Decorator>? decorators = null)
+    {
+        int line = Peek().Line;
+        DestructurePattern pattern;
+        if (Match(TokenType.LEFT_BRACKET))
+        {
+            pattern = ParseArrayPattern();
+        }
+        else
+        {
+            Consume(TokenType.LEFT_BRACE, "Expect '[' or '{' to start destructured parameter.");
+            pattern = ParseObjectPattern();
+        }
+
+        Token synthName = new Token(TokenType.IDENTIFIER, $"_param{parameterIndex}", null, line);
+        string? paramType = Match(TokenType.COLON) ? ParseTypeAnnotation() : null;
+        TypeNode? paramTypeNode = paramType is not null ? TakeTypeNode() : null;
+        Expr? defaultValue = Match(TokenType.EQUAL) ? Expression() : null;
+
+        var parameter = new Stmt.Parameter(synthName, paramType, defaultValue,
+            Decorators: decorators, TypeAnnotationNode: paramTypeNode);
+        return (parameter, pattern);
+    }
+
+    /// <summary>
+    /// Lowers destructured parameters into a body prologue: each synthetic <c>_paramN</c> is
+    /// desugared through its pattern ahead of the original body statements.
+    /// </summary>
+    private List<Stmt> PrependDestructuringPrologue(
+        List<(Token SynthName, DestructurePattern Pattern)> destructuredParams,
+        List<Stmt> body)
+    {
+        if (destructuredParams.Count == 0)
+            return body;
+
+        List<Stmt> prologue = [];
+        foreach (var (synthName, pattern) in destructuredParams)
+        {
+            var paramVar = new Expr.Variable(synthName);
+            Stmt desugar = pattern switch
+            {
+                ArrayPattern ap => DesugarArrayPattern(ap, paramVar),
+                ObjectPattern op => DesugarObjectPattern(op, paramVar),
+                _ => throw new Exception("Unknown pattern type")
+            };
+            prologue.Add(desugar);
+        }
+        return prologue.Concat(body).ToList();
+    }
+}

--- a/References/SharpTsManifestLoader.cs
+++ b/References/SharpTsManifestLoader.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using SharpTS.Configuration;
 
 namespace SharpTS.References;
 
@@ -9,63 +10,20 @@ public static class SharpTsManifestLoader
 {
     public const string FileName = "sharpts.json";
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true,
-        ReadCommentHandling = JsonCommentHandling.Skip,
-        AllowTrailingCommas = true
-    };
+    private static JsonSerializerOptions JsonOptions => FileDiscovery.LenientJsonOptions;
 
     /// <summary>
     /// Finds and loads the nearest sharpts.json in <paramref name="startDirectory"/>
-    /// or its parents.
+    /// or its parents. Walk policy (temp/user-profile ceilings) is
+    /// <see cref="FileDiscovery.FindNearestFile"/>.
     /// </summary>
-    /// <remarks>
-    /// The upward walk stops (exclusive) at the system temp root and the user profile
-    /// root — a sharpts.json sitting in those directories is ambient noise from
-    /// unrelated tooling, not the manifest of the project being run. Each ceiling is
-    /// still searched when it IS the start directory. (Same policy as
-    /// <see cref="Packaging.PackageJsonLoader.FindAndLoad"/>.)
-    /// </remarks>
     /// <returns>The loaded manifest, or null when none exists.</returns>
     /// <exception cref="Exception">When a found manifest fails to parse — unlike
     /// discovery misses, a malformed manifest is a hard error naming the file.</exception>
     public static SharpTsManifest? FindAndLoad(string startDirectory)
     {
-        var dir = new DirectoryInfo(startDirectory);
-
-        var ceilings = new[]
-            {
-                Path.GetTempPath(),
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
-            }
-            .Where(p => !string.IsNullOrEmpty(p))
-            .Select(p => Path.GetFullPath(p).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
-            .ToArray();
-
-        bool isStartDirectory = true;
-        while (dir != null)
-        {
-            var currentPath = dir.FullName.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-            // Stop when the walk ASCENDS into a ceiling directory; only search
-            // a ceiling when the caller started there.
-            if (!isStartDirectory &&
-                ceilings.Any(c => string.Equals(currentPath, c, StringComparison.OrdinalIgnoreCase)))
-            {
-                return null;
-            }
-
-            var manifestPath = Path.Combine(dir.FullName, FileName);
-            if (File.Exists(manifestPath))
-            {
-                return Load(manifestPath);
-            }
-            isStartDirectory = false;
-            dir = dir.Parent;
-        }
-
-        return null;
+        var path = FileDiscovery.FindNearestFile(startDirectory, FileName);
+        return path is null ? null : Load(path);
     }
 
     /// <summary>

--- a/Runtime/BuiltIns/JSONBuiltIns.cs
+++ b/Runtime/BuiltIns/JSONBuiltIns.cs
@@ -35,8 +35,7 @@ public static class JSONBuiltIns
         object? parsed;
         try
         {
-            using var doc = JsonDocument.Parse(text);
-            parsed = ConvertJsonElement(doc.RootElement);
+            parsed = RuntimeJson.Parse(text);
         }
         catch (JsonException)
         {
@@ -54,25 +53,6 @@ public static class JSONBuiltIns
         }
 
         return RuntimeValue.FromBoxed(parsed);
-    }
-
-    private static object? ConvertJsonElement(JsonElement element)
-    {
-        return element.ValueKind switch
-        {
-            JsonValueKind.Null => null,
-            JsonValueKind.True => true,
-            JsonValueKind.False => false,
-            JsonValueKind.Number => element.GetDouble(),
-            JsonValueKind.String => element.GetString(),
-            JsonValueKind.Array => new SharpTSArray(
-                element.EnumerateArray().Select(ConvertJsonElement).ToList()),
-            JsonValueKind.Object => new SharpTSObject(
-                element.EnumerateObject().ToDictionary(
-                    p => p.Name,
-                    p => ConvertJsonElement(p.Value))),
-            _ => null
-        };
     }
 
     /// <summary>

--- a/Runtime/RuntimeJson.cs
+++ b/Runtime/RuntimeJson.cs
@@ -1,0 +1,43 @@
+using System.Text.Json;
+using SharpTS.Runtime.Types;
+
+namespace SharpTS.Runtime;
+
+/// <summary>
+/// Single authoritative conversion from <see cref="JsonElement"/> trees to SharpTS runtime
+/// values (<see cref="SharpTSArray"/> / <see cref="SharpTSObject"/>, doubles, strings, bools,
+/// null). Shared by JSON.parse, fetch Request/Response bodies, and IPC deserialization.
+/// Exception translation stays at each caller (JSON.parse throws its syntax error; body
+/// readers reject their promise) — callers wrap <see cref="Parse"/> in their own try/catch.
+/// The compiled-standalone converter in Compilation/RuntimeTypes.Json.cs is intentionally
+/// separate: it produces List/Dictionary shapes and must not depend on SharpTS runtime types.
+/// </summary>
+internal static class RuntimeJson
+{
+    /// <summary>Parses JSON text into SharpTS runtime values. Throws <see cref="JsonException"/> on invalid input.</summary>
+    public static object? Parse(string text)
+    {
+        using var doc = JsonDocument.Parse(text);
+        return FromElement(doc.RootElement);
+    }
+
+    /// <summary>Recursively converts a <see cref="JsonElement"/> to SharpTS runtime values.</summary>
+    public static object? FromElement(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Null => null,
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Number => element.GetDouble(),
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Array => new SharpTSArray(
+                element.EnumerateArray().Select(FromElement).ToList()),
+            JsonValueKind.Object => new SharpTSObject(
+                element.EnumerateObject().ToDictionary(
+                    p => p.Name,
+                    p => FromElement(p.Value))),
+            _ => null
+        };
+    }
+}

--- a/Runtime/Types/IpcSerializer.cs
+++ b/Runtime/Types/IpcSerializer.cs
@@ -22,8 +22,7 @@ public static class IpcSerializer
     public static object? Deserialize(string json)
     {
         if (string.IsNullOrEmpty(json)) return null;
-        var doc = JsonDocument.Parse(json);
-        return FromJsonElement(doc.RootElement);
+        return RuntimeJson.Parse(json);
     }
 
     private static object? ToJsonElement(object? value)
@@ -42,19 +41,4 @@ public static class IpcSerializer
         };
     }
 
-    private static object? FromJsonElement(JsonElement element)
-    {
-        return element.ValueKind switch
-        {
-            JsonValueKind.Null => null,
-            JsonValueKind.True => true,
-            JsonValueKind.False => false,
-            JsonValueKind.Number => element.GetDouble(),
-            JsonValueKind.String => element.GetString(),
-            JsonValueKind.Array => new SharpTSArray(element.EnumerateArray().Select(FromJsonElement).ToList()),
-            JsonValueKind.Object => new SharpTSObject(
-                element.EnumerateObject().ToDictionary(p => p.Name, p => FromJsonElement(p.Value))),
-            _ => null
-        };
-    }
 }

--- a/Runtime/Types/SharpTSFetchResponse.cs
+++ b/Runtime/Types/SharpTSFetchResponse.cs
@@ -105,44 +105,13 @@ public class SharpTSFetchResponse : ITypeCategorized
         var text = await ReadBodyAsStringAsync();
         try
         {
-            return ParseJson(text);
+            return RuntimeJson.Parse(text);
         }
         catch (JsonException ex)
         {
             throw new SharpTSPromiseRejectedException(
                 new SharpTSSyntaxError($"Unexpected token in JSON: {ex.Message}"));
         }
-    }
-
-    /// <summary>
-    /// Parses JSON text into SharpTS runtime values.
-    /// </summary>
-    private static object? ParseJson(string text)
-    {
-        using var doc = JsonDocument.Parse(text);
-        return ConvertJsonElement(doc.RootElement);
-    }
-
-    /// <summary>
-    /// Converts a JsonElement to SharpTS runtime values.
-    /// </summary>
-    private static object? ConvertJsonElement(JsonElement element)
-    {
-        return element.ValueKind switch
-        {
-            JsonValueKind.Null => null,
-            JsonValueKind.True => true,
-            JsonValueKind.False => false,
-            JsonValueKind.Number => element.GetDouble(),
-            JsonValueKind.String => element.GetString(),
-            JsonValueKind.Array => new SharpTSArray(
-                element.EnumerateArray().Select(ConvertJsonElement).ToList()),
-            JsonValueKind.Object => new SharpTSObject(
-                element.EnumerateObject().ToDictionary(
-                    p => p.Name,
-                    p => ConvertJsonElement(p.Value))),
-            _ => null
-        };
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSRequest.cs
+++ b/Runtime/Types/SharpTSRequest.cs
@@ -113,7 +113,7 @@ public class SharpTSRequest : ITypeCategorized
         var text = ReadBodyAsString();
         try
         {
-            return ParseJson(text);
+            return RuntimeJson.Parse(text);
         }
         catch (JsonException ex)
         {
@@ -162,31 +162,6 @@ public class SharpTSRequest : ITypeCategorized
             throw new Exception("Runtime Error: cannot clone Request after body has been consumed");
 
         return new SharpTSRequest(_url, _method, _headers, _body, _credentials, _bodyBytes);
-    }
-
-    private static object? ParseJson(string text)
-    {
-        using var doc = JsonDocument.Parse(text);
-        return ConvertJsonElement(doc.RootElement);
-    }
-
-    private static object? ConvertJsonElement(JsonElement element)
-    {
-        return element.ValueKind switch
-        {
-            JsonValueKind.Null => null,
-            JsonValueKind.True => true,
-            JsonValueKind.False => false,
-            JsonValueKind.Number => element.GetDouble(),
-            JsonValueKind.String => element.GetString(),
-            JsonValueKind.Array => new SharpTSArray(
-                element.EnumerateArray().Select(ConvertJsonElement).ToList()),
-            JsonValueKind.Object => new SharpTSObject(
-                element.EnumerateObject().ToDictionary(
-                    p => p.Name,
-                    p => ConvertJsonElement(p.Value))),
-            _ => null
-        };
     }
 
     public override string ToString() => $"Request {{ method: {Method}, url: {Url} }}";

--- a/Runtime/Types/SharpTSResponse.cs
+++ b/Runtime/Types/SharpTSResponse.cs
@@ -121,7 +121,7 @@ public class SharpTSResponse : ITypeCategorized
         var text = ReadBodyAsString();
         try
         {
-            return ParseJson(text);
+            return RuntimeJson.Parse(text);
         }
         catch (JsonException ex)
         {
@@ -161,31 +161,6 @@ public class SharpTSResponse : ITypeCategorized
             throw new Exception("Runtime Error: cannot clone Response after body has been consumed");
 
         return new SharpTSResponse(_status, _statusText, _headers, _bodyBytes, _type);
-    }
-
-    private static object? ParseJson(string text)
-    {
-        using var doc = JsonDocument.Parse(text);
-        return ConvertJsonElement(doc.RootElement);
-    }
-
-    private static object? ConvertJsonElement(JsonElement element)
-    {
-        return element.ValueKind switch
-        {
-            JsonValueKind.Null => null,
-            JsonValueKind.True => true,
-            JsonValueKind.False => false,
-            JsonValueKind.Number => element.GetDouble(),
-            JsonValueKind.String => element.GetString(),
-            JsonValueKind.Array => new SharpTSArray(
-                element.EnumerateArray().Select(ConvertJsonElement).ToList()),
-            JsonValueKind.Object => new SharpTSObject(
-                element.EnumerateObject().ToDictionary(
-                    p => p.Name,
-                    p => ConvertJsonElement(p.Value))),
-            _ => null
-        };
     }
 
     public override string ToString() => $"Response {{ status: {Status}, ok: {Ok} }}";

--- a/SharpTS.Tests/CompilerTests/CompilationContextFactoryTests.cs
+++ b/SharpTS.Tests/CompilerTests/CompilationContextFactoryTests.cs
@@ -1,0 +1,75 @@
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>
+/// Architecture guard for the layered CompilationContext factories
+/// (Compilation/ILCompiler.ContextFactories.cs): every production emission context must come
+/// from a named factory, so module-top-level state (IsModuleTopLevel, #562) cannot leak into
+/// function or state-machine contexts and new call sites cannot copy a stale 40-property
+/// initializer.
+/// </summary>
+public class CompilationContextFactoryTests
+{
+    /// <summary>
+    /// Files allowed to construct CompilationContext directly. Only the factory layer itself.
+    /// If you need a new context shape, add a factory (or an Apply* overlay helper) to
+    /// ILCompiler.ContextFactories.cs instead of constructing inline.
+    /// </summary>
+    private static readonly HashSet<string> ConstructionAllowlist = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Compilation/ILCompiler.ContextFactories.cs",
+    };
+
+    [Fact]
+    public void CompilationContext_IsOnlyConstructedInTheFactoryLayer()
+    {
+        var repoRoot = FindRepoRoot();
+        var compilationDir = Path.Combine(repoRoot, "Compilation");
+        var violations = new List<string>();
+
+        foreach (var file in Directory.GetFiles(compilationDir, "*.cs", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(repoRoot, file).Replace('\\', '/');
+            if (ConstructionAllowlist.Contains(relative))
+                continue;
+
+            var lines = File.ReadAllLines(file);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                var trimmed = lines[i].TrimStart();
+                if (trimmed.StartsWith("//") || trimmed.StartsWith("*") || trimmed.StartsWith("/*"))
+                    continue;
+
+                // Nested helper types (e.g. CompilationContext.ExtraScopeBinding) are fine —
+                // only the context itself is factory-restricted.
+                if (trimmed.Contains("new CompilationContext("))
+                {
+                    violations.Add($"{relative}:{i + 1}: {trimmed}");
+                }
+            }
+        }
+
+        Assert.True(violations.Count == 0,
+            $"Found {violations.Count} direct CompilationContext construction(s) outside the factory layer.\n" +
+            "Create emission contexts via the factories in Compilation/ILCompiler.ContextFactories.cs " +
+            "(CreateBaseCompilationContext / CreateModuleMemberContext / CreateModuleTopLevelContext / " +
+            "CreateEntryPointTopLevelContext / ...) and apply scope-specific values as visible overlays.\n\n" +
+            string.Join("\n", violations));
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null)
+        {
+            if (Directory.Exists(Path.Combine(dir, "Compilation")) &&
+                File.Exists(Path.Combine(dir, "SharpTS.csproj")))
+            {
+                return dir;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Could not find repository root");
+    }
+}

--- a/SharpTS.Tests/TypeCheckerTests/MemberResolutionParityTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/MemberResolutionParityTests.cs
@@ -1,0 +1,138 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// Parity tests for member resolution: accessing the same member directly and through a
+/// constrained type parameter, union, or intersection must resolve through the same shared
+/// CheckGetOn* leaf helpers (TypeChecker.Properties.Helpers.cs) and agree on the result.
+/// Guards the consolidation of CheckGetOnType's inline lookup blocks onto those helpers.
+/// </summary>
+public class MemberResolutionParityTests
+{
+    [Fact]
+    public void InterfaceMember_DirectAndViaConstrainedTypeParam_Agree()
+    {
+        var source = """
+            interface Named { name: string; }
+            function direct(n: Named): string { return n.name; }
+            function viaParam<T extends Named>(n: T): string { return n.name; }
+            console.log(direct({ name: "a" }));
+            console.log(viaParam({ name: "b" }));
+            """;
+
+        var result = TestHarness.RunInterpreted(source);
+        Assert.Equal("a\nb\n", result);
+    }
+
+    [Fact]
+    public void MissingInterfaceMember_ViaConstrainedTypeParam_StillTs2339()
+    {
+        var source = """
+            interface Named { name: string; }
+            function viaParam<T extends Named>(n: T): string { return n.missing; }
+            """;
+
+        var ex = Assert.ThrowsAny<Exception>(() => TestHarness.RunInterpreted(source));
+        Assert.Contains("Type Error", ex.Message);
+        Assert.Contains("missing", ex.Message);
+    }
+
+    [Fact]
+    public void ClassInstanceMember_DirectAndViaUnion_Agree()
+    {
+        var source = """
+            class A { kind: string = "a"; describe(): string { return "A:" + this.kind; } }
+            class B { kind: string = "b"; describe(): string { return "B:" + this.kind; } }
+            function viaUnion(x: A | B): string { return x.describe(); }
+            const a = new A();
+            console.log(a.describe());
+            console.log(viaUnion(new B()));
+            """;
+
+        var result = TestHarness.RunInterpreted(source);
+        Assert.Equal("A:a\nB:b\n", result);
+    }
+
+    [Fact]
+    public void PrivateMember_ViaConstrainedTypeParam_EnforcesVisibility()
+    {
+        // Direct access to a private member outside the class is TS2341; access through a
+        // constrained type parameter must enforce the same visibility (leaf-helper parity).
+        var source = """
+            class Secretive { private secret: number = 1; }
+            function viaParam<T extends Secretive>(s: T): number { return s.secret; }
+            """;
+
+        var ex = Assert.ThrowsAny<Exception>(() => TestHarness.RunInterpreted(source));
+        Assert.Contains("Type Error", ex.Message);
+        Assert.Contains("private", ex.Message);
+    }
+
+    [Fact]
+    public void GenericInstanceMember_ViaConstrainedTypeParam_SubstitutesTypeArgs()
+    {
+        var source = """
+            class Box<T> {
+                constructor(public value: T) {}
+                get doubled(): T { return this.value; }
+            }
+            function viaParam<U extends Box<number>>(b: U): number { return b.value + 1; }
+            const box = new Box<number>(41);
+            console.log(box.value + 1);
+            console.log(viaParam(box));
+            """;
+
+        var result = TestHarness.RunInterpreted(source);
+        Assert.Equal("42\n42\n", result);
+    }
+
+    [Fact]
+    public void ObjectPrototypeMember_OnInterface_ViaConstrainedTypeParam_Resolves()
+    {
+        // toString comes from Object.prototype; the shared interface leaf helper resolves it,
+        // and the constrained-type-parameter path must agree with direct access.
+        var source = """
+            interface Named { name: string; }
+            function direct(n: Named): string { return n.toString(); }
+            function viaParam<T extends Named>(n: T): string { return n.toString(); }
+            const v = { name: "x" };
+            console.log(typeof direct(v));
+            console.log(typeof viaParam(v));
+            """;
+
+        var result = TestHarness.RunInterpreted(source);
+        Assert.Equal("string\nstring\n", result);
+    }
+
+    [Fact]
+    public void StaticMember_ViaClassTypeInUnionContext_Resolves()
+    {
+        var source = """
+            class Counter {
+                static count: number = 7;
+                static bump(): number { return Counter.count + 1; }
+            }
+            console.log(Counter.count);
+            console.log(Counter.bump());
+            """;
+
+        var result = TestHarness.RunInterpreted(source);
+        Assert.Equal("7\n8\n", result);
+    }
+
+    [Fact]
+    public void RecordMember_ViaIntersection_Resolves()
+    {
+        var source = """
+            type WithId = { id: number };
+            type WithName = { name: string };
+            function viaIntersection(x: WithId & WithName): string { return x.name + x.id; }
+            console.log(viaIntersection({ id: 1, name: "n" }));
+            """;
+
+        var result = TestHarness.RunInterpreted(source);
+        Assert.Equal("n1\n", result);
+    }
+}

--- a/TypeSystem/TypeChecker.Properties.cs
+++ b/TypeSystem/TypeChecker.Properties.cs
@@ -816,38 +816,19 @@ public partial class TypeChecker
         // Handle TypeParameter recursively - delegate to constraint
         if (objType is TypeInfo.TypeParameter tp)
         {
-            if (tp.Constraint != null)
-            {
-                return CheckGetOnType(tp.Constraint, memberName);
-            }
-            throw new TypeCheckException($" Property '{memberName.Lexeme}' does not exist on type '{tp.Name}'. Consider adding a constraint to the type parameter.", tsCode: "TS2339");
+            return CheckGetOnTypeParameter(tp, memberName);
         }
 
         // Handle Interface - check own and inherited members
         if (objType is TypeInfo.Interface itf)
         {
-            foreach (var member in itf.GetAllMembers())
-            {
-                if (member.Key == memberName.Lexeme)
-                {
-                    return member.Value;
-                }
-            }
-            throw new TypeCheckException($" Property '{memberName.Lexeme}' does not exist on interface '{itf.Name}'.", line: memberName.Line, tsCode: "TS2339");
+            return CheckGetOnInterface(itf, memberName);
         }
 
         // Handle Record type - check fields and index signatures
         if (objType is TypeInfo.Record record)
         {
-            if (record.Fields.TryGetValue(memberName.Lexeme, out var fieldType))
-            {
-                return fieldType;
-            }
-            if (record.StringIndexType != null)
-            {
-                return record.StringIndexType;
-            }
-            throw new TypeCheckException($" Property '{memberName.Lexeme}' does not exist on type '{record}'.", tsCode: "TS2339");
+            return CheckGetOnRecord(record, memberName);
         }
 
         // Handle built-in types via category-based dispatch
@@ -868,73 +849,13 @@ public partial class TypeChecker
         // Handle Class type - check static members
         if (objType is TypeInfo.Class classType)
         {
-            TypeInfo? current = classType;
-            while (current != null)
-            {
-                var staticMethods = GetStaticMethods(current);
-                var staticProps = GetStaticProperties(current);
-                if (staticMethods != null && staticMethods.TryGetValue(memberName.Lexeme, out var staticMethodType))
-                {
-                    EnforceStaticMemberAccess(current, memberName);
-                    return staticMethodType;
-                }
-                if (staticProps != null && staticProps.TryGetValue(memberName.Lexeme, out var staticPropType))
-                {
-                    EnforceStaticMemberAccess(current, memberName);
-                    return staticPropType;
-                }
-                current = GetSuperclass(current);
-            }
-            return TypeInfo.Any.Shared;
+            return CheckGetOnClass(classType, memberName);
         }
 
         // Handle Instance type - check instance members
         if (objType is TypeInfo.Instance instance)
         {
-            if (instance.ClassType is TypeInfo.InstantiatedGeneric ig &&
-                ig.GenericDefinition is TypeInfo.GenericClass gc)
-            {
-                Dictionary<string, TypeInfo> subs = [];
-                for (int i = 0; i < gc.TypeParams.Count; i++)
-                    subs[gc.TypeParams[i].Name] = ig.TypeArguments[i];
-
-                if (gc.Getters?.TryGetValue(memberName.Lexeme, out var getterType) == true)
-                    return Substitute(getterType, subs);
-                if (gc.FieldTypes?.TryGetValue(memberName.Lexeme, out var fieldType) == true)
-                    return Substitute(fieldType, subs);
-                if (gc.Methods.TryGetValue(memberName.Lexeme, out var methodType))
-                {
-                    if (methodType is TypeInfo.Function funcType)
-                    {
-                        var substitutedParams = funcType.ParamTypes.Select(pt => Substitute(pt, subs)).ToList();
-                        var substitutedReturn = Substitute(funcType.ReturnType, subs);
-                        return new TypeInfo.Function(substitutedParams, substitutedReturn, funcType.RequiredParams, funcType.HasRestParam);
-                    }
-                    return methodType;
-                }
-            }
-
-            // ResolvedClassType unwraps MutableClass to its frozen Class when signature
-            // collection created the Instance before the class was frozen (common for
-            // @DotNetType shims referenced from their own method return types).
-            if (instance.ResolvedClassType is TypeInfo.Class instanceClassType)
-            {
-                TypeInfo? current = instanceClassType;
-                while (current != null)
-                {
-                    var getters = GetGetters(current);
-                    if (getters != null && getters.TryGetValue(memberName.Lexeme, out var getterType))
-                        return getterType;
-                    var methods = GetMethods(current);
-                    if (methods != null && methods.TryGetValue(memberName.Lexeme, out var methodType))
-                        return methodType;
-                    var fieldTypes = GetFieldTypes(current);
-                    if (fieldTypes != null && fieldTypes.TryGetValue(memberName.Lexeme, out var fieldType))
-                        return fieldType;
-                    current = GetSuperclass(current);
-                }
-            }
-            return TypeInfo.Any.Shared;
+            return CheckGetOnInstance(instance, memberName);
         }
 
         // Handle Union type - check if all members have the property

--- a/TypeSystem/TypeChecker.Statements.Enums.cs
+++ b/TypeSystem/TypeChecker.Statements.Enums.cs
@@ -101,72 +101,18 @@ public partial class TypeChecker
     }
 
     /// <summary>
-    /// Evaluates a constant expression for const enum members.
-    /// Supports literals, references to other enum members, and arithmetic operations.
+    /// Evaluates a constant expression for const enum members via the shared
+    /// <see cref="ConstEnumExpressionEvaluator"/>, mapping failures onto TypeCheckExceptions
+    /// with the TS code each error kind has always carried here.
     /// </summary>
-    private object EvaluateConstEnumExpression(Expr expr, Dictionary<string, object> resolvedMembers, string enumName)
+    private static object EvaluateConstEnumExpression(Expr expr, Dictionary<string, object> resolvedMembers, string enumName)
     {
-        return expr switch
-        {
-            Expr.Literal lit => lit.Value ?? throw new TypeCheckException($" Const enum expression cannot be null.", tsCode: "TS2553"),
-
-            Expr.Get g when g.Object is Expr.Variable v && v.Name.Lexeme == enumName =>
-                resolvedMembers.TryGetValue(g.Name.Lexeme, out var val)
-                    ? val
-                    : throw new TypeCheckException($" Const enum member '{g.Name.Lexeme}' referenced before definition.", tsCode: "TS2474"),
-
-            Expr.Grouping gr => EvaluateConstEnumExpression(gr.Expression, resolvedMembers, enumName),
-
-            Expr.Unary u => EvaluateConstEnumUnary(u, resolvedMembers, enumName),
-
-            Expr.Binary b => EvaluateConstEnumBinary(b, resolvedMembers, enumName),
-
-            _ => throw new TypeCheckException($" Expression type '{expr.GetType().Name}' is not allowed in const enum initializer.", tsCode: "TS2553")
-        };
-    }
-
-    private object EvaluateConstEnumUnary(Expr.Unary unary, Dictionary<string, object> resolvedMembers, string enumName)
-    {
-        var operand = EvaluateConstEnumExpression(unary.Right, resolvedMembers, enumName);
-
-        return unary.Operator.Type switch
-        {
-            TokenType.MINUS when operand is double d => -d,
-            TokenType.PLUS when operand is double d => d,
-            TokenType.TILDE when operand is double d => (double)(~(int)d),
-            _ => throw new TypeCheckException($" Operator '{unary.Operator.Lexeme}' is not allowed in const enum expressions.", tsCode: "TS2553")
-        };
-    }
-
-    private object EvaluateConstEnumBinary(Expr.Binary binary, Dictionary<string, object> resolvedMembers, string enumName)
-    {
-        var left = EvaluateConstEnumExpression(binary.Left, resolvedMembers, enumName);
-        var right = EvaluateConstEnumExpression(binary.Right, resolvedMembers, enumName);
-
-        if (left is double l && right is double r)
-        {
-            return binary.Operator.Type switch
+        return ConstEnumExpressionEvaluator.Evaluate(expr, resolvedMembers, enumName, static e =>
+            new TypeCheckException($" {e.Message}", tsCode: e.Kind switch
             {
-                TokenType.PLUS => l + r,
-                TokenType.MINUS => l - r,
-                TokenType.STAR => l * r,
-                TokenType.SLASH => l / r,
-                TokenType.PERCENT => l % r,
-                TokenType.STAR_STAR => Math.Pow(l, r),
-                TokenType.AMPERSAND => (double)((int)l & (int)r),
-                TokenType.PIPE => (double)((int)l | (int)r),
-                TokenType.CARET => (double)((int)l ^ (int)r),
-                TokenType.LESS_LESS => (double)((int)l << (int)r),
-                TokenType.GREATER_GREATER => (double)((int)l >> (int)r),
-                _ => throw new TypeCheckException($" Operator '{binary.Operator.Lexeme}' is not allowed in const enum expressions.", tsCode: "TS2553")
-            };
-        }
-
-        if (left is string ls && right is string rs && binary.Operator.Type == TokenType.PLUS)
-        {
-            return ls + rs;
-        }
-
-        throw new TypeCheckException($" Invalid operand types for operator '{binary.Operator.Lexeme}' in const enum expression.", tsCode: "TS2362");
+                ConstEnumErrorKind.ForwardReference => "TS2474",
+                ConstEnumErrorKind.InvalidOperandTypes => "TS2362",
+                _ => "TS2553",
+            }));
     }
 }

--- a/docs/plans/duplicate-logic-consolidation.md
+++ b/docs/plans/duplicate-logic-consolidation.md
@@ -1,0 +1,615 @@
+# Duplicate logic consolidation plan
+
+## Status
+
+Implemented (2026-07-26) with two review adjustments, on branch
+`refactor/duplicate-logic-consolidation`:
+
+1. **Cluster 2 gained a fifth copy**: `Runtime/Types/IpcSerializer.cs` carried a
+   byte-identical `JsonElement` converter the original inventory missed; it now
+   routes through `RuntimeJson` with the other four.
+2. **Cluster 8 (crypto byte encoding/decoding IL) is PARKED, not implemented.**
+   The June 2026 tech-debt assessment's C#-merge spike (Roslyn-compiled built-ins,
+   Cecil-merged into the persisted output) passed all gates and would replace the
+   crypto BCL-wrapper IL wholesale. Perfecting shared IL body emitters for DH/ECDH/
+   Sign is likely wasted work until that direction is decided; revisit after.
+
+Everything else below (clusters 1–7, 9, 10) is implemented. This is a
+behavior-preserving refactor plan; no consolidation described here should
+intentionally change TypeScript, JavaScript, CLI, interpreter, or
+compiled-runtime behavior.
+
+## Goal
+
+Move repeated production logic into shared functions or narrowly scoped helper
+types so that:
+
+- semantic fixes have one implementation point;
+- interpreter, type-checker, and compiler paths do not drift accidentally;
+- emitted-runtime IL patterns remain consistent;
+- new call sites reuse an established helper instead of copying an existing block;
+- standalone compiled DLL constraints remain intact.
+
+## Success criteria
+
+- Each selected duplicate cluster has one authoritative implementation.
+- Call sites retain their existing phase-specific diagnostics and defaults.
+- Interpreter and compiled-mode parity tests remain green.
+- Standalone compiled DLLs gain no new metadata reference to `SharpTS.dll`.
+- The full test suite passes after every phase.
+- No phase combines consolidation with unrelated behavior changes.
+
+## Non-goals
+
+- Merging the interpreter, type checker, and IL compiler into a single AST visitor.
+- Replacing intentional phase-specific representations.
+- Redesigning the parser grammar or `CompilationContext`.
+- Changing JavaScript coercion, omitted-argument, or error-message behavior.
+- Consolidating test setup merely to reduce test-file line count.
+
+## Guardrails
+
+1. **Preserve standalone output.** Code under `Compilation/` must continue using
+   emitted helpers or late-bound reflection where required. It must not introduce
+   direct `SharpTS.dll` references into generated assemblies.
+2. **Keep diagnostics at phase boundaries.** Shared evaluators should return a
+   structured error or accept an error factory; they should not force the
+   interpreter, type checker, and compiler to throw the same exception type.
+3. **Do not conflate `null` and `undefined`.** Emitter helpers must name their
+   default precisely. `EmitBoxedArgumentOrNull` and `EmitOmittedArgument` are not
+   interchangeable.
+4. **Preserve speculative parsing.** Arrow parsing must still backtrack on an
+   invalid candidate rather than throwing errors intended for a committed function
+   parse.
+5. **Prefer narrow helpers.** Extract the repeated semantic unit, not a large
+   options object that obscures control flow.
+6. **Characterize before moving.** Add or identify tests for edge cases before
+   changing high-fan-out code.
+
+## Inventory and priority
+
+| Priority | Duplicate cluster | Current spread | Proposed shared owner | Risk |
+|---|---|---:|---|---|
+| P0 | Type-member leaf resolution | Two dispatch paths in `TypeChecker` | Existing `CheckGetOn*` helpers | Low–medium |
+| P0 | Runtime JSON element conversion | Four exact runtime copies | `RuntimeJson` helper | Low |
+| P0 | Boxed emitter arguments and defaults | Multiple type/module emitters | `EmitterArgumentHelpers` | Low–medium |
+| P0 | Async builder reflection helpers | Two subclasses of `AsyncBuilderBase` | `AsyncBuilderBase` | Low |
+| P1 | Const-enum expression evaluation | Compiler, interpreter, type checker | Phase-neutral evaluator | Medium |
+| P1 | Weak target/value validation IL | WeakMap, WeakSet, WeakRef | Parameterized runtime-emitter helper | Low |
+| P1 | Upward configuration-file discovery | Three loaders | Filesystem discovery helper | Low |
+| P1 | Crypto byte encoding/decoding IL | DH, ECDH, Sign, crypto primitives | Shared IL body emitters | Medium |
+| P2 | `CompilationContext` initialization | 24 constructions in 13 files | Layered context factories | High |
+| P2 | Runtime parameter parsing | At least eight named-parameter tails | Parser parameter helpers | High |
+| P3 | Object integrity state | Object, instance, array plus built-in switches | Integrity-state component/interface | Medium |
+| P3 | Net/TLS server control methods | Net and TLS server types | Server lifecycle component | High |
+
+## Phase 0: characterization and baselines
+
+Before production edits:
+
+1. Record the clean full-suite result.
+2. Confirm targeted suites for every P0/P1 cluster.
+3. Add focused characterization cases only where the current behavior is not
+   already covered.
+4. For compiled-runtime changes, retain or add standalone-DLL coverage.
+
+Targeted coverage:
+
+| Area | Existing coverage to run or extend |
+|---|---|
+| Property lookup | `TypeCheckerTests`, especially class/interface/generic member access |
+| JSON conversion | `JSONTests`, `JSONProxyTests`, `HttpModuleTests`, `StandaloneDllTests` |
+| Emitter defaults | Relevant shared tests plus `ILVerificationTests` |
+| Async builders | Async/await shared tests, `ILVerificationTests` |
+| Const enums | `EnumTests`, `CliCompileTests` |
+| Weak collections/references | `WeakMapSetTests`, `WeakRefTests`, `RuntimeTypeSyncTests` |
+| File discovery | `TsConfigLoaderTests`, `PackageJsonLoaderTests`, `SharpTsManifestLoaderTests` |
+| Crypto encoding | Crypto shared tests and standalone compiled-mode coverage |
+| Parser parameters | `ArrowFunctionTests`, `FunctionTypeAnnotationTests`, rest/default/destructuring tests |
+
+## Phase 1: low-risk local extractions
+
+### 1. Reuse type-member leaf resolvers
+
+#### Problem
+
+`TypeChecker.Properties.cs::CheckGetOnType` reimplements class, interface,
+record, instance, union, and intersection lookup even though
+`TypeChecker.Properties.Helpers.cs` already contains `CheckGetOnClass`,
+`CheckGetOnInterface`, `CheckGetOnRecord`, and `CheckGetOnInstance`.
+
+The two top-level paths have intentionally different context in some cases,
+especially union missing-member handling, but the leaf lookup is duplicated.
+
+#### Plan
+
+1. Keep recursive-alias and mapped-type normalization in `CheckGetOnType`.
+2. Replace its class/interface/record/instance blocks with calls to the existing
+   `CheckGetOn*` helpers.
+3. Keep union and intersection orchestration local initially.
+4. If union behavior is later shared, represent the difference explicitly with a
+   small missing-member policy rather than exception-catching differences.
+5. Add parity tests that access the same member directly and through a constrained
+   type parameter/union.
+
+#### Acceptance
+
+- One implementation performs each class/interface/record/instance leaf lookup.
+- Static visibility enforcement still names the declaring class.
+- Generic instance substitution is unchanged.
+- Existing TS diagnostic codes remain unchanged.
+
+### 2. Centralize runtime JSON conversion
+
+#### Problem
+
+The same `JsonElement` switch appears in:
+
+- `Runtime/BuiltIns/JSONBuiltIns.cs`
+- `Runtime/Types/SharpTSFetchResponse.cs`
+- `Runtime/Types/SharpTSRequest.cs`
+- `Runtime/Types/SharpTSResponse.cs`
+- `Runtime/Types/IpcSerializer.cs` (found in review — a fifth byte-identical copy)
+
+The three body types also duplicate the small `ParseJson(string)` wrapper.
+
+#### Plan
+
+1. Add an internal runtime helper, tentatively:
+
+   ```csharp
+   internal static class RuntimeJson
+   {
+       public static object? Parse(string text);
+       public static object? FromElement(JsonElement element);
+   }
+   ```
+
+2. Return `SharpTSArray` and `SharpTSObject` exactly as the current runtime copies
+   do.
+3. Leave exception translation at each caller:
+   - `JSON.parse` keeps its current syntax-error behavior;
+   - Request/Response/Fetch keep their promise-rejection behavior.
+4. Do not route `Compilation/RuntimeTypes.Json.cs` through this helper. Its
+   `List<object?>`/`Dictionary<string, object?>` representation is intentional for
+   compiled standalone code.
+
+#### Acceptance
+
+- Only `RuntimeJson` recursively converts runtime `JsonElement` values.
+- Numeric conversion remains `GetDouble()`.
+- HTTP body-consumption and promise rejection behavior are unchanged.
+- Standalone JSON tests still pass.
+
+### 3. Add shared emitter argument helpers
+
+#### Problem
+
+`EmitSingleArgOrNull`, `EmitSecondArgOrNull`, `EmitBoxedArg`, and
+`EmitBoxedArgument` repeat the same expression/boxing/default sequence across
+Map, Set, WeakMap, WeakSet, Iterator, Process, DataView, event-related, and other
+emitters. `ExpressionEmitterBase` has a private equivalent that strategy emitters
+cannot reuse.
+
+#### Plan
+
+1. Add a helper accessible to `IEmitterContext` implementations:
+
+   ```csharp
+   internal static class EmitterArgumentHelpers
+   {
+       public static void EmitBoxedArgumentOrNull(
+           IEmitterContext emitter,
+           IReadOnlyList<Expr> arguments,
+           int index,
+           LocalBuilder[]? preEvaluated = null);
+   }
+   ```
+
+2. Migrate the exact null-default copies first:
+   Map, Set, WeakMap, WeakSet, Iterator, and Process emitters.
+3. Add separately named helpers only for repeated semantics:
+   - boxed argument or `null`;
+   - numeric argument or zero;
+   - string-coerced argument with an explicit default.
+4. Do not create a generic “optional argument” helper whose default is implicit.
+5. Do not merge `object.ToString()` and runtime JavaScript `Stringify`; they have
+   different coercion semantics.
+6. Support pre-evaluated locals so await-safe paths do not re-evaluate arguments.
+
+#### Acceptance
+
+- Exact boxed-or-null copies are removed.
+- Helper names state the emitted default.
+- Async/await argument evaluation order remains unchanged.
+- Omitted arguments that require the `$Undefined` sentinel still use
+  `EmitOmittedArgument`.
+
+### 4. Complete `AsyncBuilderBase`
+
+#### Problem
+
+`AsyncBuilderBase` already owns common awaiter accessors, but
+`AsyncStateMachineBuilder` and `AsyncArrowStateMachineBuilder` still duplicate:
+
+- type finalization and label validation;
+- builder `Create`;
+- builder `Task` getter;
+- generic builder `Start`;
+- builder `SetException`;
+- `AwaitUnsafeOnCompleted`.
+
+#### Plan
+
+1. Expose `BuilderType` as an abstract protected/public property on
+   `AsyncBuilderBase`.
+2. Implement the common reflection accessors in the base using `BuilderType`,
+   `AwaiterType`, and inherited `StateMachineType`.
+3. Implement the common `CreateType` override in the base.
+4. Keep `GetBuilderSetResultMethod` specialized:
+   `AsyncTaskMethodBuilder` has a parameterless `SetResult`, while generic builders
+   do not.
+5. Remove subclass copies only after both builders compile against the base API.
+
+#### Acceptance
+
+- Common builder accessors exist only in `AsyncBuilderBase`.
+- Both ordinary async functions and standalone/nested async arrows pass.
+- IL label validation still occurs before `CreateType`.
+
+## Phase 2: shared semantic and emitted-runtime helpers
+
+### 5. Extract const-enum expression evaluation
+
+#### Problem
+
+Literal, member-reference, grouping, unary, and binary evaluation is effectively
+triplicated in the compiler, interpreter, and type checker. Only exception types,
+message prefixes, and TypeScript diagnostic codes differ.
+
+#### Plan
+
+1. Add a phase-neutral evaluator near the AST, tentatively:
+
+   ```csharp
+   internal static class ConstEnumExpressionEvaluator
+   {
+       public static ConstEnumEvaluationResult Evaluate(
+           Expr expression,
+           IReadOnlyDictionary<string, object> resolvedMembers,
+           string enumName);
+   }
+   ```
+
+2. Return a typed error containing:
+   - error kind;
+   - operator/member name where applicable;
+   - formatted neutral message.
+3. Map error kinds at each boundary:
+   - compiler → `CompileException`;
+   - interpreter → `InterpreterException`;
+   - type checker → `TypeCheckException` with the existing TS code.
+4. Preserve numeric casts and supported operators exactly.
+5. Migrate all three callers in one change so no fourth implementation remains.
+
+#### Acceptance
+
+- Arithmetic and reference resolution have one implementation.
+- Phase-specific exception types and TS codes are preserved.
+- Forward references, invalid operands, null values, and string concatenation are
+  characterized.
+
+### 6. Share weak-target validation emission
+
+#### Problem
+
+WeakMap, WeakSet, and WeakRef each emit the same primitive probes and throw
+sequence. They differ only in method name, `EmittedRuntime` slot, and error text.
+
+#### Plan
+
+1. Add a parameterized IL body helper on `RuntimeEmitter`, for example:
+
+   ```csharp
+   private MethodBuilder EmitWeakTargetValidator(
+       TypeBuilder owner,
+       string methodName,
+       WeakTargetErrorMessages messages);
+   ```
+
+2. Keep the public/internal `EmittedRuntime` fields separate where call sites
+   require distinct method handles.
+3. Preserve construct-specific error messages.
+4. Put primitive classification in one helper so future Symbol/BigInt/null
+   conformance fixes cannot drift across weak constructs.
+
+#### Acceptance
+
+- The primitive-probe IL sequence has one source.
+- WeakMap, WeakSet, and WeakRef retain their current messages and call sites.
+- `RuntimeTypeSyncTests` and standalone weak-collection tests pass.
+
+### 7. Extract upward file discovery
+
+#### Problem
+
+`TsConfigLoader`, `PackageJsonLoader`, and `SharpTsManifestLoader` repeat:
+
+- normalization of temp and user-profile ceilings;
+- parent-directory traversal;
+- the “search a ceiling only when it is the starting directory” rule;
+- case-insensitive path comparison.
+
+All three also repeat the same lenient JSON serializer options.
+
+#### Plan
+
+1. Add an internal filesystem helper in a neutral configuration/support namespace:
+
+   ```csharp
+   internal static string? FindNearestFile(
+       string startDirectory,
+       string fileName,
+       string? stopDirectory = null);
+   ```
+
+2. Centralize ceiling normalization once.
+3. Preserve `PackageJsonLoader`'s explicit stop-directory behavior.
+4. Let each loader retain its own parse result and error translation.
+5. Optionally expose one shared read-only `JsonSerializerOptions` instance after
+   verifying no caller mutates it.
+
+#### Acceptance
+
+- All three loaders share the same upward-walk policy.
+- Start-at-ceiling and ascend-into-ceiling cases are tested.
+- Stop-directory exclusivity remains unchanged.
+- Malformed-file errors still name the correct manifest/config type.
+
+### 8. Share crypto byte encoding and decoding IL bodies
+
+**PARKED (2026-07-26).** Deliberately not implemented: the C#-merge structural
+direction (see the June 2026 tech-debt assessment; all spike gates passed) would
+replace this hand-written crypto IL wholesale, making a shared-IL-body refactor
+here likely throwaway. It is also the riskiest Phase 2 item (Sign fall-through /
+return-label behavior, non-uniform `base64url` support). Revisit only if the
+C#-merge direction is rejected.
+
+#### Problem
+
+DH and ECDH emit nearly identical Buffer/byte-array/string decoding with optional
+hex/base64 handling. DH, ECDH, Sign, and `CryptoEncodeBytes` repeat substantial
+byte-to-hex/base64/Buffer dispatch.
+
+#### Plan
+
+1. First extract host-side IL body helpers; do not immediately alias all runtime
+   methods to one `MethodBuilder`.
+2. Parameterize:
+   - how the byte array is loaded;
+   - the encoding argument index;
+   - accepted encodings (`base64url` support is not identical everywhere);
+   - invalid-input behavior.
+3. Use the shared body helper for DH and ECDH exact copies.
+4. Migrate Sign only after confirming its fall-through and return-label behavior.
+5. Consider routing wrappers to emitted `CryptoEncodeBytes` only if its accepted
+   encoding set matches the Node API being implemented.
+
+#### Acceptance
+
+- DH and ECDH decode semantics are byte-for-byte equivalent.
+- Unknown-encoding fallback remains unchanged.
+- Hex casing and Buffer return types remain unchanged.
+- No generated assembly gains a `SharpTS.dll` dependency.
+
+## Phase 3: high-fan-out compiler context factory
+
+### 9. Layer `CompilationContext` construction
+
+#### Problem
+
+There are 24 direct `new CompilationContext(...)` sites across 13
+`ILCompiler` partial files. Large object initializers repeat closure, enum, runtime,
+module, type-emitter, import, and class-expression registries.
+
+An existing method named `CreateCompilationContext` is not a safe universal base:
+it also sets module-top-level state, including `IsModuleTopLevel = true`.
+
+#### Proposed shape
+
+```csharp
+private CompilationContext CreateBaseCompilationContext(ILGenerator il);
+private CompilationContext CreateModuleTopLevelContext(ILGenerator il);
+private CompilationContext CreateFunctionContext(
+    ILGenerator il,
+    IReadOnlyList<Stmt>? body,
+    string? currentClassName = null);
+private CompilationContext CreateStateMachineContext(
+    ILGenerator il,
+    StateMachineContextOptions options);
+```
+
+The base factory should contain only values that are invariant for all emission
+contexts, such as shared registries and compilation-wide maps. Specialized
+factories apply scope-sensitive values:
+
+- current module and namespace;
+- strict-mode determination;
+- module-top-level status;
+- class/private-member context;
+- async builder maps;
+- captured/display-class fields;
+- lock-decorator fields;
+- current return type.
+
+#### Migration steps
+
+1. Inventory every assigned `CompilationContext` property by call site.
+2. Classify each property as:
+   - compilation-wide invariant;
+   - module-scoped;
+   - function-scoped;
+   - class-scoped;
+   - state-machine-scoped;
+   - call-site-only.
+3. Rename the current module helper to `CreateModuleTopLevelContext` before
+   introducing the base factory.
+4. Add `CreateBaseCompilationContext` with only proven invariants.
+5. Migrate one context family per commit:
+   - synchronous functions;
+   - class methods/accessors/constructors/statics;
+   - arrows and inner functions;
+   - generators;
+   - async and async generators;
+   - module/CommonJS entry points.
+6. Leave short call-site overlays visible rather than hiding every property behind
+   a broad options object.
+7. After migration, prevent new direct construction outside the factory file by a
+   source-level architecture test or analyzer-style test.
+
+#### Acceptance
+
+- Every production `ILCompiler` emission context comes from a named factory.
+- Module-top-level state cannot leak into function or state-machine contexts.
+- All context properties used by private members, modules, CommonJS, locks,
+  closures, and strict mode retain coverage.
+- Cross-module, async, generator, class-expression, and standalone-DLL tests pass.
+
+## Phase 4: parser parameter consolidation
+
+### 10. Extract parameter parsing components
+
+#### Problem
+
+Named runtime parameters repeatedly parse:
+
+1. `...`;
+2. identifier/contextual keyword;
+3. `?`;
+4. type annotation and `TypeNode`;
+5. default initializer;
+6. rest-last validation;
+7. `Stmt.Parameter` construction.
+
+Array/object destructured parameters and synthetic `_paramN` creation are also
+repeated in function declarations, methods, arrows, and function expressions.
+
+Not every loop is identical:
+
+- constructors allow parameter-property modifiers and decorators;
+- signatures may forbid or ignore defaults;
+- function types produce `ParameterTypeNode`, not `Stmt.Parameter`;
+- speculative arrows must backtrack rather than throw;
+- explicit `this` parameters are type-only;
+- some contexts accept contextual keywords.
+
+#### Plan
+
+1. Extract the deterministic named runtime-parameter tail first:
+
+   ```csharp
+   private ParsedParameter ParseNamedRuntimeParameter(
+       ParameterModifiers modifiers,
+       bool allowDefault);
+   ```
+
+2. Keep list-loop ownership and error/backtracking policy with each caller.
+3. Extract destructured runtime parameters separately:
+
+   ```csharp
+   private (Stmt.Parameter Parameter, DestructurePattern Pattern)
+       ParseDestructuredParameter(int parameterIndex, List<Decorator>? decorators);
+   ```
+
+4. Share the prologue generation that lowers synthetic parameters into
+   destructuring statements.
+5. Do not force function-type/signature parameter parsing through
+   `Stmt.Parameter`; share only token-level/type-annotation primitives where the
+   AST outputs genuinely differ.
+6. Convert committed function/method/function-expression parsers first.
+7. Convert speculative arrow parsing last, with explicit success/failure results.
+
+#### Acceptance
+
+- Runtime named-parameter construction has one implementation.
+- Runtime destructured-parameter construction and prologue lowering have one
+  implementation.
+- Constructor parameter properties and decorators remain supported.
+- Arrow candidates still backtrack correctly.
+- Trailing commas, rest-last errors, optional parameters, defaults, explicit
+  `this`, contextual keyword names, and nested type annotations retain tests.
+
+## Deferred candidates
+
+### Object integrity state
+
+`SharpTSObject`, `SharpTSInstance`, and `SharpTSArray` duplicate the
+frozen/sealed/extensible state transitions. `ObjectBuiltIns` then repeats type
+switches for freeze, seal, preventExtensions, and status queries.
+
+Revisit after the P0–P2 work. A small composed `ObjectIntegrityState` plus a common
+runtime interface could consolidate both the transitions and built-in switches,
+but the interface must not expose public setters or erase array-specific mutation
+rules.
+
+### Net/TLS server lifecycle
+
+`SharpTSNetServer` and `SharpTSTlsServer` share address formatting,
+`getConnections`, `ref`, and `unref`, with similar close behavior. A lifecycle
+component or base class may help, but Net's IPC/cluster behavior and callback
+adaptation make premature unification risky. Extract only exact leaf helpers unless
+a broader server abstraction is independently justified.
+
+## Suggested PR sequence
+
+1. `refactor: reuse shared type-member resolvers`
+2. `refactor: centralize runtime JSON conversion`
+3. `refactor: share boxed emitter argument helpers`
+4. `refactor: complete AsyncBuilderBase common helpers`
+5. `refactor: centralize const-enum expression evaluation`
+6. `refactor: share weak target validation emission`
+7. `refactor: centralize upward config discovery`
+8. `refactor: share crypto byte encoding and decoding emitters`
+9. `refactor: layer CompilationContext factories` — multiple small commits
+10. `refactor: consolidate parser parameter components` — multiple small commits
+
+Each PR should contain one semantic cluster, its characterization tests, and no
+feature work.
+
+## Verification
+
+Run targeted tests during each phase, then the full suite:
+
+```powershell
+dotnet test SharpTS.Tests/SharpTS.Tests.csproj --filter "FullyQualifiedName~JSONTests|FullyQualifiedName~HttpModuleTests"
+dotnet test SharpTS.Tests/SharpTS.Tests.csproj --filter "FullyQualifiedName~EnumTests"
+dotnet test SharpTS.Tests/SharpTS.Tests.csproj --filter "FullyQualifiedName~WeakMapSetTests|FullyQualifiedName~WeakRefTests"
+dotnet test SharpTS.Tests/SharpTS.Tests.csproj --filter "FullyQualifiedName~TsConfigLoaderTests|FullyQualifiedName~PackageJsonLoaderTests|FullyQualifiedName~SharpTsManifestLoaderTests"
+dotnet test SharpTS.Tests/SharpTS.Tests.csproj --filter "FullyQualifiedName~ArrowFunctionTests|FullyQualifiedName~FunctionTypeAnnotationTests"
+dotnet test SharpTS.Tests/SharpTS.Tests.csproj --filter "FullyQualifiedName~ILVerificationTests|FullyQualifiedName~StandaloneDllTests"
+dotnet test SharpTS.Tests/SharpTS.Tests.csproj
+```
+
+Also run:
+
+```powershell
+dotnet build
+git diff --check
+```
+
+For compiler/runtime-emitter phases, explicitly verify at least one representative
+standalone DLL without `SharpTS.dll` beside it.
+
+## Completion checklist
+
+- [x] P0 clusters are consolidated and fully tested.
+- [x] Phase-neutral const-enum evaluation preserves all diagnostic mappings.
+- [x] Weak emitted-runtime helper preserves standalone output (crypto: parked, see cluster 8).
+- [x] All configuration loaders use one upward-discovery policy.
+- [x] Direct `CompilationContext` construction is limited to its factory layer
+      (enforced by `CompilationContextFactoryTests`).
+- [x] Runtime parameter parsers reuse shared named/destructured components.
+- [x] Full build and test suite pass.
+- [x] `git diff --check` reports no whitespace errors.
+- [x] Follow-up opportunities are documented rather than folded into the same PRs
+      (cluster 8 parked pending the C#-merge decision; P3 deferrals unchanged).


### PR DESCRIPTION
Implements `docs/plans/duplicate-logic-consolidation.md` — a behavior-preserving consolidation of duplicated production logic — with two review adjustments. One commit per cluster.

## Clusters

1. **Type-member leaf resolvers** — `CheckGetOnType`'s inline class/interface/record/instance/type-parameter blocks now delegate to the existing `CheckGetOn*` helpers, aligning the via-union/constrained-type-parameter path with direct access (Object.prototype fallback, visibility enforcement, overloaded-method substitution). New direct-vs-indirect parity tests.
2. **Runtime JSON conversion** — five byte-identical `JsonElement` converters (JSONBuiltIns, FetchResponse, Request, Response, **IpcSerializer** — a fifth copy the original plan missed) collapse into `RuntimeJson`. Exception translation stays at each caller; `Compilation/RuntimeTypes.Json.cs` intentionally untouched.
3. **Emitter argument helpers** — the `EmitSingleArgOrNull`/`EmitSecondArgOrNull`/`EmitBoxedArg(ument)` copies across Map/Set/WeakMap/WeakSet/Iterator/Array/Process emitters become `EmitterArgumentHelpers.EmitBoxedArgumentOrNull` (incl. the #850 await-safe pre-spilled-locals path). `$Undefined`-sentinel sites (`EmitOmittedArgument`) untouched.
4. **AsyncBuilderBase** — `BuilderType`, the common builder reflection accessors (Create/Task/Start/SetException/AwaitUnsafeOnCompleted), and the label-validating `CreateType` move into the base; `SetResult` stays specialized per builder.
5. **Const-enum evaluation** — the compiler/interpreter/type-checker triplication becomes one phase-neutral `ConstEnumExpressionEvaluator` with an error factory; each phase keeps its exception type and the type checker keeps its TS codes (TS2474/TS2362/TS2553) and messages.
6. **Weak-target validation IL** — one parameterized `EmitWeakTargetValidator` emits the primitive-probe sequence for WeakMap/WeakSet/WeakRef; per-construct names, `EmittedRuntime` slots, and error wording preserved.
7. **Upward config discovery** — `TsConfigLoader`/`PackageJsonLoader`/`SharpTsManifestLoader` share `FileDiscovery.FindNearestFile` (temp/user-profile ceiling rule, stop-directory exclusivity, case-insensitive comparison) and one lenient `JsonSerializerOptions`.
8. **CompilationContext factories** — all 23 direct constructions across the ILCompiler partials now come from a layered factory file (base invariants → module-member scope → module-top-level / entry-point, the only factories setting `IsModuleTopLevel`, #562) plus `Apply*` overlay helpers; call sites keep short visible overlays. A source-scan architecture test prohibits new direct construction. Net −1,300 lines.
9. **Parser parameter components** — `ParseNamedRuntimeParameterTail` (with `allowDefault:false` for signatures), `ParseDestructuredParameter`, and `PrependDestructuringPrologue` share the per-parameter units; loop ownership, rest-last policy (throw vs backtrack), and constructor parameter-property modifiers stay with callers. Speculative arrows converted last, still backtracking.

## Deliberately NOT done

- **Cluster 8 of the plan (crypto byte encoding/decoding IL) is parked**, not implemented: the C#-merge structural direction (June 2026 tech-debt spike, all gates passed) would replace that hand-written IL wholesale, so a shared-IL-body refactor there is likely throwaway. Recorded in the plan doc.
- P3 deferrals (object integrity state, Net/TLS lifecycle) unchanged, per the plan.

## Verification

- Full suite ×3 (baseline, after the factory migration, final): **15,738 tests, zero new failures** — the only failures are the 5 pre-existing `UtilFormattingTests.StyleText_*` failures already present on unmodified main.
- Representative standalone DLL compiled and run **without SharpTS.dll co-located**: const-enum arithmetic, WeakMap/WeakSet/WeakRef incl. the exact preserved validation message, JSON parsing, async with destructured/default params — all correct, no SharpTS.dll auto-copy triggered.
- `git diff --check` clean.

## Notes for review

- Cluster 1 intentionally aligns member resolution: access through a constrained type parameter/union now enforces the same visibility rules and resolves the same `Object.prototype` members as direct access (previously the indirect path silently skipped both).
- `IpcSerializer.Deserialize` previously leaked its `JsonDocument` (no `using`); the shared helper disposes it — safe, values are fully materialized.