### PR TITLE
fix(util): honor styleText validateStream; fix compiled invalid-format detection

### DIFF
--- a/SharpTS.Tests/SharedTests/BuiltInModules/UtilFormattingTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/UtilFormattingTests.cs
@@ -16,9 +16,12 @@ public class UtilFormattingTests
     {
         var files = new Dictionary<string, string>
         {
+            // validateStream: false forces styling regardless of NO_COLOR / stream
+            // color support (Node semantics) — keeps this hermetic in non-TTY and
+            // NO_COLOR environments (CI, agent shells).
             ["main.ts"] = """
                 import { styleText } from 'util';
-                const r = styleText('red', 'hi');
+                const r = styleText('red', 'hi', { validateStream: false });
                 console.log(r === '\x1b[31mhi\x1b[39m');
                 """
         };
@@ -33,9 +36,10 @@ public class UtilFormattingTests
     {
         var files = new Dictionary<string, string>
         {
+            // validateStream: false — see StyleText_SingleFormat_WrapsInAnsiCodes.
             ["main.ts"] = """
                 import { styleText } from 'util';
-                const r = styleText(['bold', 'red'], 'x');
+                const r = styleText(['bold', 'red'], 'x', { validateStream: false });
                 console.log(r === '\x1b[1m\x1b[31mx\x1b[39m\x1b[22m');
                 """
         };

--- a/stdlib/node/util.ts
+++ b/stdlib/node/util.ts
@@ -629,17 +629,23 @@ export function styleText(format: any, text: string, options?: any): string {
     if (typeof text !== 'string') {
         throw new TypeError('The "text" argument must be of type string');
     }
-    const validate = options != null && options.validateStream === true;
-    void validate;
+    // Node: options.validateStream (default true) gates the can-this-stream-color
+    // check (approximated here by the NO_COLOR/FORCE_COLOR env probe);
+    // validateStream: false applies the styling unconditionally.
+    const validate = options == null || options.validateStream !== false;
 
     const formats: any[] = Array.isArray(format) ? format : [format];
     for (let i = 0; i < formats.length; i++) {
-        if (STYLE_CODES[formats[i]] === undefined) {
+        // `== null`, not `=== undefined`: the compiled dynamic-index path yields null
+        // for a missing key (RuntimeEmitter.Objects.Index.cs EmitDictLookup — the
+        // prototype-walk/undefined refactor is explicitly deferred there), while the
+        // interpreter yields undefined. Loose null covers both modes.
+        if (STYLE_CODES[formats[i]] == null) {
             throw new TypeError("The value '" + String(formats[i]) + "' is invalid for argument 'format'");
         }
     }
 
-    if (__colorsDisabled()) return text;
+    if (validate && __colorsDisabled()) return text;
 
     let open = '';
     let close = '';


### PR DESCRIPTION
Fixes the 5 locally-failing `UtilFormattingTests.StyleText_*` tests (both modes). These passed in CI but failed in any `NO_COLOR` environment — and one of them was passing in CI **by accident**.

## Root causes

1. **`options.validateStream` was parsed and discarded.** Node's contract: `validateStream` (default `true`) gates the color-capability check; `validateStream: false` applies styling unconditionally. Now honored, with the existing `NO_COLOR`/`FORCE_COLOR` env probe standing in for stream capability.

2. **The invalid-format check never fired in compiled mode.** `STYLE_CODES[name] === undefined` can't detect a missing key when compiled: the dynamic-index path yields `null`, not `undefined` (the deliberately-deferred prototype-walk gap documented in `RuntimeEmitter.Objects.Index.cs` `EmitDictLookup`). In CI the test passed only because the styling loop then crashed on the null pair inside the try/catch; under `NO_COLOR` the early unstyled return skipped that crash and exposed the miss as `no-throw`. Switched to `== null`, which raises the intended `TypeError` in both modes.

3. **The two ANSI-wrap tests were environment-sensitive.** They asserted styling with default options, but Node (and this implementation) legitimately returns unstyled text when colors are disabled (`NO_COLOR`, non-TTY). They now pass `{ validateStream: false }` — Node's documented way to force styling — making them hermetic in agent shells and CI alike.

## Verification

- Full suite under `NO_COLOR=1`: **15,738 / 15,738 passed** — first fully green run (these 5 were the only failures on unmodified main).
- Manual check of both env states: default suppresses under `NO_COLOR` and styles without it; `validateStream: false` styles in both; invalid format throws in both modes.

## Follow-up (not in this PR)

The compiled dynamic-index missing-key semantics (`null` instead of `undefined`, `typeof` reporting `object`) remain the deferred refactor noted in `EmitDictLookup`; this PR works around it at the single affected stdlib site rather than changing the emitter path.