### PR TITLE
chore: repo hygiene — NUL-byte fix, CPM, gitignore, CI hardening

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -38,8 +38,10 @@ jobs:
       - name: Publish results to job summary
         shell: pwsh
         run: |
+          $resultsDir = Join-Path ([System.IO.Path]::GetTempPath()) 'bench-results'
+          "BENCH_RESULTS_DIR=$resultsDir" >> $env:GITHUB_ENV
           ./benchmarks/format-results.ps1 `
-            -ResultsFile (Join-Path ([System.IO.Path]::GetTempPath()) 'bench-results/results.txt') `
+            -ResultsFile (Join-Path $resultsDir 'results.txt') `
             -DotNetVersion (dotnet --version) `
             -NodeVersion (node -v) `
             -BunVersion (bun --version) `
@@ -49,4 +51,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
-          path: /tmp/bench-results/
+          path: ${{ env.BENCH_RESULTS_DIR }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,20 +31,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # The runner's hostname is an mDNS-only `.local` name that nothing on the
-      # network answers for, so the Dns.GetHostEntry call inside the managed
-      # HttpListener's Prefixes.Add (Kerberos SPN setup) burns mDNSResponder's
-      # full 5s timeout for every guest program that calls http server.listen().
-      # Resolving it from /etc/hosts short-circuits that — saves ~2min of test time.
-      # Both address families are required: with only the 127.0.0.1 entry, the
-      # AAAA half of the dual-stack lookup still goes to mDNS and waits out the
-      # same 5s (measured on macos-latest: A-only 5053ms, A+AAAA 10ms).
-      - name: Register hostname in /etc/hosts (macOS mDNS workaround)
-        if: runner.os == 'macOS'
-        run: |
-          echo "127.0.0.1 $(hostname)" | sudo tee -a /etc/hosts
-          echo "::1 $(hostname)" | sudo tee -a /etc/hosts
-
+      # NOTE: if macOS is ever restored to the matrix, resurrect the
+      # "Register hostname in /etc/hosts (macOS mDNS workaround)" step removed in
+      # the 2026-07 cleanup (git history) — without it, every http server.listen()
+      # burns mDNSResponder's 5s timeout (measured: A-only 5053ms, A+AAAA 10ms).
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
@@ -55,6 +45,17 @@ jobs:
 
       - name: Build
         run: dotnet build --no-restore --configuration Release
+
+      # The conformance harnesses live outside SharpTS.sln (running them needs the
+      # external/ submodules, absent here), but each references SharpTS.csproj — so
+      # compile them to catch API rot that would otherwise only surface when someone
+      # runs them manually.
+      - name: Build conformance harnesses (compile-only)
+        shell: bash
+        run: |
+          dotnet build SharpTS.Test262/SharpTS.Test262.csproj --configuration Release
+          dotnet build SharpTS.Test262.Worker/SharpTS.Test262.Worker.csproj --configuration Release
+          dotnet build SharpTS.TypeScriptConformance/SharpTS.TypeScriptConformance.csproj --configuration Release
 
       # Category!=LiveNetwork excludes the opt-in tests that make real outbound
       # DNS/HTTP calls (tagged [Trait("Category","LiveNetwork")]); those depend on

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,32 @@
+name: Examples
+
+# The Examples/ showcase has zero automated coverage otherwise — a broken flagship
+# example is a first-impression bug. Manual trigger only (the harness runs every
+# example end-to-end, which is too slow and too network-adjacent for every push).
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Execution mode'
+        default: 'interpreted'
+        type: choice
+        options: [interpreted, dll, exe, all]
+
+jobs:
+  examples:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Build (Release)
+        run: dotnet build SharpTS.csproj --configuration Release
+
+      - name: Run examples
+        shell: pwsh
+        run: ./Examples/test-examples.ps1 -Mode ${{ inputs.mode || 'interpreted' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,8 +30,11 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --configuration Release
 
+      # Same exclusion as ci.yml: LiveNetwork tests make real outbound DNS/HTTP
+      # calls and can false-red on runner network hiccups — which here would block
+      # a tagged release after build but before pack/push.
       - name: Test
-        run: dotnet test --no-build --configuration Release --verbosity normal
+        run: dotnet test --no-build --configuration Release --verbosity normal --filter "Category!=LiveNetwork&Category!=LoadSensitive"
 
       - name: Publish SharpTS for SDK bundling
         run: dotnet publish SharpTS.csproj --configuration Release --no-build
@@ -59,7 +62,7 @@ jobs:
         run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
           files: ./nupkg/*

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,10 @@ Thumbs.db
 # Dependencies
 packages/
 .nuget/packages/
+node_modules/
+
+# SharpTS CLI NuGet-restore cache (created beside user scripts by sharpts.json restore)
+.sharpts/
 
 # NuGet
 *.nupkg
@@ -72,12 +76,15 @@ packages/
 TestResults/
 *.trx
 *.coverage
+coverage*.xml
+[Cc]overage/
 
 # Local perf probes & test-suite profiling artifacts (TRX dumps, CPU samples, ad-hoc benchmarks)
 .perf-*/
 
 # AI tools
 .claude/
+.agents/
 /.cursor/
 /.cursorrules/
 /.aider*
@@ -87,8 +94,9 @@ TestResults/
 /SharpTS.dll
 /NUL
 
-# BenchmarkDotNet
+# BenchmarkDotNet (incl. EtwProfiler native payload extracted to /out)
 BenchmarkDotNet.Artifacts/
+/out/
 **/CompiledTS/
 *.benchmarklog
 # VS Code Extension / Node.js

--- a/Compilation/RuntimeEmitter.TSRegExp.cs
+++ b/Compilation/RuntimeEmitter.TSRegExp.cs
@@ -208,9 +208,9 @@ public partial class RuntimeEmitter
         var freshLocal = il.DeclareLocal(typeof(Regex));
         var hitLabel = il.DefineLabel();
 
-        // key = pattern + " " + ((int)options).ToString()
+        // key = pattern + "\0" + ((int)options).ToString()
         il.Emit(OpCodes.Ldarg_0);                                        // pattern
-        il.Emit(OpCodes.Ldstr, " ");                                // separator
+        il.Emit(OpCodes.Ldstr, "\0");                                // separator
         var optionsLocal = il.DeclareLocal(typeof(int));
         il.Emit(OpCodes.Ldarg_1);                                        // options as int (RegexOptions is enum:int)
         il.Emit(OpCodes.Stloc, optionsLocal);

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Repo-wide automatic versioning from Git tags. Build-time only (PrivateAssets=All). -->
-    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
+    <!-- Repo-wide automatic versioning from Git tags. Build-time only (PrivateAssets=All).
+         Version comes from Directory.Packages.props (central package management). -->
+    <PackageReference Include="MinVer" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,32 @@
+<Project>
+  <!-- Central package management: one version per package for every project in the
+       repo (including the conformance harnesses outside SharpTS.sln). Individual
+       csproj files declare only <PackageReference Include="..."/> with no Version.
+       This also replaces the former floating PrettyPrompt "4.1.*" pin, which broke
+       restore determinism (<Deterministic>true</> in SharpTS.csproj). -->
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.14.0" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="18.0.2" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.0.2" />
+    <PackageVersion Include="Microsoft.ILVerification" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+    <PackageVersion Include="MinVer" Version="6.0.0" />
+    <PackageVersion Include="NickNa.PEPacker" Version="1.0.2" />
+    <PackageVersion Include="NuGet.Packaging" Version="7.3.1" />
+    <PackageVersion Include="NuGet.Protocol" Version="7.3.1" />
+    <PackageVersion Include="OmniSharp.Extensions.LanguageServer" Version="0.19.9" />
+    <PackageVersion Include="PrettyPrompt" Version="4.1.1" />
+    <PackageVersion Include="System.Reflection.MetadataLoadContext" Version="9.0.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageVersion Include="ZstdSharp.Port" Version="0.8.1" />
+  </ItemGroup>
+</Project>

--- a/SharpTS.LanguageServer/SharpTS.LanguageServer.csproj
+++ b/SharpTS.LanguageServer/SharpTS.LanguageServer.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="0.19.9" />
+    <PackageReference Include="OmniSharp.Extensions.LanguageServer" />
   </ItemGroup>
 
 </Project>

--- a/SharpTS.Microbenchmarks/SharpTS.Microbenchmarks.csproj
+++ b/SharpTS.Microbenchmarks/SharpTS.Microbenchmarks.csproj
@@ -19,8 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.14.0" />
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SharpTS.Sdk.Tasks/SharpTS.Sdk.Tasks.csproj
+++ b/SharpTS.Sdk.Tasks/SharpTS.Sdk.Tasks.csproj
@@ -19,8 +19,8 @@
 
   <ItemGroup>
     <!-- MSBuild task framework -->
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.0.2" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.0.2" />
+    <PackageReference Include="Microsoft.Build.Framework" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SharpTS.Sdk/SharpTS.Sdk.csproj
+++ b/SharpTS.Sdk/SharpTS.Sdk.csproj
@@ -46,4 +46,16 @@
     <None Include="readme.md" Pack="true" PackagePath="\" />
     <None Include="..\LICENSE" Pack="true" PackagePath="\" />
   </ItemGroup>
+
+  <!-- The Condition="Exists(...)" guards on the payload item groups above keep
+       ordinary builds working before the siblings are built — but they would also
+       let `dotnet pack` silently produce an SDK package with no tasks assembly and
+       no bundled compiler. Fail the pack loudly instead (CI checks the same two
+       paths in publish.yml; this makes the failure local too). -->
+  <Target Name="EnsureSdkPayloadPresent" BeforeTargets="GenerateNuspec">
+    <Error Condition="!Exists('..\SharpTS.Sdk.Tasks\bin\Release\net10.0\SharpTS.Sdk.Tasks.dll')"
+           Text="SharpTS.Sdk pack: tasks assembly missing. Build it first: dotnet build SharpTS.Sdk.Tasks -c Release" />
+    <Error Condition="!Exists('..\bin\Release\net10.0\publish\')"
+           Text="SharpTS.Sdk pack: bundled compiler missing. Publish it first: dotnet publish SharpTS.csproj -c Release" />
+  </Target>
 </Project>

--- a/SharpTS.Test262/SharpTS.Test262.csproj
+++ b/SharpTS.Test262/SharpTS.Test262.csproj
@@ -27,9 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/SharpTS.Tests/SharpTS.Tests.csproj
+++ b/SharpTS.Tests/SharpTS.Tests.csproj
@@ -26,15 +26,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Microsoft.ILVerification" Version="10.0.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.ILVerification" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="Xunit.SkippableFact" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/SharpTS.TypeScriptConformance/SharpTS.TypeScriptConformance.csproj
+++ b/SharpTS.TypeScriptConformance/SharpTS.TypeScriptConformance.csproj
@@ -17,9 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/SharpTS.csproj
+++ b/SharpTS.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <!-- Embed TypeScript standard library sources. Loaded by EmbeddedStdlibProvider
-       at user-compile time; see docs/plans/embedded-stdlib.md. -->
+       at user-compile time; see stdlib/CONTRIBUTING.md and Modules/Stdlib/. -->
   <ItemGroup>
     <EmbeddedResource Include="stdlib\**\*.ts" />
     <None Remove="stdlib\**\*.ts" />
@@ -62,8 +62,6 @@
     <None Remove="SharpTS.Microbenchmarks/**" />
     <Compile Remove="SharpTS.LanguageServer/**" />
     <None Remove="SharpTS.LanguageServer/**" />
-    <Compile Remove="SharpTS.Example.Interop/**" />
-    <None Remove="SharpTS.Example.Interop/**" />
     <Compile Remove="Examples/**" />
     <None Remove="Examples/**" />
     <Compile Remove="SharpTS.Sdk/**" />
@@ -91,8 +89,11 @@
     <ItemGroup>
       <!-- Sibling project files anywhere beneath the repo root (this project, the
            build output, and the external submodules excluded). -->
+      <!-- Dot-directories (.claude worktrees, .perf-* scratch dirs) hold full repo
+           copies whose .csproj files are not siblings of this build — same skip
+           rule as ProjectStructureTests.HasSkippedSegment (#1214). -->
       <_GuardSiblingProject Include="$(MSBuildProjectDirectory)\**\*.csproj"
-                            Exclude="$(MSBuildProjectFullPath);$(MSBuildProjectDirectory)\external\**;$(MSBuildProjectDirectory)\bin\**;$(MSBuildProjectDirectory)\obj\**" />
+                            Exclude="$(MSBuildProjectFullPath);$(MSBuildProjectDirectory)\external\**;$(MSBuildProjectDirectory)\bin\**;$(MSBuildProjectDirectory)\obj\**;$(MSBuildProjectDirectory)\.*\**" />
       <!-- Every .cs that lives under one of those sibling projects' directories. -->
       <_GuardForeignSource Include="%(_GuardSiblingProject.RootDir)%(_GuardSiblingProject.Directory)**\*.cs" />
       <!-- Set intersection Compile ∩ ForeignSource = foreign sources leaking in.
@@ -108,14 +109,14 @@
 
   <ItemGroup>
     <!-- MinVer is inherited from Directory.Build.props (repo-wide versioning). -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="NickNa.PEPacker" Version="1.0.2" />
-    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="9.0.0" />
-    <PackageReference Include="Microsoft.ILVerification" Version="10.0.0" />
-    <PackageReference Include="NuGet.Packaging" Version="7.3.1" />
-    <PackageReference Include="NuGet.Protocol" Version="7.3.1" />
-    <PackageReference Include="PrettyPrompt" Version="4.1.*" />
-    <PackageReference Include="ZstdSharp.Port" Version="0.8.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
+    <PackageReference Include="NickNa.PEPacker" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" />
+    <PackageReference Include="Microsoft.ILVerification" />
+    <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="PrettyPrompt" />
+    <PackageReference Include="ZstdSharp.Port" />
   </ItemGroup>
 
 </Project>

--- a/stdlib/CONTRIBUTING.md
+++ b/stdlib/CONTRIBUTING.md
@@ -4,8 +4,10 @@ Files under `stdlib/` are the TypeScript source for Node-compatible modules
 baked into SharpTS. They are embedded as resources in `SharpTS.dll` and
 compiled into every user output alongside the user's own code.
 
-See [docs/plans/embedded-stdlib.md](../docs/plans/embedded-stdlib.md) for the
-full architecture.
+The resolution/embedding architecture lives in `Modules/Stdlib/`
+(`StdlibProviderChain`, `EmbeddedStdlibProvider`); the sources are embedded via
+the `stdlib\**\*.ts` `EmbeddedResource` group in `SharpTS.csproj`. (The original
+migration plan doc was retired when the migration completed.)
 
 ## Authoring contract
 


### PR DESCRIPTION
First tier of the 2026-07 cleanup audit. No runtime behavior changes.

- **fix(compile):** replace two raw NUL bytes in `RuntimeEmitter.TSRegExp.cs` with `\0` escapes — they made ripgrep/grep/git-grep treat the 4,571-line file as binary and silently skip it (byte-identical emitted behavior, verified by simulation + 62 regex tests)
- **chore:** .gitignore gaps closed (`/out/` — 5.4MB of profiler DLLs was sitting there untracked-but-trackable, `coverage*.xml`, `.sharpts/`, `node_modules/`, `.agents/`); stale root `SharpTS.dll`/`nul`/`out/` deleted from disk
- **build:** `Directory.Packages.props` central package management (also pins the floating `PrettyPrompt 4.1.*` → 4.1.1, which contradicted `Deterministic=true`); dead `SharpTS.Example.Interop/**` exclusion removed; foreign-source guard now skips dot-directories (matches `ProjectStructureTests` semantics, #1214); `SharpTS.Sdk` pack fails loudly on missing payloads instead of packing empty; dead `embedded-stdlib.md` references repointed (the doc was deliberately deleted in 2ce2e75c)
- **ci:** conformance harnesses now compile-checked (they reference SharpTS.csproj but live outside the sln — API rot was invisible); `publish.yml` gets the LiveNetwork/LoadSensitive filter (a runner DNS hiccup could block a tagged release) + `action-gh-release@v2`; dead macOS step removed with breadcrumb; benchmarks artifact path un-hardcoded; new `examples.yml` (workflow_dispatch) runs the showcase harness

Verified: `dotnet build SharpTS.sln` 0 warnings/0 errors; all three conformance projects build; regex test filter green; `dotnet pack SharpTS.Sdk` now errors with a clear message when payloads are absent.