### PR TITLE
fix: ten bugs surfaced by the cleanup audit

### DIFF
--- a/Compilation/ILCompiler.Classes.cs
+++ b/Compilation/ILCompiler.Classes.cs
@@ -63,7 +63,7 @@ public partial class ILCompiler
             else
             {
                 // Warning: type not found but continue compilation
-                Console.WriteLine($"Warning: External .NET type '{clrTypeName}' not found in loaded assemblies.");
+                AddWarning($"External .NET type '{clrTypeName}' not found in loaded assemblies.");
             }
 
             // Skip DefineType - don't emit TypeBuilder for external types

--- a/Compilation/ILCompiler.Modules.cs
+++ b/Compilation/ILCompiler.Modules.cs
@@ -301,8 +301,8 @@ public partial class ILCompiler
         {
             if (!_classes.ExternalTypes.TryGetValue(name, out var existing) || existing != externalType)
             {
-                Console.WriteLine(
-                    $"Warning: dotnet: import '{name}' ({externalType.FullName}) conflicts with a " +
+                AddWarning(
+                    $"dotnet: import '{name}' ({externalType.FullName}) conflicts with a " +
                     "user-defined class of the same name; the user class wins in compiled dispatch. " +
                     "Rename the import (import { X as Alias }) to use the .NET type.");
             }

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -92,6 +92,17 @@ public partial class ILCompiler
         _runtime?.RequiredSharpTSRuntimeReasons ?? (IReadOnlyCollection<string>)Array.Empty<string>();
 
     /// <summary>
+    /// Non-fatal compilation warnings (e.g. an unresolvable external .NET type).
+    /// Collected instead of written to Console so embedders observe them and the
+    /// compiler never interleaves with the compiled program's own output; the
+    /// CLI prints them to stderr after compilation.
+    /// </summary>
+    public IReadOnlyList<string> Warnings => _warnings;
+    private readonly List<string> _warnings = [];
+
+    internal void AddWarning(string message) => _warnings.Add(message);
+
+    /// <summary>
     /// The assemblies of every external .NET type the compilation bound (@DotNetType
     /// classes and dotnet: imports). These are HARD metadata references in the emitted
     /// IL; the CLI intersects them with the sharpts.json / -r reference set to decide

--- a/Execution/Interpreter.CommonJs.cs
+++ b/Execution/Interpreter.CommonJs.cs
@@ -152,7 +152,11 @@ public partial class Interpreter
                         object? result = Evaluate(exprStmt.Expr);
                         if (result is SharpTSPromise promise)
                         {
-                            promise.Task.GetAwaiter().GetResult();
+                            // Pump the event loop while waiting: a bare GetResult()
+                            // here hard-hangs when the promise needs a timer or I/O
+                            // continuation to settle, because those continuations
+                            // only ever run on this thread.
+                            WaitForPromise(promise);
                         }
                     }
                     catch (ThrowException tex)

--- a/Execution/Interpreter.Operators.cs
+++ b/Execution/Interpreter.Operators.cs
@@ -491,8 +491,6 @@ public partial class Interpreter
 
     private enum PrimitiveHint { Default, Number, String }
 
-    private static readonly List<object?> _toPrimitiveNoArgs = new();
-
     /// <summary>
     /// True when <paramref name="value"/> is a boxed <c>new Number/String/Boolean</c>
     /// wrapper (carries a <c>__primitiveType</c> tag); yields its <c>__primitiveValue</c>.
@@ -562,7 +560,10 @@ public partial class Interpreter
         var fn = obj.GetProperty(name);
         if (fn is SharpTSArrowFunction af && af.HasOwnThis) fn = af.Bind(obj);
         if (fn is not ISharpTSCallable callable) return false;
-        var r = callable.CallBoxed(this, _toPrimitiveNoArgs);
+        // Zero-arg span, not a shared List: a callee mutating its arguments must
+        // not corrupt other calls (the old shared static list was handed to
+        // arbitrary guest callables).
+        var r = callable.CallV2(this, ReadOnlySpan<RuntimeValue>.Empty).ToObject();
         if (IsObjectLike(r)) return false;
         result = r;
         return true;
@@ -581,7 +582,7 @@ public partial class Interpreter
         result = "";
         var resolved = instance.Get(new Token(TokenType.IDENTIFIER, "toString", null, 0));
         if (resolved is not ISharpTSCallable toString) return false;
-        var coerced = toString.CallBoxed(this, _toPrimitiveNoArgs);
+        var coerced = toString.CallV2(this, ReadOnlySpan<RuntimeValue>.Empty).ToObject();
         if (IsObjectLike(coerced)) return false;
         result = coerced as string ?? Stringify(coerced);
         return true;

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -350,9 +350,17 @@ public partial class Interpreter : IDisposable
     /// Schedules a virtual timer to be executed on the main thread.
     /// Returns the VirtualTimer so it can be cancelled later.
     /// </summary>
+    // Monotonic clock for the virtual-timer queue. FireTime values are compared
+    // only against this same clock, never against wall time, so an NTP step or a
+    // manual clock change cannot fire every pending setTimeout early or stall it
+    // for the offset (same non-monotonic-clock bug class as the process.uptime()
+    // Stopwatch fix).
+    private static readonly System.Diagnostics.Stopwatch _timerClock = System.Diagnostics.Stopwatch.StartNew();
+    private static long TimerNowMs => _timerClock.ElapsedMilliseconds;
+
     internal VirtualTimer ScheduleTimer(int delayMs, int intervalMs, Action callback, bool isInterval)
     {
-        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var now = TimerNowMs;
         var fireTime = now + delayMs;
         var timer = new VirtualTimer(fireTime, intervalMs, callback, isInterval);
         lock (_virtualTimersLock)
@@ -518,7 +526,7 @@ public partial class Interpreter : IDisposable
                 return TimeSpan.FromSeconds(60);
             }
 
-            var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            var now = TimerNowMs;
             var ms = priority.FireTime - now;
 
             // Clamp to reasonable range: 0ms to 60 seconds
@@ -876,16 +884,62 @@ public partial class Interpreter : IDisposable
     /// timer callbacks without relying on background thread scheduling.
     /// Uses priority queue for O(log n) timer extraction.
     /// </summary>
+    // FinalizationRegistry instances with at least one registration, drained on
+    // event-loop ticks. Weak: tracking must not keep a guest registry alive.
+    private readonly List<WeakReference<SharpTSFinalizationRegistry>> _finalizationRegistries = [];
+    private readonly object _finalizationRegistriesLock = new();
+
+    /// <summary>
+    /// Enrolls a FinalizationRegistry so its GC-enqueued cleanups are drained on
+    /// event-loop ticks. Without this, registered cleanup callbacks never fired.
+    /// </summary>
+    internal void TrackFinalizationRegistry(SharpTSFinalizationRegistry registry)
+    {
+        lock (_finalizationRegistriesLock)
+        {
+            foreach (var wr in _finalizationRegistries)
+                if (wr.TryGetTarget(out var existing) && ReferenceEquals(existing, registry))
+                    return;
+            _finalizationRegistries.Add(new WeakReference<SharpTSFinalizationRegistry>(registry));
+        }
+    }
+
+    private void DrainFinalizationRegistries()
+    {
+        if (_finalizationRegistries.Count == 0) return;
+        List<SharpTSFinalizationRegistry>? due = null;
+        lock (_finalizationRegistriesLock)
+        {
+            for (int i = _finalizationRegistries.Count - 1; i >= 0; i--)
+            {
+                if (!_finalizationRegistries[i].TryGetTarget(out var registry))
+                {
+                    _finalizationRegistries.RemoveAt(i);
+                    continue;
+                }
+                if (registry.HasPendingCleanups) (due ??= []).Add(registry);
+            }
+        }
+        // Invoke outside the lock: cleanup callbacks are arbitrary guest code.
+        if (due != null)
+            foreach (var registry in due)
+                registry.DrainCleanups(this);
+    }
+
     internal void ProcessPendingCallbacks()
     {
         // Process microtasks first - they always run before any macrotask (timers)
         // This ensures correct JavaScript event loop semantics during busy-wait loops
         ProcessMicrotasks();
 
+        // FinalizationRegistry cleanups ride event-loop ticks (Node runs them as
+        // ordinary tasks after GC observes a target collection).
+        DrainFinalizationRegistries();
+
         // Quick checks before acquiring lock
         if (_isDisposed || !_hasScheduledTimers) return;
 
-        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        var now = TimerNowMs;
         List<VirtualTimer>? toExecute = null;
         List<VirtualTimer>? toReschedule = null;
 
@@ -1401,7 +1455,14 @@ public partial class Interpreter : IDisposable
         if (mainFunc == null)
             return;
 
-        // Get the main function from the environment (single scope traversal)
+        // Get the main function from the environment (single scope traversal).
+        // Deliberately narrowed to SharpTSFunction: `async function main()` is a
+        // SharpTSAsyncFunction and is NOT auto-invoked — hundreds of existing
+        // programs (and this repo's own test corpus) follow the pattern
+        // `async function main() {...} main();`, and auto-invoking would run
+        // them twice. The Promise<...> return types in the gate above exist for
+        // a *sync* main that returns a promise chain; WaitForPromise below
+        // pumps the event loop while that settles.
         if (!_environment.TryGet(mainFunc.Name.Lexeme, out RuntimeValue mainRV))
             return;
 
@@ -1412,19 +1473,24 @@ public partial class Interpreter : IDisposable
         var argv = ProcessBuiltIns.GetArgv();
         // Pass argv only if main expects it
         object? result = mainFunc.Parameters.Count == 0
-            ? mainFn.Call(this, [])
-            : mainFn.Call(this, [argv]);
+            ? mainFn.CallBoxed(this, [])
+            : mainFn.CallBoxed(this, [argv]);
 
-        // If result is a Promise, await it
+        // If result is a Promise, await it — pumping the event loop, because an
+        // async main() typically awaits timers/I-O whose continuations only run
+        // on this thread, and RunEventLoop starts only after this method returns.
+        // A bare GetResult() here deadlocked. If the promise can provably never
+        // settle, WaitForPromise returns with it still pending → no exit code.
         if (result is SharpTSPromise promise)
         {
-            result = promise.Task.GetAwaiter().GetResult();
+            WaitForPromise(promise);
+            result = promise.Task.IsCompletedSuccessfully ? promise.Task.Result : null;
         }
 
         // If result is a number, use it as exit code
         if (result is double exitCode)
         {
-            System.Environment.Exit((int)exitCode);
+            ProcessControl.Exit((int)exitCode);
         }
 
         // Note: RunEventLoop is called by the caller (Interpret or InterpretModules)

--- a/Program.cs
+++ b/Program.cs
@@ -697,6 +697,7 @@ static void EmitCompiledAssembly(string outputPath, bool preserveConstEnums, boo
             ILCompiler compiler = new(assemblyName, preserveConstEnums, useReferenceAssemblies, sdkPath, metadata, references, OutputTarget.Dll);
             compiler.SetDecoratorMode(decoratorMode);
             compileBody(compiler);
+            PrintCompilerWarnings(compiler);
             compiler.Save(tempDllPath);
 
             // Run IL verification on the DLL if requested
@@ -741,6 +742,7 @@ static void EmitCompiledAssembly(string outputPath, bool preserveConstEnums, boo
         ILCompiler compiler = new(assemblyName, preserveConstEnums, useReferenceAssemblies, sdkPath, metadata, references, target);
         compiler.SetDecoratorMode(decoratorMode);
         compileBody(compiler);
+        PrintCompilerWarnings(compiler);
         compiler.Save(outputPath);
 
         GenerateRuntimeConfig(outputPath);
@@ -800,6 +802,17 @@ static void CompileSingleFile(List<Stmt> statements, string outputPath, bool pre
     // Compilation Phase
     EmitCompiledAssembly(outputPath, preserveConstEnums, useReferenceAssemblies, sdkPath, verifyIL, decoratorMode, outputOptions, metadata, references, target, bundlerMode, externalRefs,
         compiler => compiler.Compile(statements, typeMap, deadCodeInfo));
+}
+
+/// <summary>
+/// Prints the compiler's collected non-fatal warnings to stderr. They are collected on the
+/// compiler (not written inside Compilation/) so embedders observe them and compiler chatter
+/// can never interleave with a compiled program's stdout.
+/// </summary>
+static void PrintCompilerWarnings(ILCompiler compiler)
+{
+    foreach (var warning in compiler.Warnings)
+        Console.Error.WriteLine($"Warning: {warning}");
 }
 
 /// <summary>

--- a/Runtime/BuiltIns/FinalizationRegistryBuiltIns.cs
+++ b/Runtime/BuiltIns/FinalizationRegistryBuiltIns.cs
@@ -11,12 +11,16 @@ public static class FinalizationRegistryBuiltIns
     {
         return name switch
         {
-            "register" => BuiltInMethod.CreateV2("register", 1, 3, static (_, recv, args) =>
+            "register" => BuiltInMethod.CreateV2("register", 1, 3, static (interp, recv, args) =>
             {
                 var registry = (SharpTSFinalizationRegistry)recv.ToObject()!;
                 var target = args.Length > 0 ? args[0].ToObject() : null;
                 var heldValue = args.Length > 1 ? args[1].ToObject() : null;
                 var token = args.Length > 2 ? args[2].ToObject() : null;
+                // Enroll with the event loop so pending cleanups actually drain:
+                // registries used to enqueue heldValues that nothing ever read,
+                // so cleanup callbacks never fired.
+                interp.TrackFinalizationRegistry(registry);
                 registry.Register(target!, heldValue, token);
                 return RuntimeValue.Null;
             }),

--- a/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
@@ -410,6 +410,11 @@ public static class ChildProcessModuleInterpreter
             {
                 stdinStream.SetWriteCallback(BuiltInMethod.CreateV2("write", 1, 3, (interp, recv, wargs) =>
                 {
+                    // A dead/closed child stdin must surface through the write
+                    // callback (err-first). Swallowing it and invoking the
+                    // callback with null made a failed child.stdin.write()
+                    // undetectable from guest code.
+                    object? writeError = null;
                     if (wargs.Length > 0 && !wargs[0].IsNull)
                     {
                         try
@@ -417,13 +422,16 @@ public static class ChildProcessModuleInterpreter
                             process.StandardInput.Write(wargs[0].ToObject()!.ToString());
                             process.StandardInput.Flush();
                         }
-                        catch { }
+                        catch
+                        {
+                            writeError = new SharpTSError("write EPIPE") { Code = "EPIPE" };
+                        }
                     }
                     if (wargs.Length > 2 && wargs[2].ToObject() is ISharpTSCallable cb)
-                        cb.Call(interpreter, [null]);
+                        cb.Call(interpreter, [writeError]);
                     else if (wargs.Length > 1 && wargs[1].ToObject() is ISharpTSCallable cb2)
-                        cb2.Call(interpreter, [null]);
-                    return RuntimeValue.True;
+                        cb2.Call(interpreter, [writeError]);
+                    return RuntimeValue.FromBoolean(writeError == null);
                 }));
 
                 // stdin.end() closes the child's StandardInput so it sees EOF.

--- a/Runtime/BuiltIns/ProcessBuiltIns.Signals.cs
+++ b/Runtime/BuiltIns/ProcessBuiltIns.Signals.cs
@@ -164,7 +164,7 @@ public static partial class ProcessBuiltIns
             }
             if (signalName is "SIGINT" or "SIGTERM" or "SIGHUP" or "SIGQUIT" or "SIGBREAK" or "SIGKILL")
             {
-                Environment.Exit(128 + _signalNumbers[signalName]);
+                ProcessControl.Exit(128 + _signalNumbers[signalName]);
             }
             return true; // Untrappable-default-ignore signals (e.g. SIGWINCH)
         }

--- a/Runtime/BuiltIns/ProcessBuiltIns.Warnings.cs
+++ b/Runtime/BuiltIns/ProcessBuiltIns.Warnings.cs
@@ -115,8 +115,8 @@ public static partial class ProcessBuiltIns
     private static object? Abort(Interpreter i, object? r, List<object?> args)
     {
         // Abnormal termination — no 'exit' event, nonzero exit, like SIGABRT.
-        Environment.FailFast("process.abort() called");
-        return null; // Never reached
+        ProcessControl.Abort("process.abort() called");
+        return null; // Reached only when an embedder's AbortHandler returns
     }
 
     /// <summary>

--- a/Runtime/BuiltIns/ProcessBuiltIns.cs
+++ b/Runtime/BuiltIns/ProcessBuiltIns.cs
@@ -362,8 +362,8 @@ public static partial class ProcessBuiltIns
         Environment.ExitCode = exitCode;
         EmitExitEvent(i, exitCode);
 
-        Environment.Exit(exitCode);
-        return null; // Never reached
+        ProcessControl.Exit(exitCode);
+        return null; // Reached only when an embedder's ExitHandler returns
     }
 
     /// <summary>

--- a/Runtime/ProcessControl.cs
+++ b/Runtime/ProcessControl.cs
@@ -1,0 +1,32 @@
+namespace SharpTS.Runtime;
+
+/// <summary>
+/// Central exit point for guest-initiated process termination: process.exit(),
+/// an untrapped fatal signal's default action, process.abort(), and a numeric
+/// return from the main() convention. Library code must route through this
+/// instead of calling Environment.Exit / Environment.FailFast directly so that
+/// embedders (the test host, REPL, LSP server) can intercept — a guest script
+/// ending itself must not take down the host unless the host chose that.
+/// Defaults preserve CLI behavior: real Environment.Exit / Environment.FailFast.
+/// </summary>
+public static class ProcessControl
+{
+    /// <summary>
+    /// Action invoked for a normal guest-requested exit. Replace to intercept
+    /// (e.g. throw a host-recognized exception); restore when done. The default
+    /// terminates the process and never returns.
+    /// </summary>
+    public static Action<int> ExitHandler { get; set; } = Environment.Exit;
+
+    /// <summary>
+    /// Action invoked for process.abort(): abnormal termination — no 'exit'
+    /// event, crash-dump semantics (Node raises SIGABRT). The default,
+    /// Environment.FailFast, writes a crash dump and cannot be caught; hosts
+    /// that must survive a guest abort replace it.
+    /// </summary>
+    public static Action<string> AbortHandler { get; set; } = static message => Environment.FailFast(message);
+
+    public static void Exit(int code) => ExitHandler(code);
+
+    public static void Abort(string message) => AbortHandler(message);
+}

--- a/Runtime/SloppyModeWarnings.cs
+++ b/Runtime/SloppyModeWarnings.cs
@@ -7,9 +7,13 @@ namespace SharpTS.Runtime;
 public static class SloppyModeWarnings
 {
     /// <summary>
-    /// Controls whether sloppy-mode warnings are emitted. Defaults to true.
+    /// Controls whether sloppy-mode warnings are emitted. Off by default: these
+    /// silent failures are spec-legal JavaScript and Node prints nothing for
+    /// them, so warning on stderr polluted ordinary program output. Opt in for
+    /// debugging with SHARPTS_SLOPPY_WARNINGS=1 (or set this when embedding).
     /// </summary>
-    public static bool Enabled { get; set; } = true;
+    public static bool Enabled { get; set; } =
+        Environment.GetEnvironmentVariable("SHARPTS_SLOPPY_WARNINGS") is "1" or "true";
 
     /// <summary>
     /// Emits a warning to stderr when an operation silently fails in sloppy mode.

--- a/Runtime/Types/SharpTSFinalizationRegistry.cs
+++ b/Runtime/Types/SharpTSFinalizationRegistry.cs
@@ -72,7 +72,7 @@ public class SharpTSFinalizationRegistry : ITypeCategorized
         {
             try
             {
-                _cleanupCallback.Call(interpreter!, [heldValue]);
+                _cleanupCallback.CallBoxed(interpreter!, [heldValue]);
             }
             catch
             {
@@ -80,6 +80,13 @@ public class SharpTSFinalizationRegistry : ITypeCategorized
             }
         }
     }
+
+    /// <summary>
+    /// Test seam: enqueues a heldValue exactly as a GC-triggered finalizer would,
+    /// so the event-loop drain wiring can be exercised deterministically (real GC
+    /// timing is unobservable from a test).
+    /// </summary>
+    internal void EnqueueCleanupForTest(object? heldValue) => _pendingCleanups.Enqueue(heldValue);
 
     /// <summary>
     /// Returns true if there are pending cleanups.

--- a/Runtime/Types/SharpTSNetServer.cs
+++ b/Runtime/Types/SharpTSNetServer.cs
@@ -633,9 +633,12 @@ public class SharpTSNetServer : SharpTSEventEmitter, IDisposable
             try { File.Delete(_pipePath); } catch { }
         }
         _cts?.Dispose();
-        foreach (var conn in _connections)
+        // Snapshot: DestroyCore fires the socket's close handler, which removes it
+        // from _connections mid-iteration. (This used to call GetMember("destroy"),
+        // which only *retrieved* the method — every live connection leaked.)
+        foreach (var conn in _connections.ToArray())
         {
-            try { conn.GetMember("destroy"); } catch { }
+            try { if (_interpreter != null) conn.DestroyCore(_interpreter, null); } catch { }
         }
         _connections.Clear();
     }

--- a/Runtime/Types/SharpTSTlsServer.cs
+++ b/Runtime/Types/SharpTSTlsServer.cs
@@ -30,7 +30,7 @@ public class SharpTSTlsServer : SharpTSEventEmitter, IDisposable
     private int _maxConnections = int.MaxValue;
     private X509Certificate2? _certificate;
     private bool _requestCert;
-    private bool _rejectUnauthorized;
+    private bool _rejectUnauthorized = true; // Node's tls.createServer default
     private List<SslApplicationProtocol>? _alpnProtocols;
     private ISharpTSCallable? _sniCallback;
 
@@ -221,6 +221,14 @@ public class SharpTSTlsServer : SharpTSEventEmitter, IDisposable
                                 ServerCertificate = cert,
                                 ClientCertificateRequired = _requestCert,
                                 EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls13,
+                                // rejectUnauthorized was parsed from options but never
+                                // applied — .NET's default validation always rejected
+                                // invalid client certs, so { rejectUnauthorized: false }
+                                // (accept the handshake, expose authorized=false; Node
+                                // semantics) could not work. Only consulted when a
+                                // client certificate was actually requested.
+                                RemoteCertificateValidationCallback = (_, _, _, errors) =>
+                                    !_requestCert || !_rejectUnauthorized || errors == SslPolicyErrors.None,
                             };
 
                             if (_alpnProtocols != null)

--- a/Runtime/Types/WebStreamsHelpers.cs
+++ b/Runtime/Types/WebStreamsHelpers.cs
@@ -388,37 +388,75 @@ internal static class WebStreamsHelpers
         var branch1 = new SharpTSReadableStream(interp, underlyingSource: null, strategy: null);
         var branch2 = new SharpTSReadableStream(interp, underlyingSource: null, strategy: null);
 
-        // Drain the source's existing queue plus any pull-generated chunks
-        // into both branches, synchronously where possible.
-        while (true)
+        PumpNext();
+
+        return new SharpTSArray(new List<object?> { branch1, branch2 });
+
+        // Feeds both branches from the source. Synchronous reads drain inline
+        // (the common already-queued case); an in-flight async pull() continues
+        // on the event loop instead of blocking it — the previous sync
+        // GetResult() here hung the loop for any source with an async pull.
+        void PumpNext()
         {
-            var readTask = source.ReadInternal();
-            if (!readTask.IsCompleted)
+            while (true)
             {
-                // An async pull is in flight — block and wait. For sync sources
-                // (all current tests) this never actually blocks because the
-                // task is completed immediately.
-                readTask.GetAwaiter().GetResult();
+                Task<object?> readTask;
+                try { readTask = source.ReadInternal(); }
+                catch (Exception ex) { Finish(ex); return; }
+
+                if (!readTask.IsCompleted)
+                {
+                    interp.Ref();
+                    readTask.ContinueWith(t => interp.EnqueueCallback(() =>
+                    {
+                        interp.Unref();
+                        if (t.IsFaulted) { Finish(t.Exception?.InnerException ?? t.Exception); return; }
+                        if (HandleResult(t.Result)) PumpNext();
+                    }), CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+                    return;
+                }
+
+                if (readTask.IsFaulted) { Finish(readTask.Exception?.InnerException ?? readTask.Exception); return; }
+                if (!HandleResult(readTask.Result)) return;
             }
-            var result = readTask.Result;
-            if (result is not IDictionary<string, object?> obj)
-            {
-                break;
-            }
+        }
+
+        // Returns true to keep pumping.
+        bool HandleResult(object? result)
+        {
+            if (result is not IDictionary<string, object?> obj) { Finish(error: null); return false; }
             var done = obj.TryGetValue("done", out var d) && d is bool db && db;
-            if (done)
+            if (done) { Finish(error: null); return false; }
+            var chunk = obj.TryGetValue("value", out var v) ? v : SharpTSUndefined.Instance;
+            EnqueueToBranch(branch1, chunk);
+            EnqueueToBranch(branch2, chunk);
+            return true;
+        }
+
+        void Finish(object? error)
+        {
+            if (error != null)
+            {
+                // A failed source read errors both branches (WHATWG tee) —
+                // silently ending them showed the consumer a short, *successful*
+                // stream.
+                branch1.ErrorInternal(error);
+                branch2.ErrorInternal(error);
+            }
+            else
             {
                 branch1.CloseInternal();
                 branch2.CloseInternal();
-                break;
             }
-            var chunk = obj.TryGetValue("value", out var v) ? v : SharpTSUndefined.Instance;
-            try { branch1.EnqueueInternal(chunk); } catch { }
-            try { branch2.EnqueueInternal(chunk); } catch { }
+            if (source.Reader == reader) source.Reader = null;
         }
 
-        if (source.Reader == reader) source.Reader = null;
-
-        return new SharpTSArray(new List<object?> { branch1, branch2 });
+        static void EnqueueToBranch(SharpTSReadableStream branch, object? chunk)
+        {
+            // A closed/canceled/errored branch skips the chunk (spec: the other
+            // branch keeps receiving); anything else must not be swallowed.
+            try { branch.EnqueueInternal(chunk); }
+            catch (InvalidOperationException) { }
+        }
     }
 }

--- a/SharpTS.Tests/InterpreterTests/FinalizationRegistryDrainTests.cs
+++ b/SharpTS.Tests/InterpreterTests/FinalizationRegistryDrainTests.cs
@@ -1,0 +1,80 @@
+using SharpTS.Execution;
+using SharpTS.Runtime;
+using SharpTS.Runtime.BuiltIns;
+using SharpTS.Runtime.Types;
+using Xunit;
+
+namespace SharpTS.Tests.InterpreterTests;
+
+/// <summary>
+/// FinalizationRegistry cleanup callbacks must actually fire: the GC finalizer
+/// path enqueued heldValues into the registry's pending queue, but nothing ever
+/// drained that queue, so registered cleanup callbacks never ran. The event
+/// loop now drains enrolled registries on each tick. Real GC timing is
+/// untestable, so these tests use the internal enqueue seam that matches
+/// exactly what the GC-triggered finalizer does.
+/// </summary>
+public class FinalizationRegistryDrainTests
+{
+    private static (SharpTSFinalizationRegistry Registry, List<object?> Received) MakeRegistry()
+    {
+        var received = new List<object?>();
+        var callback = BuiltInMethod.CreateV2("cleanup", 1, (interp, recv, args) =>
+        {
+            received.Add(args.Length > 0 ? args[0].ToObject() : null);
+            return RuntimeValue.Undefined;
+        });
+        return (new SharpTSFinalizationRegistry(callback), received);
+    }
+
+    [Fact]
+    public void PendingCleanups_DrainOnEventLoopTick()
+    {
+        using var interpreter = new Interpreter(stdout: TextWriter.Null, stderr: TextWriter.Null);
+        var (registry, received) = MakeRegistry();
+        interpreter.TrackFinalizationRegistry(registry);
+
+        registry.EnqueueCleanupForTest("held-1");
+        registry.EnqueueCleanupForTest("held-2");
+        interpreter.ProcessPendingCallbacks();
+
+        Assert.Equal(["held-1", "held-2"], received);
+    }
+
+    [Fact]
+    public void RegisterBuiltIn_EnrollsRegistryWithEventLoop()
+    {
+        using var interpreter = new Interpreter(stdout: TextWriter.Null, stderr: TextWriter.Null);
+        var (registry, received) = MakeRegistry();
+
+        // Drive the guest-visible register() built-in; it must enroll the
+        // registry with the interpreter's event loop.
+        var register = (BuiltInMethod)FinalizationRegistryBuiltIns.GetMember(registry, "register")!;
+        register.Bind(registry).CallV2(
+            interpreter,
+            [RuntimeValue.FromObject(new SharpTSObject(new Dictionary<string, object?>())), RuntimeValue.FromString("held-guest")]);
+
+        registry.EnqueueCleanupForTest("held-guest");
+        interpreter.ProcessPendingCallbacks();
+
+        Assert.Equal(["held-guest"], received);
+    }
+
+    [Fact]
+    public void UntrackedRegistry_IsNotKeptAliveByInterpreter()
+    {
+        using var interpreter = new Interpreter(stdout: TextWriter.Null, stderr: TextWriter.Null);
+        var weak = TrackCollectible(interpreter);
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        Assert.False(weak.TryGetTarget(out _));
+
+        static WeakReference<SharpTSFinalizationRegistry> TrackCollectible(Interpreter interpreter)
+        {
+            var (registry, _) = MakeRegistry();
+            interpreter.TrackFinalizationRegistry(registry);
+            return new WeakReference<SharpTSFinalizationRegistry>(registry);
+        }
+    }
+}

--- a/SharpTS.Tests/InterpreterTests/ProcessControlHookTests.cs
+++ b/SharpTS.Tests/InterpreterTests/ProcessControlHookTests.cs
@@ -1,0 +1,67 @@
+using SharpTS.Runtime;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.InterpreterTests;
+
+/// <summary>
+/// process.exit(), process.abort(), and untrapped fatal-signal defaults route
+/// through <see cref="ProcessControl"/> so an embedder (this test host included)
+/// can intercept guest-initiated termination — previously library code called
+/// Environment.Exit / Environment.FailFast directly, so any guest script doing
+/// process.exit() took down the whole host, and process.abort() additionally
+/// wrote a crash dump. Handler swaps are process-wide: tests in this class run
+/// serially (same class) and restore the defaults in finally; no other test can
+/// legitimately trigger these paths (before this change it would have died).
+/// </summary>
+public class ProcessControlHookTests
+{
+    [Fact]
+    public void ProcessExit_RoutesThroughExitHandler()
+    {
+        var original = ProcessControl.ExitHandler;
+        int? captured = null;
+        try
+        {
+            ProcessControl.ExitHandler = code => captured = code;
+            var output = TestHarness.RunInterpreted("""
+                process.exit(7);
+                console.log("after-exit");
+                """);
+            Assert.Equal(7, captured);
+            // With a handler that returns, the guest continues — that documents
+            // the embedder contract: throw from the handler to unwind instead.
+            Assert.Contains("after-exit", output);
+        }
+        finally { ProcessControl.ExitHandler = original; }
+    }
+
+    [Fact]
+    public void ProcessAbort_RoutesThroughAbortHandler()
+    {
+        var original = ProcessControl.AbortHandler;
+        string? captured = null;
+        try
+        {
+            ProcessControl.AbortHandler = message => captured = message;
+            TestHarness.RunInterpreted("process.abort();");
+            Assert.Equal("process.abort() called", captured);
+        }
+        finally { ProcessControl.AbortHandler = original; }
+    }
+
+    [Fact]
+    public void SelfSignal_DefaultAction_RoutesThroughExitHandler()
+    {
+        var original = ProcessControl.ExitHandler;
+        int? captured = null;
+        try
+        {
+            ProcessControl.ExitHandler = code => captured = code;
+            // SIGTERM = 15; Node's default action exits with 128 + signal.
+            TestHarness.RunInterpreted("process.kill(process.pid, 'SIGTERM');");
+            Assert.Equal(128 + 15, captured);
+        }
+        finally { ProcessControl.ExitHandler = original; }
+    }
+}

--- a/SharpTS.Tests/SharedTests/AsyncEntrypointPumpTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncEntrypointPumpTests.cs
@@ -1,0 +1,86 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Interpreter entry points that wait on a guest promise must pump the event
+/// loop while waiting. Previously three sites blocked with a bare
+/// <c>GetAwaiter().GetResult()</c> — async <c>main()</c>, a CommonJS module's
+/// top-level promise-yielding expression, and <c>ReadableStream.tee()</c> over
+/// a source with an async <c>pull()</c> — so a timer/IO continuation that could
+/// only run on the blocked thread never ran and the program hard-hung (these
+/// tests previously died on the harness timeout). Interpreted-only: the fixes
+/// are in the interpreter's entry points; compiled mode has its own event-loop
+/// bootstrap covered by existing shared tests.
+/// </summary>
+public class AsyncEntrypointPumpTests
+{
+    [Fact]
+    public void SyncMain_ReturningTimerPromise_Completes()
+    {
+        // The main() auto-invoke convention covers a *sync* main returning a
+        // promise chain (async main is deliberately not auto-invoked — the
+        // `async function main() {...} main();` pattern would run twice).
+        var output = TestHarness.RunInterpreted("""
+            function main(): Promise<void> {
+                return new Promise<void>(resolve => setTimeout(resolve, 10))
+                    .then(() => { console.log("main-done"); });
+            }
+            """);
+        Assert.Contains("main-done", output);
+    }
+
+    [Fact]
+    public void CommonJs_TopLevelAsyncIife_AwaitingTimer_Completes()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.cjs"] = """
+                (async () => {
+                    await new Promise(resolve => setTimeout(resolve, 10));
+                    console.log("cjs-done");
+                })();
+                """
+        };
+        var output = TestHarness.RunModules(files, "main.cjs", ExecutionMode.Interpreted);
+        Assert.Contains("cjs-done", output);
+    }
+
+    [Fact]
+    public void ReadableStreamTee_AsyncPull_DeliversToBothBranches()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                let n = 0;
+                const rs = new ReadableStream({
+                    async pull(c) {
+                        await new Promise<void>(resolve => setTimeout(resolve, 1));
+                        if (n < 3) c.enqueue(n++);
+                        else c.close();
+                    }
+                });
+                const branches = rs.tee();
+                const r1 = branches[0].getReader();
+                const r2 = branches[1].getReader();
+                async function run() {
+                    const a1 = await r1.read();
+                    const a2 = await r1.read();
+                    const a3 = await r1.read();
+                    const a4 = await r1.read();
+                    const b1 = await r2.read();
+                    const b2 = await r2.read();
+                    const b3 = await r2.read();
+                    const b4 = await r2.read();
+                    console.log(a1.value, a2.value, a3.value, a4.done);
+                    console.log(b1.value, b2.value, b3.value, b4.done);
+                }
+                run();
+                """
+        };
+        var output = TestHarness.RunModules(files, "main.ts", ExecutionMode.Interpreted);
+        Assert.Equal("0 1 2 true\n0 1 2 true\n", output);
+    }
+
+}

--- a/TypeSystem/TypeChecker.Operators.cs
+++ b/TypeSystem/TypeChecker.Operators.cs
@@ -761,10 +761,13 @@ public partial class TypeChecker
         // typeof never throws on undeclared variables - it returns "undefined"
         if (unary.Operator.Type == TokenType.TYPEOF)
         {
-            // Still type-check the operand if possible, but don't fail on undeclared variables
+            // Still type-check the operand if possible, but don't fail on undeclared
+            // variables. Only the undeclared-name failure (TS2304) is legal to
+            // swallow here — any other type error in the operand must surface.
             if (unary.Right is Expr.Variable)
             {
-                try { CheckExpr(unary.Right); } catch (TypeCheckException) { }
+                try { CheckExpr(unary.Right); }
+                catch (TypeCheckException ex) when (ex.Diagnostic.TsCode == "TS2304") { }
             }
             else
             {


### PR DESCRIPTION
Second tier of the 2026-07 cleanup audit (stacked on #1295). Every fix has a test where a deterministic one is possible; **full suite: 15,747/15,747 green** (9 new tests).

**Real bugs fixed:**
1. `SharpTSNetServer.Dispose` fetched the `destroy` method without invoking it — every live connection leaked, hidden by an empty catch
2. CommonJS top-level promise expressions and sync `main()`'s returned promise blocked with a bare `GetResult()` and **no event-loop pump** — hard hang whenever settling needed a timer/IO continuation; both now use the existing `WaitForPromise`. (Investigation also showed `async function main()` is *never* auto-invoked — deliberately kept that way and documented: 633 occurrences in the test corpus alone use `async function main() {...} main();`, which auto-invoke would double-run. First attempt did widen it: 418 tests failed with doubled output; reverted with a comment so nobody re-attempts it.)
3. **FinalizationRegistry cleanup callbacks never fired** — GC finalizers enqueued heldValues, nothing drained the queue (`DrainCleanups` had zero callers). `register()` now enrolls the registry weakly with the interpreter; ticks drain it
4. `ReadableStream.tee()` hung on async `pull()` sources (blocking drain → event-loop pump); failed source reads now error both branches per WHATWG instead of presenting a short *successful* stream
5. `child.stdin.write()` to a dead child: error swallowed **and** callback invoked with success — now err-first `EPIPE`, returns `false`. (No deterministic test: Windows pipe buffers accept writes to dead children until full; verified by inspection + child_process suite)
6. `process.abort()` called `Environment.FailFast` (crash dump, uninterceptable) and `process.exit()`/fatal-signal defaults called `Environment.Exit` from library code — any guest script could kill an embedding host. New `ProcessControl.Exit/Abort` hooks; CLI defaults unchanged
7. `tls.createServer` `rejectUnauthorized` was parsed and ignored; now applied (Node default `true`). No test — mutual-TLS cert fixtures are heavy; guarded by the TLS suite
8. Virtual-timer queue ran on wall-clock `UtcNow` — an NTP step fired every pending `setTimeout` early or stalled it; now monotonic `Stopwatch` (same class as the `process.uptime` fix)
9. `ToPrimitive` passed a **shared mutable static `List`** as the args of arbitrary guest `valueOf`/`toString` calls; now a zero-arg span
10. ILCompiler wrote warnings to stdout from inside `Compilation/` (interleaves with the program's own output; contradicts the CompilationService no-Console contract) → collected on `ILCompiler.Warnings`, CLI prints to stderr. `typeof x` swallow narrowed to TS2304. `SloppyModeWarnings` now defaults off (spec-legal silent failures; Node prints nothing) with `SHARPTS_SLOPPY_WARNINGS=1` opt-in

**Audit items resolved as not-bugs:** parameter decorators work in both modes under `--experimentalDecorators` (verified empirically — `ApplyParameterDecorators` is genuinely dead code, queued for the dead-code tier); `AbortSignal._ownedCts` is a deliberate GC pin, not a leak.