### PR TITLE
test: [ModeData] attribute sweep + shared test helpers

### DIFF
--- a/SharpTS.Tests/AutoAccessorTests/AutoAccessorTests.cs
+++ b/SharpTS.Tests/AutoAccessorTests/AutoAccessorTests.cs
@@ -10,8 +10,7 @@ public class AutoAccessorTests
 {
     #region Basic Auto-Accessor Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_BasicGetSet(ExecutionMode mode)
     {
         var code = @"
@@ -26,8 +25,7 @@ public class AutoAccessorTests
         Assert.Equal("10\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_MultipleProperties(ExecutionMode mode)
     {
         var code = @"
@@ -44,8 +42,7 @@ public class AutoAccessorTests
         Assert.Equal("15\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_WithStringType(ExecutionMode mode)
     {
         var code = @"
@@ -60,8 +57,7 @@ public class AutoAccessorTests
         Assert.Equal("Alice\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_WithInitializer(ExecutionMode mode)
     {
         var code = @"
@@ -75,8 +71,7 @@ public class AutoAccessorTests
         Assert.Equal("42\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_WithoutInitializer(ExecutionMode mode)
     {
         var code = @"
@@ -94,8 +89,7 @@ public class AutoAccessorTests
 
     #region Static Auto-Accessor Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_Static_BasicGetSet(ExecutionMode mode)
     {
         var code = @"
@@ -109,8 +103,7 @@ public class AutoAccessorTests
         Assert.Equal("5\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_Static_SharedAcrossInstances(ExecutionMode mode)
     {
         var code = @"
@@ -129,8 +122,7 @@ public class AutoAccessorTests
         Assert.Equal("3\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_Static_WithInitializer(ExecutionMode mode)
     {
         var code = @"
@@ -147,8 +139,7 @@ public class AutoAccessorTests
 
     #region Readonly Auto-Accessor Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_Readonly_CanRead(ExecutionMode mode)
     {
         var code = @"
@@ -162,8 +153,7 @@ public class AutoAccessorTests
         Assert.Equal("abc123\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_Readonly_ThrowsOnSet(ExecutionMode mode)
     {
         var code = @"
@@ -182,8 +172,7 @@ public class AutoAccessorTests
 
     #region Inheritance Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_Inheritance_InheritedFromParent(ExecutionMode mode)
     {
         var code = @"
@@ -200,8 +189,7 @@ public class AutoAccessorTests
         Assert.Equal("Rex\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_Inheritance_Override(ExecutionMode mode)
     {
         var code = @"
@@ -222,8 +210,7 @@ public class AutoAccessorTests
 
     #region Multiple Instances Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_MultipleInstances_IsolatedStorage(ExecutionMode mode)
     {
         var code = @"
@@ -244,8 +231,7 @@ public class AutoAccessorTests
 
     #region Type Inference Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_TypeInference_FromInitializer(ExecutionMode mode)
     {
         // When no explicit type annotation is provided, the type is inferred from initializer.
@@ -266,8 +252,7 @@ public class AutoAccessorTests
 
     #region Mixed Member Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_WithRegularFields(ExecutionMode mode)
     {
         var code = @"
@@ -282,8 +267,7 @@ public class AutoAccessorTests
         Assert.Equal("3\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_WithMethods(ExecutionMode mode)
     {
         var code = @"
@@ -303,8 +287,7 @@ public class AutoAccessorTests
         Assert.Equal("2\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_WithManualAccessor(ExecutionMode mode)
     {
         var code = @"
@@ -326,8 +309,7 @@ public class AutoAccessorTests
 
     #region Mixed Static and Instance Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AutoAccessor_MixedStaticAndInstance(ExecutionMode mode)
     {
         var code = @"

--- a/SharpTS.Tests/BuildTests/ProjectStructureTests.cs
+++ b/SharpTS.Tests/BuildTests/ProjectStructureTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using SharpTS.Tests.Infrastructure;
 using Xunit;
 
 namespace SharpTS.Tests.BuildTests;
@@ -19,7 +20,7 @@ public class ProjectStructureTests
     [Fact]
     public void EverySiblingProject_IsExcludedFromCoreCompilation()
     {
-        var repoRoot = FindRepoRoot();
+        var repoRoot = RepoPaths.FindRepoRoot();
         var coreCsproj = Path.Combine(repoRoot, "SharpTS.csproj");
         var csprojText = File.ReadAllText(coreCsproj);
 
@@ -82,18 +83,4 @@ public class ProjectStructureTests
             seg.Equals("obj", StringComparison.OrdinalIgnoreCase));
     }
 
-    private static string FindRepoRoot()
-    {
-        var dir = AppContext.BaseDirectory;
-        while (dir != null)
-        {
-            if (Directory.Exists(Path.Combine(dir, "Compilation")) &&
-                File.Exists(Path.Combine(dir, "SharpTS.csproj")))
-            {
-                return dir;
-            }
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new InvalidOperationException("Could not find repository root");
-    }
 }

--- a/SharpTS.Tests/CompilerTests/ArrowFunctionDefaultParameterTests.cs
+++ b/SharpTS.Tests/CompilerTests/ArrowFunctionDefaultParameterTests.cs
@@ -13,8 +13,7 @@ namespace SharpTS.Tests.CompilerTests;
 /// </summary>
 public class ArrowFunctionDefaultParameterTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionExpression_NumericDefault_OmittedArg(ExecutionMode mode)
     {
         var source = """
@@ -24,8 +23,7 @@ public class ArrowFunctionDefaultParameterTests
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Arrow_NumericDefault_OmittedArg(ExecutionMode mode)
     {
         var source = """
@@ -35,8 +33,7 @@ public class ArrowFunctionDefaultParameterTests
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Arrow_NumericDefault_ArgPresent_DefaultNotApplied(ExecutionMode mode)
     {
         var source = """
@@ -46,8 +43,7 @@ public class ArrowFunctionDefaultParameterTests
         Assert.Equal("14\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Arrow_BooleanDefault_OmittedArg(ExecutionMode mode)
     {
         var source = """
@@ -57,8 +53,7 @@ public class ArrowFunctionDefaultParameterTests
         Assert.Equal("YN\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Arrow_StringDefault_OmittedArg(ExecutionMode mode)
     {
         var source = """
@@ -68,8 +63,7 @@ public class ArrowFunctionDefaultParameterTests
         Assert.Equal("AB\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CapturingArrow_NumericDefault_OmittedArg(ExecutionMode mode)
     {
         var source = """
@@ -80,8 +74,7 @@ public class ArrowFunctionDefaultParameterTests
         Assert.Equal("107,101\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_NumericDefault_OmittedArg(ExecutionMode mode)
     {
         var source = """
@@ -91,8 +84,7 @@ public class ArrowFunctionDefaultParameterTests
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_DefaultWithAwait_OmittedArg(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/CompilerTests/ClassMethodDefaultParameterTests.cs
+++ b/SharpTS.Tests/CompilerTests/ClassMethodDefaultParameterTests.cs
@@ -25,8 +25,7 @@ public class ClassMethodDefaultParameterTests
 {
     // ---- Constructors (parameter properties, value-type + reference) -------
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Constructor_ParameterProperty_NumericDefault_Omitted(ExecutionMode mode)
     {
         var source = """
@@ -36,8 +35,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("99\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Constructor_ParameterProperty_NumericDefault_ExplicitUndefined(ExecutionMode mode)
     {
         var source = """
@@ -47,8 +45,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("99\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Constructor_ParameterProperty_NumericDefault_Present(ExecutionMode mode)
     {
         var source = """
@@ -58,8 +55,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Constructor_StringDefault_OmittedArg(ExecutionMode mode)
     {
         var source = """
@@ -69,8 +65,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("anon\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Constructor_BooleanDefault_ExplicitUndefined(ExecutionMode mode)
     {
         var source = """
@@ -83,8 +78,7 @@ public class ClassMethodDefaultParameterTests
 
     // ---- Private methods (instance + static, value-type + reference) -------
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateMethod_NumericDefault_OmittedArg(ExecutionMode mode)
     {
         var source = """
@@ -97,8 +91,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("15\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateMethod_NumericDefault_ExplicitUndefined(ExecutionMode mode)
     {
         var source = """
@@ -111,8 +104,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("15\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateMethod_MultipleDefaults_AllOmitted(ExecutionMode mode)
     {
         var source = """
@@ -125,8 +117,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateMethod_PartialApplication_RemainingDefaults(ExecutionMode mode)
     {
         var source = """
@@ -139,8 +130,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("15\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticPrivateMethod_NumericDefault_OmittedArg(ExecutionMode mode)
     {
         var source = """
@@ -155,8 +145,7 @@ public class ClassMethodDefaultParameterTests
 
     // ---- Free functions (value-type default + explicit undefined, #705 (a)) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FreeFunction_NumericDefault_ExplicitUndefined(ExecutionMode mode)
     {
         var source = """
@@ -166,8 +155,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FreeFunction_NumericDefault_OmittedArg(ExecutionMode mode)
     {
         var source = """
@@ -180,8 +168,7 @@ public class ClassMethodDefaultParameterTests
     // ---- Reference-type defaults on (virtual) instance & static methods ----
     // These fire without changing the slot type, so override matching is preserved.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethod_StringDefault_OmittedArg(ExecutionMode mode)
     {
         var source = """
@@ -192,8 +179,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("Hi World\nHi Bob\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticMethod_StringDefault_OmittedArg(ExecutionMode mode)
     {
         var source = """
@@ -203,8 +189,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("Hi World\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethod_ArgPresent_DefaultNotApplied(ExecutionMode mode)
     {
         // Argument present: no default-firing needed; value-type slot stays fast and correct.
@@ -217,8 +202,7 @@ public class ClassMethodDefaultParameterTests
 
     // ---- Override safety: widening must NOT change a virtual method's signature ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_DerivedAddsDefault_StillOverrides(ExecutionMode mode)
     {
         // Regression guard: a derived override that adds a default to a value-type param the base
@@ -233,8 +217,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_BothDefault_DispatchesToDerived(ExecutionMode mode)
     {
         var source = """
@@ -250,8 +233,7 @@ public class ClassMethodDefaultParameterTests
     // A base-typed call must reach the derived override even though its wider CLR arity would
     // otherwise take a new vtable slot. Fixed by emitting a base-arity override bridge.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_DerivedAddsValueTypeDefault_BaseTypedDispatchesToDerived(ExecutionMode mode)
     {
         var source = """
@@ -263,8 +245,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("103\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_DerivedAddsReferenceTypeDefault_BaseTypedDispatchesToDerived(ExecutionMode mode)
     {
         // Reference-type added default proves the gap is dispatch, not default-firing.
@@ -277,8 +258,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("x3Z\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_DerivedAddsNoDefaultOptional_BaseTypedDispatchesToDerived(ExecutionMode mode)
     {
         // Added optional with no default: the derived runs with the param undefined.
@@ -291,8 +271,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("D:3:u\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_DerivedAddsMultipleDefaults_BaseTypedDispatchesToDerived(ExecutionMode mode)
     {
         var source = """
@@ -304,8 +283,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("Q:1:7:z\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_ThreeLevelChain_BaseAndMidTypedReachMostDerived(ExecutionMode mode)
     {
         // Each level adds an arity; both a base-typed and a mid-typed call must land on L2.
@@ -321,8 +299,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("L2:3:1:2\nL2:3:1:2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_DerivedAddsDefault_DirectCallStillWorks(ExecutionMode mode)
     {
         // Regression: the direct (derived-typed) call path is unaffected by the bridge.
@@ -337,8 +314,7 @@ public class ClassMethodDefaultParameterTests
 
     // ---- Value-type defaults on (virtual) instance & static methods (#723/#737) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethod_NumericDefault_Omitted(ExecutionMode mode)
     {
         var source = """
@@ -348,8 +324,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("15\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethod_NumericDefault_ExplicitUndefined(ExecutionMode mode)
     {
         var source = """
@@ -359,8 +334,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("15\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticMethod_NumericDefault_Omitted(ExecutionMode mode)
     {
         var source = """
@@ -371,8 +345,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("15\n15\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethod_BooleanDefault_Omitted(ExecutionMode mode)
     {
         var source = """
@@ -383,8 +356,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("true\nfalse\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_DerivedAddsDefault_OmittedFiresDerivedDefault(ExecutionMode mode)
     {
         // The derived override adds a value-type default the base declares as required; calling it
@@ -400,8 +372,7 @@ public class ClassMethodDefaultParameterTests
 
     // ---- Generator / async-generator method defaults (#737) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorMethod_NumericDefault_Omitted(ExecutionMode mode)
     {
         var source = """
@@ -413,8 +384,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("1,10\n1,2\n1,10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FreeGenerator_NumericDefault_Omitted(ExecutionMode mode)
     {
         var source = """
@@ -424,8 +394,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("3,7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGeneratorMethod_NumericDefault_Omitted(ExecutionMode mode)
     {
         var source = """
@@ -441,8 +410,7 @@ public class ClassMethodDefaultParameterTests
 
     // ---- #739: direct call pads omitted optional with `undefined`, not null ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethod_OmittedOptional_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -452,8 +420,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticMethod_OmittedOptional_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -463,8 +430,7 @@ public class ClassMethodDefaultParameterTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Constructor_OmittedOptional_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -477,8 +443,7 @@ public class ClassMethodDefaultParameterTests
     // ---- Generator `??` over an omitted optional (regression: #739 padding exposed a latent
     //      state-machine nullish-coalescing bug that ignored the `$Undefined` sentinel) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorNullishCoalescing_OmittedOptional_EvaluatesRight(ExecutionMode mode)
     {
         // `pop(error?)` does `error ?? this.arr.pop()`. With `error` omitted (→ `undefined`), the

--- a/SharpTS.Tests/CompilerTests/CompilationContextFactoryTests.cs
+++ b/SharpTS.Tests/CompilerTests/CompilationContextFactoryTests.cs
@@ -1,3 +1,4 @@
+using SharpTS.Tests.Infrastructure;
 using Xunit;
 
 namespace SharpTS.Tests.CompilerTests;
@@ -24,7 +25,7 @@ public class CompilationContextFactoryTests
     [Fact]
     public void CompilationContext_IsOnlyConstructedInTheFactoryLayer()
     {
-        var repoRoot = FindRepoRoot();
+        var repoRoot = RepoPaths.FindRepoRoot();
         var compilationDir = Path.Combine(repoRoot, "Compilation");
         var violations = new List<string>();
 
@@ -58,18 +59,4 @@ public class CompilationContextFactoryTests
             string.Join("\n", violations));
     }
 
-    private static string FindRepoRoot()
-    {
-        var dir = AppContext.BaseDirectory;
-        while (dir != null)
-        {
-            if (Directory.Exists(Path.Combine(dir, "Compilation")) &&
-                File.Exists(Path.Combine(dir, "SharpTS.csproj")))
-            {
-                return dir;
-            }
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new InvalidOperationException("Could not find repository root");
-    }
 }

--- a/SharpTS.Tests/CompilerTests/LiveNetworkHermeticityTests.cs
+++ b/SharpTS.Tests/CompilerTests/LiveNetworkHermeticityTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using SharpTS.Tests.Infrastructure;
 using Xunit;
 
 namespace SharpTS.Tests.CompilerTests;
@@ -113,7 +114,7 @@ public class LiveNetworkHermeticityTests
     /// <summary>Enumerates (repo-relative path, absolute path) for every test .cs file, excluding bin/obj.</summary>
     private static IEnumerable<(string Relative, string Full)> EnumerateTestSources()
     {
-        var repoRoot = FindRepoRoot();
+        var repoRoot = RepoPaths.FindRepoRoot();
         var testsDir = Path.Combine(repoRoot, "SharpTS.Tests");
         foreach (var file in Directory.GetFiles(testsDir, "*.cs", SearchOption.AllDirectories))
         {
@@ -147,18 +148,4 @@ public class LiveNetworkHermeticityTests
         return host is not ("localhost" or "127.0.0.1" or "::1" or "0.0.0.0" or "");
     }
 
-    private static string FindRepoRoot()
-    {
-        var dir = AppContext.BaseDirectory;
-        while (dir != null)
-        {
-            if (Directory.Exists(Path.Combine(dir, "Compilation")) &&
-                File.Exists(Path.Combine(dir, "SharpTS.csproj")))
-            {
-                return dir;
-            }
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new InvalidOperationException("Could not find repository root");
-    }
 }

--- a/SharpTS.Tests/CompilerTests/NonEscapingArrowDirectCallTests.cs
+++ b/SharpTS.Tests/CompilerTests/NonEscapingArrowDirectCallTests.cs
@@ -14,8 +14,7 @@ namespace SharpTS.Tests.CompilerTests;
 /// </summary>
 public class NonEscapingArrowDirectCallTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CapturingArrow_InvokedByName_IsCorrect(ExecutionMode mode)
     {
         // The canonical #858 shape: arrow captures the loop var and is called directly each iteration.
@@ -33,8 +32,7 @@ public class NonEscapingArrowDirectCallTests
         Assert.Equal("999000\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CapturingArrow_MultipleTypedArgs_IsCorrect(ExecutionMode mode)
     {
         var source = """
@@ -51,8 +49,7 @@ public class NonEscapingArrowDirectCallTests
         Assert.Equal("505500\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BooleanReturningArrow_InvokedByName_IsCorrect(ExecutionMode mode)
     {
         var source = """
@@ -70,8 +67,7 @@ public class NonEscapingArrowDirectCallTests
         Assert.Equal("10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EscapingArrow_PassedAsArgument_KeepsWrapperSemantics(ExecutionMode mode)
     {
         var source = """
@@ -85,8 +81,7 @@ public class NonEscapingArrowDirectCallTests
         Assert.Equal("42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EscapingArrow_Returned_KeepsWrapperSemantics(ExecutionMode mode)
     {
         var source = """
@@ -99,8 +94,7 @@ public class NonEscapingArrowDirectCallTests
         Assert.Equal("15\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EscapingArrow_StoredInArray_KeepsWrapperSemantics(ExecutionMode mode)
     {
         var source = """
@@ -114,8 +108,7 @@ public class NonEscapingArrowDirectCallTests
         Assert.Equal("10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RecursiveArrow_ViaName_KeepsWrapperSemantics(ExecutionMode mode)
     {
         // The arrow references itself by name from within its own (nested) body, so the name is
@@ -130,8 +123,7 @@ public class NonEscapingArrowDirectCallTests
         Assert.Equal("120\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReassignedBinding_IsDisqualified_AndCorrect(ExecutionMode mode)
     {
         var source = """
@@ -145,8 +137,7 @@ public class NonEscapingArrowDirectCallTests
         Assert.Equal("107\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SameNameInTwoScopes_IsDisqualified_AndCorrect(ExecutionMode mode)
     {
         // `dup` is declared in two functions; the whole-program single-declaration guard disqualifies
@@ -165,8 +156,7 @@ public class NonEscapingArrowDirectCallTests
         Assert.Equal("2,3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonCapturingArrow_InvokedByName_IsCorrect(ExecutionMode mode)
     {
         // Non-capturing arrows fall through to the wrapper path (no display class to key on) but
@@ -181,8 +171,7 @@ public class NonEscapingArrowDirectCallTests
         Assert.Equal("42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DirectCallArrow_CapturesAcrossIterations_FreshBinding(ExecutionMode mode)
     {
         // Per-iteration `let` capture: each arrow must see its own iteration's `i`. A broken
@@ -206,8 +195,7 @@ public class NonEscapingArrowDirectCallTests
 
     // ---- #858 follow-up: non-capturing arrows compile to a direct static `call` ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonCapturingArrow_InLoop_IsCorrect(ExecutionMode mode)
     {
         // The main perf shape: a non-capturing arrow declared and called every iteration. Previously
@@ -228,8 +216,7 @@ public class NonEscapingArrowDirectCallTests
         Assert.Equal("504500\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonCapturingArrow_MultipleArgs_AndBooleanReturn(ExecutionMode mode)
     {
         var source = """
@@ -249,8 +236,7 @@ public class NonEscapingArrowDirectCallTests
         Assert.Equal("12\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonCapturingAndCapturing_InSameFunction_BothCorrect(ExecutionMode mode)
     {
         // A non-capturing arrow (static call) and a capturing arrow (callvirt Invoke) coexist; the two
@@ -271,8 +257,7 @@ public class NonEscapingArrowDirectCallTests
         Assert.Equal("19800\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonCapturingArrow_NameAlsoAParameterElsewhere_StaysCorrect(ExecutionMode mode)
     {
         // Scope-collision guard for the non-capturing path: `dup` is an optimized non-capturing arrow in

--- a/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
+++ b/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
@@ -60,7 +60,7 @@ public class StandaloneDllTests
     [Fact]
     public void CompilationFiles_ShouldNotUseTypeofForEmittedIL()
     {
-        var repoRoot = FindRepoRoot();
+        var repoRoot = RepoPaths.FindRepoRoot();
         var compilationDir = Path.Combine(repoRoot, "Compilation");
         var violations = new List<string>();
 
@@ -116,7 +116,7 @@ public class StandaloneDllTests
     [Fact]
     public void CompilationFiles_ShouldNotIntroduceNewSharpTsLateBindingOutsideAllowlist()
     {
-        var repoRoot = FindRepoRoot();
+        var repoRoot = RepoPaths.FindRepoRoot();
         var compilationDir = Path.Combine(repoRoot, "Compilation");
         var violations = new List<string>();
 
@@ -1414,18 +1414,4 @@ public class StandaloneDllTests
         }
     }
 
-    private static string FindRepoRoot()
-    {
-        var dir = AppContext.BaseDirectory;
-        while (dir != null)
-        {
-            if (Directory.Exists(Path.Combine(dir, "Compilation")) &&
-                File.Exists(Path.Combine(dir, "SharpTS.csproj")))
-            {
-                return dir;
-            }
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new InvalidOperationException("Could not find repository root");
-    }
 }

--- a/SharpTS.Tests/CompilerTests/ValueCallUndefinedPaddingTests.cs
+++ b/SharpTS.Tests/CompilerTests/ValueCallUndefinedPaddingTests.cs
@@ -12,8 +12,7 @@ namespace SharpTS.Tests.CompilerTests;
 /// </summary>
 public class ValueCallUndefinedPaddingTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CrossModuleImport_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -33,8 +32,7 @@ public class ValueCallUndefinedPaddingTests
         Assert.Equal("undefined\ntrue\nfalse\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionDeclarationAsValue_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -45,8 +43,7 @@ public class ValueCallUndefinedPaddingTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowAsValue_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -56,8 +53,7 @@ public class ValueCallUndefinedPaddingTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Callback_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -67,8 +63,7 @@ public class ValueCallUndefinedPaddingTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunctionAsValue_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -82,8 +77,7 @@ public class ValueCallUndefinedPaddingTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BuiltInCallback_OmittedTrailingArg_StillNullPadded(ExecutionMode mode)
     {
         // Regression guard: built-in array callbacks pad missing trailing slots with null
@@ -101,8 +95,7 @@ public class ValueCallUndefinedPaddingTests
     // sentinel, matching function declarations/arrows. Marking is applied to every user
     // class-method builder kind (instance, static, private, class-expression).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethodBound_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -114,8 +107,7 @@ public class ValueCallUndefinedPaddingTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethodAsValue_OmittedOptionalArg_StrictEquality(ExecutionMode mode)
     {
         var source = """
@@ -132,8 +124,7 @@ public class ValueCallUndefinedPaddingTests
         Assert.Equal("true\nfalse\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticMethodAsValue_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -144,8 +135,7 @@ public class ValueCallUndefinedPaddingTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpressionMethodAsValue_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -157,8 +147,7 @@ public class ValueCallUndefinedPaddingTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethodAsCallback_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -176,8 +165,7 @@ public class ValueCallUndefinedPaddingTests
     // instead of the sentinel on the value-call / cross-module boundary. `typeof`/`=== undefined`
     // then answered "object"/false. Marking the stub fixes all three kinds.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CrossModuleImport_AsyncFunction_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -198,8 +186,7 @@ public class ValueCallUndefinedPaddingTests
         Assert.Equal("undefined\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CrossModuleImport_Generator_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -215,8 +202,7 @@ public class ValueCallUndefinedPaddingTests
         Assert.Equal("undefined\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CrossModuleImport_AsyncGenerator_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -235,8 +221,7 @@ public class ValueCallUndefinedPaddingTests
         Assert.Equal("undefined\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunctionAsValue_OmittedOptionalArg_IsUndefined(ExecutionMode mode)
     {
         // Value-call (non-module) path for the async free-function stub.

--- a/SharpTS.Tests/GlobalThisTests.cs
+++ b/SharpTS.Tests/GlobalThisTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests;
 /// </summary>
 public class GlobalThisTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThis_Math_MatchesDirect(ExecutionMode mode)
     {
         var result1 = TestHarness.Run("""
@@ -25,8 +24,7 @@ public class GlobalThisTests
         Assert.Contains("3", result2);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThis_Console_Works(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -36,8 +34,7 @@ public class GlobalThisTests
         Assert.Contains("Hello from globalThis", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThis_SelfReference(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -47,8 +44,7 @@ public class GlobalThisTests
         Assert.Contains("true", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThis_Assignment(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -59,8 +55,7 @@ public class GlobalThisTests
         Assert.Contains("42", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThis_IndexAccess(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -71,8 +66,7 @@ public class GlobalThisTests
         Assert.Contains("hello", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThis_DynamicIndex(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -83,8 +77,7 @@ public class GlobalThisTests
         Assert.Contains("object", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThis_BuiltInConstants(ExecutionMode mode)
     {
         var r1 = TestHarness.Run("""
@@ -106,8 +99,7 @@ public class GlobalThisTests
         Assert.Contains("true", r3);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThis_ModuleScopedVarsNotAccessible(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -118,8 +110,7 @@ public class GlobalThisTests
         Assert.Contains("true", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThis_ChainedSelfReference(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -129,8 +120,7 @@ public class GlobalThisTests
         Assert.Contains("true", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThis_Process(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -140,8 +130,7 @@ public class GlobalThisTests
         Assert.Contains("object", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThis_ParseInt(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -155,8 +144,7 @@ public class GlobalThisTests
     // dereferenced) must be a real object, not null. Before the fix compiled
     // mode emitted null, so root/context detection in lodash-style packages got
     // a null root and could not initialize.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThis_ValuePosition_IsRealObject(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -169,8 +157,7 @@ public class GlobalThisTests
     }
 
     // Cross-mode: typeof checks and Object identity hold in both modes.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThis_ValuePosition_ResolvesConstructorTypeofs(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -188,8 +175,7 @@ public class GlobalThisTests
     // Type tokens, so `root.Error === Error` holds (#271). The interpreter's
     // SharpTSGlobalThis returns a distinct Error representation for this identity,
     // which is an independent pre-existing quirk outside this fix's scope.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void GlobalThis_ValuePosition_ResolvesErrorConstructorIdentity(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -202,8 +188,7 @@ public class GlobalThisTests
 
     // #271: writes through a value-position globalThis reference round-trip to
     // subsequent reads (the lodash `root.foo = ...` pattern).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThis_ValuePosition_WriteRoundTrips(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -219,8 +204,7 @@ public class GlobalThisTests
     // #271: the lodash/core-js `Function('return this')()` global probe yields
     // the same real globalThis value (compiled mode; the interpreter rejects the
     // dynamic Function constructor, so this is compiled-only).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void GlobalThis_FunctionReturnThisProbe_IsGlobalThis(ExecutionMode mode)
     {
         var result = TestHarness.Run("""

--- a/SharpTS.Tests/Infrastructure/ModeDataAttributes.cs
+++ b/SharpTS.Tests/Infrastructure/ModeDataAttributes.cs
@@ -1,0 +1,36 @@
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace SharpTS.Tests.Infrastructure;
+
+/// <summary>
+/// Supplies both execution modes to a [Theory]. Replaces the
+/// <c>[MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]</c>
+/// scaffold that was repeated ~5,900 times across the suite:
+/// <code>
+/// [Theory, ModeData]
+/// public void MyTest(ExecutionMode mode) { ... }
+/// </code>
+/// </summary>
+public sealed class ModeDataAttribute : DataAttribute
+{
+    public override IEnumerable<object[]> GetData(MethodInfo testMethod) => ExecutionModes.All;
+}
+
+/// <summary>
+/// Supplies only <see cref="ExecutionMode.Interpreted"/> — for tests of
+/// interpreter-only behavior (REPL semantics, interpreter-internal seams).
+/// </summary>
+public sealed class InterpretedOnlyDataAttribute : DataAttribute
+{
+    public override IEnumerable<object[]> GetData(MethodInfo testMethod) => ExecutionModes.InterpretedOnly;
+}
+
+/// <summary>
+/// Supplies only <see cref="ExecutionMode.Compiled"/> — for tests of
+/// compiled-mode-only behavior (IL shape, standalone-DLL constraints).
+/// </summary>
+public sealed class CompiledOnlyDataAttribute : DataAttribute
+{
+    public override IEnumerable<object[]> GetData(MethodInfo testMethod) => ExecutionModes.CompiledOnly;
+}

--- a/SharpTS.Tests/Infrastructure/RepoPaths.cs
+++ b/SharpTS.Tests/Infrastructure/RepoPaths.cs
@@ -1,0 +1,24 @@
+namespace SharpTS.Tests.Infrastructure;
+
+/// <summary>
+/// Locates the repository root from the test bin directory. One implementation
+/// replaces the byte-identical private copies in Build/Compiler/network tests
+/// (2026-07 cleanup).
+/// </summary>
+public static class RepoPaths
+{
+    public static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null)
+        {
+            if (Directory.Exists(Path.Combine(dir, "Compilation")) &&
+                File.Exists(Path.Combine(dir, "SharpTS.csproj")))
+            {
+                return dir;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("Could not find repository root");
+    }
+}

--- a/SharpTS.Tests/Infrastructure/ScriptArgsCollection.cs
+++ b/SharpTS.Tests/Infrastructure/ScriptArgsCollection.cs
@@ -1,0 +1,19 @@
+using Xunit;
+
+namespace SharpTS.Tests.Infrastructure;
+
+/// <summary>
+/// Defines the "ScriptArgs" collection. The two CommandLineArgumentTests classes
+/// mutate process-level argv state (ProcessBuiltIns script args), so they must
+/// not run concurrently with other collections reading process.argv.
+/// </summary>
+/// <remarks>
+/// Until the 2026-07 cleanup this definition did not exist, so the
+/// <c>[Collection("ScriptArgs")]</c> attributes bound to an implicit,
+/// parallelizable collection — exactly the silent hazard the ClusterTests
+/// collection documents.
+/// </remarks>
+[CollectionDefinition("ScriptArgs", DisableParallelization = true)]
+public class ScriptArgsCollection
+{
+}

--- a/SharpTS.Tests/Infrastructure/TestHarness.cs
+++ b/SharpTS.Tests/Infrastructure/TestHarness.cs
@@ -123,6 +123,19 @@ public static class TestHarness
     }
 
     /// <summary>
+    /// Parses source and throws on the first parse error. The throwing twin of
+    /// <see cref="Parse"/>; replaces the byte-identical private helper that had
+    /// spread across the parser test files (2026-07 cleanup).
+    /// </summary>
+    public static List<Stmt> ParseOrThrow(string source)
+    {
+        var lexer = new Lexer(source);
+        var tokens = lexer.ScanTokens();
+        var parser = new Parser(tokens);
+        return parser.ParseOrThrow();
+    }
+
+    /// <summary>
     /// Runs TypeScript source through the interpreter and captures console output.
     /// Uses default timeout to prevent infinite loops from hanging tests.
     /// </summary>
@@ -1218,7 +1231,7 @@ public static class TestHarness
     /// Verifies IL from in-memory PE bytes (no disk roundtrip). Used by the opt-in
     /// suite-wide verification guardrail in <see cref="RunCompiledInProcess"/>.
     /// </summary>
-    public static List<string> VerifyILBytes(byte[] bytes)
+    private static List<string> VerifyILBytes(byte[] bytes)
     {
         using var verifier = new ILVerifier();
         using var stream = new MemoryStream(bytes);

--- a/SharpTS.Tests/Infrastructure/TestPorts.cs
+++ b/SharpTS.Tests/Infrastructure/TestPorts.cs
@@ -1,0 +1,22 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace SharpTS.Tests.Infrastructure;
+
+/// <summary>
+/// Ephemeral-port allocation for server tests. One implementation replaces the
+/// byte-identical private copies that had spread across the HTTP test family
+/// (2026-07 cleanup) — including the bind-release-rebind race they all share,
+/// which now has a single place to fix.
+/// </summary>
+public static class TestPorts
+{
+    public static int GetAvailablePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/SharpTS.Tests/InterpreterTests/ProcessControlHookTests.cs
+++ b/SharpTS.Tests/InterpreterTests/ProcessControlHookTests.cs
@@ -33,7 +33,15 @@ public class ProcessControlHookTests
             // the embedder contract: throw from the handler to unwind instead.
             Assert.Contains("after-exit", output);
         }
-        finally { ProcessControl.ExitHandler = original; }
+        finally
+        {
+            ProcessControl.ExitHandler = original;
+            // process.exit publishes the code to Environment.ExitCode BEFORE the
+            // handler runs; with an intercepting handler the process survives, so
+            // the code would leak into every later test that reads it (the
+            // ProcessLifecycleTests 'exit 0' events read Environment.ExitCode).
+            Environment.ExitCode = 0;
+        }
     }
 
     [Fact]

--- a/SharpTS.Tests/ParserTests/ArrowFunctionTests.cs
+++ b/SharpTS.Tests/ParserTests/ArrowFunctionTests.cs
@@ -1,4 +1,5 @@
 using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
 using Xunit;
 
 namespace SharpTS.Tests.ParserTests;
@@ -11,17 +12,9 @@ public class ArrowFunctionTests
 {
     #region Helpers
 
-    private static List<Stmt> Parse(string source)
-    {
-        var lexer = new Lexer(source);
-        var tokens = lexer.ScanTokens();
-        var parser = new Parser(tokens);
-        return parser.ParseOrThrow();
-    }
-
     private static Expr.ArrowFunction ParseArrowFromVarOrConst(string source)
     {
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         Assert.Single(statements);
         var initializer = statements[0] switch
         {
@@ -275,7 +268,7 @@ public class ArrowFunctionTests
     [Fact]
     public void Arrow_AsCallbackArgument()
     {
-        var statements = Parse("arr.map(x => x * 2);");
+        var statements = TestHarness.ParseOrThrow("arr.map(x => x * 2);");
         var exprStmt = Assert.IsType<Stmt.Expression>(statements[0]);
         var call = Assert.IsType<Expr.Call>(exprStmt.Expr);
         Assert.Single(call.Arguments);
@@ -285,7 +278,7 @@ public class ArrowFunctionTests
     [Fact]
     public void Arrow_MultipleCallbackArguments()
     {
-        var statements = Parse("arr.reduce((acc, x) => acc + x, 0);");
+        var statements = TestHarness.ParseOrThrow("arr.reduce((acc, x) => acc + x, 0);");
         var exprStmt = Assert.IsType<Stmt.Expression>(statements[0]);
         var call = Assert.IsType<Expr.Call>(exprStmt.Expr);
         Assert.Equal(2, call.Arguments.Count);

--- a/SharpTS.Tests/ParserTests/AsiTests.cs
+++ b/SharpTS.Tests/ParserTests/AsiTests.cs
@@ -1,5 +1,6 @@
 using SharpTS.Diagnostics;
 using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
 using Xunit;
 
 namespace SharpTS.Tests.ParserTests;
@@ -12,14 +13,6 @@ namespace SharpTS.Tests.ParserTests;
 public class AsiTests
 {
     #region Helpers
-
-    private static List<Stmt> Parse(string source)
-    {
-        var lexer = new Lexer(source);
-        var tokens = lexer.ScanTokens();
-        var parser = new Parser(tokens);
-        return parser.ParseOrThrow();
-    }
 
     private static ParseDiagnosticResult ParseWithDiagnostics(string source)
     {
@@ -36,7 +29,7 @@ public class AsiTests
     [Fact]
     public void TwoDeclarations_SeparatedByNewline()
     {
-        var stmts = Parse("let x = 5\nlet y = 10");
+        var stmts = TestHarness.ParseOrThrow("let x = 5\nlet y = 10");
         Assert.Equal(2, stmts.Count);
         Assert.IsType<Stmt.Var>(stmts[0]);
         Assert.IsType<Stmt.Var>(stmts[1]);
@@ -45,7 +38,7 @@ public class AsiTests
     [Fact]
     public void TwoExpressionStatements_SeparatedByNewline()
     {
-        var stmts = Parse("x = 1\ny = 2");
+        var stmts = TestHarness.ParseOrThrow("x = 1\ny = 2");
         Assert.Equal(2, stmts.Count);
         Assert.IsType<Stmt.Expression>(stmts[0]);
         Assert.IsType<Stmt.Expression>(stmts[1]);
@@ -54,14 +47,14 @@ public class AsiTests
     [Fact]
     public void MultipleStatements_NoSemicolons()
     {
-        var stmts = Parse("let a = 1\nlet b = 2\nlet c = 3");
+        var stmts = TestHarness.ParseOrThrow("let a = 1\nlet b = 2\nlet c = 3");
         Assert.Equal(3, stmts.Count);
     }
 
     [Fact]
     public void ConstDeclaration_NoSemicolon()
     {
-        var stmts = Parse("const x = 42\nconst y = 'hello'");
+        var stmts = TestHarness.ParseOrThrow("const x = 42\nconst y = 'hello'");
         Assert.Equal(2, stmts.Count);
     }
 
@@ -72,7 +65,7 @@ public class AsiTests
     [Fact]
     public void FunctionBody_NoSemicolonBeforeBrace()
     {
-        var stmts = Parse("function f() { return 1 }");
+        var stmts = TestHarness.ParseOrThrow("function f() { return 1 }");
         Assert.Single(stmts);
         var func = Assert.IsType<Stmt.Function>(stmts[0]);
         Assert.Single(func.Body!);
@@ -81,14 +74,14 @@ public class AsiTests
     [Fact]
     public void IfBlock_NoSemicolonBeforeBrace()
     {
-        var stmts = Parse("if (true) { let x = 1 }");
+        var stmts = TestHarness.ParseOrThrow("if (true) { let x = 1 }");
         Assert.Single(stmts);
     }
 
     [Fact]
     public void Block_MultipleStatements_NoSemicolons()
     {
-        var stmts = Parse("function f() { let x = 1\nlet y = 2 }");
+        var stmts = TestHarness.ParseOrThrow("function f() { let x = 1\nlet y = 2 }");
         Assert.Single(stmts);
         var func = Assert.IsType<Stmt.Function>(stmts[0]);
         Assert.Equal(2, func.Body!.Count);
@@ -101,7 +94,7 @@ public class AsiTests
     [Fact]
     public void SingleDeclaration_AtEOF()
     {
-        var stmts = Parse("let x = 5");
+        var stmts = TestHarness.ParseOrThrow("let x = 5");
         Assert.Single(stmts);
         Assert.IsType<Stmt.Var>(stmts[0]);
     }
@@ -109,7 +102,7 @@ public class AsiTests
     [Fact]
     public void ExpressionStatement_AtEOF()
     {
-        var stmts = Parse("x = 1");
+        var stmts = TestHarness.ParseOrThrow("x = 1");
         Assert.Single(stmts);
     }
 
@@ -121,7 +114,7 @@ public class AsiTests
     public void Return_WithNewline_ReturnsUndefined()
     {
         // return\n1 → return; 1;  (returns undefined, 1 is separate expression statement)
-        var stmts = Parse("function f() { return\n1 }");
+        var stmts = TestHarness.ParseOrThrow("function f() { return\n1 }");
         var func = Assert.IsType<Stmt.Function>(stmts[0]);
         var body = func.Body!;
         Assert.Equal(2, body.Count);
@@ -133,7 +126,7 @@ public class AsiTests
     [Fact]
     public void Return_SameLine_ReturnsExpression()
     {
-        var stmts = Parse("function f() { return 42 }");
+        var stmts = TestHarness.ParseOrThrow("function f() { return 42 }");
         var func = Assert.IsType<Stmt.Function>(stmts[0]);
         var body = func.Body!;
         Assert.Single(body);
@@ -144,7 +137,7 @@ public class AsiTests
     [Fact]
     public void Return_Bare_InBlock()
     {
-        var stmts = Parse("function f() { return }");
+        var stmts = TestHarness.ParseOrThrow("function f() { return }");
         var func = Assert.IsType<Stmt.Function>(stmts[0]);
         var body = func.Body!;
         Assert.Single(body);
@@ -167,7 +160,7 @@ public class AsiTests
     [Fact]
     public void Throw_SameLine_IsValid()
     {
-        var stmts = Parse("function f() { throw new Error('x') }");
+        var stmts = TestHarness.ParseOrThrow("function f() { throw new Error('x') }");
         var func = Assert.IsType<Stmt.Function>(stmts[0]);
         var body = func.Body!;
         Assert.Single(body);
@@ -182,7 +175,7 @@ public class AsiTests
     public void Break_WithNewline_BeforeLabel_BreaksWithoutLabel()
     {
         // break\nlabel → break; label;
-        var stmts = Parse("while (true) { break\nlabel }");
+        var stmts = TestHarness.ParseOrThrow("while (true) { break\nlabel }");
         var whileStmt = Assert.IsType<Stmt.While>(stmts[0]);
         var block = Assert.IsType<Stmt.Block>(whileStmt.Body);
         Assert.Equal(2, block.Statements.Count);
@@ -194,7 +187,7 @@ public class AsiTests
     public void Continue_WithNewline_BeforeLabel_ContinuesWithoutLabel()
     {
         // continue\nlabel → continue; label;
-        var stmts = Parse("while (true) { continue\nlabel }");
+        var stmts = TestHarness.ParseOrThrow("while (true) { continue\nlabel }");
         var whileStmt = Assert.IsType<Stmt.While>(stmts[0]);
         var block = Assert.IsType<Stmt.Block>(whileStmt.Body);
         Assert.Equal(2, block.Statements.Count);
@@ -205,7 +198,7 @@ public class AsiTests
     [Fact]
     public void Break_WithLabel_SameLine()
     {
-        var stmts = Parse("outer: while (true) { break outer }");
+        var stmts = TestHarness.ParseOrThrow("outer: while (true) { break outer }");
         var labeled = Assert.IsType<Stmt.LabeledStatement>(stmts[0]);
         var whileStmt = Assert.IsType<Stmt.While>(labeled.Statement);
         var block = Assert.IsType<Stmt.Block>(whileStmt.Body);
@@ -222,7 +215,7 @@ public class AsiTests
     public void PostfixIncrement_OnNewLine_BecomesPrefix()
     {
         // x\n++\ny → x; ++y;
-        var stmts = Parse("let x = 0\nlet y = 0\nx\n++\ny");
+        var stmts = TestHarness.ParseOrThrow("let x = 0\nlet y = 0\nx\n++\ny");
         // Should be: let x = 0; let y = 0; x; ++y;
         Assert.Equal(4, stmts.Count);
     }
@@ -235,7 +228,7 @@ public class AsiTests
     public void Yield_WithNewline_YieldsUndefined()
     {
         // yield\n1 → yield; 1;
-        var stmts = Parse("function* gen() { yield\n1 }");
+        var stmts = TestHarness.ParseOrThrow("function* gen() { yield\n1 }");
         var func = Assert.IsType<Stmt.Function>(stmts[0]);
         var body = func.Body!;
         Assert.Equal(2, body.Count);
@@ -246,7 +239,7 @@ public class AsiTests
     [Fact]
     public void Yield_SameLine_YieldsExpression()
     {
-        var stmts = Parse("function* gen() { yield 42 }");
+        var stmts = TestHarness.ParseOrThrow("function* gen() { yield 42 }");
         var func = Assert.IsType<Stmt.Function>(stmts[0]);
         var body = func.Body!;
         Assert.Single(body);
@@ -262,7 +255,7 @@ public class AsiTests
     public void BinaryOperator_OnNewLine_IsContinuation()
     {
         // let x = 1\n+ 2 → let x = 1 + 2 (NOT let x = 1; +2)
-        var stmts = Parse("let x = 1\n+ 2");
+        var stmts = TestHarness.ParseOrThrow("let x = 1\n+ 2");
         Assert.Single(stmts);
         var varStmt = Assert.IsType<Stmt.Var>(stmts[0]);
         Assert.IsType<Expr.Binary>(varStmt.Initializer);
@@ -272,7 +265,7 @@ public class AsiTests
     public void MethodChain_AcrossLines()
     {
         // f()\n.method() → f().method()
-        var stmts = Parse("f()\n.toString()");
+        var stmts = TestHarness.ParseOrThrow("f()\n.toString()");
         Assert.Single(stmts);
     }
 
@@ -284,7 +277,7 @@ public class AsiTests
     public void ForLoop_RequiresExplicitSemicolons()
     {
         // for (let i = 0; i < 10; i++) {} must work with explicit semicolons
-        var stmts = Parse("for (let i = 0; i < 10; i++) {}");
+        var stmts = TestHarness.ParseOrThrow("for (let i = 0; i < 10; i++) {}");
         Assert.Single(stmts);
         Assert.IsType<Stmt.For>(stmts[0]);
     }
@@ -304,7 +297,7 @@ public class AsiTests
     [Fact]
     public void Interface_NewlineSeparatedMembers()
     {
-        var stmts = Parse("interface I {\n  x: number\n  y: string\n}");
+        var stmts = TestHarness.ParseOrThrow("interface I {\n  x: number\n  y: string\n}");
         Assert.Single(stmts);
         var iface = Assert.IsType<Stmt.Interface>(stmts[0]);
         Assert.Equal(2, iface.Members.Count);
@@ -313,7 +306,7 @@ public class AsiTests
     [Fact]
     public void Interface_CommaSeparatedMembers()
     {
-        var stmts = Parse("interface I { x: number, y: string }");
+        var stmts = TestHarness.ParseOrThrow("interface I { x: number, y: string }");
         Assert.Single(stmts);
         var iface = Assert.IsType<Stmt.Interface>(stmts[0]);
         Assert.Equal(2, iface.Members.Count);
@@ -322,7 +315,7 @@ public class AsiTests
     [Fact]
     public void Interface_SemicolonSeparatedMembers()
     {
-        var stmts = Parse("interface I { x: number; y: string; }");
+        var stmts = TestHarness.ParseOrThrow("interface I { x: number; y: string; }");
         Assert.Single(stmts);
         var iface = Assert.IsType<Stmt.Interface>(stmts[0]);
         Assert.Equal(2, iface.Members.Count);
@@ -335,7 +328,7 @@ public class AsiTests
     [Fact]
     public void ClassFields_NoSemicolons()
     {
-        var stmts = Parse("class C {\n  x: number = 5\n  y: string = ''\n}");
+        var stmts = TestHarness.ParseOrThrow("class C {\n  x: number = 5\n  y: string = ''\n}");
         Assert.Single(stmts);
     }
 
@@ -346,7 +339,7 @@ public class AsiTests
     [Fact]
     public void ImportDeclaration_NoSemicolon()
     {
-        var stmts = Parse("import { foo } from './bar'\nexport const x = 1");
+        var stmts = TestHarness.ParseOrThrow("import { foo } from './bar'\nexport const x = 1");
         Assert.Equal(2, stmts.Count);
         Assert.IsType<Stmt.Import>(stmts[0]);
         Assert.IsType<Stmt.Export>(stmts[1]);
@@ -355,7 +348,7 @@ public class AsiTests
     [Fact]
     public void SideEffectImport_NoSemicolon()
     {
-        var stmts = Parse("import './polyfill'\nlet x = 1");
+        var stmts = TestHarness.ParseOrThrow("import './polyfill'\nlet x = 1");
         Assert.Equal(2, stmts.Count);
     }
 
@@ -366,7 +359,7 @@ public class AsiTests
     [Fact]
     public void DoWhile_NoTrailingSemicolon()
     {
-        var stmts = Parse("do { x = 1 } while (true)\nlet y = 2");
+        var stmts = TestHarness.ParseOrThrow("do { x = 1 } while (true)\nlet y = 2");
         Assert.Equal(2, stmts.Count);
         Assert.IsType<Stmt.DoWhile>(stmts[0]);
         Assert.IsType<Stmt.Var>(stmts[1]);
@@ -379,7 +372,7 @@ public class AsiTests
     [Fact]
     public void TypeAlias_NoSemicolon()
     {
-        var stmts = Parse("type Foo = string\ntype Bar = number");
+        var stmts = TestHarness.ParseOrThrow("type Foo = string\ntype Bar = number");
         Assert.Equal(2, stmts.Count);
         Assert.IsType<Stmt.TypeAlias>(stmts[0]);
         Assert.IsType<Stmt.TypeAlias>(stmts[1]);
@@ -392,14 +385,14 @@ public class AsiTests
     [Fact]
     public void ExplicitSemicolons_StillValid()
     {
-        var stmts = Parse("let x = 5;\nlet y = 10;\nconsole.log(x + y);");
+        var stmts = TestHarness.ParseOrThrow("let x = 5;\nlet y = 10;\nconsole.log(x + y);");
         Assert.Equal(3, stmts.Count);
     }
 
     [Fact]
     public void MixedSemicolonsAndASI()
     {
-        var stmts = Parse("let x = 5;\nlet y = 10\nlet z = 15;");
+        var stmts = TestHarness.ParseOrThrow("let x = 5;\nlet y = 10\nlet z = 15;");
         Assert.Equal(3, stmts.Count);
     }
 
@@ -410,14 +403,14 @@ public class AsiTests
     [Fact]
     public void ArrayDestructuring_NoSemicolon()
     {
-        var stmts = Parse("let [a, b] = [1, 2]\nlet x = 3");
+        var stmts = TestHarness.ParseOrThrow("let [a, b] = [1, 2]\nlet x = 3");
         Assert.Equal(2, stmts.Count);
     }
 
     [Fact]
     public void ObjectDestructuring_NoSemicolon()
     {
-        var stmts = Parse("let { a, b } = { a: 1, b: 2 }\nlet x = 3");
+        var stmts = TestHarness.ParseOrThrow("let { a, b } = { a: 1, b: 2 }\nlet x = 3");
         Assert.Equal(2, stmts.Count);
     }
 

--- a/SharpTS.Tests/ParserTests/ClassDeclarationTests.cs
+++ b/SharpTS.Tests/ParserTests/ClassDeclarationTests.cs
@@ -1,4 +1,5 @@
 using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
 using Xunit;
 
 namespace SharpTS.Tests.ParserTests;
@@ -11,17 +12,9 @@ public class ClassDeclarationTests
 {
     #region Helpers
 
-    private static List<Stmt> Parse(string source)
-    {
-        var lexer = new Lexer(source);
-        var tokens = lexer.ScanTokens();
-        var parser = new Parser(tokens);
-        return parser.ParseOrThrow();
-    }
-
     private static Stmt.Class ParseClass(string source)
     {
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         Assert.Single(statements);
         return Assert.IsType<Stmt.Class>(statements[0]);
     }
@@ -102,7 +95,7 @@ public class ClassDeclarationTests
             class Bar { }
             class Foo extends Bar { }
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         Assert.Equal(2, statements.Count);
         var fooClass = Assert.IsType<Stmt.Class>(statements[1]);
         Assert.NotNull(fooClass.SuperclassExpr);
@@ -116,7 +109,7 @@ public class ClassDeclarationTests
             interface IBar { }
             class Foo implements IBar { }
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         Assert.Equal(2, statements.Count);
         var fooClass = Assert.IsType<Stmt.Class>(statements[1]);
         Assert.NotNull(fooClass.Interfaces);
@@ -132,7 +125,7 @@ public class ClassDeclarationTests
             interface IFoo { }
             class Foo extends Bar implements IFoo { }
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var fooClass = Assert.IsType<Stmt.Class>(statements[2]);
         Assert.NotNull(fooClass.SuperclassExpr);
         Assert.NotNull(fooClass.Interfaces);
@@ -147,7 +140,7 @@ public class ClassDeclarationTests
             interface IB { }
             class Foo implements IA, IB { }
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var fooClass = Assert.IsType<Stmt.Class>(statements[2]);
         Assert.NotNull(fooClass.Interfaces);
         Assert.Equal(2, fooClass.Interfaces.Count);
@@ -437,7 +430,7 @@ public class ClassDeclarationTests
                 override doSomething() { }
             }
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var fooClass = Assert.IsType<Stmt.Class>(statements[0]);
         Assert.True(fooClass.Methods[0].IsOverride);
     }

--- a/SharpTS.Tests/ParserTests/ExpressionParsingTests.cs
+++ b/SharpTS.Tests/ParserTests/ExpressionParsingTests.cs
@@ -1,4 +1,5 @@
 using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
 using Xunit;
 
 namespace SharpTS.Tests.ParserTests;
@@ -11,17 +12,9 @@ public class ExpressionParsingTests
 {
     #region Helpers
 
-    private static List<Stmt> Parse(string source)
-    {
-        var lexer = new Lexer(source);
-        var tokens = lexer.ScanTokens();
-        var parser = new Parser(tokens);
-        return parser.ParseOrThrow();
-    }
-
     private static Expr ParseExpression(string source)
     {
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         Assert.Single(statements);
         var exprStmt = Assert.IsType<Stmt.Expression>(statements[0]);
         return exprStmt.Expr;
@@ -297,7 +290,7 @@ public class ExpressionParsingTests
     {
         // String literals at the start of a file are parsed as directive prologue (like "use strict")
         // This is correct JavaScript/TypeScript behavior
-        var statements = Parse("\"hello\";");
+        var statements = TestHarness.ParseOrThrow("\"hello\";");
         Assert.Single(statements);
         var directive = Assert.IsType<Stmt.Directive>(statements[0]);
         Assert.Equal("hello", directive.Value);
@@ -307,7 +300,7 @@ public class ExpressionParsingTests
     public void Literal_String_InExpression()
     {
         // Test string literal in a non-directive position (after a non-directive statement)
-        var statements = Parse("0; \"hello\";");
+        var statements = TestHarness.ParseOrThrow("0; \"hello\";");
         Assert.Equal(2, statements.Count);
         var exprStmt = Assert.IsType<Stmt.Expression>(statements[1]);
         var literal = Assert.IsType<Expr.Literal>(exprStmt.Expr);

--- a/SharpTS.Tests/ParserTests/FunctionTypeAnnotationTests.cs
+++ b/SharpTS.Tests/ParserTests/FunctionTypeAnnotationTests.cs
@@ -1,4 +1,5 @@
 using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
 using Xunit;
 
 namespace SharpTS.Tests.ParserTests;
@@ -11,17 +12,9 @@ public class FunctionTypeAnnotationTests
 {
     #region Helpers
 
-    private static List<Stmt> Parse(string source)
-    {
-        var lexer = new Lexer(source);
-        var tokens = lexer.ScanTokens();
-        var parser = new Parser(tokens);
-        return parser.ParseOrThrow();
-    }
-
     private static Expr.ArrowFunction ParseArrowFromVarOrConst(string source)
     {
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         Assert.Single(statements);
         var initializer = statements[0] switch
         {
@@ -158,7 +151,7 @@ public class FunctionTypeAnnotationTests
     [Fact]
     public void VarDecl_FunctionTypeAnnotation()
     {
-        var statements = Parse("let handler: (e: Event) => void;");
+        var statements = TestHarness.ParseOrThrow("let handler: (e: Event) => void;");
         Assert.Single(statements);
         var varStmt = Assert.IsType<Stmt.Var>(statements[0]);
         Assert.Equal("handler", varStmt.Name.Lexeme);
@@ -168,7 +161,7 @@ public class FunctionTypeAnnotationTests
     [Fact]
     public void ConstDecl_FunctionTypeAnnotation()
     {
-        var statements = Parse("const callback: (x: number, y: number) => boolean = (a, b) => a > b;");
+        var statements = TestHarness.ParseOrThrow("const callback: (x: number, y: number) => boolean = (a, b) => a > b;");
         Assert.Single(statements);
         var constStmt = Assert.IsType<Stmt.Const>(statements[0]);
         Assert.Equal("callback", constStmt.Name.Lexeme);
@@ -182,7 +175,7 @@ public class FunctionTypeAnnotationTests
     [Fact]
     public void Arrow_CallbackArg_FunctionTypeReturn()
     {
-        var statements = Parse("arr.map((x): (y: number) => number => y => x * y);");
+        var statements = TestHarness.ParseOrThrow("arr.map((x): (y: number) => number => y => x * y);");
         var exprStmt = Assert.IsType<Stmt.Expression>(statements[0]);
         var call = Assert.IsType<Expr.Call>(exprStmt.Expr);
         Assert.Single(call.Arguments);
@@ -198,7 +191,7 @@ public class FunctionTypeAnnotationTests
     public void FunctionType_ThreeNamedParams()
     {
         // Function type with three named parameters
-        var statements = Parse("let fn: (a: number, b: string, c: boolean) => void;");
+        var statements = TestHarness.ParseOrThrow("let fn: (a: number, b: string, c: boolean) => void;");
         var varStmt = Assert.IsType<Stmt.Var>(statements[0]);
         Assert.Equal("(number, string, boolean) => void", varStmt.TypeAnnotation);
     }
@@ -207,7 +200,7 @@ public class FunctionTypeAnnotationTests
     public void FunctionType_AllNamedParams()
     {
         // All params have names and types
-        var statements = Parse("let fn: (a: number, b: string) => void;");
+        var statements = TestHarness.ParseOrThrow("let fn: (a: number, b: string) => void;");
         var varStmt = Assert.IsType<Stmt.Var>(statements[0]);
         Assert.Equal("(number, string) => void", varStmt.TypeAnnotation);
     }
@@ -227,41 +220,41 @@ public class FunctionTypeAnnotationTests
     public void FunctionType_BareParameterName_Parses()
     {
         // `(x) => number`: x is a parameter name with implicit `any`, not a grouped type.
-        Assert.NotEmpty(Parse("let f: (x) => number;"));
+        Assert.NotEmpty(TestHarness.ParseOrThrow("let f: (x) => number;"));
     }
 
     [Fact]
     public void FunctionType_MultipleBareParameters_Parses()
     {
-        Assert.NotEmpty(Parse("let f: (x, y) => number;"));
+        Assert.NotEmpty(TestHarness.ParseOrThrow("let f: (x, y) => number;"));
     }
 
     [Fact]
     public void FunctionType_MixedTypedAndBareParameters_Parses()
     {
-        Assert.NotEmpty(Parse("let f: (x: number, y) => number;"));
+        Assert.NotEmpty(TestHarness.ParseOrThrow("let f: (x: number, y) => number;"));
     }
 
     [Fact]
     public void FunctionType_BareOptionalParameter_Parses()
     {
         // `(x?) => number`: optional parameter with implicit `any`.
-        Assert.NotEmpty(Parse("let f: (x?) => number;"));
+        Assert.NotEmpty(TestHarness.ParseOrThrow("let f: (x?) => number;"));
     }
 
     [Fact]
     public void FunctionType_BareParameterInIndexSignature_Parses()
     {
         // The function type appears as an index-signature value: `[k: string]: (x) => number`.
-        Assert.NotEmpty(Parse("interface I { [k: string]: (x) => number; }"));
+        Assert.NotEmpty(TestHarness.ParseOrThrow("interface I { [k: string]: (x) => number; }"));
     }
 
     [Fact]
     public void GroupedType_StillParses_NotMistakenForFunctionType()
     {
         // Regression guard: a grouped/parenthesized type with no trailing `=>` stays a grouped type.
-        Assert.NotEmpty(Parse("let a: (number | string)[];"));
-        Assert.NotEmpty(Parse("let b: (Foo);"));
+        Assert.NotEmpty(TestHarness.ParseOrThrow("let a: (number | string)[];"));
+        Assert.NotEmpty(TestHarness.ParseOrThrow("let b: (Foo);"));
     }
 
     #endregion

--- a/SharpTS.Tests/ParserTests/NestedGenericsTokenSplittingTests.cs
+++ b/SharpTS.Tests/ParserTests/NestedGenericsTokenSplittingTests.cs
@@ -1,4 +1,5 @@
 using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
 using Xunit;
 
 namespace SharpTS.Tests.ParserTests;
@@ -11,14 +12,6 @@ namespace SharpTS.Tests.ParserTests;
 public class NestedGenericsTokenSplittingTests
 {
     #region Helpers
-
-    private static List<Stmt> Parse(string source)
-    {
-        var lexer = new Lexer(source);
-        var tokens = lexer.ScanTokens();
-        var parser = new Parser(tokens);
-        return parser.ParseOrThrow();
-    }
 
     private static string GetVariableType(List<Stmt> statements, string varName)
     {
@@ -43,7 +36,7 @@ public class NestedGenericsTokenSplittingTests
             interface Data { value: number; }
             let x: Partial<Readonly<Data>> = {};
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var type = GetVariableType(statements, "x");
         Assert.Equal("Partial<Readonly<Data>>", type);
     }
@@ -55,7 +48,7 @@ public class NestedGenericsTokenSplittingTests
             interface Entry<K, V> { key: K; value: V; }
             let x: Partial<Entry<string, number>> = {};
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var type = GetVariableType(statements, "x");
         Assert.Equal("Partial<Entry<string, number>>", type);
     }
@@ -67,7 +60,7 @@ public class NestedGenericsTokenSplittingTests
             interface Item { id: number; }
             let x: Partial<Readonly<Item>>[] = [];
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var type = GetVariableType(statements, "x");
         Assert.Equal("Partial<Readonly<Item>>[]", type);
     }
@@ -79,7 +72,7 @@ public class NestedGenericsTokenSplittingTests
             interface Data { x: number; }
             function process(d: Partial<Readonly<Data>>): void {}
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var func = GetFunction(statements, "process");
         Assert.Single(func.Parameters);
         Assert.Equal("Partial<Readonly<Data>>", func.Parameters[0].Type);
@@ -92,7 +85,7 @@ public class NestedGenericsTokenSplittingTests
             interface Config { debug: boolean; }
             function getConfig(): Partial<Readonly<Config>> { return {}; }
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var func = GetFunction(statements, "getConfig");
         Assert.Equal("Partial<Readonly<Config>>", func.ReturnType);
     }
@@ -108,7 +101,7 @@ public class NestedGenericsTokenSplittingTests
             interface Data { value: number; }
             let x: Partial<Readonly<Required<Data>>> = {};
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var type = GetVariableType(statements, "x");
         Assert.Equal("Partial<Readonly<Required<Data>>>", type);
     }
@@ -120,7 +113,7 @@ public class NestedGenericsTokenSplittingTests
             interface Item { id: number; }
             let x: Partial<Readonly<Required<Item>>>[] = [];
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var type = GetVariableType(statements, "x");
         Assert.Equal("Partial<Readonly<Required<Item>>>[]", type);
     }
@@ -132,7 +125,7 @@ public class NestedGenericsTokenSplittingTests
             interface Settings { enabled: boolean; }
             function apply(s: Partial<Readonly<Required<Settings>>>): void {}
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var func = GetFunction(statements, "apply");
         Assert.Single(func.Parameters);
         Assert.Equal("Partial<Readonly<Required<Settings>>>", func.Parameters[0].Type);
@@ -149,7 +142,7 @@ public class NestedGenericsTokenSplittingTests
             interface Base { val: number; }
             let x: Partial<Readonly<Required<Partial<Base>>>> = {};
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var type = GetVariableType(statements, "x");
         Assert.Equal("Partial<Readonly<Required<Partial<Base>>>>", type);
     }
@@ -161,7 +154,7 @@ public class NestedGenericsTokenSplittingTests
             interface Core { n: number; }
             let x: Partial<Readonly<Required<Partial<Readonly<Core>>>>> = {};
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var type = GetVariableType(statements, "x");
         Assert.Equal("Partial<Readonly<Required<Partial<Readonly<Core>>>>>", type);
     }
@@ -179,7 +172,7 @@ public class NestedGenericsTokenSplittingTests
             let x: Partial<Readonly<A>> = {};
             let y: Partial<Readonly<Required<B>>> = {};
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         Assert.Equal("Partial<Readonly<A>>", GetVariableType(statements, "x"));
         Assert.Equal("Partial<Readonly<Required<B>>>", GetVariableType(statements, "y"));
     }
@@ -192,7 +185,7 @@ public class NestedGenericsTokenSplittingTests
             interface B { b: string; }
             let x: Partial<Readonly<A>> | Partial<Readonly<B>> = {};
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var type = GetVariableType(statements, "x");
         Assert.Equal("Partial<Readonly<A>> | Partial<Readonly<B>>", type);
     }
@@ -204,7 +197,7 @@ public class NestedGenericsTokenSplittingTests
             interface Inner { x: number; }
             let x: Record<string, Partial<Readonly<Inner>>> = {};
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var type = GetVariableType(statements, "x");
         Assert.Equal("Record<string, Partial<Readonly<Inner>>>", type);
     }
@@ -284,7 +277,7 @@ public class NestedGenericsTokenSplittingTests
     public void Parser_RightShift_ParsesAsBinaryOperator()
     {
         var source = "let x = 16 >> 2;";
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var varStmt = statements.OfType<Stmt.Var>().First();
         var binary = varStmt.Initializer as Expr.Binary;
 
@@ -296,7 +289,7 @@ public class NestedGenericsTokenSplittingTests
     public void Parser_UnsignedRightShift_ParsesAsBinaryOperator()
     {
         var source = "let x = 16 >>> 2;";
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var varStmt = statements.OfType<Stmt.Var>().First();
         var binary = varStmt.Initializer as Expr.Binary;
 
@@ -312,7 +305,7 @@ public class NestedGenericsTokenSplittingTests
             let typed: Partial<Readonly<Num>> = { n: 32 };
             let shifted = 16 >> 2;
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
 
         // Verify nested generic type parsed correctly
         Assert.Equal("Partial<Readonly<Num>>", GetVariableType(statements, "typed"));
@@ -335,7 +328,7 @@ public class NestedGenericsTokenSplittingTests
             interface Base { id: number; }
             function process<T extends Partial<Readonly<Base>>>(x: T): void {}
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var func = GetFunction(statements, "process");
 
         Assert.NotNull(func.TypeParams);
@@ -352,7 +345,7 @@ public class NestedGenericsTokenSplittingTests
                 value: T;
             }
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var classStmt = statements.OfType<Stmt.Class>().First();
 
         Assert.NotNull(classStmt.TypeParams);
@@ -369,7 +362,7 @@ public class NestedGenericsTokenSplittingTests
     {
         // Ensure that the spaced workaround still works for backwards compatibility
         var source = "let x: Partial<Readonly<Data> > = {};";
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var type = GetVariableType(statements, "x");
         Assert.Equal("Partial<Readonly<Data>>", type);
     }
@@ -381,7 +374,7 @@ public class NestedGenericsTokenSplittingTests
             interface Empty {}
             let x: Partial<Readonly<Empty>> = {};
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var type = GetVariableType(statements, "x");
         Assert.Equal("Partial<Readonly<Empty>>", type);
     }
@@ -393,7 +386,7 @@ public class NestedGenericsTokenSplittingTests
             interface Data { values: number[]; }
             let x: Partial<Readonly<Data>>[] = [];
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var type = GetVariableType(statements, "x");
         Assert.Equal("Partial<Readonly<Data>>[]", type);
     }

--- a/SharpTS.Tests/ParserTests/PrivateFieldParserTests.cs
+++ b/SharpTS.Tests/ParserTests/PrivateFieldParserTests.cs
@@ -1,4 +1,5 @@
 using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
 using Xunit;
 
 namespace SharpTS.Tests.ParserTests;
@@ -10,17 +11,9 @@ public class PrivateFieldParserTests
 {
     #region Helpers
 
-    private static List<Stmt> Parse(string source)
-    {
-        var lexer = new Lexer(source);
-        var tokens = lexer.ScanTokens();
-        var parser = new Parser(tokens);
-        return parser.ParseOrThrow();
-    }
-
     private static Stmt.Class ParseClass(string source)
     {
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         Assert.Single(statements);
         return Assert.IsType<Stmt.Class>(statements[0]);
     }

--- a/SharpTS.Tests/ParserTests/SatisfiesParsingTests.cs
+++ b/SharpTS.Tests/ParserTests/SatisfiesParsingTests.cs
@@ -1,4 +1,5 @@
 using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
 using Xunit;
 
 namespace SharpTS.Tests.ParserTests;
@@ -8,19 +9,11 @@ namespace SharpTS.Tests.ParserTests;
 /// </summary>
 public class SatisfiesParsingTests
 {
-    private static List<Stmt> Parse(string source)
-    {
-        var lexer = new Lexer(source);
-        var tokens = lexer.ScanTokens();
-        var parser = new Parser(tokens);
-        return parser.ParseOrThrow();
-    }
-
     [Fact]
     public void Satisfies_ParsesBasicExpression()
     {
         var source = "const x = 42 satisfies number;";
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
 
         Assert.Single(statements);
         Assert.IsType<Stmt.Const>(statements[0]);
@@ -34,7 +27,7 @@ public class SatisfiesParsingTests
     public void Satisfies_ParsesObjectType()
     {
         var source = "const obj = { x: 1 } satisfies { x: number };";
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
 
         Assert.Single(statements);
         Assert.IsType<Stmt.Const>(statements[0]);
@@ -49,7 +42,7 @@ public class SatisfiesParsingTests
     public void Satisfies_ParsesUnionType()
     {
         var source = "const x = \"hello\" satisfies string | number;";
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
 
         Assert.Single(statements);
         Assert.IsType<Stmt.Const>(statements[0]);
@@ -64,7 +57,7 @@ public class SatisfiesParsingTests
     public void Satisfies_ParsesChained()
     {
         var source = "const x = 42 satisfies number satisfies number;";
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
 
         Assert.Single(statements);
         Assert.IsType<Stmt.Const>(statements[0]);
@@ -82,7 +75,7 @@ public class SatisfiesParsingTests
     public void Satisfies_ParsesArrayType()
     {
         var source = "const arr = [1, 2] satisfies number[];";
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
 
         Assert.Single(statements);
         Assert.IsType<Stmt.Const>(statements[0]);
@@ -96,7 +89,7 @@ public class SatisfiesParsingTests
     public void Satisfies_InnerExpressionPreserved()
     {
         var source = "const x = 42 satisfies number;";
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
 
         var constStmt = (Stmt.Const)statements[0];
         var sat = (Expr.Satisfies)constStmt.Initializer;
@@ -110,7 +103,7 @@ public class SatisfiesParsingTests
     {
         // 'as const' followed by 'satisfies' - should parse correctly
         var source = "const x = [1, 2] as const satisfies number[];";
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
 
         Assert.Single(statements);
         Assert.IsType<Stmt.Const>(statements[0]);
@@ -128,7 +121,7 @@ public class SatisfiesParsingTests
     public void Satisfies_ParsesGenericType()
     {
         var source = "const arr = [1, 2] satisfies Array<number>;";
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
 
         Assert.Single(statements);
         Assert.IsType<Stmt.Const>(statements[0]);

--- a/SharpTS.Tests/ParserTests/StatementParsingTests.cs
+++ b/SharpTS.Tests/ParserTests/StatementParsingTests.cs
@@ -1,4 +1,5 @@
 using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
 using Xunit;
 
 namespace SharpTS.Tests.ParserTests;
@@ -11,14 +12,6 @@ public class StatementParsingTests
 {
     #region Helpers
 
-    private static List<Stmt> Parse(string source)
-    {
-        var lexer = new Lexer(source);
-        var tokens = lexer.ScanTokens();
-        var parser = new Parser(tokens);
-        return parser.ParseOrThrow();
-    }
-
     #endregion
 
     #region If Statements
@@ -26,7 +19,7 @@ public class StatementParsingTests
     [Fact]
     public void If_Simple()
     {
-        var statements = Parse("if (true) x = 1;");
+        var statements = TestHarness.ParseOrThrow("if (true) x = 1;");
         Assert.Single(statements);
         var ifStmt = Assert.IsType<Stmt.If>(statements[0]);
         Assert.IsType<Expr.Literal>(ifStmt.Condition);
@@ -36,7 +29,7 @@ public class StatementParsingTests
     [Fact]
     public void If_WithBlock()
     {
-        var statements = Parse("if (true) { x = 1; }");
+        var statements = TestHarness.ParseOrThrow("if (true) { x = 1; }");
         var ifStmt = Assert.IsType<Stmt.If>(statements[0]);
         Assert.IsType<Stmt.Block>(ifStmt.ThenBranch);
     }
@@ -44,7 +37,7 @@ public class StatementParsingTests
     [Fact]
     public void If_WithElse()
     {
-        var statements = Parse("if (true) x = 1; else x = 2;");
+        var statements = TestHarness.ParseOrThrow("if (true) x = 1; else x = 2;");
         var ifStmt = Assert.IsType<Stmt.If>(statements[0]);
         Assert.NotNull(ifStmt.ElseBranch);
     }
@@ -52,7 +45,7 @@ public class StatementParsingTests
     [Fact]
     public void If_ElseIf()
     {
-        var statements = Parse("if (a) x = 1; else if (b) x = 2; else x = 3;");
+        var statements = TestHarness.ParseOrThrow("if (a) x = 1; else if (b) x = 2; else x = 3;");
         var ifStmt = Assert.IsType<Stmt.If>(statements[0]);
         Assert.NotNull(ifStmt.ElseBranch);
         var elseIf = Assert.IsType<Stmt.If>(ifStmt.ElseBranch);
@@ -62,7 +55,7 @@ public class StatementParsingTests
     [Fact]
     public void If_NestedCondition()
     {
-        var statements = Parse("if (x > 5 && y < 10) { z = 1; }");
+        var statements = TestHarness.ParseOrThrow("if (x > 5 && y < 10) { z = 1; }");
         var ifStmt = Assert.IsType<Stmt.If>(statements[0]);
         Assert.IsType<Expr.Logical>(ifStmt.Condition);
     }
@@ -74,7 +67,7 @@ public class StatementParsingTests
     [Fact]
     public void While_Simple()
     {
-        var statements = Parse("while (true) x++;");
+        var statements = TestHarness.ParseOrThrow("while (true) x++;");
         Assert.Single(statements);
         var whileStmt = Assert.IsType<Stmt.While>(statements[0]);
         Assert.IsType<Expr.Literal>(whileStmt.Condition);
@@ -83,7 +76,7 @@ public class StatementParsingTests
     [Fact]
     public void While_WithBlock()
     {
-        var statements = Parse("while (i < 10) { i++; }");
+        var statements = TestHarness.ParseOrThrow("while (i < 10) { i++; }");
         var whileStmt = Assert.IsType<Stmt.While>(statements[0]);
         Assert.IsType<Stmt.Block>(whileStmt.Body);
     }
@@ -95,7 +88,7 @@ public class StatementParsingTests
     [Fact]
     public void DoWhile_Simple()
     {
-        var statements = Parse("do x++; while (x < 10);");
+        var statements = TestHarness.ParseOrThrow("do x++; while (x < 10);");
         Assert.Single(statements);
         var doWhile = Assert.IsType<Stmt.DoWhile>(statements[0]);
         Assert.IsType<Expr.Binary>(doWhile.Condition);
@@ -104,7 +97,7 @@ public class StatementParsingTests
     [Fact]
     public void DoWhile_WithBlock()
     {
-        var statements = Parse("do { x++; } while (x < 10);");
+        var statements = TestHarness.ParseOrThrow("do { x++; } while (x < 10);");
         var doWhile = Assert.IsType<Stmt.DoWhile>(statements[0]);
         Assert.IsType<Stmt.Block>(doWhile.Body);
     }
@@ -117,7 +110,7 @@ public class StatementParsingTests
     public void For_Traditional()
     {
         // Note: Parser desugars for loops into while loops
-        var statements = Parse("for (let i = 0; i < 10; i++) { }");
+        var statements = TestHarness.ParseOrThrow("for (let i = 0; i < 10; i++) { }");
         // After desugaring, this becomes a block or sequence
         Assert.Single(statements);
     }
@@ -129,7 +122,7 @@ public class StatementParsingTests
     [Fact]
     public void ForOf_Simple()
     {
-        var statements = Parse("for (let x of arr) { }");
+        var statements = TestHarness.ParseOrThrow("for (let x of arr) { }");
         Assert.Single(statements);
         var forOf = Assert.IsType<Stmt.ForOf>(statements[0]);
         Assert.Equal("x", forOf.Variable.Lexeme);
@@ -142,7 +135,7 @@ public class StatementParsingTests
     [Fact]
     public void ForIn_Simple()
     {
-        var statements = Parse("for (let key in obj) { }");
+        var statements = TestHarness.ParseOrThrow("for (let key in obj) { }");
         Assert.Single(statements);
         var forIn = Assert.IsType<Stmt.ForIn>(statements[0]);
         Assert.Equal("key", forIn.Variable.Lexeme);
@@ -162,7 +155,7 @@ public class StatementParsingTests
                     break;
             }
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var switchStmt = Assert.IsType<Stmt.Switch>(statements[0]);
         Assert.Single(switchStmt.Cases);
     }
@@ -178,7 +171,7 @@ public class StatementParsingTests
                     break;
             }
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var switchStmt = Assert.IsType<Stmt.Switch>(statements[0]);
         Assert.Equal(2, switchStmt.Cases.Count);
     }
@@ -192,7 +185,7 @@ public class StatementParsingTests
                     y = 0;
             }
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var switchStmt = Assert.IsType<Stmt.Switch>(statements[0]);
         Assert.NotNull(switchStmt.DefaultBody);
     }
@@ -211,7 +204,7 @@ public class StatementParsingTests
                 console.log(e);
             }
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var tryStmt = Assert.IsType<Stmt.TryCatch>(statements[0]);
         Assert.NotNull(tryStmt.CatchBlock);
         Assert.Null(tryStmt.FinallyBlock);
@@ -227,7 +220,7 @@ public class StatementParsingTests
                 cleanup();
             }
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var tryStmt = Assert.IsType<Stmt.TryCatch>(statements[0]);
         Assert.Null(tryStmt.CatchBlock);
         Assert.NotNull(tryStmt.FinallyBlock);
@@ -245,7 +238,7 @@ public class StatementParsingTests
                 cleanup();
             }
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var tryStmt = Assert.IsType<Stmt.TryCatch>(statements[0]);
         Assert.NotNull(tryStmt.CatchBlock);
         Assert.NotNull(tryStmt.FinallyBlock);
@@ -261,7 +254,7 @@ public class StatementParsingTests
                 console.log(error);
             }
             """;
-        var statements = Parse(source);
+        var statements = TestHarness.ParseOrThrow(source);
         var tryStmt = Assert.IsType<Stmt.TryCatch>(statements[0]);
         Assert.Equal("error", tryStmt.CatchParam!.Lexeme);
     }
@@ -273,7 +266,7 @@ public class StatementParsingTests
     [Fact]
     public void Break_Simple()
     {
-        var statements = Parse("break;");
+        var statements = TestHarness.ParseOrThrow("break;");
         var breakStmt = Assert.IsType<Stmt.Break>(statements[0]);
         Assert.Null(breakStmt.Label);
     }
@@ -281,7 +274,7 @@ public class StatementParsingTests
     [Fact]
     public void Break_WithLabel()
     {
-        var statements = Parse("break outer;");
+        var statements = TestHarness.ParseOrThrow("break outer;");
         var breakStmt = Assert.IsType<Stmt.Break>(statements[0]);
         Assert.Equal("outer", breakStmt.Label!.Lexeme);
     }
@@ -289,7 +282,7 @@ public class StatementParsingTests
     [Fact]
     public void Continue_Simple()
     {
-        var statements = Parse("continue;");
+        var statements = TestHarness.ParseOrThrow("continue;");
         var continueStmt = Assert.IsType<Stmt.Continue>(statements[0]);
         Assert.Null(continueStmt.Label);
     }
@@ -297,7 +290,7 @@ public class StatementParsingTests
     [Fact]
     public void Continue_WithLabel()
     {
-        var statements = Parse("continue loop;");
+        var statements = TestHarness.ParseOrThrow("continue loop;");
         var continueStmt = Assert.IsType<Stmt.Continue>(statements[0]);
         Assert.Equal("loop", continueStmt.Label!.Lexeme);
     }
@@ -305,7 +298,7 @@ public class StatementParsingTests
     [Fact]
     public void Return_Empty()
     {
-        var statements = Parse("return;");
+        var statements = TestHarness.ParseOrThrow("return;");
         var returnStmt = Assert.IsType<Stmt.Return>(statements[0]);
         Assert.Null(returnStmt.Value);
     }
@@ -313,7 +306,7 @@ public class StatementParsingTests
     [Fact]
     public void Return_WithValue()
     {
-        var statements = Parse("return 42;");
+        var statements = TestHarness.ParseOrThrow("return 42;");
         var returnStmt = Assert.IsType<Stmt.Return>(statements[0]);
         Assert.NotNull(returnStmt.Value);
         Assert.IsType<Expr.Literal>(returnStmt.Value);
@@ -322,7 +315,7 @@ public class StatementParsingTests
     [Fact]
     public void Throw_Simple()
     {
-        var statements = Parse("throw new Error();");
+        var statements = TestHarness.ParseOrThrow("throw new Error();");
         var throwStmt = Assert.IsType<Stmt.Throw>(statements[0]);
         Assert.IsType<Expr.New>(throwStmt.Value);
     }
@@ -334,7 +327,7 @@ public class StatementParsingTests
     [Fact]
     public void Labeled_Simple()
     {
-        var statements = Parse("outer: while (true) { }");
+        var statements = TestHarness.ParseOrThrow("outer: while (true) { }");
         var labeled = Assert.IsType<Stmt.LabeledStatement>(statements[0]);
         Assert.Equal("outer", labeled.Label.Lexeme);
         Assert.IsType<Stmt.While>(labeled.Statement);
@@ -347,7 +340,7 @@ public class StatementParsingTests
     [Fact]
     public void Block_Empty()
     {
-        var statements = Parse("{ }");
+        var statements = TestHarness.ParseOrThrow("{ }");
         var block = Assert.IsType<Stmt.Block>(statements[0]);
         Assert.Empty(block.Statements);
     }
@@ -355,7 +348,7 @@ public class StatementParsingTests
     [Fact]
     public void Block_SingleStatement()
     {
-        var statements = Parse("{ x = 1; }");
+        var statements = TestHarness.ParseOrThrow("{ x = 1; }");
         var block = Assert.IsType<Stmt.Block>(statements[0]);
         Assert.Single(block.Statements);
     }
@@ -363,7 +356,7 @@ public class StatementParsingTests
     [Fact]
     public void Block_MultipleStatements()
     {
-        var statements = Parse("{ x = 1; y = 2; z = 3; }");
+        var statements = TestHarness.ParseOrThrow("{ x = 1; y = 2; z = 3; }");
         var block = Assert.IsType<Stmt.Block>(statements[0]);
         Assert.Equal(3, block.Statements.Count);
     }
@@ -375,7 +368,7 @@ public class StatementParsingTests
     [Fact]
     public void Var_Let()
     {
-        var statements = Parse("let x = 5;");
+        var statements = TestHarness.ParseOrThrow("let x = 5;");
         var varStmt = Assert.IsType<Stmt.Var>(statements[0]);
         Assert.Equal("x", varStmt.Name.Lexeme);
     }
@@ -383,7 +376,7 @@ public class StatementParsingTests
     [Fact]
     public void Var_Const()
     {
-        var statements = Parse("const x = 5;");
+        var statements = TestHarness.ParseOrThrow("const x = 5;");
         var constStmt = Assert.IsType<Stmt.Const>(statements[0]);
         Assert.NotNull(constStmt.Initializer);
     }
@@ -391,7 +384,7 @@ public class StatementParsingTests
     [Fact]
     public void Var_WithType()
     {
-        var statements = Parse("let x: number = 5;");
+        var statements = TestHarness.ParseOrThrow("let x: number = 5;");
         var varStmt = Assert.IsType<Stmt.Var>(statements[0]);
         Assert.Equal("number", varStmt.TypeAnnotation);
     }
@@ -399,7 +392,7 @@ public class StatementParsingTests
     [Fact]
     public void Var_NoInitializer()
     {
-        var statements = Parse("let x: number;");
+        var statements = TestHarness.ParseOrThrow("let x: number;");
         var varStmt = Assert.IsType<Stmt.Var>(statements[0]);
         Assert.Null(varStmt.Initializer);
     }
@@ -412,7 +405,7 @@ public class StatementParsingTests
     [Fact]
     public void ExportConst_ParsesAsConst()
     {
-        var statements = Parse("export const x = 5;");
+        var statements = TestHarness.ParseOrThrow("export const x = 5;");
         var export = Assert.IsType<Stmt.Export>(statements[0]);
         var constStmt = Assert.IsType<Stmt.Const>(export.Declaration);
         Assert.Equal("x", constStmt.Name.Lexeme);
@@ -423,7 +416,7 @@ public class StatementParsingTests
     public void ExportLet_StaysMutableVar()
     {
         // Regression guard: `let` is mutable, so it must remain a Stmt.Var.
-        var statements = Parse("export let x = 5;");
+        var statements = TestHarness.ParseOrThrow("export let x = 5;");
         var export = Assert.IsType<Stmt.Export>(statements[0]);
         var varStmt = Assert.IsType<Stmt.Var>(export.Declaration);
         Assert.Equal("x", varStmt.Name.Lexeme);
@@ -432,7 +425,7 @@ public class StatementParsingTests
     [Fact]
     public void ExportVar_StaysMutableVar()
     {
-        var statements = Parse("export var x = 5;");
+        var statements = TestHarness.ParseOrThrow("export var x = 5;");
         var export = Assert.IsType<Stmt.Export>(statements[0]);
         var varStmt = Assert.IsType<Stmt.Var>(export.Declaration);
         Assert.True(varStmt.IsVar);
@@ -444,7 +437,7 @@ public class StatementParsingTests
         // `export const x;` (non-ambient) is a parse error, consistent with bare `const x;`
         // and matching tsc's TS1155 "'const' declarations must be initialized." Before #428
         // this was silently accepted as a mutable Stmt.Var.
-        Assert.ThrowsAny<System.Exception>(() => Parse("export const x;"));
+        Assert.ThrowsAny<System.Exception>(() => TestHarness.ParseOrThrow("export const x;"));
     }
 
     #endregion
@@ -454,7 +447,7 @@ public class StatementParsingTests
     [Fact]
     public void ExpressionStatement_Call()
     {
-        var statements = Parse("console.log(\"hello\");");
+        var statements = TestHarness.ParseOrThrow("console.log(\"hello\");");
         var exprStmt = Assert.IsType<Stmt.Expression>(statements[0]);
         Assert.IsType<Expr.Call>(exprStmt.Expr);
     }
@@ -462,7 +455,7 @@ public class StatementParsingTests
     [Fact]
     public void ExpressionStatement_Assignment()
     {
-        var statements = Parse("x = 5;");
+        var statements = TestHarness.ParseOrThrow("x = 5;");
         var exprStmt = Assert.IsType<Stmt.Expression>(statements[0]);
         Assert.IsType<Expr.Assign>(exprStmt.Expr);
     }

--- a/SharpTS.Tests/ParserTests/TypedCatchBindingTests.cs
+++ b/SharpTS.Tests/ParserTests/TypedCatchBindingTests.cs
@@ -11,21 +11,13 @@ namespace SharpTS.Tests.ParserTests;
 /// </summary>
 public class TypedCatchBindingTests
 {
-    private static List<Stmt> Parse(string source)
-    {
-        var lexer = new Lexer(source);
-        var tokens = lexer.ScanTokens();
-        var parser = new Parser(tokens);
-        return parser.ParseOrThrow();
-    }
-
     [Theory]
     [InlineData("any")]
     [InlineData("unknown")]
     [InlineData("string")]
     public void CatchBindingAnnotation_Parses(string annotation)
     {
-        var stmts = Parse($"try {{ throw 1; }} catch (e: {annotation}) {{ }}");
+        var stmts = TestHarness.ParseOrThrow($"try {{ throw 1; }} catch (e: {annotation}) {{ }}");
         var tryCatch = Assert.IsType<Stmt.TryCatch>(stmts[0]);
         Assert.Equal("e", tryCatch.CatchParam?.Lexeme);
         Assert.Equal(annotation, tryCatch.CatchParamType);
@@ -34,13 +26,12 @@ public class TypedCatchBindingTests
     [Fact]
     public void CatchBinding_NoAnnotation_TypeIsNull()
     {
-        var stmts = Parse("try { throw 1; } catch (e) { }");
+        var stmts = TestHarness.ParseOrThrow("try { throw 1; } catch (e) { }");
         var tryCatch = Assert.IsType<Stmt.TryCatch>(stmts[0]);
         Assert.Null(tryCatch.CatchParamType);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CatchBinding_AnyAndUnknown_Run(ExecutionMode mode)
     {
         var source = """
@@ -52,8 +43,7 @@ public class TypedCatchBindingTests
         Assert.Equal("any 1\nunknown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void CatchBinding_OtherAnnotation_IsTypeErrorNotParseError(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/AbortControllerTests.cs
+++ b/SharpTS.Tests/SharedTests/AbortControllerTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AbortControllerTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortController_CreateAndAccessSignal(ExecutionMode mode)
     {
         var source = @"
@@ -20,8 +19,7 @@ public class AbortControllerTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortController_AbortSetsAborted(ExecutionMode mode)
     {
         var source = @"
@@ -33,8 +31,7 @@ public class AbortControllerTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortController_AbortWithReason(ExecutionMode mode)
     {
         var source = @"
@@ -46,8 +43,7 @@ public class AbortControllerTests
         Assert.Equal("custom reason\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortController_AbortWithDefaultReason(ExecutionMode mode)
     {
         var source = @"
@@ -60,8 +56,7 @@ public class AbortControllerTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_AddEventListener(ExecutionMode mode)
     {
         var source = @"
@@ -77,8 +72,7 @@ public class AbortControllerTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_MultipleListeners(ExecutionMode mode)
     {
         var source = @"
@@ -94,8 +88,7 @@ public class AbortControllerTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_RemoveEventListener(ExecutionMode mode)
     {
         var source = @"
@@ -111,8 +104,7 @@ public class AbortControllerTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_OnAbortProperty(ExecutionMode mode)
     {
         var source = @"
@@ -126,8 +118,7 @@ public class AbortControllerTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_ThrowIfAborted_NotAborted(ExecutionMode mode)
     {
         var source = @"
@@ -143,8 +134,7 @@ public class AbortControllerTests
         Assert.Equal("no throw\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_ThrowIfAborted_Aborted(ExecutionMode mode)
     {
         var source = @"
@@ -161,8 +151,7 @@ public class AbortControllerTests
         Assert.Equal("threw\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_StaticAbort(ExecutionMode mode)
     {
         var source = @"
@@ -173,8 +162,7 @@ public class AbortControllerTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_StaticAbortWithReason(ExecutionMode mode)
     {
         var source = @"
@@ -186,8 +174,7 @@ public class AbortControllerTests
         Assert.Equal("true\nmy reason\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_StaticTimeout(ExecutionMode mode)
     {
         var source = @"
@@ -198,8 +185,7 @@ public class AbortControllerTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_Any_AbortsWhenAnyAborts(ExecutionMode mode)
     {
         var source = @"
@@ -214,8 +200,7 @@ public class AbortControllerTests
         Assert.Equal("false\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_Any_AlreadyAborted(ExecutionMode mode)
     {
         var source = @"
@@ -229,8 +214,7 @@ public class AbortControllerTests
         Assert.Equal("true\nalready done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortController_AbortIdempotent(ExecutionMode mode)
     {
         var source = @"
@@ -245,8 +229,7 @@ public class AbortControllerTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_InstanceOf_BrandChecks(ExecutionMode mode)
     {
         // #246: interpreter returned false for real signals (no brand linkage
@@ -270,8 +253,7 @@ public class AbortControllerTests
     // the fix, compiled mode wrote a plain "onabort" dict key (never fired) and threw
     // "undefined is not a function" for addEventListener.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_OnAbort_DynamicReceiver_Fires(ExecutionMode mode)
     {
         var source = @"
@@ -285,8 +267,7 @@ public class AbortControllerTests
         Assert.Equal("yes\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_AddEventListener_DynamicReceiver_Fires(ExecutionMode mode)
     {
         var source = @"
@@ -300,8 +281,7 @@ public class AbortControllerTests
         Assert.Equal("yes\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_RemoveEventListener_DynamicReceiver(ExecutionMode mode)
     {
         var source = @"
@@ -318,8 +298,7 @@ public class AbortControllerTests
         Assert.Equal("0\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_ThrowIfAborted_DynamicReceiver(ExecutionMode mode)
     {
         var source = @"
@@ -334,8 +313,7 @@ public class AbortControllerTests
         Assert.Equal("noThrow\nthrew\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_AbortedAndReason_DynamicReceiver(ExecutionMode mode)
     {
         // The property reads on an `any` receiver (#224) must keep working alongside

--- a/SharpTS.Tests/SharedTests/AbstractClassTests.cs
+++ b/SharpTS.Tests/SharedTests/AbstractClassTests.cs
@@ -10,8 +10,7 @@ public class AbstractClassTests
 {
     #region Basic Abstract Classes
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbstractClass_ConcreteChild_CanBeInstantiated(ExecutionMode mode)
     {
         var source = """
@@ -33,8 +32,7 @@ public class AbstractClassTests
         Assert.Equal("300\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbstractClass_WithConcreteMethods_InheritsCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -57,8 +55,7 @@ public class AbstractClassTests
 
     #region Abstract Accessors
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbstractAccessor_ImplementedInChild_Works(ExecutionMode mode)
     {
         var source = """
@@ -80,8 +77,7 @@ public class AbstractClassTests
         Assert.Equal("John\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbstractClass_AbstractSetter_Works(ExecutionMode mode)
     {
         var source = """
@@ -110,8 +106,7 @@ public class AbstractClassTests
 
     #region Multiple Abstract Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultipleAbstractMethods_AllImplemented_Works(ExecutionMode mode)
     {
         var source = """
@@ -140,8 +135,7 @@ public class AbstractClassTests
 
     #region Abstract Inheritance Chains
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbstractClass_ExtendsAbstract_DefersImplementation(ExecutionMode mode)
     {
         var source = """
@@ -163,8 +157,7 @@ public class AbstractClassTests
         Assert.Equal("Woof\nWalking\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbstractClass_ThreeLevelChain_Works(ExecutionMode mode)
     {
         var source = """
@@ -189,8 +182,7 @@ public class AbstractClassTests
 
     #region Constructor and Fields
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbstractClass_Constructor_CalledViaSuper(ExecutionMode mode)
     {
         var source = """
@@ -214,8 +206,7 @@ public class AbstractClassTests
         Assert.Equal("Hello, World\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbstractClass_WithFields_Works(ExecutionMode mode)
     {
         var source = """
@@ -246,8 +237,7 @@ public class AbstractClassTests
 
     #region Polymorphic Behavior
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbstractClass_PolymorphicBehavior(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/AccessModifierTests.cs
+++ b/SharpTS.Tests/SharedTests/AccessModifierTests.cs
@@ -10,8 +10,7 @@ public class AccessModifierTests
 {
     #region Private Fields
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Private_Field_AccessibleWithinClass(ExecutionMode mode)
     {
         var source = """
@@ -32,8 +31,7 @@ public class AccessModifierTests
         Assert.Equal("password123\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Private_Method_AccessibleWithinClass(ExecutionMode mode)
     {
         var source = """
@@ -57,8 +55,7 @@ public class AccessModifierTests
 
     #region Protected Fields
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Protected_Field_AccessibleInSubclass(ExecutionMode mode)
     {
         var source = """
@@ -81,8 +78,7 @@ public class AccessModifierTests
         Assert.Equal("secret-key\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Protected_Method_AccessibleInSubclass(ExecutionMode mode)
     {
         var source = """
@@ -108,8 +104,7 @@ public class AccessModifierTests
 
     #region Public Fields
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Public_Field_AccessibleEverywhere(ExecutionMode mode)
     {
         var source = """
@@ -127,8 +122,7 @@ public class AccessModifierTests
         Assert.Equal("Alice\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Public_Method_AccessibleEverywhere(ExecutionMode mode)
     {
         var source = """
@@ -149,8 +143,7 @@ public class AccessModifierTests
 
     #region Readonly Fields
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readonly_Field_CanBeReadAfterInit(ExecutionMode mode)
     {
         var source = """
@@ -172,8 +165,7 @@ public class AccessModifierTests
 
     #region Combined Modifiers
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Private_Readonly_Field_Works(ExecutionMode mode)
     {
         var source = """
@@ -194,8 +186,7 @@ public class AccessModifierTests
         Assert.Equal("abc123\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MixedModifiers_WorkTogether(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ArgumentsMagicVariableTests.cs
+++ b/SharpTS.Tests/SharedTests/ArgumentsMagicVariableTests.cs
@@ -19,8 +19,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </remarks>
 public class ArgumentsMagicVariableTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Arguments_LengthAndIndexing(ExecutionMode mode)
     {
         var source = @"
@@ -35,8 +34,7 @@ public class ArgumentsMagicVariableTests
         Assert.Equal("2\n10\n20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Arguments_WithRestParam_SpreadsToDistinctIndices(ExecutionMode mode)
     {
         // Rest params aggregate trailing args into a collection, but the
@@ -58,8 +56,7 @@ public class ArgumentsMagicVariableTests
         Assert.Equal("0\n1\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Arguments_InsideArrow_InheritsFromEnclosingFunction(ExecutionMode mode)
     {
         // Per JS spec: `arguments` in an arrow is a lexical reference to the
@@ -85,8 +82,7 @@ public class ArgumentsMagicVariableTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Arguments_CapturesExtrasPastDeclaredArity(ExecutionMode mode)
     {
         // The lodash `overRest` pattern: a wrapper function declares zero (or
@@ -115,8 +111,7 @@ public class ArgumentsMagicVariableTests
         Assert.Equal("6\n100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Arguments_DirectCallWithZeroDeclaredParams_SeesExtras(ExecutionMode mode)
     {
         // Direct-call path (not through `$TSFunction.Invoke`): the emitter needs
@@ -137,8 +132,7 @@ public class ArgumentsMagicVariableTests
         Assert.Equal("2\nhello\nworld\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Arguments_InMethodOfClass(ExecutionMode mode)
     {
         var source = @"
@@ -155,8 +149,7 @@ public class ArgumentsMagicVariableTests
         Assert.Equal("foo-bar\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Arguments_IndexedTraversal(ExecutionMode mode)
     {
         // Indexed access through `arguments.length` is the legacy-JS variadic
@@ -180,8 +173,7 @@ public class ArgumentsMagicVariableTests
         Assert.Equal("\na\nabc\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Arguments_FunctionExpression_ApplyForwarding(ExecutionMode mode)
     {
         // Lodash-style wrapper: the returned function EXPRESSION binds its own
@@ -203,8 +195,7 @@ public class ArgumentsMagicVariableTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Arguments_VisibleToDirectEval(ExecutionMode mode)
     {
         // Direct eval runs against the live scope chain, so `arguments` must be

--- a/SharpTS.Tests/SharedTests/ArithmeticTests.cs
+++ b/SharpTS.Tests/SharedTests/ArithmeticTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ArithmeticTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Addition_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -21,8 +20,7 @@ public class ArithmeticTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subtraction_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -34,8 +32,7 @@ public class ArithmeticTests
         Assert.Equal("12\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Multiplication_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -46,8 +43,7 @@ public class ArithmeticTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Division_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -58,8 +54,7 @@ public class ArithmeticTests
         Assert.Equal("25\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Modulo_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -70,8 +65,7 @@ public class ArithmeticTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ComplexExpression_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -83,8 +77,7 @@ public class ArithmeticTests
         Assert.Equal("27\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comparison_LessThan_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -96,8 +89,7 @@ public class ArithmeticTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comparison_GreaterThan_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -109,8 +101,7 @@ public class ArithmeticTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comparison_Equality_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -122,8 +113,7 @@ public class ArithmeticTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comparison_NotEqual_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -135,8 +125,7 @@ public class ArithmeticTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comparison_LessThanOrEqual_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -149,8 +138,7 @@ public class ArithmeticTests
         Assert.Equal("true\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comparison_GreaterThanOrEqual_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -163,8 +151,7 @@ public class ArithmeticTests
         Assert.Equal("true\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UnaryMinus_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -176,8 +163,7 @@ public class ArithmeticTests
         Assert.Equal("-5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LogicalNot_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -189,8 +175,7 @@ public class ArithmeticTests
         Assert.Equal("false\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LogicalAnd_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -204,8 +189,7 @@ public class ArithmeticTests
         Assert.Equal("true\nfalse\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LogicalOr_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ArrayBufferTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayBufferTests.cs
@@ -10,8 +10,7 @@ public class ArrayBufferTests
 {
     #region Constructor Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayBuffer_Constructor_CreatesBufferWithSize(ExecutionMode mode)
     {
         var source = @"
@@ -22,8 +21,7 @@ public class ArrayBufferTests
         Assert.Equal("16\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayBuffer_Constructor_ZeroLength(ExecutionMode mode)
     {
         var source = @"
@@ -34,8 +32,7 @@ public class ArrayBufferTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayBuffer_Constructor_NegativeLength_ThrowsRangeError(ExecutionMode mode)
     {
         var source = @"
@@ -54,8 +51,7 @@ public class ArrayBufferTests
 
     #region ByteLength Property Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayBuffer_ByteLength_ReturnsCorrectValue(ExecutionMode mode)
     {
         var source = @"
@@ -72,8 +68,7 @@ public class ArrayBufferTests
 
     #region Slice Method Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayBuffer_Slice_CreatesNewBuffer(ExecutionMode mode)
     {
         var source = @"
@@ -85,8 +80,7 @@ public class ArrayBufferTests
         Assert.Equal("8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayBuffer_Slice_WithNegativeIndices(ExecutionMode mode)
     {
         var source = @"
@@ -98,8 +92,7 @@ public class ArrayBufferTests
         Assert.Equal("8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayBuffer_Slice_CopiesDataIndependently(ExecutionMode mode)
     {
         var source = @"
@@ -122,8 +115,7 @@ public class ArrayBufferTests
         Assert.Equal("100\n200\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayBuffer_Slice_DefaultEnd(ExecutionMode mode)
     {
         var source = @"
@@ -139,8 +131,7 @@ public class ArrayBufferTests
 
     #region IsView Static Method Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayBuffer_IsView_ReturnsTrueForTypedArray(ExecutionMode mode)
     {
         var source = @"
@@ -151,8 +142,7 @@ public class ArrayBufferTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayBuffer_IsView_ReturnsFalseForNonView(ExecutionMode mode)
     {
         var source = @"
@@ -168,8 +158,7 @@ public class ArrayBufferTests
         Assert.Equal("false\nfalse\nfalse\nfalse\nfalse\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayBuffer_IsView_AllTypedArrays(ExecutionMode mode)
     {
         var source = @"
@@ -193,8 +182,7 @@ public class ArrayBufferTests
 
     #region TypedArray over ArrayBuffer Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Int32Array_OverArrayBuffer_SharesMemory(ExecutionMode mode)
     {
         var source = @"
@@ -208,8 +196,7 @@ public class ArrayBufferTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedArray_OverArrayBuffer_WithByteOffset(ExecutionMode mode)
     {
         var source = @"
@@ -222,8 +209,7 @@ public class ArrayBufferTests
         Assert.Equal("4\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Uint8Array_OverArrayBuffer_WorksCorrectly(ExecutionMode mode)
     {
         var source = @"
@@ -238,8 +224,7 @@ public class ArrayBufferTests
         Assert.Equal("255\n128\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AllTypedArrays_OverArrayBuffer(ExecutionMode mode)
     {
         var source = @"
@@ -285,8 +270,7 @@ public class ArrayBufferTests
         Assert.Equal("4294967295", lines[6]);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedArray_Buffer_ReturnsArrayBuffer(ExecutionMode mode)
     {
         var source = @"
@@ -303,8 +287,7 @@ public class ArrayBufferTests
 
     #region TypedArray Array-literal Constructor Tests (#782)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedArray_FromArrayLiteral_CopiesElements(ExecutionMode mode)
     {
         var source = @"
@@ -315,8 +298,7 @@ public class ArrayBufferTests
         Assert.Equal("1 2 3 3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedArray_Int32_FromArrayLiteral_CopiesElements(ExecutionMode mode)
     {
         var source = @"
@@ -327,8 +309,7 @@ public class ArrayBufferTests
         Assert.Equal("100 -300 3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedArray_CopyFromTypedArray(ExecutionMode mode)
     {
         var source = @"
@@ -340,8 +321,7 @@ public class ArrayBufferTests
         Assert.Equal("10 20 30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void TypedArray_Spread_ProducesArray(ExecutionMode mode)
     {
         var source = @"
@@ -357,8 +337,7 @@ public class ArrayBufferTests
 
     #region Mixed ArrayBuffer and SharedArrayBuffer Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayBuffer_IsNotShared(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/ArrayConcatSpreadTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayConcatSpreadTests.cs
@@ -18,8 +18,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ArrayConcatSpreadTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Concat_SpreadOfArrayOfArrays_FlattensOneLevel(ExecutionMode mode)
     {
         // The issue repro: ...[[1, 2]] spreads into concat([1, 2]), which then
@@ -31,8 +30,7 @@ public class ArrayConcatSpreadTests
         Assert.Equal("[0,1,2]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Concat_SpreadOfFlatArray_AppendsElements(ExecutionMode mode)
     {
         // ...[1, 2] spreads into concat(1, 2); neither arg is an array, so each
@@ -44,8 +42,7 @@ public class ArrayConcatSpreadTests
         Assert.Equal("[0,1,2]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Concat_SpreadOfMultipleArrays_FlattensEach(ExecutionMode mode)
     {
         // ...[[1,2],[3]] spreads into concat([1,2], [3]) → each flattened once.
@@ -56,8 +53,7 @@ public class ArrayConcatSpreadTests
         Assert.Equal("[0,1,2,3]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Concat_MixedSpreadAndPlainArgs(ExecutionMode mode)
     {
         // concat(2, ...[[3, 4]], 5) → append 2, flatten [3,4], append 5.
@@ -68,8 +64,7 @@ public class ArrayConcatSpreadTests
         Assert.Equal("[1,2,3,4,5]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Concat_SpreadOfBoxedStringArrays(ExecutionMode mode)
     {
         // The bug is not numeric-specific — boxed (string) element arrays spread
@@ -81,8 +76,7 @@ public class ArrayConcatSpreadTests
         Assert.Equal("[\"a\",\"b\",\"c\"]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Concat_SpreadOfVariable(ExecutionMode mode)
     {
         // Spread source as a named variable (not an inline literal) routes
@@ -95,8 +89,7 @@ public class ArrayConcatSpreadTests
         Assert.Equal("[0,1,2]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Concat_SpreadOfEmptyArray_NoOp(ExecutionMode mode)
     {
         // Spreading an empty array contributes no arguments.
@@ -107,8 +100,7 @@ public class ArrayConcatSpreadTests
         Assert.Equal("[0]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Concat_SpreadInsideAsyncFunction(ExecutionMode mode)
     {
         // Exercises the async emitter: the spread element list is produced by an

--- a/SharpTS.Tests/SharedTests/ArrayCopyWithinTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayCopyWithinTests.cs
@@ -11,8 +11,7 @@ public class ArrayCopyWithinTests
 {
     #region Basic CopyWithin Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_BasicCopy(ExecutionMode mode)
     {
         var source = """
@@ -25,8 +24,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("4,5,3,4,5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_ReturnsSameArray(ExecutionMode mode)
     {
         var source = """
@@ -39,8 +37,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_WithStartAndEnd(ExecutionMode mode)
     {
         var source = """
@@ -53,8 +50,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("4,2,3,4,5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_CopyToMiddle(ExecutionMode mode)
     {
         var source = """
@@ -71,8 +67,7 @@ public class ArrayCopyWithinTests
 
     #region Negative Index Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_NegativeTarget(ExecutionMode mode)
     {
         var source = """
@@ -85,8 +80,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("1,2,3,1,2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_NegativeStart(ExecutionMode mode)
     {
         var source = """
@@ -99,8 +93,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("4,5,3,4,5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_NegativeEnd(ExecutionMode mode)
     {
         var source = """
@@ -113,8 +106,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("3,4,3,4,5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_AllNegativeIndices(ExecutionMode mode)
     {
         var source = """
@@ -131,8 +123,7 @@ public class ArrayCopyWithinTests
 
     #region Overlapping Region Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_OverlappingForward(ExecutionMode mode)
     {
         // Copying from index 0 to index 1 with overlap
@@ -148,8 +139,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("1,1,2,3,4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_OverlappingBackward(ExecutionMode mode)
     {
         // Copying from index 2 to index 0 with overlap
@@ -169,8 +159,7 @@ public class ArrayCopyWithinTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_EmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -183,8 +172,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_SingleElement(ExecutionMode mode)
     {
         var source = """
@@ -197,8 +185,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_TargetBeyondLength(ExecutionMode mode)
     {
         var source = """
@@ -211,8 +198,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("1,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_StartBeyondLength(ExecutionMode mode)
     {
         var source = """
@@ -225,8 +211,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("1,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_EndBeforeStart(ExecutionMode mode)
     {
         var source = """
@@ -239,8 +224,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("1,2,3,4,5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_SameTargetAndStart(ExecutionMode mode)
     {
         var source = """
@@ -253,8 +237,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("1,2,3,4,5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_NegativeTargetBeyondLength(ExecutionMode mode)
     {
         var source = """
@@ -271,8 +254,7 @@ public class ArrayCopyWithinTests
 
     #region Chaining Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_Chaining(ExecutionMode mode)
     {
         var source = """
@@ -291,8 +273,7 @@ public class ArrayCopyWithinTests
 
     #region MDN Examples
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_MDNExample1(ExecutionMode mode)
     {
         // MDN: [1, 2, 3, 4, 5].copyWithin(-2)
@@ -307,8 +288,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("1,2,3,1,2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_MDNExample2(ExecutionMode mode)
     {
         // MDN: [1, 2, 3, 4, 5].copyWithin(0, 3)
@@ -323,8 +303,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("4,5,3,4,5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_MDNExample3(ExecutionMode mode)
     {
         // MDN: [1, 2, 3, 4, 5].copyWithin(0, 3, 4)
@@ -339,8 +318,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("4,2,3,4,5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_MDNExample4(ExecutionMode mode)
     {
         // MDN: [1, 2, 3, 4, 5].copyWithin(-2, -3, -1)
@@ -359,8 +337,7 @@ public class ArrayCopyWithinTests
 
     #region With Different Types
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_WithStrings(ExecutionMode mode)
     {
         var source = """
@@ -373,8 +350,7 @@ public class ArrayCopyWithinTests
         Assert.Equal("d,e,c,d,e\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_CopyWithin_WithObjects(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ArrayFillTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayFillTests.cs
@@ -11,8 +11,7 @@ public class ArrayFillTests
 {
     #region Basic Fill Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Fill_FillsEntireArray(ExecutionMode mode)
     {
         var source = """
@@ -25,8 +24,7 @@ public class ArrayFillTests
         Assert.Equal("0,0,0,0,0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Fill_ReturnsSameArray(ExecutionMode mode)
     {
         var source = """
@@ -39,8 +37,7 @@ public class ArrayFillTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Fill_WithDifferentValueType(ExecutionMode mode)
     {
         var source = """
@@ -57,8 +54,7 @@ public class ArrayFillTests
 
     #region Start Index Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Fill_WithStartIndex(ExecutionMode mode)
     {
         var source = """
@@ -71,8 +67,7 @@ public class ArrayFillTests
         Assert.Equal("1,2,0,0,0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Fill_WithNegativeStartIndex(ExecutionMode mode)
     {
         var source = """
@@ -85,8 +80,7 @@ public class ArrayFillTests
         Assert.Equal("1,2,3,0,0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Fill_StartIndexBeyondLength(ExecutionMode mode)
     {
         var source = """
@@ -99,8 +93,7 @@ public class ArrayFillTests
         Assert.Equal("1,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Fill_NegativeStartIndexBeyondLength(ExecutionMode mode)
     {
         var source = """
@@ -117,8 +110,7 @@ public class ArrayFillTests
 
     #region End Index Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Fill_WithStartAndEndIndex(ExecutionMode mode)
     {
         var source = """
@@ -131,8 +123,7 @@ public class ArrayFillTests
         Assert.Equal("1,0,0,0,5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Fill_WithNegativeEndIndex(ExecutionMode mode)
     {
         var source = """
@@ -145,8 +136,7 @@ public class ArrayFillTests
         Assert.Equal("1,0,0,0,5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Fill_EndIndexBeforeStart(ExecutionMode mode)
     {
         var source = """
@@ -159,8 +149,7 @@ public class ArrayFillTests
         Assert.Equal("1,2,3,4,5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Fill_EndIndexBeyondLength(ExecutionMode mode)
     {
         var source = """
@@ -177,8 +166,7 @@ public class ArrayFillTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Fill_EmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -191,8 +179,7 @@ public class ArrayFillTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Fill_SingleElement(ExecutionMode mode)
     {
         var source = """
@@ -205,8 +192,7 @@ public class ArrayFillTests
         Assert.Equal("99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Fill_WithNull(ExecutionMode mode)
     {
         var source = """
@@ -221,8 +207,7 @@ public class ArrayFillTests
         Assert.Equal("null\nnull\nnull\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Fill_WithObject(ExecutionMode mode)
     {
         // Test that fill uses the same object reference for all elements
@@ -243,8 +228,7 @@ public class ArrayFillTests
 
     #region Chaining Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Fill_Chaining(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ArrayFlatTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayFlatTests.cs
@@ -10,8 +10,7 @@ public class ArrayFlatTests
 {
     #region Flat Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Flat_DefaultDepth_FlattensOneLevel(ExecutionMode mode)
     {
         var source = """
@@ -28,8 +27,7 @@ public class ArrayFlatTests
         Assert.Equal("5\n1\n2\n3\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Flat_DepthTwo_FlattensNested(ExecutionMode mode)
     {
         var source = """
@@ -45,8 +43,7 @@ public class ArrayFlatTests
         Assert.Equal("4\n1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Flat_DepthZero_ShallowCopy(ExecutionMode mode)
     {
         var source = """
@@ -60,8 +57,7 @@ public class ArrayFlatTests
         Assert.Equal("2\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Flat_LargeDepth_FlattensCompletely(ExecutionMode mode)
     {
         var source = """
@@ -79,8 +75,7 @@ public class ArrayFlatTests
         Assert.Equal("5\n1\n2\n3\n4\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Flat_EmptyArray_ReturnsEmpty(ExecutionMode mode)
     {
         var source = """
@@ -93,8 +88,7 @@ public class ArrayFlatTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Flat_NoNestedArrays_ReturnsCopy(ExecutionMode mode)
     {
         var source = """
@@ -114,8 +108,7 @@ public class ArrayFlatTests
 
     #region FlatMap Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FlatMap_ArrayResult_Flattens(ExecutionMode mode)
     {
         var source = """
@@ -134,8 +127,7 @@ public class ArrayFlatTests
         Assert.Equal("6\n1\n2\n2\n4\n3\n6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FlatMap_NonArrayResult_AddedDirectly(ExecutionMode mode)
     {
         var source = """
@@ -151,8 +143,7 @@ public class ArrayFlatTests
         Assert.Equal("3\n2\n4\n6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FlatMap_EmptyArrayResult_Filters(ExecutionMode mode)
     {
         var source = """
@@ -167,8 +158,7 @@ public class ArrayFlatTests
         Assert.Equal("2\n2\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FlatMap_ReceivesIndexAndArray(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ArrayHofAnnotatedCallbackTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayHofAnnotatedCallbackTests.cs
@@ -20,8 +20,7 @@ public class ArrayHofAnnotatedCallbackTests
 {
     // ── Adapter path: annotated callbacks inside a function (the benchmark shape) ──
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AnnotatedMap_Number(ExecutionMode mode)
     {
         var source = """
@@ -34,8 +33,7 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("2,4,6,8,10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AnnotatedFilter_BooleanPredicate(ExecutionMode mode)
     {
         var source = """
@@ -48,8 +46,7 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("2,4,6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AnnotatedReduce_TwoTypedParams(ExecutionMode mode)
     {
         var source = """
@@ -62,8 +59,7 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("15\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AnnotatedChain_MapFilterReduce(ExecutionMode mode)
     {
         // The array-methods benchmark shape: every callback param is annotated.
@@ -80,8 +76,7 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("40\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AnnotatedPredicates_FindSomeEveryFindIndex(ExecutionMode mode)
     {
         var source = """
@@ -98,8 +93,7 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("4,true,true,2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AnnotatedForEach_Void(ExecutionMode mode)
     {
         var source = """
@@ -114,8 +108,7 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AnnotatedStringParam_MapsToLength(ExecutionMode mode)
     {
         var source = """
@@ -130,8 +123,7 @@ public class ArrayHofAnnotatedCallbackTests
 
     // ── Coercion parity: non-integer / NaN elements must marshal identically ──
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AnnotatedMap_FloatAndNaN(ExecutionMode mode)
     {
         var source = """
@@ -146,8 +138,7 @@ public class ArrayHofAnnotatedCallbackTests
 
     // ── Fallback cases: must NOT take the 1-arg adapter, must stay correct ──
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultiArgCallback_UsesIndex_FallsBack(ExecutionMode mode)
     {
         // 2-param map callback uses the index → arity guard keeps it on the reflective
@@ -164,8 +155,7 @@ public class ArrayHofAnnotatedCallbackTests
 
     // ── #861 L3: capturing annotated arrows (instance adapter on the display class) ──
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CapturingAnnotatedArrow_Map(ExecutionMode mode)
     {
         // Capturing arrow → instance adapter on the display class (L3); the captured value must
@@ -181,8 +171,7 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("11,12,13\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CapturingAnnotatedArrow_Reduce(ExecutionMode mode)
     {
         var source = """
@@ -196,8 +185,7 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("515\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CapturingAnnotatedArrow_PerIterationFreshCapture(ExecutionMode mode)
     {
         // The display instance must be built FRESH at each call so each closure captures the
@@ -216,8 +204,7 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("10,11,12\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CapturingBooleanPredicate_Filter(ExecutionMode mode)
     {
         // L3 (capturing instance adapter) + L4 (bool-returning adapter → *DirectBool): a captured
@@ -233,8 +220,7 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("4,5,6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BooleanPredicate_SomeEvery_ShortCircuit(ExecutionMode mode)
     {
         // L4 bool adapter under the short-circuiting some/every must agree with the reflective path.
@@ -250,8 +236,7 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("true,false\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CapturingAnnotatedArrow_Chained(ExecutionMode mode)
     {
         // Capturing arrows across a chained map().filter().reduce() (L1 capturing adapter + L2 round-trip).
@@ -268,8 +253,7 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UntypedCallback_StillWorks(ExecutionMode mode)
     {
         // Unannotated callback keeps the pre-existing untyped direct/reflective path.
@@ -285,8 +269,7 @@ public class ArrayHofAnnotatedCallbackTests
 
     // ── #861 L2: chained-stage round-trip elimination ──
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ChainedMapFilter_AssignedToArrayVariable(ExecutionMode mode)
     {
         // The final stage's result is consumed as an array value, so its $Array wrap must be
@@ -302,8 +285,7 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("6,8,10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ChainedMapFilter_LengthOnResult(ExecutionMode mode)
     {
         // .length on the chain result requires the final $Array wrap to survive.
@@ -317,8 +299,7 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ChainedMapSlice_MixedCallbackAndPlainArgs(ExecutionMode mode)
     {
         // Inner map (callback) feeds outer slice (plain args) — the bare List must flow across the
@@ -333,8 +314,7 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("4,6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ChainedFilterMap_UntypedAndAnnotatedMixed(ExecutionMode mode)
     {
         // Inner filter is annotated, outer map is untyped — both stages chain through a bare List.
@@ -348,8 +328,7 @@ public class ArrayHofAnnotatedCallbackTests
         Assert.Equal("20,40,60\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstBoundAnnotatedCallback_Resolves(ExecutionMode mode)
     {
         // const-bound arrow callback resolves through ConstArrowBindings and takes the

--- a/SharpTS.Tests/SharedTests/ArrayIteratorTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayIteratorTests.cs
@@ -11,8 +11,7 @@ public class ArrayIteratorTests
 {
     #region entries() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Entries_ReturnsIndexValuePairs(ExecutionMode mode)
     {
         var source = """
@@ -26,8 +25,7 @@ public class ArrayIteratorTests
         Assert.Equal("0:10\n1:20\n2:30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Entries_WithManualDestructuring(ExecutionMode mode)
     {
         var source = """
@@ -43,8 +41,7 @@ public class ArrayIteratorTests
         Assert.Equal("0=a\n1=b\n2=c\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Entries_EmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -60,8 +57,7 @@ public class ArrayIteratorTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Entries_WithMixedTypes(ExecutionMode mode)
     {
         var source = """
@@ -75,8 +71,7 @@ public class ArrayIteratorTests
         Assert.Equal("0:1\n1:two\n2:3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Entries_WithArrayFrom(ExecutionMode mode)
     {
         var source = """
@@ -95,8 +90,7 @@ public class ArrayIteratorTests
 
     #region keys() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Keys_ReturnsIndices(ExecutionMode mode)
     {
         var source = """
@@ -110,8 +104,7 @@ public class ArrayIteratorTests
         Assert.Equal("0\n1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Keys_EmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -127,8 +120,7 @@ public class ArrayIteratorTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Keys_CanAccessArrayElements(ExecutionMode mode)
     {
         var source = """
@@ -142,8 +134,7 @@ public class ArrayIteratorTests
         Assert.Equal("100\n200\n300\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Keys_WithArrayFrom(ExecutionMode mode)
     {
         var source = """
@@ -160,8 +151,7 @@ public class ArrayIteratorTests
 
     #region values() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Values_ReturnsElements(ExecutionMode mode)
     {
         var source = """
@@ -175,8 +165,7 @@ public class ArrayIteratorTests
         Assert.Equal("10\n20\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Values_EmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -192,8 +181,7 @@ public class ArrayIteratorTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Values_WithStrings(ExecutionMode mode)
     {
         var source = """
@@ -207,8 +195,7 @@ public class ArrayIteratorTests
         Assert.Equal("hello\nworld\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Values_WithArrayFrom(ExecutionMode mode)
     {
         var source = """
@@ -221,8 +208,7 @@ public class ArrayIteratorTests
         Assert.Equal("1-2-3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Values_CountsNullAndUndefined(ExecutionMode mode)
     {
         var source = """
@@ -242,8 +228,7 @@ public class ArrayIteratorTests
 
     #region Break/Continue Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Entries_WithBreak(ExecutionMode mode)
     {
         var source = """
@@ -261,8 +246,7 @@ public class ArrayIteratorTests
         Assert.Equal("0:1\n1:2\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Keys_WithContinue(ExecutionMode mode)
     {
         var source = """
@@ -277,8 +261,7 @@ public class ArrayIteratorTests
         Assert.Equal("0\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Values_WithBreak(ExecutionMode mode)
     {
         var source = """
@@ -297,8 +280,7 @@ public class ArrayIteratorTests
 
     #region Null and Boolean Stringification Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Entries_WithNull_StringifiesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -312,8 +294,7 @@ public class ArrayIteratorTests
         Assert.Equal("0:1\n1:null\n2:2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Entries_WithBoolean_StringifiesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -327,8 +308,7 @@ public class ArrayIteratorTests
         Assert.Equal("0:1\n1:true\n2:2\n3:false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringConcat_WithNull_JavaScriptStyle(ExecutionMode mode)
     {
         var source = """
@@ -340,8 +320,7 @@ public class ArrayIteratorTests
         Assert.Equal("value:null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringConcat_WithBoolean_LowercaseTrue(ExecutionMode mode)
     {
         var source = """
@@ -353,8 +332,7 @@ public class ArrayIteratorTests
         Assert.Equal("bool:true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringConcat_WithBoolean_LowercaseFalse(ExecutionMode mode)
     {
         var source = """
@@ -366,8 +344,7 @@ public class ArrayIteratorTests
         Assert.Equal("bool:false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringConcat_MultipleNullsAndBooleans(ExecutionMode mode)
     {
         var source = """
@@ -385,8 +362,7 @@ public class ArrayIteratorTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Entries_SingleElement(ExecutionMode mode)
     {
         var source = """
@@ -400,8 +376,7 @@ public class ArrayIteratorTests
         Assert.Equal("0:42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Keys_LargeArray(ExecutionMode mode)
     {
         var source = """
@@ -418,8 +393,7 @@ public class ArrayIteratorTests
         Assert.Equal("45\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Values_WithObjects(ExecutionMode mode)
     {
         var source = """
@@ -433,8 +407,7 @@ public class ArrayIteratorTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Entries_NestedArrays(ExecutionMode mode)
     {
         var source = """
@@ -454,8 +427,7 @@ public class ArrayIteratorTests
 
     #region Destructuring in for...of Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_ArrayDestructuring_EntriesPattern(ExecutionMode mode)
     {
         var source = """
@@ -471,8 +443,7 @@ public class ArrayIteratorTests
         Assert.Equal("0:a,1:b,2:c\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_ArrayDestructuring_MapEntries(ExecutionMode mode)
     {
         var source = """
@@ -490,8 +461,7 @@ public class ArrayIteratorTests
         Assert.Equal("x=10;y=20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_ObjectDestructuring(ExecutionMode mode)
     {
         var source = """
@@ -510,8 +480,7 @@ public class ArrayIteratorTests
         Assert.Equal("Alice is 30; Bob is 25\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_ArrayDestructuring_WithRest(ExecutionMode mode)
     {
         var source = """
@@ -527,8 +496,7 @@ public class ArrayIteratorTests
         Assert.Equal("1:3; 5:3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_ArrayDestructuring_WithBreak(ExecutionMode mode)
     {
         var source = """
@@ -545,8 +513,7 @@ public class ArrayIteratorTests
         Assert.Equal("0:a,1:b\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_ArrayDestructuring_WithContinue(ExecutionMode mode)
     {
         var source = """
@@ -563,8 +530,7 @@ public class ArrayIteratorTests
         Assert.Equal("0:a,2:c\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_ObjectDestructuring_WithRename(ExecutionMode mode)
     {
         var source = """
@@ -580,8 +546,7 @@ public class ArrayIteratorTests
         Assert.Equal("1,2; 3,4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_ArrayDestructuring_WithHole(ExecutionMode mode)
     {
         var source = """
@@ -597,8 +562,7 @@ public class ArrayIteratorTests
         Assert.Equal("1,3; 4,6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_ArrayDestructuring_WithLet(ExecutionMode mode)
     {
         var source = """
@@ -614,8 +578,7 @@ public class ArrayIteratorTests
         Assert.Equal("a=1,b=2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_ArrayDestructuring_MapWithTypedValues(ExecutionMode mode)
     {
         // Tests destructuring Map entries with typed key/value
@@ -638,8 +601,7 @@ public class ArrayIteratorTests
         Assert.Equal("alpha,beta,gamma\n6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_ArrayDestructuring_NestedArrays(ExecutionMode mode)
     {
         // Tests destructuring nested arrays in for...of
@@ -656,8 +618,7 @@ public class ArrayIteratorTests
         Assert.Equal("1-2-3; 4-5-6; 7-8-9\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_ArrayDestructuring_ArrayEntries_Computation(ExecutionMode mode)
     {
         // Tests using destructured values in computation
@@ -675,8 +636,7 @@ public class ArrayIteratorTests
         Assert.Equal("200\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForAwaitOf_ArrayDestructuring(ExecutionMode mode)
     {
         var source = """
@@ -705,8 +665,7 @@ public class ArrayIteratorTests
 
     #region Spread Iterator Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spread_ArrayEntries_CreatesArray(ExecutionMode mode)
     {
         var source = """
@@ -722,8 +681,7 @@ public class ArrayIteratorTests
         Assert.Equal("3\n0:a\n1:b\n2:c\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spread_ArrayKeys_CreatesArray(ExecutionMode mode)
     {
         var source = """
@@ -736,8 +694,7 @@ public class ArrayIteratorTests
         Assert.Equal("0,1,2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spread_ArrayValues_CreatesArray(ExecutionMode mode)
     {
         var source = """
@@ -750,8 +707,7 @@ public class ArrayIteratorTests
         Assert.Equal("10,20,30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spread_Set_CreatesArray(ExecutionMode mode)
     {
         var source = """
@@ -764,8 +720,7 @@ public class ArrayIteratorTests
         Assert.Equal("1,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spread_Map_CreatesArrayOfTuples(ExecutionMode mode)
     {
         var source = """
@@ -781,8 +736,7 @@ public class ArrayIteratorTests
         Assert.Equal("2\nx,10; y,20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spread_Map_NestedElementAccess(ExecutionMode mode)
     {
         // Tests that arr[i][0] and arr[i][1] work correctly on spread Map entries
@@ -802,8 +756,7 @@ public class ArrayIteratorTests
         Assert.Equal("a\n100\nb\n200\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spread_Map_JsonStringify_ProducesArrayOfPairs(ExecutionMode mode)
     {
         // #953: in compiled mode spread Map entries were boxed KeyValuePair structs, not real
@@ -818,8 +771,7 @@ public class ArrayIteratorTests
         Assert.Equal("[[0,0.5],[1,1.5]]\n[[\"a\",1],[\"b\",2]]\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_Iteration_MaterializesRealArrays(ExecutionMode mode)
     {
         // #953 root-cause fix is shared across for-of / Array.from / Object.fromEntries.
@@ -833,8 +785,7 @@ public class ArrayIteratorTests
         Assert.Equal("1 2\n[[1,2],[3,4]]\n{\"x\":1}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spread_MapEntries_NestedElementAccess(ExecutionMode mode)
     {
         // Tests explicit .entries() call with nested access
@@ -851,8 +802,7 @@ public class ArrayIteratorTests
         Assert.Equal("x=1\ny=2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spread_Map_AccessInLoop(ExecutionMode mode)
     {
         // Tests iterating over spread Map entries with element access
@@ -871,8 +821,7 @@ public class ArrayIteratorTests
         Assert.Equal("one:1\ntwo:2\nthree:3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spread_String_CreatesCharArray(ExecutionMode mode)
     {
         var source = """
@@ -884,8 +833,7 @@ public class ArrayIteratorTests
         Assert.Equal("h-e-l-l-o\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spread_Generator_CreatesArray(ExecutionMode mode)
     {
         var source = """
@@ -902,8 +850,7 @@ public class ArrayIteratorTests
         Assert.Equal("1,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spread_Iterator_WithOtherElements(ExecutionMode mode)
     {
         // Use any[] type to handle mixed number and tuple elements

--- a/SharpTS.Tests/SharedTests/ArrayLocalPromotionTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayLocalPromotionTests.cs
@@ -18,8 +18,7 @@ public class ArrayLocalPromotionTests
 {
     // ── Positive cases: promotable shapes ──────────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_BoolSieve_CountsPrimes(ExecutionMode mode)
     {
         // The count-primes shape: const boolean[] built by push, then index read/write.
@@ -45,8 +44,7 @@ public class ArrayLocalPromotionTests
         Assert.Equal("8\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_NumberArray_PushIndexLength(ExecutionMode mode)
     {
         var source = """
@@ -65,8 +63,7 @@ public class ArrayLocalPromotionTests
         Assert.Equal("120\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_IndexWrite_ReturnsAssignedValue(ExecutionMode mode)
     {
         // `arr[i] = v` is an expression whose value is the assigned RHS.
@@ -85,8 +82,7 @@ public class ArrayLocalPromotionTests
 
     // ── Escape cases: must fall back, must stay correct ────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Escape_PassedToFunctionThatPushes(ExecutionMode mode)
     {
         // Passing the array as an argument escapes — a bare List<T> can't be mutated
@@ -106,8 +102,7 @@ public class ArrayLocalPromotionTests
         Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Escape_Returned(ExecutionMode mode)
     {
         var source = """
@@ -125,8 +120,7 @@ public class ArrayLocalPromotionTests
         Assert.Equal("2\n8\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Escape_Spread(ExecutionMode mode)
     {
         var source = """
@@ -144,8 +138,7 @@ public class ArrayLocalPromotionTests
         Assert.Equal("10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Escape_ForOf(ExecutionMode mode)
     {
         var source = """
@@ -162,8 +155,7 @@ public class ArrayLocalPromotionTests
         Assert.Equal("60\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Escape_OtherMethod_Map(ExecutionMode mode)
     {
         // .map is not a permitted use → no promotion; result must still be correct.
@@ -182,8 +174,7 @@ public class ArrayLocalPromotionTests
         Assert.Equal("12\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Escape_OutOfRangeReadIsUndefined(ExecutionMode mode)
     {
         // A read past the end must yield undefined (JS semantics). Reading `xs[5]`
@@ -201,8 +192,7 @@ public class ArrayLocalPromotionTests
         Assert.Equal("[1]\nundefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Escape_AnyTypedElementWrite_NotPromoted(ExecutionMode mode)
     {
         // An `any`-typed element write disqualifies promotion (the typed setter would
@@ -224,8 +214,7 @@ public class ArrayLocalPromotionTests
         Assert.Equal("42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_AutoExtendOnIndexWrite(ExecutionMode mode)
     {
         // Writing at index == length extends the array by one (auto-extend path).
@@ -245,8 +234,7 @@ public class ArrayLocalPromotionTests
         Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_PerScope_NameCollisionDoesNotPoison(ExecutionMode mode)
     {
         // `xs` in build() is a clean push/index/length array and must promote even though an
@@ -276,8 +264,7 @@ public class ArrayLocalPromotionTests
 
     // ── Typed-HOF pipeline (#861): typed reduce over a promoted number[] ────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReduce_PromotedNumberArray(ExecutionMode mode)
     {
         // arr used only via push + reduce(non-capturing typed numeric reducer) → promoted to
@@ -295,8 +282,7 @@ public class ArrayLocalPromotionTests
         Assert.Equal("10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReduce_CapturingReducer_FallsBackCorrectly(ExecutionMode mode)
     {
         // The reducer captures `base`, so it cannot bind as a direct typed delegate — the analyzer
@@ -316,8 +302,7 @@ public class ArrayLocalPromotionTests
         Assert.Equal("303\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedMap_ThenIndexLength(ExecutionMode mode)
     {
         // `doubled` = arr.map(typed mapper) is itself promoted to List<double> (its source arr is
@@ -338,8 +323,7 @@ public class ArrayLocalPromotionTests
         Assert.Equal("20\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedMap_ThenReduce_Chain(ExecutionMode mode)
     {
         // Full typed chain: arr (List<double>) → map → doubled (List<double>) → reduce → double.
@@ -357,8 +341,7 @@ public class ArrayLocalPromotionTests
         Assert.Equal("20\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedMap_ResultReturned_FallsBackCorrectly(ExecutionMode mode)
     {
         // The map result escapes (returned), so it must NOT be a bare List<double> — falls back to
@@ -378,8 +361,7 @@ public class ArrayLocalPromotionTests
         Assert.Equal("3\n10\n12\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedFilter_ThenLength(ExecutionMode mode)
     {
         var source = """
@@ -398,8 +380,7 @@ public class ArrayLocalPromotionTests
         Assert.Equal("20\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedPipeline_MapFilterReduce(ExecutionMode mode)
     {
         // The full array-methods benchmark shape: build → map → filter → reduce, every stage typed.

--- a/SharpTS.Tests/SharedTests/ArrayMethodAwaitArgTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayMethodAwaitArgTests.cs
@@ -15,8 +15,7 @@ namespace SharpTS.Tests.SharedTests;
 public class ArrayMethodAwaitArgTests
 {
     // The exact #850 repro: an async arrow that WRITES a captured variable, awaited inside push().
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Push_AwaitedWriteCaptureArrow(ExecutionMode mode)
     {
         var source = """
@@ -36,8 +35,7 @@ public class ArrayMethodAwaitArgTests
     }
 
     // Same shape but a READ-ONLY capture — confirms the bug was never about write-capture promotion.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Push_AwaitedReadOnlyCaptureArrow(ExecutionMode mode)
     {
         var source = """
@@ -56,8 +54,7 @@ public class ArrayMethodAwaitArgTests
         Assert.Equal("6,5\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Push_MultipleAwaitedArgs(ExecutionMode mode)
     {
         var source = """
@@ -73,8 +70,7 @@ public class ArrayMethodAwaitArgTests
         Assert.Equal("1,2,3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Unshift_AwaitedArg(ExecutionMode mode)
     {
         var source = """
@@ -90,8 +86,7 @@ public class ArrayMethodAwaitArgTests
         Assert.Equal("1,2,3,4\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Slice_AwaitedArgs(ExecutionMode mode)
     {
         var source = """
@@ -106,8 +101,7 @@ public class ArrayMethodAwaitArgTests
         Assert.Equal("20,30\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Splice_AwaitedArgs(ExecutionMode mode)
     {
         var source = """
@@ -123,8 +117,7 @@ public class ArrayMethodAwaitArgTests
         Assert.Equal("10,99,30\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Concat_AwaitedArg(ExecutionMode mode)
     {
         var source = """
@@ -139,8 +132,7 @@ public class ArrayMethodAwaitArgTests
         Assert.Equal("1,2,3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reduce_AwaitedInitialValue(ExecutionMode mode)
     {
         var source = """
@@ -155,8 +147,7 @@ public class ArrayMethodAwaitArgTests
         Assert.Equal("106\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IndexOf_AwaitedArgs(ExecutionMode mode)
     {
         var source = """
@@ -171,8 +162,7 @@ public class ArrayMethodAwaitArgTests
         Assert.Equal("3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Includes_AwaitedArg(ExecutionMode mode)
     {
         var source = """
@@ -187,8 +177,7 @@ public class ArrayMethodAwaitArgTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fill_AwaitedArgs(ExecutionMode mode)
     {
         var source = """
@@ -204,8 +193,7 @@ public class ArrayMethodAwaitArgTests
         Assert.Equal("0,7,7,0\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CopyWithin_AwaitedArgs(ExecutionMode mode)
     {
         var source = """
@@ -221,8 +209,7 @@ public class ArrayMethodAwaitArgTests
         Assert.Equal("4,5,3,4,5\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void At_AwaitedArg(ExecutionMode mode)
     {
         var source = """
@@ -239,8 +226,7 @@ public class ArrayMethodAwaitArgTests
 
     // The original issue surfaced via a sync arrow capture plus an unrelated awaited call inside push
     // (variant D) — also fixed, since the trigger is purely the nested await in the array argument.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Push_SyncArrowCaptureWithUnrelatedAwait(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ArrayMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayMethodTests.cs
@@ -11,8 +11,7 @@ public class ArrayMethodTests
 {
     #region Find Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Find_ReturnsMatchingElement(ExecutionMode mode)
     {
         var source = """
@@ -25,8 +24,7 @@ public class ArrayMethodTests
         Assert.Equal("4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Find_ReturnsUndefinedWhenNotFound(ExecutionMode mode)
     {
         // ECMA-262 23.1.3.10: Array.prototype.find returns undefined when no element matches.
@@ -44,8 +42,7 @@ public class ArrayMethodTests
 
     #region FindIndex Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_FindIndex_ReturnsIndex(ExecutionMode mode)
     {
         var source = """
@@ -57,8 +54,7 @@ public class ArrayMethodTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_FindIndex_ReturnsMinusOneWhenNotFound(ExecutionMode mode)
     {
         var source = """
@@ -74,8 +70,7 @@ public class ArrayMethodTests
 
     #region Some/Every Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Some_ReturnsTrueWhenMatch(ExecutionMode mode)
     {
         var source = """
@@ -87,8 +82,7 @@ public class ArrayMethodTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Some_ReturnsFalseWhenNoMatch(ExecutionMode mode)
     {
         var source = """
@@ -100,8 +94,7 @@ public class ArrayMethodTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Every_ReturnsTrueWhenAllMatch(ExecutionMode mode)
     {
         var source = """
@@ -113,8 +106,7 @@ public class ArrayMethodTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Every_ReturnsFalseWhenSomeDontMatch(ExecutionMode mode)
     {
         var source = """
@@ -130,8 +122,7 @@ public class ArrayMethodTests
 
     #region Reduce Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Reduce_WithInitialValue_ReturnsResult(ExecutionMode mode)
     {
         var source = """
@@ -144,8 +135,7 @@ public class ArrayMethodTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Reduce_WithoutInitialValue_UsesFirstElement(ExecutionMode mode)
     {
         var source = """
@@ -162,8 +152,7 @@ public class ArrayMethodTests
 
     #region ReduceRight Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ReduceRight_WithInitialValue_ReturnsResult(ExecutionMode mode)
     {
         var source = """
@@ -176,8 +165,7 @@ public class ArrayMethodTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_With_OutOfBounds_ThrowsRangeError(ExecutionMode mode)
     {
         // Array.prototype.with must throw a real RangeError for out-of-bounds indices. Compiled
@@ -201,8 +189,7 @@ public class ArrayMethodTests
         Assert.Equal("true/true\ntrue/true\n1,9,3\n1,2,9\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ReduceRight_WithoutInitialValue_UsesLastElement(ExecutionMode mode)
     {
         var source = """
@@ -215,8 +202,7 @@ public class ArrayMethodTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ReduceRight_IteratesRightToLeft(ExecutionMode mode)
     {
         var source = """
@@ -229,8 +215,7 @@ public class ArrayMethodTests
         Assert.Equal("dcba\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ReduceRight_WithIndex_PassesCorrectIndices(ExecutionMode mode)
     {
         var source = """
@@ -247,8 +232,7 @@ public class ArrayMethodTests
         Assert.Equal("2,1,0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ReduceRight_SingleElement_WithInitial(ExecutionMode mode)
     {
         var source = """
@@ -261,8 +245,7 @@ public class ArrayMethodTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ReduceRight_SingleElement_WithoutInitial(ExecutionMode mode)
     {
         var source = """
@@ -279,8 +262,7 @@ public class ArrayMethodTests
 
     #region Includes/IndexOf Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Includes_ReturnsTrueWhenFound(ExecutionMode mode)
     {
         var source = """
@@ -292,8 +274,7 @@ public class ArrayMethodTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Includes_ReturnsFalseWhenNotFound(ExecutionMode mode)
     {
         var source = """
@@ -305,8 +286,7 @@ public class ArrayMethodTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_IndexOf_ReturnsIndex(ExecutionMode mode)
     {
         var source = """
@@ -318,8 +298,7 @@ public class ArrayMethodTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_IndexOf_ReturnsMinusOneWhenNotFound(ExecutionMode mode)
     {
         var source = """
@@ -335,8 +314,7 @@ public class ArrayMethodTests
 
     #region Join/Concat/Reverse Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Join_ReturnsJoinedString(ExecutionMode mode)
     {
         var source = """
@@ -348,8 +326,7 @@ public class ArrayMethodTests
         Assert.Equal("1,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Join_WithEmptySeparator_ConcatenatesElements(ExecutionMode mode)
     {
         var source = """
@@ -361,8 +338,7 @@ public class ArrayMethodTests
         Assert.Equal("123\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Join_NestedArrays_JoinRecursively(ExecutionMode mode)
     {
         // ECMA-262 23.1.3.16: each element is ToString-coerced, so a nested array
@@ -377,8 +353,7 @@ public class ArrayMethodTests
         Assert.Equal("1,2-3\n1,2,3\n1,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Join_PlainObject_UsesObjectObject(ExecutionMode mode)
     {
         // A plain object element ToString-coerces to "[object Object]" (its inherited
@@ -390,8 +365,7 @@ public class ArrayMethodTests
         Assert.Equal("[object Object], [object Object]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Join_ErrorElement_DispatchesToString(ExecutionMode mode)
     {
         // An Error element in a joined/coerced array dispatches Error.prototype.toString
@@ -407,8 +381,7 @@ public class ArrayMethodTests
         Assert.Equal("RangeError: boom, y\nRangeError: boom\nRangeError: boom\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Join_UserToString_DispatchesToString(ExecutionMode mode)
     {
         // A user class with its own toString() is dispatched per element (#922
@@ -422,8 +395,7 @@ public class ArrayMethodTests
         Assert.Equal("(1,2)|(1,2)\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Concat_ReturnsNewArray(ExecutionMode mode)
     {
         var source = """
@@ -439,8 +411,7 @@ public class ArrayMethodTests
         Assert.Equal("4\n1\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Reverse_ReversesInPlace(ExecutionMode mode)
     {
         var source = """
@@ -458,8 +429,7 @@ public class ArrayMethodTests
 
     #region Chained Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ChainedMethods_Work(ExecutionMode mode)
     {
         var source = """
@@ -478,8 +448,7 @@ public class ArrayMethodTests
 
     #region ES2023 FindLast/FindLastIndex
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_FindLast_ReturnsLastMatchingElement(ExecutionMode mode)
     {
         var source = """
@@ -492,8 +461,7 @@ public class ArrayMethodTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_FindLast_ReturnsUndefinedWhenNotFound(ExecutionMode mode)
     {
         // ECMA-262 23.1.3.11: Array.prototype.findLast returns undefined when no element matches.
@@ -507,8 +475,7 @@ public class ArrayMethodTests
         Assert.Equal("undefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_FindLast_EmptyArrayReturnsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -521,8 +488,7 @@ public class ArrayMethodTests
         Assert.Equal("undefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_FindLastIndex_ReturnsLastMatchingIndex(ExecutionMode mode)
     {
         var source = """
@@ -534,8 +500,7 @@ public class ArrayMethodTests
         Assert.Equal("4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_FindLastIndex_ReturnsMinusOneWhenNotFound(ExecutionMode mode)
     {
         var source = """
@@ -547,8 +512,7 @@ public class ArrayMethodTests
         Assert.Equal("-1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_FindLastIndex_EmptyArrayReturnsMinusOne(ExecutionMode mode)
     {
         var source = """
@@ -564,8 +528,7 @@ public class ArrayMethodTests
 
     #region ES2023 ToReversed
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToReversed_ReturnsNewReversedArray(ExecutionMode mode)
     {
         var source = """
@@ -580,8 +543,7 @@ public class ArrayMethodTests
         Assert.Equal("5\n1\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToReversed_OriginalUnchanged(ExecutionMode mode)
     {
         var source = """
@@ -595,8 +557,7 @@ public class ArrayMethodTests
         Assert.Equal("1,2,3\n3,2,1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToReversed_EmptyArrayReturnsEmpty(ExecutionMode mode)
     {
         var source = """
@@ -609,8 +570,7 @@ public class ArrayMethodTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToReversed_SingleElementArray(ExecutionMode mode)
     {
         var source = """
@@ -627,8 +587,7 @@ public class ArrayMethodTests
 
     #region ES2023 With
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_With_ReplacesElementAtIndex(ExecutionMode mode)
     {
         var source = """
@@ -642,8 +601,7 @@ public class ArrayMethodTests
         Assert.Equal("1,99,3\n1,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_With_NegativeIndex(ExecutionMode mode)
     {
         var source = """
@@ -656,8 +614,7 @@ public class ArrayMethodTests
         Assert.Equal("1,2,99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_With_FirstElement(ExecutionMode mode)
     {
         var source = """
@@ -670,8 +627,7 @@ public class ArrayMethodTests
         Assert.Equal("99,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_With_LastElement(ExecutionMode mode)
     {
         var source = """
@@ -684,8 +640,7 @@ public class ArrayMethodTests
         Assert.Equal("1,2,99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_With_OriginalUnchanged(ExecutionMode mode)
     {
         var source = """
@@ -703,8 +658,7 @@ public class ArrayMethodTests
 
     #region ES2022 At
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_At_PositiveIndex(ExecutionMode mode)
     {
         var source = """
@@ -718,8 +672,7 @@ public class ArrayMethodTests
         Assert.Equal("1\n3\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_At_NegativeIndex(ExecutionMode mode)
     {
         var source = """
@@ -733,8 +686,7 @@ public class ArrayMethodTests
         Assert.Equal("5\n4\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_At_OutOfBoundsReturnsUndefined(ExecutionMode mode)
     {
         // ECMA-262 23.1.3.1 specifies `at()` returns undefined (not null) for
@@ -749,8 +701,7 @@ public class ArrayMethodTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_At_EmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -763,8 +714,7 @@ public class ArrayMethodTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_At_SingleElement(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ArrayPrototypeToObjectTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayPrototypeToObjectTests.cs
@@ -21,8 +21,7 @@ public class ArrayPrototypeToObjectTests
 {
     // ── callback's `obj` argument is a wrapper object for a primitive `this` ──
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForEach_OnStringPrimitive_CallbackReceivesStringWrapper(ExecutionMode mode)
     {
         var source = """
@@ -35,8 +34,7 @@ public class ArrayPrototypeToObjectTests
         Assert.Equal("object:true;object:true;\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_OnStringPrimitive_ObjArgIsStringWrapper(ExecutionMode mode)
     {
         var source = """
@@ -48,8 +46,7 @@ public class ArrayPrototypeToObjectTests
         Assert.Equal("[true,true]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Filter_OnStringPrimitive_ObjArgIsStringWrapper(ExecutionMode mode)
     {
         // Keeps every element because `obj instanceof String` is true for each.
@@ -62,8 +59,7 @@ public class ArrayPrototypeToObjectTests
         Assert.Equal("[\"a\",\"b\"]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Some_OnStringPrimitive_ObjArgIsStringWrapper(ExecutionMode mode)
     {
         var source = """
@@ -74,8 +70,7 @@ public class ArrayPrototypeToObjectTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Every_OnStringPrimitive_ObjArgIsStringWrapper(ExecutionMode mode)
     {
         // Mirrors Test262 built-ins/Array/prototype/every/15.4.4.16-1-7.js:
@@ -89,8 +84,7 @@ public class ArrayPrototypeToObjectTests
         Assert.Equal("false\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reduce_OnStringPrimitive_ObjArgIsStringWrapper(ExecutionMode mode)
     {
         var source = """
@@ -102,8 +96,7 @@ public class ArrayPrototypeToObjectTests
         Assert.Equal("TT\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReduceRight_OnStringPrimitive_ObjArgIsStringWrapper(ExecutionMode mode)
     {
         var source = """
@@ -115,8 +108,7 @@ public class ArrayPrototypeToObjectTests
         Assert.Equal("TT\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_OnStringPrimitive_ElementsAreChars(ExecutionMode mode)
     {
         // The element argument (kValue) is still the per-index character string,
@@ -130,8 +122,7 @@ public class ArrayPrototypeToObjectTests
 
     // ── String OBJECT receiver: ToObject is identity, wrapper passes through ──
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Every_OnStringObject_ObjArgIsStringWrapper(ExecutionMode mode)
     {
         // Mirrors Test262 .../every/15.4.4.16-1-8.js.
@@ -146,8 +137,7 @@ public class ArrayPrototypeToObjectTests
 
     // ── plain array-like / real array receivers must be unaffected ───────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_OnRealArray_ObjArgIsTheArray(ExecutionMode mode)
     {
         var source = """
@@ -159,8 +149,7 @@ public class ArrayPrototypeToObjectTests
         Assert.Equal("[10,20,30]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_OnPlainArrayLike_PassesReceiverThrough(ExecutionMode mode)
     {
         var source = """
@@ -173,8 +162,7 @@ public class ArrayPrototypeToObjectTests
 
     // ── Object.defineProperties reads Properties via Get (accessor getters) ──
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefineProperties_BooleanObjectProperties_GetterThisIsWrapper(ExecutionMode mode)
     {
         // Mirrors Test262 built-ins/Object/defineProperties/15.2.3.7-2-4.js:
@@ -194,8 +182,7 @@ public class ArrayPrototypeToObjectTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefineProperties_NumberObjectProperties_GetterThisIsWrapper(ExecutionMode mode)
     {
         // Mirrors Test262 .../defineProperties/15.2.3.7-2-6.js.
@@ -213,8 +200,7 @@ public class ArrayPrototypeToObjectTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefineProperties_SkipsNonEnumerableSourceProperty(ExecutionMode mode)
     {
         // ObjectDefineProperties only processes own ENUMERABLE keys of Properties.

--- a/SharpTS.Tests/SharedTests/ArraySortTests.cs
+++ b/SharpTS.Tests/SharedTests/ArraySortTests.cs
@@ -10,8 +10,7 @@ public class ArraySortTests
 {
     #region Default Lexicographic Sort
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Sort_DefaultLexicographic_NumbersAsStrings(ExecutionMode mode)
     {
         // JavaScript: [10, 2, 1].sort() -> [1, 10, 2] (lexicographic)
@@ -25,8 +24,7 @@ public class ArraySortTests
         Assert.Equal("1,10,2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Sort_DefaultLexicographic_Strings(ExecutionMode mode)
     {
         var source = """
@@ -39,8 +37,7 @@ public class ArraySortTests
         Assert.Equal("apple,banana,cherry\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Sort_ReturnsReferenceToSameArray(ExecutionMode mode)
     {
         var source = """
@@ -53,8 +50,7 @@ public class ArraySortTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Sort_MutatesOriginalArray(ExecutionMode mode)
     {
         var source = """
@@ -73,8 +69,7 @@ public class ArraySortTests
 
     #region Sort With Compare Function
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Sort_NumericAscending(ExecutionMode mode)
     {
         var source = """
@@ -87,8 +82,7 @@ public class ArraySortTests
         Assert.Equal("1,2,10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Sort_NumericDescending(ExecutionMode mode)
     {
         var source = """
@@ -101,8 +95,7 @@ public class ArraySortTests
         Assert.Equal("10,2,1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Sort_CustomObjectProperty(ExecutionMode mode)
     {
         var source = """
@@ -126,8 +119,7 @@ public class ArraySortTests
 
     #region Stability
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Sort_IsStable(ExecutionMode mode)
     {
         // Objects with same key should preserve original order
@@ -153,8 +145,7 @@ public class ArraySortTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Sort_EmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -167,8 +158,7 @@ public class ArraySortTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Sort_SingleElement(ExecutionMode mode)
     {
         var source = """
@@ -181,8 +171,7 @@ public class ArraySortTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Sort_LargerArray(ExecutionMode mode)
     {
         var source = """
@@ -195,8 +184,7 @@ public class ArraySortTests
         Assert.Equal("1,2,3,4,5,6,7,8,9\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Sort_UndefinedMovedToEnd(ExecutionMode mode)
     {
         // JavaScript spec: undefined values are always sorted to end
@@ -220,8 +208,7 @@ public class ArraySortTests
 
     #region ToSorted
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToSorted_ReturnsNewArray(ExecutionMode mode)
     {
         var source = """
@@ -234,8 +221,7 @@ public class ArraySortTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToSorted_OriginalUnchanged(ExecutionMode mode)
     {
         var source = """
@@ -248,8 +234,7 @@ public class ArraySortTests
         Assert.Equal("3,1,2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToSorted_DefaultLexicographic(ExecutionMode mode)
     {
         var source = """
@@ -262,8 +247,7 @@ public class ArraySortTests
         Assert.Equal("1,10,2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToSorted_WithCompareFn(ExecutionMode mode)
     {
         var source = """
@@ -276,8 +260,7 @@ public class ArraySortTests
         Assert.Equal("1,2,10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToSorted_Chained(ExecutionMode mode)
     {
         var source = """
@@ -297,8 +280,7 @@ public class ArraySortTests
 
     #region Frozen Array Behavior
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Sort_FrozenArray_ReturnsUnchanged(ExecutionMode mode)
     {
         var source = """
@@ -314,8 +296,7 @@ public class ArraySortTests
         Assert.Equal("true\n3,1,2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToSorted_FrozenArray_Works(ExecutionMode mode)
     {
         var source = """
@@ -334,8 +315,7 @@ public class ArraySortTests
 
     #region Comparator Throws (#921)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Sort_ComparatorThrow_ReachesGuestCatchAsError(ExecutionMode mode)
     {
         // A guest throw from the comparator must surface verbatim to the guest catch, not be
@@ -357,8 +337,7 @@ public class ArraySortTests
         Assert.Equal("object\ntrue\nfrom comparator\nTypeError\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToSorted_ComparatorThrow_ReachesGuestCatchAsError(ExecutionMode mode)
     {
         var source = """
@@ -377,8 +356,7 @@ public class ArraySortTests
         Assert.Equal("object\ntrue\nfrom comparator\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Sort_ComparatorThrowRawString_PreservesGuestIdentity(ExecutionMode mode)
     {
         // A raw string throw keeps its guest identity (string, not Error) — consistent with #694.

--- a/SharpTS.Tests/SharedTests/ArraySpliceTests.cs
+++ b/SharpTS.Tests/SharedTests/ArraySpliceTests.cs
@@ -10,8 +10,7 @@ public class ArraySpliceTests
 {
     #region Basic Splice Operations
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_DeleteMiddleElements(ExecutionMode mode)
     {
         // [1,2,3,4,5].splice(1, 2) -> deleted [2,3], arr becomes [1,4,5]
@@ -26,8 +25,7 @@ public class ArraySpliceTests
         Assert.Equal("2,3\n1,4,5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_InsertWithoutDeleting(ExecutionMode mode)
     {
         // [1,2,3].splice(1, 0, 'a', 'b') -> deleted [], arr becomes [1,'a','b',2,3]
@@ -42,8 +40,7 @@ public class ArraySpliceTests
         Assert.Equal("0\n1,a,b,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_ReplaceElement(ExecutionMode mode)
     {
         // [1,2,3].splice(1, 1, 'x') -> deleted [2], arr becomes [1,'x',3]
@@ -62,8 +59,7 @@ public class ArraySpliceTests
 
     #region Negative Indices
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_NegativeStart_DeleteToEnd(ExecutionMode mode)
     {
         // [1,2,3].splice(-1) -> deleted [3], arr becomes [1,2]
@@ -78,8 +74,7 @@ public class ArraySpliceTests
         Assert.Equal("3\n1,2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_NegativeStart_WithDeleteCount(ExecutionMode mode)
     {
         // [1,2,3].splice(-2, 1) -> deleted [2], arr becomes [1,3]
@@ -94,8 +89,7 @@ public class ArraySpliceTests
         Assert.Equal("2\n1,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_NegativeStart_BeyondLength(ExecutionMode mode)
     {
         // [1,2,3].splice(-10, 1) -> start clamps to 0, deleted [1], arr becomes [2,3]
@@ -114,8 +108,7 @@ public class ArraySpliceTests
 
     #region No DeleteCount
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_NoDeleteCount_DeleteToEnd(ExecutionMode mode)
     {
         // [1,2,3].splice(1) -> deleted [2,3], arr becomes [1]
@@ -134,8 +127,7 @@ public class ArraySpliceTests
 
     #region Start Beyond Length
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_StartBeyondLength_InsertAtEnd(ExecutionMode mode)
     {
         // [1,2,3].splice(10, 1, 'x') -> deleted [], arr becomes [1,2,3,'x']
@@ -154,8 +146,7 @@ public class ArraySpliceTests
 
     #region Coercion Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_NaN_Start_TreatedAsZero(ExecutionMode mode)
     {
         // [1,2,3].splice(NaN, 1) -> start=0, deleted [1]
@@ -170,8 +161,7 @@ public class ArraySpliceTests
         Assert.Equal("1\n2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_Float_Truncated(ExecutionMode mode)
     {
         // [1,2,3].splice(0.9, 1.9) -> truncated to (0,1), deleted [1]
@@ -190,8 +180,7 @@ public class ArraySpliceTests
 
     #region Empty Array
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_EmptyArray_InsertElements(ExecutionMode mode)
     {
         // [].splice(0, 0, 1, 2) -> deleted [], arr becomes [1,2]
@@ -206,8 +195,7 @@ public class ArraySpliceTests
         Assert.Equal("0\n1,2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_NoArguments_ReturnsEmpty(ExecutionMode mode)
     {
         // [1,2,3].splice() -> deleted [], arr unchanged
@@ -226,8 +214,7 @@ public class ArraySpliceTests
 
     #region ToSpliced
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToSpliced_ReturnsNewArray(ExecutionMode mode)
     {
         var source = """
@@ -242,8 +229,7 @@ public class ArraySpliceTests
         Assert.Equal("1,a,3\n1,2,3\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToSpliced_OriginalUnchanged(ExecutionMode mode)
     {
         var source = """
@@ -257,8 +243,7 @@ public class ArraySpliceTests
         Assert.Equal("1,2,3\n2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToSpliced_NegativeStart(ExecutionMode mode)
     {
         var source = """
@@ -271,8 +256,7 @@ public class ArraySpliceTests
         Assert.Equal("1,2,3,99,5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToSpliced_NoArguments_ReturnsCopy(ExecutionMode mode)
     {
         var source = """
@@ -286,8 +270,7 @@ public class ArraySpliceTests
         Assert.Equal("1,2,3\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToSpliced_InsertMultiple(ExecutionMode mode)
     {
         var source = """
@@ -300,8 +283,7 @@ public class ArraySpliceTests
         Assert.Equal("1,a,b,c,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToSpliced_DeleteAll(ExecutionMode mode)
     {
         var source = """
@@ -318,8 +300,7 @@ public class ArraySpliceTests
 
     #region Frozen/Sealed Arrays
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_OnFrozenArray_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """
@@ -332,8 +313,7 @@ public class ArraySpliceTests
         Assert.Contains("TypeError", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_ToSpliced_OnFrozenArray_Works(ExecutionMode mode)
     {
         // toSpliced creates a new array, so it works on frozen arrays
@@ -349,8 +329,7 @@ public class ArraySpliceTests
         Assert.Equal("1,99,3\n1,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_OnSealedArray_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """
@@ -367,8 +346,7 @@ public class ArraySpliceTests
 
     #region Additional Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_DeleteMoreThanAvailable(ExecutionMode mode)
     {
         // Deleting more elements than available should delete up to the end
@@ -383,8 +361,7 @@ public class ArraySpliceTests
         Assert.Equal("2,3\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_ZeroDeleteCount(ExecutionMode mode)
     {
         var source = """
@@ -398,8 +375,7 @@ public class ArraySpliceTests
         Assert.Equal("0\n1,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Splice_NegativeDeleteCount_TreatedAsZero(ExecutionMode mode)
     {
         // Negative deleteCount should be treated as 0

--- a/SharpTS.Tests/SharedTests/ArrayStaticTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayStaticTests.cs
@@ -10,8 +10,7 @@ public class ArrayStaticTests
 {
     #region Array.isArray Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_IsArray_ReturnsTrue_ForArray(ExecutionMode mode)
     {
         var source = """
@@ -23,8 +22,7 @@ public class ArrayStaticTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_IsArray_ReturnsTrue_ForEmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -36,8 +34,7 @@ public class ArrayStaticTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_IsArray_ReturnsFalse_ForNumber(ExecutionMode mode)
     {
         var source = """
@@ -49,8 +46,7 @@ public class ArrayStaticTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_IsArray_ReturnsFalse_ForString(ExecutionMode mode)
     {
         var source = """
@@ -62,8 +58,7 @@ public class ArrayStaticTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_IsArray_ReturnsFalse_ForObject(ExecutionMode mode)
     {
         var source = """
@@ -75,8 +70,7 @@ public class ArrayStaticTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_IsArray_ReturnsFalse_ForNull(ExecutionMode mode)
     {
         var source = """
@@ -92,8 +86,7 @@ public class ArrayStaticTests
 
     #region Array.from Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_From_CreatesArrayFromArray(ExecutionMode mode)
     {
         var source = """
@@ -108,8 +101,7 @@ public class ArrayStaticTests
         Assert.Equal("3\n1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_From_CreatesArrayFromString(ExecutionMode mode)
     {
         var source = """
@@ -124,8 +116,7 @@ public class ArrayStaticTests
         Assert.Equal("3\na\nb\nc\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_From_WithMapFunction(ExecutionMode mode)
     {
         var source = """
@@ -140,8 +131,7 @@ public class ArrayStaticTests
         Assert.Equal("3\n2\n4\n6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_From_MapFunctionWithIndex(ExecutionMode mode)
     {
         var source = """
@@ -155,8 +145,7 @@ public class ArrayStaticTests
         Assert.Equal("10\n21\n32\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_From_EmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -169,8 +158,7 @@ public class ArrayStaticTests
         Assert.Equal("0\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_From_FromSet(ExecutionMode mode)
     {
         var source = """
@@ -186,8 +174,7 @@ public class ArrayStaticTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_From_WithGenerator(ExecutionMode mode)
     {
         var source = """
@@ -207,8 +194,7 @@ public class ArrayStaticTests
         Assert.Equal("3\n1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_From_CustomIterator(ExecutionMode mode)
     {
         var source = """
@@ -240,8 +226,7 @@ public class ArrayStaticTests
 
     #region Array.of Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Of_CreatesArrayFromArguments(ExecutionMode mode)
     {
         var source = """
@@ -256,8 +241,7 @@ public class ArrayStaticTests
         Assert.Equal("3\n1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Of_SingleNumber(ExecutionMode mode)
     {
         var source = """
@@ -270,8 +254,7 @@ public class ArrayStaticTests
         Assert.Equal("1\n7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Of_NoArguments(ExecutionMode mode)
     {
         var source = """
@@ -284,8 +267,7 @@ public class ArrayStaticTests
         Assert.Equal("0\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Of_MixedTypes(ExecutionMode mode)
     {
         var source = """
@@ -301,8 +283,7 @@ public class ArrayStaticTests
         Assert.Equal("4\n1\ntwo\ntrue\nnull\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Of_WithStrings(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ArraySubclassTests.cs
+++ b/SharpTS.Tests/SharedTests/ArraySubclassTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ArraySubclassTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsArray_ArrayBehaviorAndBrand(ExecutionMode mode)
     {
         var source = """
@@ -30,8 +29,7 @@ public class ArraySubclassTests
         Assert.Equal("2\n1 2\ntrue\ntrue\ntrue\n[1,2]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsArray_MethodsFieldsAndIteration(ExecutionMode mode)
     {
         var source = """
@@ -54,8 +52,7 @@ public class ArraySubclassTests
         Assert.Equal("7\nsum\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsArray_ConstructorWithSuper(ExecutionMode mode)
     {
         var source = """
@@ -74,8 +71,7 @@ public class ArraySubclassTests
         Assert.Equal("b\n2 true true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsArray_SuperWithLengthArgument(ExecutionMode mode)
     {
         // ECMA-262 §23.1.1.1: a single numeric constructor argument sets the
@@ -97,8 +93,7 @@ public class ArraySubclassTests
         Assert.Equal("3\n2 x y\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsArray_GetterResolves(ExecutionMode mode)
     {
         var source = """
@@ -115,8 +110,7 @@ public class ArraySubclassTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void ExtendsUnbridgedBuiltIn_PreciseRuntimeError(ExecutionMode mode)
     {
         // Built-ins without a subclassing bridge (Error/Array/#233 and

--- a/SharpTS.Tests/SharedTests/ArrayTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrayTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ArrayTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayLiteral_CreatesArray(ExecutionMode mode)
     {
         var source = """
@@ -21,8 +20,7 @@ public class ArrayTests
         Assert.Equal("[1, 2, 3]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayIndexing_ReturnsCorrectElement(ExecutionMode mode)
     {
         var source = """
@@ -36,8 +34,7 @@ public class ArrayTests
         Assert.Equal("10\n20\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayLength_ReturnsCorrectLength(ExecutionMode mode)
     {
         var source = """
@@ -49,8 +46,7 @@ public class ArrayTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayPush_AddsElement(ExecutionMode mode)
     {
         var source = """
@@ -64,8 +60,7 @@ public class ArrayTests
         Assert.Equal("3\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayPop_RemovesAndReturnsLastElement(ExecutionMode mode)
     {
         var source = """
@@ -79,8 +74,7 @@ public class ArrayTests
         Assert.Equal("3\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayShift_RemovesAndReturnsFirstElement(ExecutionMode mode)
     {
         var source = """
@@ -95,8 +89,7 @@ public class ArrayTests
         Assert.Equal("1\n2\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayUnshift_AddsElementAtBeginning(ExecutionMode mode)
     {
         var source = """
@@ -110,8 +103,7 @@ public class ArrayTests
         Assert.Equal("1\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArraySlice_ReturnsSubarray(ExecutionMode mode)
     {
         var source = """
@@ -126,8 +118,7 @@ public class ArrayTests
         Assert.Equal("3\n2\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayMap_TransformsElements(ExecutionMode mode)
     {
         var source = """
@@ -145,8 +136,7 @@ public class ArrayTests
         Assert.Equal("2\n4\n6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayFilter_FiltersElements(ExecutionMode mode)
     {
         var source = """
@@ -165,8 +155,7 @@ public class ArrayTests
         Assert.Equal("3\n2\n4\n6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayForEach_IteratesElements(ExecutionMode mode)
     {
         var source = """
@@ -181,8 +170,7 @@ public class ArrayTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayIndexAssignment_ModifiesElement(ExecutionMode mode)
     {
         var source = """
@@ -195,8 +183,7 @@ public class ArrayTests
         Assert.Equal("99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedArray_AccessesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -211,8 +198,7 @@ public class ArrayTests
         Assert.Equal("1\n2\n3\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EmptyArray_HasZeroLength(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ArrowContextualTypingTests.cs
+++ b/SharpTS.Tests/SharedTests/ArrowContextualTypingTests.cs
@@ -13,8 +13,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ArrowContextualTypingTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SortComparator_StringAtNumericIndex(ExecutionMode mode)
     {
         var source = """
@@ -31,8 +30,7 @@ public class ArrowContextualTypingTests
         Assert.Equal("1,0,2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SortComparator_ThisCaptureInClass(ExecutionMode mode)
     {
         // Exercises the URLSearchParams.sort pattern directly.
@@ -68,8 +66,7 @@ public class ArrowContextualTypingTests
         Assert.Equal("a,b,c\n1,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MapCallback_InfersElementType(ExecutionMode mode)
     {
         var source = """
@@ -81,8 +78,7 @@ public class ArrowContextualTypingTests
         Assert.Equal("ALICE,BOB\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FilterCallback_InfersElementType(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/AsConstTests.cs
+++ b/SharpTS.Tests/SharedTests/AsConstTests.cs
@@ -10,8 +10,7 @@ public class AsConstTests
 {
     #region Basic as const Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_ArrayToTuple_TypeInferredCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -25,8 +24,7 @@ public class AsConstTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_MixedTypeArray_Works(ExecutionMode mode)
     {
         var source = """
@@ -40,8 +38,7 @@ public class AsConstTests
         Assert.Equal("1\ntwo\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_ObjectLiteral_Works(ExecutionMode mode)
     {
         var source = """
@@ -54,8 +51,7 @@ public class AsConstTests
         Assert.Equal("1\nhello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_NestedStructure_Works(ExecutionMode mode)
     {
         var source = """
@@ -69,8 +65,7 @@ public class AsConstTests
         Assert.Equal("1\n2\ntest\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_RuntimePassThrough_Works(ExecutionMode mode)
     {
         var source = """
@@ -86,8 +81,7 @@ public class AsConstTests
         Assert.Equal("60\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_StringLiterals_Works(ExecutionMode mode)
     {
         var source = """
@@ -100,8 +94,7 @@ public class AsConstTests
         Assert.Equal("pending\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_EmptyArray_Works(ExecutionMode mode)
     {
         var source = """
@@ -113,8 +106,7 @@ public class AsConstTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_BooleanLiterals_Works(ExecutionMode mode)
     {
         var source = """
@@ -131,8 +123,7 @@ public class AsConstTests
 
     #region Complex as const Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_DeeplyNestedObject_Works(ExecutionMode mode)
     {
         var source = """
@@ -152,8 +143,7 @@ public class AsConstTests
         Assert.Equal("localhost\n8080\nauth\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_ArrayOfObjects_Works(ExecutionMode mode)
     {
         var source = """
@@ -169,8 +159,7 @@ public class AsConstTests
         Assert.Equal("0\n20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_NullValue_Works(ExecutionMode mode)
     {
         var source = """
@@ -184,8 +173,7 @@ public class AsConstTests
         Assert.Equal("1\nnull\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_InFunctionReturn_Works(ExecutionMode mode)
     {
         var source = """
@@ -201,8 +189,7 @@ public class AsConstTests
         Assert.Equal("dark\n14\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_SpreadIntoArray_Works(ExecutionMode mode)
     {
         var source = """
@@ -217,8 +204,7 @@ public class AsConstTests
         Assert.Equal("5\n1\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_SpreadIntoObject_Works(ExecutionMode mode)
     {
         var source = """
@@ -233,8 +219,7 @@ public class AsConstTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_WithMethodCalls_Works(ExecutionMode mode)
     {
         var source = """
@@ -249,8 +234,7 @@ public class AsConstTests
         Assert.Equal("6\n2\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_FilterOperation_Works(ExecutionMode mode)
     {
         var source = """
@@ -265,8 +249,7 @@ public class AsConstTests
         Assert.Equal("2\n2\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_ReduceOperation_Works(ExecutionMode mode)
     {
         var source = """
@@ -279,8 +262,7 @@ public class AsConstTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_IndexAccess_Works(ExecutionMode mode)
     {
         var source = """
@@ -293,8 +275,7 @@ public class AsConstTests
         Assert.Equal("east\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConst_ObjectWithArrayProperty_Works(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/AsyncArrowCapturedWriteTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncArrowCapturedWriteTests.cs
@@ -12,8 +12,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncArrowCapturedWriteTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_WritesCapturedVariable(ExecutionMode mode)
     {
         var source = """
@@ -29,8 +28,7 @@ public class AsyncArrowCapturedWriteTests
         Assert.Equal("5\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_CompoundWriteToCapturedVariable(ExecutionMode mode)
     {
         var source = """
@@ -48,8 +46,7 @@ public class AsyncArrowCapturedWriteTests
         Assert.Equal("aba\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_WritesCapturedVariableAfterAwait(ExecutionMode mode)
     {
         var source = """
@@ -65,8 +62,7 @@ public class AsyncArrowCapturedWriteTests
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_MultipleCapturedWrites(ExecutionMode mode)
     {
         var source = """
@@ -82,8 +78,7 @@ public class AsyncArrowCapturedWriteTests
         Assert.Equal("3 6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_TwoCapturedStoresAcrossAwait(ExecutionMode mode)
     {
         // #673: a nested async arrow with TWO writes to a captured variable straddling an await

--- a/SharpTS.Tests/SharedTests/AsyncArrowDeferredSpillTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncArrowDeferredSpillTests.cs
@@ -22,8 +22,7 @@ public class AsyncArrowDeferredSpillTests
     private static string Defer(object v, int ms)
         => $"new Promise<number>(r => setTimeout(() => r({v}), {ms}))";
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedArrow_BinaryConcat_PrefixSurvivesDeferredAwait(ExecutionMode mode)
     {
         // The exact shape from the issue.
@@ -37,8 +36,7 @@ public class AsyncArrowDeferredSpillTests
         Assert.Equal("z1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StandaloneArrow_BinaryConcat_PrefixSurvivesDeferredAwait(ExecutionMode mode)
     {
         var source = $$"""
@@ -48,8 +46,7 @@ public class AsyncArrowDeferredSpillTests
         Assert.Equal("z1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StandaloneArrow_TwoDeferredAwaits(ExecutionMode mode)
     {
         var source = $$"""
@@ -63,8 +60,7 @@ public class AsyncArrowDeferredSpillTests
         Assert.Equal("A1B2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StandaloneArrow_TemplateLiteral_DeferredAwaits(ExecutionMode mode)
     {
         var source = $$"""
@@ -74,8 +70,7 @@ public class AsyncArrowDeferredSpillTests
         Assert.Equal("v=q-5-6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StandaloneArrow_ArrayAndObject_DeferredAwaits(ExecutionMode mode)
     {
         var source = $$"""
@@ -89,8 +84,7 @@ public class AsyncArrowDeferredSpillTests
         Assert.Equal("x,1,y z2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedArrow_CapturesOuterLocalAndSpillsAcrossAwait(ExecutionMode mode)
     {
         // Arrow captures an outer local (prefix) AND spills it across the await.

--- a/SharpTS.Tests/SharedTests/AsyncArrowFunctionTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncArrowFunctionTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncArrowFunctionTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_BasicReturn(ExecutionMode mode)
     {
         var source = """
@@ -28,8 +27,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_ExpressionBody(ExecutionMode mode)
     {
         var source = """
@@ -45,8 +43,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_WithAwait(ExecutionMode mode)
     {
         var source = """
@@ -68,8 +65,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_WithParameters(ExecutionMode mode)
     {
         var source = """
@@ -87,8 +83,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_CaptureLocal(ExecutionMode mode)
     {
         var source = """
@@ -107,8 +102,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_CaptureParameter(ExecutionMode mode)
     {
         var source = """
@@ -126,8 +120,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("50\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_ModifyOuter(ExecutionMode mode)
     {
         // Tests by-reference capture - arrow modifies outer variable
@@ -147,8 +140,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_OuterModifiesAfter(ExecutionMode mode)
     {
         // Tests by-reference capture - outer modifies after arrow creation
@@ -173,8 +165,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_MultipleAwaits(ExecutionMode mode)
     {
         var source = """
@@ -200,8 +191,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_InClassMethod(ExecutionMode mode)
     {
         // Test async arrow capturing 'this' in class method
@@ -228,8 +218,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_CaptureThis(ExecutionMode mode)
     {
         var source = """
@@ -259,8 +248,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("50\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_NestedBasic(ExecutionMode mode)
     {
         var source = """
@@ -282,8 +270,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_NestedWithMutation(ExecutionMode mode)
     {
         // Test nested arrows with by-reference capture and mutation
@@ -308,8 +295,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("10\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_ChainedCalls(ExecutionMode mode)
     {
         // Note: Nested await in call arguments (await f(await g(x))) is a known limitation
@@ -330,8 +316,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("11\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_ImmediatelyInvoked(ExecutionMode mode)
     {
         var source = """
@@ -348,8 +333,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_ReturnString(ExecutionMode mode)
     {
         var source = """
@@ -367,8 +351,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("Hello, World!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_MultipleArrows(ExecutionMode mode)
     {
         var source = """
@@ -389,8 +372,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("60\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_SyncArrowInside_CapturesLocal(ExecutionMode mode)
     {
         // Non-async arrow inside async arrow capturing outer variable
@@ -411,8 +393,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_SyncArrowInside_MultipleSyncArrows(ExecutionMode mode)
     {
         // Multiple non-async arrows inside async arrow
@@ -435,8 +416,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_SyncArrowInside_NonCapturing(ExecutionMode mode)
     {
         // Non-capturing non-async arrow inside async arrow
@@ -456,8 +436,7 @@ public class AsyncArrowFunctionTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_SyncArrowInside_CapturesParameter(ExecutionMode mode)
     {
         // Non-async arrow capturing async arrow's parameter
@@ -481,8 +460,7 @@ public class AsyncArrowFunctionTests
     // (e.g. an immediately-invoked async arrow) failed to compile with "Async arrow with nested
     // arrows does not have SelfBoxedField set." — the standalone arrow never provisioned the
     // <>__selfBoxed field the nested-arrow emit requires. The interpreter was always correct.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_NestsAsyncArrowIife_Compiles(ExecutionMode mode)
     {
         var source = """
@@ -496,8 +474,7 @@ public class AsyncArrowFunctionTests
 
     // #615: deeper and repeated nesting of self-contained async arrows inside a standalone async
     // arrow.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_NestsAsyncArrows_DeepAndRepeated(ExecutionMode mode)
     {
         var source = """
@@ -517,8 +494,7 @@ public class AsyncArrowFunctionTests
     // is emitted as an independent TSFunction over its own stub (null target); passing the
     // enclosing arrow's boxed state machine as the target would clobber the first parameter
     // (InvalidCastException at the call site).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_NestsParameterizedAsyncArrow(ExecutionMode mode)
     {
         var source = """
@@ -538,8 +514,7 @@ public class AsyncArrowFunctionTests
     // async-iterator protocol. Previously the arrow emitter had no EmitForOf override, so the loop
     // fell through to the synchronous for-of path and threw InvalidCastException casting the
     // async-generator state machine to IEnumerable in compiled mode.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_ForAwaitOfAsyncGenerator(ExecutionMode mode)
     {
         var source = """
@@ -558,8 +533,7 @@ public class AsyncArrowFunctionTests
 
     // #430/#645: breaking out of a `for await` inside an async arrow must run the loop's cleanup
     // (iterator.return()) path without corrupting the loop variable binding.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_ForAwaitBreakRunsCleanup(ExecutionMode mode)
     {
         var source = """
@@ -580,8 +554,7 @@ public class AsyncArrowFunctionTests
 
     // #430/#645: the async-arrow `for await` must also honor the custom Symbol.asyncIterator
     // protocol (not only the $IAsyncGenerator fast path).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_ForAwaitCustomAsyncIterator(ExecutionMode mode)
     {
         var source = """
@@ -610,8 +583,7 @@ public class AsyncArrowFunctionTests
     // #430/#645: the loop variable bound inside an async-arrow `for await` must resolve to the
     // arrow's own local store. The original fix landed `null` values here because the binding was
     // registered in Ctx.Locals while the arrow's resolver reads its private local map.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_ForAwaitAccumulatesCapturedVariable(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/AsyncArrowNestedCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncArrowNestedCaptureTests.cs
@@ -15,8 +15,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncArrowNestedCaptureTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAsyncArrow_ReadsSingleCapture(ExecutionMode mode)
     {
         var source = """
@@ -31,8 +30,7 @@ public class AsyncArrowNestedCaptureTests
         Assert.Equal("105\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAsyncArrow_ReadsCaptureAndOwnParameter(ExecutionMode mode)
     {
         var source = """
@@ -85,8 +83,7 @@ public class AsyncArrowNestedCaptureTests
         Assert.Throws<CompileException>(() => TestHarness.RunCompiled(source));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAsyncArrow_MultipleCaptures(ExecutionMode mode)
     {
         // Three captures from the enclosing top-level async arrow ride together in the
@@ -103,8 +100,7 @@ public class AsyncArrowNestedCaptureTests
         Assert.Equal("60\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAsyncArrow_MultipleCaptures_MixedWithOwnParameter(ExecutionMode mode)
     {
         // Captures are unpacked from the object[] target before the arrow's own parameter,
@@ -121,8 +117,7 @@ public class AsyncArrowNestedCaptureTests
         Assert.Equal("103\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAsyncArrow_MultipleCapturesOfEnclosingParameters(ExecutionMode mode)
     {
         // Captures resolve through the enclosing arrow's ParameterFields (not LocalFields),
@@ -138,8 +133,7 @@ public class AsyncArrowNestedCaptureTests
         Assert.Equal("42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StandaloneAsyncArrow_MultipleCapturesFromEnclosingFunction(ExecutionMode mode)
     {
         // A standalone async arrow (no enclosing async state machine — here the enclosing
@@ -160,8 +154,7 @@ public class AsyncArrowNestedCaptureTests
         Assert.Equal("60\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAsyncArrow_TransitiveCaptureThroughStandaloneArrow(ExecutionMode mode)
     {
         // `a` is captured by `g` (a standalone capture on g's own state machine, because g
@@ -185,8 +178,7 @@ public class AsyncArrowNestedCaptureTests
         Assert.Equal("15\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAsyncArrow_RelayOnlyCaptureToDeeperArrow(ExecutionMode mode)
     {
         // #716: the intermediate arrow `g` does NOT itself read `a` — it captures it solely so the
@@ -208,8 +200,7 @@ public class AsyncArrowNestedCaptureTests
         Assert.Equal("8\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAsyncArrow_RelayOnlyCaptureThroughTwoIntermediates(ExecutionMode mode)
     {
         // #716 across two relay-only intermediates: both `g` and `h` forward `a` to the deepest `k`.
@@ -231,8 +222,7 @@ public class AsyncArrowNestedCaptureTests
         Assert.Equal("10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAsyncArrow_RelayOnlyMultipleCaptures(ExecutionMode mode)
     {
         // #716: more than one relay-only capture forwarded through the intermediate arrow.

--- a/SharpTS.Tests/SharedTests/AsyncArrowSyncWriteCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncArrowSyncWriteCaptureTests.cs
@@ -13,8 +13,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncArrowSyncWriteCaptureTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StandaloneAsyncArrow_SyncArrowWritesCapturedLocal(ExecutionMode mode)
     {
         var source = """
@@ -31,8 +30,7 @@ public class AsyncArrowSyncWriteCaptureTests
         Assert.Equal("6,6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAsyncArrow_SyncArrowWritesCapturedLocal(ExecutionMode mode)
     {
         // The async arrow is itself nested inside an async function — it still needs its OWN function DC
@@ -54,8 +52,7 @@ public class AsyncArrowSyncWriteCaptureTests
         Assert.Equal("6,6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StandaloneAsyncArrow_CompoundAssignCapturedLocal(ExecutionMode mode)
     {
         var source = """
@@ -72,8 +69,7 @@ public class AsyncArrowSyncWriteCaptureTests
         Assert.Equal("7,7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StandaloneAsyncArrow_WriteCapturedBlockScopeShadow_DoesNotLeak(ExecutionMode mode)
     {
         // Combines this fix with #838: the written capture is a nested-block shadow of an outer binding;
@@ -99,8 +95,7 @@ public class AsyncArrowSyncWriteCaptureTests
         Assert.Equal("6,6,100\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StandaloneAsyncArrow_TwoArrowsWriteDistinctCapturedLocals(ExecutionMode mode)
     {
         var source = """
@@ -119,8 +114,7 @@ public class AsyncArrowSyncWriteCaptureTests
         Assert.Equal("2,11,2,11\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StandaloneAsyncArrow_CapturedWriteSurvivesAcrossAwait(ExecutionMode mode)
     {
         // The mutation straddles an await — the DC lives on the (reference-held) state machine field, so

--- a/SharpTS.Tests/SharedTests/AsyncAwaitTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncAwaitTests.cs
@@ -11,8 +11,7 @@ public class AsyncAwaitTests
 {
     #region Basic Async Functions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_ReturnsPromise(ExecutionMode mode)
     {
         var source = """
@@ -27,8 +26,7 @@ public class AsyncAwaitTests
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_AwaitReturnsValue(ExecutionMode mode)
     {
         var source = """
@@ -46,8 +44,7 @@ public class AsyncAwaitTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrowFunction_Works(ExecutionMode mode)
     {
         var source = """
@@ -65,8 +62,7 @@ public class AsyncAwaitTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrowFunction_ExpressionBody(ExecutionMode mode)
     {
         var source = """
@@ -82,8 +78,7 @@ public class AsyncAwaitTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_VoidReturn(ExecutionMode mode)
     {
         var source = """
@@ -105,8 +100,7 @@ public class AsyncAwaitTests
 
     #region Await in Control Flow
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AwaitInLoop(ExecutionMode mode)
     {
         var source = """
@@ -127,8 +121,7 @@ public class AsyncAwaitTests
         Assert.Equal("6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AwaitInConditional(ExecutionMode mode)
     {
         var source = """
@@ -153,8 +146,7 @@ public class AsyncAwaitTests
 
     #region Chained and Nested Calls
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ChainedAwaits(ExecutionMode mode)
     {
         var source = """
@@ -180,8 +172,7 @@ public class AsyncAwaitTests
         Assert.Equal("Result: 20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAsyncCalls(ExecutionMode mode)
     {
         var source = """
@@ -203,8 +194,7 @@ public class AsyncAwaitTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultipleAwaitsSameFunction(ExecutionMode mode)
     {
         var source = """
@@ -227,8 +217,7 @@ public class AsyncAwaitTests
 
     #region Await with Non-Promise
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AwaitOnNonPromise_ReturnsValue(ExecutionMode mode)
     {
         var source = """
@@ -247,8 +236,7 @@ public class AsyncAwaitTests
 
     #region Async Class Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncClassMethod(ExecutionMode mode)
     {
         var source = """
@@ -273,8 +261,7 @@ public class AsyncAwaitTests
 
     #region Parameters and Return Types
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncWithParameters(ExecutionMode mode)
     {
         var source = """
@@ -292,8 +279,7 @@ public class AsyncAwaitTests
         Assert.Equal("Hello, World\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncWithDefaultParameters(ExecutionMode mode)
     {
         var source = """
@@ -313,8 +299,7 @@ public class AsyncAwaitTests
         Assert.Equal("Hello, Guest\nHello, Alice\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncWithObjectReturn(ExecutionMode mode)
     {
         var source = """
@@ -332,8 +317,7 @@ public class AsyncAwaitTests
         Assert.Equal("30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncWithArrayReturn(ExecutionMode mode)
     {
         var source = """
@@ -355,8 +339,7 @@ public class AsyncAwaitTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_BooleanReturn(ExecutionMode mode)
     {
         var source = """
@@ -374,8 +357,7 @@ public class AsyncAwaitTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_WithLocalVariables(ExecutionMode mode)
     {
         var source = """
@@ -399,8 +381,7 @@ public class AsyncAwaitTests
 
     #region Await in Expressions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AwaitInTemplateLiteral(ExecutionMode mode)
     {
         var source = """
@@ -417,8 +398,7 @@ public class AsyncAwaitTests
         Assert.Equal("Hello, World!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AwaitInTernary(ExecutionMode mode)
     {
         var source = """
@@ -436,8 +416,7 @@ public class AsyncAwaitTests
         Assert.Equal("yes\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AwaitWithLogicalOperator(ExecutionMode mode)
     {
         var source = """
@@ -460,8 +439,7 @@ public class AsyncAwaitTests
         Assert.Equal("false\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AwaitWithNullishCoalescing(ExecutionMode mode)
     {
         var source = """
@@ -483,8 +461,7 @@ public class AsyncAwaitTests
 
     #region Try/Catch
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncWithTryCatch(ExecutionMode mode)
     {
         var source = """
@@ -510,8 +487,7 @@ public class AsyncAwaitTests
 
     #region Type Checking
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeChecker_AwaitOutsideAsync_ThrowsError(ExecutionMode mode)
     {
         var source = """
@@ -524,8 +500,7 @@ public class AsyncAwaitTests
         Assert.Contains("await", exception.Message.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeChecker_AsyncReturnsPromise(ExecutionMode mode)
     {
         var source = """
@@ -544,8 +519,7 @@ public class AsyncAwaitTests
 
     #region Super in Async Methods (Compiler)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_SuperMethodCall(ExecutionMode mode)
     {
         var source = """
@@ -572,8 +546,7 @@ public class AsyncAwaitTests
         Assert.Equal("Hello World\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_SuperMethodCallBeforeAwait(ExecutionMode mode)
     {
         var source = """
@@ -601,8 +574,7 @@ public class AsyncAwaitTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_SuperMethodCallAfterAwait(ExecutionMode mode)
     {
         var source = """
@@ -629,8 +601,7 @@ public class AsyncAwaitTests
         Assert.Equal("8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_SuperWithParameters(ExecutionMode mode)
     {
         var source = """
@@ -661,8 +632,7 @@ public class AsyncAwaitTests
 
     #region Capturing Arrow Functions in Async
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_CapturingArrowLocal(ExecutionMode mode)
     {
         var source = """
@@ -683,8 +653,7 @@ public class AsyncAwaitTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_CapturingArrowParameter(ExecutionMode mode)
     {
         var source = """
@@ -704,8 +673,7 @@ public class AsyncAwaitTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_CapturingArrowMultipleVariables(ExecutionMode mode)
     {
         var source = """
@@ -726,8 +694,7 @@ public class AsyncAwaitTests
         Assert.Equal("30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_CapturingArrowThis(ExecutionMode mode)
     {
         var source = """
@@ -754,8 +721,7 @@ public class AsyncAwaitTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_CapturingArrowBeforeAwait(ExecutionMode mode)
     {
         var source = """
@@ -776,8 +742,7 @@ public class AsyncAwaitTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_CapturingArrowPassedToMethod(ExecutionMode mode)
     {
         var source = """
@@ -819,8 +784,7 @@ public class AsyncAwaitTests
     /// resolve that happens in a later statement would deadlock — a separate
     /// known compiled-mode behavior, not what this test pins.
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void TopLevelThen_ResolvedLater_RunsCallbackWithItsParameter(ExecutionMode mode)
     {
         var source = """
@@ -845,8 +809,7 @@ public class AsyncAwaitTests
     // literal was emitted as CLR null (no SharpTSUndefined arm in the base EmitLiteral), and `===`
     // used the null≡undefined-collapsing loose equality helper instead of strict. The awaited null
     // must stay null-ish (typeof "object", === null) but must NOT be === undefined.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Await_NullResolvedPromise_IsNotStrictUndefined(ExecutionMode mode)
     {
         var source = """
@@ -866,8 +829,7 @@ public class AsyncAwaitTests
 
     // #600 (companion): the `undefined` literal must be the undefined sentinel inside an async body,
     // and `===` must keep null and undefined distinct while loose `==` still collapses them.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Await_UndefinedResolvedPromise_AndStrictEquality(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/AsyncBlockScopeShadowTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncBlockScopeShadowTests.cs
@@ -13,8 +13,7 @@ public class AsyncBlockScopeShadowTests
 {
     #region Async function (#766)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_NestedBlockConstShadow_DoesNotLeakToOuter(ExecutionMode mode)
     {
         // A const in a nested block that shadows an outer body-level const must get its own slot
@@ -32,8 +31,7 @@ public class AsyncBlockScopeShadowTests
         Assert.Equal("100\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_NestedBlockShadow_LiveAcrossAwait_GetsOwnField(ExecutionMode mode)
     {
         // The inner shadow is itself read after an await, so it must hoist to its OWN field, distinct
@@ -56,8 +54,7 @@ public class AsyncBlockScopeShadowTests
         Assert.Equal("5/100\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_NestedBlockLetShadow_ReassignedAcrossAwait(ExecutionMode mode)
     {
         // A let shadow compound-assigned across awaits keeps its own value, separate from the outer
@@ -82,8 +79,7 @@ public class AsyncBlockScopeShadowTests
         Assert.Equal("12/7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_NestedBlockShadowsParameter(ExecutionMode mode)
     {
         // An inner block const may shadow a (hoisted) parameter without clobbering it (#766).
@@ -104,8 +100,7 @@ public class AsyncBlockScopeShadowTests
 
     #region Async arrow (#766)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_NestedBlockConstShadow_DoesNotLeakToOuter(ExecutionMode mode)
     {
         // Same shadow leak in a compiled async arrow's state machine (#766).
@@ -126,8 +121,7 @@ public class AsyncBlockScopeShadowTests
 
     #region Async generator (#766 + #768)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_NestedBlockConstShadow_DoesNotLeakToOuter(ExecutionMode mode)
     {
         // Compiled: the nested-block shadow leaked onto the outer binding's hoisted field → [0, 0] (#766).
@@ -150,8 +144,7 @@ public class AsyncBlockScopeShadowTests
         Assert.Equal("0,100\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_NestedBlockShadow_LiveAcrossYield_GetsOwnField(ExecutionMode mode)
     {
         // Both the inner shadow and the outer binding survive the suspension on their own slots (#766).
@@ -177,8 +170,7 @@ public class AsyncBlockScopeShadowTests
         Assert.Equal("0,1,100\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_NestedBlockBindingBeforeAwait_YieldsValue(ExecutionMode mode)
     {
         // #768: distinct names (no shadowing). The interpreter lost a nested-block binding's value when
@@ -201,8 +193,7 @@ public class AsyncBlockScopeShadowTests
         Assert.Equal("0,100\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_NestedBlockLetBeforeAwait_Reassigned(ExecutionMode mode)
     {
         // #768 variant: a nested-block let read/updated before any await must keep its value.
@@ -223,8 +214,7 @@ public class AsyncBlockScopeShadowTests
         Assert.Equal("5,9\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_NestedBlockShadow_CapturedByArrow_DoesNotLeak(ExecutionMode mode)
     {
         // An inner block const that shadows an outer binding AND is read by a nested arrow gets its own
@@ -258,8 +248,7 @@ public class AsyncBlockScopeShadowTests
 
     #region Read-capture of a shadow by an inner arrow (#837, async analog of #767)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_NestedBlockShadow_CapturedByArrow(ExecutionMode mode)
     {
         // An inner block const that shadows an outer binding AND is read by a nested arrow gets its own
@@ -288,8 +277,7 @@ public class AsyncBlockScopeShadowTests
         Assert.Equal("5,100\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_NestedBlockShadow_CapturedByArrow(ExecutionMode mode)
     {
         // Async-ARROW analog of the above (#837): the shadow read by an inner arrow gets its own slot.
@@ -313,8 +301,7 @@ public class AsyncBlockScopeShadowTests
         Assert.Equal("5,100\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_TwoShadowsReadCapturedByDistinctArrows(ExecutionMode mode)
     {
         // Two independent nested-block shadows, each read by its own arrow, must each get their own slot
@@ -351,8 +338,7 @@ public class AsyncBlockScopeShadowTests
 
     #region Write-capture of a shadow by an inner sync arrow (#838, write analog of #767)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_NestedBlockShadow_WriteCapturedByArrow(ExecutionMode mode)
     {
         // An inner block let that shadows an outer binding AND is WRITTEN by a nested sync arrow gets its
@@ -379,8 +365,7 @@ public class AsyncBlockScopeShadowTests
         Assert.Equal("6,6,100\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_NestedBlockShadow_WriteCapturedByArrow(ExecutionMode mode)
     {
         // Async-GENERATOR analog (#838): the write-captured shadow gets its own renamed DC field, shared

--- a/SharpTS.Tests/SharedTests/AsyncCallApplyBindTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncCallApplyBindTests.cs
@@ -22,8 +22,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </remarks>
 public class AsyncCallApplyBindTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_Call_PassesArguments(ExecutionMode mode)
     {
         // The headline repro from the issue: used to throw "undefined is not a function".
@@ -35,8 +34,7 @@ public class AsyncCallApplyBindTests
         Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunctionExpression_Call_BindsThis(ExecutionMode mode)
     {
         var source = """
@@ -47,8 +45,7 @@ public class AsyncCallApplyBindTests
         Assert.Equal("42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunctionExpression_Apply_BindsThis(ExecutionMode mode)
     {
         var source = """
@@ -59,8 +56,7 @@ public class AsyncCallApplyBindTests
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunctionExpression_Bind_BindsThis(ExecutionMode mode)
     {
         var source = """
@@ -72,8 +68,7 @@ public class AsyncCallApplyBindTests
         Assert.Equal("9\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_Bind_IgnoresThisAppliesPartialArgs(ExecutionMode mode)
     {
         // True async arrows ignore the bound `this` (lexical) but still honor partial args.
@@ -85,8 +80,7 @@ public class AsyncCallApplyBindTests
         Assert.Equal("15\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunctionExpression_CallBindsThis_AcrossAwait(ExecutionMode mode)
     {
         // The bound `this` must survive a state-machine suspension/resume.

--- a/SharpTS.Tests/SharedTests/AsyncCallbackResumeTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncCallbackResumeTests.cs
@@ -11,8 +11,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncCallbackResumeTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void FsReadFile_Callback_KeepsProcessAlive(ExecutionMode mode)
     {
         // #205: with no other pending work, the process must stay alive until
@@ -36,8 +35,7 @@ public class AsyncCallbackResumeTests
         Assert.Equal("callback fired: hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncCallback_ResumesWithModuleScope_AfterAwait(ExecutionMode mode)
     {
         // #207: an async arrow passed to a built-in (server.listen) suspends at
@@ -64,8 +62,7 @@ public class AsyncCallbackResumeTests
         Assert.Equal("before await\nafter await\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncCallback_FetchAfterAwait_InListenCallback(ExecutionMode mode)
     {
         // The full #207 repro: await fetch() against the just-started server,

--- a/SharpTS.Tests/SharedTests/AsyncClassMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncClassMethodTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncClassMethodTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_ReadThisProperty(ExecutionMode mode)
     {
         var source = """
@@ -33,8 +32,7 @@ public class AsyncClassMethodTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_WriteThisProperty(ExecutionMode mode)
     {
         var source = """
@@ -57,8 +55,7 @@ public class AsyncClassMethodTests
         Assert.Equal("99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_IncrementThisProperty(ExecutionMode mode)
     {
         var source = """
@@ -84,8 +81,7 @@ public class AsyncClassMethodTests
         Assert.Equal("0\n1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_MultipleProperties(ExecutionMode mode)
     {
         var source = """
@@ -115,8 +111,7 @@ public class AsyncClassMethodTests
         Assert.Equal("(0,0)\n(5,10)\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_PropertyWithAwait(ExecutionMode mode)
     {
         var source = """
@@ -143,8 +138,7 @@ public class AsyncClassMethodTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_AssignmentExpression(ExecutionMode mode)
     {
         // Tests that property assignment returns the assigned value
@@ -169,8 +163,7 @@ public class AsyncClassMethodTests
         Assert.Equal("returned: 42\nproperty: 42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_ChainedPropertyAccess(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/AsyncFinallyTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncFinallyTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncFinallyTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_WithAwait_BasicCase(ExecutionMode mode)
     {
         var source = """
@@ -32,8 +31,7 @@ public class AsyncFinallyTests
         Assert.Equal("in try\ncleanup called\nafter try/finally\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_WithAwait_ExceptionInTry_WithCatch(ExecutionMode mode)
     {
         var source = """
@@ -58,8 +56,7 @@ public class AsyncFinallyTests
         Assert.Equal("in try\nin catch: error from try\ncleanup called\nafter try/catch/finally\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_WithAwait_ExceptionInTry_NoCatch_Rethrows(ExecutionMode mode)
     {
         var source = """
@@ -90,8 +87,7 @@ public class AsyncFinallyTests
         Assert.Equal("in try\ncleanup called\nouter caught: error from try\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_WithAwait_AwaitInBothTryAndFinally(ExecutionMode mode)
     {
         var source = """
@@ -117,8 +113,7 @@ public class AsyncFinallyTests
         Assert.Equal("got: 42\ncleanup called\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_WithAwait_ExceptionInAwaitedCall_Rethrows(ExecutionMode mode)
     {
         var source = """
@@ -152,8 +147,7 @@ public class AsyncFinallyTests
         Assert.Equal("cleanup called\ncaught: async error\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_WithAwait_MultipleAwaitsInFinally(ExecutionMode mode)
     {
         var source = """
@@ -179,8 +173,7 @@ public class AsyncFinallyTests
         Assert.Equal("in try\nstep1\nstep2\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_WithAwait_NestedTryFinally(ExecutionMode mode)
     {
         var source = """
@@ -210,8 +203,7 @@ public class AsyncFinallyTests
         Assert.Equal("outer try\ninner try\ncleanup1\ncleanup2\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_WithAwait_ExceptionInFinallyReplacesOriginal(ExecutionMode mode)
     {
         var source = """
@@ -239,8 +231,7 @@ public class AsyncFinallyTests
         Assert.Equal("caught: finally error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_WithAwait_ReturnsValueFromTry(ExecutionMode mode)
     {
         var source = """
@@ -265,8 +256,7 @@ public class AsyncFinallyTests
         Assert.Equal("cleanup\ngot: 42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_WithAwait_AwaitInAllBlocks(ExecutionMode mode)
     {
         var source = """
@@ -303,8 +293,7 @@ public class AsyncFinallyTests
     // run the try's finally. Previously the compiled state machine jumped straight to the loop label,
     // skipping the (now flag-based) finally. ---
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_ContinueOutOfTryWithAwait_RunsFinally(ExecutionMode mode)
     {
         // The issue repro: `continue` crosses the finally on iteration i==1.
@@ -330,8 +319,7 @@ public class AsyncFinallyTests
         Assert.Equal("b0f0f1b2f2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_BreakOutOfTryWithAwait_RunsFinally(ExecutionMode mode)
     {
         var source = """
@@ -356,8 +344,7 @@ public class AsyncFinallyTests
         Assert.Equal("b0f0f1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_ContinueOutOfTryWithAwait_AwaitingFinally_RunsFinally(ExecutionMode mode)
     {
         // The finally itself awaits — previously dropped entirely on the continue.
@@ -384,8 +371,7 @@ public class AsyncFinallyTests
         Assert.Equal("b0f0f1b2f2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_ReturnOutOfTryWithAwait_NoAwaitFinally_RunsFinally(ExecutionMode mode)
     {
         // The `return` half: a no-await finally was previously only run when the finally itself awaited.
@@ -412,8 +398,7 @@ public class AsyncFinallyTests
         Assert.Equal("finally ran\nret5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_BreakOutOfNestedTriesWithAwait_RunsBothFinallysInnermostFirst(ExecutionMode mode)
     {
         var source = """
@@ -442,8 +427,7 @@ public class AsyncFinallyTests
         Assert.Equal("i0o0b1i1o1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_LabeledBreakOutOfTryWithAwait_RunsFinally(ExecutionMode mode)
     {
         var source = """
@@ -470,8 +454,7 @@ public class AsyncFinallyTests
         Assert.Equal("00ff\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_BreakTargetingLoopInsideTryWithAwait_DoesNotRunFinally(ExecutionMode mode)
     {
         // Regression: a break whose target loop is *inside* the try crosses no finally, so the finally

--- a/SharpTS.Tests/SharedTests/AsyncFunctionExpressionTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncFunctionExpressionTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncFunctionExpressionTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunctionExpression_Anonymous_ResolvesValue(ExecutionMode mode)
     {
         // The exact repro from issue #635.
@@ -23,8 +22,7 @@ public class AsyncFunctionExpressionTests
         Assert.Equal("9\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunctionExpression_Named_ResolvesValue(ExecutionMode mode)
     {
         var source = """
@@ -35,8 +33,7 @@ public class AsyncFunctionExpressionTests
         Assert.Equal("42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunctionExpression_Awaited(ExecutionMode mode)
     {
         var source = """
@@ -51,8 +48,7 @@ public class AsyncFunctionExpressionTests
         Assert.Equal("8\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunctionExpression_ImmediatelyInvoked(ExecutionMode mode)
     {
         var source = """
@@ -62,8 +58,7 @@ public class AsyncFunctionExpressionTests
         Assert.Equal("ran\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunctionExpression_AwaitInsideBody(ExecutionMode mode)
     {
         var source = """
@@ -80,8 +75,7 @@ public class AsyncFunctionExpressionTests
         Assert.Equal("30\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunctionExpression_AsCallbackArgument(ExecutionMode mode)
     {
         // Async function expression passed directly as an argument (a common position that the
@@ -94,8 +88,7 @@ public class AsyncFunctionExpressionTests
         Assert.Equal("5\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGeneratorFunctionExpression_ForAwaitOf(ExecutionMode mode)
     {
         // `async function*` expression — the `function` keyword path also accepts the `*`, giving an

--- a/SharpTS.Tests/SharedTests/AsyncFunctionReturnValueTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncFunctionReturnValueTests.cs
@@ -11,8 +11,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncFunctionReturnValueTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_BareReturn_ResolvesUndefined(ExecutionMode mode)
     {
         var source = """
@@ -28,8 +27,7 @@ public class AsyncFunctionReturnValueTests
         Assert.Equal("undefined\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_OffEnd_ResolvesUndefined(ExecutionMode mode)
     {
         var source = """
@@ -45,8 +43,7 @@ public class AsyncFunctionReturnValueTests
         Assert.Equal("undefined\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_BareReturn_ResolvesUndefined(ExecutionMode mode)
     {
         var source = """
@@ -61,8 +58,7 @@ public class AsyncFunctionReturnValueTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_OffEnd_ResolvesUndefined(ExecutionMode mode)
     {
         var source = """
@@ -77,8 +73,7 @@ public class AsyncFunctionReturnValueTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_ReturnNull_ResolvesNull(ExecutionMode mode)
     {
         // Care-case: an explicit `return null;` must keep resolving with null, not undefined.
@@ -99,8 +94,7 @@ public class AsyncFunctionReturnValueTests
         Assert.Equal("object\nnull\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_ReturnValue_Preserved(ExecutionMode mode)
     {
         var source = """
@@ -115,8 +109,7 @@ public class AsyncFunctionReturnValueTests
         Assert.Equal("42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_OffEnd_ResolvesUndefined(ExecutionMode mode)
     {
         var source = """
@@ -137,8 +130,7 @@ public class AsyncFunctionReturnValueTests
         Assert.Equal("undefined\nundefined\nundefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_AwaitThenOffEnd_ResolvesUndefined(ExecutionMode mode)
     {
         // The implicit-completion value must be undefined even when the body suspends on an
@@ -156,8 +148,7 @@ public class AsyncFunctionReturnValueTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_BareReturnInTryWithAwaitFinally_ResolvesUndefined(ExecutionMode mode)
     {
         // A bare `return;` inside a try whose finally awaits routes through the pending-return
@@ -177,8 +168,7 @@ public class AsyncFunctionReturnValueTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_AwaitOfUndefinedResolving_YieldsUndefined(ExecutionMode mode)
     {
         // Awaiting an async function that resolves with the implicit undefined must observe

--- a/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
@@ -14,8 +14,7 @@ public class AsyncGeneratorTests
 {
     #region Basic Async Generator Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_BasicYield_ReturnsValues(ExecutionMode mode)
     {
         var source = """
@@ -45,8 +44,7 @@ public class AsyncGeneratorTests
         Assert.Equal("1 false\n2 false\n3 false\nundefined true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ObjectMethod_ReadsThis(ExecutionMode mode)
     {
         // #775/#923: an object async-generator method reads instance state via `this`. The value-call
@@ -68,8 +66,7 @@ public class AsyncGeneratorTests
         Assert.Equal("7\n8\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForAwaitOf_AsyncGeneratorObjectMethod_ReadsThis(ExecutionMode mode)
     {
         // #923: inline `for await (... of o.gen())` over an async-generator object method must thread
@@ -89,8 +86,7 @@ public class AsyncGeneratorTests
         Assert.Equal("42\n43\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGeneratorFunctionExpression_AsObjectProperty_ReadsThis(ExecutionMode mode)
     {
         // #923: the other `HasOwnThis` lift shape — an `async function*` EXPRESSION assigned to an
@@ -110,8 +106,7 @@ public class AsyncGeneratorTests
         Assert.Equal("5\n10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGeneratorFunctionExpression_DotCallBindsThis(ExecutionMode mode)
     {
         // #775: an `async function*` expression bound via `.call` reads `this`.
@@ -130,8 +125,7 @@ public class AsyncGeneratorTests
         Assert.Equal("9\n10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_EmptyGenerator_ReturnsDoneImmediately(ExecutionMode mode)
     {
         var source = """
@@ -150,8 +144,7 @@ public class AsyncGeneratorTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_WithAwait_AwaitsBeforeYield(ExecutionMode mode)
     {
         var source = """
@@ -181,8 +174,7 @@ public class AsyncGeneratorTests
         Assert.Equal("10\n20\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_WithParameters_UsesParameters(ExecutionMode mode)
     {
         var source = """
@@ -205,8 +197,7 @@ public class AsyncGeneratorTests
         Assert.Equal("5\n6\n7\n8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_SingleYield_Works(ExecutionMode mode)
     {
         var source = """
@@ -230,8 +221,7 @@ public class AsyncGeneratorTests
         Assert.Equal("42 false\nundefined true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_YieldInLoop_Works(ExecutionMode mode)
     {
         var source = """
@@ -259,8 +249,7 @@ public class AsyncGeneratorTests
 
     #region for await...of Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForAwaitOf_AsyncGenerator_IteratesValues(ExecutionMode mode)
     {
         var source = """
@@ -283,8 +272,7 @@ public class AsyncGeneratorTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForAwaitOf_AsyncGeneratorWithAwait_IteratesAwaitedValues(ExecutionMode mode)
     {
         var source = """
@@ -311,8 +299,7 @@ public class AsyncGeneratorTests
         Assert.Equal("10\n20\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForAwaitOf_WithBreak_StopsIteration(ExecutionMode mode)
     {
         var source = """
@@ -340,8 +327,7 @@ public class AsyncGeneratorTests
         Assert.Equal("0\n1\n2\n3\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForAwaitOf_WithContinue_SkipsIteration(ExecutionMode mode)
     {
         var source = """
@@ -367,8 +353,7 @@ public class AsyncGeneratorTests
         Assert.Equal("1\n3\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForAwaitOf_EmptyAsyncGenerator_NoIterations(ExecutionMode mode)
     {
         var source = """
@@ -389,8 +374,7 @@ public class AsyncGeneratorTests
         Assert.Equal("iterations: 0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForAwaitOf_MultipleLoops_Works(ExecutionMode mode)
     {
         var source = """
@@ -419,8 +403,7 @@ public class AsyncGeneratorTests
     // context. SharpTS does not support top-level await, so — like a top-level `await` expression —
     // it must be rejected by the type checker rather than silently degrading to a synchronous
     // `for...of` (which then throws a misleading 'not iterable' runtime error in both modes).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForAwaitOf_TopLevel_RejectedByTypeChecker(ExecutionMode mode)
     {
         var source = """
@@ -434,8 +417,7 @@ public class AsyncGeneratorTests
 
     // #672: `for await...of` inside a non-async function is likewise an await outside an async
     // context and must be rejected (TS conformance), not run as a synchronous `for...of`.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForAwaitOf_InNonAsyncFunction_RejectedByTypeChecker(ExecutionMode mode)
     {
         var source = """
@@ -454,8 +436,7 @@ public class AsyncGeneratorTests
 
     #region Async Generator .return() and .throw() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_Return_ClosesGenerator(ExecutionMode mode)
     {
         var source = """
@@ -482,8 +463,7 @@ public class AsyncGeneratorTests
         Assert.Equal("1\n42 true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_Throw_ThrowsError(ExecutionMode mode)
     {
         var source = """
@@ -510,8 +490,7 @@ public class AsyncGeneratorTests
         Assert.Equal("1\nCaught: Test error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ReturnWithoutValue_ReturnsUndefined(ExecutionMode mode)
     {
         // ECMA-262 §27.6.1.3: AsyncGenerator.prototype.return(value) with value absent resolves to
@@ -536,8 +515,7 @@ public class AsyncGeneratorTests
         Assert.Equal("undefined true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ThrowWithoutValue_RejectsWithUndefined(ExecutionMode mode)
     {
         // throw() with no argument rejects with undefined, not null (#618).
@@ -555,8 +533,7 @@ public class AsyncGeneratorTests
         Assert.Equal("rejected undefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_BareReturn_CompletesWithUndefined(ExecutionMode mode)
     {
         // A value-less `return;` completes with undefined, not null; `return null;` still reports null (#540).
@@ -578,8 +555,7 @@ public class AsyncGeneratorTests
         Assert.Equal("bare undefined\nretNull null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ManualNextOnThrowingGenerator_RejectsCatchably(ExecutionMode mode)
     {
         // A throwing async generator settles its final next() as a rejection (catchable via await),
@@ -600,8 +576,7 @@ public class AsyncGeneratorTests
         Assert.Equal("1 err=b\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_RejectedAwaitInTry_CaughtByOwnCatch(ExecutionMode mode)
     {
         // A rejected await inside a try in an async generator is caught by that try's catch, which
@@ -619,8 +594,7 @@ public class AsyncGeneratorTests
         Assert.Equal("caught boom\nv1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ThrowInTryAfterYield_CatchBindsValue(ExecutionMode mode)
     {
         // A throw in a flag-based try (one containing a yield) is caught and the catch parameter binds
@@ -644,8 +618,7 @@ public class AsyncGeneratorTests
 
     #region yield* Delegation Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_YieldStar_DelegatesToSyncIterable(ExecutionMode mode)
     {
         var source = """
@@ -666,8 +639,7 @@ public class AsyncGeneratorTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_YieldStar_DelegatesToAsyncGenerator(ExecutionMode mode)
     {
         var source = """
@@ -695,8 +667,7 @@ public class AsyncGeneratorTests
         Assert.Equal("start\na\nb\nend\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_YieldStar_EmptyIterable(ExecutionMode mode)
     {
         var source = """
@@ -719,8 +690,7 @@ public class AsyncGeneratorTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_YieldStar_NestedDelegation(ExecutionMode mode)
     {
         var source = """
@@ -755,8 +725,7 @@ public class AsyncGeneratorTests
 
     #region Return Value Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ReturnsValue_IncludedInFinalResult(ExecutionMode mode)
     {
         var source = """
@@ -783,8 +752,7 @@ public class AsyncGeneratorTests
         Assert.Equal("1 false\n2 false\nfinal true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ImplicitReturn_ReturnsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -807,8 +775,7 @@ public class AsyncGeneratorTests
         Assert.Equal("undefined true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_EarlyReturn_SkipsRemainingYields(ExecutionMode mode)
     {
         var source = """
@@ -838,8 +805,7 @@ public class AsyncGeneratorTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_InNamespace_Works(ExecutionMode mode)
     {
         var source = """
@@ -864,8 +830,7 @@ public class AsyncGeneratorTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_WithStringYields_Works(ExecutionMode mode)
     {
         var source = """
@@ -887,8 +852,7 @@ public class AsyncGeneratorTests
         Assert.Equal("hello\nworld\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_YieldingObjects_Works(ExecutionMode mode)
     {
         var source = """
@@ -910,8 +874,7 @@ public class AsyncGeneratorTests
         Assert.Equal("Alice 30\nBob 25\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_YieldingArrays_Works(ExecutionMode mode)
     {
         var source = """
@@ -933,8 +896,7 @@ public class AsyncGeneratorTests
         Assert.Equal("1,2,3\n4,5,6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ConditionalYield_Works(ExecutionMode mode)
     {
         var source = """
@@ -964,8 +926,7 @@ public class AsyncGeneratorTests
         Assert.Equal("With middle:\n1\n2\n3\nWithout middle:\n1\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_YieldNull_Works(ExecutionMode mode)
     {
         var source = """
@@ -988,8 +949,7 @@ public class AsyncGeneratorTests
         Assert.Equal("null\n1\nnull\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_YieldBoolean_Works(ExecutionMode mode)
     {
         var source = """
@@ -1011,8 +971,7 @@ public class AsyncGeneratorTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_AwaitInYieldExpression_Works(ExecutionMode mode)
     {
         var source = """
@@ -1041,8 +1000,7 @@ public class AsyncGeneratorTests
 
     #region yield await Regression Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_MultipleAwaitsBetweenYields_Works(ExecutionMode mode)
     {
         var source = """
@@ -1071,8 +1029,7 @@ public class AsyncGeneratorTests
         Assert.Equal("6\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_MultipleYieldAwait_InSequence(ExecutionMode mode)
     {
         var source = """
@@ -1099,8 +1056,7 @@ public class AsyncGeneratorTests
         Assert.Equal("10\n20\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_MixedYieldAndYieldAwait(ExecutionMode mode)
     {
         var source = """
@@ -1129,8 +1085,7 @@ public class AsyncGeneratorTests
         Assert.Equal("1\n20\n3\n40\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_YieldAwaitThenStandaloneAwait(ExecutionMode mode)
     {
         var source = """
@@ -1158,8 +1113,7 @@ public class AsyncGeneratorTests
         Assert.Equal("10\n20\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_YieldAwaitWithComputation(ExecutionMode mode)
     {
         var source = """
@@ -1189,8 +1143,7 @@ public class AsyncGeneratorTests
 
     #region Completion / resume value semantics — #481, #540
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ResumedYield_EvaluatesToUndefined(ExecutionMode mode)
     {
         // The resumed `yield` expression evaluates to undefined (no value sent), not null (#481, the
@@ -1205,8 +1158,7 @@ public class AsyncGeneratorTests
         Assert.Equal("r=undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_YieldStarCompletion_EvaluatesToUndefined(ExecutionMode mode)
     {
         // The completion value of `yield* inner()` (when the delegate has no explicit return value) is
@@ -1221,8 +1173,7 @@ public class AsyncGeneratorTests
         Assert.Equal("v2\nv3\nx=undefined\nv4\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_NextAfterDone_ReportsUndefinedNotStaleReturn(ExecutionMode mode)
     {
         // The return value is delivered exactly once; every later next() reports undefined, not the
@@ -1242,8 +1193,7 @@ public class AsyncGeneratorTests
         Assert.Equal("1\n42\nundefined\nundefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_NextAfterReturn_ReportsUndefinedNotLastYielded(ExecutionMode mode)
     {
         // After return(v) delivers { value: v, done: true }, a later next() reports undefined — the
@@ -1266,8 +1216,7 @@ public class AsyncGeneratorTests
 
     #region Re-entrant next() — "already running" guard (#542)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ReentrantNext_RejectsInsteadOfStackOverflow(ExecutionMode mode)
     {
         // An async generator whose body advances itself (a re-entrant next()) is rejected with a
@@ -1294,8 +1243,7 @@ public class AsyncGeneratorTests
         Assert.Equal("caught: TypeError Async generator is already running\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void AsyncGenerator_ReentrantNext_AfterPendingAwait_Rejects(ExecutionMode mode)
     {
         // Re-entrancy issued *after* a genuinely-pending (setTimeout-backed) await — once the body has
@@ -1328,8 +1276,7 @@ public class AsyncGeneratorTests
 
     #region Genuinely-async awaits and request queuing (#631 / #542)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_PendingAwait_ForAwaitOf_YieldsAllValues(ExecutionMode mode)
     {
         // A not-yet-settled (setTimeout-backed) await inside an async generator consumed by for await…of
@@ -1349,8 +1296,7 @@ public class AsyncGeneratorTests
         Assert.Equal("v1\nv2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_PendingAwait_DirectNext_ResolvesInOrder(ExecutionMode mode)
     {
         // Driving a pending-await async generator by awaiting next() directly. #631 (compiled). Also
@@ -1376,8 +1322,7 @@ public class AsyncGeneratorTests
         Assert.Equal("7 false 8 false undefined true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_PendingRejection_InTry_ReachesCatch(ExecutionMode mode)
     {
         // A pending (genuinely-async) rejected await must reach the consumer's catch through for await…of.
@@ -1398,8 +1343,7 @@ public class AsyncGeneratorTests
         Assert.Equal("caught boom\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ConcurrentNext_QueuesInOrder(ExecutionMode mode)
     {
         // Two next() calls issued before the first settles must be serviced FIFO (ECMA-262 §27.6.3
@@ -1424,8 +1368,7 @@ public class AsyncGeneratorTests
         Assert.Equal("1 false 2 false\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ForAwaitBody_WritesOuterBinding(ExecutionMode mode)
     {
         // #689: a `let`/`const` declared before a `for await…of` over a (genuinely-async) async generator
@@ -1450,8 +1393,7 @@ public class AsyncGeneratorTests
         Assert.Equal("12\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_DirectNext_PreservesCallerScope(ExecutionMode mode)
     {
         // #690 (env-leak symptom): after the first `await it.next()` drives the generator, bindings
@@ -1477,8 +1419,7 @@ public class AsyncGeneratorTests
         Assert.Equal("T 1 2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ForAwaitBody_OuterBinding_SurvivesNestedAwaitBody(ExecutionMode mode)
     {
         // #689 hardening: a generator body whose await is nested inside a delegated expression
@@ -1503,8 +1444,7 @@ public class AsyncGeneratorTests
         Assert.Equal("24\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_DirectNext_OuterBinding_SurvivesNestedAwaitBody(ExecutionMode mode)
     {
         // #752: the direct `await it.next()` form of the nested-await body shape
@@ -1530,8 +1470,7 @@ public class AsyncGeneratorTests
         Assert.Equal("T 2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ForAwaitOf_OverPendingAsyncGenerator_SuspendsNotBlocks(ExecutionMode mode)
     {
         // A `for await…of` INSIDE an async generator, consuming a genuinely-async (setTimeout-backed)
@@ -1554,8 +1493,7 @@ public class AsyncGeneratorTests
         Assert.Equal("v10\nv20\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ForAwaitOf_BreakAwaitsReturn(ExecutionMode mode)
     {
         // Breaking out of a `for await…of` inside an async generator must await the inner iterator's
@@ -1580,8 +1518,7 @@ public class AsyncGeneratorTests
         Assert.Equal("v10\nend\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ForAwaitOf_InsideTryFinally_RunsFinally(ExecutionMode mode)
     {
         // A `for await…of` inside a try in an async generator suspends; the finally still runs after the
@@ -1606,8 +1543,7 @@ public class AsyncGeneratorTests
         Assert.Equal("v10\nv20\nfinally\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_YieldStar_DelegatesToPendingAsyncGenerator(ExecutionMode mode)
     {
         // yield* delegating to a genuinely-async (setTimeout-backed) async generator must drive the
@@ -1631,8 +1567,7 @@ public class AsyncGeneratorTests
         Assert.Equal("a1\na2\ndone\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ValueLiveAcrossAwait_IsPreserved(ExecutionMode mode)
     {
         // A value live on the IL evaluation stack across an await inside an async generator — here the
@@ -1658,8 +1593,7 @@ public class AsyncGeneratorTests
 
     #region Sent Value Tests (next(v) — issue #473)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_NextWithSentValue_PlainYield(ExecutionMode mode)
     {
         // The resumed `yield` expression evaluates to the value passed to next(v) (ECMA-262 §27.6.3.6).
@@ -1681,8 +1615,7 @@ public class AsyncGeneratorTests
         Assert.Equal("1\n52\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_FirstNextIgnoresSentValue(ExecutionMode mode)
     {
         // The first next() call always ignores its sent value — yield evaluates to undefined
@@ -1704,8 +1637,7 @@ public class AsyncGeneratorTests
         Assert.Equal("hello\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_NextWithSentValue_Accumulator(ExecutionMode mode)
     {
         // Sum accumulates sent values across multiple next(v) calls.
@@ -1733,8 +1665,7 @@ public class AsyncGeneratorTests
         Assert.Equal("10\n30\n35\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_NextWithSentValue_NullAndUndefined(ExecutionMode mode)
     {
         // next(null) delivers null; bare next() delivers undefined (not null).
@@ -1769,8 +1700,7 @@ public class AsyncGeneratorTests
     // hoists function declarations in async bodies (Interpreter.Async.ExecuteBlockAsync), and the
     // compiler now hoists the function-scope forwarding binding for a PLAIN/ASYNC (non-generator)
     // encloser — where the forwarding arrow reads its captures live at call time.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGeneratorExpression_CapturesAsyncFunctionLocal_IsCallable(ExecutionMode mode)
     {
         var source = """
@@ -1787,8 +1717,7 @@ public class AsyncGeneratorTests
     }
 
     // The same forward-reference gap applied to a SYNC generator expression nested in an async function.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SyncGeneratorExpression_CapturesAsyncFunctionLocal_IsCallable(ExecutionMode mode)
     {
         var source = """
@@ -1807,8 +1736,7 @@ public class AsyncGeneratorTests
     // binding is hoisted to the generator body top, and its read-only forwarded capture (`y`) is routed
     // through the generator's #674 function display class so the hoisted forwarder reads it LIVE — not a
     // stale by-value snapshot. (Previously interpreter-only + a compiled-fails-cleanly guard.)
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGeneratorExpression_CapturesAsyncGeneratorLocal(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/AsyncGeneratorTryFinallyTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncGeneratorTryFinallyTests.cs
@@ -27,8 +27,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncGeneratorTryFinallyTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void BreakOutOfTryFinally_RunsFinallyBeforeBreaking(ExecutionMode mode)
     {
         // The exact #559 repro: break leaving the try must run the finally first (was invalid IL).
@@ -45,8 +44,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v1\nFIN\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ContinueOutOfTryFinally_RunsFinallyThatIteration(ExecutionMode mode)
     {
         // `continue` from inside the try must run the finally before the next iteration, and the code
@@ -70,8 +68,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("got0\nafter0\nfin0\ngot1\nfin1\ngot2\nafter2\nfin2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ThrowFromCatch_RunsFinallyThenPropagates(ExecutionMode mode)
     {
         // The exact #559 repro: a throw inside the catch must still run the finally before the
@@ -89,8 +86,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v1\nFIN\nouter b\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ReturnFromCatch_RunsFinallyBeforeCompleting(ExecutionMode mode)
     {
         // A `return` from the catch body must run the finally; the yield after the try must not run.
@@ -106,8 +102,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v1\nFIN\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ReturnInsideTryFinally_RunsFinallyBeforeCompleting(ExecutionMode mode)
     {
         // `return` inside the try must run the finally before the generator completes; the statement
@@ -129,8 +124,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v1\nfin\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ReturnInsideNestedTryFinally_RunsAllEnclosingFinallys(ExecutionMode mode)
     {
         var source = """
@@ -154,8 +148,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v1\ninner\nouter\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void BreakThroughNestedFinallys_RunsInnerThenOuter(ExecutionMode mode)
     {
         // A break that leaves two enclosing trys runs both finallys, innermost first.
@@ -174,8 +167,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v1\ninner\nouter\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void LabeledBreakToOuterLoop_RunsInterveningFinally(ExecutionMode mode)
     {
         // A labeled break targeting the outer loop runs the finally of the inner loop's try.
@@ -194,8 +186,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v0\nfin00\nv1\nfin01\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void LabeledContinueToOuterLoop_RunsInterveningFinally(ExecutionMode mode)
     {
         // The labeled-`continue` sibling of LabeledBreakToOuterLoop (#586/#589). `continue outer` must
@@ -218,8 +209,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v0\nfin00\nv10\nfin10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void BreakToLoopBetweenTwoTrys_RunsOnlyInnerFinally(ExecutionMode mode)
     {
         // The break targets a loop that sits *between* two trys: only the finally inside that loop
@@ -240,8 +230,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v0\ninner0\nv1\ninner1\nafter-loop\nOUTER\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void BreakWithYieldingFinally_DrivesFinallyThenBreaks(ExecutionMode mode)
     {
         // The finally that runs on the break path itself yields; the break completes only after the
@@ -260,8 +249,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v1\nv2\nv3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ReturnInTry_WithYieldingFinally_CompletesAfterFinallyYields(ExecutionMode mode)
     {
         // The finally itself yields, suspending MoveNextAsync between the `return` and the completion.
@@ -284,8 +272,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v1\nv2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ThrowFromFinally_RunsEnclosingFinallyThenPropagates(ExecutionMode mode)
     {
         // A throw raised inside a finally body must still run the enclosing finally before it
@@ -305,8 +292,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v1\nOUTER\ncaught boom\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void BreakOutOfInnerCatchlessTry_RunsOuterFinally(ExecutionMode mode)
     {
         // The break leaves an inner try/catch that has no finally, nested in an outer try-with-
@@ -326,8 +312,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v1\nOUTERFIN\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void YieldStarInTryFinally_DelegatesThenRunsFinally(ExecutionMode mode)
     {
         var source = """
@@ -350,8 +335,7 @@ public class AsyncGeneratorTryFinallyTests
 
     // ---- await inside the protected region (async-generator-specific) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void AwaitThenReturnInTryFinally_RunsFinally(ExecutionMode mode)
     {
         // An await suspension precedes the return inside the try; the finally must still run.
@@ -366,8 +350,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v1\nFIN\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void AwaitThenBreakOutOfTryFinally_RunsFinally(ExecutionMode mode)
     {
         var source = """
@@ -383,8 +366,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v5\nFIN\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void AwaitThenContinueOutOfTryFinally_RunsFinallyEachIteration(ExecutionMode mode)
     {
         var source = """
@@ -402,8 +384,7 @@ public class AsyncGeneratorTryFinallyTests
 
     // ---- #597: return in a NO-yield try, and return value preserved across a yielding finally ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ReturnInNoYieldTry_RunsFinally(ExecutionMode mode)
     {
         // #597(a): the `return` sits in a try whose body has NO suspension (a real IL try via
@@ -419,8 +400,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v0\nf\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ReturnValueInTry_WithYieldingFinally_PreservesReturnValue(ExecutionMode mode)
     {
         // #597(b): when the finally yields, its yielded value must not clobber the return value in
@@ -440,8 +420,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("{\"value\":9,\"done\":false}\n{\"value\":5,\"done\":true}\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void BreakOutOfNoYieldTry_NestedInYieldingTry_RunsOuterFinally(ExecutionMode mode)
     {
         // A break inside an inner NO-yield try (real IL) nested in an outer flag-based try-with-finally
@@ -464,8 +443,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v0\nOUTERFIN\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ContinueOutOfNoYieldTry_NestedInYieldingTry_RunsOuterFinallyEachIteration(ExecutionMode mode)
     {
         // The continue sibling of the break case above: continue from an inner no-yield try nested in
@@ -495,8 +473,7 @@ public class AsyncGeneratorTryFinallyTests
     // CompiledOnly: the interpreter eagerly drains the async generator body, so its internal logs
     // interleave out of Node order (a separate concern, #564).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void CatchParamAfterYieldInCatchBody_PreservesValue(ExecutionMode mode)
     {
         // The exact #569 repro: `e` is read after the `yield 0` inside the catch.
@@ -511,8 +488,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v1\nv0\ncaught boom\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void CatchParamAfterAwaitInCatchBody_PreservesValue(ExecutionMode mode)
     {
         // The await sibling: `e` is read after an `await` suspension inside the catch.
@@ -534,8 +510,7 @@ public class AsyncGeneratorTryFinallyTests
     // value, set by both the sync-segment capture and the rejected-await routing (#617). CompiledOnly:
     // the interpreter's eager-drain ordering (#564) is a separate concern.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ThrowNullIntoFlagBasedTryCatch_IsCaught(ExecutionMode mode)
     {
         // The exact #628 repro: throw null after a yield, caught in the same try's catch.
@@ -548,8 +523,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v1\ncaught isNull=true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ThrowUndefinedIntoFlagBasedTryCatch_IsCaught(ExecutionMode mode)
     {
         // throw undefined likewise reaches the catch (was skipped). Asserted via `=== undefined`.
@@ -562,8 +536,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v1\nisUndef=true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void RejectedNullAwaitInTry_IsCaughtWithNullBinding(ExecutionMode mode)
     {
         // A rejected await whose reason is null must reach the catch (the await-routing present flag,
@@ -577,8 +550,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("isNull=true\nv1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void FalsyNonNullThrowIntoFlagBasedTryCatch_StillCaught(ExecutionMode mode)
     {
         // Boundary guard: a falsy-but-non-null thrown value (0) boxes to a non-null reference and was
@@ -597,8 +569,7 @@ public class AsyncGeneratorTryFinallyTests
     // flag-based try's capture local (running the finally(s) inside that try first) and branched to its
     // cleanup, instead of a real IL throw that bypasses the flag-based catch.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void RethrowFromCatch_CaughtByEnclosingTryCatch(ExecutionMode mode)
     {
         // The exact async #632 repro: a rejected await is caught by the inner catch, which rethrows; the
@@ -617,8 +588,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("inner caught inner\nouter caught rethrown\nv1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void RethrowFromCatch_WithInterveningFinally_RunsFinallyThenOuterCatch(ExecutionMode mode)
     {
         // The inner try has a finally: a throw escaping the inner catch runs that finally before the
@@ -639,8 +609,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v0\nC1 inner\nF1\nouter rethrown\nv1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void UncaughtThrowFromCatchlessTryFinally_CaughtByEnclosingTry(ExecutionMode mode)
     {
         // An uncaught exception leaving a catch-less inner try/finally must, after its finally runs,
@@ -662,8 +631,7 @@ public class AsyncGeneratorTryFinallyTests
     // ---- #675: a real exception escaping a nested real-IL try/catch inside a flag-based catch/finally
     // body must reach an enclosing flag-based try's catch (async-generator analog of the sync #675) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void RealThrowEscapingNestedTryInCatchBody_CaughtByEnclosingTry(ExecutionMode mode)
     {
         // A nested real-IL try/catch inside a flag-based catch body rethrows; the in-flight value must
@@ -686,8 +654,7 @@ public class AsyncGeneratorTryFinallyTests
         Assert.Equal("v0\nC3 b\nouter c\nv1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void RealThrowEscapingNestedTryInFinallyBody_CaughtByEnclosingTry(ExecutionMode mode)
     {
         // The finally-body analog.

--- a/SharpTS.Tests/SharedTests/AsyncIteratorEdgeCaseTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncIteratorEdgeCaseTests.cs
@@ -13,8 +13,7 @@ public class AsyncIteratorEdgeCaseTests
 {
     #region Async From Sync (#1287)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForAwaitOf_SyncBuiltins_AwaitsValues(ExecutionMode mode)
     {
         var source = """
@@ -35,8 +34,7 @@ public class AsyncIteratorEdgeCaseTests
         Assert.Equal("[1,2,3,4,5,\"o\",\"k\",[\"a\",6]]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForAwaitOf_SyncIterators_CloseOnBreak(ExecutionMode mode)
     {
         var source = """
@@ -71,8 +69,7 @@ public class AsyncIteratorEdgeCaseTests
         Assert.Equal("true true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForAwaitOf_SyncIterable_WorksInAsyncArrowAndAsyncGenerator(ExecutionMode mode)
     {
         var source = """
@@ -102,8 +99,7 @@ public class AsyncIteratorEdgeCaseTests
 
     #region Error Handling
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncIterator_RejectedPromiseInNext_PropagatesError(ExecutionMode mode)
     {
         var source = """
@@ -144,8 +140,7 @@ public class AsyncIteratorEdgeCaseTests
         Assert.Equal("got: 1\ncaught: iterator error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncIterator_ThrowInForAwaitBody_CatchesError(ExecutionMode mode)
     {
         var source = """
@@ -182,8 +177,7 @@ public class AsyncIteratorEdgeCaseTests
     // spans wrapped in a real IL try that routes a throw to the enclosing flag-based catch. Before the fix
     // the throw escaped the state machine (only an await-free, jump-free body was guarded).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncIterator_ThrowInForAwaitBodyThatAwaits_CatchesError(ExecutionMode mode)
     {
         // The exact #691 repro: the body awaits and then throws synchronously.
@@ -203,8 +197,7 @@ public class AsyncIteratorEdgeCaseTests
         Assert.Equal("caught body error\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncIterator_ThrowInForAwaitBodyThatBreaks_CatchesError(ExecutionMode mode)
     {
         // The body contains a top-level break and a synchronous throw; the throw must still be caught, and
@@ -227,8 +220,7 @@ public class AsyncIteratorEdgeCaseTests
         Assert.Equal("caught boom seen=1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncIterator_ThrowInForAwaitBodyThatContinuesAndAwaits_CatchesError(ExecutionMode mode)
     {
         // The body awaits, continues, and throws synchronously — all three in one body.
@@ -251,8 +243,7 @@ public class AsyncIteratorEdgeCaseTests
         Assert.Equal("caught err3 sum=2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncIterator_ForAwaitBodyBreakContinueNoThrow_StillWorks(ExecutionMode mode)
     {
         // Guard against regressing normal break/continue in a for-await body (no enclosing try): the body
@@ -274,8 +265,7 @@ public class AsyncIteratorEdgeCaseTests
         Assert.Equal("sum=5\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_TryFinally_CleanupRuns(ExecutionMode mode)
     {
         var source = """
@@ -310,8 +300,7 @@ public class AsyncIteratorEdgeCaseTests
 
     #region Promise Chains with Iterators
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PromiseAll_WithAsyncGenerator_CollectsResults(ExecutionMode mode)
     {
         var source = """
@@ -342,8 +331,7 @@ public class AsyncIteratorEdgeCaseTests
         Assert.Equal("3\n60\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncIterator_NestedPromiseResolveInNext_Flattens(ExecutionMode mode)
     {
         // Regression test: nested Promise.resolve in iterator.next() should flatten
@@ -380,8 +368,7 @@ public class AsyncIteratorEdgeCaseTests
         Assert.Equal("60\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncIterator_WithAwaitBeforeYield_HandlesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -416,8 +403,7 @@ public class AsyncIteratorEdgeCaseTests
 
     #region State Management
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncIterator_MultipleForAwaitLoops_IndependentState(ExecutionMode mode)
     {
         var source = """
@@ -451,8 +437,7 @@ public class AsyncIteratorEdgeCaseTests
         Assert.Equal("6\n6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_BreakThenNewLoop_StateReset(ExecutionMode mode)
     {
         var source = """
@@ -489,8 +474,7 @@ public class AsyncIteratorEdgeCaseTests
         Assert.Equal("first: 2\nsecond: 5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_SharedReference_MaintainsState(ExecutionMode mode)
     {
         var source = """
@@ -531,8 +515,7 @@ public class AsyncIteratorEdgeCaseTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncIterator_YieldNull_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -560,8 +543,7 @@ public class AsyncIteratorEdgeCaseTests
         Assert.Equal("3\nnull\n42\nnull\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncIterator_YieldZero_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -583,8 +565,7 @@ public class AsyncIteratorEdgeCaseTests
         Assert.Equal("0\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncIterator_EmptyAsyncIterable_NoIterations(ExecutionMode mode)
     {
         var source = """
@@ -613,8 +594,7 @@ public class AsyncIteratorEdgeCaseTests
         Assert.Equal("count: 0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncIterator_SingleValue_IteratesOnce(ExecutionMode mode)
     {
         var source = """
@@ -647,8 +627,7 @@ public class AsyncIteratorEdgeCaseTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncIterator_WithContinue_SkipsValues(ExecutionMode mode)
     {
         var source = """
@@ -676,8 +655,7 @@ public class AsyncIteratorEdgeCaseTests
         Assert.Equal("9\n", output);  // 1 + 3 + 5 = 9
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CustomAsyncIterator_WorksCorrectly(ExecutionMode mode)
     {
         // Test that custom async iterators work correctly

--- a/SharpTS.Tests/SharedTests/AsyncMemberIncrementTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncMemberIncrementTests.cs
@@ -14,8 +14,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncMemberIncrementTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_PropertyAndIndex_AllForms(ExecutionMode mode)
     {
         var source = """
@@ -34,8 +33,7 @@ public class AsyncMemberIncrementTests
         Assert.Equal("2 11 4 5 7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_ResultValueSemantics(ExecutionMode mode)
     {
         // Postfix yields the (ToNumber-coerced) original; prefix yields the new value.
@@ -52,8 +50,7 @@ public class AsyncMemberIncrementTests
         Assert.Equal("5 7 7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_MemberIncrement(ExecutionMode mode)
     {
         var source = """
@@ -72,8 +69,7 @@ public class AsyncMemberIncrementTests
         Assert.Equal("6 0\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_MemberIncrement(ExecutionMode mode)
     {
         var source = """
@@ -88,8 +84,7 @@ public class AsyncMemberIncrementTests
         Assert.Equal("42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_MemberIncrement(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/AsyncMethodArrowCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncMethodArrowCaptureTests.cs
@@ -20,8 +20,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncMethodArrowCaptureTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_Arrow_WritesCapturedVariable(ExecutionMode mode)
     {
         var source = """
@@ -39,8 +38,7 @@ public class AsyncMethodArrowCaptureTests
         Assert.Equal("9\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_Arrow_WritesCapturedVariableAfterAwait(ExecutionMode mode)
     {
         var source = """
@@ -58,8 +56,7 @@ public class AsyncMethodArrowCaptureTests
         Assert.Equal("99\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_Arrow_CompoundWriteWithAwaitAndMultipleCaptures(ExecutionMode mode)
     {
         var source = """
@@ -82,8 +79,7 @@ public class AsyncMethodArrowCaptureTests
         Assert.Equal("12:a\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_SuspendingArrow_NoCapture(ExecutionMode mode)
     {
         // Pre-existing InvalidProgramException: a suspending async arrow in an async method, even
@@ -101,8 +97,7 @@ public class AsyncMethodArrowCaptureTests
         Assert.Equal("5\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_SuspendingArrow_ReadsCapture(ExecutionMode mode)
     {
         var source = """
@@ -119,8 +114,7 @@ public class AsyncMethodArrowCaptureTests
         Assert.Equal("101\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_Arrow_WritesCapturedParameter(ExecutionMode mode)
     {
         // The promoted variable is a method PARAMETER (copied into the function DC by the stub), not a
@@ -139,8 +133,7 @@ public class AsyncMethodArrowCaptureTests
         Assert.Equal("11\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncStaticMethod_Arrow_WritesCapturedVariableAfterAwait(ExecutionMode mode)
     {
         // Static async methods take a separate emission path (EmitStaticAsyncMethodBody) with the
@@ -160,8 +153,7 @@ public class AsyncMethodArrowCaptureTests
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncStaticMethod_SuspendingArrow_NoCapture(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/AsyncMethodNestedCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncMethodNestedCaptureTests.cs
@@ -14,8 +14,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncMethodNestedCaptureTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncInstanceMethod_SyncArrowWritesCapturedLocal(ExecutionMode mode)
     {
         var source = """
@@ -34,8 +33,7 @@ public class AsyncMethodNestedCaptureTests
         Assert.Equal("6,6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncStaticMethod_SyncArrowWritesCapturedLocal(ExecutionMode mode)
     {
         var source = """
@@ -54,8 +52,7 @@ public class AsyncMethodNestedCaptureTests
         Assert.Equal("6,6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_SyncArrowCompoundAssignCapturedLocal(ExecutionMode mode)
     {
         // `+=` and `++` go through distinct emitter paths than plain `=` — both must route to the DC.
@@ -75,8 +72,7 @@ public class AsyncMethodNestedCaptureTests
         Assert.Equal("7,7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_TwoArrowsWriteDistinctCapturedLocals(ExecutionMode mode)
     {
         // Two independent captured locals, each written by its own arrow, must not cross-contaminate.
@@ -98,8 +94,7 @@ public class AsyncMethodNestedCaptureTests
         Assert.Equal("2,11,2,11\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_WriteCapturedBlockScopeShadow_DoesNotLeak(ExecutionMode mode)
     {
         // Combines this fix with #838: the written capture is a nested-block shadow of an outer binding;
@@ -127,8 +122,7 @@ public class AsyncMethodNestedCaptureTests
         Assert.Equal("6,6,100\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_AsyncArrowWriteCaptureStillWorks(ExecutionMode mode)
     {
         // Regression guard for #682: a direct-child ASYNC arrow writing a captured method local still

--- a/SharpTS.Tests/SharedTests/AsyncNaNStrictEqualityTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncNaNStrictEqualityTests.cs
@@ -28,8 +28,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncNaNStrictEqualityTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_NaNStrictEquality(ExecutionMode mode)
     {
         // The exact repro from #642.
@@ -45,8 +44,7 @@ public class AsyncNaNStrictEqualityTests
         Assert.Equal("false\nfalse\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_ComputedNaN_NotEqual(ExecutionMode mode)
     {
         // A NaN produced at runtime (not the literal) — exercises the same fast path.
@@ -61,8 +59,7 @@ public class AsyncNaNStrictEqualityTests
         Assert.Equal("false\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_AfterAwait_NaNStillNotEqual(ExecutionMode mode)
     {
         // Equality evaluated after a suspension point still runs through the async fast path.
@@ -79,8 +76,7 @@ public class AsyncNaNStrictEqualityTests
     // #648: previously interpreted-only because a bare NaN/Infinity inside a compiled async arrow
     // resolved to null (NaN === NaN → null === null → true). Now cross-mode after the
     // AsyncArrowMoveNextEmitter global-constant fix.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_NaNStrictEquality(ExecutionMode mode)
     {
         // The exact repro from #648.
@@ -98,8 +94,7 @@ public class AsyncNaNStrictEqualityTests
     // must resolve to real values inside a compiled async arrow, not a null load. A param named
     // `NaN` must still shadow the global (resolver runs before the constant check), matching
     // ECMA-262 lexical lookup.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_GlobalConstantsResolve(ExecutionMode mode)
     {
         var source = """
@@ -122,8 +117,7 @@ public class AsyncNaNStrictEqualityTests
     // After an await the arrow body runs from a resumed state-machine label; the global constants
     // must still resolve there too (the suspend/resume path is where #648's null load was most
     // surprising).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_AfterAwait_NaNStillNotEqual(ExecutionMode mode)
     {
         var source = """
@@ -137,8 +131,7 @@ public class AsyncNaNStrictEqualityTests
         Assert.Equal("false\nNaN\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_NaNStrictEquality(ExecutionMode mode)
     {
         var source = """
@@ -156,8 +149,7 @@ public class AsyncNaNStrictEqualityTests
 
     // ---- Already-correct contexts: assert cross-mode parity so they don't regress ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TopLevel_NaNStrictEquality(ExecutionMode mode)
     {
         var source = """
@@ -167,8 +159,7 @@ public class AsyncNaNStrictEqualityTests
         Assert.Equal("false\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NaNStrictEquality(ExecutionMode mode)
     {
         var source = """
@@ -183,8 +174,7 @@ public class AsyncNaNStrictEqualityTests
 
     // ---- Guard: ordinary number equality is unaffected by the Double.Equals -> == change ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_OrdinaryNumberEquality_Unaffected(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/AsyncNestedAwaitTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncNestedAwaitTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncNestedAwaitTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAwait_GlobalFunction_SingleArg(ExecutionMode mode)
     {
         var source = """
@@ -31,8 +30,7 @@ public class AsyncNestedAwaitTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAwait_GlobalFunction_MultipleArgs(ExecutionMode mode)
     {
         var source = """
@@ -53,8 +51,7 @@ public class AsyncNestedAwaitTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAwait_ArrowFunction_SingleArg(ExecutionMode mode)
     {
         var source = """
@@ -73,8 +70,7 @@ public class AsyncNestedAwaitTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAwait_ArrowFunction_MultipleArgs(ExecutionMode mode)
     {
         var source = """
@@ -93,8 +89,7 @@ public class AsyncNestedAwaitTests
         Assert.Equal("9\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAwait_ChainedCalls(ExecutionMode mode)
     {
         var source = """
@@ -114,8 +109,7 @@ public class AsyncNestedAwaitTests
         Assert.Equal("11\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAwait_MixedArgsWithLiteral(ExecutionMode mode)
     {
         var source = """
@@ -136,8 +130,7 @@ public class AsyncNestedAwaitTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAwait_InMethodCall(ExecutionMode mode)
     {
         var source = """
@@ -161,8 +154,7 @@ public class AsyncNestedAwaitTests
         Assert.Equal("14\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAwait_DeeplyNested(ExecutionMode mode)
     {
         var source = """
@@ -180,8 +172,7 @@ public class AsyncNestedAwaitTests
         Assert.Equal("4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedAwait_WithAwaitInCallee(ExecutionMode mode)
     {
         // Callee itself is loaded via await

--- a/SharpTS.Tests/SharedTests/AsyncTryCatchTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncTryCatchTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncTryCatchTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTryCatch_AwaitInTry_ExceptionCaught(ExecutionMode mode)
     {
         var source = """
@@ -32,8 +31,7 @@ public class AsyncTryCatchTests
         Assert.Equal("caught: async error!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTryCatch_AwaitInTry_NoException(ExecutionMode mode)
     {
         var source = """
@@ -55,8 +53,7 @@ public class AsyncTryCatchTests
         Assert.Equal("got: 42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTryCatch_MultipleAwaitsInTry(ExecutionMode mode)
     {
         var source = """
@@ -84,8 +81,7 @@ public class AsyncTryCatchTests
         Assert.Equal("a: 10\ncaught: error on second\nafter\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTryCatch_NestedTryCatch(ExecutionMode mode)
     {
         var source = """
@@ -112,8 +108,7 @@ public class AsyncTryCatchTests
         Assert.Equal("inner caught: inner error\nouter caught: rethrow from inner\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTryCatch_SyncExceptionBeforeAwait(ExecutionMode mode)
     {
         var source = """
@@ -136,8 +131,7 @@ public class AsyncTryCatchTests
         Assert.Equal("caught: sync error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTryCatch_SyncExceptionAfterAwait(ExecutionMode mode)
     {
         var source = """
@@ -160,8 +154,7 @@ public class AsyncTryCatchTests
         Assert.Equal("got: 42\ncaught: sync error after\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTryCatch_CatchParameter(ExecutionMode mode)
     {
         var source = """
@@ -182,8 +175,7 @@ public class AsyncTryCatchTests
         Assert.Equal("error was: the error message\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTryCatch_CodeAfterCatch(ExecutionMode mode)
     {
         var source = """
@@ -209,8 +201,7 @@ public class AsyncTryCatchTests
         Assert.Equal("caught\nafter: 99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTryCatch_TryWithoutAwait_CatchAfterTry(ExecutionMode mode)
     {
         // Try block has no await, but there's await after the try/catch
@@ -234,8 +225,7 @@ public class AsyncTryCatchTests
         Assert.Equal("caught: sync error\ngot: 42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTryCatch_InnerCatchRethrows(ExecutionMode mode)
     {
         var source = """
@@ -265,8 +255,7 @@ public class AsyncTryCatchTests
         Assert.Equal("inner: original\nouter: wrapped: original\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTryCatch_AwaitEmbeddedInCallArgument_RejectionSkipsStatement(ExecutionMode mode)
     {
         // Regression: when the await is embedded in a larger statement
@@ -292,8 +281,7 @@ public class AsyncTryCatchTests
         Assert.Equal("caught boom\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTryCatch_AwaitEmbeddedInConcat_RejectionSkipsStatement(ExecutionMode mode)
     {
         // The await must be the FIRST operand: `"v:" + (await ...)` inside a
@@ -318,8 +306,7 @@ public class AsyncTryCatchTests
         Assert.Equal("caught boom\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTryCatch_AwaitAfterNestedTry_RejectionStillCaught(ExecutionMode mode)
     {
         // Regression: emitting a nested try-with-awaits cleared the outer

--- a/SharpTS.Tests/SharedTests/AsyncTryControlFlowTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncTryControlFlowTests.cs
@@ -17,8 +17,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncTryControlFlowTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BreakOutOfSimpleTry_InAsync(ExecutionMode mode)
     {
         // The exact #727 break repro.
@@ -36,8 +35,7 @@ public class AsyncTryControlFlowTests
         Assert.Equal("n=2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ContinueOutOfSimpleTry_InAsync(ExecutionMode mode)
     {
         // The exact #727 continue repro.
@@ -55,8 +53,7 @@ public class AsyncTryControlFlowTests
         Assert.Equal("sum=9\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BreakOutOfTryContainingAwait_InAsync(ExecutionMode mode)
     {
         // break leaves a try whose body awaits → the flag-based try path. The escaping break must be
@@ -80,8 +77,7 @@ public class AsyncTryControlFlowTests
         Assert.Equal("n=1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BreakOutOfTryWithFinally_NoAwait_RunsFinally(ExecutionMode mode)
     {
         // A try with no awaits is a real IL try/finally (EmitSimpleTryCatch). The break Leaves it,
@@ -100,8 +96,7 @@ public class AsyncTryControlFlowTests
         Assert.Equal("t0f0t1f1f2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BreakToInnerLoopInsideTry_DoesNotEscapeTry(ExecutionMode mode)
     {
         // The break targets a loop nested INSIDE the try, so it stays a legal in-region branch and the
@@ -121,8 +116,7 @@ public class AsyncTryControlFlowTests
         Assert.Equal("j0after\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SwitchBreakInsideTry_InAsync(ExecutionMode mode)
     {
         // An unlabeled break inside a switch that is inside a try belongs to the switch, not the loop.

--- a/SharpTS.Tests/SharedTests/AsyncTrySuspensionWalkerTests.cs
+++ b/SharpTS.Tests/SharedTests/AsyncTrySuspensionWalkerTests.cs
@@ -23,8 +23,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncTrySuspensionWalkerTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTry_AwaitInsideSwitch(ExecutionMode mode)
     {
         var source = """
@@ -52,8 +51,7 @@ public class AsyncTrySuspensionWalkerTests
     // sync-segment mini try/catch), so before #914 the compiled raw throw escaped the guest try and
     // faulted the Task. Fixed by AsyncFunctionMoveNextEmitter.EmitThrow routing a top-level throw into
     // the active flag-based try's exception local (running any intervening finally first).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTry_AwaitInsideThrow(ExecutionMode mode)
     {
         var source = """
@@ -70,8 +68,7 @@ public class AsyncTrySuspensionWalkerTests
         Assert.Equal("caught: boom\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTry_AwaitInsideConsoleLog(ExecutionMode mode)
     {
         // console.log(...) is an ordinary expression statement; its call arm was missing.
@@ -94,8 +91,7 @@ public class AsyncTrySuspensionWalkerTests
     // took the real-IL lowering (illegal BranchIntoTry resume → InvalidProgramException).
     // Fixed in #914 by delegating the walker to the canonical ExprContainsSuspension
     // (the CompoundSetIndex emission already spilled the receiver/index correctly).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTry_AwaitInCompoundIndexedAssign(ExecutionMode mode)
     {
         // arr[0] += await ... exercises CompoundAssign + GetIndex + SetIndex.
@@ -115,8 +111,7 @@ public class AsyncTrySuspensionWalkerTests
         Assert.Equal("arr0: 15\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTry_AwaitInIndexExpression(ExecutionMode mode)
     {
         // arr[await ...] exercises GetIndex with the await in the index.
@@ -136,8 +131,7 @@ public class AsyncTrySuspensionWalkerTests
         Assert.Equal("v: 30\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTry_AwaitInsideLabeledStatement(ExecutionMode mode)
     {
         // The labeled loop wraps the await; pre-fix the missing LabeledStatement
@@ -163,8 +157,7 @@ public class AsyncTrySuspensionWalkerTests
     // had been added). Each puts an await inside a composite the walker must descend into, within
     // a try; under-reporting any of them would re-expose the BranchIntoTry resume failure.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTry_AwaitInCompoundMemberAssign(ExecutionMode mode)
     {
         // obj.x += await ... is Expr.CompoundSet.
@@ -184,8 +177,7 @@ public class AsyncTrySuspensionWalkerTests
         Assert.Equal("x: 15\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTry_AwaitInLogicalIndexedAssign(ExecutionMode mode)
     {
         // arr[0] ||= await ... is Expr.LogicalSetIndex; arr[0] is falsy so the RHS await runs.
@@ -205,8 +197,7 @@ public class AsyncTrySuspensionWalkerTests
         Assert.Equal("arr0: 5\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTry_AwaitInArrayLiteral(ExecutionMode mode)
     {
         // [await ...] is Expr.ArrayLiteral with a suspending element.
@@ -225,8 +216,7 @@ public class AsyncTrySuspensionWalkerTests
         Assert.Equal("a: 3,9\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTry_AwaitInTemplateLiteral(ExecutionMode mode)
     {
         // `v=${await ...}` is Expr.TemplateLiteral with a suspending interpolation.
@@ -245,8 +235,7 @@ public class AsyncTrySuspensionWalkerTests
         Assert.Equal("v=4\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTry_ThrowAwait_RunsOwnFinallyThenCatch(ExecutionMode mode)
     {
         // The routed throw lands in this try's catch and its own finally still runs after (#914).
@@ -266,8 +255,7 @@ public class AsyncTrySuspensionWalkerTests
         Assert.Equal("caught: boom\nfinally\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncTry_ThrowAwait_NestedInIf_RoutesToCatch(ExecutionMode mode)
     {
         // The `if` is the segment-breaker (its branch contains the await); the throw is emitted while

--- a/SharpTS.Tests/SharedTests/AwaitDeferredSpillTests.cs
+++ b/SharpTS.Tests/SharedTests/AwaitDeferredSpillTests.cs
@@ -23,30 +23,26 @@ public class AwaitDeferredSpillTests
     private static string Run(string body, ExecutionMode mode)
         => TestHarness.Run(Defer + "class C { x: any = 0; }\nasync function m() {\n" + body + "\n}\nm();\n", mode);
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BinaryConcat_PrefixSurvivesDeferredAwait(ExecutionMode mode)
     {
         // The exact shape from the issue: the "concat: " prefix is pushed before the await.
         Assert.Equal("concat: 6\n", Run("""console.log("concat: " + (await defer(6, 5)));""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BinaryConcat_TwoDeferredAwaits(ExecutionMode mode)
     {
         Assert.Equal("L-R\n", Run("""console.log((await defer("L", 5)) + "-" + (await defer("R", 5)));""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TemplateLiteral_TwoDeferredAwaits(ExecutionMode mode)
     {
         Assert.Equal("a1-2\n", Run("""console.log(`${"a"}${await defer(1, 5)}-${await defer(2, 5)}`);""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TaggedTemplate_DeferredAwait(ExecutionMode mode)
     {
         Assert.Equal("p|7\n", Run(
@@ -56,30 +52,26 @@ public class AwaitDeferredSpillTests
             """, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConsoleLog_MultiArg_DeferredAwaitBetweenArgs(ExecutionMode mode)
     {
         Assert.Equal("A B C\n", Run("""console.log("A", await defer("B", 5), "C");""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayLiteral_DeferredAwaitBetweenElements(ExecutionMode mode)
     {
         Assert.Equal("[x, 9, y]\n", Run("""console.log(["x", await defer(9, 5), "y"]);""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectLiteral_DeferredAwaitAfterEarlierProperty(ExecutionMode mode)
     {
         Assert.Equal("""{"a":"x","b":10}""" + "\n", Run(
             """console.log(JSON.stringify({ a: "x", b: await defer(10, 5) }));""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ComputedKeyObjectLiteral_DeferredAwait(ExecutionMode mode)
     {
         Assert.Equal("""{"dyn":12,"other":99}""" + "\n", Run(
@@ -89,8 +81,7 @@ public class AwaitDeferredSpillTests
             """, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IndexSet_DeferredAwaitInIndexAndValue(ExecutionMode mode)
     {
         Assert.Equal("8\nZ\n", Run(
@@ -103,8 +94,7 @@ public class AwaitDeferredSpillTests
             """, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssign_DeferredAwaitRhs(ExecutionMode mode)
     {
         Assert.Equal("17\n17\n", Run(
@@ -119,8 +109,7 @@ public class AwaitDeferredSpillTests
             """, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LogicalAssign_DeferredAwaitRhs(ExecutionMode mode)
     {
         Assert.Equal("11\n11\n", Run(
@@ -135,8 +124,7 @@ public class AwaitDeferredSpillTests
             """, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PropertySet_DeferredAwaitValue(ExecutionMode mode)
     {
         Assert.Equal("5\n", Run(
@@ -161,16 +149,14 @@ public class AwaitDeferredSpillTests
     private static string RunRest(string body, ExecutionMode mode)
         => TestHarness.Run(Defer + RestScaffold + "async function m() {\n" + body + "\n}\nm();\n", mode);
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RestParamCall_DeferredAwaitArg(ExecutionMode mode)
     {
         // The exact issue repro shape: await in the second (rest) argument.
         Assert.Equal("x,1\n", RunRest("""console.log(g("x", await defer(1, 5)));""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RestParamCall_RegularParamSurvivesDeferredAwait(ExecutionMode mode)
     {
         // `h`'s typed regular param "X" is spilled before the deferred await in the rest arg;
@@ -178,15 +164,13 @@ public class AwaitDeferredSpillTests
         Assert.Equal("X|y,Z\n", RunRest("""console.log(h("X", "y", await defer("Z", 5)));""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RestParamCall_TwoDeferredAwaits(ExecutionMode mode)
     {
         Assert.Equal("p,q\n", RunRest("""console.log(g(await defer("p", 5), await defer("q", 5)));""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RestParamCall_SpreadBetweenDeferredAwaits(ExecutionMode mode)
     {
         // Spread element plus deferred awaits on both sides — exercises the spread/ExpandCallArgs
@@ -195,8 +179,7 @@ public class AwaitDeferredSpillTests
             """const arr = [10, 20]; console.log(g(await defer(0, 5), ...arr, await defer(30, 5)));""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeferredThenableSpecies_PrefixSurvives(ExecutionMode mode)
     {
         // The original issue repro: a Promise subclass whose @@species is a general
@@ -239,31 +222,27 @@ public class AwaitDeferredSpillTests
     private static string RunFns(string body, ExecutionMode mode)
         => TestHarness.Run(Defer + FixedArityScaffold + "async function m() {\n" + body + "\n}\nm();\n", mode);
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FixedArityCall_EarlierStringArgSurvivesDeferredAwait(ExecutionMode mode)
     {
         // The exact #436 repro shape: f("A", await ...) lost "A" → "nullB".
         Assert.Equal("AB\n", RunFns("""console.log(concat2("A", await defer("B", 5)));""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FixedArityCall_NumericArgsSurviveDeferredAwait(ExecutionMode mode)
     {
         // Numeric (double) parameters: earlier args boxed across the await, unboxed back on load.
         Assert.Equal("6\n", RunFns("""console.log(add3(1, await defer(2, 5), 3));""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FixedArityCall_TwoDeferredAwaitArgs(ExecutionMode mode)
     {
         Assert.Equal("12\n", RunFns("""console.log(add3(await defer(3, 5), 4, await defer(5, 5)));""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FixedArityCall_BooleanArgBeforeDeferredAwait(ExecutionMode mode)
     {
         Assert.Equal("yes\n", RunFns("""console.log(pick(true, await defer("yes", 5), "no"));""", mode));
@@ -282,22 +261,19 @@ public class AwaitDeferredSpillTests
     private static string RunMethods(string body, ExecutionMode mode)
         => TestHarness.Run(Defer + MethodScaffold + "async function m() {\n" + body + "\n}\nm();\n", mode);
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethodCall_EarlierArgSurvivesDeferredAwait(ExecutionMode mode)
     {
         Assert.Equal("AB\n", RunMethods("""const c = new Calc(); console.log(c.join("A", await defer("B", 5)));""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticMethodCall_EarlierArgSurvivesDeferredAwait(ExecutionMode mode)
     {
         Assert.Equal("42\n", RunMethods("""console.log(Calc.mul(6, await defer(7, 5)));""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalChainMethodCall_EarlierArgSurvivesDeferredAwait(ExecutionMode mode)
     {
         Assert.Equal("AB\n", RunMethods(
@@ -312,23 +288,20 @@ public class AwaitDeferredSpillTests
     // await-state counter and crashing the compiler with "The given key 'N' was not present in the
     // dictionary." The arguments are now spilled once before the string-vs-generic split.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalChainStringMethod_DeferredAwaitArg(ExecutionMode mode)
     {
         // The exact #614 repro shape: substring (a direct runtime string method) on `any?.`.
         Assert.Equal("ell\n", Run("""const s: any = "hello"; console.log(s?.substring(await defer(1, 5), 4));""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalChainStringMethod_TwoDeferredAwaits(ExecutionMode mode)
     {
         Assert.Equal("hel\n", Run("""const s: any = "hello"; console.log(s?.substring(await defer(0, 5), await defer(3, 5)));""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalChainStringMethod_DefaultCasePath_DeferredAwaitArg(ExecutionMode mode)
     {
         // charAt is dispatchable but not one of the direct switch cases, so it routes through the
@@ -336,8 +309,7 @@ public class AwaitDeferredSpillTests
         Assert.Equal("e\n", Run("""const s: any = "hello"; console.log(s?.charAt(await defer(1, 5)));""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DynamicDispatchStringMethod_DeferredAwaitArg(ExecutionMode mode)
     {
         // Non-optional dynamic dispatch (EmitDynamicMethodCallPreservingThis) has the same
@@ -345,8 +317,7 @@ public class AwaitDeferredSpillTests
         Assert.Equal("ell\n", Run("""const s: any = "hello"; console.log(s.substring(await defer(1, 5), 4));""", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalChainStringMethod_NonStringReceiverWithOwnMethod_DeferredAwaitArg(ExecutionMode mode)
     {
         // Receiver is not a string at runtime, so the generic (non-string) branch runs, reading the
@@ -356,8 +327,7 @@ public class AwaitDeferredSpillTests
             mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalChainStringMethod_NullishReceiverShortCircuits(ExecutionMode mode)
     {
         Assert.Equal("undefined\n", Run("""const n: any = null; console.log(n?.substring(await defer(1, 5), 4));""", mode));
@@ -383,8 +353,7 @@ public class AwaitDeferredSpillTests
             "m();\n",
             mode);
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalChainStringMethod_MissingOnNonStringReceiver_DoesNotEvaluateAwaitArg(ExecutionMode mode)
     {
         // The #627 repro: substring on a non-string object that lacks it. Both modes short-circuit to
@@ -393,8 +362,7 @@ public class AwaitDeferredSpillTests
             "const o: any = { foo: 1 };", "o?.substring(mark() + (await defer(0, 5)), 4)", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalChainNonStringMethod_MissingOnReceiver_DoesNotEvaluateAwaitArg(ExecutionMode mode)
     {
         // The non-dispatchable-name sibling (slice) was already consistent — it never had a string
@@ -404,8 +372,7 @@ public class AwaitDeferredSpillTests
             "const o: any = { foo: 1 };", "o?.slice(mark() + (await defer(0, 5)), 4)", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalChainStringMethod_StringReceiver_EvaluatesAwaitArg(ExecutionMode mode)
     {
         // A string receiver DOES have the method, so the argument must evaluate (side effect runs) and

--- a/SharpTS.Tests/SharedTests/AwaitReceiverIncrementTests.cs
+++ b/SharpTS.Tests/SharedTests/AwaitReceiverIncrementTests.cs
@@ -20,8 +20,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AwaitReceiverIncrementTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PostfixIncrement_AwaitInGetReceiver_DoesNotThrow(ExecutionMode mode)
     {
         // The exact repro from issue #451.
@@ -38,8 +37,7 @@ public class AwaitReceiverIncrementTests
         Assert.Equal("ok\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PostfixIncrement_AwaitInGetReceiver_MutatesAndReturnsOld(ExecutionMode mode)
     {
         var source = """
@@ -56,8 +54,7 @@ public class AwaitReceiverIncrementTests
         Assert.Equal("1 2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrefixIncrement_AwaitInGetReceiver_ReturnsNew(ExecutionMode mode)
     {
         var source = """
@@ -74,8 +71,7 @@ public class AwaitReceiverIncrementTests
         Assert.Equal("2 2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrefixDecrement_AwaitInGetIndexReceiver(ExecutionMode mode)
     {
         var source = """
@@ -92,8 +88,7 @@ public class AwaitReceiverIncrementTests
         Assert.Equal("9 9\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PostfixIncrement_AwaitInIndexExpression(ExecutionMode mode)
     {
         var source = """
@@ -109,8 +104,7 @@ public class AwaitReceiverIncrementTests
         Assert.Equal("6 6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PostfixIncrement_AwaitInBothReceiverAndIndex(ExecutionMode mode)
     {
         var source = """
@@ -128,8 +122,7 @@ public class AwaitReceiverIncrementTests
         Assert.Equal("3 4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PostfixIncrement_AwaitDeepInNestedReceiver(ExecutionMode mode)
     {
         var source = """
@@ -146,8 +139,7 @@ public class AwaitReceiverIncrementTests
         Assert.Equal("5 6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Increment_AwaitInReceiver_UsableAsSubexpression(ExecutionMode mode)
     {
         var source = """
@@ -164,8 +156,7 @@ public class AwaitReceiverIncrementTests
         Assert.Equal("105 6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadAndAssign_ThroughAwaitReceiver_StillWork(ExecutionMode mode)
     {
         // The issue notes these always worked; guard against the fix regressing them.
@@ -187,8 +178,7 @@ public class AwaitReceiverIncrementTests
         Assert.Equal("1 9\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PlainIncrements_StillWorkInsideAsyncFunction(ExecutionMode mode)
     {
         // Regression guard: variable / plain-receiver / plain-index increments
@@ -212,8 +202,7 @@ public class AwaitReceiverIncrementTests
         Assert.Equal("-1 8 0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AwaitInReceiver_InsideAsyncArrow(ExecutionMode mode)
     {
         var source = """
@@ -231,8 +220,7 @@ public class AwaitReceiverIncrementTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AwaitInReceiver_InsideAsyncGenerator(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/AwaitStackSpillTests.cs
+++ b/SharpTS.Tests/SharedTests/AwaitStackSpillTests.cs
@@ -12,8 +12,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AwaitStackSpillTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConsoleLog_MultiArg_InlineAwait(ExecutionMode mode)
     {
         var source = """
@@ -29,8 +28,7 @@ public class AwaitStackSpillTests
         Assert.Equal("t1 5\nm 5 n 5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BinaryOperands_InlineAwait(ExecutionMode mode)
     {
         var source = """
@@ -48,8 +46,7 @@ public class AwaitStackSpillTests
         Assert.Equal("x5\ntrue\n5\n32\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayAndObjectLiterals_InlineAwait(ExecutionMode mode)
     {
         var source = """
@@ -68,8 +65,7 @@ public class AwaitStackSpillTests
         Assert.Equal("[1, 5]\n{ a: 5 }\n{ dyn: 5 }\n[5, 2]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PropertyAndIndexAssignment_InlineAwait(ExecutionMode mode)
     {
         var source = """
@@ -91,8 +87,7 @@ public class AwaitStackSpillTests
         Assert.Equal("5\n8\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAndLogicalAssignment_InlineAwait(ExecutionMode mode)
     {
         var source = """
@@ -120,8 +115,7 @@ public class AwaitStackSpillTests
         Assert.Equal("6\n6\n5\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TaggedTemplate_InlineAwait(ExecutionMode mode)
     {
         var source = """
@@ -137,8 +131,7 @@ public class AwaitStackSpillTests
         Assert.Equal("a5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateMembers_InlineAwait(ExecutionMode mode)
     {
         var source = """
@@ -162,8 +155,7 @@ public class AwaitStackSpillTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConsoleError_MultiArg_InlineAwait_DoesNotCrash(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/BareBuiltInClassRefTests.cs
+++ b/SharpTS.Tests/SharedTests/BareBuiltInClassRefTests.cs
@@ -24,8 +24,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </remarks>
 public class BareBuiltInClassRefTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promise_BareValue_TypeofIsFunction(ExecutionMode mode)
     {
         var source = @"
@@ -36,8 +35,7 @@ public class BareBuiltInClassRefTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promise_InstanceOf_ResolvedPromise(ExecutionMode mode)
     {
         var source = @"
@@ -48,8 +46,7 @@ public class BareBuiltInClassRefTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_BareValue_TypeofIsFunction(ExecutionMode mode)
     {
         var source = @"
@@ -60,8 +57,7 @@ public class BareBuiltInClassRefTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_InstanceOf_FromReturnsTrue(ExecutionMode mode)
     {
         var source = @"
@@ -72,8 +68,7 @@ public class BareBuiltInClassRefTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TextEncoder_BareValue_TypeofIsFunction(ExecutionMode mode)
     {
         var source = @"
@@ -84,8 +79,7 @@ public class BareBuiltInClassRefTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TextEncoder_InstanceOf_NewInstance(ExecutionMode mode)
     {
         var source = @"
@@ -96,8 +90,7 @@ public class BareBuiltInClassRefTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TextDecoder_BareValue_TypeofIsFunction(ExecutionMode mode)
     {
         var source = @"
@@ -108,8 +101,7 @@ public class BareBuiltInClassRefTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TextDecoder_InstanceOf_NewInstance(ExecutionMode mode)
     {
         var source = @"
@@ -120,8 +112,7 @@ public class BareBuiltInClassRefTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BareBuiltIn_InstanceOf_NegativeCases(ExecutionMode mode)
     {
         // Negative checks — each bare-referencable class should reject the
@@ -141,8 +132,7 @@ public class BareBuiltInClassRefTests
     // bare-identifier form (`var x = Int8Array`, `typeof Uint8Array`,
     // `x instanceof ArrayBuffer`) threw `Undefined variable` in compiled mode.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedArrayCtors_BareValue_TypeofAndTag(ExecutionMode mode)
     {
         // One representative per element width/signedness/kind plus the three
@@ -170,8 +160,7 @@ public class BareBuiltInClassRefTests
     // interp brand-checks each constructor value's instance predicate
     // (IBuiltInTypeConstructor). Both must agree with Node.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedArrayCtors_InstanceOf_OwnConstructor(ExecutionMode mode)
     {
         var source = """
@@ -186,8 +175,7 @@ public class BareBuiltInClassRefTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedArrayCtors_InstanceOf_DistinctElementTypesDoNotMatch(ExecutionMode mode)
     {
         // Each typed array directly extends the abstract %TypedArray%, not each
@@ -202,8 +190,7 @@ public class BareBuiltInClassRefTests
         Assert.Equal("false\nfalse\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BinaryTypes_InstanceOf_Object(ExecutionMode mode)
     {
         // Every typed-array / buffer / view instance is also an Object (#334).
@@ -217,8 +204,7 @@ public class BareBuiltInClassRefTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Primitives_InstanceOf_Object_AreFalse(ExecutionMode mode)
     {
         // Per ECMA-262 OrdinaryHasInstance, a primitive (or undefined) operand
@@ -238,8 +224,7 @@ public class BareBuiltInClassRefTests
         Assert.Equal("false\nfalse\nfalse\nfalse\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Objects_InstanceOf_Object_AreTrue(ExecutionMode mode)
     {
         // Every non-primitive guest value — object/array literals, functions,

--- a/SharpTS.Tests/SharedTests/BigIntTests.cs
+++ b/SharpTS.Tests/SharedTests/BigIntTests.cs
@@ -11,8 +11,7 @@ public class BigIntTests
 {
     #region Literal and Typeof Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_LiteralSyntax_Works(ExecutionMode mode)
     {
         var source = """
@@ -24,8 +23,7 @@ public class BigIntTests
         Assert.Equal("123n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_TypeofReturnsBigint(ExecutionMode mode)
     {
         var source = """
@@ -42,8 +40,7 @@ public class BigIntTests
 
     #region Constructor Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_ConstructorFromNumber_Works(ExecutionMode mode)
     {
         var source = """
@@ -56,8 +53,7 @@ public class BigIntTests
         Assert.Equal("42n\nbigint\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_ConstructorFromString_Works(ExecutionMode mode)
     {
         var source = """
@@ -69,8 +65,7 @@ public class BigIntTests
         Assert.Equal("12345n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_ConstructorFromHexString_Works(ExecutionMode mode)
     {
         var source = """
@@ -82,8 +77,7 @@ public class BigIntTests
         Assert.Equal("255n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_TypeAnnotation_Works(ExecutionMode mode)
     {
         var source = """
@@ -99,8 +93,7 @@ public class BigIntTests
 
     #region Arithmetic Operations
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_Addition_Works(ExecutionMode mode)
     {
         var source = """
@@ -113,8 +106,7 @@ public class BigIntTests
         Assert.Equal("30n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_Subtraction_Works(ExecutionMode mode)
     {
         var source = """
@@ -127,8 +119,7 @@ public class BigIntTests
         Assert.Equal("20n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_Multiplication_Works(ExecutionMode mode)
     {
         var source = """
@@ -141,8 +132,7 @@ public class BigIntTests
         Assert.Equal("42n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_Division_TruncatesTowardZero(ExecutionMode mode)
     {
         var source = """
@@ -155,8 +145,7 @@ public class BigIntTests
         Assert.Equal("2n\n-2n\n5n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_Remainder_Works(ExecutionMode mode)
     {
         var source = """
@@ -168,8 +157,7 @@ public class BigIntTests
         Assert.Equal("1n\n2n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_Exponentiation_Works(ExecutionMode mode)
     {
         var source = """
@@ -181,8 +169,7 @@ public class BigIntTests
         Assert.Equal("1024n\n81n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_UnaryNegation_Works(ExecutionMode mode)
     {
         var source = """
@@ -199,8 +186,7 @@ public class BigIntTests
 
     #region Bitwise Operations
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_BitwiseAnd_Works(ExecutionMode mode)
     {
         var source = """
@@ -211,8 +197,7 @@ public class BigIntTests
         Assert.Equal("8n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_BitwiseOr_Works(ExecutionMode mode)
     {
         var source = """
@@ -223,8 +208,7 @@ public class BigIntTests
         Assert.Equal("14n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_BitwiseXor_Works(ExecutionMode mode)
     {
         var source = """
@@ -235,8 +219,7 @@ public class BigIntTests
         Assert.Equal("6n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_BitwiseNot_Works(ExecutionMode mode)
     {
         var source = """
@@ -248,8 +231,7 @@ public class BigIntTests
         Assert.Equal("-6n\n5n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_LeftShift_Works(ExecutionMode mode)
     {
         var source = """
@@ -261,8 +243,7 @@ public class BigIntTests
         Assert.Equal("1024n\n40n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_RightShift_Works(ExecutionMode mode)
     {
         var source = """
@@ -278,8 +259,7 @@ public class BigIntTests
 
     #region Comparison Operations
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_Equality_Works(ExecutionMode mode)
     {
         var source = """
@@ -293,8 +273,7 @@ public class BigIntTests
         Assert.Equal("true\nfalse\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_Comparisons_Work(ExecutionMode mode)
     {
         var source = """
@@ -314,8 +293,7 @@ public class BigIntTests
 
     #region Large Numbers
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_LargeNumbers_Work(ExecutionMode mode)
     {
         var source = """
@@ -328,8 +306,7 @@ public class BigIntTests
         Assert.Equal("9007199254740993n\n9007199254740994n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_VeryLargeNumbers_Work(ExecutionMode mode)
     {
         var source = """
@@ -346,8 +323,7 @@ public class BigIntTests
 
     #region Usage in Functions and Variables
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_InFunction_Works(ExecutionMode mode)
     {
         var source = """
@@ -361,8 +337,7 @@ public class BigIntTests
         Assert.Equal("300n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_AsVariable_Works(ExecutionMode mode)
     {
         var source = """
@@ -375,8 +350,7 @@ public class BigIntTests
         Assert.Equal("15n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_ZeroAndNegative_Work(ExecutionMode mode)
     {
         var source = """
@@ -389,8 +363,7 @@ public class BigIntTests
         Assert.Equal("0n\n-1n\n-100n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_ChainedOperations_Work(ExecutionMode mode)
     {
         var source = """
@@ -402,8 +375,7 @@ public class BigIntTests
         Assert.Equal("27n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_InTernary_Works(ExecutionMode mode)
     {
         var source = """
@@ -415,8 +387,7 @@ public class BigIntTests
         Assert.Equal("10n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_Reassignment_Works(ExecutionMode mode)
     {
         var source = """
@@ -433,8 +404,7 @@ public class BigIntTests
 
     #region Type Errors
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_MixedWithNumber_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """
@@ -445,8 +415,7 @@ public class BigIntTests
         Assert.Contains("Type Error", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_UnsignedRightShift_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """
@@ -461,8 +430,7 @@ public class BigIntTests
 
     #region Coercion and Methods (#912)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_ToString_NoRadix(ExecutionMode mode)
     {
         var source = """
@@ -473,8 +441,7 @@ public class BigIntTests
         Assert.Equal("123\n0\n-42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_ToString_Radix(ExecutionMode mode)
     {
         var source = """
@@ -488,8 +455,7 @@ public class BigIntTests
         Assert.Equal("ff\n11111111\n377\n73\n-ff\n0\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_ToString_Radix_ArbitraryPrecision(ExecutionMode mode)
     {
         var source = """
@@ -498,8 +464,7 @@ public class BigIntTests
         Assert.Equal("18ee90ff6c373e0ee4e3f0ad2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_StringCoercion_IsBareNumericForm(ExecutionMode mode)
     {
         // ECMA-262 ToString(bigint) has no "n" suffix (that form is console.log-only).
@@ -512,8 +477,7 @@ public class BigIntTests
         Assert.Equal("42\n42\n42\n-7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_ConsoleLog_KeepsDebugForm(ExecutionMode mode)
     {
         // console.log / inspection keeps the "42n" debug form even though String() drops it.
@@ -524,8 +488,7 @@ public class BigIntTests
         Assert.Equal("42n\n5n\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_NumberCoercion(ExecutionMode mode)
     {
         var source = """
@@ -536,8 +499,7 @@ public class BigIntTests
         Assert.Equal("42\n-7\n0\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_BooleanCoercion(ExecutionMode mode)
     {
         // ToBoolean(bigint): 0n is falsy, every other bigint is truthy.
@@ -552,8 +514,7 @@ public class BigIntTests
         Assert.Equal("false\ntrue\ntrue\ntrue\nf\nt\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_LooseEquality_WithNumber(ExecutionMode mode)
     {
         // ECMA-262 7.2.15: bigint == number compares mathematical values.
@@ -567,8 +528,7 @@ public class BigIntTests
         Assert.Equal("true\nfalse\nfalse\nfalse\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_LooseEquality_WithStringAndBoolean(ExecutionMode mode)
     {
         var source = """
@@ -582,8 +542,7 @@ public class BigIntTests
         Assert.Equal("true\nfalse\ntrue\ntrue\ntrue\nfalse\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_StrictEquality_AcrossTypes_IsFalse(ExecutionMode mode)
     {
         // A bigint is never the same Type as a number, so === is always false.
@@ -600,8 +559,7 @@ public class BigIntTests
 
     #region Instanceof Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_InstanceOf_Object_IsFalse(ExecutionMode mode)
     {
         // bigint is a primitive; instanceof must return false, not throw a
@@ -614,8 +572,7 @@ public class BigIntTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_InstanceOf_UserClass_IsFalse(ExecutionMode mode)
     {
         var source = """
@@ -630,8 +587,7 @@ public class BigIntTests
 
     #region Bigint Literal Types (#1207)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_LiteralTypedOperands_UseBigintArithmetic(ExecutionMode mode)
     {
         // const-bound operands carry TypeInfo.BigIntLiteral in the type map; the
@@ -648,8 +604,7 @@ public class BigIntTests
         Assert.Equal("5n\n110\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_TypeofGuard_BranchSurvivesDeadCodeAnalysis(ExecutionMode mode)
     {
         // The compiled dead-code analyzer had no "bigint" arm in its typeof matcher,
@@ -665,8 +620,7 @@ public class BigIntTests
         Assert.Equal("big\nlit\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_LiteralTypedReceiver_MethodCallWorks(ExecutionMode mode)
     {
         // toString(radix) on a BigIntLiteral-typed receiver must route through the
@@ -680,8 +634,7 @@ public class BigIntTests
         Assert.Equal("ff\n255\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BigInt_LiteralUnionNarrowing_RunsCorrectBranch(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/BlockScopingTests.cs
+++ b/SharpTS.Tests/SharedTests/BlockScopingTests.cs
@@ -13,8 +13,7 @@ public class BlockScopingTests
 {
     #region For Loop Block Scoping
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForLoop_LetVariable_AccessibleWithinLoop(ExecutionMode mode)
     {
         var source = """
@@ -28,8 +27,7 @@ public class BlockScopingTests
         Assert.Equal("012\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForLoop_LetVariable_ShadowsOuterVariable(ExecutionMode mode)
     {
         var source = """
@@ -43,8 +41,7 @@ public class BlockScopingTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForLoop_NestedLoops_IndependentScopes(ExecutionMode mode)
     {
         var source = """
@@ -64,8 +61,7 @@ public class BlockScopingTests
 
     #region Block Statement Scoping
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BlockStatement_LetVariable_AccessibleWithinBlock(ExecutionMode mode)
     {
         var source = """
@@ -80,8 +76,7 @@ public class BlockScopingTests
         Assert.Equal("inside\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BlockStatement_LetVariable_ShadowsOuterVariable(ExecutionMode mode)
     {
         var source = """
@@ -96,8 +91,7 @@ public class BlockScopingTests
         Assert.Equal("inner\nouter\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedBlocks_EachHasOwnScope(ExecutionMode mode)
     {
         var source = """
@@ -120,8 +114,7 @@ public class BlockScopingTests
 
     #region If/Else Block Scoping
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IfElse_SeparateScopes(ExecutionMode mode)
     {
         var source = """
@@ -143,8 +136,7 @@ public class BlockScopingTests
 
     #region While Loop Block Scoping
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WhileLoop_LetVariable_AccessibleWithinLoop(ExecutionMode mode)
     {
         var source = """
@@ -165,8 +157,7 @@ public class BlockScopingTests
 
     #region Const Block Scoping
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForLoop_ConstVariable_NewBindingEachIteration(ExecutionMode mode)
     {
         var source = """
@@ -185,8 +176,7 @@ public class BlockScopingTests
 
     #region Multiple Variables Same Name Different Scopes
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SameVariableName_DifferentScopes_Independent(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/BoundMethodCallApplyBindTests.cs
+++ b/SharpTS.Tests/SharedTests/BoundMethodCallApplyBindTests.cs
@@ -21,8 +21,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </remarks>
 public class BoundMethodCallApplyBindTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Push_VariadicDirect(ExecutionMode mode)
     {
         // Pre-existing bug: arr.push(a, b, c) in compiled mode only pushed the first arg.
@@ -38,8 +37,7 @@ public class BoundMethodCallApplyBindTests
         Assert.Equal("4\n10\n20\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Unshift_VariadicDirect(ExecutionMode mode)
     {
         // JS `arr.unshift(a, b, c)` on [x,y] yields [a,b,c,x,y].
@@ -57,8 +55,7 @@ public class BoundMethodCallApplyBindTests
         Assert.Equal("5\n1\n2\n3\n4\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Push_CallSingleArg(ExecutionMode mode)
     {
         var source = @"
@@ -72,8 +69,7 @@ public class BoundMethodCallApplyBindTests
         Assert.Equal("4\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Push_CallMultipleArgs(ExecutionMode mode)
     {
         var source = @"
@@ -88,8 +84,7 @@ public class BoundMethodCallApplyBindTests
         Assert.Equal("4\n10\n20\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Push_ApplyWithArrayArg(ExecutionMode mode)
     {
         var source = @"
@@ -103,8 +98,7 @@ public class BoundMethodCallApplyBindTests
         Assert.Equal("5\n5\n6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Push_BindThenCall(ExecutionMode mode)
     {
         // bind with receiver + partial args, then invoke with more args.
@@ -121,8 +115,7 @@ public class BoundMethodCallApplyBindTests
         Assert.Equal("6\n100\n101\n102\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_Get_CallAndApply(ExecutionMode mode)
     {
         var source = @"
@@ -137,8 +130,7 @@ public class BoundMethodCallApplyBindTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_Set_CallChainable(ExecutionMode mode)
     {
         var source = @"
@@ -153,8 +145,7 @@ public class BoundMethodCallApplyBindTests
         Assert.Equal("100\n200\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_Get_BindWithPartialArg(ExecutionMode mode)
     {
         // `.bind(m, 'key')` prepends 'key' so calling with no args invokes get('key').
@@ -171,8 +162,7 @@ public class BoundMethodCallApplyBindTests
         Assert.Equal("42\n99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Has_CallAndApply(ExecutionMode mode)
     {
         var source = @"
@@ -187,8 +177,7 @@ public class BoundMethodCallApplyBindTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Add_BindThenCall(ExecutionMode mode)
     {
         var source = @"
@@ -204,8 +193,7 @@ public class BoundMethodCallApplyBindTests
         Assert.Equal("2\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BoundMethod_NameProperty(ExecutionMode mode)
     {
         // `.name` on a bound array/map/set method returns the captured method name.
@@ -221,8 +209,7 @@ public class BoundMethodCallApplyBindTests
         Assert.Equal("push\nget\nhas\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BoundMethod_TypeofAfterBind(ExecutionMode mode)
     {
         // A bind() result must still report as 'function'.
@@ -235,8 +222,7 @@ public class BoundMethodCallApplyBindTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CrossModule_MapGet_CallAndApply(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BroadcastChannelTests.cs
+++ b/SharpTS.Tests/SharedTests/BroadcastChannelTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class BroadcastChannelTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BroadcastChannel_HasName(ExecutionMode mode)
     {
         var source = @"
@@ -22,8 +21,7 @@ public class BroadcastChannelTests
         Assert.Equal("chan-1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BroadcastChannel_DeliversBetweenChannelsWithSameName(ExecutionMode mode)
     {
         var source = @"
@@ -40,8 +38,7 @@ public class BroadcastChannelTests
         Assert.Equal("b got: hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BroadcastChannel_SenderDoesNotReceiveOwnMessages(ExecutionMode mode)
     {
         var source = @"
@@ -57,8 +54,7 @@ public class BroadcastChannelTests
         Assert.Equal("done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BroadcastChannel_DifferentNamesDoNotInteract(ExecutionMode mode)
     {
         var source = @"
@@ -76,8 +72,7 @@ public class BroadcastChannelTests
         Assert.Equal("done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BroadcastChannel_PostAfterCloseThrows(ExecutionMode mode)
     {
         var source = @"
@@ -94,8 +89,7 @@ public class BroadcastChannelTests
         Assert.Equal("caught\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BroadcastChannel_DeliversToMultipleSubscribers(ExecutionMode mode)
     {
         var source = @"
@@ -115,8 +109,7 @@ public class BroadcastChannelTests
         Assert.Contains("c: hi\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BroadcastChannel_AddEventListenerWorks(ExecutionMode mode)
     {
         var source = @"
@@ -133,8 +126,7 @@ public class BroadcastChannelTests
         Assert.Equal("got: world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BroadcastChannel_OnmessageSetterWorks(ExecutionMode mode)
     {
         var source = @"
@@ -151,8 +143,7 @@ public class BroadcastChannelTests
         Assert.Equal("onmsg: slot\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BroadcastChannel_OnmessageAndOnListenerBothFire(ExecutionMode mode)
     {
         var source = @"
@@ -169,8 +160,7 @@ public class BroadcastChannelTests
         Assert.Contains("onmsg: hi\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BroadcastChannel_StructuredCloneMutationIsolation(ExecutionMode mode)
     {
         // Per-receiver deep clone: mutating the received object on the listener side
@@ -204,8 +194,7 @@ public class BroadcastChannelTests
     /// <c>onmessageerror</c> property handler was itself never invoked (only the EventEmitter
     /// 'messageerror' event fired) — both are fixed together here.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BroadcastChannel_PostUncloneable_FiresMessageError(ExecutionMode mode)
     {
         var source = @"
@@ -224,8 +213,7 @@ public class BroadcastChannelTests
         Assert.DoesNotContain("should-not-fire", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BroadcastChannel_WorksInsideAsyncFunction(ExecutionMode mode)
     {
         // Regression: exercises the async state-machine emitter path for
@@ -245,8 +233,7 @@ public class BroadcastChannelTests
         Assert.Equal("async got: from async\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BroadcastChannel_ModuleQualifiedNewWorks(ExecutionMode mode)
     {
         // Regression: `new wt.BroadcastChannel(name)` via TryEmitModuleQualifiedConstructor.

--- a/SharpTS.Tests/SharedTests/BufferTests.cs
+++ b/SharpTS.Tests/SharedTests/BufferTests.cs
@@ -11,8 +11,7 @@ public class BufferTests
 {
     #region Type Annotation and Basic Operations
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_TypeAnnotation_Works(ExecutionMode mode)
     {
         var source = """
@@ -24,8 +23,7 @@ public class BufferTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_TypeInference_Works(ExecutionMode mode)
     {
         var source = """
@@ -38,8 +36,7 @@ public class BufferTests
         Assert.Equal("test\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Alloc_Works(ExecutionMode mode)
     {
         var source = """
@@ -51,8 +48,7 @@ public class BufferTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Length_Property(ExecutionMode mode)
     {
         var source = """
@@ -68,8 +64,7 @@ public class BufferTests
 
     #region toString Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_ToString_Default(ExecutionMode mode)
     {
         var source = """
@@ -81,8 +76,7 @@ public class BufferTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_ToString_WithEncoding(ExecutionMode mode)
     {
         var source = """
@@ -98,8 +92,7 @@ public class BufferTests
 
     #region slice Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Slice_WithBothArgs(ExecutionMode mode)
     {
         var source = """
@@ -112,8 +105,7 @@ public class BufferTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Slice_StartOnly(ExecutionMode mode)
     {
         var source = """
@@ -126,8 +118,7 @@ public class BufferTests
         Assert.Equal("world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Slice_NoArgs(ExecutionMode mode)
     {
         var source = """
@@ -140,8 +131,7 @@ public class BufferTests
         Assert.Equal("test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Slice_NegativeStart(ExecutionMode mode)
     {
         var source = """
@@ -158,8 +148,7 @@ public class BufferTests
 
     #region copy Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Copy_Basic(ExecutionMode mode)
     {
         var source = """
@@ -174,8 +163,7 @@ public class BufferTests
         Assert.Equal("5\nhello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Copy_WithOffsets(ExecutionMode mode)
     {
         var source = """
@@ -190,8 +178,7 @@ public class BufferTests
         Assert.Equal("5\nworld\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Copy_Partial(ExecutionMode mode)
     {
         var source = """
@@ -210,8 +197,7 @@ public class BufferTests
 
     #region compare Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Compare_Less(ExecutionMode mode)
     {
         var source = """
@@ -224,8 +210,7 @@ public class BufferTests
         Assert.Equal("-1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Compare_Equal(ExecutionMode mode)
     {
         var source = """
@@ -238,8 +223,7 @@ public class BufferTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Compare_Greater(ExecutionMode mode)
     {
         var source = """
@@ -252,8 +236,7 @@ public class BufferTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Compare_DifferentLengths(ExecutionMode mode)
     {
         var source = """
@@ -271,8 +254,7 @@ public class BufferTests
 
     #region equals Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Equals_True(ExecutionMode mode)
     {
         var source = """
@@ -285,8 +267,7 @@ public class BufferTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Equals_False_DifferentContent(ExecutionMode mode)
     {
         var source = """
@@ -299,8 +280,7 @@ public class BufferTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Equals_False_DifferentLength(ExecutionMode mode)
     {
         var source = """
@@ -317,8 +297,7 @@ public class BufferTests
 
     #region fill Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Fill_WithNumber(ExecutionMode mode)
     {
         var source = """
@@ -331,8 +310,7 @@ public class BufferTests
         Assert.Equal("AAAAA\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Fill_WithString(ExecutionMode mode)
     {
         var source = """
@@ -345,8 +323,7 @@ public class BufferTests
         Assert.Equal("XYXYXY\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Fill_WithRange(ExecutionMode mode)
     {
         var source = """
@@ -361,8 +338,7 @@ public class BufferTests
         Assert.Equal("0\n88\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Fill_ReturnsThis(ExecutionMode mode)
     {
         var source = """
@@ -378,8 +354,7 @@ public class BufferTests
 
     #region write Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Write_Basic(ExecutionMode mode)
     {
         var source = """
@@ -393,8 +368,7 @@ public class BufferTests
         Assert.Equal("5\nhello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Write_WithOffset(ExecutionMode mode)
     {
         var source = """
@@ -413,8 +387,7 @@ public class BufferTests
 
     #region readUInt8 Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_ReadUInt8_Basic(ExecutionMode mode)
     {
         var source = """
@@ -427,8 +400,7 @@ public class BufferTests
         Assert.Equal("65\n66\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_ReadUInt8_DefaultOffset(ExecutionMode mode)
     {
         var source = """
@@ -440,8 +412,7 @@ public class BufferTests
         Assert.Equal("88\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_ReadUInt8_InExpression(ExecutionMode mode)
     {
         var source = """
@@ -458,8 +429,7 @@ public class BufferTests
 
     #region writeUInt8 Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_WriteUInt8_Basic(ExecutionMode mode)
     {
         var source = """
@@ -476,8 +446,7 @@ public class BufferTests
         Assert.Equal("1\n2\n255\n128\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_WriteUInt8_DefaultOffset(ExecutionMode mode)
     {
         var source = """
@@ -494,8 +463,7 @@ public class BufferTests
 
     #region toJSON Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_ToJSON_Structure(ExecutionMode mode)
     {
         var source = """
@@ -515,8 +483,7 @@ public class BufferTests
 
     #region Complex Scenarios
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_MethodChaining(ExecutionMode mode)
     {
         var source = """
@@ -529,8 +496,7 @@ public class BufferTests
         Assert.Equal("DD\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_AsFunctionParameter(ExecutionMode mode)
     {
         var source = """
@@ -544,8 +510,7 @@ public class BufferTests
         Assert.Equal("4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_AsFunctionReturnType(ExecutionMode mode)
     {
         var source = """
@@ -559,8 +524,7 @@ public class BufferTests
         Assert.Equal("CCC\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_InArray(ExecutionMode mode)
     {
         var source = """
@@ -576,8 +540,7 @@ public class BufferTests
         Assert.Equal("one\ntwo\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_InConditional(ExecutionMode mode)
     {
         var source = """
@@ -595,8 +558,7 @@ public class BufferTests
         Assert.Equal("AAA\nBBB\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_CompareResultInExpression(ExecutionMode mode)
     {
         var source = """
@@ -614,8 +576,7 @@ public class BufferTests
 
     #region Multi-byte Read Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_ReadInt8_Basic(ExecutionMode mode)
     {
         var source = """
@@ -630,8 +591,7 @@ public class BufferTests
         Assert.Equal("127\n-128\n-1\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_ReadUInt16LE_Basic(ExecutionMode mode)
     {
         var source = """
@@ -648,8 +608,7 @@ public class BufferTests
         Assert.Equal("22136\n4660\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_ReadUInt16BE_Basic(ExecutionMode mode)
     {
         var source = """
@@ -666,8 +625,7 @@ public class BufferTests
         Assert.Equal("4660\n22136\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_ReadUInt32LE_Basic(ExecutionMode mode)
     {
         var source = """
@@ -683,8 +641,7 @@ public class BufferTests
         Assert.Equal("305419896\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_ReadUInt32BE_Basic(ExecutionMode mode)
     {
         var source = """
@@ -700,8 +657,7 @@ public class BufferTests
         Assert.Equal("305419896\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_ReadInt16LE_Signed(ExecutionMode mode)
     {
         var source = """
@@ -715,8 +671,7 @@ public class BufferTests
         Assert.Equal("-1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_ReadInt32LE_Signed(ExecutionMode mode)
     {
         var source = """
@@ -732,8 +687,7 @@ public class BufferTests
         Assert.Equal("-1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_ReadFloatLE_RoundTrip(ExecutionMode mode)
     {
         var source = """
@@ -747,8 +701,7 @@ public class BufferTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_ReadDoubleLE_RoundTrip(ExecutionMode mode)
     {
         var source = """
@@ -766,8 +719,7 @@ public class BufferTests
 
     #region Multi-byte Write Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_WriteInt8_Basic(ExecutionMode mode)
     {
         var source = """
@@ -782,8 +734,7 @@ public class BufferTests
         Assert.Equal("255\n127\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_WriteUInt16LE_Basic(ExecutionMode mode)
     {
         var source = """
@@ -800,8 +751,7 @@ public class BufferTests
         Assert.Equal("52\n18\n120\n86\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_WriteUInt16BE_Basic(ExecutionMode mode)
     {
         var source = """
@@ -818,8 +768,7 @@ public class BufferTests
         Assert.Equal("18\n52\n86\n120\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_WriteUInt32_RoundTrip(ExecutionMode mode)
     {
         var source = """
@@ -834,8 +783,7 @@ public class BufferTests
         Assert.Equal("305419896\n305419896\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_WriteInt16_RoundTrip(ExecutionMode mode)
     {
         var source = """
@@ -850,8 +798,7 @@ public class BufferTests
         Assert.Equal("-1000\n-1000\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_WriteInt32_RoundTrip(ExecutionMode mode)
     {
         var source = """
@@ -866,8 +813,7 @@ public class BufferTests
         Assert.Equal("-100000\n-100000\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_WriteFloat_RoundTrip(ExecutionMode mode)
     {
         var source = """
@@ -884,8 +830,7 @@ public class BufferTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_WriteDouble_RoundTrip(ExecutionMode mode)
     {
         var source = """
@@ -900,8 +845,7 @@ public class BufferTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Write_ReturnsNextOffset(ExecutionMode mode)
     {
         var source = """
@@ -921,8 +865,7 @@ public class BufferTests
 
     #region Search Method Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_IndexOf_ByteValue(ExecutionMode mode)
     {
         var source = """
@@ -936,8 +879,7 @@ public class BufferTests
         Assert.Equal("2\n5\n-1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Includes_Basic(ExecutionMode mode)
     {
         var source = """
@@ -955,8 +897,7 @@ public class BufferTests
 
     #region Swap Method Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Swap16_Basic(ExecutionMode mode)
     {
         var source = """
@@ -972,8 +913,7 @@ public class BufferTests
         Assert.Equal("2\n1\n4\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Swap32_Basic(ExecutionMode mode)
     {
         var source = """
@@ -991,8 +931,7 @@ public class BufferTests
         Assert.Equal("4\n3\n2\n1\n8\n7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Swap64_Basic(ExecutionMode mode)
     {
         var source = """
@@ -1008,8 +947,7 @@ public class BufferTests
         Assert.Equal("8\n7\n2\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Swap_Chaining(ExecutionMode mode)
     {
         var source = """
@@ -1026,8 +964,7 @@ public class BufferTests
 
     #region Endianness Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Endianness_Conversion(ExecutionMode mode)
     {
         var source = """
@@ -1040,8 +977,7 @@ public class BufferTests
         Assert.Equal("78563412\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Mixed_Endianness(ExecutionMode mode)
     {
         var source = """
@@ -1062,8 +998,7 @@ public class BufferTests
 
     #region BigInt Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_ReadBigInt64LE_Basic(ExecutionMode mode)
     {
         var source = """
@@ -1083,8 +1018,7 @@ public class BufferTests
         Assert.Equal("1n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_WriteBigInt64LE_RoundTrip(ExecutionMode mode)
     {
         var source = """
@@ -1098,8 +1032,7 @@ public class BufferTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_BigInt_RoundTrip(ExecutionMode mode)
     {
         var source = """
@@ -1118,8 +1051,7 @@ public class BufferTests
 
     #region Issue #45 — compiled Buffer index access
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_IndexAccess_ReturnsByteValue(ExecutionMode mode)
     {
         // Regression for #45: `randomBytes(n)[i]` returned $Undefined in
@@ -1144,8 +1076,7 @@ public class BufferTests
             Assert.Equal("number true", lines[i]);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_IndexAccess_NumericOperations(ExecutionMode mode)
     {
         // Regression for #45: `bytes[i] % n` threw InvalidCastException
@@ -1160,8 +1091,7 @@ public class BufferTests
         Assert.Equal("1\n256\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_IndexAssign_StoresMaskedByte(ExecutionMode mode)
     {
         // Matches Node.js semantics: assignment is masked to 0xFF.
@@ -1177,8 +1107,7 @@ public class BufferTests
         Assert.Equal("42 44 255\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_IndexAccess_OutOfRange_ReturnsNaN(ExecutionMode mode)
     {
         // Matches SharpTSBuffer.this[int] — out-of-range reads yield NaN in
@@ -1198,8 +1127,7 @@ public class BufferTests
 
     #region buffer module exports (#1160)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BufferModule_AtobBtoa_RoundTrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1216,8 +1144,7 @@ public class BufferTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BufferModule_GlobalAtobBtoa(ExecutionMode mode)
     {
         // atob/btoa are also globals (no import).
@@ -1230,8 +1157,7 @@ public class BufferTests
         Assert.Equal("U2hhcnBUUw==\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BufferModule_IsUtf8IsAscii(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1248,8 +1174,7 @@ public class BufferTests
         Assert.Equal("true\nfalse\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BufferModule_Transcode(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1266,8 +1191,7 @@ public class BufferTests
         Assert.Equal("hello\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BufferModule_ConstantsAndSlowBuffer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1291,8 +1215,7 @@ public class BufferTests
 
     #region Buffer statics + read/write matrix (#1161)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Of_And_PoolSize(ExecutionMode mode)
     {
         var source = """
@@ -1306,8 +1229,7 @@ public class BufferTests
         Assert.Equal("Hi\n2\n8192\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_VariableLengthReadWrite(ExecutionMode mode)
     {
         var source = """
@@ -1326,8 +1248,7 @@ public class BufferTests
         Assert.Equal("197121\n66051\n394500\n197121\n-1000\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_Subarray(ExecutionMode mode)
     {
         var source = """
@@ -1340,8 +1261,7 @@ public class BufferTests
         Assert.Equal("141e\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_LowercaseUintAliases(ExecutionMode mode)
     {
         var source = """
@@ -1357,8 +1277,7 @@ public class BufferTests
         Assert.Equal("1\n1\n513\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Buffer_CopyBytesFrom(ExecutionMode mode)
     {
         var source = """
@@ -1381,8 +1300,7 @@ public class BufferTests
     // documented follow-up (see the compiled deferral test below), so the behavioral
     // tests are interpreter-only.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Blob_SizeTypeTextSlice(ExecutionMode mode)
     {
         var source = """
@@ -1397,8 +1315,7 @@ public class BufferTests
         Assert.Equal("13\ntext/plain\nHello, world!\nHello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Blob_ArrayBufferBytesStream(ExecutionMode mode)
     {
         var source = """
@@ -1423,8 +1340,7 @@ public class BufferTests
         Assert.Equal("4\n4 97\n4 97\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void File_NameLastModified(ExecutionMode mode)
     {
         var source = """
@@ -1440,8 +1356,7 @@ public class BufferTests
         Assert.Equal("f.txt\n12345\n4\ntext/plain\ndata\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Blob_BufferModuleImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1460,8 +1375,7 @@ public class BufferTests
         Assert.Equal("2\na.txt\nundefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void Blob_CompiledThrowsClearDeferral(ExecutionMode mode)
     {
         // Compiled mode emits a clear, documented deferral error rather than the

--- a/SharpTS.Tests/SharedTests/BuiltInClassValueResolutionTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInClassValueResolutionTests.cs
@@ -19,8 +19,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </remarks>
 public class BuiltInClassValueResolutionTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceOf_Date(ExecutionMode mode)
     {
         var source = @"
@@ -31,8 +30,7 @@ public class BuiltInClassValueResolutionTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceOf_RegExp(ExecutionMode mode)
     {
         var source = @"
@@ -43,8 +41,7 @@ public class BuiltInClassValueResolutionTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceOf_Map(ExecutionMode mode)
     {
         var source = @"
@@ -55,8 +52,7 @@ public class BuiltInClassValueResolutionTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceOf_Set(ExecutionMode mode)
     {
         var source = @"
@@ -67,8 +63,7 @@ public class BuiltInClassValueResolutionTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceOf_Error(ExecutionMode mode)
     {
         var source = @"
@@ -79,8 +74,7 @@ public class BuiltInClassValueResolutionTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceOf_Date_InsideFunction(ExecutionMode mode)
     {
         // The original repro lived inside a function body. Keep one test at
@@ -98,8 +92,7 @@ public class BuiltInClassValueResolutionTests
         Assert.Equal("date\nstring\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceOf_Date_InsideImportedModule(ExecutionMode mode)
     {
         // Exercises the stdlib-module code path — specifically the same

--- a/SharpTS.Tests/SharedTests/BuiltInMethodLengthAndReceiverTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInMethodLengthAndReceiverTests.cs
@@ -13,8 +13,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class BuiltInMethodLengthAndReceiverTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RegExpPrototypeMethods_ExposeLength(ExecutionMode mode)
     {
         var source = """
@@ -27,8 +26,7 @@ public class BuiltInMethodLengthAndReceiverTests
         Assert.Equal("1\n1\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CrossCuttingBuiltInMethods_ExposeLength(ExecutionMode mode)
     {
         // §17: each built-in function's `length` is its formal parameter count.
@@ -45,8 +43,7 @@ public class BuiltInMethodLengthAndReceiverTests
         Assert.Equal("1\n2\n1\n1\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RegExpExec_OnNonRegExpReceiver_ThrowsTypeError(ExecutionMode mode)
     {
         // §22.2.6.x: exec/test require `this` to have the [[RegExpMatcher]] slot;

--- a/SharpTS.Tests/SharedTests/BuiltInModules/AssertCallableTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/AssertCallableTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class AssertCallableTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_Callable_PassesAndThrows(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -31,8 +30,7 @@ public class AssertCallableTests
         Assert.Equal("threw:true\nok is fn:true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_Rejects_ResolvesWhenPromiseRejects(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -58,8 +56,7 @@ public class AssertCallableTests
         Assert.Equal("rejects-ok\nno-reject-throws:true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_DoesNotReject_PassesWhenNoRejection(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -78,8 +75,7 @@ public class AssertCallableTests
         Assert.Equal("does-not-reject-ok\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_Match_And_DoesNotMatch(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -100,8 +96,7 @@ public class AssertCallableTests
         Assert.Equal("match-throws:true,dnm-throws:true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_IfError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -120,8 +115,7 @@ public class AssertCallableTests
         Assert.Equal("ifError-throws:true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_LooseDeepEqual_Coerces(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -144,8 +138,7 @@ public class AssertCallableTests
         Assert.Equal("loose-deep-ok\nnot-deep-ok\nstrict-throws:true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_NamedImports_OfNewFunctions(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/AssertModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/AssertModuleTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class AssertModuleTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_Ok_PassesForTruthyValues(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -29,8 +28,7 @@ public class AssertModuleTests
         Assert.Equal("all passed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_Ok_ThrowsForFalsy(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -50,8 +48,7 @@ public class AssertModuleTests
         Assert.Equal("caught\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_StrictEqual_PassesForEqualValues(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -69,8 +66,7 @@ public class AssertModuleTests
         Assert.Equal("all passed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_StrictEqual_ThrowsForUnequalValues(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -90,8 +86,7 @@ public class AssertModuleTests
         Assert.Equal("caught\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_StrictEqual_ThrowsForDifferentTypes(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -111,8 +106,7 @@ public class AssertModuleTests
         Assert.Equal("caught type mismatch\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_NotStrictEqual_PassesForUnequalValues(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -130,8 +124,7 @@ public class AssertModuleTests
         Assert.Equal("all passed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_NotStrictEqual_ThrowsForEqualValues(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -151,8 +144,7 @@ public class AssertModuleTests
         Assert.Equal("caught\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_DeepStrictEqual_PassesForEqualObjects(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -168,8 +160,7 @@ public class AssertModuleTests
         Assert.Equal("objects passed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_DeepStrictEqual_PassesForEqualArrays(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -185,8 +176,7 @@ public class AssertModuleTests
         Assert.Equal("arrays passed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_DeepStrictEqual_ThrowsForDifferentObjects(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -206,8 +196,7 @@ public class AssertModuleTests
         Assert.Equal("caught\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_DeepStrictEqual_ThrowsForDifferentArrays(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -227,8 +216,7 @@ public class AssertModuleTests
         Assert.Equal("caught\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_Equal_PassesForLooselyEqualValues(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -245,8 +233,7 @@ public class AssertModuleTests
         Assert.Equal("all passed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_NotEqual_PassesForDifferentValues(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -263,8 +250,7 @@ public class AssertModuleTests
         Assert.Equal("all passed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_Fail_AlwaysThrows(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -284,8 +270,7 @@ public class AssertModuleTests
         Assert.Equal("caught\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_Fail_WithDefaultMessage(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -305,8 +290,7 @@ public class AssertModuleTests
         Assert.Equal("caught default\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_NamespaceImport_Works(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -323,8 +307,7 @@ public class AssertModuleTests
         Assert.Equal("namespace import works\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_CustomMessage_IsUsed(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -344,8 +327,7 @@ public class AssertModuleTests
         Assert.Equal("threw with message\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Assert_MultipleAssertions_InSequence(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/AssertStrictTrackerTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/AssertStrictTrackerTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class AssertStrictTrackerTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Strict_LooseFormsAliasStrict(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -32,8 +31,7 @@ public class AssertStrictTrackerTests
         Assert.Equal("equal-strict-throws:true,deep-strict-throws:true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Strict_IsCallableAndSelfReferential(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -52,8 +50,7 @@ public class AssertStrictTrackerTests
         Assert.Equal("callable-throws:true\nself:true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PartialDeepStrictEqual_Contains(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -76,8 +73,7 @@ public class AssertStrictTrackerTests
         Assert.Equal("pass\nmissing-throws:true\nstrict-leaf-throws:true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CallTracker_VerifyPassesWhenCallCountMatches(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -99,8 +95,7 @@ public class AssertStrictTrackerTests
         Assert.Equal("42\nreport-empty:true\nverified\ngetCalls:2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CallTracker_VerifyThrowsWhenCountMismatches(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/AsyncHooksTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/AsyncHooksTests.cs
@@ -10,8 +10,7 @@ public class AsyncHooksTests
 {
     #region Import Patterns
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncHooks_NamedImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -27,8 +26,7 @@ public class AsyncHooksTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncHooks_NamespaceImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -44,8 +42,7 @@ public class AsyncHooksTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncHooks_NodePrefixImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -65,8 +62,7 @@ public class AsyncHooksTests
 
     #region Constructor
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Constructor(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -87,8 +83,7 @@ public class AsyncHooksTests
 
     #region getStore
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_GetStore_ReturnsUndefined_Outside(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -108,8 +103,7 @@ public class AsyncHooksTests
 
     #region run
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Run_SetsStore(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -127,8 +121,7 @@ public class AsyncHooksTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Run_RestoresAfter(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -145,8 +138,7 @@ public class AsyncHooksTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Run_ReturnsCallbackResult(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -163,8 +155,7 @@ public class AsyncHooksTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Run_NestedRuns(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -190,8 +181,7 @@ public class AsyncHooksTests
 
     #region enterWith
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_EnterWith_SetsStore(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -212,8 +202,7 @@ public class AsyncHooksTests
 
     #region exit
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Exit_ClearsStore(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -238,8 +227,7 @@ public class AsyncHooksTests
 
     #region disable
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Disable_PreventsAccess(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -263,8 +251,7 @@ public class AsyncHooksTests
 
     #region Multiple Instances
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_MultipleInstances_Independent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -290,8 +277,7 @@ public class AsyncHooksTests
 
     #region Store with Object Values
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Run_WithObjectStore(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -310,8 +296,7 @@ public class AsyncHooksTests
         Assert.Equal("abc-123\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Run_WithNullStore(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -329,8 +314,7 @@ public class AsyncHooksTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Run_WithNumberStore(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -352,8 +336,7 @@ public class AsyncHooksTests
 
     #region Async Context Propagation
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Run_AsyncCallback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -371,8 +354,7 @@ public class AsyncHooksTests
         Assert.Equal("async-value\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Run_AsyncCallback_AcrossAwait(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -396,8 +378,7 @@ public class AsyncHooksTests
         Assert.Equal("across-await\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Run_AsyncCallback_NestedAwait(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -422,8 +403,7 @@ public class AsyncHooksTests
         Assert.Equal("nested-await\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Run_PromiseThen(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -443,8 +423,7 @@ public class AsyncHooksTests
         Assert.Equal("in-then\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Run_NestedAsyncRuns(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -469,8 +448,7 @@ public class AsyncHooksTests
         Assert.Equal("outer\ninner\nouter\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Run_AsyncWithObjectStore(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -499,8 +477,7 @@ public class AsyncHooksTests
 
     #region Cross-Module Access
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_CrossModule_SharedInstance(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -532,8 +509,7 @@ public class AsyncHooksTests
 
     #region enterWith Advanced
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_EnterWith_OverwritesPrevious(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -556,8 +532,7 @@ public class AsyncHooksTests
 
     #region Run Restores on Exception
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_Run_RestoresOnException(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -584,8 +559,7 @@ public class AsyncHooksTests
 
     #region Multiple Instances Advanced
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncLocalStorage_MultipleInstances_NestedRunsDifferentInstances(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessAsyncTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class ChildProcessAsyncTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exec_ReturnsChildProcess(ExecutionMode mode)
     {
         var echoCommand = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -32,8 +31,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spawn_ReturnsChildProcess(ExecutionMode mode)
     {
         var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -59,8 +57,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpawnSync_Input_FeedsStdin(ExecutionMode mode)
     {
         // The `input` option feeds the synchronous child's stdin; `sort` echoes it back sorted.
@@ -77,8 +74,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("sorted:apple\nbanana\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecSync_StillWorks(ExecutionMode mode)
     {
         var echoCommand = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -98,8 +94,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exec_ChildProcess_HasKillMethod(ExecutionMode mode)
     {
         var echoCommand = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -121,8 +116,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exec_ChildProcess_Properties(ExecutionMode mode)
     {
         var echoCommand = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -143,8 +137,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spawn_Stdio_Ignore_NullsStreams(ExecutionMode mode)
     {
         // stdio:'ignore' discards the child's output and sets the stdio streams to null,
@@ -163,8 +156,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("out=true err=true\nclose:0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spawn_Stdio_Array_PipesOnlyStdout(ExecutionMode mode)
     {
         // stdio array: [stdin=ignore, stdout=pipe, stderr=ignore] — only stdout is a stream.
@@ -183,8 +175,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("out:arrayform stdin=true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spawn_Shell_RunsThroughShell(ExecutionMode mode)
     {
         // `echo shellworks` is a shell builtin / single shell command line — it only resolves
@@ -204,8 +195,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("shell:shellworks\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spawn_MissingCommand_EmitsEnoentError(ExecutionMode mode)
     {
         // A missing executable emits an async 'error' event with code 'ENOENT' (+ syscall/path),
@@ -223,8 +213,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("code=ENOENT syscall=spawn this_command_does_not_exist_xyz path=this_command_does_not_exist_xyz\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spawn_Kill_SetsKilledAndSignal(ExecutionMode mode)
     {
         // Spawn a long-running process, kill it, and observe live killed/signalCode in 'exit'.
@@ -247,8 +236,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("killed=true signal=SIGTERM\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exec_ExitCode_IsLiveAfterClose(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -264,8 +252,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("exitCode=0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spawn_Stdout_DataAndClose(ExecutionMode mode)
     {
         var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -291,8 +278,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("end:spawned\nclose:0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spawn_Stdin_RoundTrip(ExecutionMode mode)
     {
         // `sort` reads all of stdin and writes it back; a single line round-trips unchanged.
@@ -315,8 +301,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("got:hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spawn_HasStdinStream(ExecutionMode mode)
     {
         var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -339,8 +324,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecFile_ReturnsChildProcess(ExecutionMode mode)
     {
         var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -365,8 +349,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fork_IpcRoundTrip(ExecutionMode mode)
     {
         // Parent forks a child .ts module, exchanges a JSON message over IPC, then disconnects.
@@ -395,8 +378,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("parent got: got world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fork_TypeIsFunction(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -411,8 +393,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecFileSync_CapturesOutput(ExecutionMode mode)
     {
         var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -435,8 +416,7 @@ public class ChildProcessAsyncTests
         Assert.Contains("sync_output", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exec_Callback_FiresWithStdout(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -453,8 +433,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("cb:true:hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exec_EmitsCloseThenExit(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -471,8 +450,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("close:0\nexit:0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exec_Encoding_Buffer_ReturnsBuffer(ExecutionMode mode)
     {
         // encoding:'buffer' makes stdout a Buffer instead of a string.
@@ -490,8 +468,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("isBuf:true val:hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecSync_Input_FeedsStdin(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -507,8 +484,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("execSync:apple\nbanana\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecFileSync_Input_FeedsStdin(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -524,8 +500,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("execFileSync:berry\ncherry\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spawn_WindowsVerbatimArguments_Honored(ExecutionMode mode)
     {
         // windowsVerbatimArguments passes args as a raw command line; verify a normal spawn
@@ -550,8 +525,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("vb:vbworks\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exec_MaxBuffer_Overflow_Errors(ExecutionMode mode)
     {
         // Output longer than maxBuffer kills the child and surfaces ERR_CHILD_PROCESS_STDIO_MAXBUFFER.
@@ -569,8 +543,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("code:ERR_CHILD_PROCESS_STDIO_MAXBUFFER\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exec_NonZeroExit_CallbackReceivesError(ExecutionMode mode)
     {
         var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -591,8 +564,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("err:true:code:3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecFile_Callback_FiresWithStdout(ExecutionMode mode)
     {
         var command = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
@@ -616,8 +588,7 @@ public class ChildProcessAsyncTests
         Assert.Equal("filecb:true:filecb\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exec_ChildProcess_HasPidProperty(ExecutionMode mode)
     {
         var echoCommand = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ChildProcessModuleTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class ChildProcessModuleTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecSync_EchoCommand_ReturnsOutput(ExecutionMode mode)
     {
         // Use a simple echo command that works on all platforms
@@ -33,8 +32,7 @@ public class ChildProcessModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecSync_WithEnvironment_PassesEnvVars(ExecutionMode mode)
     {
         // Test that environment variables are passed through
@@ -56,8 +54,7 @@ public class ChildProcessModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpawnSync_ReturnsStatusObject(ExecutionMode mode)
     {
         // spawnSync should return an object with status, stdout, stderr
@@ -85,8 +82,7 @@ public class ChildProcessModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpawnSync_WithArgs_PassesArguments(ExecutionMode mode)
     {
         // spawnSync should pass arguments correctly
@@ -111,8 +107,7 @@ public class ChildProcessModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecFileSync_RunsFileDirectly(ExecutionMode mode)
     {
         // execFileSync should execute a file without a shell
@@ -137,8 +132,7 @@ public class ChildProcessModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecFileSync_ThrowsOnNonZeroExit(ExecutionMode mode)
     {
         // execFileSync should throw on non-zero exit code
@@ -167,8 +161,7 @@ public class ChildProcessModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecSync_ThrowsOnNonZeroExit(ExecutionMode mode)
     {
         // execSync should throw on non-zero exit code
@@ -194,8 +187,7 @@ public class ChildProcessModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpawnSync_NonZeroExit_ReturnsStatus(ExecutionMode mode)
     {
         // spawnSync should NOT throw but return non-zero status
@@ -219,8 +211,7 @@ public class ChildProcessModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpawnSync_StdoutCapture(ExecutionMode mode)
     {
         // spawnSync should capture stdout content
@@ -244,8 +235,7 @@ public class ChildProcessModuleTests
         Assert.Equal("captured_output\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedImport_AllMethods(ExecutionMode mode)
     {
         // All methods should be importable via named imports

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CjsBuiltInModuleRequireTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CjsBuiltInModuleRequireTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class CjsBuiltInModuleRequireTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cjs_Require_Path_Join(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -27,8 +26,7 @@ public class CjsBuiltInModuleRequireTests
         Assert.Equal("function\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cjs_Require_Assert_Ok(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -43,8 +41,7 @@ public class CjsBuiltInModuleRequireTests
         Assert.Equal("passed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cjs_Require_Tty_Isatty(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -62,8 +59,7 @@ public class CjsBuiltInModuleRequireTests
     /// <summary>
     /// Tests require() of multiple built-in modules in the same CJS file.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cjs_Require_MultipleModules(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -90,8 +86,7 @@ public class CjsBuiltInModuleRequireTests
     /// fields. Both paths landed with the path migration; this test pins that os's
     /// equivalent shape also works.
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cjs_Require_Os_Platform(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -109,8 +104,7 @@ public class CjsBuiltInModuleRequireTests
     /// <summary>
     /// Regression: querystring (also an embedded stdlib ESM module) via require().
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cjs_Require_Querystring_Parse(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -142,8 +136,7 @@ public class CjsBuiltInModuleRequireTests
     /// MODULE_NOT_FOUND at startup (#1217, fixed by running the require-literal walk over
     /// ESM bodies scoped to stdlib specifiers).
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cjs_Require_PrimitiveSeamFacade_FromEsmEntry(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -167,8 +160,7 @@ public class CjsBuiltInModuleRequireTests
     /// Regression (#1217): the require() call sits inside a function body in an ESM module —
     /// the discovery walk must find nested require literals, not just top-level statements.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cjs_Require_StdlibFacade_InsideFunction_FromEsmEntry(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -190,8 +182,7 @@ public class CjsBuiltInModuleRequireTests
     /// Regression (#1210): dynamic import() of a stdlib facade never statically imported hits
     /// the same lazy path — the facade's primitive:* deps must execute on demand.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void DynamicImport_PrimitiveSeamFacade_WithoutStaticImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ClusterModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ClusterModuleTests.cs
@@ -72,8 +72,7 @@ public class ClusterModuleTests : IDisposable
 
     #region Import and Basic Properties
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsPrimary_InMainThread_ReturnsTrue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -89,8 +88,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsMaster_AliasForIsPrimary(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -105,8 +103,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Import_Named(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -123,8 +120,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Equal("true\nfalse\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetupPrimary_StoresSettings(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -144,8 +140,7 @@ public class ClusterModuleTests : IDisposable
 
     #region Fork and Worker Lifecycle (dual-mode: compiled fork bridges to interpreted workers, #1171)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fork_WorkerExitsSuccessfully(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -169,8 +164,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("worker exited:", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fork_WorkerSeesIsWorkerTrue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -193,8 +187,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("worker isWorker: true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fork_WorkerToParentMessaging(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -220,8 +213,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("received: hello from worker", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fork_ParentToWorkerMessaging(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -252,8 +244,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("echo: hello from primary", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fork_WorkerExitEvent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -276,8 +267,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("exit code: 0", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fork_ClusterWorkersDict(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -306,8 +296,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("different: true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_Disconnect(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -337,8 +326,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("disconnected", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_Kill(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -364,8 +352,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("worker killed", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cluster_DisconnectAll(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -411,8 +398,7 @@ public class ClusterModuleTests : IDisposable
 
     #region Cluster Port Sharing
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fork_WorkersShareNetPort(ExecutionMode mode)
     {
         var port = GetFreePort();
@@ -480,8 +466,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("responses: 4", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Fork_WorkerExitReleasesSlot(ExecutionMode mode)
     {
         var port = GetFreePort();
@@ -536,8 +521,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("after kill: worker-", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Fork_LastWorkerExitStopsListener(ExecutionMode mode)
     {
         var port = GetFreePort();
@@ -585,8 +569,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("worker exited", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Fork_WorkersShareHttpPort(ExecutionMode mode)
     {
         var port = GetFreePort();
@@ -641,8 +624,7 @@ public class ClusterModuleTests : IDisposable
 
     #region Live State, Events, Worker + Settings Completeness (#1166)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LiveWorkers_ReflectedThroughImportedBinding(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -669,8 +651,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("after exit: 0", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Setup_EventFiresOnSetupPrimary(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -691,8 +672,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("done", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Listening_EventFiresWithAddress(ExecutionMode mode)
     {
         var port = GetFreePort();
@@ -724,8 +704,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains($"worker-level listening: {port}", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WorkerProcess_PidConnectedAndMessageForwarding(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -754,8 +733,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("connected: true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_DestroyEmitsExitWithSignal(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -781,8 +759,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("exit: code=null signal=SIGTERM ead=true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Settings_DefaultsAndMergeSemantics(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -808,8 +785,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("silent after merge: false", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SchedulingPolicy_ConstantsAndRoundTrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -833,8 +809,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("rr round-trips: true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WorkerArgv_HonorsSettingsArgs(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -860,8 +835,7 @@ public class ClusterModuleTests : IDisposable
         Assert.Contains("argv2: alpha", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Silent_SuppressesWorkerConsoleOutput(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -887,8 +861,7 @@ public class ClusterModuleTests : IDisposable
         Assert.DoesNotContain("WORKER_NOISE", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RoundRobin_DistributesConnectionsAcrossWorkers(ExecutionMode mode)
     {
         var port = GetFreePort();

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CryptoAsyncTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CryptoAsyncTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class CryptoAsyncTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pbkdf2_Async_ReturnsBuffer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -28,8 +27,7 @@ public class CryptoAsyncTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pbkdf2_Async_MatchesSync(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -48,8 +46,7 @@ public class CryptoAsyncTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Scrypt_Async_ReturnsBuffer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -68,8 +65,7 @@ public class CryptoAsyncTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Scrypt_Async_WithOptions(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -87,8 +83,7 @@ public class CryptoAsyncTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenerateKeyPair_Async_Rsa(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -109,8 +104,7 @@ public class CryptoAsyncTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenerateKeyPair_Async_Ec(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -129,8 +123,7 @@ public class CryptoAsyncTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Hkdf_Async_ReturnsBuffer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -149,8 +142,7 @@ public class CryptoAsyncTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Hkdf_Async_MatchesSync(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CryptoCipherTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CryptoCipherTests.cs
@@ -10,8 +10,7 @@ public class CryptoCipherTests
 {
     #region CBC Mode Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_Aes256Cbc_RoundTrip(ExecutionMode mode)
     {
         // Encrypt then decrypt, verify match
@@ -40,8 +39,7 @@ public class CryptoCipherTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_Aes128Cbc_RoundTrip(ExecutionMode mode)
     {
         // Test with AES-128-CBC
@@ -70,8 +68,7 @@ public class CryptoCipherTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_Aes192Cbc_RoundTrip(ExecutionMode mode)
     {
         // Test with AES-192-CBC
@@ -98,8 +95,7 @@ public class CryptoCipherTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_Cbc_MultipleUpdates(ExecutionMode mode)
     {
         // Multiple update() calls should work correctly
@@ -129,8 +125,7 @@ public class CryptoCipherTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_Cbc_EmptyInput(ExecutionMode mode)
     {
         // Empty plaintext should still work
@@ -157,8 +152,7 @@ public class CryptoCipherTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_Cbc_Base64Encoding(ExecutionMode mode)
     {
         // Test with base64 encoding
@@ -187,8 +181,7 @@ public class CryptoCipherTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_Cbc_BufferOutput(ExecutionMode mode)
     {
         // Test with Buffer output (default)
@@ -216,8 +209,7 @@ public class CryptoCipherTests
 
     #region GCM Mode Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_Aes256Gcm_RoundTrip_String(ExecutionMode mode)
     {
         // GCM mode with auth tag using string output
@@ -246,8 +238,7 @@ public class CryptoCipherTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_Aes256Gcm_RoundTrip_Buffer(ExecutionMode mode)
     {
         // GCM mode with auth tag using Buffer output
@@ -276,8 +267,7 @@ public class CryptoCipherTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_Aes128Gcm_RoundTrip(ExecutionMode mode)
     {
         // AES-128-GCM mode
@@ -306,8 +296,7 @@ public class CryptoCipherTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_Gcm_WithAAD(ExecutionMode mode)
     {
         // GCM with additional authenticated data
@@ -339,8 +328,7 @@ public class CryptoCipherTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_Gcm_GetAuthTagReturnsBuffer(ExecutionMode mode)
     {
         // getAuthTag should return a Buffer
@@ -369,8 +357,7 @@ public class CryptoCipherTests
 
     #region Error Handling Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_InvalidAlgorithm(ExecutionMode mode)
     {
         // Unknown algorithm should throw
@@ -394,8 +381,7 @@ public class CryptoCipherTests
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_WrongKeySize(ExecutionMode mode)
     {
         // Wrong key size should throw
@@ -419,8 +405,7 @@ public class CryptoCipherTests
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_WrongIVSize(ExecutionMode mode)
     {
         // Wrong IV size should throw
@@ -444,8 +429,7 @@ public class CryptoCipherTests
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_UpdateAfterFinal(ExecutionMode mode)
     {
         // Calling update after final should throw
@@ -473,8 +457,7 @@ public class CryptoCipherTests
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_DoubleFinal(ExecutionMode mode)
     {
         // Calling final twice should throw
@@ -502,8 +485,7 @@ public class CryptoCipherTests
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateDecipheriv_Gcm_MissingAuthTag(ExecutionMode mode)
     {
         // GCM decryption without setAuthTag should throw
@@ -529,8 +511,7 @@ public class CryptoCipherTests
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_Gcm_GetAuthTagBeforeFinal(ExecutionMode mode)
     {
         // Calling getAuthTag before final should throw
@@ -557,8 +538,7 @@ public class CryptoCipherTests
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_Cbc_GetAuthTagThrows(ExecutionMode mode)
     {
         // getAuthTag on CBC cipher should throw
@@ -590,8 +570,7 @@ public class CryptoCipherTests
 
     #region Buffer Input Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_BufferInput(ExecutionMode mode)
     {
         // Using Buffer as input with hex encoding for simpler output handling
@@ -623,8 +602,7 @@ public class CryptoCipherTests
 
     #region Chaining Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_SetAutoPaddingChaining(ExecutionMode mode)
     {
         // setAutoPadding should return this for chaining
@@ -646,8 +624,7 @@ public class CryptoCipherTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_SetAADChaining(ExecutionMode mode)
     {
         // setAAD should return this for chaining
@@ -674,8 +651,7 @@ public class CryptoCipherTests
 
     #region Input Encoding Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_HexInputEncoding(ExecutionMode mode)
     {
         // Test hex input encoding for cipher
@@ -707,8 +683,7 @@ public class CryptoCipherTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateCipheriv_Base64InputEncoding(ExecutionMode mode)
     {
         // Test base64 input encoding for cipher

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CryptoHkdfTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CryptoHkdfTests.cs
@@ -10,8 +10,7 @@ public class CryptoHkdfTests
 {
     #region Basic Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_HkdfSync_ReturnsBuffer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -33,8 +32,7 @@ public class CryptoHkdfTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_HkdfSync_DifferentKeyLengths(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -60,8 +58,7 @@ public class CryptoHkdfTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_HkdfSync_Deterministic(ExecutionMode mode)
     {
         // Same inputs should produce same output
@@ -89,8 +86,7 @@ public class CryptoHkdfTests
 
     #region Different Inputs Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_HkdfSync_DifferentInputsProduceDifferentOutput(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -114,8 +110,7 @@ public class CryptoHkdfTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_HkdfSync_DifferentSalts(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -139,8 +134,7 @@ public class CryptoHkdfTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_HkdfSync_DifferentInfo(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -168,8 +162,7 @@ public class CryptoHkdfTests
 
     #region Input Variations Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_HkdfSync_EmptySaltAndInfo(ExecutionMode mode)
     {
         // Empty salt and info should be valid
@@ -193,8 +186,7 @@ public class CryptoHkdfTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_HkdfSync_StringInputs(ExecutionMode mode)
     {
         // String inputs should be converted to UTF-8 bytes
@@ -214,8 +206,7 @@ public class CryptoHkdfTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_HkdfSync_ZeroKeyLength(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -238,8 +229,7 @@ public class CryptoHkdfTests
 
     #region Hash Algorithm Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_HkdfSync_SHA1(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -258,8 +248,7 @@ public class CryptoHkdfTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_HkdfSync_SHA384(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -278,8 +267,7 @@ public class CryptoHkdfTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_HkdfSync_SHA512(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -302,8 +290,7 @@ public class CryptoHkdfTests
 
     #region Error Handling Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_HkdfSync_InvalidDigest_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -328,8 +315,7 @@ public class CryptoHkdfTests
 
     #region RFC 5869 Test Vectors
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_HkdfSync_RFC5869_TestVector1(ExecutionMode mode)
     {
         // RFC 5869 Test Case 1 (SHA-256)

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CryptoInfoTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CryptoInfoTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class CryptoInfoTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GetHashes_ReturnsArray(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -26,8 +25,7 @@ public class CryptoInfoTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GetHashes_ContainsSha256(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -45,8 +43,7 @@ public class CryptoInfoTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GetCiphers_ReturnsArray(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -63,8 +60,7 @@ public class CryptoInfoTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GetCiphers_ContainsAesCbc(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CryptoKDFTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CryptoKDFTests.cs
@@ -11,8 +11,7 @@ public class CryptoKDFTests
 {
     // ============ PBKDF2 TESTS ============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pbkdf2Sync_ReturnsBuffer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -29,8 +28,7 @@ public class CryptoKDFTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pbkdf2Sync_Sha256_KnownVector(ExecutionMode mode)
     {
         // RFC 6070 test vector for PBKDF2-HMAC-SHA256
@@ -48,8 +46,7 @@ public class CryptoKDFTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pbkdf2Sync_Sha1_KnownVector(ExecutionMode mode)
     {
         // RFC 6070 test vector for PBKDF2-HMAC-SHA1
@@ -67,8 +64,7 @@ public class CryptoKDFTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pbkdf2Sync_Sha512(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -93,8 +89,7 @@ public class CryptoKDFTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pbkdf2Sync_Sha384(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -111,8 +106,7 @@ public class CryptoKDFTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pbkdf2Sync_DifferentIterations(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -129,8 +123,7 @@ public class CryptoKDFTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pbkdf2Sync_DifferentSalts(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -147,8 +140,7 @@ public class CryptoKDFTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pbkdf2Sync_BufferPassword(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -166,8 +158,7 @@ public class CryptoKDFTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pbkdf2Sync_BufferSalt(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -185,8 +176,7 @@ public class CryptoKDFTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pbkdf2Sync_UnsupportedAlgorithmThrows(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -208,8 +198,7 @@ public class CryptoKDFTests
 
     // ============ SCRYPT TESTS ============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScryptSync_ReturnsBuffer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -226,8 +215,7 @@ public class CryptoKDFTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScryptSync_KnownVector(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -246,8 +234,7 @@ public class CryptoKDFTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScryptSync_DefaultParameters(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -272,8 +259,7 @@ public class CryptoKDFTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScryptSync_DifferentSalts(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -290,8 +276,7 @@ public class CryptoKDFTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScryptSync_DifferentPasswords(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -308,8 +293,7 @@ public class CryptoKDFTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScryptSync_DifferentCostParameter(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -326,8 +310,7 @@ public class CryptoKDFTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScryptSync_BufferPassword(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -345,8 +328,7 @@ public class CryptoKDFTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScryptSync_BufferSalt(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -364,8 +346,7 @@ public class CryptoKDFTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScryptSync_CostAlias(ExecutionMode mode)
     {
         // 'cost' is an alias for 'N'
@@ -383,8 +364,7 @@ public class CryptoKDFTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScryptSync_BlockSizeAlias(ExecutionMode mode)
     {
         // 'blockSize' is an alias for 'r'
@@ -402,8 +382,7 @@ public class CryptoKDFTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScryptSync_ParallelizationAlias(ExecutionMode mode)
     {
         // 'parallelization' is an alias for 'p'
@@ -421,8 +400,7 @@ public class CryptoKDFTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScryptSync_Deterministic(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -441,8 +419,7 @@ public class CryptoKDFTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScryptSync_WithOptions(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CryptoKeyEcdhParityTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CryptoKeyEcdhParityTests.cs
@@ -17,8 +17,7 @@ public class CryptoKeyEcdhParityTests
 {
     // ----- Dual-mode (compiled + interpreted) -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Ecdh_TwoParty_RawPoint_Agreement(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -40,8 +39,7 @@ public class CryptoKeyEcdhParityTests
         Assert.Equal("true\ntrue\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Ecdh_GetPrivateKey_RawScalar(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -59,8 +57,7 @@ public class CryptoKeyEcdhParityTests
         Assert.Equal("true\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Ecdh_GetPublicKey_CompressedFormat(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -79,8 +76,7 @@ public class CryptoKeyEcdhParityTests
         Assert.Equal("true\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsymmetricKeyDetails_NamedCurve_P384(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -96,8 +92,7 @@ public class CryptoKeyEcdhParityTests
         Assert.Equal("true\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenerateKeySync_Aes256(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -112,8 +107,7 @@ public class CryptoKeyEcdhParityTests
         Assert.Equal("true\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenerateKey_Callback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -130,8 +124,7 @@ public class CryptoKeyEcdhParityTests
         Assert.Equal("true\ntrue\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fips_Shims(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -147,8 +140,7 @@ public class CryptoKeyEcdhParityTests
 
     // ----- Interpreter-only (compiled-deferred surface) -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void KeyObject_JwkRoundTrip_Rsa(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -167,8 +159,7 @@ public class CryptoKeyEcdhParityTests
         Assert.Equal("true\ntrue\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void KeyObject_Equals(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -186,8 +177,7 @@ public class CryptoKeyEcdhParityTests
         Assert.Equal("true\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void CreatePublicKey_FromPrivateKeyObject(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -204,8 +194,7 @@ public class CryptoKeyEcdhParityTests
         Assert.Equal("true\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Ecdh_ConvertKey_And_OneShotDiffieHellman(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CryptoKeyExchangeTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CryptoKeyExchangeTests.cs
@@ -10,8 +10,7 @@ public class CryptoKeyExchangeTests
 {
     #region Diffie-Hellman Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GetDiffieHellman_Modp14(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -29,8 +28,7 @@ public class CryptoKeyExchangeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GetDiffieHellman_InvalidGroup_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -50,8 +48,7 @@ public class CryptoKeyExchangeTests
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_DiffieHellman_GenerateKeys_ReturnsBuffer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -69,8 +66,7 @@ public class CryptoKeyExchangeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_DiffieHellman_GenerateKeys_HexEncoding(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -90,8 +86,7 @@ public class CryptoKeyExchangeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_DiffieHellman_ComputeSecret_TwoParties(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -120,8 +115,7 @@ public class CryptoKeyExchangeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_DiffieHellman_GetPrime(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -141,8 +135,7 @@ public class CryptoKeyExchangeTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_DiffieHellman_GetGenerator(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -161,8 +154,7 @@ public class CryptoKeyExchangeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_DiffieHellman_VerifyError_IsZero(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -182,8 +174,7 @@ public class CryptoKeyExchangeTests
 
     #region ECDH Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateECDH_P256(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -201,8 +192,7 @@ public class CryptoKeyExchangeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateECDH_P384(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -220,8 +210,7 @@ public class CryptoKeyExchangeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateECDH_P521(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -239,8 +228,7 @@ public class CryptoKeyExchangeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateECDH_InvalidCurve_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -260,8 +248,7 @@ public class CryptoKeyExchangeTests
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_ECDH_GenerateKeys_ReturnsBuffer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -279,8 +266,7 @@ public class CryptoKeyExchangeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_ECDH_ComputeSecret_TwoParties(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -309,8 +295,7 @@ public class CryptoKeyExchangeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_ECDH_GetPublicKey(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -329,8 +314,7 @@ public class CryptoKeyExchangeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_ECDH_GetPrivateKey(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -349,8 +333,7 @@ public class CryptoKeyExchangeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_ECDH_DifferentCurves_DifferentKeyLengths(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CryptoKeyObjectTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CryptoKeyObjectTests.cs
@@ -54,8 +54,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
 
     #region createSecretKey Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateSecretKey_FromBuffer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -74,8 +73,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateSecretKey_FromStringUtf8(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -94,8 +92,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateSecretKey_FromStringHex(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -114,8 +111,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateSecretKey_FromStringBase64(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -134,8 +130,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateSecretKey_Export(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -156,8 +151,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateSecretKey_NoAsymmetricKeyType(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -175,8 +169,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateSecretKey_NoAsymmetricKeyDetails(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -197,8 +190,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
 
     #region createPublicKey Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePublicKey_FromPem(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -218,8 +210,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePublicKey_AsymmetricKeyType(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -238,8 +229,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePublicKey_AsymmetricKeyDetails_RSA(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -260,8 +250,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePublicKey_Export(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -282,8 +271,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePublicKey_NoSymmetricKeySize(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -302,8 +290,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePublicKey_FromObject(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -323,8 +310,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePublicKey_FromGeneratedKeyPair(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -348,8 +334,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
 
     #region createPrivateKey Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePrivateKey_FromPem(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -369,8 +354,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePrivateKey_AsymmetricKeyType(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -389,8 +373,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePrivateKey_AsymmetricKeyDetails_RSA(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -412,8 +395,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePrivateKey_Export(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -434,8 +416,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePrivateKey_FromGeneratedKeyPair(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -459,8 +440,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
 
     #region EC Key Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePrivateKey_EC(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -480,8 +460,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePublicKey_EC(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -501,8 +480,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePublicKey_EC_AsymmetricKeyDetails(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -525,8 +503,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePublicKey_EC_AsymmetricKeyDetails_Compiled(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -550,8 +527,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
 
     #region Error Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePublicKey_InvalidPem_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -572,8 +548,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreatePrivateKey_InvalidPem_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -594,8 +569,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateSecretKey_InvalidEncoding_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CryptoKeyPairTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CryptoKeyPairTests.cs
@@ -10,8 +10,7 @@ public class CryptoKeyPairTests
 {
     #region RSA Key Generation Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GenerateKeyPairSync_RSA_2048(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -32,8 +31,7 @@ public class CryptoKeyPairTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GenerateKeyPairSync_RSA_4096(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -54,8 +52,7 @@ public class CryptoKeyPairTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GenerateKeyPairSync_RSA_DefaultOptions(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -77,8 +74,7 @@ public class CryptoKeyPairTests
 
     #region EC Key Generation Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GenerateKeyPairSync_EC_P256(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -99,8 +95,7 @@ public class CryptoKeyPairTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GenerateKeyPairSync_EC_P384(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -119,8 +114,7 @@ public class CryptoKeyPairTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GenerateKeyPairSync_EC_P521(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -139,8 +133,7 @@ public class CryptoKeyPairTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GenerateKeyPairSync_EC_DefaultCurve(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -162,8 +155,7 @@ public class CryptoKeyPairTests
 
     #region Error Handling Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GenerateKeyPairSync_InvalidType_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -187,8 +179,7 @@ public class CryptoKeyPairTests
 
     #region Integration Tests with Sign/Verify
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GenerateKeyPairSync_RSA_WorksWithCreateSign(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -219,8 +210,7 @@ public class CryptoKeyPairTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GenerateKeyPairSync_EC_WorksWithCreateSign(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CryptoModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CryptoModuleTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class CryptoModuleTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateHash(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -89,8 +88,7 @@ public class CryptoModuleTests
         Assert.Equal(expected, output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_RandomBytes(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -134,8 +132,7 @@ public class CryptoModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_RandomFillSync(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -190,8 +187,7 @@ public class CryptoModuleTests
         Assert.Equal(expected, output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_RandomUUID(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -236,8 +232,7 @@ public class CryptoModuleTests
         Assert.Equal(expected, output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_RandomInt(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -278,8 +273,7 @@ public class CryptoModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateHmac(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CryptoOneShotHashTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CryptoOneShotHashTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class CryptoOneShotHashTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Hash_OneShot_MatchesCreateHash(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -29,8 +28,7 @@ public class CryptoOneShotHashTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Hash_DefaultsToHex(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -45,8 +43,7 @@ public class CryptoOneShotHashTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_HashCopy_MatchesIndependentDigest(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -68,8 +65,7 @@ public class CryptoOneShotHashTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Sha3_256(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -84,8 +80,7 @@ public class CryptoOneShotHashTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Shake256_HonorsOutputLength(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -102,8 +97,7 @@ public class CryptoOneShotHashTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_GetHashes_IncludesSha3(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CryptoRsaEncryptTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CryptoRsaEncryptTests.cs
@@ -54,8 +54,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
 
     #region Basic Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_PublicEncrypt_ReturnsBuffer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -76,8 +75,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_PublicEncrypt_PrivateDecrypt_Roundtrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -100,8 +98,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_PublicEncrypt_PrivateDecrypt_WithGeneratedKeyPair(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -123,8 +120,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_PublicEncrypt_StringInput(ExecutionMode mode)
     {
         // publicEncrypt should also accept string input (UTF-8 encoded)
@@ -151,8 +147,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
 
     #region Security Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_PrivateDecrypt_FailsWithWrongKey(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -181,8 +176,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_EncryptionProducesDifferentOutputEachTime(ExecutionMode mode)
     {
         // OAEP padding includes randomness, so encrypting the same message twice
@@ -214,8 +208,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
 
     #region Error Handling Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_PublicEncrypt_ThrowsOnInvalidKey(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -236,8 +229,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_PublicEncrypt_MessageSizeLimit(ExecutionMode mode)
     {
         // RSA-2048 with OAEP-SHA1 can encrypt at most 214 bytes

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CryptoSignVerifyTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CryptoSignVerifyTests.cs
@@ -54,8 +54,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
 
     #region Object Creation Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateSign_ReturnsSignObject(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -73,8 +72,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_CreateVerify_ReturnsVerifyObject(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -92,8 +90,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Sign_UpdateReturnsThis(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -110,8 +107,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Verify_UpdateReturnsThis(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -132,8 +128,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
 
     #region Algorithm Support Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Sign_SupportsRsaSha256Algorithm(ExecutionMode mode)
     {
         // RSA-SHA256 prefixed algorithm should work the same as sha256
@@ -150,8 +145,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Sign_SupportsSha384Algorithm(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -167,8 +161,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Sign_SupportsSha512Algorithm(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -188,8 +181,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
 
     #region Sign and Verify Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_SignAndVerify_RoundTrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -221,8 +213,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Verify_ReturnsFalseForInvalidSignature(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -251,8 +242,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Sign_MultipleUpdates(ExecutionMode mode)
     {
         // Multiple updates should work the same as a single update with concatenated data
@@ -284,8 +274,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Sign_MethodChaining(ExecutionMode mode)
     {
         // Test that update().sign() chaining works
@@ -310,8 +299,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
 
     #region Encoding Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Sign_Base64Encoding(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -335,8 +323,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_SignAndVerify_Base64(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -365,8 +352,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Sign_ReturnsBuffer_WhenNoEncoding(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -394,8 +380,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
 
     #region Error Handling Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Sign_ThrowsOnUnsupportedAlgorithm(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -415,8 +400,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Sign_ThrowsOnDoubleSign(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -443,8 +427,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Sign_ThrowsOnUpdateAfterSign(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -471,8 +454,7 @@ Mm5eSbKNFWASjBGZFqzraPS5TfxJl5gnZCSGYRo1Uf56B9b9owv8Q2eZ/fJIR7Iv
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Crypto_Verify_ThrowsOnDoubleVerify(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CryptoTimingSafeEqualTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CryptoTimingSafeEqualTests.cs
@@ -12,8 +12,7 @@ public class CryptoTimingSafeEqualTests
 {
     // ============ BASIC FUNCTIONALITY TESTS ============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_EqualBuffers_ReturnsTrue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -30,8 +29,7 @@ public class CryptoTimingSafeEqualTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_DifferentBuffers_ReturnsFalse(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -48,8 +46,7 @@ public class CryptoTimingSafeEqualTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_EmptyBuffers_ReturnsTrue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -66,8 +63,7 @@ public class CryptoTimingSafeEqualTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_SingleByte_Equal(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -84,8 +80,7 @@ public class CryptoTimingSafeEqualTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_SingleByte_NotEqual(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -104,8 +99,7 @@ public class CryptoTimingSafeEqualTests
 
     // ============ LENGTH MISMATCH TESTS ============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_DifferentLengths_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -127,8 +121,7 @@ public class CryptoTimingSafeEqualTests
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_EmptyVsNonEmpty_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -152,8 +145,7 @@ public class CryptoTimingSafeEqualTests
 
     // ============ CRYPTO USE CASES ============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_HashComparison(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -170,8 +162,7 @@ public class CryptoTimingSafeEqualTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_HmacComparison(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -188,8 +179,7 @@ public class CryptoTimingSafeEqualTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_DifferentHashes(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -208,8 +198,7 @@ public class CryptoTimingSafeEqualTests
 
     // ============ RETURN TYPE TESTS ============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_ReturnsBoolean(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -229,8 +218,7 @@ public class CryptoTimingSafeEqualTests
 
     // ============ LARGE BUFFER TESTS ============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_LargeBuffers_Equal(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -247,8 +235,7 @@ public class CryptoTimingSafeEqualTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_LargeBuffers_OneByteDifferent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -268,8 +255,7 @@ public class CryptoTimingSafeEqualTests
 
     // ============ STRING INPUT TESTS ============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_StringInputs_Equal(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -286,8 +272,7 @@ public class CryptoTimingSafeEqualTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_StringInputs_NotEqual(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -304,8 +289,7 @@ public class CryptoTimingSafeEqualTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_StringInputs_DifferentLengths_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -325,8 +309,7 @@ public class CryptoTimingSafeEqualTests
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimingSafeEqual_MixedInputs_BufferAndString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CryptoWebCryptoTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CryptoWebCryptoTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class CryptoWebCryptoTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subtle_Digest_Sha256_KnownVector(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -32,8 +31,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetRandomValues_FillsAndReturnsSameArray(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -53,8 +51,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThisCrypto_RandomUUID_And_WebcryptoAlias(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -72,8 +69,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subtle_AesGcm_GenerateEncryptDecrypt_RoundTrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -99,8 +95,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subtle_AesCbc_RoundTrip_WithAad_Gcm(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -129,8 +124,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subtle_Hmac_SignVerify(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -151,8 +145,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Subtle_Hmac_MatchesCreateHmac_InterpOnly(ExecutionMode mode)
     {
         // Interp-only: compiled createHmac's named-import key conversion doesn't
@@ -176,8 +169,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subtle_Ecdsa_SignVerify(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -203,8 +195,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subtle_Rsa_OaepRoundTrip_And_PssSign(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -239,8 +230,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subtle_Pbkdf2_DeriveBits_MatchesPbkdf2Sync(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -262,8 +252,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subtle_Hkdf_DeriveBits_MatchesHkdfSync(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -285,8 +274,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subtle_Ecdh_DeriveBits_TwoParty(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -309,8 +297,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subtle_DeriveKey_Pbkdf2ToAesGcm(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -342,8 +329,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subtle_ImportExport_RawAndSpkiPkcs8_RoundTrips(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -379,8 +365,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subtle_ExportKey_Jwk_SecretOct(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -402,8 +387,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subtle_WrapUnwrapKey_RawAesGcm(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -428,8 +412,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subtle_UnsupportedAlgorithms_ThrowClearErrors(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -458,8 +441,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subtle_ExportKey_NotExtractable_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -487,8 +469,7 @@ public class CryptoWebCryptoTests
     // ── Interpreted-only: jwk import/export of asymmetric keys is a documented
     //    compiled-mode ceiling (use spki/pkcs8 there). ─────────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Subtle_Jwk_AsymmetricExportImport_InterpOnly(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -519,8 +500,7 @@ public class CryptoWebCryptoTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void GetRandomValues_QuotaExceeded_InterpOnly(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/CryptoX509Tests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/CryptoX509Tests.cs
@@ -50,8 +50,7 @@ KQIDAQAB
 
     private static string Escape(string pem) => pem.Replace("\r\n", "\n").Replace("\n", "\\n");
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void X509_Parse_And_CoreProperties(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -78,8 +77,7 @@ KQIDAQAB
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void X509_SubjectAltName_And_CheckHost(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -106,8 +104,7 @@ KQIDAQAB
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void X509_Verify_PublicKey_And_ToString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -130,8 +127,7 @@ KQIDAQAB
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void X509_KeyUsage_And_ExtKeyUsage(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -151,8 +147,7 @@ KQIDAQAB
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void X509_NamedImport_Construction(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -169,8 +164,7 @@ KQIDAQAB
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void X509_FromBuffer_Pem(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -189,8 +183,7 @@ KQIDAQAB
 
     // --- interpreter-only surface (compiled defers: checkEmail, toLegacyObject, email SANs) ---
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void X509_CheckEmail_And_LegacyObject_InterpOnly(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -219,8 +212,7 @@ KQIDAQAB
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void X509_ValidDates_DualMode(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/DgramModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/DgramModuleTests.cs
@@ -10,8 +10,7 @@ public class DgramModuleTests
 {
     #region Import Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_Import_Namespace(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -27,8 +26,7 @@ public class DgramModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_Import_Named(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -47,8 +45,7 @@ public class DgramModuleTests
 
     #region createSocket Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_CreateSocket_Udp4(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -68,8 +65,7 @@ public class DgramModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_CreateSocket_HasEventEmitterMethods(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -92,8 +88,7 @@ public class DgramModuleTests
 
     #region Bind Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_Bind_EmitsListeningEvent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -115,8 +110,7 @@ public class DgramModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_Bind_WithCallback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -139,8 +133,7 @@ public class DgramModuleTests
 
     #region Send and Receive Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_SendReceive_BasicMessage(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -169,8 +162,7 @@ public class DgramModuleTests
         Assert.Contains("true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_SendReceive_BufferMessage(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -203,8 +195,7 @@ public class DgramModuleTests
 
     #region Close Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_Close_EmitsCloseEvent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -225,8 +216,7 @@ public class DgramModuleTests
         Assert.Contains("closed", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_Close_WithCallback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -250,8 +240,7 @@ public class DgramModuleTests
 
     #region Address Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_Address_ReturnsInfo(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -277,8 +266,7 @@ public class DgramModuleTests
 
     #region Socket Options Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_SetBroadcast(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -298,8 +286,7 @@ public class DgramModuleTests
         Assert.Contains("broadcast-set", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_SetTTL(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -323,8 +310,7 @@ public class DgramModuleTests
 
     #region Connected Mode Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_Socket_Connect_And_Send(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -353,8 +339,7 @@ public class DgramModuleTests
         Assert.Contains("connected-msg", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_Socket_Disconnect(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -382,8 +367,7 @@ public class DgramModuleTests
         Assert.Contains("true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_Socket_RemoteAddress(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -407,8 +391,7 @@ public class DgramModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_Socket_BufferSize_GetSet(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -434,8 +417,7 @@ public class DgramModuleTests
         Assert.Contains("set-ok", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_Socket_Connect_Event(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/DnsAsyncTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/DnsAsyncTests.cs
@@ -47,8 +47,7 @@ public class DnsAsyncTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolve4_FakeServer(ExecutionMode mode)
     {
         using var server = CreateAddressServer();
@@ -64,8 +63,7 @@ public class DnsAsyncTests
         Assert.Equal("true\ntrue\n127.0.0.1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolve_DefaultRrtypeA_FakeServer(ExecutionMode mode)
     {
         using var server = CreateAddressServer();
@@ -81,8 +79,7 @@ public class DnsAsyncTests
         Assert.Equal("true\ntrue\n127.0.0.1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolve4_NestedInsideCallback_CallbackFires(ExecutionMode mode)
     {
         // #239: in compiled mode, dns.* calls inside another callback (or any
@@ -102,8 +99,7 @@ public class DnsAsyncTests
         Assert.Equal("outer true\ninner true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolve4_InsideTimerCallback_CallbackFires(ExecutionMode mode)
     {
         using var server = CreateAddressServer();
@@ -119,8 +115,7 @@ public class DnsAsyncTests
         Assert.Equal("dns-in-timer true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolve4_InsideFunctionBody_CallbackFires(ExecutionMode mode)
     {
         using var server = CreateAddressServer();
@@ -137,8 +132,7 @@ public class DnsAsyncTests
         Assert.Equal("fn true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reverse_Loopback(ExecutionMode mode)
     {
         // dns.reverse uses the OS resolver (getaddrinfo); 127.0.0.1 reverse-resolves
@@ -159,8 +153,7 @@ public class DnsAsyncTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DnsConstants_Defined(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -179,8 +172,7 @@ public class DnsAsyncTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DnsPromises_Resolve4_FakeServer(ExecutionMode mode)
     {
         using var server = CreateAddressServer();
@@ -197,8 +189,7 @@ public class DnsAsyncTests
         Assert.Equal("true\n127.0.0.1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DnsPromises_Lookup(ExecutionMode mode)
     {
         // dns.lookup uses the OS resolver (hosts file) rather than a live DNS query, so
@@ -220,8 +211,7 @@ public class DnsAsyncTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DnsPromises_ViaModule_FakeServer(ExecutionMode mode)
     {
         using var server = CreateAddressServer();

--- a/SharpTS.Tests/SharedTests/BuiltInModules/DnsFakeServerModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/DnsFakeServerModuleTests.cs
@@ -115,8 +115,7 @@ public class DnsFakeServerModuleTests
         Assert.Equal("true\n" + expected, output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolve_WithMxRrtype_FakeServer_ExactValues(ExecutionMode mode)
     {
         using var server = CreateRecordServer();
@@ -132,8 +131,7 @@ public class DnsFakeServerModuleTests
         Assert.Equal("true\nmail.fake.test\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DnsPromises_ResolveMxAndTxt_FakeServer_ExactValues(ExecutionMode mode)
     {
         using var server = CreateRecordServer();
@@ -152,8 +150,7 @@ public class DnsFakeServerModuleTests
         Assert.Equal("mail.fake.test\n10\nv=spf1 -all\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ResolveTxt_TruncatedUdp_FallsBackToTcp(ExecutionMode mode)
     {
         using var server = new FakeDnsServer(
@@ -173,8 +170,7 @@ public class DnsFakeServerModuleTests
         Assert.Equal(1, server.TcpQueryCount);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ResolveMx_Nxdomain_CallsBackWithError(ExecutionMode mode)
     {
         using var server = new FakeDnsServer((request, _) => DnsPackets.Response(request, 3));
@@ -191,8 +187,7 @@ public class DnsFakeServerModuleTests
         Assert.Equal(1, server.QueryCount); // NXDOMAIN is final — no retry
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ResolveNs_Nxdomain_Promise_Rejects(ExecutionMode mode)
     {
         using var server = new FakeDnsServer((request, _) => DnsPackets.Response(request, 3));
@@ -213,8 +208,7 @@ public class DnsFakeServerModuleTests
         Assert.Equal("error caught\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ResolveMx_ServerNeverAnswers_TimesOutAfterRetries(ExecutionMode mode)
     {
         using var server = new FakeDnsServer((_, _) => null); // swallow every query
@@ -231,8 +225,7 @@ public class DnsFakeServerModuleTests
         Assert.Equal(3, server.QueryCount); // initial attempt + MaxRetries (2)
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolver_SetServers_QueriesFakeServer(ExecutionMode mode)
     {
         // No env redirection here: the Resolver is pointed at the fake explicitly
@@ -257,8 +250,7 @@ public class DnsFakeServerModuleTests
         Assert.Equal("true\nmail.fake.test\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolve4_CnameOnlyAnswer_FollowsChain(ExecutionMode mode)
     {
         // CNAME-chain following (#1073): a response carrying ONLY a CNAME makes the
@@ -283,8 +275,7 @@ public class DnsFakeServerModuleTests
         Assert.Equal(2, server.QueryCount);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolve4_CnameLoop_BoundedAndErrors(ExecutionMode mode)
     {
         // A CNAME pointing at itself must terminate at the chase depth bound and
@@ -304,8 +295,7 @@ public class DnsFakeServerModuleTests
         Assert.Equal(9, server.QueryCount); // initial + MaxCnameChaseDepth (8)
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ResolveCaa_CriticalFlagsByte_Parity(ExecutionMode mode)
     {
         // Node reports the whole CAA flags byte as 'critical' (#1073).

--- a/SharpTS.Tests/SharedTests/BuiltInModules/DnsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/DnsModuleTests.cs
@@ -10,8 +10,7 @@ public class DnsModuleTests
 {
     #region Import Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_Import_Namespace(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -28,8 +27,7 @@ public class DnsModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_Import_Named(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -49,8 +47,7 @@ public class DnsModuleTests
 
     #region Constants Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_Constants_Defined(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -71,8 +68,7 @@ public class DnsModuleTests
 
     #region dns.lookup Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_Lookup_Localhost_ReturnsObject(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -89,8 +85,7 @@ public class DnsModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_Lookup_Localhost_HasAddressAndFamily(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -107,8 +102,7 @@ public class DnsModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_Lookup_Localhost_AddressIsValid(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -127,8 +121,7 @@ public class DnsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_Lookup_Localhost_FamilyIs4Or6(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -144,8 +137,7 @@ public class DnsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_Lookup_WithFamilyOption_IPv4(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -187,8 +179,7 @@ public class DnsModuleTests
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_Lookup_RequiresHostname(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -208,8 +199,7 @@ public class DnsModuleTests
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Dns_Lookup_Callback_InvokedWithAddressAndFamily(ExecutionMode mode)
     {
         // #206: the callback form must invoke (err, address, family)
@@ -230,8 +220,7 @@ public class DnsModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Dns_Lookup_Callback_AllOption_ReceivesArray(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -274,8 +263,7 @@ public class DnsModuleTests
 
     #region dns.lookupService Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Dns_LookupService_Callback_InvokedWithHostnameAndService(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -294,8 +282,7 @@ public class DnsModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_LookupService_LocalhostPort80_ReturnsObject(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -312,8 +299,7 @@ public class DnsModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_LookupService_HasHostnameAndService(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -330,8 +316,7 @@ public class DnsModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_LookupService_ServiceIsPortString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -347,8 +332,7 @@ public class DnsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_LookupService_InvalidAddress_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/DnsRecordTypeTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/DnsRecordTypeTests.cs
@@ -90,8 +90,7 @@ public class DnsRecordTypeTests
 
     #region API surface tests (no network)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_Import_NewMethods_Exist(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -114,8 +113,7 @@ public class DnsRecordTypeTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DnsPromises_Import_NewMethods_Exist(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -138,8 +136,7 @@ public class DnsRecordTypeTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_NamedImport_ResolveMx(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/DnsResolverTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/DnsResolverTests.cs
@@ -11,8 +11,7 @@ public class DnsResolverTests
 {
     #region Construction and typeof
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolver_CanBeConstructed(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -29,8 +28,7 @@ public class DnsResolverTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolver_ImportNamed(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -50,8 +48,7 @@ public class DnsResolverTests
 
     #region getServers / setServers
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolver_GetServers_InitiallyEmpty(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -69,8 +66,7 @@ public class DnsResolverTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolver_SetServers_ThenGetServers(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -90,8 +86,7 @@ public class DnsResolverTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolver_SetServers_InvalidAddress_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -112,8 +107,7 @@ public class DnsResolverTests
         Assert.Equal("error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolver_SetServers_ReplacesExisting(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -137,8 +131,7 @@ public class DnsResolverTests
 
     #region Resolver has all resolve methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolver_HasAllMethods(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -175,8 +168,7 @@ public class DnsResolverTests
 
     #region Resolver.resolve4 against a fake server (setServers)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolver_Resolve4_FakeServer_CallbackStyle(ExecutionMode mode)
     {
         // resolve4 uses the DNS wire protocol; point the Resolver at a loopback fake
@@ -213,8 +205,7 @@ public class DnsResolverTests
 
     #region Multiple resolvers are independent
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolver_MultipleInstances_IndependentServers(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -240,8 +231,7 @@ public class DnsResolverTests
 
     #region cancel is a no-op
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolver_Cancel_DoesNotThrow(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/EventsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/EventsModuleTests.cs
@@ -10,8 +10,7 @@ public class EventsModuleTests
 {
     #region Import Patterns
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Events_NamedImport_EventEmitter(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -27,8 +26,7 @@ public class EventsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Events_NamespaceImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -48,8 +46,7 @@ public class EventsModuleTests
 
     #region Constructor
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_Constructor_CreatesInstance(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -70,8 +67,7 @@ public class EventsModuleTests
 
     #region On / Emit
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_On_Emit_BasicUsage(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -92,8 +88,7 @@ public class EventsModuleTests
         Assert.Equal("received: hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_Emit_MultipleArguments(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -114,8 +109,7 @@ public class EventsModuleTests
         Assert.Equal("6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_Emit_MultipleListeners(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -136,8 +130,7 @@ public class EventsModuleTests
         Assert.Equal("first\nsecond\nthird\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_Emit_ReturnsTrue_WhenHasListeners(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -161,8 +154,7 @@ public class EventsModuleTests
 
     #region Once
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_Once_FiresOnlyOnce(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -184,8 +176,7 @@ public class EventsModuleTests
         Assert.Equal("fired\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_Once_WithArguments(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -209,8 +200,7 @@ public class EventsModuleTests
 
     #region Off / RemoveListener
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_Off_RemovesListener(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -234,8 +224,7 @@ public class EventsModuleTests
         Assert.Equal("called\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_RemoveListener_Alias(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -260,8 +249,7 @@ public class EventsModuleTests
 
     #region RemoveAllListeners
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_RemoveAllListeners_SpecificEvent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -284,8 +272,7 @@ public class EventsModuleTests
         Assert.Equal("other\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_RemoveAllListeners_AllEvents(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -312,8 +299,7 @@ public class EventsModuleTests
 
     #region Listener Inspection
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_ListenerCount(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -336,8 +322,7 @@ public class EventsModuleTests
         Assert.Equal("0\n1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_EventNames(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -360,8 +345,7 @@ public class EventsModuleTests
         Assert.Equal("3\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_Listeners_ReturnsArray(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -390,8 +374,7 @@ public class EventsModuleTests
 
     #region Prepend Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_PrependListener(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -411,8 +394,7 @@ public class EventsModuleTests
         Assert.Equal("first\nsecond\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_PrependOnceListener_Interpreted(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -434,8 +416,7 @@ public class EventsModuleTests
         Assert.Equal("prepended once\nregular\n---\nregular\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_PrependOnceListener_Compiled(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -463,8 +444,7 @@ public class EventsModuleTests
 
     #region Max Listeners
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_GetMaxListeners_DefaultValue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -480,8 +460,7 @@ public class EventsModuleTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_SetMaxListeners(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -499,8 +478,7 @@ public class EventsModuleTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_DefaultMaxListeners_StaticProperty(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -519,8 +497,7 @@ public class EventsModuleTests
 
     #region Method Chaining
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_MethodChaining(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -548,8 +525,7 @@ public class EventsModuleTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_RemoveDuringEmit_Interpreted(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -581,8 +557,7 @@ public class EventsModuleTests
         Assert.Equal("listener1\nlistener2\n---\nlistener1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_RemoveDuringEmit_Compiled(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -618,8 +593,7 @@ public class EventsModuleTests
         Assert.Equal("1,2,3,---,1,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_AddDuringEmit_Interpreted(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -649,8 +623,7 @@ public class EventsModuleTests
         Assert.Equal("listener1: 0\n---\nlistener1: 1\nadded\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_AddDuringEmit_Compiled(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -684,8 +657,7 @@ public class EventsModuleTests
         Assert.Equal("1,2,---,1,2,new\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_SameListenerMultipleTimes(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -710,8 +682,7 @@ public class EventsModuleTests
         Assert.Equal("3\nfired\nfired\nfired\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_AddListener_Alias(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -729,8 +700,7 @@ public class EventsModuleTests
         Assert.Equal("addListener works\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitter_MultipleEmitters(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/EventsRejectionMonitorTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/EventsRejectionMonitorTests.cs
@@ -12,8 +12,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class EventsRejectionMonitorTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CaptureRejections_RoutesAsyncListenerRejectionToError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -37,8 +36,7 @@ public class EventsRejectionMonitorTests
         Assert.Equal("routed:boom\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CaptureRejections_Off_DoesNotRouteToError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -62,8 +60,7 @@ public class EventsRejectionMonitorTests
         Assert.Equal("not-routed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ErrorMonitor_ObservesAndStillThrowsWhenUnhandled(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -87,8 +84,7 @@ public class EventsRejectionMonitorTests
         Assert.Equal("boom|true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ErrorMonitor_WithRegularListener_DoesNotThrow(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -114,8 +110,7 @@ public class EventsRejectionMonitorTests
         Assert.Equal("mr|false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UnhandledError_OnDirectEmitter_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -139,8 +134,7 @@ public class EventsRejectionMonitorTests
         Assert.Equal("true:unhandled\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UnhandledNonErrorEvent_DoesNotThrow(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -156,8 +150,7 @@ public class EventsRejectionMonitorTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ErrorMonitor_And_CaptureRejectionSymbol_AreSymbols(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -173,8 +166,7 @@ public class EventsRejectionMonitorTests
         Assert.Equal("symbol\nsymbol\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventEmitterAsyncResource_Surface(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/EventsStaticHelpersTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/EventsStaticHelpersTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class EventsStaticHelpersTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Once_ResolvesWithEventArguments(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -32,8 +31,7 @@ public class EventsStaticHelpersTests
         Assert.Equal("1,2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Once_StaticForm_Works(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -54,8 +52,7 @@ public class EventsStaticHelpersTests
         Assert.Equal("hi\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Once_RejectsOnError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -80,8 +77,7 @@ public class EventsStaticHelpersTests
         Assert.Equal("caught:boom\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Once_RejectsOnAlreadyAbortedSignal(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -107,8 +103,7 @@ public class EventsStaticHelpersTests
         Assert.Equal("aborted:AbortError\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void On_AsyncIterator_YieldsEventArgs(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -136,8 +131,7 @@ public class EventsStaticHelpersTests
         Assert.Equal("1,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void On_AsyncIterator_AbortEndsIteration(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -167,8 +161,7 @@ public class EventsStaticHelpersTests
         Assert.Equal("1|AbortError\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetEventListeners_ReturnsListeners(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -189,8 +182,7 @@ public class EventsStaticHelpersTests
         Assert.Equal("2\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetMaxListeners_PerEmitterAndDefault(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -211,8 +203,7 @@ public class EventsStaticHelpersTests
         Assert.Equal("15\n10\n7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticListenerCount_CountsListeners(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -232,8 +223,7 @@ public class EventsStaticHelpersTests
         Assert.Equal("2\n2\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AddAbortListener_FiresOnAbort(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -256,8 +246,7 @@ public class EventsStaticHelpersTests
         Assert.Equal("fired:1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AddAbortListener_DisposePreventsFiring(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -281,8 +270,7 @@ public class EventsStaticHelpersTests
         Assert.Equal("fired:0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AddAbortListener_AlreadyAbortedFiresOnMicrotask(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsAsyncTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsAsyncTests.cs
@@ -12,8 +12,7 @@ public class FsAsyncTests
 {
     #region fs/promises module - Basic Operations
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromises_WriteFile_And_ReadFile_WithEncoding(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -36,8 +35,7 @@ public class FsAsyncTests
         Assert.Equal("Hello Async World\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromises_WriteFile_And_ReadFile_AsBuffer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -60,8 +58,7 @@ public class FsAsyncTests
         Assert.Equal("Buffer Test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromises_AppendFile(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -89,8 +86,7 @@ public class FsAsyncTests
 
     #region fs/promises module - File Stats
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromises_Stat_File(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -113,8 +109,7 @@ public class FsAsyncTests
         Assert.Equal("true false 12\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromises_Stat_Directory(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -141,8 +136,7 @@ public class FsAsyncTests
 
     #region fs/promises module - Directory Operations
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromises_Mkdir_And_Rmdir(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -166,8 +160,7 @@ public class FsAsyncTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromises_Mkdir_Recursive(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -193,8 +186,7 @@ public class FsAsyncTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromises_Readdir(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -225,8 +217,7 @@ public class FsAsyncTests
 
     #region fs/promises module - File Operations
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromises_Rename(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -250,8 +241,7 @@ public class FsAsyncTests
         Assert.Equal("content\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromises_CopyFile(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -276,8 +266,7 @@ public class FsAsyncTests
         Assert.Equal("copy content\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromises_Access(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -305,8 +294,7 @@ public class FsAsyncTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromises_Access_NonExistent_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -335,8 +323,7 @@ public class FsAsyncTests
 
     #region fs.promises namespace
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromisesNamespace_WriteFile_And_ReadFile(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -359,8 +346,7 @@ public class FsAsyncTests
         Assert.Equal("Namespace Test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromisesNamespace_Stat(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -383,8 +369,7 @@ public class FsAsyncTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromisesNamespace_Constants(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -402,8 +387,7 @@ public class FsAsyncTests
         Assert.Equal("true\n0\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromisesNamespace_AppendFile(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -431,8 +415,7 @@ public class FsAsyncTests
 
     #region Error Handling
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromises_ReadFile_NonExistent_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -457,8 +440,7 @@ public class FsAsyncTests
         Assert.Equal("threw true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromises_Unlink_NonExistent_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -487,8 +469,7 @@ public class FsAsyncTests
 
     #region Truncate
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromises_Truncate(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsModuleTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 public class FsModuleTests
 {
     private static string Uid() => Guid.NewGuid().ToString("N")[..8];
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_ExistsSync_ReturnsTrueForExistingFile(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -27,8 +26,7 @@ public class FsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_ExistsSync_ReturnsFalseForNonexistentFile(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -43,8 +41,7 @@ public class FsModuleTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_WriteFileSync_And_ReadFileSync_WorkTogether(ExecutionMode mode)
     {
         var uid = Uid();
@@ -69,8 +66,7 @@ public class FsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_AppendFileSync_AppendsToFile(ExecutionMode mode)
     {
         var uid = Uid();
@@ -96,8 +92,7 @@ public class FsModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_MkdirSync_And_RmdirSync_WorkTogether(ExecutionMode mode)
     {
         var uid = Uid();
@@ -120,8 +115,7 @@ public class FsModuleTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_ReaddirSync_ListsDirectoryContents(ExecutionMode mode)
     {
         var uid = Uid();
@@ -150,8 +144,7 @@ public class FsModuleTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_StatSync_ReturnsFileInfo(ExecutionMode mode)
     {
         var uid = Uid();
@@ -179,8 +172,7 @@ public class FsModuleTests
         Assert.Equal("true\nfalse\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_StatSync_ReturnsDirectoryInfo(ExecutionMode mode)
     {
         var uid = Uid();
@@ -206,8 +198,7 @@ public class FsModuleTests
         Assert.Equal("false\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_CopyFileSync_CopiesFile(ExecutionMode mode)
     {
         var uid = Uid();
@@ -237,8 +228,7 @@ public class FsModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_RenameSync_RenamesFile(ExecutionMode mode)
     {
         var uid = Uid();
@@ -265,8 +255,7 @@ public class FsModuleTests
         Assert.Equal("false\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_UnlinkSync_DeletesFile(ExecutionMode mode)
     {
         var uid = Uid();
@@ -289,8 +278,7 @@ public class FsModuleTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_AccessSync_DoesNotThrowForExistingFile(ExecutionMode mode)
     {
         var uid = Uid();
@@ -320,8 +308,7 @@ public class FsModuleTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_AccessSync_ThrowsForNonexistentFile(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -343,8 +330,7 @@ public class FsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_RmdirSync_WithRecursive_DeletesNestedDirectories(ExecutionMode mode)
     {
         var uniqueDir = $"test_rmdir_recursive_{Guid.NewGuid():N}";
@@ -368,8 +354,7 @@ public class FsModuleTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_Constants_ExportsAccessConstants(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -387,8 +372,7 @@ public class FsModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_TruncateSync_TruncatesFile(ExecutionMode mode)
     {
         var uid = Uid();
@@ -419,8 +403,7 @@ public class FsModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_TruncateSync_ExtendsFileWithZeros(ExecutionMode mode)
     {
         var uid = Uid();
@@ -446,8 +429,7 @@ public class FsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_SymlinkSync_CreatesSymbolicLink(ExecutionMode mode)
     {
         var uid = Uid();
@@ -474,8 +456,7 @@ public class FsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_RealpathSync_ResolvesAbsolutePath(ExecutionMode mode)
     {
         var uid = Uid();
@@ -502,8 +483,7 @@ public class FsModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_UtimesSync_SetsFileTimes(ExecutionMode mode)
     {
         var uid = Uid();
@@ -532,8 +512,7 @@ public class FsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_LstatSync_ReturnsSymlinkInfo(ExecutionMode mode)
     {
         var uid = Uid();
@@ -561,8 +540,7 @@ public class FsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_ReaddirSync_WithFileTypes_ReturnsDirentObjects(ExecutionMode mode)
     {
         var uid = Uid();
@@ -610,8 +588,7 @@ public class FsModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_ChmodSync_DoesNotThrowOnUnix(ExecutionMode mode)
     {
         // This test checks that chmodSync doesn't throw on Unix
@@ -643,8 +620,7 @@ public class FsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_ReadlinkSync_ThrowsForNonSymlink(ExecutionMode mode)
     {
         var uid = Uid();
@@ -674,8 +650,7 @@ public class FsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_TruncateSync_ThrowsForNonexistentFile(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -697,8 +672,7 @@ public class FsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_RealpathSync_ThrowsForNonexistentFile(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -722,8 +696,7 @@ public class FsModuleTests
 
     #region File Descriptor APIs
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_OpenSync_ReturnsFileDescriptor(ExecutionMode mode)
     {
         var uid = Uid();
@@ -748,8 +721,7 @@ public class FsModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_CloseSync_ClosesDescriptor(ExecutionMode mode)
     {
         var uid = Uid();
@@ -779,8 +751,7 @@ public class FsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_CloseSync_ThrowsForInvalidFd(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -802,8 +773,7 @@ public class FsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_ReadSync_ReadsIntoBuffer(ExecutionMode mode)
     {
         var uid = Uid();
@@ -833,8 +803,7 @@ public class FsModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_WriteSync_WritesFromBuffer(ExecutionMode mode)
     {
         var uid = Uid();
@@ -864,8 +833,7 @@ public class FsModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_FstatSync_ReturnsStats(ExecutionMode mode)
     {
         var uid = Uid();
@@ -893,8 +861,7 @@ public class FsModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_FtruncateSync_TruncatesFile(ExecutionMode mode)
     {
         var uid = Uid();
@@ -926,8 +893,7 @@ public class FsModuleTests
 
     #region Directory Utilities
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_MkdtempSync_CreatesUniqueDirectory(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -948,8 +914,7 @@ public class FsModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_ReaddirSync_Recursive_ListsAllEntries(ExecutionMode mode)
     {
         var uid = Uid();
@@ -981,8 +946,7 @@ public class FsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_OpendirSync_ReturnsDir(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1015,8 +979,7 @@ public class FsModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_Dir_ReadSync_ReturnsNullWhenDone(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1056,8 +1019,7 @@ public class FsModuleTests
 
     #region Hard Links
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_LinkSync_CreatesHardLink(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1087,8 +1049,7 @@ public class FsModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_LinkSync_ThrowsForMissingSource(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1110,8 +1071,7 @@ public class FsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_LinkSync_ThrowsForExistingDest(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1148,8 +1108,7 @@ public class FsModuleTests
 
     #region Mixed Module Imports
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MixedModuleImports_WorkTogether(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1182,8 +1141,7 @@ public class FsModuleTests
     // the callback forms from the promise primitives, so they run identically in
     // both modes. These tests pin that parity.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_CallbackReadFile_ReturnsData(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1205,8 +1163,7 @@ public class FsModuleTests
         Assert.Equal("DATA:callback-data\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_CallbackReadFile_NoEncoding_ReturnsBuffer(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1229,8 +1186,7 @@ public class FsModuleTests
         Assert.Equal("3:abc\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_CallbackWriteFile_ThenReadBack(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1252,8 +1208,7 @@ public class FsModuleTests
         Assert.Equal("READBACK:written-via-cb\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_CallbackReadFile_MissingFile_PassesError(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1273,8 +1228,7 @@ public class FsModuleTests
         Assert.Equal("ERR:yes\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_PromisesReadFile_RoundTrips(ExecutionMode mode)
     {
         // fs.promises.write/readFile round-trips through await in both modes and
@@ -1308,8 +1262,7 @@ public class FsModuleTests
 
     // Identical asserts across ExecutionModes.All enforce interp==compiled parity.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_WriteReadBuffer_BinaryRoundTrip(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1330,8 +1283,7 @@ public class FsModuleTests
         Assert.Equal("true\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_Encoding_HexAndBase64(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1353,8 +1305,7 @@ public class FsModuleTests
         Assert.Equal("Hello\n48656c6c6f\nHi\nSGk\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_Encoding_Latin1AndUtf16le(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1380,8 +1331,7 @@ public class FsModuleTests
 
     #region Sync option semantics + constants (#979)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_MkdirSync_NonRecursive_ThrowsEexistAndEnoent(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1403,8 +1353,7 @@ public class FsModuleTests
         Assert.Equal("EEXIST\nENOENT\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_MkdirSync_Recursive_ReturnsFirstCreated(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1424,8 +1373,7 @@ public class FsModuleTests
         Assert.Equal("true\ntrue\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_AccessSync_WriteOk_ThrowsOnReadOnly(ExecutionMode mode)
     {
         var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"ro_{Uid()}.txt");
@@ -1455,8 +1403,7 @@ public class FsModuleTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_Constants_AreComplete(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1478,8 +1425,7 @@ public class FsModuleTests
 
     #region Stats/Dirent unification (#977)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_Stat_SyncAndAsyncSameShapeAndPredicates(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1509,8 +1455,7 @@ public class FsModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_Stat_BigIntOption(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1531,8 +1476,7 @@ public class FsModuleTests
         Assert.Equal("true\ntrue\ntrue\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_Dirent_ParentPathAndPredicates(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1566,8 +1510,7 @@ public class FsModuleTests
 
     #region mkdtemp absolute prefix (#984)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_MkdtempSync_AbsolutePrefix_NotDoubled(ExecutionMode mode)
     {
         // Canonical usage mkdtempSync(path.join(os.tmpdir(), 'foo-')) — the compiled
@@ -1589,8 +1532,7 @@ public class FsModuleTests
 
     #region promises.opendir + watch (#975)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_PromisesOpendir_AsyncIteratesEntries(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1618,8 +1560,7 @@ public class FsModuleTests
         Assert.Equal("count:3 sawDir:true\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_PromisesWatch_AsyncIteratorTerminatesOnAbort(ExecutionMode mode)
     {
         // Real FSWatcher event timing is non-deterministic (and flaky under load), so
@@ -1668,8 +1609,7 @@ public class FsModuleTests
 
     #region async chown + callback fd ops (#974)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_CallbackFdOps_OpenReadWriteFstatClose(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1705,8 +1645,7 @@ public class FsModuleTests
         Assert.Equal("5:WORLD\n11:true\n2:XY\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_CallbackFd_BadFd_And_Chown_Invoke(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1736,8 +1675,7 @@ public class FsModuleTests
     // #986: every sync fd op on a stale descriptor surfaces EBADF (not EINVAL) in both
     // modes. The compiled fd table already threw EBADF, but EmitWithFsErrorHandling's
     // catch-all re-mapped any non-BCL exception to the EINVAL default before the fix.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_SyncFdOps_BadFd_ReturnEBADF(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1763,8 +1701,7 @@ public class FsModuleTests
     // modes — the compiled side threw ENOSYS but the catch-all clobbered it to EINVAL.
     // Windows-gated: on Unix the compiled side is a documented no-op (P/Invoke from IL),
     // so it diverges from the interpreter's real syscall there (out of scope for #986).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_SyncChownLchown_Windows_ReturnENOSYS(ExecutionMode mode)
     {
         if (!OperatingSystem.IsWindows())
@@ -1791,8 +1728,7 @@ public class FsModuleTests
 
     #region rm / cp (#973)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_RmSync_RecursiveForceAndEisdir(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1817,8 +1753,7 @@ public class FsModuleTests
         Assert.Equal("true\nok\nERR_FS_EISDIR\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_CpSync_RecursiveErrorOnExistAndFilter(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1850,8 +1785,7 @@ public class FsModuleTests
 
     #region FileHandle / fsPromises.open (#972)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_FileHandle_OpenWriteReadStatTruncateClose(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1885,8 +1819,7 @@ public class FsModuleTests
         Assert.Equal("11\n5:WORLD\n11:true\n5\nHELLO\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_FileHandle_CreateReadStream_And_OpenMissingRejects(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1926,8 +1859,7 @@ public class FsModuleTests
 
     #region long-tail ops (#976)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_LongTail_DurabilityAndFdMetadata(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1965,8 +1897,7 @@ public class FsModuleTests
         Assert.Equal("rt:true\nfchown:true\ncbfsync:ok\nbadfd:true\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_LongTail_VectoredIo(ExecutionMode mode)
     {
         var uid = Uid();
@@ -1994,8 +1925,7 @@ public class FsModuleTests
         Assert.Equal("4:4:ABCD\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_LongTail_Statfs(ExecutionMode mode)
     {
         var uid = Uid();
@@ -2022,8 +1952,7 @@ public class FsModuleTests
         Assert.Equal("sync:true\nbigint:true\npromise:true\ncb:4096\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_LongTail_Glob(ExecutionMode mode)
     {
         var uid = Uid();
@@ -2057,8 +1986,7 @@ public class FsModuleTests
         Assert.Equal("star:a.txt\nss:a.txt,sub/c.txt\nq:b.log\nnone:0\ncb:a.txt\niter:a.txt\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_LongTail_LchmodEnosys_Lutimes_Exists(ExecutionMode mode)
     {
         var uid = Uid();
@@ -2093,8 +2021,7 @@ public class FsModuleTests
 
     #region fs/promises real backgrounding (#971)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FsPromises_RealAsync_ParityLivenessConcurrency(ExecutionMode mode)
     {
         var uid = Uid();

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsStreamTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsStreamTests.cs
@@ -12,8 +12,7 @@ public class FsStreamTests
 
     #region createReadStream
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CreateReadStream_ReadsFile(ExecutionMode mode)
     {
         var tempFile = Path.GetTempFileName();
@@ -40,8 +39,7 @@ public class FsStreamTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CreateReadStream_EndEvent(ExecutionMode mode)
     {
         var tempFile = Path.GetTempFileName();
@@ -69,8 +67,7 @@ public class FsStreamTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CreateReadStream_Path_Property(ExecutionMode mode)
     {
         var tempFile = Path.GetTempFileName();
@@ -99,8 +96,7 @@ public class FsStreamTests
 
     #region createWriteStream
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CreateWriteStream_WritesFile(ExecutionMode mode)
     {
         var tempFile = Path.GetTempFileName();
@@ -130,8 +126,7 @@ public class FsStreamTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CreateWriteStream_End_WritesAndCloses(ExecutionMode mode)
     {
         var tempFile = Path.GetTempFileName();
@@ -160,8 +155,7 @@ public class FsStreamTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CreateWriteStream_Path_Property(ExecutionMode mode)
     {
         var tempFile = Path.GetTempFileName();
@@ -186,8 +180,7 @@ public class FsStreamTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CreateReadStream_PipeToWriteStream(ExecutionMode mode)
     {
         var srcFile = Path.GetTempFileName();
@@ -224,8 +217,7 @@ public class FsStreamTests
 
     #region option/event parity (#980)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadStream_EventsBytesReadChunking(ExecutionMode mode)
     {
         var tempFile = Path.GetTempFileName();
@@ -252,8 +244,7 @@ public class FsStreamTests
         finally { File.Delete(tempFile); }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadStream_EmitCloseFalse_And_StartEnd(ExecutionMode mode)
     {
         var tempFile = Path.GetTempFileName();
@@ -286,8 +277,7 @@ public class FsStreamTests
         finally { File.Delete(tempFile); }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WriteStream_EventsBytesWrittenContent(ExecutionMode mode)
     {
         var dstFile = Path.GetTempFileName();
@@ -310,8 +300,7 @@ public class FsStreamTests
         finally { File.Delete(dstFile); }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pipe_ReadToWrite_MovesContent(ExecutionMode mode)
     {
         var srcFile = Path.GetTempFileName();

--- a/SharpTS.Tests/SharedTests/BuiltInModules/FsWatchTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/FsWatchTests.cs
@@ -12,8 +12,7 @@ public class FsWatchTests
 
     #region fs.watch()
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Watch_DetectsFileChange(ExecutionMode mode)
     {
         var tempFile = Path.GetTempFileName();
@@ -48,8 +47,7 @@ public class FsWatchTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Watch_CloseStopsWatching(ExecutionMode mode)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), "sharpts_watch_test_" + Guid.NewGuid().ToString("N"));
@@ -76,8 +74,7 @@ public class FsWatchTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Watch_OnMethodForEvents(ExecutionMode mode)
     {
         var tempFile = Path.GetTempFileName();
@@ -117,8 +114,7 @@ public class FsWatchTests
 
     #region fs.watchFile()
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WatchFile_DetectsStatChange(ExecutionMode mode)
     {
         var tempFile = Path.GetTempFileName();
@@ -153,8 +149,7 @@ public class FsWatchTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UnwatchFile_StopsWatching(ExecutionMode mode)
     {
         var tempFile = Path.GetTempFileName();
@@ -187,8 +182,7 @@ public class FsWatchTests
 
     #region Flowing Streams
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadStream_FlowingMode_AutoDrainsOnDataListener(ExecutionMode mode)
     {
         var tempFile = Path.GetTempFileName();
@@ -216,8 +210,7 @@ public class FsWatchTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_PauseResume_FlowControl(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -238,8 +231,7 @@ public class FsWatchTests
         Assert.Contains("chunks:a,b,c", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_ResumeAfterPause(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/NodeErrorTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/NodeErrorTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class NodeErrorTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadFileSync_NonexistentFile_ThrowsENOENT(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -31,8 +30,7 @@ public class NodeErrorTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StatSync_NonexistentFile_ThrowsENOENT(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -53,8 +51,7 @@ public class NodeErrorTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReaddirSync_NonexistentDir_ThrowsENOENT(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -75,8 +72,7 @@ public class NodeErrorTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UnlinkSync_NonexistentFile_ThrowsENOENT(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -97,8 +93,7 @@ public class NodeErrorTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RmdirSync_NonexistentDir_ThrowsENOENT(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -119,8 +114,7 @@ public class NodeErrorTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RenameSync_NonexistentFile_ThrowsENOENT(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -141,8 +135,7 @@ public class NodeErrorTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CopyFileSync_NonexistentFile_ThrowsENOENT(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -163,8 +156,7 @@ public class NodeErrorTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AccessSync_NonexistentFile_ThrowsENOENT(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -185,8 +177,7 @@ public class NodeErrorTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NodeError_HasPathProperty(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -205,8 +196,7 @@ public class NodeErrorTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NodeError_MessageIncludesCode(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/OsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/OsModuleTests.cs
@@ -5,8 +5,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 
 public class OsModuleTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Platform_ReturnsValidPlatform(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -21,8 +20,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Arch_ReturnsValidArchitecture(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -37,8 +35,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Hostname_ReturnsNonEmpty(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -53,8 +50,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Homedir_ReturnsNonEmpty(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -69,8 +65,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Tmpdir_ReturnsNonEmpty(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -85,8 +80,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Type_ReturnsValidType(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -101,8 +95,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Release_ReturnsNonEmpty(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -117,8 +110,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Cpus_ReturnsNonEmptyArray(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -133,8 +125,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Totalmem_ReturnsPositiveNumber(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -149,8 +140,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Freemem_ReturnsPositiveNumber(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -165,8 +155,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_EOL_ReturnsValidLineEnding(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -181,8 +170,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_UserInfo_ReturnsValidObject(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -200,8 +188,7 @@ public class OsModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Freemem_IsLessThanTotalmem(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -217,8 +204,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Freemem_IsReasonableAmount(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -234,8 +220,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Totalmem_IsReasonableAmount(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -251,8 +236,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Memory_ValuesAreRealistic(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -274,8 +258,7 @@ public class OsModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Cpus_HaveValidProperties(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -293,8 +276,7 @@ public class OsModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Homedir_IsAbsolutePath(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -311,8 +293,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Tmpdir_IsAbsolutePath(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -329,8 +310,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Platform_MatchesType(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -350,8 +330,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Loadavg_ReturnsArrayOfThreeNumbers(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -373,8 +352,7 @@ public class OsModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_Loadavg_WindowsReturnsZeros(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -394,8 +372,7 @@ public class OsModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_NetworkInterfaces_ReturnsObject(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -411,8 +388,7 @@ public class OsModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_NetworkInterfaces_IsValidObject(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -430,8 +406,7 @@ public class OsModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Os_DefaultImport_ExposesNamespace(ExecutionMode mode)
     {
         // #66: `import os from 'node:os'` used to fail type-checking with

--- a/SharpTS.Tests/SharedTests/BuiltInModules/PathModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/PathModuleTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class PathModuleTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Join_CombinesPaths(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -27,8 +26,7 @@ public class PathModuleTests
         Assert.True(output.Contains("foo\\bar\\baz") || output.Contains("foo/bar/baz"));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Basename_ReturnsFileName(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -47,8 +45,7 @@ public class PathModuleTests
         Assert.Contains("file.js\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Dirname_ReturnsDirectory(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -65,8 +62,7 @@ public class PathModuleTests
         Assert.Contains("true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Extname_ReturnsExtension(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -83,8 +79,7 @@ public class PathModuleTests
         Assert.Equal(".txt\n.gz\n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_IsAbsolute_ChecksAbsolutePaths(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -107,8 +102,7 @@ public class PathModuleTests
         Assert.Contains("false", lines);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Normalize_NormalizesPath(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -125,8 +119,7 @@ public class PathModuleTests
         Assert.Contains("true", output.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Sep_ReturnsSeparator(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -142,8 +135,7 @@ public class PathModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Delimiter_ReturnsDelimiter(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -159,8 +151,7 @@ public class PathModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Parse_ParsesPath(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -180,8 +171,7 @@ public class PathModuleTests
         Assert.Contains(".txt\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Format_FormatsPath(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -198,8 +188,7 @@ public class PathModuleTests
         Assert.Contains("true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Resolve_ResolvesPath(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -216,8 +205,7 @@ public class PathModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Relative_ReturnsRelativePath(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -235,8 +223,7 @@ public class PathModuleTests
 
     #region POSIX Path Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Posix_Sep_ReturnsForwardSlash(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -251,8 +238,7 @@ public class PathModuleTests
         Assert.Equal("/\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Posix_Delimiter_ReturnsColon(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -267,8 +253,7 @@ public class PathModuleTests
         Assert.Equal(":\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Posix_Join_UsesForwardSlash(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -283,8 +268,7 @@ public class PathModuleTests
         Assert.Equal("foo/bar/baz\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Posix_IsAbsolute_ChecksPosixPaths(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -304,8 +288,7 @@ public class PathModuleTests
         Assert.Equal("false", lines[2]); // C:\foo is NOT absolute in POSIX
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Posix_Basename_ReturnsFilename(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -322,8 +305,7 @@ public class PathModuleTests
         Assert.Contains("file\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Posix_Dirname_ReturnsDirectory(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -338,8 +320,7 @@ public class PathModuleTests
         Assert.Equal("/foo/bar\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Posix_Normalize_NormalizesPosixPath(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -354,8 +335,7 @@ public class PathModuleTests
         Assert.Equal("/foo/baz\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Posix_Parse_ParsesPosixPath(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -384,8 +364,7 @@ public class PathModuleTests
 
     #region Win32 Path Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Win32_Sep_ReturnsBackslash(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -400,8 +379,7 @@ public class PathModuleTests
         Assert.Equal("\\\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Win32_Delimiter_ReturnsSemicolon(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -416,8 +394,7 @@ public class PathModuleTests
         Assert.Equal(";\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Win32_Join_UsesBackslash(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -432,8 +409,7 @@ public class PathModuleTests
         Assert.Equal("foo\\bar\\baz\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Win32_IsAbsolute_ChecksWin32Paths(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -461,8 +437,7 @@ public class PathModuleTests
         Assert.Equal("false", lines[4]); // C: — drive-relative, not absolute
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Win32_Basename_ReturnsFilename(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -479,8 +454,7 @@ public class PathModuleTests
         Assert.Contains("file\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Win32_Dirname_ReturnsDirectory(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -495,8 +469,7 @@ public class PathModuleTests
         Assert.Equal("C:\\foo\\bar\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Win32_Normalize_NormalizesWin32Path(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -511,8 +484,7 @@ public class PathModuleTests
         Assert.Equal("C:\\foo\\baz\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_Win32_Parse_ParsesWin32Path(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -539,8 +511,7 @@ public class PathModuleTests
 
     #endregion
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_DefaultImport_ExposesNamespace(ExecutionMode mode)
     {
         // #66: default import from `node:path` needs to yield the namespace,

--- a/SharpTS.Tests/SharedTests/BuiltInModules/PathWin32ConformanceTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/PathWin32ConformanceTests.cs
@@ -75,8 +75,7 @@ public class PathWin32ConformanceTests
         Assert.True(output.Contains("ALL OK"), $"path.win32.{what} diverges from Node:\n{output}");
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Win32_Normalize_MatchesNode(ExecutionMode mode)
     {
         // Single-leading-separator cases are the regression guard: before the fix
@@ -108,8 +107,7 @@ public class PathWin32ConformanceTests
             """, mode, "normalize");
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Win32_IsAbsolute_MatchesNode(ExecutionMode mode)
     {
         RunTable("""
@@ -130,8 +128,7 @@ public class PathWin32ConformanceTests
             """, mode, "isAbsolute");
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Win32_Join_MatchesNode(ExecutionMode mode)
     {
         RunTable("""
@@ -150,8 +147,7 @@ public class PathWin32ConformanceTests
             """, mode, "join");
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Win32_Dirname_MatchesNode(ExecutionMode mode)
     {
         // Note: Node's win32 dirname preserves the input separators rather than
@@ -167,8 +163,7 @@ public class PathWin32ConformanceTests
             """, mode, "dirname");
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Win32_Parse_MatchesNode(ExecutionMode mode)
     {
         RunTable("""
@@ -186,8 +181,7 @@ public class PathWin32ConformanceTests
     /// normalize bug was reachable through the most common path APIs of all.
     /// Guarded only where the host actually is Windows.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PlatformDefault_OnWindows_RootedPathsSurvive(ExecutionMode mode)
     {
         if (!OperatingSystem.IsWindows()) return;

--- a/SharpTS.Tests/SharedTests/BuiltInModules/PerfHooksModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/PerfHooksModuleTests.cs
@@ -11,8 +11,7 @@ public class PerfHooksModuleTests
 {
     #region Import Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_Import_Namespace(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -28,8 +27,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_Import_Named(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -44,8 +42,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_Import_PerformanceObserver(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -64,8 +61,7 @@ public class PerfHooksModuleTests
 
     #region performance.now() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_PerformanceNow_ReturnsNumber(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -81,8 +77,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_PerformanceNow_NonNegative(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -98,8 +93,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_PerformanceNow_Increasing(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -120,8 +114,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_PerformanceNow_MeasuresElapsed(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -146,8 +139,7 @@ public class PerfHooksModuleTests
 
     #region performance.timeOrigin Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_TimeOrigin_ReturnsNumber(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -163,8 +155,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_TimeOrigin_ReasonableValue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -186,8 +177,7 @@ public class PerfHooksModuleTests
 
     #region performance.mark() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_Mark_CreatesEntry(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -206,8 +196,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_Mark_StartTimeIncreases(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -226,8 +215,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_Mark_AppearsInGetEntries(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -249,8 +237,7 @@ public class PerfHooksModuleTests
 
     #region performance.measure() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_Measure_BetweenMarks(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -272,8 +259,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_Measure_FromMarkToNow(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -294,8 +280,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_Measure_NameOnly(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -317,8 +302,7 @@ public class PerfHooksModuleTests
 
     #region performance.getEntries*() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_GetEntries_ReturnsAll(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -338,8 +322,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_GetEntriesByName_FiltersCorrectly(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -360,8 +343,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_GetEntriesByName_WithType(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -384,8 +366,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_GetEntriesByType_FiltersCorrectly(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -416,8 +397,7 @@ public class PerfHooksModuleTests
 
     #region performance.clearMarks() / clearMeasures() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_ClearMarks_RemovesAll(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -439,8 +419,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_ClearMarks_ByName(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -464,8 +443,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_ClearMeasures_RemovesAll(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -491,8 +469,7 @@ public class PerfHooksModuleTests
 
     #region PerformanceObserver Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_Observer_ReceivesEntries(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -512,8 +489,7 @@ public class PerfHooksModuleTests
         Assert.Contains("callback-fired", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_Observer_Disconnect(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -536,8 +512,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_Observer_FiltersByEntryType(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -563,8 +538,7 @@ public class PerfHooksModuleTests
 
     #region Practical Usage Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_MeasureFunctionDuration(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -593,8 +567,7 @@ public class PerfHooksModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PerfHooks_MarkAndMeasureWorkflow(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ProcessEventEmitterTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ProcessEventEmitterTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class ProcessEventEmitterTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_On_RegistersAndEmitsEvent(ExecutionMode mode)
     {
         var source = """
@@ -25,8 +24,7 @@ public class ProcessEventEmitterTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_On_PassesArguments(ExecutionMode mode)
     {
         var source = """
@@ -42,8 +40,7 @@ public class ProcessEventEmitterTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Once_CalledOnlyOnce(ExecutionMode mode)
     {
         var source = """
@@ -60,8 +57,7 @@ public class ProcessEventEmitterTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Emit_ReturnsTrueWhenListenersExist(ExecutionMode mode)
     {
         var source = """
@@ -74,8 +70,7 @@ public class ProcessEventEmitterTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Emit_ReturnsFalseWhenNoListeners(ExecutionMode mode)
     {
         var source = """
@@ -87,8 +82,7 @@ public class ProcessEventEmitterTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_RemoveListener_RemovesSpecificListener(ExecutionMode mode)
     {
         var source = """
@@ -105,8 +99,7 @@ public class ProcessEventEmitterTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_ListenerCount_ReturnsCorrectCount(ExecutionMode mode)
     {
         var source = """
@@ -119,8 +112,7 @@ public class ProcessEventEmitterTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_EventNames_ReturnsRegisteredEvents(ExecutionMode mode)
     {
         var source = """
@@ -135,8 +127,7 @@ public class ProcessEventEmitterTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_RemoveAllListeners_ClearsAllForEvent(ExecutionMode mode)
     {
         var source = """
@@ -150,8 +141,7 @@ public class ProcessEventEmitterTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_On_MethodChaining(ExecutionMode mode)
     {
         var source = """
@@ -169,8 +159,7 @@ public class ProcessEventEmitterTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_MultipleListeners_AllCalled(ExecutionMode mode)
     {
         var source = """
@@ -189,8 +178,7 @@ public class ProcessEventEmitterTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_StillHasOriginalProperties(ExecutionMode mode)
     {
         // Ensure EventEmitter integration doesn't break existing process properties

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ProcessGlobalTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ProcessGlobalTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class ProcessGlobalTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Platform_ReturnsValidPlatform(ExecutionMode mode)
     {
         var source = """
@@ -21,8 +20,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Arch_ReturnsValidArchitecture(ExecutionMode mode)
     {
         var source = """
@@ -34,8 +32,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Pid_ReturnsPositiveNumber(ExecutionMode mode)
     {
         var source = """
@@ -48,8 +45,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Version_ReturnsVersionString(ExecutionMode mode)
     {
         var source = """
@@ -63,8 +59,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Cwd_ReturnsCurrentDirectory(ExecutionMode mode)
     {
         var source = """
@@ -77,8 +72,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Env_ReturnsEnvObject(ExecutionMode mode)
     {
         var source = """
@@ -90,8 +84,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Env_ContainsPathVariable(ExecutionMode mode)
     {
         // PATH is typically set on most systems (PATH on Windows/Unix, or Path on some systems)
@@ -106,8 +99,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Argv_ReturnsArray(ExecutionMode mode)
     {
         var source = """
@@ -119,8 +111,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Argv_ContainsElements(ExecutionMode mode)
     {
         var source = """
@@ -132,8 +123,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_MultipleProperties_WorkTogether(ExecutionMode mode)
     {
         var source = """
@@ -149,8 +139,7 @@ public class ProcessGlobalTests
 
     // ============ PROCESS ENHANCEMENT TESTS ============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Hrtime_ReturnsArray(ExecutionMode mode)
     {
         var source = """
@@ -163,8 +152,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Hrtime_ReturnsPositiveSeconds(ExecutionMode mode)
     {
         var source = """
@@ -176,8 +164,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Hrtime_ReturnsValidNanoseconds(ExecutionMode mode)
     {
         var source = """
@@ -191,8 +178,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Hrtime_WithPrevious_ReturnsDiff(ExecutionMode mode)
     {
         var source = """
@@ -213,8 +199,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Uptime_ReturnsPositiveNumber(ExecutionMode mode)
     {
         var source = """
@@ -227,8 +212,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Uptime_IsSmallForNewProcess(ExecutionMode mode)
     {
         // Compiled mode uses Process.StartTime, which in our in-process test runner is
@@ -245,8 +229,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_MemoryUsage_ReturnsObject(ExecutionMode mode)
     {
         var source = """
@@ -258,8 +241,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_MemoryUsage_HasRss(ExecutionMode mode)
     {
         var source = """
@@ -272,8 +254,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_MemoryUsage_HasHeapTotal(ExecutionMode mode)
     {
         var source = """
@@ -286,8 +267,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_MemoryUsage_HasHeapUsed(ExecutionMode mode)
     {
         var source = """
@@ -300,8 +280,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_MemoryUsage_HeapUsedLessThanTotal(ExecutionMode mode)
     {
         var source = """
@@ -313,8 +292,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_AllEnhancements_WorkTogether(ExecutionMode mode)
     {
         var source = """
@@ -332,8 +310,7 @@ public class ProcessGlobalTests
 
     // ============ ENHANCED VALIDATION TESTS ============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Cwd_IsAbsolutePath(ExecutionMode mode)
     {
         // Current working directory should be an absolute path
@@ -350,8 +327,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Argv_FirstElementIsPath(ExecutionMode mode)
     {
         // argv[0] should be a path (the executable)
@@ -370,8 +346,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Hrtime_MeasuresRealTime(ExecutionMode mode)
     {
         // Two calls to hrtime should show time elapsed
@@ -392,8 +367,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Uptime_IncreasesOverTime(ExecutionMode mode)
     {
         // Two calls to uptime should show increasing values
@@ -412,8 +386,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_MemoryUsage_AllPropertiesPresent(ExecutionMode mode)
     {
         // memoryUsage should have all expected properties
@@ -430,8 +403,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Env_HasCommonVariables(ExecutionMode mode)
     {
         // PATH (or Path on some systems) should exist
@@ -446,8 +418,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Platform_MatchesOs(ExecutionMode mode)
     {
         // process.platform should match os.platform()
@@ -463,8 +434,7 @@ public class ProcessGlobalTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Arch_MatchesOs(ExecutionMode mode)
     {
         // process.arch should match os.arch()

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ProcessLifecycleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ProcessLifecycleTests.cs
@@ -19,8 +19,7 @@ public class ProcessLifecycleTests
         ProcessBuiltIns.ResetProcessState();
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_ExitEvent_FiresAtNaturalEnd(ExecutionMode mode)
     {
         var source = """
@@ -32,8 +31,7 @@ public class ProcessLifecycleTests
         Assert.Equal("main\nexit 0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_BeforeExit_FiresBeforeExit(ExecutionMode mode)
     {
         var source = """
@@ -46,8 +44,7 @@ public class ProcessLifecycleTests
         Assert.Equal("main\nbeforeExit 0\nexit 0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_BeforeExit_ListenerCanScheduleMoreWork(ExecutionMode mode)
     {
         // A beforeExit listener scheduling async work re-enters the loop and
@@ -67,8 +64,7 @@ public class ProcessLifecycleTests
         Assert.Equal("extra work\nexit after 2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Warning_EventCarriesNameMessageAndCode(ExecutionMode mode)
     {
         var source = """
@@ -82,8 +78,7 @@ public class ProcessLifecycleTests
         Assert.Equal("CustomWarning boom W123\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_NoDeprecation_SuppressesDeprecationWarnings(ExecutionMode mode)
     {
         var source = """
@@ -98,8 +93,7 @@ public class ProcessLifecycleTests
         Assert.Equal("fired: false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Process_UnhandledRejection_And_RejectionHandled(ExecutionMode mode)
     {
         // Compiled-mode promise rejection tracking is a documented deferral
@@ -121,8 +115,7 @@ public class ProcessLifecycleTests
         Assert.Equal("unhandled: boom\nhandled\nend\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Kill_SelfSignal_DispatchesToListener(ExecutionMode mode)
     {
         // NOTE: no process.exit() here — the harness runs guest code in-process,
@@ -142,8 +135,7 @@ public class ProcessLifecycleTests
         Assert.Equal("after kill\ngot SIGINT\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Kill_SignalZero_ExistenceCheck(ExecutionMode mode)
     {
         var source = """
@@ -161,8 +153,7 @@ public class ProcessLifecycleTests
         Assert.Equal("true\nnonexistent threw: true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_ExitEvent_FiresOnProcessExitThroughModuleListener(ExecutionMode mode)
     {
         // Listener registered through the module surface fires for the global

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ProcessNextTickTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ProcessNextTickTests.cs
@@ -11,8 +11,7 @@ public class ProcessNextTickTests
 {
     #region Import Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NextTick_Import_FromProcessModule(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -27,8 +26,7 @@ public class ProcessNextTickTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NextTick_ProcessGlobal_IsFunction(ExecutionMode mode)
     {
         var source = """
@@ -43,8 +41,7 @@ public class ProcessNextTickTests
 
     #region Execution Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NextTick_ExecutesCallback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -64,8 +61,7 @@ public class ProcessNextTickTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NextTick_ViaProcessGlobal_ExecutesCallback(ExecutionMode mode)
     {
         var source = """
@@ -81,8 +77,7 @@ public class ProcessNextTickTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NextTick_ReturnsUndefined(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -102,8 +97,7 @@ public class ProcessNextTickTests
 
     #region Arguments Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NextTick_PassesArguments_ThreeArgs(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -127,8 +121,7 @@ public class ProcessNextTickTests
         Assert.Equal("42\nhello\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NextTick_PassesArguments_TwoArgs(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -154,8 +147,7 @@ public class ProcessNextTickTests
     // Regression for #1149: the facade forwards `...args` to the primitive instead
     // of hand-unrolling an arity ladder, so more than 8 trailing args now survive in
     // both interpreter and compiled modes (the old ladder capped at 8).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NextTick_PassesArguments_BeyondEightArgs(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -178,8 +170,7 @@ public class ProcessNextTickTests
 
     // Regression for #1149: a caller-side spread (`...payload`) is expanded by the
     // built-in module emitter rather than packed as a single nested-array element.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NextTick_ForwardsCallerSpread(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -204,8 +195,7 @@ public class ProcessNextTickTests
 
     #region Multiple Callbacks Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NextTick_MultipleCallbacks_AllExecute(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -232,8 +222,7 @@ public class ProcessNextTickTests
 
     #region Error Handling Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NextTick_ThrowsWithoutCallback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ProcessStdioTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ProcessStdioTests.cs
@@ -11,8 +11,7 @@ public class ProcessStdioTests
 {
     #region process.stdout
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdout_Write_OutputsData(ExecutionMode mode)
     {
         var source = """
@@ -24,8 +23,7 @@ public class ProcessStdioTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdout_Write_ReturnsTrue(ExecutionMode mode)
     {
         var source = """
@@ -37,8 +35,7 @@ public class ProcessStdioTests
         Assert.Equal("testtrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdout_IsObject(ExecutionMode mode)
     {
         var source = """
@@ -49,8 +46,7 @@ public class ProcessStdioTests
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdout_HasWritableProperties(ExecutionMode mode)
     {
         var source = """
@@ -61,8 +57,7 @@ public class ProcessStdioTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdout_HasOnMethod(ExecutionMode mode)
     {
         var source = """
@@ -73,8 +68,7 @@ public class ProcessStdioTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdout_OnDrain_RegistersListener(ExecutionMode mode)
     {
         var source = """
@@ -89,8 +83,7 @@ public class ProcessStdioTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdout_IsTTY_IsBoolean(ExecutionMode mode)
     {
         var source = """
@@ -105,8 +98,7 @@ public class ProcessStdioTests
 
     #region process.stderr
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStderr_IsObject(ExecutionMode mode)
     {
         var source = """
@@ -117,8 +109,7 @@ public class ProcessStdioTests
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStderr_IsTTY_IsBoolean(ExecutionMode mode)
     {
         var source = """
@@ -129,8 +120,7 @@ public class ProcessStdioTests
         Assert.Equal("boolean\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStderr_HasWritableProperties(ExecutionMode mode)
     {
         var source = """
@@ -141,8 +131,7 @@ public class ProcessStdioTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStderr_HasOnMethod(ExecutionMode mode)
     {
         var source = """
@@ -157,8 +146,7 @@ public class ProcessStdioTests
 
     #region process.stdin
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdin_IsObject(ExecutionMode mode)
     {
         var source = """
@@ -169,8 +157,7 @@ public class ProcessStdioTests
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdin_IsTTY_IsBoolean(ExecutionMode mode)
     {
         var source = """
@@ -181,8 +168,7 @@ public class ProcessStdioTests
         Assert.Equal("boolean\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdin_HasReadableProperties(ExecutionMode mode)
     {
         var source = """
@@ -193,8 +179,7 @@ public class ProcessStdioTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdin_HasOnMethod(ExecutionMode mode)
     {
         var source = """
@@ -205,8 +190,7 @@ public class ProcessStdioTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdin_HasPauseResume(ExecutionMode mode)
     {
         var source = """
@@ -218,8 +202,7 @@ public class ProcessStdioTests
         Assert.Equal("function\nfunction\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdin_HasSetEncoding(ExecutionMode mode)
     {
         var source = """
@@ -234,8 +217,7 @@ public class ProcessStdioTests
 
     #region Stream method chaining
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdin_SetEncoding_ReturnsThis(ExecutionMode mode)
     {
         var source = """
@@ -251,8 +233,7 @@ public class ProcessStdioTests
 
     #region Module import patterns
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessModule_StdoutWrite(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -267,8 +248,7 @@ public class ProcessStdioTests
         Assert.Equal("module test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessModule_StdinType(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -289,8 +269,7 @@ public class ProcessStdioTests
 
     #region EventEmitter integration
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdout_EventEmitter_Methods(ExecutionMode mode)
     {
         var source = """
@@ -306,8 +285,7 @@ public class ProcessStdioTests
         Assert.Equal("function\nfunction\nfunction\nfunction\nfunction\nfunction\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdin_EventEmitter_Methods(ExecutionMode mode)
     {
         var source = """
@@ -327,8 +305,7 @@ public class ProcessStdioTests
 
     #region Writable stream interface
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdout_WritableInterface(ExecutionMode mode)
     {
         var source = """
@@ -342,8 +319,7 @@ public class ProcessStdioTests
         Assert.Equal("function\nfunction\nfunction\nfunction\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdout_WritableStateProperties(ExecutionMode mode)
     {
         var source = """
@@ -360,8 +336,7 @@ public class ProcessStdioTests
 
     #region Readable stream interface
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdin_ReadableInterface(ExecutionMode mode)
     {
         var source = """
@@ -377,8 +352,7 @@ public class ProcessStdioTests
         Assert.Equal("function\nfunction\nfunction\nfunction\nfunction\nfunction\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessStdin_ReadableStateProperties(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ProcessSurfaceTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ProcessSurfaceTests.cs
@@ -14,8 +14,7 @@ public class ProcessSurfaceTests
 {
     // ---- #1079: module facade === global ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessModule_DefaultExport_IsTheGlobalProcess(ExecutionMode mode)
     {
         var source = """
@@ -29,8 +28,7 @@ public class ProcessSurfaceTests
         Assert.Equal("true\nfunction function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessModule_ExitCode_SettableThroughDefaultExport(ExecutionMode mode)
     {
         var source = """
@@ -46,8 +44,7 @@ public class ProcessSurfaceTests
         Assert.Equal("7\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessModule_NamedExports_ExposeTheFullSurface(ExecutionMode mode)
     {
         var source = """
@@ -62,8 +59,7 @@ public class ProcessSurfaceTests
         Assert.Equal("function function function function\n24.15.0\nfunction\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_ValuePosition_IsLiveObject(ExecutionMode mode)
     {
         var source = """
@@ -76,8 +72,7 @@ public class ProcessSurfaceTests
         Assert.Equal("true function true\n[object process]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_ExpandoAssignment_RoundTrips(ExecutionMode mode)
     {
         var source = """
@@ -91,8 +86,7 @@ public class ProcessSurfaceTests
 
     // ---- #1082: diagnostics ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_CpuUsage_ReturnsMicrosecondsAndSupportsDelta(ExecutionMode mode)
     {
         var source = """
@@ -107,8 +101,7 @@ public class ProcessSurfaceTests
         Assert.Equal("number number\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_ResourceUsage_HasNodeShape(ExecutionMode mode)
     {
         var source = """
@@ -121,8 +114,7 @@ public class ProcessSurfaceTests
         Assert.Equal("true true true\nnumber number\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_HrtimeBigint_ReturnsBigint(ExecutionMode mode)
     {
         var source = """
@@ -133,8 +125,7 @@ public class ProcessSurfaceTests
         Assert.Equal("bigint\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Process_HrtimeBigint_IsMonotonic(ExecutionMode mode)
     {
         // Interpreted-only: compiled dynamic comparison of two any-typed
@@ -150,8 +141,7 @@ public class ProcessSurfaceTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_MemoryUsageRss_ReturnsPositiveNumber(ExecutionMode mode)
     {
         var source = """
@@ -164,8 +154,7 @@ public class ProcessSurfaceTests
         Assert.Equal("number true\ntrue true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_MemoryQueries_ReturnNumbers(ExecutionMode mode)
     {
         var source = """
@@ -180,8 +169,7 @@ public class ProcessSurfaceTests
 
     // ---- #1083: umask ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Umask_GetAndSetRoundTrip(ExecutionMode mode)
     {
         var source = """
@@ -199,8 +187,7 @@ public class ProcessSurfaceTests
 
     // ---- #1084: report ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Report_GetReport_HasDocumentedShape(ExecutionMode mode)
     {
         var source = """
@@ -218,8 +205,7 @@ public class ProcessSurfaceTests
 
     // ---- #1085: identity / info properties ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_IdentityProperties_HaveExpectedShapes(ExecutionMode mode)
     {
         var source = """
@@ -240,8 +226,7 @@ public class ProcessSurfaceTests
             output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_Title_SetAndGetRoundTrips(ExecutionMode mode)
     {
         var source = """
@@ -258,8 +243,7 @@ public class ProcessSurfaceTests
     // ---- #1086: POSIX identity (platform-conditional; compiled POSIX is a
     //      documented interpreter-first deferral, so interp-only) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Process_PosixIdentity_MatchesPlatform(ExecutionMode mode)
     {
         var source = """
@@ -277,8 +261,7 @@ public class ProcessSurfaceTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Process_SourceMapsFlag_Settable(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/BuiltInModules/QuerystringModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/QuerystringModuleTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class QuerystringModuleTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Querystring_Parse_ParsesSimpleString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -26,8 +25,7 @@ public class QuerystringModuleTests
         Assert.Equal("bar\nqux\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Querystring_Parse_HandlesUrlEncoding(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -44,8 +42,7 @@ public class QuerystringModuleTests
         Assert.Equal("John Doe\nNew York\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Querystring_Parse_HandlesPlusAsSpace(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -61,8 +58,7 @@ public class QuerystringModuleTests
         Assert.Equal("John Doe\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Querystring_Parse_HandlesEmptyValue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -79,8 +75,7 @@ public class QuerystringModuleTests
         Assert.Equal("true\nvalue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Querystring_Parse_CustomSeparator(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -97,8 +92,7 @@ public class QuerystringModuleTests
         Assert.Equal("bar\nqux\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Querystring_Stringify_CreatesQueryString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -115,8 +109,7 @@ public class QuerystringModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Querystring_Stringify_EncodesSpecialChars(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -132,8 +125,7 @@ public class QuerystringModuleTests
         Assert.Contains("hello%20world", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Querystring_Escape_EncodesString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -150,8 +142,7 @@ public class QuerystringModuleTests
         Assert.Contains("%26", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Querystring_Unescape_DecodesString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -167,8 +158,7 @@ public class QuerystringModuleTests
         Assert.Equal("hello world\nhello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Querystring_DecodeAlias_WorksLikeParse(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -184,8 +174,7 @@ public class QuerystringModuleTests
         Assert.Equal("bar\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Querystring_EncodeAlias_WorksLikeStringify(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -201,8 +190,7 @@ public class QuerystringModuleTests
         Assert.Equal("key=value\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Querystring_NamespaceImport_Works(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -220,8 +208,7 @@ public class QuerystringModuleTests
         Assert.Equal("1\nb=2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Querystring_RoundTrip_PreservesData(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ReadlineModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ReadlineModuleTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class ReadlineModuleTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CreateInterface_ReturnsObject(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -26,8 +25,7 @@ public class ReadlineModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Module_HasQuestionSync(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -42,8 +40,7 @@ public class ReadlineModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Module_HasCreateInterface(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -58,8 +55,7 @@ public class ReadlineModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_HasEventEmitterMethods(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -77,8 +73,7 @@ public class ReadlineModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_SetAndGetPrompt(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -95,8 +90,7 @@ public class ReadlineModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_DefaultPrompt(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -112,8 +106,7 @@ public class ReadlineModuleTests
         Assert.Equal("> \n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_Close_EmitsEvent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -132,8 +125,7 @@ public class ReadlineModuleTests
         Assert.Contains("true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_Close_EmitsEvent_WithCount(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -152,8 +144,7 @@ public class ReadlineModuleTests
         Assert.Contains("count: 1", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_PauseResume(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -173,8 +164,7 @@ public class ReadlineModuleTests
         Assert.Contains("ok", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_PauseResume_EmitsEvents(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -196,8 +186,7 @@ public class ReadlineModuleTests
         Assert.Contains("resumed", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_Write(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -213,8 +202,7 @@ public class ReadlineModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_PromptWithCustomPrefix(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -230,8 +218,7 @@ public class ReadlineModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_Question_Exists(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -247,8 +234,7 @@ public class ReadlineModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_MultipleSetPrompt(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -267,8 +253,7 @@ public class ReadlineModuleTests
         Assert.Equal("a> \nb> \n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedImport_CreateInterface(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamModuleTests.cs
@@ -10,8 +10,7 @@ public class StreamModuleTests
 {
     #region Import Patterns
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_NamedImport_Readable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -27,8 +26,7 @@ public class StreamModuleTests
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_NamedImport_Writable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -44,8 +42,7 @@ public class StreamModuleTests
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_NamedImport_All(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -64,8 +61,7 @@ public class StreamModuleTests
         Assert.Equal("function\nfunction\nfunction\nfunction\nfunction\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_NamespaceImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -85,8 +81,7 @@ public class StreamModuleTests
 
     #region Readable Stream
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_Push_Read(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -108,8 +103,7 @@ public class StreamModuleTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_Read_ReturnsNull_WhenEmpty(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -127,8 +121,7 @@ public class StreamModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_Push_Null_SignalsEnd(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -147,8 +140,7 @@ public class StreamModuleTests
         Assert.Equal("false\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_Properties(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -170,8 +162,7 @@ public class StreamModuleTests
         Assert.Equal("true\nfalse\n0\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_Destroy(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -191,8 +182,7 @@ public class StreamModuleTests
         Assert.Equal("false\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_EndEvent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -218,8 +208,7 @@ public class StreamModuleTests
 
     #region Writable Stream
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Writable_Write_WithCallback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -247,8 +236,7 @@ public class StreamModuleTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Writable_Properties(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -273,8 +261,7 @@ public class StreamModuleTests
         Assert.Equal("true\nfalse\nfalse\nfalse\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Writable_FinishEvent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -295,8 +282,7 @@ public class StreamModuleTests
         Assert.Equal("finish event fired\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Writable_Cork_Uncork(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -325,8 +311,7 @@ public class StreamModuleTests
         Assert.Equal("before uncork: 0\nafter uncork: 2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Writable_End_WithChunk(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -353,8 +338,7 @@ public class StreamModuleTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Writable_Final_Callback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -389,8 +373,7 @@ public class StreamModuleTests
 
     #region Pipe
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_Pipe_Writable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -421,8 +404,7 @@ public class StreamModuleTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_Pipe_ReturnsDestination(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -446,8 +428,7 @@ public class StreamModuleTests
 
     #region Duplex Stream
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Duplex_ReadAndWrite(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -479,8 +460,7 @@ public class StreamModuleTests
         Assert.Equal("write: hello\nworld\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Duplex_Properties(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -504,8 +484,7 @@ public class StreamModuleTests
 
     #region Transform Stream
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Transform_BasicTransformation(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -531,8 +510,7 @@ public class StreamModuleTests
         Assert.Equal("HELLO\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Transform_Pipe_Chain(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -574,8 +552,7 @@ public class StreamModuleTests
 
     #region PassThrough Stream
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PassThrough_PassesDataUnchanged(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -598,8 +575,7 @@ public class StreamModuleTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PassThrough_InPipeline(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -636,8 +612,7 @@ public class StreamModuleTests
 
     #region Events
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_CloseEvent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -662,8 +637,7 @@ public class StreamModuleTests
 
     #region Flowing Mode
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_FlowingMode_DataEvent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -689,8 +663,7 @@ public class StreamModuleTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_FlowingMode_EndEvent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -718,8 +691,7 @@ public class StreamModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_FlowingMode_Pause_Resume(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -748,8 +720,7 @@ public class StreamModuleTests
         Assert.Equal("paused: 1\nresumed: 3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_Pipe_EntersFlowingMode(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -780,8 +751,7 @@ public class StreamModuleTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_ReadableFlowing_Property(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -802,8 +772,7 @@ public class StreamModuleTests
         Assert.Equal("false\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_FlowingMode_MultiplePush(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -834,8 +803,7 @@ public class StreamModuleTests
 
     #region Drain
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Writable_WritableHighWaterMark_Property(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -855,8 +823,7 @@ public class StreamModuleTests
 
     #region stream.finished()
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Finished_CallsCallbackAfterReadableEnds(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -876,8 +843,7 @@ public class StreamModuleTests
         Assert.Contains("finished ok", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Finished_CallsCallbackAfterWritableFinishes(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -898,8 +864,7 @@ public class StreamModuleTests
         Assert.Contains("finished ok", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Finished_CallsCallbackWithErrorOnStreamError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -918,8 +883,7 @@ public class StreamModuleTests
         Assert.Contains("error: true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Finished_CleanupRemovesListeners(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -941,8 +905,7 @@ public class StreamModuleTests
         Assert.Contains("done", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Finished_OptionsReadableFalse(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -968,8 +931,7 @@ public class StreamModuleTests
 
     #region stream.pipeline()
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Pipeline_ReadableToWritable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -998,8 +960,7 @@ public class StreamModuleTests
         Assert.Contains("chunks: hello,world", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Pipeline_ReadableTransformWritable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1033,8 +994,7 @@ public class StreamModuleTests
         Assert.Contains("results: HELLO", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Pipeline_ReturnsDestinationStream(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1057,8 +1017,7 @@ public class StreamModuleTests
 
     #region Readable.from()
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_ReadableFrom_ArrayObjectMode(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1079,8 +1038,7 @@ public class StreamModuleTests
         Assert.Contains("1 2 3", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_ReadableFrom_StringArray(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1102,8 +1060,7 @@ public class StreamModuleTests
 
     #region Missing Events
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_PauseEvent_FiresOnPause(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1120,8 +1077,7 @@ public class StreamModuleTests
         Assert.Contains("paused", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_ResumeEvent_FiresOnResume(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1139,8 +1095,7 @@ public class StreamModuleTests
         Assert.Contains("resumed", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_PrefinishEvent_FiresBeforeFinish(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1162,8 +1117,7 @@ public class StreamModuleTests
         Assert.Contains("prefinish,finish", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_AutoDestroy_DestroysAfterEnd(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1191,8 +1145,7 @@ public class StreamModuleTests
 
     #region highWaterMark
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_HighWaterMark_PushReturnsFalse(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1210,8 +1163,7 @@ public class StreamModuleTests
         Assert.Contains("true false", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_HighWaterMark_CustomValue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1231,8 +1183,7 @@ public class StreamModuleTests
         Assert.Contains("true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_HighWaterMark_ObjectModeDefault16(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1254,8 +1205,7 @@ public class StreamModuleTests
         Assert.Contains("16", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Writable_HighWaterMark_WriteReturnsFalse(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1279,8 +1229,7 @@ public class StreamModuleTests
         Assert.Contains("true false", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Writable_HighWaterMark_DrainEvent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1308,8 +1257,7 @@ public class StreamModuleTests
         Assert.Contains("after: true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_ReadableHighWaterMark_Property(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1325,8 +1273,7 @@ public class StreamModuleTests
         Assert.Contains("1024", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_WritableHighWaterMark_Property(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1342,8 +1289,7 @@ public class StreamModuleTests
         Assert.Contains("2048", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Writable_SyncWrite_NeverBackpressures(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1364,8 +1310,7 @@ public class StreamModuleTests
         Assert.Contains("true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Writable_WritableLength_TracksInFlight(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1395,8 +1340,7 @@ public class StreamModuleTests
 
     #region toArray, forEach, isReadable, isWritable
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Readable_ToArray(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1416,8 +1360,7 @@ public class StreamModuleTests
         Assert.Contains("3 1 2 3", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Readable_ForEach(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1437,8 +1380,7 @@ public class StreamModuleTests
         Assert.Contains("a,b", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_IsReadable_IsWritable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1462,8 +1404,7 @@ public class StreamModuleTests
 
     #region map/filter
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Readable_Map(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1493,8 +1434,7 @@ public class StreamModuleTests
         Assert.Contains("2,4,6", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Readable_Filter(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1525,8 +1465,7 @@ public class StreamModuleTests
         Assert.Contains("3,4", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Readable_MapFilter_Chaining(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1559,8 +1498,7 @@ public class StreamModuleTests
 
     // #1026: `Readable.prototype.map` must return a Transform stream, NOT an array — i.e. the
     // call must dispatch to $Readable.Map, not the Array/Iterator map emitter. Verifies parity.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Readable_Map_ReturnsStream_NotArray(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1581,8 +1519,7 @@ public class StreamModuleTests
 
     #region addAbortSignal
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_AddAbortSignal_ReturnsStream(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1600,8 +1537,7 @@ public class StreamModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_AddAbortSignal_DestroysOnAbort(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1623,8 +1559,7 @@ public class StreamModuleTests
         Assert.Equal("error:AbortError,close true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_AddAbortSignal_AlreadyAborted_DestroysImmediately(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1649,8 +1584,7 @@ public class StreamModuleTests
 
     #region Async iteration (Symbol.asyncIterator) — #1024
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_AsyncIterator_SyncProducer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1672,8 +1606,7 @@ public class StreamModuleTests
         Assert.Equal("1,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_AsyncIterator_SlowProducer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1700,8 +1633,7 @@ public class StreamModuleTests
         Assert.Equal("10,20,30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_AsyncIterator_EarlyBreak_Destroys(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1723,8 +1655,7 @@ public class StreamModuleTests
         Assert.Equal("a,b true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_AsyncIterator_ErrorRejects(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1754,8 +1685,7 @@ public class StreamModuleTests
         Assert.Equal("got x\ncaught: boom\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_AsyncIterator_FromArray(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1780,8 +1710,7 @@ public class StreamModuleTests
 
     #region Async iterator helpers (reduce/some/every/find/flatMap/drop/take/asIndexedPairs) — #1025
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_Helper_ReduceSomeEveryFind(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1807,8 +1736,7 @@ public class StreamModuleTests
         Assert.Equal("10\n10\ntrue\nfalse\ntrue\nfalse\n3\nundefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_Helper_DropTake(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1828,8 +1756,7 @@ public class StreamModuleTests
         Assert.Equal("3,4,5\n1,2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_Helper_FlatMap(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1850,8 +1777,7 @@ public class StreamModuleTests
         Assert.Equal("1,10,2,20,3,30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_Helper_AsIndexedPairs(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1876,8 +1802,7 @@ public class StreamModuleTests
 
     #region compose + Duplex.from — #1028
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_Compose_TransformChain(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1899,8 +1824,7 @@ public class StreamModuleTests
         Assert.Equal("A!,B!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_DuplexFrom_Iterable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1925,8 +1849,7 @@ public class StreamModuleTests
 
     #region isErrored + get/setDefaultHighWaterMark + prefinish ordering — #1030
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_IsErrored(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1945,8 +1868,7 @@ public class StreamModuleTests
         Assert.Equal("false\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_DefaultHighWaterMark_GetSet(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1964,8 +1886,7 @@ public class StreamModuleTests
         Assert.Equal("16384\n16\n99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stream_PrefinishFinishOrdering(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1989,8 +1910,7 @@ public class StreamModuleTests
 
     #region Node↔Web conversions (toWeb/fromWeb) — #1029 (interpreter-only documented subset)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Stream_Readable_ToWeb(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -2013,8 +1933,7 @@ public class StreamModuleTests
         Assert.Equal("a,b\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Stream_Readable_FromWeb(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamObjectModeTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamObjectModeTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class StreamObjectModeTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_ObjectMode_PushAndReadObjects(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -31,8 +30,7 @@ public class StreamObjectModeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_ObjectMode_ReadReturnsOneObjectAtATime(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -54,8 +52,7 @@ public class StreamObjectModeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_ObjectMode_ReadableObjectModeProperty(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -73,8 +70,7 @@ public class StreamObjectModeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Writable_ObjectMode_AcceptsObjects(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -102,8 +98,7 @@ public class StreamObjectModeTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Writable_ObjectMode_WritableObjectModeProperty(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -121,8 +116,7 @@ public class StreamObjectModeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Transform_ObjectMode_TransformsObjects(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -147,8 +141,7 @@ public class StreamObjectModeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_ObjectMode_PushArraysAsValues(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -168,8 +161,7 @@ public class StreamObjectModeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readable_ObjectMode_PushNumbers(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -191,8 +183,7 @@ public class StreamObjectModeTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Duplex_ObjectMode_BothSides(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamPromisesTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamPromisesTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class StreamPromisesTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StreamPromises_Import_Pipeline(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -24,8 +23,7 @@ public class StreamPromisesTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StreamPromises_Import_Finished(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -40,8 +38,7 @@ public class StreamPromisesTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StreamPromises_PropertyAccess(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -57,8 +54,7 @@ public class StreamPromisesTests
         Assert.Equal("function\nfunction\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StreamPromises_Pipeline_ReturnsPromise(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -81,8 +77,7 @@ public class StreamPromisesTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StreamPromises_Pipeline_ConnectsStreams(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -104,8 +99,7 @@ public class StreamPromisesTests
         Assert.Contains("function", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StreamPromises_Finished_ReturnsCleanupFunction(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamsWebBasicTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamsWebBasicTests.cs
@@ -15,8 +15,7 @@ public class StreamsWebBasicTests
 {
     #region ReadableStream
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadableStream_ConstructorEnqueueCloseRead(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -46,8 +45,7 @@ public class StreamsWebBasicTests
         Assert.Equal("hello false\nworld false\nundefined true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void ReadableStream_From_ImportedConstructor(ExecutionMode mode)
     {
         // #210: static-property dispatch on the imported constructor wrapper
@@ -78,8 +76,7 @@ public class StreamsWebBasicTests
 
     #region Read result JS semantics (regression: MakeReadResult must behave like a real object)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadResult_ObjectKeys(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -101,8 +98,7 @@ public class StreamsWebBasicTests
         Assert.Equal("value,done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadResult_JsonStringify(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -124,8 +120,7 @@ public class StreamsWebBasicTests
         Assert.Equal("{\"value\":\"hello\",\"done\":false}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadResult_ForInIteration(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -149,8 +144,7 @@ public class StreamsWebBasicTests
         Assert.Equal("done,value\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadResult_ObjectSpread(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -177,8 +171,7 @@ public class StreamsWebBasicTests
 
     #region WritableStream
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadableStream_IsLockedAfterGetReader(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -195,8 +188,7 @@ public class StreamsWebBasicTests
         Assert.Equal("false\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadableStream_DesiredSizeReflectsBackpressure(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -219,8 +211,7 @@ public class StreamsWebBasicTests
         Assert.Equal("2\n1\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadableStream_PullCallbackInvokedOnRead(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -249,8 +240,7 @@ public class StreamsWebBasicTests
         Assert.Equal("0 1 2 true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadableStream_ErrorPropagatesToReader(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -279,8 +269,7 @@ public class StreamsWebBasicTests
         Assert.Contains("boom", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WritableStream_WriteCloseSequence(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -311,8 +300,7 @@ public class StreamsWebBasicTests
 
     #region TransformStream
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TransformStream_BasicTransformViaPipeThrough(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -352,8 +340,7 @@ public class StreamsWebBasicTests
 
     #region pipeTo
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadableStream_PipeToWritable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -387,8 +374,7 @@ public class StreamsWebBasicTests
 
     #region Module import
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StreamWeb_ImportNamedExports(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -415,8 +401,7 @@ public class StreamsWebBasicTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StreamWeb_CountQueuingStrategy(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StreamsWebSemanticTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StreamsWebSemanticTests.cs
@@ -47,8 +47,7 @@ public class StreamsWebSemanticTests
     /// <c>done:true</c> immediately. Fixing requires async state machine
     /// emission.</para>
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void ReadableStream_PendingReadResolvedByLaterEnqueue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -83,8 +82,7 @@ public class StreamsWebSemanticTests
     /// Pull callback returns a Promise that resolves after a tick. Reader
     /// should wait for the pull promise before dequeueing.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadableStream_AsyncPullCallback(ExecutionMode mode)
     {
         // Compiled mode: pure-IL $ReadableStream.Read() now sync-awaits a
@@ -127,8 +125,7 @@ public class StreamsWebSemanticTests
     /// (via <c>EmitUnwrapResultToTask</c>) correctly unwraps a compiled async
     /// function's returned task.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WritableStream_AsyncWriteCallback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -164,8 +161,7 @@ public class StreamsWebSemanticTests
     /// User <c>write(chunk, controller)</c> accesses the second argument.
     /// Tests whether the stream actually passes a controller object.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WritableStream_WriteCallbackReceivesController(ExecutionMode mode)
     {
         // Compiled mode: $WritableStream now instantiates a real
@@ -201,8 +197,7 @@ public class StreamsWebSemanticTests
     /// Concurrent writes (not awaited individually) should be serialized
     /// internally — only one user write callback runs at a time.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void WritableStream_ConcurrentWritesAreSerialized(ExecutionMode mode)
     {
         // KNOWN LIMITATION in compiled mode: the emitted $WritableStream has
@@ -255,8 +250,7 @@ public class StreamsWebSemanticTests
     /// <c>chunk.byteLength</c> (or the strategy's <c>size(chunk)</c>), not by
     /// 1 per chunk.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void ReadableStream_ByteLengthStrategyWeighting(ExecutionMode mode)
     {
         // KNOWN LIMITATION in compiled mode: $ReadableStreamDefaultController.DesiredSize
@@ -299,8 +293,7 @@ public class StreamsWebSemanticTests
     /// lost. Fixed by switching to the eager-drain approach that the pure-IL
     /// emitted <c>$ReadableStream.Tee</c> already used.
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadableStream_Tee_BothBranchesReceiveAllChunks(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -372,8 +365,7 @@ public class StreamsWebSemanticTests
     /// Ref, #325) and <c>EventLoopParkedResumeTests</c> (visible parked-resume
     /// handoff, #1211/#1212).
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void ReadableStream_PipeTo_AbortSignalCancelsSourceAndAbortsDest(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -514,8 +506,7 @@ public class StreamsWebSemanticTests
 
     #region TransformStream controller.terminate
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TransformStream_ControllerTerminateInsideTransform(ExecutionMode mode)
     {
         // Interpreter-side: FIXED. terminate() now closes the readable (per
@@ -565,8 +556,7 @@ public class StreamsWebSemanticTests
 
     #region ReadableStream Symbol.asyncIterator
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void ReadableStream_AsyncIteratorForAwaitOf(ExecutionMode mode)
     {
         // KNOWN LIMITATION in both modes (gap from original review): neither
@@ -618,8 +608,7 @@ public class StreamsWebSemanticTests
     /// is a separate known-broken path (timer-driven async resumption) and
     /// orthogonal to the parking feature being validated here.
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ReadableStream_PendingReadResolvedByLaterEnqueue_Compiled(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -651,8 +640,7 @@ public class StreamsWebSemanticTests
     /// reader drains the pending-reads queue with <c>{value:undefined, done:true}</c>,
     /// not leaving the reader hanging forever.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ReadableStream_PendingReadResolvedByLaterClose_Compiled(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -690,8 +678,7 @@ public class StreamsWebSemanticTests
     /// abort is needed, and issue #22 (timer-callback dispatch of
     /// $PromiseResolveCallback) does not apply.
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ReadableStream_PipeTo_PreAbortedSignal_Compiled(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -746,8 +733,7 @@ public class StreamsWebSemanticTests
     /// the entire sequence runs synchronously on the main thread, so there is
     /// no thread-pool continuation race and the assertion is load-independent.
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ReadableStream_PipeTo_MidPipeAbortSignal_Compiled(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -800,8 +786,7 @@ public class StreamsWebSemanticTests
     /// the chunk flows. The interpreter already handled this via its real async
     /// pump (<c>WebStreamsHelpers.PipeTo</c>).</para>
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReadableStream_PipeTo_PushSourceViaTimer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -835,8 +820,7 @@ public class StreamsWebSemanticTests
     /// <see cref="ReadableStream_PipeTo_AbortSignalCancelsSourceAndAbortsDest"/>),
     /// whereas the compiled pump runs synchronously and is deterministic.
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ReadableStream_PipeTo_PushSourceDelayedAbort_Compiled(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -876,8 +860,7 @@ public class StreamsWebSemanticTests
     /// pump the way a push source read does. CompiledOnly: this is a compiled-pump
     /// gap; the interpreter's async pump already awaits writes.
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ReadableStream_PipeTo_PushStyleWrite_Compiled(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -903,8 +886,7 @@ public class StreamsWebSemanticTests
     /// Verifies that erroring a <c>$ReadableStream</c> that has a parked
     /// reader rejects the pending-reads queue via <c>TrySetException</c>.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void ReadableStream_PendingReadRejectedByLaterError_Compiled(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -941,8 +923,7 @@ public class StreamsWebSemanticTests
     /// must return Promise objects usable with <c>.then()</c>/<c>.catch()</c>,
     /// not raw Tasks whose property access throws.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void ReadableStreamReader_ReadAndClosed_AreThenable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -965,8 +946,7 @@ public class StreamsWebSemanticTests
     /// #223 audit follow-through: writer <c>write()</c>/<c>close()</c>/<c>ready</c>/
     /// <c>closed</c> must be thenable Promise objects as well.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void WritableStreamWriter_WriteReadyClosed_AreThenable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/StringDecoderModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/StringDecoderModuleTests.cs
@@ -10,8 +10,7 @@ public class StringDecoderModuleTests
 {
     #region Import Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringDecoder_Import_Named(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -26,8 +25,7 @@ public class StringDecoderModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringDecoder_Import_Namespace(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -46,8 +44,7 @@ public class StringDecoderModuleTests
 
     #region Constructor Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringDecoder_Constructor_DefaultEncoding(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -63,8 +60,7 @@ public class StringDecoderModuleTests
         Assert.Equal("utf8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringDecoder_Constructor_Utf8Encoding(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -80,8 +76,7 @@ public class StringDecoderModuleTests
         Assert.Equal("utf8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringDecoder_Constructor_Latin1Encoding(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -101,8 +96,7 @@ public class StringDecoderModuleTests
 
     #region Write Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringDecoder_Write_SimpleAscii(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -120,8 +114,7 @@ public class StringDecoderModuleTests
         Assert.Equal("Hello, World!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringDecoder_Write_Utf8(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -143,8 +136,7 @@ public class StringDecoderModuleTests
 
     #region End Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringDecoder_End_NoArgument(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -163,8 +155,7 @@ public class StringDecoderModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringDecoder_End_WithBuffer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -186,8 +177,7 @@ public class StringDecoderModuleTests
 
     #region Chained Writes Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringDecoder_Write_MultipleChunks(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/TimersModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/TimersModuleTests.cs
@@ -11,8 +11,7 @@ public class TimersModuleTests
 {
     #region Import Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timers_Import_Namespace(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -33,8 +32,7 @@ public class TimersModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timers_Import_Named(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -54,8 +52,7 @@ public class TimersModuleTests
 
     #region setTimeout Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timers_SetTimeout_ReturnsHandle(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -72,8 +69,7 @@ public class TimersModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timers_SetTimeout_ExecutesCallback_Interpreted(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -93,8 +89,7 @@ public class TimersModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timers_SetTimeout_ExecutesCallback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -114,8 +109,7 @@ public class TimersModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timers_ClearTimeout_CancelsCallback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -140,8 +134,7 @@ public class TimersModuleTests
 
     #region setInterval Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timers_SetInterval_ReturnsHandle(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -163,8 +156,7 @@ public class TimersModuleTests
 
     #region setImmediate Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timers_SetImmediate_ReturnsHandle(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -181,8 +173,7 @@ public class TimersModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timers_SetImmediate_ExecutesCallback_Interpreted(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -202,8 +193,7 @@ public class TimersModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timers_SetImmediate_ExecutesCallback_Compiled(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -223,8 +213,7 @@ public class TimersModuleTests
         Assert.Contains("done", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timers_ClearImmediate_CancelsCallback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -252,8 +241,7 @@ public class TimersModuleTests
     // Regression for #1149: the timers facade forwards `...args` to the primitive
     // instead of hand-unrolling an arity ladder, so more than 8 trailing args now
     // survive in both interpreter and compiled modes (the old ladder capped at 8).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timers_SetTimeout_ForwardsBeyondEightArgs(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -275,8 +263,7 @@ public class TimersModuleTests
     }
 
     // Regression for #1149: setImmediate forwards a caller-side spread (`...payload`).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timers_SetImmediate_ForwardsCallerSpread(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/TimersPromisesModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/TimersPromisesModuleTests.cs
@@ -11,8 +11,7 @@ public class TimersPromisesModuleTests
 {
     #region Import Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_Import_Namespace(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -30,8 +29,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_Import_Named(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -47,8 +45,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_Import_NodePrefix(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -67,8 +64,7 @@ public class TimersPromisesModuleTests
 
     #region setTimeout Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetTimeout_ReturnsPromise(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -84,8 +80,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetTimeout_ResolvesWithValue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -104,8 +99,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetTimeout_ResolvesWithNumericValue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -124,8 +118,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetTimeout_DefaultValue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -144,8 +137,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetTimeout_ZeroDelay(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -164,8 +156,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("immediate\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetTimeout_ThenChaining(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -186,8 +177,7 @@ public class TimersPromisesModuleTests
 
     #region setImmediate Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetImmediate_ReturnsPromise(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -203,8 +193,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetImmediate_ResolvesWithValue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -223,8 +212,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("quick\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetImmediate_DefaultValue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -247,8 +235,7 @@ public class TimersPromisesModuleTests
 
     #region Multiple Timers
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_MultipleSetTimeout_Sequential(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -269,8 +256,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("first\nsecond\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetTimeout_MixedWithSetImmediate(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -295,8 +281,7 @@ public class TimersPromisesModuleTests
 
     #region setInterval AsyncIterable Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetInterval_ForAwaitOf_Basic(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -320,8 +305,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("tick\ntick\ntick\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetInterval_ForAwaitOf_NumericValue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -344,8 +328,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetInterval_ForAwaitOf_BreakCleanup(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -366,8 +349,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("after break\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetInterval_ForAwaitOf_DefaultValue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -392,8 +374,7 @@ public class TimersPromisesModuleTests
 
     #region AbortSignal Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetTimeout_AbortSignal_PreAborted(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -419,8 +400,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("AbortError: The operation was aborted\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetImmediate_AbortSignal_PreAborted(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -446,8 +426,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("AbortError: The operation was aborted\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetInterval_AbortSignal_PreAborted(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -475,8 +454,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("AbortError: The operation was aborted\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetTimeout_AbortSignal_MidDelay(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -506,8 +484,7 @@ public class TimersPromisesModuleTests
         Assert.Equal("caught\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TimersPromises_SetInterval_AbortSignal_MidIteration(ExecutionMode mode)
     {
         // Aborts the signal from within the loop after 3 iterations.

--- a/SharpTS.Tests/SharedTests/BuiltInModules/TtyModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/TtyModuleTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class TtyModuleTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Tty_Isatty_ReturnsBoolean(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -24,8 +23,7 @@ public class TtyModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Tty_Isatty_InvalidFd_ReturnsFalse(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -39,8 +37,7 @@ public class TtyModuleTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Tty_Isatty_TypeofIsFunction(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -54,8 +51,7 @@ public class TtyModuleTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Tty_Isatty_NamedImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -70,8 +66,7 @@ public class TtyModuleTests
         Assert.Equal("function\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Tty_Isatty_Cjs_Require(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/UrlModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/UrlModuleTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class UrlModuleTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Url_Parse_ParsesFullUrl(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -31,8 +30,7 @@ public class UrlModuleTests
         Assert.Contains("/path", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Url_Parse_ParsesQueryString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -50,8 +48,7 @@ public class UrlModuleTests
         Assert.Contains("foo=bar", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Url_Parse_ParsesHash(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -67,8 +64,7 @@ public class UrlModuleTests
         Assert.Contains("#section", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Url_Parse_HandlesDefaultPort(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -86,8 +82,7 @@ public class UrlModuleTests
         Assert.Contains("example.com", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Url_Format_CreatesUrlString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -108,8 +103,7 @@ public class UrlModuleTests
         Assert.Contains("https://example.com/path?key=value", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Url_Format_HandlesPort(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -130,8 +124,7 @@ public class UrlModuleTests
         Assert.Contains("localhost:3000", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Url_Resolve_ResolvesRelativeUrl(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -147,8 +140,7 @@ public class UrlModuleTests
         Assert.Contains("example.com/other/path", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Url_Resolve_ResolvesAbsoluteUrl(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -164,8 +156,7 @@ public class UrlModuleTests
         Assert.Contains("example.com/absolute", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Url_Resolve_KeepsFullUrl(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -181,8 +172,7 @@ public class UrlModuleTests
         Assert.Contains("other.com/path", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Url_NamespaceImport_Works(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -201,8 +191,7 @@ public class UrlModuleTests
         Assert.Contains("true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Url_ParseFormat_RoundTrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -222,8 +211,7 @@ public class UrlModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Url_Parse_HandlesHttpProtocol(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -245,8 +233,7 @@ public class UrlModuleTests
         Assert.Contains("/api/users", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Url_Parse_HandlesFileProtocol(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/UtilFormattingTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/UtilFormattingTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class UtilFormattingTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StyleText_SingleFormat_WrapsInAnsiCodes(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -30,8 +29,7 @@ public class UtilFormattingTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StyleText_ArrayOfFormats_Nests(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -48,8 +46,7 @@ public class UtilFormattingTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StyleText_InvalidFormat_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -69,8 +66,7 @@ public class UtilFormattingTests
         Assert.Equal("threw\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FormatWithOptions_InspectsObject(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -85,8 +81,7 @@ public class UtilFormattingTests
         Assert.Equal("{ a: 1 }\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetSystemErrorMessage_ReturnsDescription(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -102,8 +97,7 @@ public class UtilFormattingTests
         Assert.Equal("ENOENT\nno such file or directory\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Debuglog_SectionOff_IsNoOp(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -121,8 +115,7 @@ public class UtilFormattingTests
         Assert.Equal("enabled:false\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Inspect_DepthOption_LimitsRecursion(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -137,8 +130,7 @@ public class UtilFormattingTests
         Assert.Equal("{ a: [Object] }\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Inspect_MaxArrayLength_Truncates(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -153,8 +145,7 @@ public class UtilFormattingTests
         Assert.Equal("[ 1, 2, ... 3 more items ]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Inspect_Colors_AppliesAnsi(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -169,8 +160,7 @@ public class UtilFormattingTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Inspect_CustomHook_ControlsOutput(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/UtilModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/UtilModuleTests.cs
@@ -15,8 +15,7 @@ public class UtilModuleTests
 {
     #region Format Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Format_StringPlaceholder(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -32,8 +31,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Format_NumberPlaceholder(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -49,8 +47,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Format_FloatPlaceholder(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -66,8 +63,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Format_MultiplePlaceholders(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -83,8 +79,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Format_ExtraArguments(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -100,8 +95,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Format_EscapedPercent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -122,8 +116,7 @@ public class UtilModuleTests
 
     #region Inspect Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Inspect_ReturnsString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -139,8 +132,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Inspect_ObjectContent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -157,8 +149,7 @@ public class UtilModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Inspect_ArrayContent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -180,8 +171,7 @@ public class UtilModuleTests
 
     #region Types Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsArray_True(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -196,8 +186,7 @@ public class UtilModuleTests
         Assert.Contains("true", output.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsArray_False(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -213,8 +202,7 @@ public class UtilModuleTests
         Assert.Equal("false\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsFunction_True(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -229,8 +217,7 @@ public class UtilModuleTests
         Assert.Contains("true", output.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsFunction_False(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -246,8 +233,7 @@ public class UtilModuleTests
         Assert.Equal("false\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsNull_True(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -262,8 +248,7 @@ public class UtilModuleTests
         Assert.Contains("true", output.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsNull_False(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -280,8 +265,7 @@ public class UtilModuleTests
         Assert.Equal("false\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsUndefined_True(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -296,8 +280,7 @@ public class UtilModuleTests
         Assert.Contains("true", output.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsUndefined_False(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -313,8 +296,7 @@ public class UtilModuleTests
         Assert.Equal("false\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsPromise_True(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -330,8 +312,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsPromise_False(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -347,8 +328,7 @@ public class UtilModuleTests
         Assert.Equal("false\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsRegExp_True(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -364,8 +344,7 @@ public class UtilModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsRegExp_False(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -381,8 +360,7 @@ public class UtilModuleTests
         Assert.Equal("false\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsMap_True(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -397,8 +375,7 @@ public class UtilModuleTests
         Assert.Contains("true", output.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsMap_False(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -414,8 +391,7 @@ public class UtilModuleTests
         Assert.Equal("false\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsSet_True(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -430,8 +406,7 @@ public class UtilModuleTests
         Assert.Contains("true", output.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsSet_False(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -448,8 +423,7 @@ public class UtilModuleTests
         Assert.Equal("false\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsTypedArray_True(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -465,8 +439,7 @@ public class UtilModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsTypedArray_False(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -482,8 +455,7 @@ public class UtilModuleTests
         Assert.Equal("false\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsDate_True(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -498,8 +470,7 @@ public class UtilModuleTests
         Assert.Contains("true", output.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsDate_False(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -514,8 +485,7 @@ public class UtilModuleTests
         Assert.Contains("false", output.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsNativeError_True(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -530,8 +500,7 @@ public class UtilModuleTests
         Assert.Contains("true", output.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsNativeError_False(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -547,8 +516,7 @@ public class UtilModuleTests
         Assert.Equal("false\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsBoxedPrimitive_False(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -564,8 +532,7 @@ public class UtilModuleTests
         Assert.Equal("false\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsWeakMap_True(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -580,8 +547,7 @@ public class UtilModuleTests
         Assert.Contains("true", output.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsWeakMap_False(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -596,8 +562,7 @@ public class UtilModuleTests
         Assert.Contains("false", output.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsWeakSet_False_ForSet(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -612,8 +577,7 @@ public class UtilModuleTests
         Assert.Contains("false", output.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsArrayBuffer_True(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -628,8 +592,7 @@ public class UtilModuleTests
         Assert.Contains("true", output.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsArrayBuffer_False(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -648,8 +611,7 @@ public class UtilModuleTests
 
     #region Deprecate Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Deprecate_ReturnsWrappedFunction(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -667,8 +629,7 @@ public class UtilModuleTests
         Assert.Contains("true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Deprecate_WarnsOnFirstCallOnly(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -692,8 +653,7 @@ public class UtilModuleTests
 
     #region Callbackify Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Callbackify_CallsCallbackWithResult(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -713,8 +673,7 @@ public class UtilModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Callbackify_CallsCallbackWithErrorOnThrow(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -738,8 +697,7 @@ public class UtilModuleTests
 
     #region Promisify Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promisify_ReturnsPromise(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -759,8 +717,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promisify_ResolvesWithValue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -783,8 +740,7 @@ public class UtilModuleTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promisify_RejectsOnError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -811,8 +767,7 @@ public class UtilModuleTests
         Assert.Equal("caught error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promisify_PassesArgumentsToOriginalFunction(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -839,8 +794,7 @@ public class UtilModuleTests
 
     #region Inherits Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Inherits_SetsSuperProperty(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -862,8 +816,7 @@ public class UtilModuleTests
 
     #region TextEncoder Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TextEncoder_EncodingPropertyIsUtf8(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -879,8 +832,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TextEncoder_EncodesUnicodeCorrectly(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -901,8 +853,7 @@ public class UtilModuleTests
 
     #region TextDecoder Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TextDecoder_DefaultEncodingIsUtf8(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -918,8 +869,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TextDecoder_DecodesUtf8Buffer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -937,8 +887,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TextEncoder_TextDecoder_RoundTrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -962,8 +911,7 @@ public class UtilModuleTests
 
     #region IsDeepStrictEqual Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsDeepStrictEqual_PrimitivesEqual(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -980,8 +928,7 @@ public class UtilModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsDeepStrictEqual_PrimitivesNotEqual(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -998,8 +945,7 @@ public class UtilModuleTests
         Assert.Equal("false\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsDeepStrictEqual_NaNEqualsNaN(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1014,8 +960,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsDeepStrictEqual_ArraysEqual(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1031,8 +976,7 @@ public class UtilModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsDeepStrictEqual_ArraysNotEqual(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1047,8 +991,7 @@ public class UtilModuleTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsDeepStrictEqual_ObjectsEqual(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1064,8 +1007,7 @@ public class UtilModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsDeepStrictEqual_ObjectsNotEqual(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1084,8 +1026,7 @@ public class UtilModuleTests
 
     #region ParseArgs Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ParseArgs_BooleanOption(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1106,8 +1047,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ParseArgs_StringOption(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1128,8 +1068,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ParseArgs_ShortOption(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1150,8 +1089,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ParseArgs_Positionals(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1175,8 +1113,7 @@ public class UtilModuleTests
 
     #region ToUSVString Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ToUSVString_RegularString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1191,8 +1128,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ToUSVString_Emoji(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1208,8 +1144,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ToUSVString_LoneSurrogate(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1230,8 +1165,7 @@ public class UtilModuleTests
 
     #region StripVTControlCharacters Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StripVTControlCharacters_RemovesAnsiColors(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1247,8 +1181,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StripVTControlCharacters_PreservesPlainText(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1268,8 +1201,7 @@ public class UtilModuleTests
 
     #region GetSystemErrorName Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetSystemErrorName_ReturnsENOENT(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1284,8 +1216,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetSystemErrorName_ReturnsEACCES(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1300,8 +1231,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetSystemErrorName_ReturnsEPERM(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1320,8 +1250,7 @@ public class UtilModuleTests
 
     #region GetSystemErrorMap Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetSystemErrorMap_ReturnsMap(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1338,8 +1267,7 @@ public class UtilModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetSystemErrorMap_ContainsENOENT(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1362,8 +1290,7 @@ public class UtilModuleTests
 
     #region Interpreted-Only Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Typeof_BuiltInMethod_ReturnsFunction(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1380,8 +1307,7 @@ public class UtilModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsFunction_AllTypes(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1402,8 +1328,7 @@ public class UtilModuleTests
         Assert.Equal("true\ntrue\ntrue\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_IsWeakSet_True(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1418,8 +1343,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TextDecoder_SupportsLatin1(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1438,8 +1362,7 @@ public class UtilModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TextDecoder_SupportsUtf16le(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1455,8 +1378,7 @@ public class UtilModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ParseArgs_OptionTerminator(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1479,8 +1401,7 @@ public class UtilModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ParseArgs_MultipleValues(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1638,8 +1559,7 @@ public class UtilModuleTests
 
     #endregion
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Util_DefaultImport_ExposesNamespace(ExecutionMode mode)
     {
         // #66: default import from `node:util` needs to yield the namespace

--- a/SharpTS.Tests/SharedTests/BuiltInModules/UtilTypesHelpersTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/UtilTypesHelpersTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests.BuiltInModules;
 /// </summary>
 public class UtilTypesHelpersTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Types_ExpandedPredicates(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -34,8 +33,7 @@ public class UtilTypesHelpersTests
         Assert.Equal("true\ntrue\ntrue\ntrue\nfalse\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MIMEType_Parses(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -56,8 +54,7 @@ public class UtilTypesHelpersTests
         Assert.Equal("text\nhtml\ntext/html\nutf-8\ntrue\ntext/html;charset=utf-8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MIMEParams_SetGetDelete(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -78,8 +75,7 @@ public class UtilTypesHelpersTests
         Assert.Equal("1\nnull\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Aborted_ResolvesOnAbort(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -100,8 +96,7 @@ public class UtilTypesHelpersTests
         Assert.Equal("resolved\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Aborted_AlreadyAborted_ResolvesImmediately(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -122,8 +117,7 @@ public class UtilTypesHelpersTests
         Assert.Equal("resolved\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ParseEnv_ParsesDotenv(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -141,8 +135,7 @@ public class UtilTypesHelpersTests
         Assert.Equal("bar\nqux\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LegacyAliases_Work(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -167,8 +160,7 @@ public class UtilTypesHelpersTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n{\"a\":1,\"b\":2}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetCallSites_ReturnsArray(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/VmModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/VmModuleTests.cs
@@ -26,8 +26,7 @@ public class VmModuleTests
 {
     #region Import Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_Import_Namespace(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -44,8 +43,7 @@ public class VmModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_Import_Named(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -66,8 +64,7 @@ public class VmModuleTests
 
     #region runInNewContext Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_RunInNewContext_BasicExpression(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -83,8 +80,7 @@ public class VmModuleTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_RunInNewContext_MultiStatement(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -100,8 +96,7 @@ public class VmModuleTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_RunInNewContext_ContextSeeding(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -117,8 +112,7 @@ public class VmModuleTests
         Assert.Equal("30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_RunInNewContext_ContextMutation(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -135,8 +129,7 @@ public class VmModuleTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_RunInNewContext_Isolation(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -158,8 +151,7 @@ public class VmModuleTests
         Assert.Equal("isolated\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_RunInNewContext_WithConsoleLog(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -174,8 +166,7 @@ public class VmModuleTests
         Assert.Equal("hello from vm\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_RunInNewContext_EmptyCode(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -195,8 +186,7 @@ public class VmModuleTests
 
     #region runInThisContext Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Vm_RunInThisContext_SharesScope(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -217,8 +207,7 @@ public class VmModuleTests
 
     #region createContext / isContext Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CreateContext_IsContext(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -236,8 +225,7 @@ public class VmModuleTests
         Assert.Equal("false\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CreateContext_Empty(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -258,8 +246,7 @@ public class VmModuleTests
 
     #region runInContext (module-level) / constants Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_RunInContext_Basic(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -275,8 +262,7 @@ public class VmModuleTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_RunInContext_WritesBack(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -293,8 +279,7 @@ public class VmModuleTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_RunInContext_NonContext_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -314,8 +299,7 @@ public class VmModuleTests
         Assert.Equal("caught error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_Constants_Exist(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -335,8 +319,7 @@ public class VmModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Vm_Constants_AreSymbols(ExecutionMode mode)
     {
         // typeof reports 'symbol' in the interpreter; compiled-mode typeof of a
@@ -359,8 +342,7 @@ public class VmModuleTests
 
     #region createContext options + measureMemory Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CreateContext_MicrotaskMode_AfterEvaluate(ExecutionMode mode)
     {
         // With microtaskMode:'afterEvaluate', the queued .then microtask runs before
@@ -379,8 +361,7 @@ public class VmModuleTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CreateContext_CodeGeneration_StringsFalse_BlocksEval(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -401,8 +382,7 @@ public class VmModuleTests
         Assert.Equal("blocked\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CreateContext_CodeGeneration_Default_AllowsEval(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -418,8 +398,7 @@ public class VmModuleTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CreateContext_NameOrigin_Accepted(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -435,8 +414,7 @@ public class VmModuleTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_MeasureMemory_ResolvesShape(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -456,8 +434,7 @@ public class VmModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Vm_MeasureMemory_RangeIsArray(ExecutionMode mode)
     {
         // jsMemoryRange is a 2-element Array; Array.isArray/.length only fully recognize it
@@ -484,8 +461,7 @@ public class VmModuleTests
 
     #region Script Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_Script_RunInNewContext(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -504,8 +480,7 @@ public class VmModuleTests
         Assert.Equal("3\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Vm_Script_RunInThisContext(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -523,8 +498,7 @@ public class VmModuleTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_Script_RunInContext(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -542,8 +516,7 @@ public class VmModuleTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_Script_MultipleRuns(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -565,8 +538,7 @@ public class VmModuleTests
 
     #region Script/compileFunction options + cachedData Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_Script_Filename_InSyntaxError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -586,8 +558,7 @@ public class VmModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_Script_OffsetsAndDisplayErrors_Accepted(ExecutionMode mode)
     {
         // filename/lineOffset/columnOffset/displayErrors are honored without altering
@@ -607,8 +578,7 @@ public class VmModuleTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_Script_CreateCachedData_ReturnsValue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -625,8 +595,7 @@ public class VmModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Vm_Script_CreateCachedData_IsBuffer(ExecutionMode mode)
     {
         // The marker is a real Buffer; Buffer.isBuffer/length only recognize it within
@@ -647,8 +616,7 @@ public class VmModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_Script_ProduceCachedData(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -665,8 +633,7 @@ public class VmModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_Script_CachedData_RoundTrips_NotRejected(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -684,8 +651,7 @@ public class VmModuleTests
         Assert.Equal("false\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Vm_Script_Filename_InTimeoutErrorStack(ExecutionMode mode)
     {
         // The origin frame is attached to errors that propagate as a live guest error
@@ -710,8 +676,7 @@ public class VmModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CompileFunction_Filename_InSyntaxError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -735,8 +700,7 @@ public class VmModuleTests
 
     #region SourceTextModule (ESM-in-vm) Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_SourceTextModule_LinkEvaluate_ImportsDependency(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -760,8 +724,7 @@ public class VmModuleTests
         Assert.Equal("43\nhi42\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_SourceTextModule_StatusTransitions(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -784,8 +747,7 @@ public class VmModuleTests
         Assert.Equal("unlinked\nlinked\nevaluated\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_SourceTextModule_DependencySpecifiers_Count(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -801,8 +763,7 @@ public class VmModuleTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Vm_SourceTextModule_DependencySpecifiers_Indexing(ExecutionMode mode)
     {
         // dependencySpecifiers is an Array; element indexing is observable within the
@@ -822,8 +783,7 @@ public class VmModuleTests
         Assert.Equal("x\ny\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_SourceTextModule_LinkerError_SetsErrored(ExecutionMode mode)
     {
         // The error path is exercised synchronously (link/evaluate complete synchronously in
@@ -846,8 +806,7 @@ public class VmModuleTests
         Assert.Equal("errored\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_SourceTextModule_DefaultExport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -873,8 +832,7 @@ public class VmModuleTests
 
     #region SyntheticModule Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_SyntheticModule_ImportedBySourceTextModule_LiveBinding(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -902,8 +860,7 @@ public class VmModuleTests
         Assert.Equal("43\nhello!\n42\nevaluated\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_SyntheticModule_SetExportBeforeLink_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -928,8 +885,7 @@ public class VmModuleTests
 
     #region importModuleDynamically Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_Script_ImportModuleDynamically_ResolvesViaHook(ExecutionMode mode)
     {
         // The result of the in-vm dynamic import is written back to a context scalar to
@@ -954,8 +910,7 @@ public class VmModuleTests
         Assert.Equal("123\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_Script_ImportModuleDynamically_UseMainContextDefaultLoader_Accepted(ExecutionMode mode)
     {
         // Passing the USE_MAIN_CONTEXT_DEFAULT_LOADER sentinel falls back to the default
@@ -979,8 +934,7 @@ public class VmModuleTests
 
     #region Error Handling Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_RunInNewContext_SyntaxError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1000,8 +954,7 @@ public class VmModuleTests
         Assert.Equal("caught error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_RunInNewContext_RuntimeError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1025,8 +978,7 @@ public class VmModuleTests
 
     #region Context Functions Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_RunInNewContext_FunctionInContext(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1049,8 +1001,7 @@ public class VmModuleTests
 
     #region compileFunction Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CompileFunction_BasicReturn(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1066,8 +1017,7 @@ public class VmModuleTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CompileFunction_WithParams(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1083,8 +1033,7 @@ public class VmModuleTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CompileFunction_NoParams(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1100,8 +1049,7 @@ public class VmModuleTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CompileFunction_MultiStatement(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1117,8 +1065,7 @@ public class VmModuleTests
         Assert.Equal("30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CompileFunction_Reusable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1136,8 +1083,7 @@ public class VmModuleTests
         Assert.Equal("9\n25\n49\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CompileFunction_ConsoleLog(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1153,8 +1099,7 @@ public class VmModuleTests
         Assert.Equal("from compiled fn\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CompileFunction_SyntaxError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1174,8 +1119,7 @@ public class VmModuleTests
         Assert.Equal("caught error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CompileFunction_NamespaceImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1191,8 +1135,7 @@ public class VmModuleTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CompileFunction_ParsingContext(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1209,8 +1152,7 @@ public class VmModuleTests
         Assert.Equal("50\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CompileFunction_ContextExtensions(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1228,8 +1170,7 @@ public class VmModuleTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Vm_CompileFunction_ContextWithFunction(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1250,8 +1191,7 @@ public class VmModuleTests
 
     #region timeout
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Vm_RunInNewContext_Timeout_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1271,8 +1211,7 @@ public class VmModuleTests
         Assert.Contains("caught:Script execution timed out", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Vm_RunInNewContext_NoTimeout_Completes(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1288,8 +1227,7 @@ public class VmModuleTests
         Assert.Contains("4950", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Vm_RunInThisContext_Timeout_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1309,8 +1247,7 @@ public class VmModuleTests
         Assert.Contains("caught:Script execution timed out", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Vm_Script_RunInNewContext_Timeout_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInModules/ZlibModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInModules/ZlibModuleTests.cs
@@ -11,8 +11,7 @@ public class ZlibModuleTests
 {
     #region Gzip Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Gzip_RoundTrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -30,8 +29,7 @@ public class ZlibModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Gzip_CompressesData(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -48,8 +46,7 @@ public class ZlibModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Gzip_StringInput(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -66,8 +63,7 @@ public class ZlibModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Gzip_WithLevel(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -95,8 +91,7 @@ public class ZlibModuleTests
 
     #region Deflate Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Deflate_RoundTrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -114,8 +109,7 @@ public class ZlibModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_DeflateRaw_RoundTrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -133,8 +127,7 @@ public class ZlibModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Deflate_CompressesData(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -155,8 +148,7 @@ public class ZlibModuleTests
 
     #region Brotli Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Brotli_RoundTrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -174,8 +166,7 @@ public class ZlibModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Brotli_CompressesData(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -192,8 +183,7 @@ public class ZlibModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Brotli_LargeData(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -216,8 +206,7 @@ public class ZlibModuleTests
 
     #region Zstd Tests (Interpreter Only - requires ZstdSharp.dll for compiled)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Zstd_RoundTrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -235,8 +224,7 @@ public class ZlibModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Zstd_CompressesData(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -253,8 +241,7 @@ public class ZlibModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Zstd_LargeData(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -277,8 +264,7 @@ public class ZlibModuleTests
 
     #region Unzip (Auto-Detect) Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Unzip_DetectsGzip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -296,8 +282,7 @@ public class ZlibModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Unzip_DetectsDeflate(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -319,8 +304,7 @@ public class ZlibModuleTests
 
     #region Constants Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Constants_CompressionLevels(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -338,8 +322,7 @@ public class ZlibModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Constants_Strategies(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -358,8 +341,7 @@ public class ZlibModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Constants_ReturnCodes(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -376,8 +358,7 @@ public class ZlibModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Constants_Brotli_Extended(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -396,8 +377,7 @@ public class ZlibModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Constants_Brotli_Basic(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -414,8 +394,7 @@ public class ZlibModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Constants_Zstd(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -436,8 +415,7 @@ public class ZlibModuleTests
 
     #region Return Type Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_ReturnsBuffer_Full(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -457,8 +435,7 @@ public class ZlibModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_ReturnsBuffer_Basic(ExecutionMode mode)
     {
         // Note: zstdCompressSync and deflateRawSync excluded due to deployment requirements
@@ -481,8 +458,7 @@ public class ZlibModuleTests
 
     #region Empty Input Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_EmptyInput(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -509,8 +485,7 @@ public class ZlibModuleTests
 
     #region Binary Data Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_BinaryData(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -545,8 +520,7 @@ public class ZlibModuleTests
 
     #region Named Import Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_NamedImports(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -569,8 +543,7 @@ public class ZlibModuleTests
 
     #region Streaming API Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_CreateGzip_WriteAndRead(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -599,8 +572,7 @@ public class ZlibModuleTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_CreateDeflate_WriteAndVerify(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -629,8 +601,7 @@ public class ZlibModuleTests
         Assert.Equal("compressed data\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_CreateBrotliCompress_WriteAndVerify(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -659,8 +630,7 @@ public class ZlibModuleTests
         Assert.Equal("brotli test data\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_CreateGzip_WriteAndCollect(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -691,8 +661,7 @@ public class ZlibModuleTests
         Assert.Equal("streaming compression\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_CreateDeflateRaw_WriteAndVerify(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -721,8 +690,7 @@ public class ZlibModuleTests
         Assert.Equal("raw deflate test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_CreateUnzip_AutoDetectsGzip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -756,8 +724,7 @@ public class ZlibModuleTests
 
     #region Async Callback API Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Gzip_Async_Callback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -781,8 +748,7 @@ public class ZlibModuleTests
         Assert.Equal("async gzip test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Deflate_Async_Callback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -805,8 +771,7 @@ public class ZlibModuleTests
         Assert.Equal("async deflate\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_BrotliCompress_Async_Callback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -833,8 +798,7 @@ public class ZlibModuleTests
 
     #region Named Import Tests for Streaming APIs
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_NamedImport_CreateGzip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -867,8 +831,7 @@ public class ZlibModuleTests
 
     #region crc32 / codes / constants (#1162)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Crc32_KnownValue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -884,8 +847,7 @@ public class ZlibModuleTests
         Assert.Equal("907060870\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Crc32_EmptyIsZero(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -900,8 +862,7 @@ public class ZlibModuleTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Crc32_RunningValueChains(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -920,8 +881,7 @@ public class ZlibModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Crc32_NamedImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -936,8 +896,7 @@ public class ZlibModuleTests
         Assert.Equal("907060870\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Codes_Bidirectional(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -956,8 +915,7 @@ public class ZlibModuleTests
         Assert.Equal("0\n1\n-3\nZ_OK\nZ_DATA_ERROR\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Constants_Completeness(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -981,8 +939,7 @@ public class ZlibModuleTests
 
     #region Compression options (#1163)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Deflate_LevelExtremesRoundTrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1003,8 +960,7 @@ public class ZlibModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Deflate_StrategyRoundTrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1021,8 +977,7 @@ public class ZlibModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Brotli_QualityExtremesDifferAndRoundTrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1047,8 +1002,7 @@ public class ZlibModuleTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Brotli_WindowRoundTrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1070,8 +1024,7 @@ public class ZlibModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Deflate_DictionaryRoundTrip(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1091,8 +1044,7 @@ public class ZlibModuleTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_MaxOutputLength_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1119,8 +1071,7 @@ public class ZlibModuleTests
 
     #region Stream control methods (#1164)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Stream_FlushAndCounters(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1147,8 +1098,7 @@ public class ZlibModuleTests
         Assert.Equal("flushed\ntrue\n17\n17\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Stream_Close(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1165,8 +1115,7 @@ public class ZlibModuleTests
         Assert.Equal("close-event\nclose-cb\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Stream_Reset(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1197,8 +1146,7 @@ public class ZlibModuleTests
 
     #region Facade Tests (stdlib/node/zlib.ts over primitive:zlib)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Async_BadInput_InvokesErrorCallback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1218,8 +1166,7 @@ public class ZlibModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_Codes_BidirectionalMapping(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1236,8 +1183,7 @@ public class ZlibModuleTests
         Assert.Equal("-3\nZ_DATA_ERROR\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Zlib_NamedImports_ThroughFacade(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/BuiltInSingletonValueFormTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInSingletonValueFormTests.cs
@@ -16,8 +16,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class BuiltInSingletonValueFormTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_AsValue_MethodsDispatch(ExecutionMode mode)
     {
         var source = @"
@@ -32,8 +31,7 @@ public class BuiltInSingletonValueFormTests
         Assert.Equal("function\n2\n3\n3\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Json_AsValue_MethodsDispatch(ExecutionMode mode)
     {
         var source = @"
@@ -46,8 +44,7 @@ public class BuiltInSingletonValueFormTests
         Assert.Equal("function\n{\"a\":1}\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_AsValue_MethodIdentityIsStable(ExecutionMode mode)
     {
         // The value-form wrapper must be the same identity-cached method the bare
@@ -64,8 +61,7 @@ public class BuiltInSingletonValueFormTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_AsValue_MethodsAreNonEnumerable(ExecutionMode mode)
     {
         // Math's methods are non-enumerable per ECMA-262 §17, so `Object.keys(Math)`
@@ -80,8 +76,7 @@ public class BuiltInSingletonValueFormTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Json_StaticMethodIdentityIsStable(ExecutionMode mode)
     {
         // #299: JSON.parse / JSON.stringify are single built-in function objects
@@ -96,8 +91,7 @@ public class BuiltInSingletonValueFormTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void Math_ValuesAndEntriesExcludeNonEnumerableBuiltIns(ExecutionMode mode)
     {
         // #298: Object.values/entries must apply the same own-enumerable filter
@@ -115,8 +109,7 @@ public class BuiltInSingletonValueFormTests
         Assert.Equal("1\n1\n42\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void Json_ValuesAndEntriesExcludeNonEnumerableBuiltIns(ExecutionMode mode)
     {
         // #298: same own-enumerable filter for the JSON singleton.
@@ -131,8 +124,7 @@ public class BuiltInSingletonValueFormTests
         Assert.Equal("1\n1\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PlainObject_ValuesAndEntriesUnaffectedByEnumerableFilter(ExecutionMode mode)
     {
         // Guard the #298 fix: a plain object literal (no installed descriptors,
@@ -146,8 +138,7 @@ public class BuiltInSingletonValueFormTests
         Assert.Equal("1,2,3\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Math_AsValue_ValuesAndEntriesAreEmpty(ExecutionMode mode)
     {
         // Object.values/entries on Math return only its own enumerable properties;

--- a/SharpTS.Tests/SharedTests/BuiltInStructuralTypeTests.cs
+++ b/SharpTS.Tests/SharedTests/BuiltInStructuralTypeTests.cs
@@ -22,8 +22,7 @@ public class BuiltInStructuralTypeTests
 {
     // ----- keyof over built-ins -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_Date_AcceptsMemberName(ExecutionMode mode)
     {
         var source = """
@@ -33,8 +32,7 @@ public class BuiltInStructuralTypeTests
         Assert.Equal("getTime\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_RegExp_AcceptsMemberName(ExecutionMode mode)
     {
         var source = """
@@ -44,8 +42,7 @@ public class BuiltInStructuralTypeTests
         Assert.Equal("source\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_Map_AcceptsMemberName(ExecutionMode mode)
     {
         var source = """
@@ -55,8 +52,7 @@ public class BuiltInStructuralTypeTests
         Assert.Equal("get\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_Set_AcceptsMemberName(ExecutionMode mode)
     {
         var source = """
@@ -66,8 +62,7 @@ public class BuiltInStructuralTypeTests
         Assert.Equal("add\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_Promise_AcceptsMemberName(ExecutionMode mode)
     {
         var source = """
@@ -77,8 +72,7 @@ public class BuiltInStructuralTypeTests
         Assert.Equal("then\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_Date_RejectsNonMember(ExecutionMode mode)
     {
         // keyof Date is the union of its members; a non-member literal must not be assignable.
@@ -90,8 +84,7 @@ public class BuiltInStructuralTypeTests
 
     // ----- structural assignability with a built-in source -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Structural_Date_AssignableToMatchingShape(ExecutionMode mode)
     {
         var source = """
@@ -102,8 +95,7 @@ public class BuiltInStructuralTypeTests
         Assert.Equal("number\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Structural_Map_AssignableToMatchingShape(ExecutionMode mode)
     {
         var source = """
@@ -115,8 +107,7 @@ public class BuiltInStructuralTypeTests
         Assert.Equal("1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Structural_RegExp_AssignableToMatchingShape(ExecutionMode mode)
     {
         var source = """
@@ -127,8 +118,7 @@ public class BuiltInStructuralTypeTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Structural_Date_MissingMember_Rejected(ExecutionMode mode)
     {
         var source = """
@@ -138,8 +128,7 @@ public class BuiltInStructuralTypeTests
         Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Structural_Date_WrongMemberType_Rejected(ExecutionMode mode)
     {
         // getTime returns number, not string — width subtyping must still type-check member types.
@@ -152,8 +141,7 @@ public class BuiltInStructuralTypeTests
 
     // ----- keyof feeding indexed access and mapped types over a built-in -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IndexedAccess_OverBuiltIn_ResolvesMemberType(ExecutionMode mode)
     {
         var source = """
@@ -164,8 +152,7 @@ public class BuiltInStructuralTypeTests
         Assert.Equal("function\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MappedType_OverKeyOfBuiltIn_TypeChecks(ExecutionMode mode)
     {
         var source = """
@@ -178,8 +165,7 @@ public class BuiltInStructuralTypeTests
 
     // ----- #530: the projection extended to Error (and the other GetXxxMemberType built-ins) -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_Error_AcceptsMemberName(ExecutionMode mode)
     {
         var source = """
@@ -189,8 +175,7 @@ public class BuiltInStructuralTypeTests
         Assert.Equal("message\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_Error_RejectsNonMember(ExecutionMode mode)
     {
         var source = """
@@ -199,8 +184,7 @@ public class BuiltInStructuralTypeTests
         Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Structural_Error_AssignableToMatchingShape(ExecutionMode mode)
     {
         // The verbatim repro from #530: an Error value satisfies a matching structural shape.
@@ -212,8 +196,7 @@ public class BuiltInStructuralTypeTests
         Assert.Equal("boom\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Structural_Error_MissingMember_Rejected(ExecutionMode mode)
     {
         var source = """
@@ -225,8 +208,7 @@ public class BuiltInStructuralTypeTests
 
     // ----- #529: the weak-type check (TS2559) now sees a built-in source's members -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakType_BuiltInSource_NoSharedMember_Rejected(ExecutionMode mode)
     {
         // tsc: TS2559 — Date has no properties in common with the all-optional target. Before #529 the
@@ -237,8 +219,7 @@ public class BuiltInStructuralTypeTests
         Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakType_BuiltInSource_SharedMember_Accepted(ExecutionMode mode)
     {
         // The weak-type rule fires only when NOTHING is in common: a target sharing a member name with

--- a/SharpTS.Tests/SharedTests/CallSignatureTests.cs
+++ b/SharpTS.Tests/SharedTests/CallSignatureTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class CallSignatureTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CallSignature_BasicInterface(ExecutionMode mode)
     {
         var code = """
@@ -26,8 +25,7 @@ public class CallSignatureTests
         Assert.Equal("HELLO\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CallSignature_WithMultipleParameters(ExecutionMode mode)
     {
         var code = """
@@ -43,8 +41,7 @@ public class CallSignatureTests
         Assert.Equal("8\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CallSignature_WithTwoParameters(ExecutionMode mode)
     {
         var code = """
@@ -63,8 +60,7 @@ public class CallSignatureTests
         Assert.Equal("Hello World\nHi World\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CallSignature_ReturnsVoid(ExecutionMode mode)
     {
         var code = """
@@ -82,8 +78,7 @@ public class CallSignatureTests
         Assert.Equal("LOG: test\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CallSignature_MultipleSignatures(ExecutionMode mode)
     {
         var code = """

--- a/SharpTS.Tests/SharedTests/CaughtErrorIdentityTests.cs
+++ b/SharpTS.Tests/SharedTests/CaughtErrorIdentityTests.cs
@@ -20,8 +20,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class CaughtErrorIdentityTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GuestThrownErrorShapedString_IsCaughtVerbatim_NotReTyped(ExecutionMode mode)
     {
         // A guest throw of an error-prefixed string is a plain string value in JS — it must NOT
@@ -39,8 +38,7 @@ public class CaughtErrorIdentityTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InternalRuntimeError_CaughtByGuest_IsErrorInstance(ExecutionMode mode)
     {
         // `1n ** -1n` is a runtime error in both modes; caught by guest code it must be an Error
@@ -53,8 +51,7 @@ public class CaughtErrorIdentityTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void InternalRuntimeError_CaughtByGuest_RecoversTypedError(ExecutionMode mode)
     {
         // Interpreter-specific: the "Runtime Error: " wrapper with no inner JS error name is
@@ -77,8 +74,7 @@ public class CaughtErrorIdentityTests
     // not flattened to a host Exception and re-typed at the downstream catch. These crossed the
     // boundary correctly in compiled mode already; the fix brings the interpreter to parity.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GuestStringThrow_AcrossFunctionCall_IsCaughtVerbatim(ExecutionMode mode)
     {
         var source = """
@@ -94,8 +90,7 @@ public class CaughtErrorIdentityTests
         Assert.Equal("string\nfalse\nTypeError: via-fn\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GuestStringThrow_AcrossHostCallback_IsCaughtVerbatim(ExecutionMode mode)
     {
         // Array.forEach invokes the guest callback through a host frame — the throw must cross it
@@ -112,8 +107,7 @@ public class CaughtErrorIdentityTests
         Assert.Equal("string\nfalse\nTypeError: in-forEach\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GuestErrorObject_AcrossHostCallback_KeepsIdentity(ExecutionMode mode)
     {
         // Anchor: a genuine Error object thrown across the same host frame must remain an Error

--- a/SharpTS.Tests/SharedTests/CjsAccessorImportTests.cs
+++ b/SharpTS.Tests/SharedTests/CjsAccessorImportTests.cs
@@ -12,8 +12,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class CjsAccessorImportTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedImport_Reads_GetterDefinedExport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -38,8 +37,7 @@ public class CjsAccessorImportTests
         Assert.Equal("hi world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedImport_GetterClosesOverLaterBinding(ExecutionMode mode)
     {
         // Mirrors uuid's layout: Object.defineProperty calls come before the var that the

--- a/SharpTS.Tests/SharedTests/ClassExpandoStaticTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassExpandoStaticTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ClassExpandoStaticTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringKeyedExpandoStatic_RoundTrips(ExecutionMode mode)
     {
         var source = """
@@ -23,8 +22,7 @@ public class ClassExpandoStaticTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SymbolKeyedExpandoStatic_RoundTrips(ExecutionMode mode)
     {
         var source = """
@@ -38,8 +36,7 @@ public class ClassExpandoStaticTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExpandoStatics_InAsyncContext_RoundTrip(ExecutionMode mode)
     {
         var source = """
@@ -59,8 +56,7 @@ public class ClassExpandoStaticTests
 
     // Both modes walk the constructor parent chain for expando statics (#265);
     // Node inherits them via Object.getPrototypeOf(D) === C.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExpandoStatics_InheritedThroughSubclassChain(ExecutionMode mode)
     {
         var source = """
@@ -78,8 +74,7 @@ public class ClassExpandoStaticTests
 
     // An own expando static on the subclass shadows the inherited one (#265),
     // and setting it on the subclass must not mutate the base's own value.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExpandoStatics_OwnShadowsInherited(ExecutionMode mode)
     {
         var source = """
@@ -101,8 +96,7 @@ public class ClassExpandoStaticTests
     }
 
     // A two-level chain resolves an expando static set on the grandparent (#265).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExpandoStatics_InheritedThroughTwoLevels(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ClassExpressionTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassExpressionTests.cs
@@ -10,8 +10,7 @@ public class ClassExpressionTests
 {
     #region Anonymous Class Expressions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AnonymousClassExpression_Basic(ExecutionMode mode)
     {
         var source = """
@@ -26,8 +25,7 @@ public class ClassExpressionTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AnonymousClassExpression_WithMethod(ExecutionMode mode)
     {
         var source = """
@@ -48,8 +46,7 @@ public class ClassExpressionTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AnonymousClassExpression_WithConstructor(ExecutionMode mode)
     {
         var source = """
@@ -74,8 +71,7 @@ public class ClassExpressionTests
 
     #region Named Class Expressions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedClassExpression_Basic(ExecutionMode mode)
     {
         var source = """
@@ -97,8 +93,7 @@ public class ClassExpressionTests
 
     #region Inheritance
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_WithInheritance(ExecutionMode mode)
     {
         var source = """
@@ -118,8 +113,7 @@ public class ClassExpressionTests
         Assert.Equal("10\n20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_SuperCall(ExecutionMode mode)
     {
         var source = """
@@ -143,8 +137,7 @@ public class ClassExpressionTests
         Assert.Equal("Rex barks\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_InheritedMethod_NotOverridden(ExecutionMode mode)
     {
         // A child class expression that does NOT override a parent method must
@@ -169,8 +162,7 @@ public class ClassExpressionTests
         Assert.Equal("Fido makes a sound\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_MultiLevelInheritedMethod(ExecutionMode mode)
     {
         // Three-level class-expression chain: the grandchild inherits the
@@ -199,8 +191,7 @@ public class ClassExpressionTests
 
     #region Arrays and Variables
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_MultipleClassesInArray(ExecutionMode mode)
     {
         // Note: new <expression>() syntax isn't supported yet.
@@ -219,8 +210,7 @@ public class ClassExpressionTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_AssignedToVariable(ExecutionMode mode)
     {
         // Class expressions can be assigned to variables and instantiated
@@ -240,8 +230,7 @@ public class ClassExpressionTests
 
     #region Static Members
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_StaticField(ExecutionMode mode)
     {
         var source = """
@@ -255,8 +244,7 @@ public class ClassExpressionTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_StaticMethod(ExecutionMode mode)
     {
         var source = """
@@ -276,8 +264,7 @@ public class ClassExpressionTests
 
     #region Accessors (get / set)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_Getter(ExecutionMode mode)
     {
         // Regression for #283: a named getter on a class expression returned undefined
@@ -298,8 +285,7 @@ public class ClassExpressionTests
         Assert.Equal("3\nhi\nw3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_Getter_DynamicAccess(ExecutionMode mode)
     {
         // Dynamic (bracket) access also routes through the class-expr GetProperty body (#283).
@@ -316,8 +302,7 @@ public class ClassExpressionTests
         Assert.Equal("w7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_Setter(ExecutionMode mode)
     {
         // Symmetric gap (#283): the class-expr SetProperty body never dispatched setters,
@@ -337,8 +322,7 @@ public class ClassExpressionTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_Setter_DynamicAccess(ExecutionMode mode)
     {
         // Dynamic (bracket) assignment must invoke the setter in both modes. Compiled mode is
@@ -358,8 +342,7 @@ public class ClassExpressionTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_MethodBody_ResolvesCapturedTopLevelVariable(ExecutionMode mode)
     {
         // Regression for #300: a class-expression method or accessor body
@@ -386,8 +369,7 @@ public class ClassExpressionTests
 
     #region Generic Class Expressions (#291)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericClassExpression_InferredConstructorArg(ExecutionMode mode)
     {
         // Regression for #291: a generic class EXPRESSION rejected constructor
@@ -407,8 +389,7 @@ public class ClassExpressionTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericClassExpression_ExplicitTypeArg(ExecutionMode mode)
     {
         // Explicit type argument on a generic class expression (`new Box<number>(42)`).
@@ -429,8 +410,7 @@ public class ClassExpressionTests
 
     #region Generator Methods (#765)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_GeneratorMethod_Works(ExecutionMode mode)
     {
         // #765: a generator method in a class expression was emitted on the linear path and its
@@ -444,8 +424,7 @@ public class ClassExpressionTests
         Assert.Equal("1,2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_GeneratorMethod_CapturesThis(ExecutionMode mode)
     {
         // Exercises `this`/constructor-parameter access and a loop inside a class-expression generator.
@@ -460,8 +439,7 @@ public class ClassExpressionTests
         Assert.Equal("1,2,3,4\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_GeneratorMethod_YieldStar(ExecutionMode mode)
     {
         var source = """
@@ -472,8 +450,7 @@ public class ClassExpressionTests
         Assert.Equal("1,2,3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_StaticGeneratorMethod_Works(ExecutionMode mode)
     {
         var source = """
@@ -484,8 +461,7 @@ public class ClassExpressionTests
         Assert.Equal("7,8\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_AsyncGeneratorMethod_Works(ExecutionMode mode)
     {
         var source = """
@@ -497,8 +473,7 @@ public class ClassExpressionTests
         Assert.Equal("1\n2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_StaticAsyncGeneratorMethod_Works(ExecutionMode mode)
     {
         var source = """
@@ -514,8 +489,7 @@ public class ClassExpressionTests
     // machine returning a Promise. The compiled path previously emitted a synchronous stub that
     // returned the raw value, so `.then` threw (Double is not a Task) and an `await` in the body
     // emitted invalid IL. The interpreter and type-checker (#793) already handled these.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_AsyncMethod_ThenReceivesValue(ExecutionMode mode)
     {
         var source = """
@@ -526,8 +500,7 @@ public class ClassExpressionTests
         Assert.Equal("5\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_StaticAsyncMethod_ThenReceivesValue(ExecutionMode mode)
     {
         var source = """
@@ -538,8 +511,7 @@ public class ClassExpressionTests
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_AsyncMethod_AwaitsAndReadsInstanceField(ExecutionMode mode)
     {
         // A real suspension point (await) plus a `this` field read proves the state machine and
@@ -565,8 +537,7 @@ public class ClassExpressionTests
     // back as Generator<Void>, so `for (const n of new C(...).gen()) sum += n` failed type-check
     // with "Compound assignment requires numeric operands".
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_InferredGeneratorMethodReturn_ReachesCallSite(ExecutionMode mode)
     {
         var source = """
@@ -582,8 +553,7 @@ public class ClassExpressionTests
         Assert.Equal("10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_InferredPlainMethodReturn_ReachesCallSite(ExecutionMode mode)
     {
         var source = """
@@ -597,8 +567,7 @@ public class ClassExpressionTests
         Assert.Equal("10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_InferredAsyncMethodReturn_ReachesCallSite(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ClassMethodNameTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassMethodNameTests.cs
@@ -12,8 +12,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ClassMethodNameTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MethodNamedGet(ExecutionMode mode)
     {
         var source = """
@@ -27,8 +26,7 @@ public class ClassMethodNameTests
         Assert.Equal("got x\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MethodNamedSet(ExecutionMode mode)
     {
         var source = """
@@ -45,8 +43,7 @@ public class ClassMethodNameTests
         Assert.Equal("a=b\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MethodNamedDelete(ExecutionMode mode)
     {
         var source = """
@@ -63,8 +60,7 @@ public class ClassMethodNameTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetAccessor_StillWorks(ExecutionMode mode)
     {
         // Regression: `get value()` must still parse as an accessor, not as
@@ -84,8 +80,7 @@ public class ClassMethodNameTests
         Assert.Equal("42\n99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetMethod_Coexists_WithGetAccessor_DifferentClasses(ExecutionMode mode)
     {
         var source = """
@@ -110,8 +105,7 @@ public class ClassMethodNameTests
     // that user code and stdlib hit (URLSearchParams etc.); fields with
     // these names are vanishingly rare.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticAndInstanceMethod_ShareName(ExecutionMode mode)
     {
         // Issue #722: static members live on the constructor, instance members
@@ -128,8 +122,7 @@ public class ClassMethodNameTests
         Assert.Equal("static instance\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticOverload_Coexists_WithInstanceMethod_SameName(ExecutionMode mode)
     {
         // Overload resolution must still run independently per namespace: an
@@ -147,8 +140,7 @@ public class ClassMethodNameTests
         Assert.Equal("static:1 static:a instance\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_StaticAndInstanceMethod_ShareName(ExecutionMode mode)
     {
         // Same fix applies to class expressions (issue #722, site 3).

--- a/SharpTS.Tests/SharedTests/ClassTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ClassTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassDeclaration_CreatesInstance(ExecutionMode mode)
     {
         var source = """
@@ -27,8 +26,7 @@ public class ClassTests
         Assert.Equal("Alice\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedMethod_ResolvesUnderDynamicDispatch(ExecutionMode mode)
     {
         // Accessing an inherited method through an `any`-typed receiver forces
@@ -53,8 +51,7 @@ public class ClassTests
         Assert.Equal("Fido sound\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassMethod_CanBeInvoked(ExecutionMode mode)
     {
         var source = """
@@ -75,8 +72,7 @@ public class ClassTests
         Assert.Equal("Hello, World\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassInheritance_ExtendsParent(ExecutionMode mode)
     {
         var source = """
@@ -105,8 +101,7 @@ public class ClassTests
         Assert.Equal("Rex barks\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SuperCall_InvokesParentMethod(ExecutionMode mode)
     {
         var source = """
@@ -132,8 +127,7 @@ public class ClassTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultipleFields_InitializedCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -154,8 +148,7 @@ public class ClassTests
         Assert.Equal("3\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MethodWithParameters_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -176,8 +169,7 @@ public class ClassTests
         Assert.Equal("8\n24\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MethodCallingOtherMethod_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -197,8 +189,7 @@ public class ClassTests
         Assert.Equal("25\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FieldModification_PersistsChanges(ExecutionMode mode)
     {
         var source = """
@@ -222,8 +213,7 @@ public class ClassTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedField_AccessibleFromChild(ExecutionMode mode)
     {
         var source = """
@@ -249,8 +239,7 @@ public class ClassTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultipleInstances_IndependentState(ExecutionMode mode)
     {
         var source = """
@@ -273,8 +262,7 @@ public class ClassTests
         Assert.Equal("1\n2\n10\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedConstructor_Basic(ExecutionMode mode)
     {
         // Dog extends Animal with no explicit constructor - should inherit Animal's constructor
@@ -301,8 +289,7 @@ public class ClassTests
         Assert.Equal("Rex barks!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedConstructor_MultiLevel(ExecutionMode mode)
     {
         // C extends B extends A - C should inherit A's constructor through B
@@ -327,8 +314,7 @@ public class ClassTests
         Assert.Equal("30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedConstructor_MultipleParameters(ExecutionMode mode)
     {
         // Child inherits parent's constructor with multiple parameters
@@ -354,8 +340,7 @@ public class ClassTests
         Assert.Equal("(3, 4)\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedConstructor_GenericParent(ExecutionMode mode)
     {
         // StringBox extends Box<string> - should inherit Box's constructor
@@ -379,8 +364,7 @@ public class ClassTests
         Assert.Equal("HELLO\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedConstructor_GenericParent_MultipleTypeParams(ExecutionMode mode)
     {
         // StringNumberPair extends Pair<string, number>
@@ -406,8 +390,7 @@ public class ClassTests
         Assert.Equal("count = 42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedConstructor_GenericParent_TypeParamForwarding(ExecutionMode mode)
     {
         // Derived<T> extends Base<T> - forwards type parameter
@@ -431,8 +414,7 @@ public class ClassTests
         Assert.Equal("test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedConstructor_GenericParent_MixedTypeArgs(ExecutionMode mode)
     {
         // Mixed<X> extends Triple<string, X, number> - some concrete, some forwarded
@@ -462,8 +444,7 @@ public class ClassTests
         Assert.Equal("hello\ntrue\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedConstructor_GenericParent_WithOwnMethod(ExecutionMode mode)
     {
         // NumberBox extends Box<number> with its own method
@@ -487,8 +468,7 @@ public class ClassTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedConstructor_TypeError_WrongArgCount(ExecutionMode mode)
     {
         // Should get a type error when wrong number of arguments passed
@@ -508,8 +488,7 @@ public class ClassTests
         Assert.Contains("expected at least 1 argument", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedConstructor_TypeError_WrongArgType(ExecutionMode mode)
     {
         // Should get a type error when wrong argument type passed
@@ -529,8 +508,7 @@ public class ClassTests
         Assert.Contains("expected type 'string'", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticMethod_ThisBindsToClass(ExecutionMode mode)
     {
         var source = """
@@ -551,8 +529,7 @@ public class ClassTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticGetter_ReturnsLiteral(ExecutionMode mode)
     {
         var source = """
@@ -566,8 +543,7 @@ public class ClassTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticGetter_CanReadStaticField(ExecutionMode mode)
     {
         var source = """
@@ -582,8 +558,7 @@ public class ClassTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticSetter_MutatesStaticField(ExecutionMode mode)
     {
         var source = """
@@ -601,8 +576,7 @@ public class ClassTests
         Assert.Equal("12\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticGetter_NewThisConstructsClass(ExecutionMode mode)
     {
         // Canonical semver pattern: `static get ANY() { return new this("any"); }`
@@ -621,8 +595,7 @@ public class ClassTests
         Assert.Equal("any\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceofGenericClass_Works(ExecutionMode mode)
     {
         // Regression: compiled `b instanceof Box` emitted the OPEN generic
@@ -643,8 +616,7 @@ public class ClassTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceofUserClass_InsideAsyncFunction(ExecutionMode mode)
     {
         // Regression: state-machine emitters resolved user class identifiers

--- a/SharpTS.Tests/SharedTests/ClassToStringCoercionTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassToStringCoercionTests.cs
@@ -11,8 +11,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ClassToStringCoercionTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PlainClass_StringCoercion_BrandsAsObjectObject(ExecutionMode mode)
     {
         // No toString override → Object.prototype brand "[object Object]" (Node),
@@ -28,8 +27,7 @@ public class ClassToStringCoercionTests
         Assert.Equal("[object Object]\n[object Object]\n[object Object]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UserToString_StringCoercion_InvokesOverride(ExecutionMode mode)
     {
         var source = @"
@@ -43,8 +41,7 @@ public class ClassToStringCoercionTests
         Assert.Equal("bar!\nbar!\nv=bar!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UserToString_ReturningNumber_CoercesToStringForm(ExecutionMode mode)
     {
         // toString returning a primitive number is a valid OrdinaryToPrimitive

--- a/SharpTS.Tests/SharedTests/ClassTypeofIsFunctionTests.cs
+++ b/SharpTS.Tests/SharedTests/ClassTypeofIsFunctionTests.cs
@@ -18,8 +18,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </remarks>
 public class ClassTypeofIsFunctionTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeofClass_ReturnsFunction_SameModule(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -33,8 +32,7 @@ public class ClassTypeofIsFunctionTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeofClass_ReturnsFunction_ImportedClass(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/CommaOperatorTests.cs
+++ b/SharpTS.Tests/SharedTests/CommaOperatorTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class CommaOperatorTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comma_ReturnsLastValue(ExecutionMode mode)
     {
         var source = """
@@ -21,8 +20,7 @@ public class CommaOperatorTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comma_EvaluatesAllExpressions(ExecutionMode mode)
     {
         var source = """
@@ -38,8 +36,7 @@ public class CommaOperatorTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comma_SideEffectsExecuteLeftToRight(ExecutionMode mode)
     {
         var source = """
@@ -57,8 +54,7 @@ public class CommaOperatorTests
         Assert.Equal("abc\nc\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comma_InForLoopIncrement(ExecutionMode mode)
     {
         var source = """
@@ -74,8 +70,7 @@ public class CommaOperatorTests
         Assert.Equal("0:10 1:9 2:8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comma_InForLoopInitializer(ExecutionMode mode)
     {
         var source = """
@@ -92,8 +87,7 @@ public class CommaOperatorTests
         Assert.Equal("3\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comma_InExpressionStatement(ExecutionMode mode)
     {
         var source = """
@@ -108,8 +102,7 @@ public class CommaOperatorTests
         Assert.Equal("5\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comma_TwoOperands(ExecutionMode mode)
     {
         var source = """
@@ -121,8 +114,7 @@ public class CommaOperatorTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comma_WithDifferentTypes(ExecutionMode mode)
     {
         var source = """
@@ -134,8 +126,7 @@ public class CommaOperatorTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comma_DoesNotAffectFunctionArguments(ExecutionMode mode)
     {
         var source = """
@@ -149,8 +140,7 @@ public class CommaOperatorTests
         Assert.Equal("6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comma_DoesNotAffectArrayLiterals(ExecutionMode mode)
     {
         var source = """
@@ -165,8 +155,7 @@ public class CommaOperatorTests
         Assert.Equal("3\n1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comma_NestedInParens(ExecutionMode mode)
     {
         var source = """
@@ -178,8 +167,7 @@ public class CommaOperatorTests
         Assert.Equal("4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comma_WithFunctionCalls(ExecutionMode mode)
     {
         var source = """
@@ -197,8 +185,7 @@ public class CommaOperatorTests
         Assert.Equal("3\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Comma_ComplexForLoop(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/CommandLineArgumentTests.cs
+++ b/SharpTS.Tests/SharedTests/CommandLineArgumentTests.cs
@@ -16,8 +16,7 @@ public class CommandLineArgumentTests
 {
     #region process.argv.slice(2) — User Arguments
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessArgv_SliceTwo_ReturnsUserArgs(ExecutionMode mode)
     {
         var source = """
@@ -30,8 +29,7 @@ public class CommandLineArgumentTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessArgv_SliceTwo_JoinsCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -43,8 +41,7 @@ public class CommandLineArgumentTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessArgv_EmptyArgs_SliceTwoIsEmpty(ExecutionMode mode)
     {
         var source = """
@@ -59,8 +56,7 @@ public class CommandLineArgumentTests
 
     #region Argument Preservation
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessArgv_ArgsWithSpaces_PreservedCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -73,8 +69,7 @@ public class CommandLineArgumentTests
         Assert.Equal("hello world\nfoo bar\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessArgv_ManyArguments_AllPreserved(ExecutionMode mode)
     {
         var source = """
@@ -88,8 +83,7 @@ public class CommandLineArgumentTests
         Assert.Equal("10\narg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessArgv_SpecialCharacters_PreservedCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -109,8 +103,7 @@ public class CommandLineArgumentTests
 
     #region argv Structure
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessArgv_LengthIncludesRuntimeAndScript(ExecutionMode mode)
     {
         // argv = [runtime_path, script_or_dll_path, ...user_args]
@@ -123,8 +116,7 @@ public class CommandLineArgumentTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessArgv_IndexOneIsNonEmptyString(ExecutionMode mode)
     {
         // argv[1] is the script path (interpreter) or DLL path (compiled)

--- a/SharpTS.Tests/SharedTests/CommonJSModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/CommonJSModuleTests.cs
@@ -59,8 +59,7 @@ public class CommonJSModuleTests
 
     #region Module Execution Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportAssignment_StringLiteral(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -78,8 +77,7 @@ public class CommonJSModuleTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportAssignment_Object(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -100,8 +98,7 @@ public class CommonJSModuleTests
         Assert.Equal("1.0.0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportAssignment_Class(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -126,8 +123,7 @@ public class CommonJSModuleTests
         Assert.Equal("1.0.0\nHello from MyLibrary\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportAssignment_Function(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -148,8 +144,7 @@ public class CommonJSModuleTests
         Assert.Equal("Hello, World!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ImportRequire_ES6Module(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -171,8 +166,7 @@ public class CommonJSModuleTests
         Assert.Equal("3.14159\n16\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ImportRequire_AliasAccessInsideFunction(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/ComputedAccessorNameTests.cs
+++ b/SharpTS.Tests/SharedTests/ComputedAccessorNameTests.cs
@@ -13,8 +13,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ComputedAccessorNameTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticSymbolGetter_SpeciesPattern(ExecutionMode mode)
     {
         var source = """
@@ -28,8 +27,7 @@ public class ComputedAccessorNameTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceSymbolGetterAndSetter(ExecutionMode mode)
     {
         var source = """
@@ -48,8 +46,7 @@ public class ComputedAccessorNameTests
         Assert.Equal("Tagged!\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticSymbolGetter_InheritedThroughSubclassChain(ExecutionMode mode)
     {
         var source = """
@@ -68,8 +65,7 @@ public class ComputedAccessorNameTests
     // The class-expression emission path gained a .cctor registration hook +
     // synthetic-method body emission mirroring the class-declaration path (#266),
     // so these now run in both modes.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SymbolAccessor_InClassExpression(ExecutionMode mode)
     {
         var source = """
@@ -83,8 +79,7 @@ public class ComputedAccessorNameTests
         Assert.Equal("expr\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SymbolAccessor_InClassExpression_GetterSetterWithFieldAndModuleLocalKey(ExecutionMode mode)
     {
         // Getter + setter sharing one symbol slot, a well-known key reading an
@@ -108,8 +103,7 @@ public class ComputedAccessorNameTests
         Assert.Equal("tag5 5\ntag99 99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SymbolAccessor_InClassExpression_Static(ExecutionMode mode)
     {
         // Static symbol-keyed getter on a class expression dispatches through the
@@ -127,8 +121,7 @@ public class ComputedAccessorNameTests
 
     // A get and set accessor for the SAME symbol must coexist (they merge into one
     // registry slot) and the .cctor registration must not disturb static field init.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SymbolGetterAndSetter_SameKey_WithStaticField(ExecutionMode mode)
     {
         var source = """
@@ -153,8 +146,7 @@ public class ComputedAccessorNameTests
     // evaluated in the lazily-run class .cctor, which executes after the
     // top-level binding is assigned, so `key` resolves correctly. Getter and
     // setter share one registry slot.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SymbolAccessor_ModuleLocalKey(ExecutionMode mode)
     {
         var source = """
@@ -174,8 +166,7 @@ public class ComputedAccessorNameTests
         Assert.Equal("10\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LiteralComputedKeys_FoldToOrdinaryNames(ExecutionMode mode)
     {
         var source = """
@@ -189,8 +180,7 @@ public class ComputedAccessorNameTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringAndKeywordAccessorNames_Parse(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ComputedSymbolMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/ComputedSymbolMethodTests.cs
@@ -13,8 +13,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ComputedSymbolMethodTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectReturningIterator_ForOf_Works(ExecutionMode mode)
     {
         var source = """
@@ -30,8 +29,7 @@ public class ComputedSymbolMethodTests
         Assert.Equal("0\n1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorIterator_ForOfAndSpread_Works(ExecutionMode mode)
     {
         var source = """
@@ -43,8 +41,7 @@ public class ComputedSymbolMethodTests
         Assert.Equal("1\n2\n2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorIterator_CapturesThis(ExecutionMode mode)
     {
         var source = """
@@ -62,8 +59,7 @@ public class ComputedSymbolMethodTests
         Assert.Equal("10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorIterator_ElementTypeIsNumber(ExecutionMode mode)
     {
         // The spread must yield number[], not Iterator<number>[] — the factory's iterator
@@ -80,8 +76,7 @@ public class ComputedSymbolMethodTests
     // #791: non-symbol computed keys (string/number) fold to a string-named method. Bodies emit as
     // synthetic $symmethod_N and register in the symbol-method registry under the property-key string;
     // named/string-index access consults the registry as a fallback in $IHasFields.GetProperty.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonSymbolComputedMethodKey_FoldsToNamedMethod(ExecutionMode mode)
     {
         var source = """
@@ -93,8 +88,7 @@ public class ComputedSymbolMethodTests
         Assert.Equal("42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringLiteralComputedMethodKey_BothAccessForms(ExecutionMode mode)
     {
         // Literal key, accessed both by name and by string index.
@@ -108,8 +102,7 @@ public class ComputedSymbolMethodTests
         Assert.Equal("42\n42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MutableLocalComputedMethodKey_FoldsToNamedMethod(ExecutionMode mode)
     {
         // Fully dynamic form: the key is a mutable local, unknowable at compile time.
@@ -122,8 +115,7 @@ public class ComputedSymbolMethodTests
         Assert.Equal("42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericComputedMethodKey_FoldsToStringKey(ExecutionMode mode)
     {
         // A numeric key folds to its property-key string ("1"), reachable via either index form.
@@ -137,8 +129,7 @@ public class ComputedSymbolMethodTests
         Assert.Equal("7\n7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedComputedMethodKey_ResolvesOnSubclass(ExecutionMode mode)
     {
         // A computed key declared on the base resolves through the subclass via the base-chain walk.
@@ -151,8 +142,7 @@ public class ComputedSymbolMethodTests
         Assert.Equal("99\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGeneratorIterator_ForAwait_Works(ExecutionMode mode)
     {
         var source = """
@@ -166,8 +156,7 @@ public class ComputedSymbolMethodTests
         Assert.Equal("10\n20\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericIterableClass_Works(ExecutionMode mode)
     {
         // Exercises the symbol registry's generic-class handling (registry keyed by the open
@@ -183,8 +172,7 @@ public class ComputedSymbolMethodTests
         Assert.Equal("1\n2\n3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedComputedIterator_Works(ExecutionMode mode)
     {
         // A subclass inherits the base's [Symbol.iterator] via the registry's base-chain walk.
@@ -203,8 +191,7 @@ public class ComputedSymbolMethodTests
     // compiled mode the bracket-get wraps the method in `$TSFunction(obj, method)`, mirroring the
     // string-key method path. for...of / spread / for-await (which pass the receiver themselves) were
     // already unaffected.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DirectSymbolMethodAccess_ReturnsCallable(ExecutionMode mode)
     {
         var source = """
@@ -219,8 +206,7 @@ public class ComputedSymbolMethodTests
     // Class *expressions* now wire computed symbol-keyed methods through the same synthetic-method +
     // registry path as class declarations, including the generator state machine (#755 sub-case 2,
     // building on the class-expression generator routing in #765).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_ComputedSymbolMethod_Works(ExecutionMode mode)
     {
         var source = """
@@ -234,8 +220,7 @@ public class ComputedSymbolMethodTests
     // Class expression carrying an async computed symbol method (`async *[Symbol.asyncIterator]()`),
     // consumed with for-await — exercises the class-expression async-generator + symbol-registry
     // paths together (#755 sub-case 2).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExpression_AsyncComputedSymbolMethod_Works(ExecutionMode mode)
     {
         var source = """
@@ -267,8 +252,7 @@ public class ComputedSymbolMethodTests
     // Tests are kept free of dynamic `this` inside the generator (object generator methods lose
     // `this` in both modes — pre-existing #775).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectLiteral_ComputedGeneratorMethod_Iterates(ExecutionMode mode)
     {
         var source = """
@@ -279,8 +263,7 @@ public class ComputedSymbolMethodTests
         Assert.Equal("1\n2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectLiteral_NamedGeneratorMethod_Iterates(ExecutionMode mode)
     {
         var source = """
@@ -291,8 +274,7 @@ public class ComputedSymbolMethodTests
         Assert.Equal("10\n20\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectLiteral_AsyncMethod_Resolves(ExecutionMode mode)
     {
         var source = """
@@ -303,8 +285,7 @@ public class ComputedSymbolMethodTests
         Assert.Equal("async: 5\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectLiteral_AsyncGeneratorMethod_Iterates(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ConditionalTypeTests.cs
+++ b/SharpTS.Tests/SharedTests/ConditionalTypeTests.cs
@@ -13,8 +13,7 @@ public class ConditionalTypeTests
 {
     #region Basic Conditional Types (12 tests)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_BasicTrue_ReturnsTrue(ExecutionMode mode)
     {
         var source = """
@@ -26,8 +25,7 @@ public class ConditionalTypeTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_BasicFalse_ReturnsFalse(ExecutionMode mode)
     {
         var source = """
@@ -39,8 +37,7 @@ public class ConditionalTypeTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_StringLiteralExtendsString_ReturnsTrue(ExecutionMode mode)
     {
         var source = """
@@ -52,8 +49,7 @@ public class ConditionalTypeTests
         Assert.Equal("yes\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_NumberLiteralExtendsNumber_ReturnsTrue(ExecutionMode mode)
     {
         var source = """
@@ -65,8 +61,7 @@ public class ConditionalTypeTests
         Assert.Equal("yes\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_BooleanExtendsBoolean_ReturnsTrue(ExecutionMode mode)
     {
         var source = """
@@ -78,8 +73,7 @@ public class ConditionalTypeTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_NullExtendsNull_ReturnsTrue(ExecutionMode mode)
     {
         var source = """
@@ -91,8 +85,7 @@ public class ConditionalTypeTests
         Assert.Equal("null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_ArrayExtendsArray_ReturnsTrue(ExecutionMode mode)
     {
         var source = """
@@ -104,8 +97,7 @@ public class ConditionalTypeTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_NonArrayExtendsArray_ReturnsFalse(ExecutionMode mode)
     {
         var source = """
@@ -117,8 +109,7 @@ public class ConditionalTypeTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_AnyExtendsAny_ReturnsTrue(ExecutionMode mode)
     {
         var source = """
@@ -130,8 +121,7 @@ public class ConditionalTypeTests
         Assert.Equal("yes\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_NeverExtendsAny_ReturnsNever(ExecutionMode mode)
     {
         // never distributes to empty, so never extends any ? X : Y = never
@@ -146,8 +136,7 @@ public class ConditionalTypeTests
         Assert.Equal("test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_RecordExtendsRecord_ReturnsTrue(ExecutionMode mode)
     {
         // Use { } instead of object keyword
@@ -160,8 +149,7 @@ public class ConditionalTypeTests
         Assert.Equal("match\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_PrimitiveExtendsRecord_ReturnsFalse(ExecutionMode mode)
     {
         // Use { } instead of object keyword
@@ -178,8 +166,7 @@ public class ConditionalTypeTests
 
     #region Distribution Over Unions (10 tests)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_UnionDistribution_DistributesCorrectly(ExecutionMode mode)
     {
         // string | number extends string ? "str" : "other"
@@ -196,8 +183,7 @@ public class ConditionalTypeTests
         Assert.Equal("str\nother\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_ToArray_DistributesOverUnion(ExecutionMode mode)
     {
         // ToArray<string> = string[], verify assignment works
@@ -210,8 +196,7 @@ public class ConditionalTypeTests
         Assert.Equal("passed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_FilterStrings_FiltersUnion(ExecutionMode mode)
     {
         // Filter<string | number | boolean> where we keep only strings
@@ -225,8 +210,7 @@ public class ConditionalTypeTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_NonNullable_FiltersNull(ExecutionMode mode)
     {
         // NonNullable<string | null> = string
@@ -239,8 +223,7 @@ public class ConditionalTypeTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_Extract_ExtractsMatchingTypes(ExecutionMode mode)
     {
         // Extract<string | number | boolean, string | boolean> = string | boolean
@@ -253,8 +236,7 @@ public class ConditionalTypeTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_Exclude_ExcludesMatchingTypes(ExecutionMode mode)
     {
         // Exclude<string | number | boolean, string> = number | boolean
@@ -267,8 +249,7 @@ public class ConditionalTypeTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_AllNever_ResultsInNever(ExecutionMode mode)
     {
         // FilterString<number | boolean> = never | never = never
@@ -283,8 +264,7 @@ public class ConditionalTypeTests
         Assert.Equal("test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_SingleUnionMember_NoDistribution(ExecutionMode mode)
     {
         // Single type, no distribution needed
@@ -297,8 +277,7 @@ public class ConditionalTypeTests
         Assert.Equal("str\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_UnionWithNever_NeverDisappears(ExecutionMode mode)
     {
         // string | never = string
@@ -311,8 +290,7 @@ public class ConditionalTypeTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_DistributeWithLiteral_Works(ExecutionMode mode)
     {
         // "a" | "b" | 1 extends string ? "str" : "other"
@@ -330,8 +308,7 @@ public class ConditionalTypeTests
 
     #region Infer Keyword (10 tests)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InferType_ArrayElement_ExtractsElement(ExecutionMode mode)
     {
         var source = """
@@ -343,8 +320,7 @@ public class ConditionalTypeTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InferType_NumberArrayElement_ExtractsNumber(ExecutionMode mode)
     {
         var source = """
@@ -356,8 +332,7 @@ public class ConditionalTypeTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InferType_NonArrayReturnsNever_FallsBack(ExecutionMode mode)
     {
         // ElementType<string> = never (no match)
@@ -370,8 +345,7 @@ public class ConditionalTypeTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InferType_PromiseValue_ExtractsValue(ExecutionMode mode)
     {
         var source = """
@@ -383,8 +357,7 @@ public class ConditionalTypeTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InferType_NonPromise_ReturnsSelf(ExecutionMode mode)
     {
         var source = """
@@ -396,8 +369,7 @@ public class ConditionalTypeTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InferType_InferUsedInTrueBranch_Works(ExecutionMode mode)
     {
         var source = """
@@ -409,8 +381,7 @@ public class ConditionalTypeTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InferType_NestedArray_FlattenOnce(ExecutionMode mode)
     {
         // Flatten<string[][]> = string[], verify assignment works
@@ -423,8 +394,7 @@ public class ConditionalTypeTests
         Assert.Equal("passed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InferType_MapValue_ExtractsValue(ExecutionMode mode)
     {
         var source = """
@@ -436,8 +406,7 @@ public class ConditionalTypeTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InferType_SetElement_ExtractsElement(ExecutionMode mode)
     {
         var source = """
@@ -449,8 +418,7 @@ public class ConditionalTypeTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InferType_UnionDistribution_InfersFromEach(ExecutionMode mode)
     {
         // ElementType<string[] | number[]> = string | number
@@ -469,8 +437,7 @@ public class ConditionalTypeTests
 
     #region Nested and Recursive Conditionals (8 tests)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_NestedConditional_Works(ExecutionMode mode)
     {
         var source = """
@@ -486,8 +453,7 @@ public class ConditionalTypeTests
         Assert.Equal("string\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_NestedConditional_SecondBranch(ExecutionMode mode)
     {
         var source = """
@@ -503,8 +469,7 @@ public class ConditionalTypeTests
         Assert.Equal("number\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_NestedConditional_ThirdBranch(ExecutionMode mode)
     {
         var source = """
@@ -520,8 +485,7 @@ public class ConditionalTypeTests
         Assert.Equal("boolean\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_NestedConditional_FallbackBranch(ExecutionMode mode)
     {
         var source = """
@@ -537,8 +501,7 @@ public class ConditionalTypeTests
         Assert.Equal("unknown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_ConditionalInTrueBranch_Works(ExecutionMode mode)
     {
         // Test that conditional types evaluate correct branches
@@ -551,8 +514,7 @@ public class ConditionalTypeTests
         Assert.Equal("greeting\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_ConditionalInFalseBranch_Works(ExecutionMode mode)
     {
         // Test that conditional types evaluate correct branches
@@ -565,8 +527,7 @@ public class ConditionalTypeTests
         Assert.Equal("other\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_TwoTypeParams_Works(ExecutionMode mode)
     {
         var source = """
@@ -580,8 +541,7 @@ public class ConditionalTypeTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalType_ThreeTypeParams_Works(ExecutionMode mode)
     {
         var source = """
@@ -599,8 +559,7 @@ public class ConditionalTypeTests
 
     #region Utility Types with Conditionals (6 tests)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UtilityType_NonNullable_Implementation(ExecutionMode mode)
     {
         var source = """
@@ -612,8 +571,7 @@ public class ConditionalTypeTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UtilityType_Extract_Implementation(ExecutionMode mode)
     {
         // Use type alias for the union to avoid parser issues with union in generic args
@@ -628,8 +586,7 @@ public class ConditionalTypeTests
         Assert.Equal("a\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UtilityType_Exclude_Implementation(ExecutionMode mode)
     {
         // Use type alias for the union to avoid parser issues with union in generic args
@@ -643,8 +600,7 @@ public class ConditionalTypeTests
         Assert.Equal("b\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UtilityType_Awaited_Simple(ExecutionMode mode)
     {
         var source = """
@@ -656,8 +612,7 @@ public class ConditionalTypeTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UtilityType_UnwrapArray_Implementation(ExecutionMode mode)
     {
         var source = """
@@ -669,8 +624,7 @@ public class ConditionalTypeTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UtilityType_IsAny_SimpleCheck(ExecutionMode mode)
     {
         var source = """
@@ -686,8 +640,7 @@ public class ConditionalTypeTests
 
     #region Edge Cases (6 tests)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EdgeCase_EmptyUnion_IsNever(ExecutionMode mode)
     {
         // never extends any should still work
@@ -700,8 +653,7 @@ public class ConditionalTypeTests
         Assert.Equal("test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EdgeCase_UnknownExtendsUnknown_Works(ExecutionMode mode)
     {
         var source = """
@@ -713,8 +665,7 @@ public class ConditionalTypeTests
         Assert.Equal("yes\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EdgeCase_VoidExtends_Works(ExecutionMode mode)
     {
         var source = """
@@ -726,8 +677,7 @@ public class ConditionalTypeTests
         Assert.Equal("void\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EdgeCase_StringLiteralUnion_Distributes(ExecutionMode mode)
     {
         // Use type alias for the union
@@ -741,8 +691,7 @@ public class ConditionalTypeTests
         Assert.Equal("A\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EdgeCase_TrueLiteralCheck(ExecutionMode mode)
     {
         // Test true literal check specifically
@@ -757,8 +706,7 @@ public class ConditionalTypeTests
         Assert.Equal("yes\nno\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EdgeCase_StringUnionDistribution_Works(ExecutionMode mode)
     {
         // Use type alias for the union

--- a/SharpTS.Tests/SharedTests/ConsoleTests.cs
+++ b/SharpTS.Tests/SharedTests/ConsoleTests.cs
@@ -13,8 +13,7 @@ public class ConsoleTests
 {
     #region Basic Output
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Log_OutputsToStdout(ExecutionMode mode)
     {
         var source = """
@@ -26,8 +25,7 @@ public class ConsoleTests
         Assert.Equal("Hello\nWorld\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Log_MultipleArguments(ExecutionMode mode)
     {
         var source = """
@@ -38,8 +36,7 @@ public class ConsoleTests
         Assert.Equal("Hello World 123\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Log_NoArguments_PrintsNewline(ExecutionMode mode)
     {
         var source = """
@@ -52,8 +49,7 @@ public class ConsoleTests
         Assert.Equal("Line1\n\nLine2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Info_AliasForLog(ExecutionMode mode)
     {
         var source = """
@@ -65,8 +61,7 @@ public class ConsoleTests
         Assert.Equal("Info message\nMultiple args 42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Debug_AliasForLog(ExecutionMode mode)
     {
         var source = """
@@ -78,8 +73,7 @@ public class ConsoleTests
         Assert.Equal("Debug message\nMultiple args\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Info_NoArguments_PrintsNewline(ExecutionMode mode)
     {
         var source = """
@@ -92,8 +86,7 @@ public class ConsoleTests
         Assert.Equal("Line1\n\nLine2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Debug_NoArguments_PrintsNewline(ExecutionMode mode)
     {
         var source = """
@@ -110,8 +103,7 @@ public class ConsoleTests
 
     #region Stderr Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Error_DoesNotCrash(ExecutionMode mode)
     {
         var source = """
@@ -125,8 +117,7 @@ public class ConsoleTests
         Assert.Contains("After\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Warn_DoesNotCrash(ExecutionMode mode)
     {
         var source = """
@@ -144,8 +135,7 @@ public class ConsoleTests
 
     #region Timing Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Time_And_TimeEnd_WorkTogether(ExecutionMode mode)
     {
         var source = """
@@ -164,8 +154,7 @@ public class ConsoleTests
         Assert.Contains("Done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Time_DefaultLabel(ExecutionMode mode)
     {
         var source = """
@@ -181,8 +170,7 @@ public class ConsoleTests
         Assert.Contains("Finished\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Time_CaseSensitiveLabels(ExecutionMode mode)
     {
         var source = """
@@ -200,8 +188,7 @@ public class ConsoleTests
         Assert.Contains("Done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_TimeLog_PrintsWithoutStopping(ExecutionMode mode)
     {
         var source = """
@@ -219,8 +206,7 @@ public class ConsoleTests
         Assert.Contains("Done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_TimeEnd_NoMatchingTimer_DoesNotCrash(ExecutionMode mode)
     {
         var source = """
@@ -232,8 +218,7 @@ public class ConsoleTests
         Assert.Contains("Still running\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_TimeLog_NoMatchingTimer_DoesNotCrash(ExecutionMode mode)
     {
         var source = """
@@ -245,8 +230,7 @@ public class ConsoleTests
         Assert.Contains("Still running\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Time_MultipleLabeledTimers(ExecutionMode mode)
     {
         var source = """
@@ -267,8 +251,7 @@ public class ConsoleTests
 
     #region Assert
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Assert_TruthyCondition_NoOutput(ExecutionMode mode)
     {
         var source = """
@@ -283,8 +266,7 @@ public class ConsoleTests
         Assert.Equal("Done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Assert_FalsyCondition_DoesNotCrash(ExecutionMode mode)
     {
         var source = """
@@ -296,8 +278,7 @@ public class ConsoleTests
         Assert.Contains("Still running\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Assert_MultipleFalsyConditions(ExecutionMode mode)
     {
         var source = """
@@ -316,8 +297,7 @@ public class ConsoleTests
 
     #region Count
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Count_IncrementsCounter(ExecutionMode mode)
     {
         var source = """
@@ -332,8 +312,7 @@ public class ConsoleTests
         Assert.Contains("calls: 3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Count_DefaultLabel(ExecutionMode mode)
     {
         var source = """
@@ -346,8 +325,7 @@ public class ConsoleTests
         Assert.Contains("default: 2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_CountReset_ResetsCounter(ExecutionMode mode)
     {
         var source = """
@@ -370,8 +348,7 @@ public class ConsoleTests
 
     #region Table
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Table_ArrayOfObjects(ExecutionMode mode)
     {
         var source = """
@@ -383,8 +360,7 @@ public class ConsoleTests
         Assert.Contains("Done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Table_ArrayOfObjects_HasTableBorders(ExecutionMode mode)
     {
         var source = """
@@ -399,8 +375,7 @@ public class ConsoleTests
         Assert.Contains("Done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Table_WithColumnFilter(ExecutionMode mode)
     {
         var source = """
@@ -412,8 +387,7 @@ public class ConsoleTests
         Assert.Contains("Done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Table_EmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -430,8 +404,7 @@ public class ConsoleTests
 
     #region Dir
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Dir_Object(ExecutionMode mode)
     {
         var source = """
@@ -443,8 +416,7 @@ public class ConsoleTests
         Assert.Contains("Done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Dir_Object_ShowsProperties(ExecutionMode mode)
     {
         var source = """
@@ -462,8 +434,7 @@ public class ConsoleTests
 
     #region Group
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Group_IncreasesIndentation(ExecutionMode mode)
     {
         var source = """
@@ -482,8 +453,7 @@ public class ConsoleTests
         Assert.Contains("Outside again\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Group_PrintsLabel(ExecutionMode mode)
     {
         var source = """
@@ -499,8 +469,7 @@ public class ConsoleTests
         Assert.Contains("Done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_GroupCollapsed_SameAsGroup(ExecutionMode mode)
     {
         var source = """
@@ -516,8 +485,7 @@ public class ConsoleTests
         Assert.Contains("Done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_GroupEnd_DecreasesIndentation(ExecutionMode mode)
     {
         var source = """
@@ -538,8 +506,7 @@ public class ConsoleTests
         Assert.Contains("Back to 0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_GroupEnd_ExtraCallsIgnored(ExecutionMode mode)
     {
         var source = """
@@ -556,8 +523,7 @@ public class ConsoleTests
 
     #region Trace
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Trace_PrintsMessage(ExecutionMode mode)
     {
         var source = """
@@ -570,8 +536,7 @@ public class ConsoleTests
         Assert.Contains("Done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Trace_NoMessage(ExecutionMode mode)
     {
         var source = """
@@ -584,8 +549,7 @@ public class ConsoleTests
         Assert.Contains("Done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Trace_MultipleArguments(ExecutionMode mode)
     {
         var source = """
@@ -602,8 +566,7 @@ public class ConsoleTests
 
     #region Format Specifiers
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Log_FormatSpecifier_String(ExecutionMode mode)
     {
         var source = """
@@ -614,8 +577,7 @@ public class ConsoleTests
         Assert.Equal("Hello World!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Log_FormatSpecifier_Integer(ExecutionMode mode)
     {
         var source = """
@@ -628,8 +590,7 @@ public class ConsoleTests
         Assert.Contains("Negative: -3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Log_FormatSpecifier_Object(ExecutionMode mode)
     {
         var source = """
@@ -640,8 +601,7 @@ public class ConsoleTests
         Assert.Contains("Object: { a: 1, b: 2 }\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Log_FormatSpecifier_Float(ExecutionMode mode)
     {
         var source = """
@@ -652,8 +612,7 @@ public class ConsoleTests
         Assert.Contains("Float: 3.14159\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Log_FormatSpecifier_Json(ExecutionMode mode)
     {
         var source = """
@@ -664,8 +623,7 @@ public class ConsoleTests
         Assert.Contains("JSON: {\"name\":\"test\",\"value\":42}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Log_FormatSpecifier_MultipleSpecifiers(ExecutionMode mode)
     {
         var source = """
@@ -676,8 +634,7 @@ public class ConsoleTests
         Assert.Equal("Name: Alice, Age: 30, Score: 95.5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Log_FormatSpecifier_EscapedPercent(ExecutionMode mode)
     {
         var source = """
@@ -688,8 +645,7 @@ public class ConsoleTests
         Assert.Equal("100% complete\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Log_FormatSpecifier_ExtraArgs(ExecutionMode mode)
     {
         var source = """
@@ -700,8 +656,7 @@ public class ConsoleTests
         Assert.Equal("Value: one two three\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Log_FormatSpecifier_MissingArgs(ExecutionMode mode)
     {
         var source = """
@@ -713,8 +668,7 @@ public class ConsoleTests
         Assert.Equal("Hello World %s\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Log_FormatSpecifier_Integer_SpecialValues(ExecutionMode mode)
     {
         var source = """
@@ -737,8 +691,7 @@ public class ConsoleTests
         Assert.Contains("Bool false: 0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Console_Log_FormatSpecifier_NoSpecifiers_NoFormatting(ExecutionMode mode)
     {
         // Ensure strings without format specifiers are not treated as format strings

--- a/SharpTS.Tests/SharedTests/ConstTypeParameterTests.cs
+++ b/SharpTS.Tests/SharedTests/ConstTypeParameterTests.cs
@@ -11,8 +11,7 @@ public class ConstTypeParameterTests
 {
     #region Basic Const Type Parameter Functions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstTypeParam_BasicFunction(ExecutionMode mode)
     {
         var source = """
@@ -28,8 +27,7 @@ public class ConstTypeParameterTests
         Assert.Equal("42\nhello\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstTypeParam_WithConstraint(ExecutionMode mode)
     {
         var source = """
@@ -43,8 +41,7 @@ public class ConstTypeParameterTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstTypeParam_MultipleTypeParams(ExecutionMode mode)
     {
         var source = """
@@ -59,8 +56,7 @@ public class ConstTypeParameterTests
         Assert.Equal("name=Alice\nage=30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstTypeParam_MixedConstAndNonConst(ExecutionMode mode)
     {
         var source = """
@@ -79,8 +75,7 @@ public class ConstTypeParameterTests
 
     #region Const Type Parameter Classes
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstTypeParam_InClass(ExecutionMode mode)
     {
         var source = """
@@ -103,8 +98,7 @@ public class ConstTypeParameterTests
         Assert.Equal("42\nhello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstTypeParam_ClassWithConstraint(ExecutionMode mode)
     {
         var source = """
@@ -127,8 +121,7 @@ public class ConstTypeParameterTests
 
     #region Const Type Parameter with Complex Types
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstTypeParam_WithObjectLiteral(ExecutionMode mode)
     {
         var source = """
@@ -144,8 +137,7 @@ public class ConstTypeParameterTests
         Assert.Equal("Alice\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstTypeParam_WithArrayLiteral(ExecutionMode mode)
     {
         var source = """
@@ -160,8 +152,7 @@ public class ConstTypeParameterTests
         Assert.Equal("10\na\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstTypeParam_NestedObjects(ExecutionMode mode)
     {
         var source = """
@@ -180,8 +171,7 @@ public class ConstTypeParameterTests
 
     #region Explicit Type Arguments with Const
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstTypeParam_ExplicitTypeArg(ExecutionMode mode)
     {
         var source = """
@@ -200,8 +190,7 @@ public class ConstTypeParameterTests
 
     #region Default Type Parameters with Const
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstTypeParam_WithDefault(ExecutionMode mode)
     {
         var source = """
@@ -220,8 +209,7 @@ public class ConstTypeParameterTests
 
     #region Generic Method in Class with Const
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstTypeParam_GenericMethodInClass(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ConstructorReturnValueTests.cs
+++ b/SharpTS.Tests/SharedTests/ConstructorReturnValueTests.cs
@@ -20,8 +20,7 @@ public class ConstructorReturnValueTests
 {
     // ---- The issue repro: a constructor returning an arrow yields the arrow, not `this` ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstructorReturningArrow_YieldsArrow(ExecutionMode mode)
     {
         var source = """
@@ -42,8 +41,7 @@ public class ConstructorReturnValueTests
         Assert.Equal("function\nfn-result:X\nundefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionExpressionConstructorReturningArrow_YieldsArrow(ExecutionMode mode)
     {
         // The function-expression construct path (SharpTSArrowFunction with HasOwnThis).
@@ -61,8 +59,7 @@ public class ConstructorReturnValueTests
 
     // ---- Other object return types win too ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstructorReturningObject_YieldsObject(ExecutionMode mode)
     {
         var source = """
@@ -74,8 +71,7 @@ public class ConstructorReturnValueTests
         Assert.Equal("undefined 2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstructorReturningArray_YieldsArray(ExecutionMode mode)
     {
         var source = """
@@ -86,8 +82,7 @@ public class ConstructorReturnValueTests
         Assert.Equal("true 9 8\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstructorReturningClassInstance_YieldsInstance(ExecutionMode mode)
     {
         var source = """
@@ -101,8 +96,7 @@ public class ConstructorReturnValueTests
 
     // ---- Primitive returns are ignored: `this` wins ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstructorReturningNumber_YieldsThis(ExecutionMode mode)
     {
         var source = """
@@ -113,8 +107,7 @@ public class ConstructorReturnValueTests
         Assert.Equal("object 1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstructorReturningString_YieldsThis(ExecutionMode mode)
     {
         var source = """
@@ -125,8 +118,7 @@ public class ConstructorReturnValueTests
         Assert.Equal("object 1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstructorReturningBoolean_YieldsThis(ExecutionMode mode)
     {
         var source = """
@@ -137,8 +129,7 @@ public class ConstructorReturnValueTests
         Assert.Equal("object 1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstructorReturningNull_YieldsThis(ExecutionMode mode)
     {
         var source = """
@@ -149,8 +140,7 @@ public class ConstructorReturnValueTests
         Assert.Equal("object 1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstructorFallingOffEnd_YieldsThis(ExecutionMode mode)
     {
         // No return at all — `this` wins. (Interacts with #603: the boxed Call now returns the

--- a/SharpTS.Tests/SharedTests/ConstructorSignatureTests.cs
+++ b/SharpTS.Tests/SharedTests/ConstructorSignatureTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ConstructorSignatureTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstructorSignature_BasicInterface(ExecutionMode mode)
     {
         var code = """
@@ -45,8 +44,7 @@ public class ConstructorSignatureTests
         Assert.Equal("10\n20\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NewOnVariable_SimpleClass(ExecutionMode mode)
     {
         var code = """
@@ -66,8 +64,7 @@ public class ConstructorSignatureTests
         Assert.Equal("42\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NewOnVariable_FunctionReturnsInstance(ExecutionMode mode)
     {
         var code = """
@@ -90,8 +87,7 @@ public class ConstructorSignatureTests
         Assert.Equal("test\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstructorSignature_WithOptionalParam(ExecutionMode mode)
     {
         var code = """
@@ -122,8 +118,7 @@ public class ConstructorSignatureTests
         Assert.Equal("custom\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NewOnNamespacedClass(ExecutionMode mode)
     {
         var code = """

--- a/SharpTS.Tests/SharedTests/ControlFlowTests.cs
+++ b/SharpTS.Tests/SharedTests/ControlFlowTests.cs
@@ -10,8 +10,7 @@ public class ControlFlowTests
 {
     #region Switch Statements
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Switch_BasicCase_MatchesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -33,8 +32,7 @@ public class ControlFlowTests
         Assert.Equal("two\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Switch_DefaultCase_ExecutesWhenNoMatch(ExecutionMode mode)
     {
         var source = """
@@ -56,8 +54,7 @@ public class ControlFlowTests
         Assert.Equal("other\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Switch_FallThrough_ExecutesMultipleCases(ExecutionMode mode)
     {
         var source = """
@@ -78,8 +75,7 @@ public class ControlFlowTests
         Assert.Equal("two\nthree\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Switch_WithString_MatchesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -104,8 +100,7 @@ public class ControlFlowTests
 
     #region For-of Loops
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_Basic_IteratesArray(ExecutionMode mode)
     {
         var source = """
@@ -119,8 +114,7 @@ public class ControlFlowTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_WithBreak_ExitsLoop(ExecutionMode mode)
     {
         var source = """
@@ -137,8 +131,7 @@ public class ControlFlowTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_WithContinue_SkipsIteration(ExecutionMode mode)
     {
         var source = """
@@ -155,8 +148,7 @@ public class ControlFlowTests
         Assert.Equal("1\n2\n4\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_WithStrings_IteratesElements(ExecutionMode mode)
     {
         var source = """
@@ -174,8 +166,7 @@ public class ControlFlowTests
 
     #region Typeof Operator
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Typeof_Number_ReturnsNumber(ExecutionMode mode)
     {
         var source = """
@@ -187,8 +178,7 @@ public class ControlFlowTests
         Assert.Equal("number\nnumber\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Typeof_String_ReturnsString(ExecutionMode mode)
     {
         var source = """
@@ -200,8 +190,7 @@ public class ControlFlowTests
         Assert.Equal("string\nstring\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Typeof_Boolean_ReturnsBoolean(ExecutionMode mode)
     {
         var source = """
@@ -213,8 +202,7 @@ public class ControlFlowTests
         Assert.Equal("boolean\nboolean\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Typeof_Array_ReturnsObject(ExecutionMode mode)
     {
         var source = """
@@ -226,8 +214,7 @@ public class ControlFlowTests
         Assert.Equal("object\nobject\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Typeof_Object_ReturnsObject(ExecutionMode mode)
     {
         var source = """
@@ -238,8 +225,7 @@ public class ControlFlowTests
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Typeof_Function_ReturnsFunction(ExecutionMode mode)
     {
         var source = """
@@ -251,8 +237,7 @@ public class ControlFlowTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Typeof_Null_ReturnsObject(ExecutionMode mode)
     {
         var source = """
@@ -268,8 +253,7 @@ public class ControlFlowTests
 
     #region Instanceof Operator
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Instanceof_DirectInstance_ReturnsTrue(ExecutionMode mode)
     {
         var source = """
@@ -282,8 +266,7 @@ public class ControlFlowTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Instanceof_InheritedInstance_ReturnsTrue(ExecutionMode mode)
     {
         var source = """
@@ -298,8 +281,7 @@ public class ControlFlowTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Instanceof_DifferentClass_ReturnsFalse(ExecutionMode mode)
     {
         var source = """
@@ -313,8 +295,7 @@ public class ControlFlowTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Instanceof_ParentNotChild_ReturnsFalse(ExecutionMode mode)
     {
         var source = """
@@ -332,8 +313,7 @@ public class ControlFlowTests
 
     #region Break and Continue in While Loops
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void While_WithBreak_ExitsLoop(ExecutionMode mode)
     {
         var source = """
@@ -351,8 +331,7 @@ public class ControlFlowTests
         Assert.Equal("0\n1\n2\n3\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void While_WithContinue_SkipsIteration(ExecutionMode mode)
     {
         var source = """
@@ -374,8 +353,7 @@ public class ControlFlowTests
 
     #region For Loops
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void For_Basic_IteratesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -388,8 +366,7 @@ public class ControlFlowTests
         Assert.Equal("0\n1\n2\n3\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void For_WithBreak_ExitsLoop(ExecutionMode mode)
     {
         var source = """
@@ -405,8 +382,7 @@ public class ControlFlowTests
         Assert.Equal("0\n1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void For_WithContinue_ExecutesIncrement(ExecutionMode mode)
     {
         var source = """
@@ -424,8 +400,7 @@ public class ControlFlowTests
         Assert.Equal("8\n", output);  // 0+1+3+4 = 8
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void For_WithContinue_DoesNotInfiniteLoop(ExecutionMode mode)
     {
         var source = """
@@ -441,8 +416,7 @@ public class ControlFlowTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void For_ContinueAtStart_StillIncrements(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/CrossModuleChainedLogicalOrTests.cs
+++ b/SharpTS.Tests/SharedTests/CrossModuleChainedLogicalOrTests.cs
@@ -10,15 +10,14 @@ namespace SharpTS.Tests.SharedTests;
 /// evaluates truthy when each individual sub-expression is false.
 /// </summary>
 /// <remarks>
-/// The workaround in <c>stdlib/node/assert.ts</c> is to bind each
-/// sub-condition to a local first. When this bug is fixed, remove the
-/// <see cref="TheoryAttribute.Skip"/> attribute below and the workaround in
-/// <c>deepEquals</c> can be reverted to an inline compound expression.
+/// Regression note: the compiler bug is fixed (this test runs un-skipped in
+/// both modes and passes). <c>stdlib/node/assert.ts</c>'s <c>deepEquals</c>
+/// still uses the bind-each-sub-condition-to-a-local workaround from the
+/// broken era; it is behavior-equivalent, so reverting it is optional.
 /// </remarks>
 public class CrossModuleChainedLogicalOrTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ChainedLogicalOr_WithTypeofAndNull_AcrossModuleImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/CrossModuleNameCollisionTests.cs
+++ b/SharpTS.Tests/SharedTests/CrossModuleNameCollisionTests.cs
@@ -14,8 +14,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class CrossModuleNameCollisionTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportedFunctionSurvivesConstShadowingInImporter(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -34,8 +33,7 @@ public class CrossModuleNameCollisionTests
         Assert.Equal("from-lib\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LibModuleReferencesOwnExportedFunctionDespiteImporterConflict(ExecutionMode mode)
     {
         // lib.ts should see its OWN `foo` via hoisting even when main.ts has
@@ -58,8 +56,7 @@ public class CrossModuleNameCollisionTests
         Assert.Equal("lib: function\nmain: ok\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TwoModulesDeclaringSameConstName(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -88,8 +85,7 @@ public class CrossModuleNameCollisionTests
     // was a flat map keyed by local name, so the second module to load
     // clobbered the first's binding. With `os` imported before `process`,
     // os.ts's `__platform()` call was mis-routed to process's binding.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OsBeforeProcess_PlatformAndArchResolveCorrectly(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -111,8 +107,7 @@ public class CrossModuleNameCollisionTests
         Assert.Contains("pid-typeof: number", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProcessBeforeOs_PlatformAndArchResolveCorrectly(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -145,8 +140,7 @@ public class CrossModuleNameCollisionTests
     // sync. These run in BOTH modes: compiled pins the fix, interpreted guards the (already
     // correct) reference behavior.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TwoModulesDeclaringSameAsyncFunctionName(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -168,8 +162,7 @@ public class CrossModuleNameCollisionTests
         Assert.Equal("A B\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TwoModulesDeclaringSameGeneratorFunctionName(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -191,8 +184,7 @@ public class CrossModuleNameCollisionTests
         Assert.Equal("A1,A2\nB1,B2\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TwoModulesDeclaringSameAsyncGeneratorFunctionName(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -217,8 +209,7 @@ public class CrossModuleNameCollisionTests
         Assert.Equal("A1\nA2\nB1\nB2\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TwoModulesDefaultExportingSameAsyncFunctionName(ExecutionMode mode)
     {
         // The `export default` store branch is distinct from named exports; cover the
@@ -242,8 +233,7 @@ public class CrossModuleNameCollisionTests
         Assert.Equal("DA DB\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TwoModulesMixingAsyncAndSyncSameFunctionName(ExecutionMode mode)
     {
         // One module's `dup` is async (qualified state-machine stub), the other's is sync
@@ -267,8 +257,7 @@ public class CrossModuleNameCollisionTests
         Assert.Equal("async sync\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TwoModulesSameAsyncFunctionNameEachCapturingOwnModuleConst(ExecutionMode mode)
     {
         // Each colliding async function captures a module-level const of the same name. Beyond

--- a/SharpTS.Tests/SharedTests/CrossModuleRestParamTests.cs
+++ b/SharpTS.Tests/SharedTests/CrossModuleRestParamTests.cs
@@ -17,8 +17,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class CrossModuleRestParamTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RestParam_AcrossModuleImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -38,8 +37,7 @@ public class CrossModuleRestParamTests
         Assert.Equal("a,b,c\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectLiteralMethod_AcrossModuleImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -63,8 +61,7 @@ public class CrossModuleRestParamTests
 
     // ---- #426: state-machine functions (generator/async/async-generator) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorRestParam_AcrossModuleImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -86,8 +83,7 @@ public class CrossModuleRestParamTests
         Assert.Equal("10,20,\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncRestParam_AcrossModuleImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -109,8 +105,7 @@ public class CrossModuleRestParamTests
         Assert.Equal("sum=6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGeneratorRestParam_AcrossModuleImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -137,8 +132,7 @@ public class CrossModuleRestParamTests
         Assert.Equal("agen=101,102,103,\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorLeadingRegularParamThenRest_AcrossModuleImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -160,8 +154,7 @@ public class CrossModuleRestParamTests
         Assert.Equal("n1,n2,\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorEmptyRest_AcrossModuleImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -184,8 +177,7 @@ public class CrossModuleRestParamTests
         Assert.Equal("[]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadOfImportedGeneratorRestResult(ExecutionMode mode)
     {
         // Secondary #426 symptom: spreading the imported rest-param generator's

--- a/SharpTS.Tests/SharedTests/DataViewTests.cs
+++ b/SharpTS.Tests/SharedTests/DataViewTests.cs
@@ -10,8 +10,7 @@ public class DataViewTests
 {
     #region Constructor Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_Constructor_CreatesViewOverArrayBuffer(ExecutionMode mode)
     {
         var source = @"
@@ -24,8 +23,7 @@ public class DataViewTests
         Assert.Equal("16\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_Constructor_WithByteOffset(ExecutionMode mode)
     {
         var source = @"
@@ -38,8 +36,7 @@ public class DataViewTests
         Assert.Equal("12\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_Constructor_WithByteOffsetAndLength(ExecutionMode mode)
     {
         var source = @"
@@ -52,8 +49,7 @@ public class DataViewTests
         Assert.Equal("8\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_Constructor_OverSharedArrayBuffer(ExecutionMode mode)
     {
         var source = @"
@@ -66,8 +62,7 @@ public class DataViewTests
         Assert.Equal("16\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_Constructor_InvalidOffset_ThrowsRangeError(ExecutionMode mode)
     {
         var source = @"
@@ -83,8 +78,7 @@ public class DataViewTests
         Assert.Equal("error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_Constructor_InvalidLength_ThrowsRangeError(ExecutionMode mode)
     {
         var source = @"
@@ -104,8 +98,7 @@ public class DataViewTests
 
     #region Buffer Property Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_Buffer_ReturnsUnderlyingArrayBuffer(ExecutionMode mode)
     {
         var source = @"
@@ -122,8 +115,7 @@ public class DataViewTests
 
     #region Int8/Uint8 Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_SetGetInt8(ExecutionMode mode)
     {
         var source = @"
@@ -138,8 +130,7 @@ public class DataViewTests
         Assert.Equal("127\n-128\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_SetGetUint8(ExecutionMode mode)
     {
         var source = @"
@@ -158,8 +149,7 @@ public class DataViewTests
 
     #region Int16/Uint16 Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_SetGetInt16_BigEndian(ExecutionMode mode)
     {
         var source = @"
@@ -174,8 +164,7 @@ public class DataViewTests
         Assert.Equal("4660\n18\n52\n", output); // 0x1234 = 4660, big-endian: [0x12, 0x34]
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_SetGetInt16_LittleEndian(ExecutionMode mode)
     {
         var source = @"
@@ -190,8 +179,7 @@ public class DataViewTests
         Assert.Equal("4660\n52\n18\n", output); // 0x1234 = 4660, little-endian: [0x34, 0x12]
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_SetGetUint16(ExecutionMode mode)
     {
         var source = @"
@@ -208,8 +196,7 @@ public class DataViewTests
 
     #region Int32/Uint32 Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_SetGetInt32_BigEndian(ExecutionMode mode)
     {
         var source = @"
@@ -222,8 +209,7 @@ public class DataViewTests
         Assert.Equal("305419896\n", output); // 0x12345678 = 305419896
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_SetGetInt32_LittleEndian(ExecutionMode mode)
     {
         var source = @"
@@ -236,8 +222,7 @@ public class DataViewTests
         Assert.Equal("305419896\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_SetGetUint32(ExecutionMode mode)
     {
         var source = @"
@@ -250,8 +235,7 @@ public class DataViewTests
         Assert.Equal("4294967295\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_NegativeInt32(ExecutionMode mode)
     {
         var source = @"
@@ -269,8 +253,7 @@ public class DataViewTests
 
     #region Float32/Float64 Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_SetGetFloat32(ExecutionMode mode)
     {
         var source = @"
@@ -284,8 +267,7 @@ public class DataViewTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_SetGetFloat64(ExecutionMode mode)
     {
         var source = @"
@@ -299,8 +281,7 @@ public class DataViewTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_Float64_Endianness(ExecutionMode mode)
     {
         var source = @"
@@ -321,8 +302,7 @@ public class DataViewTests
 
     #region BigInt64/BigUint64 Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_SetGetBigInt64(ExecutionMode mode)
     {
         var source = @"
@@ -336,8 +316,7 @@ public class DataViewTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_SetGetBigUint64(ExecutionMode mode)
     {
         var source = @"
@@ -351,8 +330,7 @@ public class DataViewTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_NegativeBigInt64(ExecutionMode mode)
     {
         var source = @"
@@ -370,8 +348,7 @@ public class DataViewTests
 
     #region Out of Bounds Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_GetInt8_OutOfBounds_ThrowsRangeError(ExecutionMode mode)
     {
         var source = @"
@@ -388,8 +365,7 @@ public class DataViewTests
         Assert.Equal("error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_GetInt32_OutOfBounds_ThrowsRangeError(ExecutionMode mode)
     {
         var source = @"
@@ -406,8 +382,7 @@ public class DataViewTests
         Assert.Equal("error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_SetFloat64_OutOfBounds_ThrowsRangeError(ExecutionMode mode)
     {
         var source = @"
@@ -428,8 +403,7 @@ public class DataViewTests
 
     #region ArrayBuffer.isView Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayBuffer_IsView_ReturnsTrueForDataView(ExecutionMode mode)
     {
         var source = @"
@@ -445,8 +419,7 @@ public class DataViewTests
 
     #region Shared Memory Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_SharesMemoryWithTypedArray(ExecutionMode mode)
     {
         var source = @"
@@ -464,8 +437,7 @@ public class DataViewTests
         Assert.Equal("18\n52\n86\n120\n", output); // 0x12, 0x34, 0x56, 0x78
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_WithOffset_SharesMemory(ExecutionMode mode)
     {
         var source = @"
@@ -492,8 +464,7 @@ public class DataViewTests
 
     #region Default Endianness Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DataView_DefaultEndianness_IsBigEndian(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/DateTests.cs
+++ b/SharpTS.Tests/SharedTests/DateTests.cs
@@ -10,8 +10,7 @@ public class DateTests
 {
     #region Constructor Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_NoArgs_CreatesCurrentDate(ExecutionMode mode)
     {
         // Date with no args should create a date near current time
@@ -25,8 +24,7 @@ public class DateTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_Milliseconds_CreatesFromEpoch(ExecutionMode mode)
     {
         // Create date from milliseconds since epoch
@@ -38,8 +36,7 @@ public class DateTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_Components_CreatesCorrectDate(ExecutionMode mode)
     {
         // Create date from year, month, day
@@ -54,8 +51,7 @@ public class DateTests
         Assert.Equal("2024\n0\n15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_Components_WithTime(ExecutionMode mode)
     {
         var source = @"
@@ -72,8 +68,7 @@ public class DateTests
         Assert.Equal("2024\n5\n20\n14\n30\n45\n123\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_ISOString_ParsesCorrectly(ExecutionMode mode)
     {
         var source = @"
@@ -88,8 +83,7 @@ public class DateTests
 
     #region Static Method Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_Now_ReturnsNumber(ExecutionMode mode)
     {
         var source = @"
@@ -101,8 +95,7 @@ public class DateTests
         Assert.Equal("number\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_FunctionCall_ReturnsString(ExecutionMode mode)
     {
         // Date() called without 'new' returns a string
@@ -118,8 +111,7 @@ public class DateTests
 
     #region Getter Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_GetMonth_Returns0Indexed(ExecutionMode mode)
     {
         // January is 0, December is 11
@@ -133,8 +125,7 @@ public class DateTests
         Assert.Equal("0\n11\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_GetDay_ReturnsCorrectDayOfWeek(ExecutionMode mode)
     {
         // 2024-01-01 is Monday (day 1), Sunday is 0
@@ -146,8 +137,7 @@ public class DateTests
         Assert.Equal("0\n", output); // January 7, 2024 is Sunday
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_GetTimezoneOffset_ReturnsNumber(ExecutionMode mode)
     {
         var source = @"
@@ -163,8 +153,7 @@ public class DateTests
 
     #region Setter Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_SetFullYear_MutatesAndReturnsTimestamp(ExecutionMode mode)
     {
         var source = @"
@@ -177,8 +166,7 @@ public class DateTests
         Assert.Equal("2025\nnumber\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_SetMonth_MutatesDate(ExecutionMode mode)
     {
         var source = @"
@@ -190,8 +178,7 @@ public class DateTests
         Assert.Equal("6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_SetDate_MutatesDay(ExecutionMode mode)
     {
         var source = @"
@@ -203,8 +190,7 @@ public class DateTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_SetHours_MutatesTime(ExecutionMode mode)
     {
         var source = @"
@@ -216,8 +202,7 @@ public class DateTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_SetTime_SetsFromEpoch(ExecutionMode mode)
     {
         var source = @"
@@ -233,8 +218,7 @@ public class DateTests
 
     #region Conversion Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_ToISOString_ReturnsUTCFormat(ExecutionMode mode)
     {
         var source = @"
@@ -247,8 +231,7 @@ public class DateTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_ToJSON_ReturnsISOString(ExecutionMode mode)
     {
         // toJSON returns the same ISO string as toISOString for a valid date (#491).
@@ -260,8 +243,7 @@ public class DateTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_ToJSON_InvalidDate_ReturnsNull(ExecutionMode mode)
     {
         // ECMA-262 §21.4.4.37: toJSON returns null for a non-finite (Invalid) date,
@@ -274,8 +256,7 @@ public class DateTests
         Assert.Equal("null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_ValueOf_ReturnsTimestamp(ExecutionMode mode)
     {
         var source = @"
@@ -286,8 +267,7 @@ public class DateTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_ToString_ReturnsString(ExecutionMode mode)
     {
         var source = @"
@@ -304,8 +284,7 @@ public class DateTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_InvalidString_CreatesInvalidDate(ExecutionMode mode)
     {
         var source = @"
@@ -317,8 +296,7 @@ public class DateTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_MonthOverflow_RollsOver(ExecutionMode mode)
     {
         // Month 12 should roll over to next year
@@ -331,8 +309,7 @@ public class DateTests
         Assert.Equal("2025\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_TwoDigitYear_MapsTo1900s(ExecutionMode mode)
     {
         // Years 0-99 in constructor should map to 1900-1999
@@ -348,8 +325,7 @@ public class DateTests
 
     #region UTC, Locale, and Legacy Methods (issue #516)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_UTCGetters_ReadEpochInUTC(ExecutionMode mode)
     {
         // UTC getters read the stored instant directly, so the result is timezone-independent.
@@ -362,8 +338,7 @@ public class DateTests
         Assert.Equal("1970 0 1 4\n0 0 0 0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_UTCSetters_MutateInUTC(ExecutionMode mode)
     {
         // Single-argument setters behave identically in both modes (no optional args dropped).
@@ -383,8 +358,7 @@ public class DateTests
         Assert.Equal("2020 5 15\n13 30 45 500\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_SetUTCMonth_RollsOver(ExecutionMode mode)
     {
         // setUTCMonth(13) advances into the next year (month 1 = February).
@@ -398,8 +372,7 @@ public class DateTests
         Assert.Equal("2025 1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_ToUTCString_FormatsInRFC7231(ExecutionMode mode)
     {
         var source = @"
@@ -410,8 +383,7 @@ public class DateTests
         Assert.Equal("Thu, 01 Jan 1970 00:00:00 GMT\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_ToLocaleMethods_ReturnStrings(ExecutionMode mode)
     {
         // Output is locale/host-defined, so assert only that they return non-empty strings.
@@ -425,8 +397,7 @@ public class DateTests
         Assert.Equal("string true\nstring true\nstring true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_GetYearAndSetYear_AnnexB(ExecutionMode mode)
     {
         // getYear/setYear operate in local time; constructing and reading locally is TZ-independent.
@@ -443,8 +414,7 @@ public class DateTests
         Assert.Equal("124\n1999\n2005\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_InvalidDate_NewMembersDegradeGracefully(ExecutionMode mode)
     {
         var source = @"
@@ -458,8 +428,7 @@ public class DateTests
         Assert.Equal("Invalid Date\nInvalid Date\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_SetMinutesAndSeconds_MutateInBothModes(ExecutionMode mode)
     {
         // Regression guard: compiled setMinutes/setSeconds/setMilliseconds were previously
@@ -475,8 +444,7 @@ public class DateTests
         Assert.Equal("45 50 123\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_MultiArgSetters_HonorOptionalArgs(ExecutionMode mode)
     {
         // #536: both modes honor the optional trailing arguments of the multi-argument setters
@@ -496,8 +464,7 @@ public class DateTests
         Assert.Equal("2020 5 15\n13 30 45 500\n8 15 5 40\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_MultiArgSetters_OverflowRollsOverAllAtOnce(ExecutionMode mode)
     {
         // setUTCFullYear(2020, 1, 31) = Feb 31 2020 -> Mar 2 (leap year), computed all-at-once,
@@ -511,8 +478,7 @@ public class DateTests
         Assert.Equal("2020 2 2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_UTC_ReturnsUTCTimestamp(ExecutionMode mode)
     {
         // #538: Date.UTC builds a UTC timestamp; month defaults 0, date 1; 2-digit years map to
@@ -529,8 +495,7 @@ public class DateTests
         Assert.Equal("1704067200000\n1718458245500\n1704067200000\n0\ntrue\n2000-01-01T00:00:00.000Z\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_Parse_ReturnsTimestampOrNaN(ExecutionMode mode)
     {
         // #538: Date.parse returns the timestamp for a parseable string (NaN otherwise), and is
@@ -544,8 +509,7 @@ public class DateTests
         Assert.Equal("1705314600000\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_UTCAndParse_ValueForm(ExecutionMode mode)
     {
         // #538: the statics are also usable in value form (e.g. const f = Date.UTC).
@@ -559,8 +523,7 @@ public class DateTests
         Assert.Equal("1704067200000\n1705314600000\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Date_ToLocale_HonorsLocaleAndOptions(ExecutionMode mode)
     {
         // #539: locale and options are honored. Exact locale-formatted output is host-dependent

--- a/SharpTS.Tests/SharedTests/DeadCodeEliminationTests.cs
+++ b/SharpTS.Tests/SharedTests/DeadCodeEliminationTests.cs
@@ -15,8 +15,7 @@ public class DeadCodeEliminationTests
 {
     #region Level 1: Constant Condition Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IfTrue_OnlyThenBranchExecutes(ExecutionMode mode)
     {
         var source = """
@@ -30,8 +29,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("then\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IfFalse_OnlyElseBranchExecutes(ExecutionMode mode)
     {
         var source = """
@@ -45,8 +43,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("else\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IfFalse_NoElse_NothingExecutes(ExecutionMode mode)
     {
         var source = """
@@ -59,8 +56,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("after\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LogicalAnd_FalseShortCircuits(ExecutionMode mode)
     {
         var source = """
@@ -74,8 +70,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("else\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LogicalOr_TrueShortCircuits(ExecutionMode mode)
     {
         var source = """
@@ -89,8 +84,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("then\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Negation_NotFalse_ExecutesThen(ExecutionMode mode)
     {
         var source = """
@@ -104,8 +98,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("then\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Negation_NotTrue_ExecutesElse(ExecutionMode mode)
     {
         var source = """
@@ -119,8 +112,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("else\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ComplexLogical_TrueAndTrue_ExecutesThen(ExecutionMode mode)
     {
         var source = """
@@ -134,8 +126,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("then\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ComplexLogical_FalseOrFalse_ExecutesElse(ExecutionMode mode)
     {
         var source = """
@@ -153,8 +144,7 @@ public class DeadCodeEliminationTests
 
     #region Level 2: Type-Based Condition Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeofString_AlwaysTrue_ExecutesThen(ExecutionMode mode)
     {
         var source = """
@@ -169,8 +159,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("is string\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeofString_AlwaysFalse_SkipsEntireIf(ExecutionMode mode)
     {
         var source = """
@@ -184,8 +173,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeofNumber_AlwaysTrue_ExecutesThen(ExecutionMode mode)
     {
         var source = """
@@ -200,8 +188,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("is number\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeofBoolean_AlwaysFalse_ExecutesElse(ExecutionMode mode)
     {
         var source = """
@@ -216,8 +203,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("not boolean\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeofNotEqual_StringIsNotNumber_ExecutesThen(ExecutionMode mode)
     {
         var source = """
@@ -232,8 +218,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("not number\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeofStrictEqual_StringIsString_ExecutesThen(ExecutionMode mode)
     {
         var source = """
@@ -248,8 +233,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("is string\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeofStrictNotEqual_NumberIsNotString_ExecutesThen(ExecutionMode mode)
     {
         var source = """
@@ -264,8 +248,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("not string\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UnionType_MixedTypeof_BothBranchesReachable(ExecutionMode mode)
     {
         var source = """
@@ -287,8 +270,7 @@ public class DeadCodeEliminationTests
 
     #region Level 3: Control Flow Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AfterReturn_CodeNotExecuted(ExecutionMode mode)
     {
         var source = """
@@ -303,8 +285,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("before\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AfterThrow_CodeNotExecuted(ExecutionMode mode)
     {
         var source = """
@@ -323,8 +304,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("before\ncaught\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AfterBreak_CodeNotExecuted(ExecutionMode mode)
     {
         var source = """
@@ -342,8 +322,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("0\n1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AfterContinue_CodeNotExecuted(ExecutionMode mode)
     {
         var source = """
@@ -361,8 +340,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("1\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnFromFunctionCall_AfterCodeNotExecuted(ExecutionMode mode)
     {
         // Test that code after return with function call result is not executed
@@ -382,8 +360,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("before\ngetValue\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IfBothBranchesReturn_AfterIfNotExecuted(ExecutionMode mode)
     {
         var source = """
@@ -402,8 +379,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultipleReturns_OnlyFirstExecuted(ExecutionMode mode)
     {
         var source = """
@@ -425,8 +401,7 @@ public class DeadCodeEliminationTests
 
     #region Exhaustive Switch Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExhaustiveSwitch_DefaultNotExecuted(ExecutionMode mode)
     {
         var source = """
@@ -445,8 +420,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonExhaustiveSwitch_DefaultExecuted(ExecutionMode mode)
     {
         var source = """
@@ -463,8 +437,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("default\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SwitchWithThreeOptions_AllCasesCovered(ExecutionMode mode)
     {
         var source = """
@@ -489,8 +462,7 @@ public class DeadCodeEliminationTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedIfTrue_BothLevelsOptimized(ExecutionMode mode)
     {
         var source = """
@@ -508,8 +480,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("inner then\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedIfFalse_BothLevelsOptimized(ExecutionMode mode)
     {
         var source = """
@@ -527,8 +498,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("inner else\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WhileFalse_BodyNeverExecutes(ExecutionMode mode)
     {
         var source = """
@@ -541,8 +511,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("after\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TernaryWithTrue_ReturnsFirstValue(ExecutionMode mode)
     {
         var source = """
@@ -553,8 +522,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TernaryWithFalse_ReturnsSecondValue(ExecutionMode mode)
     {
         var source = """
@@ -565,8 +533,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GroupedCondition_TrueInParens_ExecutesThen(ExecutionMode mode)
     {
         var source = """
@@ -580,8 +547,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("then\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DoubleNegation_NotNotTrue_ExecutesThen(ExecutionMode mode)
     {
         var source = """
@@ -595,8 +561,7 @@ public class DeadCodeEliminationTests
         Assert.Equal("then\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionWithMultipleExitPoints_CorrectPathExecutes(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/DeclareFieldTests.cs
+++ b/SharpTS.Tests/SharedTests/DeclareFieldTests.cs
@@ -11,8 +11,7 @@ public class DeclareFieldTests
 {
     #region Instance Declare Fields
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeclareField_Instance_ReturnsNull(ExecutionMode mode)
     {
         var source = """
@@ -27,8 +26,7 @@ public class DeclareFieldTests
         Assert.Equal("null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeclareField_Instance_CanBeSetExternally(ExecutionMode mode)
     {
         var source = """
@@ -44,8 +42,7 @@ public class DeclareFieldTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeclareField_MultipleInstances_IndependentValues(ExecutionMode mode)
     {
         var source = """
@@ -68,8 +65,7 @@ public class DeclareFieldTests
 
     #region Static Declare Fields
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeclareField_Static_ReturnsNull(ExecutionMode mode)
     {
         var source = """
@@ -83,8 +79,7 @@ public class DeclareFieldTests
         Assert.Equal("null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeclareField_Static_CanBeSetExternally(ExecutionMode mode)
     {
         var source = """
@@ -103,8 +98,7 @@ public class DeclareFieldTests
 
     #region Mixed Fields
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeclareField_MixedWithRegularFields(ExecutionMode mode)
     {
         var source = """
@@ -121,8 +115,7 @@ public class DeclareFieldTests
         Assert.Equal("null\ndefault\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeclareField_StaticWithOtherStaticFields(ExecutionMode mode)
     {
         var source = """
@@ -146,8 +139,7 @@ public class DeclareFieldTests
 
     #region Access Modifiers
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeclareField_WithReadonly_AccessUninitialized(ExecutionMode mode)
     {
         // Readonly declare fields exist but can only be read (not assigned after construction)
@@ -163,8 +155,7 @@ public class DeclareFieldTests
         Assert.Equal("null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeclareField_WithPrivateAccess(ExecutionMode mode)
     {
         var source = """
@@ -193,8 +184,7 @@ public class DeclareFieldTests
 
     #region Class Expression
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeclareField_ClassExpression(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/DecoratorTests.cs
+++ b/SharpTS.Tests/SharedTests/DecoratorTests.cs
@@ -14,8 +14,7 @@ public class DecoratorTests
 {
     #region Legacy (Stage 2) Decorators
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LegacyClassDecorator_Simple(ExecutionMode mode)
     {
         const string source = """
@@ -33,8 +32,7 @@ public class DecoratorTests
         Assert.Equal("Class decorated\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LegacyClassDecorator_Factory(ExecutionMode mode)
     {
         const string source = """
@@ -55,8 +53,7 @@ public class DecoratorTests
         Assert.Equal("Tagged with: important\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LegacyMethodDecorator_Simple(ExecutionMode mode)
     {
         const string source = """
@@ -79,8 +76,7 @@ public class DecoratorTests
         Assert.Equal("Method decorated: greet\nHello!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LegacyFieldDecorator_Simple(ExecutionMode mode)
     {
         const string source = """
@@ -101,8 +97,7 @@ public class DecoratorTests
         Assert.Equal("Field decorated: name\ntest\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LegacyMultipleDecorators_RightToLeft(ExecutionMode mode)
     {
         const string source = """
@@ -126,8 +121,7 @@ public class DecoratorTests
         Assert.Equal("second\nfirst\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LegacyParameterDecorator_Simple(ExecutionMode mode)
     {
         const string source = """
@@ -153,8 +147,7 @@ public class DecoratorTests
 
     #region TC39 Stage 3 Decorators
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stage3ClassDecorator_Simple(ExecutionMode mode)
     {
         const string source = """
@@ -172,8 +165,7 @@ public class DecoratorTests
         Assert.Equal("Class class: MyClass\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stage3MethodDecorator_Simple(ExecutionMode mode)
     {
         const string source = """
@@ -196,8 +188,7 @@ public class DecoratorTests
         Assert.Equal("Method method: greet\nHello!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stage3FieldDecorator_Simple(ExecutionMode mode)
     {
         const string source = """
@@ -218,8 +209,7 @@ public class DecoratorTests
         Assert.Equal("Field field: name\ntest\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Stage3Decorator_ContextStatic(ExecutionMode mode)
     {
         const string source = """
@@ -245,8 +235,7 @@ public class DecoratorTests
     #region Reflect Metadata
 
     /// <summary>Compiled mode: Reflect metadata API is not available.</summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReflectMetadata_DefineAndGet(ExecutionMode mode)
     {
         const string source = """
@@ -263,8 +252,7 @@ public class DecoratorTests
     }
 
     /// <summary>Compiled mode: Reflect metadata API is not available.</summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReflectMetadata_PropertyKey(ExecutionMode mode)
     {
         const string source = """
@@ -281,8 +269,7 @@ public class DecoratorTests
     }
 
     /// <summary>Compiled mode: Reflect metadata API is not available.</summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReflectMetadata_HasMetadata(ExecutionMode mode)
     {
         const string source = """
@@ -298,8 +285,7 @@ public class DecoratorTests
     }
 
     /// <summary>Compiled mode: Reflect metadata API is not available.</summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReflectMetadata_GetKeys(ExecutionMode mode)
     {
         const string source = """
@@ -316,8 +302,7 @@ public class DecoratorTests
     }
 
     /// <summary>Compiled mode: Reflect metadata API is not available.</summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReflectMetadata_DeleteMetadata(ExecutionMode mode)
     {
         const string source = """
@@ -333,8 +318,7 @@ public class DecoratorTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReflectMetadata_DecoratorFactory(ExecutionMode mode)
     {
         const string source = """
@@ -394,8 +378,7 @@ public class DecoratorTests
     // only checked EXPORT before parsing decorators, so `@dec export class` fell through
     // to "Decorators are not valid here." These cover every export-class form.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LegacyClassDecorator_OnExportClass(ExecutionMode mode)
     {
         const string source = """
@@ -413,8 +396,7 @@ public class DecoratorTests
         Assert.Equal("Class decorated\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LegacyClassDecorator_OnExportDefaultClass(ExecutionMode mode)
     {
         const string source = """
@@ -432,8 +414,7 @@ public class DecoratorTests
         Assert.Equal("Class decorated\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LegacyClassDecorator_OnExportAbstractClass(ExecutionMode mode)
     {
         const string source = """

--- a/SharpTS.Tests/SharedTests/DefaultParameterTests.cs
+++ b/SharpTS.Tests/SharedTests/DefaultParameterTests.cs
@@ -11,8 +11,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class DefaultParameterTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParam_StringValue_AppliedAcrossModuleImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -33,8 +32,7 @@ public class DefaultParameterTests
         Assert.Equal("Hello, World\nHi, World\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParam_MultipleDefaults_AppliedAcrossModuleImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -56,8 +54,7 @@ public class DefaultParameterTests
         Assert.Equal("app-v1\napp_v1\napp_prod\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParam_DirectCall_StillWorks(ExecutionMode mode)
     {
         // Direct same-module calls must continue to work — the overload-generator
@@ -74,8 +71,7 @@ public class DefaultParameterTests
         Assert.Equal("Hello, World\nHi, World\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParam_NumericValue_DirectCall(ExecutionMode mode)
     {
         // Numeric (value-type) defaults work for direct same-module calls via OverloadGenerator,
@@ -95,8 +91,7 @@ public class DefaultParameterTests
         Assert.Equal("8\n14\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParam_NumericValue_AppliedAcrossModuleImport(ExecutionMode mode)
     {
         // #925: a VALUE-TYPE default (`number`) on a module-exported function must fire through the
@@ -117,8 +112,7 @@ public class DefaultParameterTests
         Assert.Equal("8\n14\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParam_BooleanAndBigIntValue_AppliedAcrossModuleImport(ExecutionMode mode)
     {
         // #925: the value-type-default fix covers `boolean` and `bigint` defaults too, not just `number`.
@@ -137,8 +131,7 @@ public class DefaultParameterTests
         Assert.Equal("true\n7n\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParam_NumericValue_ValueCallBoundary(ExecutionMode mode)
     {
         // #925: same fix via the value-call path — a function stored in a value and called with the
@@ -152,8 +145,7 @@ public class DefaultParameterTests
         Assert.Equal("8\n14\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParam_NumericValue_AsyncFunction_AcrossModuleImport(ExecutionMode mode)
     {
         // #925: an exported ASYNC function with a value-type default fires it through the boundary.
@@ -174,8 +166,7 @@ public class DefaultParameterTests
         Assert.Equal("8\n14\n", TestHarness.RunModules(files, "main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParam_ExplicitUndefined_FiresDefault(ExecutionMode mode)
     {
         // Per JS spec, passing explicit `undefined` must trigger the default.
@@ -222,8 +213,7 @@ public class DefaultParameterTests
         Assert.Equal("-1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParam_FunctionExpression_OmittedArg_AppliesDefault(ExecutionMode mode)
     {
         // #646: a function *expression* (or arrow) used to drop the default in compiled mode,
@@ -237,8 +227,7 @@ public class DefaultParameterTests
         Assert.Equal("7\n14\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParam_ArrowFunction_OmittedArg_AppliesDefault(ExecutionMode mode)
     {
         // #646
@@ -250,8 +239,7 @@ public class DefaultParameterTests
         Assert.Equal("7\n14\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParam_AsyncArrow_OmittedArg_AppliesDefault(ExecutionMode mode)
     {
         // #646 / #635: the async function-expression / async-arrow path inherits the same
@@ -263,8 +251,7 @@ public class DefaultParameterTests
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParam_ReferencesEarlierParam_Arrow(ExecutionMode mode)
     {
         // #698: a later default may reference any earlier parameter. The arrow / function-expression
@@ -277,8 +264,7 @@ public class DefaultParameterTests
         Assert.Equal("15\n6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParam_ReferencesEarlierParam_FunctionDeclaration(ExecutionMode mode)
     {
         // #698: function-declaration earlier-param default. Compiled mode used to crash at runtime
@@ -292,8 +278,7 @@ public class DefaultParameterTests
         Assert.Equal("10\n6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParam_ReferencesEarlierParam_StringValue(ExecutionMode mode)
     {
         // #698: reference-typed earlier-param default (exercises a different conversion path
@@ -306,8 +291,7 @@ public class DefaultParameterTests
         Assert.Equal("xx\nxy\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParam_ReferencesEarlierDefaultedParam_Chain(ExecutionMode mode)
     {
         // #698: a default may reference an earlier *defaulted* parameter, e.g. c = a + b where b is
@@ -323,8 +307,7 @@ public class DefaultParameterTests
         Assert.Equal("12\n14\n10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void DefaultParam_ReferencesEarlierParam_Method(ExecutionMode mode)
     {
         // #698: a method default referencing an earlier parameter type-checks and evaluates correctly

--- a/SharpTS.Tests/SharedTests/DeleteOperatorTests.cs
+++ b/SharpTS.Tests/SharedTests/DeleteOperatorTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class DeleteOperatorTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Delete_ObjectProperty_ReturnsTrue(ExecutionMode mode)
     {
         var source = """
@@ -23,8 +22,7 @@ public class DeleteOperatorTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Delete_ComputedProperty_ReturnsTrue(ExecutionMode mode)
     {
         var source = """
@@ -38,8 +36,7 @@ public class DeleteOperatorTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Delete_ExistingProperty_Works(ExecutionMode mode)
     {
         var source = """
@@ -54,8 +51,7 @@ public class DeleteOperatorTests
         Assert.Equal("bar\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Delete_FrozenObject_ReturnsFalse(ExecutionMode mode)
     {
         var source = """
@@ -70,8 +66,7 @@ public class DeleteOperatorTests
         Assert.Equal("false\ntest\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Delete_SealedObject_ReturnsFalse(ExecutionMode mode)
     {
         var source = """
@@ -86,8 +81,7 @@ public class DeleteOperatorTests
         Assert.Equal("false\ntest\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Delete_MultipleProperties(ExecutionMode mode)
     {
         var source = """
@@ -103,8 +97,7 @@ public class DeleteOperatorTests
         Assert.Equal("true\n2\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Delete_Expression_EvaluatesOperand(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/DestructuringTests.cs
+++ b/SharpTS.Tests/SharedTests/DestructuringTests.cs
@@ -11,8 +11,7 @@ public class DestructuringTests
 {
     #region Array Destructuring
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayDestructuring_BasicAssignment(ExecutionMode mode)
     {
         var source = """
@@ -26,8 +25,7 @@ public class DestructuringTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayDestructuring_WithRest(ExecutionMode mode)
     {
         var source = """
@@ -42,8 +40,7 @@ public class DestructuringTests
         Assert.Equal("1\n3\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayDestructuring_WithHoles(ExecutionMode mode)
     {
         var source = """
@@ -56,8 +53,7 @@ public class DestructuringTests
         Assert.Equal("1\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayDestructuring_TrailingComma(ExecutionMode mode)
     {
         var source = """
@@ -74,8 +70,7 @@ public class DestructuringTests
 
     #region Object Destructuring
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectDestructuring_BasicAssignment(ExecutionMode mode)
     {
         var source = """
@@ -89,8 +84,7 @@ public class DestructuringTests
         Assert.Equal("Alice\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectDestructuring_WithRename(ExecutionMode mode)
     {
         var source = """
@@ -103,8 +97,7 @@ public class DestructuringTests
         Assert.Equal("Bob\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectDestructuring_WithDefault(ExecutionMode mode)
     {
         var source = """
@@ -126,8 +119,7 @@ public class DestructuringTests
     // desugared `[a, b] = src` to positional index access, which mis-evaluated (and
     // the type checker rejected) generators, Set and Map.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayDestructuring_OverGenerator(ExecutionMode mode)
     {
         var source = """
@@ -141,8 +133,7 @@ public class DestructuringTests
         Assert.Equal("10\n20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayDestructuring_OverGeneratorWithRest(ExecutionMode mode)
     {
         var source = """
@@ -159,8 +150,7 @@ public class DestructuringTests
         Assert.Equal("1\n3\n2\n3\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayDestructuring_OverSet(ExecutionMode mode)
     {
         var source = """
@@ -174,8 +164,7 @@ public class DestructuringTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayDestructuring_OverSetWithHoleAndDefault(ExecutionMode mode)
     {
         // Set has three values [10, 20, 30]; index 3 is missing → default applies.
@@ -190,8 +179,7 @@ public class DestructuringTests
         Assert.Equal("20\n99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayDestructuring_OverMapEntry(ExecutionMode mode)
     {
         // Iterating a Map yields [key, value] entries.
@@ -206,8 +194,7 @@ public class DestructuringTests
         Assert.Equal("k\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayDestructuring_NestedOverMapEntries(ExecutionMode mode)
     {
         // Nested pattern destructures each [key, value] entry positionally.
@@ -224,8 +211,7 @@ public class DestructuringTests
         Assert.Equal("a\n1\nb\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayDestructuring_OverCustomIterable(ExecutionMode mode)
     {
         var source = """
@@ -251,8 +237,7 @@ public class DestructuringTests
         Assert.Equal("0\n10\n20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayDestructuring_GeneratorElementTypeIsUsable(ExecutionMode mode)
     {
         // The destructured bindings carry the iterable's element type (number), so
@@ -268,8 +253,7 @@ public class DestructuringTests
         Assert.Equal("12\n35\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayDestructuring_FastPathArrayUnchanged(ExecutionMode mode)
     {
         // Regression guard: the iterator-protocol normalization must not disturb the
@@ -293,8 +277,7 @@ public class DestructuringTests
 
     #region Nested Destructuring
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedDestructuring_Arrays(ExecutionMode mode)
     {
         var source = """
@@ -310,8 +293,7 @@ public class DestructuringTests
         Assert.Equal("1\n2\n3\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedDestructuring_Objects(ExecutionMode mode)
     {
         var source = """
@@ -324,8 +306,7 @@ public class DestructuringTests
         Assert.Equal("test@test.com\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MixedDestructuring_ObjectWithArray(ExecutionMode mode)
     {
         var source = """
@@ -347,8 +328,7 @@ public class DestructuringTests
     // is a non-indexable union and the nested `[m]` pattern fails to type-check. The binding pattern's
     // shape is threaded as a tuple context so the literal infers as `[number[], number]`.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedDestructuring_MixedArrayLiteral_Declaration(ExecutionMode mode)
     {
         var source = """
@@ -361,8 +341,7 @@ public class DestructuringTests
         Assert.Equal("7\n8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedDestructuring_MixedArrayLiteral_Assignment(ExecutionMode mode)
     {
         var source = """
@@ -377,8 +356,7 @@ public class DestructuringTests
         Assert.Equal("7\n8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedDestructuring_MixedArrayLiteral_ExplicitTupleAnnotation(ExecutionMode mode)
     {
         var source = """
@@ -391,8 +369,7 @@ public class DestructuringTests
         Assert.Equal("7\n8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedDestructuring_MixedArrayLiteral_DeepNesting(ExecutionMode mode)
     {
         var source = """
@@ -407,8 +384,7 @@ public class DestructuringTests
 
     // Bonus: a flat mixed literal source now infers element types positionally (matching tsc), so the
     // element methods (`toFixed`/`toUpperCase`) type-check instead of reporting a spurious error.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Destructuring_FlatMixedArrayLiteral_ElementTypesUsable(ExecutionMode mode)
     {
         var source = """
@@ -423,8 +399,7 @@ public class DestructuringTests
 
     // Regression guard: a UNIFORM nested literal must stay an array (`number[]`), NOT be over-tupled —
     // `a.push(...)` would fail to type-check on a fixed-length tuple.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedDestructuring_UniformArrayLiteral_StaysArray(ExecutionMode mode)
     {
         var source = """
@@ -444,8 +419,7 @@ public class DestructuringTests
 
     // #753: a rest element over a STRING source must collect a fresh ARRAY of characters, not bind
     // the trailing substring. Non-rest character bindings are identical either way.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayDestructuring_StringRest_BindsCharArray(ExecutionMode mode)
     {
         var source = """
@@ -460,8 +434,7 @@ public class DestructuringTests
         Assert.Equal("h\ntrue\n4\ne-l-l-o\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayDestructuring_StringNonRest_Unchanged(ExecutionMode mode)
     {
         var source = """
@@ -478,8 +451,7 @@ public class DestructuringTests
     #region Assignment Destructuring (#754)
 
     // #754: destructuring assignment to EXISTING l-values (no const/let), array and object patterns.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AssignmentDestructuring_ArrayBasicAndSwap(ExecutionMode mode)
     {
         var source = """
@@ -494,8 +466,7 @@ public class DestructuringTests
         Assert.Equal("1 2\n2 1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AssignmentDestructuring_DefaultsHolesAndRest(ExecutionMode mode)
     {
         var source = """
@@ -514,8 +485,7 @@ public class DestructuringTests
         Assert.Equal("5 9\n2 4\n1 true 2,3,4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AssignmentDestructuring_MemberTargets(ExecutionMode mode)
     {
         var source = """
@@ -529,8 +499,7 @@ public class DestructuringTests
         Assert.Equal("10 20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AssignmentDestructuring_Object_RenameRestAndDefault(ExecutionMode mode)
     {
         var source = """
@@ -549,8 +518,7 @@ public class DestructuringTests
 
     // The right-hand side is normalized through the #685 iterator protocol, so a non-indexable
     // iterable (Set) destructures by assignment just like a declaration.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AssignmentDestructuring_IteratorSource(ExecutionMode mode)
     {
         var source = """
@@ -565,8 +533,7 @@ public class DestructuringTests
 
     // An assignment expression evaluates to its right-hand side (the ORIGINAL rhs, not the
     // normalized array), so it composes in expression position and chains.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AssignmentDestructuring_ExpressionPositionAndChained(ExecutionMode mode)
     {
         var source = """
@@ -588,8 +555,7 @@ public class DestructuringTests
 
     // #784: a destructuring default applies ONLY when the matched value is `undefined`, never `null`
     // (ECMA-262), unlike `??`. Declaration form, array and object patterns.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Defaults_AppliedForUndefinedNotNull_Declaration(ExecutionMode mode)
     {
         var source = """
@@ -607,8 +573,7 @@ public class DestructuringTests
     // #784: same undefined-only rule for assignment destructuring (#754 form), AND a value-type default
     // over an ABSENT element must yield the default — not NaN. The lowered spill temp lives inside an
     // expression, so an unboxed numeric slot would coerce the runtime `undefined` sentinel (compiled).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Defaults_AssignmentDestructuring_UndefinedOnlyAndValueType(ExecutionMode mode)
     {
         var source = """
@@ -627,8 +592,7 @@ public class DestructuringTests
 
     // #784: the default expression is evaluated lazily (only when undefined) and the matched value is
     // read exactly once (a getter is not invoked twice).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Defaults_LazyAndSingleEvaluation(ExecutionMode mode)
     {
         var source = """
@@ -656,8 +620,7 @@ public class DestructuringTests
     // #781/#1288: typed arrays and Buffers are normalized to a fresh Array before destructuring.
     // This keeps ordinary element bindings working and makes a rest binding a real Array rather
     // than a typed-array/Buffer slice.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayDestructuring_TypedArrayAndBufferSources(ExecutionMode mode)
     {
         var source = """
@@ -681,8 +644,7 @@ public class DestructuringTests
 
     // #780: `({ a = 5 } = src)` — the object-pattern cover-grammar form is now accepted by the parser and
     // routes through the #754 assignment-destructuring lowering (undefined-only default, #784).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AssignmentDestructuring_ObjectShorthandDefault(ExecutionMode mode)
     {
         var source = """
@@ -716,8 +678,7 @@ public class DestructuringTests
     #region Nested Pattern with Default in Assignment Destructuring (#779)
 
     // #779: a nested array/object pattern that itself carries a default in an ASSIGNMENT destructuring.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AssignmentDestructuring_NestedArrayPatternWithDefault(ExecutionMode mode)
     {
         var source = """
@@ -730,8 +691,7 @@ public class DestructuringTests
         Assert.Equal("1 9\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AssignmentDestructuring_NestedObjectPatternWithDefault(ExecutionMode mode)
     {
         var source = """
@@ -754,8 +714,7 @@ public class DestructuringTests
     // not declare that property, must NOT report a spurious "Property does not exist" (TS2339) — the
     // default makes the access safe (tsc accepts these). Covers the declaration form and the shipped
     // #780/#754 assignment forms, with empty/closed object sources.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Defaulted_OverEmptySource_Declaration(ExecutionMode mode)
     {
         var source = """
@@ -767,8 +726,7 @@ public class DestructuringTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Defaulted_OverEmptySource_AssignmentShorthandAndRename(ExecutionMode mode)
     {
         var source = """
@@ -781,8 +739,7 @@ public class DestructuringTests
         Assert.Equal("5 5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Defaulted_NestedPatternDefault_OverEmptyAndPresentSource(ExecutionMode mode)
     {
         // The inner default `{}` lacks `x`; the read must stay tolerant. With a present source the
@@ -799,8 +756,7 @@ public class DestructuringTests
 
     // #796: a source that DECLARES the property (even optional) still narrows the defaulted binding
     // to the property type — the tolerance must not regress the well-typed case.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Defaulted_OverDeclaredOptionalSource_StillWorks(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/DgramTransportParityTests.cs
+++ b/SharpTS.Tests/SharedTests/DgramTransportParityTests.cs
@@ -12,8 +12,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class DgramTransportParityTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_MulticastControls_LoopbackInterfaceMembership(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -42,8 +41,7 @@ public class DgramTransportParityTests
         Assert.Equal("loopback on\nloopback off\niface set\njoined\ndropped\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_SourceSpecificMembership_JoinAndLeave(ExecutionMode mode)
     {
         // SSM support varies by platform — assert only that both modes agree
@@ -79,8 +77,7 @@ public class DgramTransportParityTests
         Assert.Contains("udp6 ssm rejected", actual);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dgram_ConnectedSend_ValidatesDestination(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/DnsTransportParityTests.cs
+++ b/SharpTS.Tests/SharedTests/DnsTransportParityTests.cs
@@ -11,8 +11,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class DnsTransportParityTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_DefaultResultOrder_GetSetAndValidation(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -32,8 +31,7 @@ public class DnsTransportParityTests
         Assert.Equal("verbatim\nipv6first\nbogus rejected\nipv6first\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_ResultOrder_AffectsLookupFamily(ExecutionMode mode)
     {
         // 'localhost' resolves to 127.0.0.1 everywhere; with ipv4first the lookup
@@ -52,8 +50,7 @@ public class DnsTransportParityTests
         Assert.Equal("family 4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dns_Resolver_SetLocalAddress_ValidatesAndAccepts(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/DotNetImportTests.cs
+++ b/SharpTS.Tests/SharedTests/DotNetImportTests.cs
@@ -39,8 +39,7 @@ public class DotNetImportTests
 
     #region Single-type form
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SingleTypeForm_ConstructChainAndProperty(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -94,8 +93,7 @@ public class DotNetImportTests
 
     #region Namespace form, aliases, nested types
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceForm_ResolvesEachNamedImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -112,8 +110,7 @@ public class DotNetImportTests
         Assert.Equal("36\n9\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AliasImport_BindsLocalName(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -130,8 +127,7 @@ public class DotNetImportTests
         Assert.Equal("aliased\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticReadonlyField_Resolves(ExecutionMode mode)
     {
         // Guid.empty is a static FIELD (not property) — the member surface must include
@@ -148,8 +144,7 @@ public class DotNetImportTests
         Assert.Equal("00000000-0000-0000-0000-000000000000\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedType_ResolvesThroughDeclaringTypeSpecifier(ExecutionMode mode)
     {
         // System.Environment is a type; SpecialFolder is its nested enum — the namespace-form
@@ -166,8 +161,7 @@ public class DotNetImportTests
         Assert.Equal("Desktop\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EnumImport_MembersAndToString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -187,8 +181,7 @@ public class DotNetImportTests
 
     #region Cross-module and type identity
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CrossModule_InstanceFlowsBetweenModules(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -214,8 +207,7 @@ public class DotNetImportTests
         Assert.Equal("from-maker+main\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BothSpecifierForms_YieldTheSameType(ExecutionMode mode)
     {
         // The synthesized class is cached per CLR type, so the namespace form and the
@@ -240,8 +232,7 @@ public class DotNetImportTests
         Assert.Equal("same\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOnlyImport_UsableInAnnotations(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -268,8 +259,7 @@ public class DotNetImportTests
 
     #region Discovery-tool alignment
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DiscoveryToolImportLine_RoundTripsThroughThePipeline(ExecutionMode mode)
     {
         // The exact import line `--gen-decl` prints must load, type-check, and run —

--- a/SharpTS.Tests/SharedTests/EnumTests.cs
+++ b/SharpTS.Tests/SharedTests/EnumTests.cs
@@ -11,8 +11,7 @@ public class EnumTests
 {
     #region Numeric Enums
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericEnum_ForwardMapping_ReturnsValue(ExecutionMode mode)
     {
         var source = """
@@ -32,8 +31,7 @@ public class EnumTests
         Assert.Equal("0\n1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericEnum_ReverseMapping_ReturnsName(ExecutionMode mode)
     {
         var source = """
@@ -51,8 +49,7 @@ public class EnumTests
         Assert.Equal("Up\nDown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericEnum_CustomStart_AutoIncrements(ExecutionMode mode)
     {
         var source = """
@@ -72,8 +69,7 @@ public class EnumTests
         Assert.Equal("10\n11\n12\n13\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericEnum_ExplicitValues_SetsCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -91,8 +87,7 @@ public class EnumTests
         Assert.Equal("200\n404\n500\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericEnum_VariableAssignment_Works(ExecutionMode mode)
     {
         var source = """
@@ -108,8 +103,7 @@ public class EnumTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericEnum_InConditional_ComparesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -133,8 +127,7 @@ public class EnumTests
 
     #region String Enums
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringEnum_ForwardMapping_ReturnsValue(ExecutionMode mode)
     {
         var source = """
@@ -152,8 +145,7 @@ public class EnumTests
         Assert.Equal("success\nerror\npending\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringEnum_VariableAssignment_Works(ExecutionMode mode)
     {
         var source = """
@@ -169,8 +161,7 @@ public class EnumTests
         Assert.Equal("success\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringEnum_InConditional_ComparesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -194,8 +185,7 @@ public class EnumTests
 
     #region Heterogeneous Enums
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HeterogeneousEnum_MixedValues_Works(ExecutionMode mode)
     {
         var source = """
@@ -211,8 +201,7 @@ public class EnumTests
         Assert.Equal("0\nyes\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HeterogeneousEnum_NumericReverseMapping_Works(ExecutionMode mode)
     {
         var source = """
@@ -227,8 +216,7 @@ public class EnumTests
         Assert.Equal("No\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Enum_UsedInSwitch_Works(ExecutionMode mode)
     {
         var source = """
@@ -259,8 +247,7 @@ public class EnumTests
 
     #region Const Enums
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstEnum_NumericForwardMapping_ReturnsValue(ExecutionMode mode)
     {
         var source = """
@@ -280,8 +267,7 @@ public class EnumTests
         Assert.Equal("0\n1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstEnum_NumericAutoIncrement_Works(ExecutionMode mode)
     {
         var source = """
@@ -299,8 +285,7 @@ public class EnumTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstEnum_NumericCustomValues_Works(ExecutionMode mode)
     {
         var source = """
@@ -318,8 +303,7 @@ public class EnumTests
         Assert.Equal("200\n404\n500\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstEnum_StringForwardMapping_Works(ExecutionMode mode)
     {
         var source = """
@@ -337,8 +321,7 @@ public class EnumTests
         Assert.Equal("success\nerror\npending\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstEnum_ComputedMemberValue_Works(ExecutionMode mode)
     {
         var source = """
@@ -358,8 +341,7 @@ public class EnumTests
         Assert.Equal("1\n2\n12\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstEnum_VariableAssignment_Works(ExecutionMode mode)
     {
         var source = """
@@ -375,8 +357,7 @@ public class EnumTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstEnum_ConditionalComparison_Works(ExecutionMode mode)
     {
         var source = """
@@ -396,8 +377,7 @@ public class EnumTests
         Assert.Equal("going up\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstEnum_SwitchStatement_Works(ExecutionMode mode)
     {
         var source = """
@@ -424,8 +404,7 @@ public class EnumTests
         Assert.Equal("green\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstEnum_ReverseMapping_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ErrorHandlingTests.cs
+++ b/SharpTS.Tests/SharedTests/ErrorHandlingTests.cs
@@ -10,8 +10,7 @@ public class ErrorHandlingTests
 {
     #region Basic Try/Catch
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryCatch_CatchesThrow(ExecutionMode mode)
     {
         var source = """
@@ -26,8 +25,7 @@ public class ErrorHandlingTests
         Assert.Equal("caught\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryCatch_CatchesStringThrow(ExecutionMode mode)
     {
         var source = """
@@ -42,8 +40,7 @@ public class ErrorHandlingTests
         Assert.Equal("error message\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryCatch_CatchesNumberThrow(ExecutionMode mode)
     {
         var source = """
@@ -62,8 +59,7 @@ public class ErrorHandlingTests
 
     #region Finally Clause
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryFinally_FinallyAlwaysRuns(ExecutionMode mode)
     {
         var source = """
@@ -78,8 +74,7 @@ public class ErrorHandlingTests
         Assert.Equal("try\nfinally\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryCatchFinally_AllBlocksExecute(ExecutionMode mode)
     {
         var source = """
@@ -97,8 +92,7 @@ public class ErrorHandlingTests
         Assert.Equal("try\ncatch\nfinally\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryCatch_FinallyRunsWithoutError(ExecutionMode mode)
     {
         var source = """
@@ -115,8 +109,7 @@ public class ErrorHandlingTests
         Assert.Equal("no error\nfinally runs\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_RunsWithReturn(ExecutionMode mode)
     {
         var source = """
@@ -138,8 +131,7 @@ public class ErrorHandlingTests
 
     #region Nested Try/Catch
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryCatch_NestedBlocks(ExecutionMode mode)
     {
         var source = """
@@ -163,8 +155,7 @@ public class ErrorHandlingTests
 
     #region Function Call Exceptions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryCatch_CatchFromFunctionCall(ExecutionMode mode)
     {
         var source = """
@@ -186,8 +177,7 @@ public class ErrorHandlingTests
 
     #region Code After Catch
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryCatch_CodeAfterCatchExecutes(ExecutionMode mode)
     {
         var source = """
@@ -207,8 +197,7 @@ public class ErrorHandlingTests
 
     #region Optional Catch Binding
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryCatch_OptionalCatchBinding_CatchesThrow(ExecutionMode mode)
     {
         var source = """
@@ -223,8 +212,7 @@ public class ErrorHandlingTests
         Assert.Equal("caught without param\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryCatch_OptionalCatchBinding_WithFinally(ExecutionMode mode)
     {
         var source = """
@@ -241,8 +229,7 @@ public class ErrorHandlingTests
         Assert.Equal("caught\nfinally\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryCatch_OptionalCatchBinding_NoError(ExecutionMode mode)
     {
         var source = """
@@ -258,8 +245,7 @@ public class ErrorHandlingTests
         Assert.Equal("no error\nafter\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryCatch_NestedOptionalCatchBinding(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ErrorTests.cs
+++ b/SharpTS.Tests/SharedTests/ErrorTests.cs
@@ -10,8 +10,7 @@ public class ErrorTests
 {
     #region Constructor Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_NoArgs_CreatesErrorWithEmptyMessage(ExecutionMode mode)
     {
         var source = @"
@@ -23,8 +22,7 @@ public class ErrorTests
         Assert.Equal("Error\n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_WithMessage_CreatesErrorWithMessage(ExecutionMode mode)
     {
         var source = @"
@@ -36,8 +34,7 @@ public class ErrorTests
         Assert.Equal("Error\nSomething went wrong\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_CalledWithoutNew_StillCreatesError(ExecutionMode mode)
     {
         var source = @"
@@ -49,8 +46,7 @@ public class ErrorTests
         Assert.Equal("Error\nWithout new\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_ToString_FormatsCorrectly(ExecutionMode mode)
     {
         var source = @"
@@ -61,8 +57,7 @@ public class ErrorTests
         Assert.Equal("Error: Test error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_ToString_NoMessage(ExecutionMode mode)
     {
         var source = @"
@@ -73,8 +68,7 @@ public class ErrorTests
         Assert.Equal("Error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_StringCoercion_InvokesToString(ExecutionMode mode)
     {
         // String(e), `${e}` and "" + e must all go through Error.prototype.toString
@@ -89,8 +83,7 @@ public class ErrorTests
         Assert.Equal("TypeError: boom\nTypeError: boom\nTypeError: boom\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_StringCoercion_NoMessage(ExecutionMode mode)
     {
         var source = @"
@@ -101,8 +94,7 @@ public class ErrorTests
         Assert.Equal("RangeError\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_StringCoercion_FromCatch(ExecutionMode mode)
     {
         var source = @"
@@ -117,8 +109,7 @@ public class ErrorTests
         Assert.Equal("TypeError: caught\nTypeError: caught\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Instance_StringCoercion_InvokesUserToString(ExecutionMode mode)
     {
         // #922 generalization: a user class with its own toString() is dispatched
@@ -135,8 +126,7 @@ public class ErrorTests
         Assert.Equal("(1,2)\n(1,2)\n(1,2)\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Instance_StringCoercion_NoToString_KeepsDefault(ExecutionMode mode)
     {
         // A plain instance with no toString() brands as Node's ordinary-object
@@ -150,8 +140,7 @@ public class ErrorTests
         Assert.Equal("[object Object]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_HasStackProperty(ExecutionMode mode)
     {
         var source = @"
@@ -166,8 +155,7 @@ public class ErrorTests
 
     #region Error Subtype Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeError_CreatesWithCorrectName(ExecutionMode mode)
     {
         var source = @"
@@ -179,8 +167,7 @@ public class ErrorTests
         Assert.Equal("TypeError\nInvalid type\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RangeError_CreatesWithCorrectName(ExecutionMode mode)
     {
         var source = @"
@@ -192,8 +179,7 @@ public class ErrorTests
         Assert.Equal("RangeError\nOut of range\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReferenceError_CreatesWithCorrectName(ExecutionMode mode)
     {
         var source = @"
@@ -205,8 +191,7 @@ public class ErrorTests
         Assert.Equal("ReferenceError\nUndefined variable\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SyntaxError_CreatesWithCorrectName(ExecutionMode mode)
     {
         var source = @"
@@ -218,8 +203,7 @@ public class ErrorTests
         Assert.Equal("SyntaxError\nUnexpected token\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URIError_CreatesWithCorrectName(ExecutionMode mode)
     {
         var source = @"
@@ -231,8 +215,7 @@ public class ErrorTests
         Assert.Equal("URIError\nInvalid URI\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EvalError_CreatesWithCorrectName(ExecutionMode mode)
     {
         var source = @"
@@ -248,8 +231,7 @@ public class ErrorTests
 
     #region Error Subtype Without New
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeError_CalledWithoutNew_StillCreatesError(ExecutionMode mode)
     {
         var source = @"
@@ -261,8 +243,7 @@ public class ErrorTests
         Assert.Equal("TypeError\nWithout new\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RangeError_CalledWithoutNew_StillCreatesError(ExecutionMode mode)
     {
         var source = @"
@@ -277,8 +258,7 @@ public class ErrorTests
 
     #region AggregateError Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AggregateError_WithErrors_CreatesCorrectly(ExecutionMode mode)
     {
         var source = @"
@@ -292,8 +272,7 @@ public class ErrorTests
         Assert.Equal("AggregateError\nMultiple errors\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AggregateError_WithEmptyArray_CreatesCorrectly(ExecutionMode mode)
     {
         var source = @"
@@ -306,8 +285,7 @@ public class ErrorTests
         Assert.Equal("AggregateError\nNo errors\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AggregateError_DefaultMessage(ExecutionMode mode)
     {
         var source = @"
@@ -322,8 +300,7 @@ public class ErrorTests
 
     #region Mutable Properties Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_NameIsMutable(ExecutionMode mode)
     {
         var source = @"
@@ -335,8 +312,7 @@ public class ErrorTests
         Assert.Equal("CustomError\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_MessageIsMutable(ExecutionMode mode)
     {
         var source = @"
@@ -352,8 +328,7 @@ public class ErrorTests
 
     #region Throw/Catch Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_CanBeThrown(ExecutionMode mode)
     {
         var source = @"
@@ -368,8 +343,7 @@ public class ErrorTests
         Assert.Equal("Error\nThrown error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeError_CanBeThrown(ExecutionMode mode)
     {
         var source = @"
@@ -384,8 +358,7 @@ public class ErrorTests
         Assert.Equal("TypeError\nType error thrown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_RethrowPreservesProperties(ExecutionMode mode)
     {
         var source = @"
@@ -409,8 +382,7 @@ public class ErrorTests
 
     #region Error.cause Tests (ES2022)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_WithCause_SetsCauseProperty(ExecutionMode mode)
     {
         var source = @"
@@ -423,8 +395,7 @@ public class ErrorTests
         Assert.Equal("wrapped\noriginal\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_WithStringCause_SetsCauseProperty(ExecutionMode mode)
     {
         var source = @"
@@ -436,8 +407,7 @@ public class ErrorTests
         Assert.Equal("failed\nnetwork timeout\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_WithNumberCause_SetsCauseProperty(ExecutionMode mode)
     {
         var source = @"
@@ -448,8 +418,7 @@ public class ErrorTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_WithoutCause_CauseIsUndefined(ExecutionMode mode)
     {
         var source = @"
@@ -460,8 +429,7 @@ public class ErrorTests
         Assert.Equal("undefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeError_WithCause_SetsCauseProperty(ExecutionMode mode)
     {
         var source = @"
@@ -475,8 +443,7 @@ public class ErrorTests
         Assert.Equal("TypeError\ntype mismatch\nroot cause\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_CauseChaining_ThreeLevels(ExecutionMode mode)
     {
         var source = @"
@@ -491,8 +458,7 @@ public class ErrorTests
         Assert.Equal("top\nmiddle\nroot\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_CauseInTryCatch_PreservedAfterThrow(ExecutionMode mode)
     {
         var source = @"
@@ -509,8 +475,7 @@ public class ErrorTests
         Assert.Equal("wrapper\nRangeError\nout of range\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_CauseIsMutable(ExecutionMode mode)
     {
         var source = @"
@@ -522,8 +487,7 @@ public class ErrorTests
         Assert.Equal("manually set\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_CalledWithoutNew_WithCause(ExecutionMode mode)
     {
         var source = @"
@@ -539,8 +503,7 @@ public class ErrorTests
 
     #region Error as Global Variable (Issue #24)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeofError_ReturnsFunction(ExecutionMode mode)
     {
         var source = @"
@@ -552,8 +515,7 @@ public class ErrorTests
         Assert.Equal("function\nfunction\nfunction\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExtendsError_Basic(ExecutionMode mode)
     {
         var source = @"
@@ -571,8 +533,7 @@ public class ErrorTests
         Assert.Equal("MyError\ntest\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExtendsError_InstanceofMyError(ExecutionMode mode)
     {
         var source = @"
@@ -590,8 +551,7 @@ public class ErrorTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExtendsTypeError(ExecutionMode mode)
     {
         var source = @"
@@ -612,8 +572,7 @@ public class ErrorTests
         Assert.Equal("CustomTypeError\nbad type\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExtendsError_MultiLevel(ExecutionMode mode)
     {
         var source = @"
@@ -642,8 +601,7 @@ public class ErrorTests
         Assert.Equal("AppError\nserver error\n500\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassExtendsError_NoExplicitConstructor(ExecutionMode mode)
     {
         var source = @"
@@ -669,8 +627,7 @@ public class ErrorTests
     /// synthesizes a real <c>RangeError</c>, matching compiled mode which throws a real
     /// <c>$RangeError</c>. Asserted identical in both modes.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BuiltInRangeError_CaughtAsRangeErrorInstance(ExecutionMode mode)
     {
         var source = @"
@@ -693,8 +650,7 @@ public class ErrorTests
     /// no initial value throws <c>"TypeError: ..."</c> from the built-in. The caught value
     /// must be a real <c>TypeError</c> in both modes.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BuiltInTypeError_CaughtAsTypeErrorInstance(ExecutionMode mode)
     {
         var source = @"
@@ -718,8 +674,7 @@ public class ErrorTests
     /// caught as the typed Error by an outer <c>try</c>. Guards the catch-binding coercion
     /// against the host-error string round-trip across the boundary.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BuiltInError_AcrossFunctionBoundary_CaughtAsTypedError(ExecutionMode mode)
     {
         var source = @"
@@ -740,8 +695,7 @@ public class ErrorTests
     /// identity when caught (the catch-binding coercion only touches prefixed strings), and a
     /// guest <c>throw</c> of a plain string stays a string.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GuestThrows_PreserveValueIdentity(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/ErrorTypeReferenceTests.cs
+++ b/SharpTS.Tests/SharedTests/ErrorTypeReferenceTests.cs
@@ -15,8 +15,7 @@ public class ErrorTypeReferenceTests
 {
     // ----- member access is typed (the core fix) -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ErrorAnnotation_MessageIsString(ExecutionMode mode)
     {
         var source = """
@@ -27,8 +26,7 @@ public class ErrorTypeReferenceTests
         Assert.Equal("boom\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ErrorAnnotation_MessageNotAssignableToNumber(ExecutionMode mode)
     {
         // Before #528 `e.message` was `any`, so this was wrongly accepted; now it is a TS2322.
@@ -39,8 +37,7 @@ public class ErrorTypeReferenceTests
         Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeErrorAnnotation_IsAlsoStructured(ExecutionMode mode)
     {
         // The fix covers every built-in error subtype, not just `Error`.
@@ -51,8 +48,7 @@ public class ErrorTypeReferenceTests
         Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ErrorAnnotation_UnknownMemberRejected(ExecutionMode mode)
     {
         var source = """
@@ -64,8 +60,7 @@ public class ErrorTypeReferenceTests
 
     // ----- assignability -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_AcceptsSpecificErrorSubtype(ExecutionMode mode)
     {
         // A specific error is assignable to the base Error target.
@@ -76,8 +71,7 @@ public class ErrorTypeReferenceTests
         Assert.Equal("boom\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SiblingErrors_AreMutuallyAssignable(ExecutionMode mode)
     {
         // The built-in error subtypes add no members over Error (tsc models them as empty
@@ -90,8 +84,7 @@ public class ErrorTypeReferenceTests
         Assert.Equal("boom\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_AssignableToMatchingStructuralShape(ExecutionMode mode)
     {
         // A built-in error structurally satisfies an object type spelling out its members.
@@ -102,8 +95,7 @@ public class ErrorTypeReferenceTests
         Assert.Equal("boom\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UserSubclassOfError_AssignableToError(ExecutionMode mode)
     {
         // `class X extends Error` is a nominal subtype of Error.
@@ -117,8 +109,7 @@ public class ErrorTypeReferenceTests
         Assert.Equal("boom\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AggregateError_HasErrorsProperty(ExecutionMode mode)
     {
         var source = """
@@ -128,8 +119,7 @@ public class ErrorTypeReferenceTests
         Assert.Equal("1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PlainError_NotAssignableToAggregateError(ExecutionMode mode)
     {
         // AggregateError adds `errors`, which a plain Error lacks — so the reverse assignment fails.
@@ -139,8 +129,7 @@ public class ErrorTypeReferenceTests
         Assert.ThrowsAny<TypeCheckException>(() => TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ErrorParameter_TypesArgument(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/EvalTests.cs
+++ b/SharpTS.Tests/SharedTests/EvalTests.cs
@@ -14,8 +14,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class EvalTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Eval_WhitespaceTolerance_ResolvesGlobals(ExecutionMode mode)
     {
         // Test262 S11.2.1_A1.1-style: eval tolerates interior whitespace and resolves globals.
@@ -27,8 +26,7 @@ public class EvalTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Eval_ReturnsCompletionValueOfExpression(ExecutionMode mode)
     {
         var source = """
@@ -39,8 +37,7 @@ public class EvalTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Eval_NonStringArgument_ReturnedUnchanged(ExecutionMode mode)
     {
         // ECMA-262 §19.2.1: eval(non-string) returns the argument unchanged.
@@ -52,8 +49,7 @@ public class EvalTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Eval_StatementsThenCompletionValue(ExecutionMode mode)
     {
         var source = """
@@ -64,8 +60,7 @@ public class EvalTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Eval_BuiltinMethodCalls(ExecutionMode mode)
     {
         var source = """
@@ -77,8 +72,7 @@ public class EvalTests
         Assert.Equal("ABC\n7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Eval_DirectEval_SeesCallerLocals(ExecutionMode mode)
     {
         // Direct-eval semantics: the evaluated source resolves against the caller's scope.

--- a/SharpTS.Tests/SharedTests/EventLoopContinuationTests.cs
+++ b/SharpTS.Tests/SharedTests/EventLoopContinuationTests.cs
@@ -33,8 +33,7 @@ public class EventLoopContinuationTests : IDisposable
 
     public void Dispose() => _server.Dispose();
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TopLevelAsync_SequentialFetches_RunsContinuationAfterAwait(ExecutionMode mode)
     {
         // The continuation after each await (and the closure capture of `tag`)

--- a/SharpTS.Tests/SharedTests/FetchCookieTests.cs
+++ b/SharpTS.Tests/SharedTests/FetchCookieTests.cs
@@ -48,8 +48,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== 1. Set-Cookie stored, sent on next request ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cookies_StoredAndResent_DefaultCredentials(ExecutionMode mode)
     {
         var source = $$"""
@@ -68,8 +67,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== 2. credentials: 'omit' does not send stored cookies ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cookies_OmitDoesNotSendStored(ExecutionMode mode)
     {
         var source = $$"""
@@ -88,8 +86,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== 2b. credentials: 'include' sends stored cookies (same as default) ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cookies_IncludeBehavesLikeSameOriginForSameHost(ExecutionMode mode)
     {
         // Without a top-level realm, 'include' and 'same-origin' both use the
@@ -111,8 +108,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== 3. credentials: 'omit' does not store Set-Cookie ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cookies_OmitDoesNotStoreSetCookie(ExecutionMode mode)
     {
         var source = $$"""
@@ -131,8 +127,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== 4. Cross-host isolation ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Cookies_CrossHostIsolation(ExecutionMode mode)
     {
         // Set a cookie for our test server, then verify a different host doesn't get it.
@@ -157,8 +152,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== 5. Expired cookie removed ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cookies_ExpiredCookieNotSent(ExecutionMode mode)
     {
         var source = $$"""
@@ -177,8 +171,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== 6. HttpOnly cookie sent in subsequent requests ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cookies_HttpOnlyCookieSentInSubsequentRequest(ExecutionMode mode)
     {
         var source = $$"""
@@ -197,8 +190,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== 7. Multiple Set-Cookie preserved as array via getSetCookie() ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cookies_GetSetCookieReturnsArray(ExecutionMode mode)
     {
         var source = $$"""
@@ -218,8 +210,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== 8. headers.get('set-cookie') returns first ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cookies_HeadersGetReturnsFirstSetCookie(ExecutionMode mode)
     {
         var source = $$"""
@@ -236,8 +227,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== 9. Cookies survive a redirect chain ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cookies_StoredFromRedirectIntermediate(ExecutionMode mode)
     {
         // Hit a redirect that sets a cookie, follow to /echo-cookie which echoes the
@@ -258,8 +248,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== 10. cookieJar.clear() removes all cookies ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Cookies_ClearJarRemovesAll(ExecutionMode mode)
     {
         // Step 1: store a cookie
@@ -287,8 +276,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== Invalid URL handling — both methods throw, symmetric ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cookies_GetCookiesThrowsOnInvalidUrl(ExecutionMode mode)
     {
         var source = """
@@ -305,8 +293,7 @@ public class FetchCookieTests : IDisposable
         Assert.Equal("typeerror\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cookies_SetCookieThrowsOnInvalidUrl(ExecutionMode mode)
     {
         var source = """
@@ -325,8 +312,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== 11. cookieJar.getCookies(url) returns the right header ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Cookies_GetCookieHeaderReturnsSentValue(ExecutionMode mode)
     {
         var source = $$"""
@@ -343,8 +329,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== http.get/http.request cookies ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Cookies_HttpModuleSharesJarWithFetch(ExecutionMode mode)
     {
         // Set a cookie via fetch, then read it back via http.get. The ClientRequest (#1043)
@@ -370,8 +355,7 @@ public class FetchCookieTests : IDisposable
         Assert.Contains("session=abc123", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Cookies_HttpRequestStoresAndSendsCookies(ExecutionMode mode)
     {
         // Pure http.request flow: set via http.request, read via http.request — proves the
@@ -401,8 +385,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== 13. fetch.cookieJar.getCookies(url) from script (both modes) ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cookies_FetchCookieJarGetCookies_FromScript(ExecutionMode mode)
     {
         var source = $$"""
@@ -420,8 +403,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== 14. fetch.cookieJar.setCookie() from script ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cookies_FetchCookieJarSetCookie_FromScript(ExecutionMode mode)
     {
         var source = $$"""
@@ -440,8 +422,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== 15. fetch.cookieJar.clear() from script ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cookies_FetchCookieJarClear_FromScript(ExecutionMode mode)
     {
         var source = $$"""
@@ -461,8 +442,7 @@ public class FetchCookieTests : IDisposable
 
     // ========== 12. Concurrent fetches don't race the jar ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Cookies_ConcurrentFetchesDoNotRaceJar(ExecutionMode mode)
     {
         // Fire 20 parallel fetches that each set the same cookie, then check that

--- a/SharpTS.Tests/SharedTests/FetchRedirectTests.cs
+++ b/SharpTS.Tests/SharedTests/FetchRedirectTests.cs
@@ -24,8 +24,7 @@ public class FetchRedirectTests : IDisposable
 
     #region redirect: "follow" (default)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_RedirectFollow_Default_FollowsRedirect(ExecutionMode mode)
     {
         var source = $$"""
@@ -42,8 +41,7 @@ public class FetchRedirectTests : IDisposable
         Assert.Equal("200\nredirected content\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_RedirectFollow_Explicit_FollowsRedirect(ExecutionMode mode)
     {
         var source = $$"""
@@ -64,8 +62,7 @@ public class FetchRedirectTests : IDisposable
 
     #region redirect: "manual"
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_RedirectManual_Returns302(ExecutionMode mode)
     {
         var source = $$"""
@@ -80,8 +77,7 @@ public class FetchRedirectTests : IDisposable
         Assert.Equal("302\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_RedirectManual_Returns301(ExecutionMode mode)
     {
         var source = $$"""
@@ -96,8 +92,7 @@ public class FetchRedirectTests : IDisposable
         Assert.Equal("301\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_RedirectManual_OkIsFalse(ExecutionMode mode)
     {
         var source = $$"""
@@ -112,8 +107,7 @@ public class FetchRedirectTests : IDisposable
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_RedirectManual_NonRedirectWorksNormally(ExecutionMode mode)
     {
         // When redirect is "manual" but the response is not a redirect, it should work normally
@@ -134,8 +128,7 @@ public class FetchRedirectTests : IDisposable
 
     #region Response properties
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_Response_TypeProperty(ExecutionMode mode)
     {
         var source = $$"""
@@ -150,8 +143,7 @@ public class FetchRedirectTests : IDisposable
         Assert.Equal("basic\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_Response_RedirectedProperty_NoRedirect(ExecutionMode mode)
     {
         var source = $$"""
@@ -170,8 +162,7 @@ public class FetchRedirectTests : IDisposable
 
     #region redirect: "error"
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_RedirectError_ThrowsOnRedirect(ExecutionMode mode)
     {
         var source = $$"""
@@ -190,8 +181,7 @@ public class FetchRedirectTests : IDisposable
         Assert.Equal("caught\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_RedirectError_NonRedirectWorksNormally(ExecutionMode mode)
     {
         // When redirect is "error" but the response is not a redirect, it should work normally

--- a/SharpTS.Tests/SharedTests/FetchTests.cs
+++ b/SharpTS.Tests/SharedTests/FetchTests.cs
@@ -33,8 +33,7 @@ public class FetchTests : IDisposable
 
     // ========== Headers API tests ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Headers_Get_ReturnsValue(ExecutionMode mode)
     {
         var source = @"
@@ -45,8 +44,7 @@ public class FetchTests : IDisposable
         Assert.Equal("text/html\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Headers_Get_ReturnsNull(ExecutionMode mode)
     {
         var source = @"
@@ -57,8 +55,7 @@ public class FetchTests : IDisposable
         Assert.Equal("null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Headers_Has_ReturnsBool(ExecutionMode mode)
     {
         var source = @"
@@ -70,8 +67,7 @@ public class FetchTests : IDisposable
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Headers_Set_OverwritesValue(ExecutionMode mode)
     {
         var source = @"
@@ -83,8 +79,7 @@ public class FetchTests : IDisposable
         Assert.Equal("application/json\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Headers_Delete_RemovesHeader(ExecutionMode mode)
     {
         var source = @"
@@ -96,8 +91,7 @@ public class FetchTests : IDisposable
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Headers_Append_AddsMultipleValues(ExecutionMode mode)
     {
         var source = @"
@@ -110,8 +104,7 @@ public class FetchTests : IDisposable
         Assert.Equal("text/html, application/json\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Headers_ForEach_IteratesAll(ExecutionMode mode)
     {
         var source = @"
@@ -127,8 +120,7 @@ public class FetchTests : IDisposable
         Assert.Equal("accept: text/html; content-type: application/json\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Headers_CaseInsensitive(ExecutionMode mode)
     {
         var source = @"
@@ -141,8 +133,7 @@ public class FetchTests : IDisposable
         Assert.Equal("text/html\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Headers_Entries_ReturnsIterator(ExecutionMode mode)
     {
         var source = @"
@@ -157,8 +148,7 @@ public class FetchTests : IDisposable
         Assert.Equal("accept=text/html,host=example.com\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Headers_Keys_ReturnsIterator(ExecutionMode mode)
     {
         var source = @"
@@ -173,8 +163,7 @@ public class FetchTests : IDisposable
         Assert.Equal("accept,host\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Headers_Values_ReturnsIterator(ExecutionMode mode)
     {
         var source = @"
@@ -191,8 +180,7 @@ public class FetchTests : IDisposable
 
     // ========== Response Headers from fetch ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchResponse_Headers_Get(ExecutionMode mode)
     {
         var source = $$"""
@@ -207,8 +195,7 @@ public class FetchTests : IDisposable
         Assert.Contains("application/json", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchResponse_Headers_Has(ExecutionMode mode)
     {
         var source = $$"""
@@ -222,8 +209,7 @@ public class FetchTests : IDisposable
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchResponse_Headers_ForEach(ExecutionMode mode)
     {
         var source = $$"""
@@ -243,8 +229,7 @@ public class FetchTests : IDisposable
 
     // ========== AbortSignal integration tests ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_AbortSignal_AbortBeforeFetch(ExecutionMode mode)
     {
         var source = $$"""
@@ -269,8 +254,7 @@ public class FetchTests : IDisposable
 
     // ========== Error handling tests ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_NoArguments_Throws(ExecutionMode mode)
     {
         var source = @"
@@ -290,8 +274,7 @@ public class FetchTests : IDisposable
 
     // ========== Response methods ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchResponse_StatusText_ReturnsText(ExecutionMode mode)
     {
         var source = $$"""
@@ -306,8 +289,7 @@ public class FetchTests : IDisposable
         Assert.Equal("404\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchResponse_Url_ReturnsUrl(ExecutionMode mode)
     {
         var source = $$"""
@@ -321,8 +303,7 @@ public class FetchTests : IDisposable
         Assert.Contains("json", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchResponse_BodyUsed_TracksConsumption(ExecutionMode mode)
     {
         var source = $$"""
@@ -338,8 +319,7 @@ public class FetchTests : IDisposable
         Assert.Equal("false\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchResponse_Clone_Works(ExecutionMode mode)
     {
         var source = $$"""
@@ -358,8 +338,7 @@ public class FetchTests : IDisposable
 
     // ========== HTTP methods ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_PatchMethod(ExecutionMode mode)
     {
         var source = $$"""
@@ -377,8 +356,7 @@ public class FetchTests : IDisposable
         Assert.Equal("PATCH\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_HeadMethod(ExecutionMode mode)
     {
         var source = $$"""
@@ -395,8 +373,7 @@ public class FetchTests : IDisposable
         Assert.Equal("200\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_JsonBody(ExecutionMode mode)
     {
         var source = $$"""
@@ -419,8 +396,7 @@ public class FetchTests : IDisposable
 
     // ========== Headers with fetch options ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_WithHeadersObject(ExecutionMode mode)
     {
         var source = $$"""
@@ -443,8 +419,7 @@ public class FetchTests : IDisposable
 
     // ========== Fetch integration tests (migrated from CompilerTests/FetchIntegrationTests.cs) ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchJson_ParsesResponse(ExecutionMode mode)
     {
         var source = $$"""
@@ -460,8 +435,7 @@ public class FetchTests : IDisposable
         Assert.Equal("Hello\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchText_ReturnsBody(ExecutionMode mode)
     {
         var source = $$"""
@@ -476,8 +450,7 @@ public class FetchTests : IDisposable
         Assert.Equal("Hello, World!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchPost_SendsBody(ExecutionMode mode)
     {
         var source = $$"""
@@ -496,8 +469,7 @@ public class FetchTests : IDisposable
         Assert.Equal("POST\ntest body\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchWithCustomHeaders_SendsHeaders(ExecutionMode mode)
     {
         var source = $$"""
@@ -518,8 +490,7 @@ public class FetchTests : IDisposable
         Assert.Equal("CustomValue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchArrayBuffer_ReturnsBinary(ExecutionMode mode)
     {
         var source = $$"""
@@ -535,8 +506,7 @@ public class FetchTests : IDisposable
         Assert.Equal("5\nHello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchResponseHeaders_TypeofIsObject(ExecutionMode mode)
     {
         var source = $$"""
@@ -550,8 +520,7 @@ public class FetchTests : IDisposable
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchPutMethod_SendsCorrectMethod(ExecutionMode mode)
     {
         var source = $$"""
@@ -569,8 +538,7 @@ public class FetchTests : IDisposable
         Assert.Equal("PUT\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchDeleteMethod_SendsCorrectMethod(ExecutionMode mode)
     {
         var source = $$"""
@@ -589,8 +557,7 @@ public class FetchTests : IDisposable
 
     // ========== Response.body (ReadableStream) tests ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_ResponseBody_Exists(ExecutionMode mode)
     {
         var source = $$"""
@@ -606,8 +573,7 @@ public class FetchTests : IDisposable
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_ResponseBody_IsReadable(ExecutionMode mode)
     {
         var source = $$"""
@@ -624,8 +590,7 @@ public class FetchTests : IDisposable
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_ResponseBody_ReadData(ExecutionMode mode)
     {
         var source = $$"""
@@ -642,8 +607,7 @@ public class FetchTests : IDisposable
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_ResponseBody_BodyUsedAfterAccess(ExecutionMode mode)
     {
         var source = $$"""
@@ -660,8 +624,7 @@ public class FetchTests : IDisposable
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fetch_ResponseBody_ReadBinaryData(ExecutionMode mode)
     {
         var source = $$"""

--- a/SharpTS.Tests/SharedTests/FinalizationRegistryTests.cs
+++ b/SharpTS.Tests/SharedTests/FinalizationRegistryTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class FinalizationRegistryTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FinalizationRegistry_CreateAndRegister(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -23,8 +22,7 @@ public class FinalizationRegistryTests
         Assert.Contains("registered", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FinalizationRegistry_Unregister_ReturnsTrue(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -38,8 +36,7 @@ public class FinalizationRegistryTests
         Assert.Contains("true", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FinalizationRegistry_Unregister_UnknownToken_ReturnsFalse(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -54,8 +51,7 @@ public class FinalizationRegistryTests
         Assert.Contains("false", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FinalizationRegistry_Typeof(ExecutionMode mode)
     {
         var result = TestHarness.Run("""
@@ -65,8 +61,7 @@ public class FinalizationRegistryTests
         Assert.Contains("true", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FinalizationRegistry_Constructor_RequiresCallback(ExecutionMode mode)
     {
         var ex = Assert.ThrowsAny<Exception>(() =>

--- a/SharpTS.Tests/SharedTests/ForLoopPerIterationBindingTests.cs
+++ b/SharpTS.Tests/SharedTests/ForLoopPerIterationBindingTests.cs
@@ -23,8 +23,7 @@ public class ForLoopPerIterationBindingTests
 {
     // ---- Headline repro: arrow capturing the loop `let` ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowCapturesLetLoopVar_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -36,8 +35,7 @@ public class ForLoopPerIterationBindingTests
     }
 
     // The #622 headline repro: a generator created per iteration capturing the loop variable.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorCapturesLetLoopVar_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -50,8 +48,7 @@ public class ForLoopPerIterationBindingTests
 
     // ---- Multi-declarator: every declared name is per-iteration ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultiDeclarator_AllNamesPerIteration(ExecutionMode mode)
     {
         var source = """
@@ -64,8 +61,7 @@ public class ForLoopPerIterationBindingTests
 
     // ---- continue keeps per-iteration semantics ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ContinuePath_StillPerIteration(ExecutionMode mode)
     {
         var source = """
@@ -78,8 +74,7 @@ public class ForLoopPerIterationBindingTests
 
     // ---- Nested loops: inner closure captures both per-iteration bindings ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedLoops_BothBindingsPerIteration(ExecutionMode mode)
     {
         var source = """
@@ -92,8 +87,7 @@ public class ForLoopPerIterationBindingTests
 
     // ---- Single-statement body (no block braces) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NoBraceBody_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -111,8 +105,7 @@ public class ForLoopPerIterationBindingTests
     // the body BOTH mutates AND a closure captures, so closures reference-capture the live cell
     // (end-of-body value 0/1/2) instead of snapshotting the mid-body value (10/11/12). The cheap
     // value-snapshot path (#649) still serves the common non-mutating case.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BodyMutatesLoopVar_CapturesLiveSlot(ExecutionMode mode)
     {
         var source = """
@@ -125,8 +118,7 @@ public class ForLoopPerIterationBindingTests
 
     // Same mutate-and-restore pattern inside a SYNC function body (cell lives as a local
     // in the function frame). Exercises the function-context EmitFor path.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BodyMutatesLoopVar_SyncFunctionBody(ExecutionMode mode)
     {
         var source = """
@@ -143,8 +135,7 @@ public class ForLoopPerIterationBindingTests
     // The cell is shared by reference, so a closure that WRITES the loop binding mutates that
     // iteration's binding and a sibling reader observes it. Each iteration k: writer increments
     // binding k (k → k+1), reader returns k+1. node: 1,2,3.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BodyMutatesLoopVar_ClosureWritesThrough(ExecutionMode mode)
     {
         var source = """
@@ -159,8 +150,7 @@ public class ForLoopPerIterationBindingTests
 
     // Same as above but the writer uses `i++` (postfix increment in a closure), exercising
     // the increment emitter's captured-cell write-through path.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BodyMutatesLoopVar_ClosureIncrementsThrough(ExecutionMode mode)
     {
         var source = """
@@ -175,8 +165,7 @@ public class ForLoopPerIterationBindingTests
 
     // Nested loops where BOTH loop vars are mutate-and-restored and captured by the inner
     // closure — each needs its own cell, copied forward independently.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedLoops_BothBindingsMutated(ExecutionMode mode)
     {
         var source = """
@@ -198,8 +187,7 @@ public class ForLoopPerIterationBindingTests
     // has no direct await/yield — the per-iteration cell is an IL local that lives for the
     // whole loop within one MoveNext segment. Loops whose body itself suspends remain on the
     // snapshot path (cell-as-field is a further follow-up).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BodyMutatesLoopVar_AsyncFunctionBody(ExecutionMode mode)
     {
         var source = """
@@ -213,8 +201,7 @@ public class ForLoopPerIterationBindingTests
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BodyMutatesLoopVar_GeneratorBody(ExecutionMode mode)
     {
         var source = """
@@ -230,8 +217,7 @@ public class ForLoopPerIterationBindingTests
 
     // Async generator: consumed via `.next()` (a compiled async generator consumed through
     // `for await…of` is a separate pre-existing gap that hangs even without the mutation).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BodyMutatesLoopVar_AsyncGeneratorBody(ExecutionMode mode)
     {
         var source = """
@@ -250,8 +236,7 @@ public class ForLoopPerIterationBindingTests
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BodyMutatesLoopVar_AsyncArrowBody(ExecutionMode mode)
     {
         var source = """
@@ -267,8 +252,7 @@ public class ForLoopPerIterationBindingTests
 
     // ---- Negative: `var` is function-scoped — one shared binding, closures read the final value ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void VarLoopVar_SharedBinding_ReadsFinal(ExecutionMode mode)
     {
         var source = """
@@ -281,8 +265,7 @@ public class ForLoopPerIterationBindingTests
 
     // ---- Negative: a bare-expression initializer assigns an outer var — one shared binding ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExpressionInitializer_OuterVar_ReadsFinal(ExecutionMode mode)
     {
         var source = """
@@ -296,8 +279,7 @@ public class ForLoopPerIterationBindingTests
 
     // ---- A fresh per-iteration const is unaffected (already correct in both modes) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerConstSnapshot_StillWorks(ExecutionMode mode)
     {
         var source = """
@@ -315,8 +297,7 @@ public class ForLoopPerIterationBindingTests
     // remained a local that each closure snapshots.) The fix keeps these per-iteration loop bindings
     // out of the function display class, so they are snapshotted per iteration like the top-level case.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SyncFunctionBody_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -330,8 +311,7 @@ public class ForLoopPerIterationBindingTests
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunctionBody_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -345,8 +325,7 @@ public class ForLoopPerIterationBindingTests
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassMethodBody_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -362,8 +341,7 @@ public class ForLoopPerIterationBindingTests
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowBody_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -377,8 +355,7 @@ public class ForLoopPerIterationBindingTests
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunctionBody_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -399,8 +376,7 @@ public class ForLoopPerIterationBindingTests
     // loop-body closure also captures the per-iteration loop variable: the per-iteration exclusion
     // must apply only to the loop binding, not to ordinary captured locals. `outer` ends at 3 for
     // every closure; `k` is per-iteration.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionBody_OuterCapturedVarStaysShared(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/FunctionMethodsTests.cs
+++ b/SharpTS.Tests/SharedTests/FunctionMethodsTests.cs
@@ -10,8 +10,7 @@ public class FunctionMethodsTests
 {
     #region Bind Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Bind_PartialApplication_PrependArgs(ExecutionMode mode)
     {
         var source = """
@@ -26,8 +25,7 @@ public class FunctionMethodsTests
         Assert.Equal("8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Bind_ArrowFunction_IgnoresThisArg(ExecutionMode mode)
     {
         var source = """
@@ -41,8 +39,7 @@ public class FunctionMethodsTests
         Assert.Equal("arrow\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Bind_ChainedBind_PreservesFirstThis(ExecutionMode mode)
     {
         // Test that chained bind preserves the first 'this' binding
@@ -66,8 +63,7 @@ public class FunctionMethodsTests
 
     #region Call Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Call_WithMultipleArgs(ExecutionMode mode)
     {
         var source = """
@@ -81,8 +77,7 @@ public class FunctionMethodsTests
         Assert.Equal("6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Call_ArrowFunction_IgnoresThisArg(ExecutionMode mode)
     {
         var source = """
@@ -99,8 +94,7 @@ public class FunctionMethodsTests
 
     #region Apply Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Apply_SpreadArrayArgs(ExecutionMode mode)
     {
         var source = """
@@ -115,8 +109,7 @@ public class FunctionMethodsTests
         Assert.Equal("6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Apply_NullArgs_CallsWithNoArgs(ExecutionMode mode)
     {
         var source = """
@@ -130,8 +123,7 @@ public class FunctionMethodsTests
         Assert.Equal("Hi\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Apply_EmptyArgs_CallsWithNoArgs(ExecutionMode mode)
     {
         var source = """
@@ -149,8 +141,7 @@ public class FunctionMethodsTests
 
     #region Function Length Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionLength_ReturnsArity(ExecutionMode mode)
     {
         var source = """
@@ -164,8 +155,7 @@ public class FunctionMethodsTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionLength_ZeroParams(ExecutionMode mode)
     {
         var source = """
@@ -183,8 +173,7 @@ public class FunctionMethodsTests
 
     #region Function Name Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionName_ReturnsName(ExecutionMode mode)
     {
         var source = """
@@ -196,8 +185,7 @@ public class FunctionMethodsTests
         Assert.Equal("myFunction\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BoundFunctionName_PrefixedWithBound(ExecutionMode mode)
     {
         var source = """
@@ -214,8 +202,7 @@ public class FunctionMethodsTests
 
     #region Type Error Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void FunctionInvalidMember_ReturnsUndefined(ExecutionMode mode)
     {
         // JS functions are objects and support arbitrary property access —
@@ -241,8 +228,7 @@ public class FunctionMethodsTests
 
     #region Bound Function Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BoundFunction_CannotBeUsedAsConstructor(ExecutionMode mode)
     {
         // In JavaScript, bound functions cannot be used with 'new' for class constructors

--- a/SharpTS.Tests/SharedTests/FunctionMissingPropertyTests.cs
+++ b/SharpTS.Tests/SharedTests/FunctionMissingPropertyTests.cs
@@ -14,8 +14,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class FunctionMissingPropertyTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MissingProperty_OffFunctionDeclaration_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -27,8 +26,7 @@ public class FunctionMissingPropertyTests
         Assert.Equal("undefined\ntrue\nfalse\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MissingProperty_OffArrow_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -39,8 +37,7 @@ public class FunctionMissingPropertyTests
         Assert.Equal("undefined\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UserAssignedProperty_StillRoundTrips_MissIsUndefined(ExecutionMode mode)
     {
         // The miss path must not disturb genuine user-assigned properties:
@@ -55,8 +52,7 @@ public class FunctionMissingPropertyTests
         Assert.Equal("42\nundefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MissingProperty_OffConstructorReturnedArrow_IsUndefined(ExecutionMode mode)
     {
         // The discovery case from #651: a constructor returning an arrow yields

--- a/SharpTS.Tests/SharedTests/FunctionReturnValueTests.cs
+++ b/SharpTS.Tests/SharedTests/FunctionReturnValueTests.cs
@@ -23,8 +23,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class FunctionReturnValueTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BareReturn_IsUndefined(ExecutionMode mode)
     {
         // Bare `return;` is equivalent to `return undefined` — undefined, not null.
@@ -37,8 +36,7 @@ public class FunctionReturnValueTests
         Assert.Equal("undefined\ntrue\nfalse\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OffEndCompletion_IsUndefined(ExecutionMode mode)
     {
         // Falling off the end of the body completes with undefined. In compiled mode such a
@@ -52,8 +50,7 @@ public class FunctionReturnValueTests
         Assert.Equal("undefined\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowBareReturn_IsUndefined(ExecutionMode mode)
     {
         // A block-bodied arrow shares the same return emission as a function declaration, so a
@@ -66,8 +63,7 @@ public class FunctionReturnValueTests
         Assert.Equal("undefined\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnNull_IsNull(ExecutionMode mode)
     {
         // `return null;` is distinct from a bare `return;`: the value is JS null, not undefined.
@@ -79,8 +75,7 @@ public class FunctionReturnValueTests
         Assert.Equal("object\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void AsyncFunction_BareReturn_ResolvesUndefined(ExecutionMode mode)
     {
         // The async return path (ExecuteReturnAsyncVT) got the same fix as the sync VisitReturn:

--- a/SharpTS.Tests/SharedTests/FunctionShadowingCallTests.cs
+++ b/SharpTS.Tests/SharedTests/FunctionShadowingCallTests.cs
@@ -14,8 +14,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class FunctionShadowingCallTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Parameter_ShadowsTopLevelFunction_InCall(ExecutionMode mode)
     {
         var source = """
@@ -26,8 +25,7 @@ public class FunctionShadowingCallTests
         Assert.Equal("20", TestHarness.Run(source, mode).Trim());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LocalConst_ShadowsTopLevelFunction_InCall(ExecutionMode mode)
     {
         var source = """
@@ -38,8 +36,7 @@ public class FunctionShadowingCallTests
         Assert.Equal("20", TestHarness.Run(source, mode).Trim());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedFunction_ShadowsTopLevelFunction_InCall(ExecutionMode mode)
     {
         var source = """
@@ -50,8 +47,7 @@ public class FunctionShadowingCallTests
         Assert.Equal("20", TestHarness.Run(source, mode).Trim());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UnshadowedTopLevelFunction_StillCalledDirectly(ExecutionMode mode)
     {
         // Control: a function with no shadowing binding in scope must still reach the top-level h.
@@ -64,8 +60,7 @@ public class FunctionShadowingCallTests
         Assert.Equal("20,1", TestHarness.Run(source, mode).Trim());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LetParameter_ShadowsTopLevelFunction_InCall(ExecutionMode mode)
     {
         // A reassigned `let` still shadows the top-level function for the rest of the body; the call

--- a/SharpTS.Tests/SharedTests/GeneratorArrowBodyTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorArrowBodyTests.cs
@@ -13,8 +13,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class GeneratorArrowBodyTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NonCapturingArrowCallbackInsideYield(ExecutionMode mode)
     {
         // #435: the arrow lives inside the yielded expression, so it was never collected →
@@ -31,8 +30,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("m=2,4,6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_CapturingClosureReadsLoopVariable(ExecutionMode mode)
     {
         // #669: per-iteration `for (let k …)` bindings captured by a closure created inside the
@@ -51,8 +49,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("012\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ArrowReadsCapturedLocal(ExecutionMode mode)
     {
         var source = """
@@ -66,8 +63,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("11,12,13\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ArrowReadsCapturedParameter(ExecutionMode mode)
     {
         var source = """
@@ -80,8 +76,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("101,102,103\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ArrowReadsCapturedTopLevelVar(ExecutionMode mode)
     {
         // #732: a TOP-LEVEL (module-level) variable captured by an arrow inside the generator body.
@@ -99,8 +94,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("11,12,13\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ArrowWritesCapturedTopLevelVar(ExecutionMode mode)
     {
         // #732 (write case): an arrow inside the generator body WRITES a captured top-level binding.
@@ -116,8 +110,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("6\n6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_InstanceMethodArrowReadsCapturedTopLevelVar(ExecutionMode mode)
     {
         // #732 for an INSTANCE generator method — the separate EmitGeneratorMethodBody context also
@@ -131,8 +124,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("11,12,13\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_InstanceMethodArrowWritesCapturedTopLevelVar(ExecutionMode mode)
     {
         // #732 instance-method write case.
@@ -145,8 +137,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_InstanceMethodArrowCapturesThis(ExecutionMode mode)
     {
         // #435/#669: `this` is referenced only inside the arrow, so the generator analyzer must
@@ -162,8 +153,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("8,9,10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ForEachMutatesCapturedObjectNotBinding(ExecutionMode mode)
     {
         // A callback that mutates the captured array OBJECT (push) — not the binding — is fine:
@@ -180,8 +170,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("2,4,6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ForEachWritesCapturedBinding(ExecutionMode mode)
     {
         // #674: an arrow that WRITES a captured generator local. The mutation must reach the
@@ -199,8 +188,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("123\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_CallbackAccumulatesIntoCapturedNumber(ExecutionMode mode)
     {
         // #674, numeric accumulator — the canonical `reduce`-by-side-effect shape.
@@ -216,8 +204,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_MultipleMutatedCaptures(ExecutionMode mode)
     {
         // #674: two distinct captured locals mutated by one callback — each gets its own DC field.
@@ -233,8 +220,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("10,24\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_CallbackMutatesCapturedParameter(ExecutionMode mode)
     {
         // #674: the mutated capture is a generator PARAMETER — the stub seeds it into the DC.
@@ -249,8 +235,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("106\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NestedCallbackWritesCaptureThroughToGenerator(ExecutionMode mode)
     {
         // #674 (the case the compile-time guard could not see): a NESTED arrow writes a variable
@@ -267,8 +252,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_MutatedAndReadOnlyCapturesMixed(ExecutionMode mode)
     {
         // #674: a read-only capture (`base`, by-value snapshot) and a mutated capture (`total`,
@@ -285,8 +269,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("36\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_CapturedWriteSurvivesAcrossYield(ExecutionMode mode)
     {
         // #674: the mutated capture is also live across a yield. The DC lives on a state-machine
@@ -306,8 +289,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("before:0|after:6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_InstanceMethodWritesCapturedBinding(ExecutionMode mode)
     {
         // #724: an INSTANCE generator method whose arrow WRITES a captured method local. The method's
@@ -327,8 +309,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_InstanceMethodCallbackMutatesCapturedParameter(ExecutionMode mode)
     {
         // #724: the mutated capture is a method PARAMETER (value-typed in the stub). The instance stub
@@ -341,8 +322,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("106\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_InstanceMethodMixesThisAndMutatedLocal(ExecutionMode mode)
     {
         // #724 + #435: the arrow reads `this` (via the state machine's ThisField) AND writes a captured
@@ -358,8 +338,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("36\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_InstanceMethodCapturedWriteSurvivesAcrossYield(ExecutionMode mode)
     {
         // #724: the mutated capture is live across a yield — the DC lives on a state-machine field so
@@ -375,8 +354,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("b:0|a:6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_TwoClassesSameMethodNameWriteCaptureIndependently(ExecutionMode mode)
     {
         // #724: two classes declaring a `*g()` with a write-capture must get DISTINCT function display
@@ -390,8 +368,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("3 103\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_WritesCapturedBinding(ExecutionMode mode)
     {
         // #725: a sync arrow inside an ASYNC generator (`async function*`) body that WRITES a captured
@@ -411,8 +388,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_CapturedWriteSurvivesAcrossAwait(ExecutionMode mode)
     {
         // #725: the mutated capture is live across an actual `await` suspension — the DC lives on the
@@ -430,8 +406,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_MixedMutatedAndReadOnlyCaptures(ExecutionMode mode)
     {
         // #725: a read-only capture (`base`, by-value snapshot) and a mutated capture (`total`, function
@@ -448,8 +423,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("36\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_InstanceMethodWritesCapturedBinding(ExecutionMode mode)
     {
         // #725: the async-generator INSTANCE method analogue — the function DC is registered in
@@ -468,8 +442,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ArrowReadsCapturedTopLevelVar(ExecutionMode mode)
     {
         // #725 also threads $entryPointDC into arrows nested in an async generator body (the async
@@ -489,8 +462,7 @@ public class GeneratorArrowBodyTests
     // reading the $Undefined sentinel (NaN for value defaults, the missing string for ref defaults).
     // Only the omitted-arg path was broken; supplying the argument always worked.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_DefaultedParamCapturedByArrow_OmittedUsesDefault(ExecutionMode mode)
     {
         // value-type default, captured by a forEach arrow — free-function generator.
@@ -502,8 +474,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("11\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_DefaultedParamCapturedByArrow_SuppliedWins(ExecutionMode mode)
     {
         // Regression guard: a supplied argument must beat the default on the captured path too.
@@ -515,8 +486,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("106\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_RefDefaultedParamCapturedByArrow_InstanceMethod(ExecutionMode mode)
     {
         // reference-type (string) default, captured — instance generator method.
@@ -529,8 +499,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("x123\nY123\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_DefaultedParamCapturedByArrow_OmittedUsesDefault(ExecutionMode mode)
     {
         // value-type default, captured — async generator.
@@ -542,8 +511,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("11\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ClassExpressionMethodWritesCapturedBinding(ExecutionMode mode)
     {
         // #789: the class-EXPRESSION analogue of #724. Class expressions are only collected during the
@@ -563,8 +531,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ClassExpressionMethodMutatesCapturedParameter(ExecutionMode mode)
     {
         // #789: the mutated capture is a method PARAMETER (value-typed in the stub) — class-expr analogue
@@ -577,8 +544,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("106\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ClassExpressionMethodMixesThisAndMutatedLocal(ExecutionMode mode)
     {
         // #789: the arrow reads `this` (state machine ThisField) AND writes a captured local (function DC)
@@ -594,8 +560,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("36\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ClassExpressionMethodCapturedWriteSurvivesAcrossYield(ExecutionMode mode)
     {
         // #789: the mutated capture is live across a yield — the DC lives on a state-machine field so it
@@ -611,8 +576,7 @@ public class GeneratorArrowBodyTests
         Assert.Equal("b:0|a:6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_ClassExpressionMethodWritesCapturedBinding(ExecutionMode mode)
     {
         // #789: the async-generator class-EXPRESSION analogue of #725 — the function DC is registered in

--- a/SharpTS.Tests/SharedTests/GeneratorClosureCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorClosureCaptureTests.cs
@@ -11,8 +11,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class GeneratorClosureCaptureTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_CapturesOuterLetByReference_NotSnapshot(ExecutionMode mode)
     {
         // The canonical #541 repro: x is mutated after the generator is created but before
@@ -28,8 +27,7 @@ public class GeneratorClosureCaptureTests
         Assert.Equal("42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_SelfReferenceResolvesLive(ExecutionMode mode)
     {
         // The shape from #521: the generator's own binding is assigned the generator instance
@@ -44,8 +42,7 @@ public class GeneratorClosureCaptureTests
         Assert.Equal("generator\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_MutationBetweenYieldsIsVisible(ExecutionMode mode)
     {
         var source = """
@@ -61,8 +58,7 @@ public class GeneratorClosureCaptureTests
         Assert.Equal("10 20\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_WriteToCapturedVarPropagatesToOuterScope(ExecutionMode mode)
     {
         // A write to a captured variable from inside the generator body must update the
@@ -78,8 +74,7 @@ public class GeneratorClosureCaptureTests
         Assert.Equal("100\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_IncrementAndCompoundOnCapturedVar(ExecutionMode mode)
     {
         var source = """
@@ -94,8 +89,7 @@ public class GeneratorClosureCaptureTests
         Assert.Equal("2 12 12\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_InstanceMethodCapturesOuterByReference(ExecutionMode mode)
     {
         var source = """
@@ -109,8 +103,7 @@ public class GeneratorClosureCaptureTests
         Assert.Equal("55\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_CapturedVarInLoopBodyReadLive(ExecutionMode mode)
     {
         // Combines by-reference capture with the loop-body hoisting path (#497).
@@ -125,8 +118,7 @@ public class GeneratorClosureCaptureTests
         Assert.Equal("200 201 202\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_YieldStarDelegateSeesCapturedMutation(ExecutionMode mode)
     {
         var source = """
@@ -141,8 +133,7 @@ public class GeneratorClosureCaptureTests
         Assert.Equal("9 9\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_MultipleInstancesShareCapturedVar(ExecutionMode mode)
     {
         var source = """
@@ -157,8 +148,7 @@ public class GeneratorClosureCaptureTests
         Assert.Equal("7 7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ReferencesTopLevelFunctionAsValue(ExecutionMode mode)
     {
         // Referencing a top-level function as a value inside a generator previously read a
@@ -172,8 +162,7 @@ public class GeneratorClosureCaptureTests
         Assert.Equal("H\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_CapturingArrowCalledInsideBody(ExecutionMode mode)
     {
         // Calling a *capturing* arrow inside a generator body previously failed in compiled mode with
@@ -191,8 +180,7 @@ public class GeneratorClosureCaptureTests
         Assert.Equal("10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NestedGeneratorCapturingLocal_IsLifted(ExecutionMode mode)
     {
         // The #583 §1 repro: a nested generator that captures an enclosing local is lambda-lifted (the
@@ -210,8 +198,7 @@ public class GeneratorClosureCaptureTests
         Assert.Equal("10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_NestedAsyncCapturingLocal_IsLifted(ExecutionMode mode)
     {
         // The async analogue of #583 §1: a nested async function capturing an enclosing local lifts too.
@@ -227,8 +214,7 @@ public class GeneratorClosureCaptureTests
         Assert.Equal("11\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_PlainNestedFunctionCapturingLocal_IsLifted(ExecutionMode mode)
     {
         // A plain function nested in a generator, capturing an enclosing local (#583 §1, case-B analogue):

--- a/SharpTS.Tests/SharedTests/GeneratorErrorIdentityTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorErrorIdentityTests.cs
@@ -20,8 +20,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class GeneratorErrorIdentityTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void RuntimeTypeError_CaughtInGeneratorBody_InstanceofHolds(ExecutionMode mode)
     {
         // The exact #543 repro: a "not a function" TypeError caught inside the generator body.
@@ -37,8 +36,7 @@ public class GeneratorErrorIdentityTests
         Assert.Equal("true TypeError\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void RuntimeTypeError_CaughtInGeneratorBody_AfterYield_InstanceofHolds(ExecutionMode mode)
     {
         // The flag-based shape: a yield before the throwing call forces the try into the flag-based
@@ -55,8 +53,7 @@ public class GeneratorErrorIdentityTests
         Assert.Equal("true TypeError\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExplicitlyThrownError_CaughtInGeneratorBody_InstanceofHolds(ExecutionMode mode)
     {
         // Explicit `throw new RangeError(...)` caught in-body keeps its identity in both modes.

--- a/SharpTS.Tests/SharedTests/GeneratorTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTests.cs
@@ -12,8 +12,7 @@ public class GeneratorTests
 {
     #region For...Of Integration
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ForOfLoop_IteratesAllValues(ExecutionMode mode)
     {
         var source = """
@@ -32,8 +31,7 @@ public class GeneratorTests
         Assert.Equal("10\n20\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_WithParameters_UsesParameters(ExecutionMode mode)
     {
         var source = """
@@ -56,8 +54,7 @@ public class GeneratorTests
 
     #region For...In Integration (#547)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ForInLoop_YieldsAllKeys(ExecutionMode mode)
     {
         // A for...in whose body yields must continue past the first key: the key list and index
@@ -74,8 +71,7 @@ public class GeneratorTests
         Assert.Equal("a,b,c\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ForInLoop_TwoYieldsPerKey_AccumulatesAcrossSuspension(ExecutionMode mode)
     {
         // Two yields per iteration force the loop to re-enter mid-body; the index must persist (#547).
@@ -91,8 +87,7 @@ public class GeneratorTests
         Assert.Equal("x,10,y,20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ForInLoop_Nested_YieldsCartesianProduct(ExecutionMode mode)
     {
         // Nested for...in loops, each with its own hoisted key-list/index fields.
@@ -113,8 +108,7 @@ public class GeneratorTests
 
     #region Yield* Delegation
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_YieldStarArray_DelegatesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -131,8 +125,7 @@ public class GeneratorTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_YieldStarGenerator_DelegatesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -156,8 +149,7 @@ public class GeneratorTests
         Assert.Equal("1\n2\n3\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_YieldStar_ForwardsSentValue(ExecutionMode mode)
     {
         // ECMA-262 §14.4.14: the value passed to the outer's next(v) is forwarded
@@ -180,8 +172,7 @@ public class GeneratorTests
         Assert.Equal("inner got 99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_YieldStar_ForwardsAcrossYields_AndYieldsCompletionValue(ExecutionMode mode)
     {
         // Each next(v) feeds the inner's successive yields, and the delegate's
@@ -208,8 +199,7 @@ public class GeneratorTests
         Assert.Equal("a\nb\nret inner:1,2\nafter\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_YieldStar_Nested_ForwardsSentValue(ExecutionMode mode)
     {
         // A resume value must thread through every level of nested delegation.
@@ -229,8 +219,7 @@ public class GeneratorTests
         Assert.Equal("a got 42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_YieldStar_InExpression_ForwardsSentValue(ExecutionMode mode)
     {
         // yield* as a sub-expression (operand-spill path) still forwards the resume
@@ -253,8 +242,7 @@ public class GeneratorTests
         Assert.Equal("R:15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_YieldStar_CustomIterator_ForwardsNextSentValue(ExecutionMode mode)
     {
         // ECMA-262 §14.4.14: the value passed to the outer's next(v) must be forwarded
@@ -281,8 +269,7 @@ public class GeneratorTests
         Assert.Equal("start\ngot:42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_YieldStar_CustomIterator_ForwardsMultipleSentValues(ExecutionMode mode)
     {
         // Each successive next(v) on the outer must be forwarded to the custom iterator's next(v).
@@ -314,8 +301,7 @@ public class GeneratorTests
 
     #region Control Flow
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_WhileLoop_YieldsMultipleTimes(ExecutionMode mode)
     {
         var source = """
@@ -335,8 +321,7 @@ public class GeneratorTests
         Assert.Equal("3\n2\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_IfStatement_ConditionalYield(ExecutionMode mode)
     {
         var source = """
@@ -367,8 +352,7 @@ public class GeneratorTests
 
     #region Closures
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_Closure_CapturesVariables(ExecutionMode mode)
     {
         var source = """
@@ -391,8 +375,7 @@ public class GeneratorTests
 
     #region Iterator Protocol (.next())
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_BasicYield_ReturnsValues(ExecutionMode mode)
     {
         var source = """
@@ -413,8 +396,7 @@ public class GeneratorTests
         Assert.Equal("1\n2\n3\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_EmptyGenerator_ReturnsDoneImmediately(ExecutionMode mode)
     {
         var source = """
@@ -429,8 +411,7 @@ public class GeneratorTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_IteratorResult_HasCorrectStructure(ExecutionMode mode)
     {
         var source = """
@@ -451,8 +432,7 @@ public class GeneratorTests
         Assert.Equal("First value: 42\nFirst done: false\nSecond done: true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_MultipleInstances_IndependentState(ExecutionMode mode)
     {
         var source = """
@@ -479,8 +459,7 @@ public class GeneratorTests
 
     #region Resume Values (next(v)) — issue #452
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NextWithValue_DeliveredToYield(ExecutionMode mode)
     {
         // ECMA-262 §27.5.3.3: `yield expr` evaluates to the argument of the
@@ -504,8 +483,7 @@ public class GeneratorTests
         Assert.Equal("first 1\ngot 42\nr1 2\ngot 43\nr2 99\ndone true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_AccumulatorPattern_UsesSentValues(ExecutionMode mode)
     {
         // The classic two-way generator: each next(n) feeds the running total.
@@ -528,8 +506,7 @@ public class GeneratorTests
         Assert.Equal("0\n5\n15\n18\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_AccumulatorPattern_CompoundAssignAcrossYield(ExecutionMode mode)
     {
         // #497: the same two-way accumulator, but the running total is read *before* the yield
@@ -556,8 +533,7 @@ public class GeneratorTests
         Assert.Equal("0\n5\n15\n18\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_AccumulatorPattern_CompoundAssignAcrossYield_DoWhile(ExecutionMode mode)
     {
         // #497: do-while is one of the loop forms that lacked loop-body hoisting pre-fix.
@@ -579,8 +555,7 @@ public class GeneratorTests
         Assert.Equal("0\n5\n15\n18\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_AccumulatorPattern_CompoundAssignAcrossYield_For(ExecutionMode mode)
     {
         // #497: an unbounded for(;;) likewise lacked loop-body hoisting pre-fix.
@@ -602,8 +577,7 @@ public class GeneratorTests
         Assert.Equal("0\n5\n15\n18\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_LoopCarriedLocal_ReadBeforeYield_SurvivesAcrossIterations(ExecutionMode mode)
     {
         // #497 (general shape): a counted for-loop whose induction-adjacent local is read in the
@@ -628,8 +602,7 @@ public class GeneratorTests
         Assert.Equal("0\n10\n30\n60\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_BareNext_ResumesWithUndefined(ExecutionMode mode)
     {
         var source = """
@@ -646,8 +619,7 @@ public class GeneratorTests
         Assert.Equal("undefined undefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NextWithNull_ResumesWithNull(ExecutionMode mode)
     {
         // next(null) must deliver null (typeof "object"), distinct from a bare
@@ -666,8 +638,7 @@ public class GeneratorTests
         Assert.Equal("null object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ForOf_ResumesYieldWithUndefined(ExecutionMode mode)
     {
         // for...of drives the generator without passing a value, so a yield used
@@ -686,8 +657,7 @@ public class GeneratorTests
         Assert.Equal("yielded 10\nresumed undefined undefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_SentValue_UsedInExpression(ExecutionMode mode)
     {
         var source = """
@@ -704,8 +674,7 @@ public class GeneratorTests
         Assert.Equal("doubled 42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_InstanceMethod_NextWithValue_AndThis(ExecutionMode mode)
     {
         var source = """
@@ -732,8 +701,7 @@ public class GeneratorTests
 
     #region Yield* with String
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_YieldStarString_DelegatesCharacters(ExecutionMode mode)
     {
         var source = """
@@ -754,8 +722,7 @@ public class GeneratorTests
 
     #region Yield* with Map and Set
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_YieldStarMap_DelegatesEntries(ExecutionMode mode)
     {
         var source = """
@@ -775,8 +742,7 @@ public class GeneratorTests
         Assert.Equal("a:1\nb:2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_YieldStarSet_DelegatesValues(ExecutionMode mode)
     {
         var source = """
@@ -804,8 +770,7 @@ public class GeneratorTests
     // return()/throw() injecting an abrupt completion at the suspended yield, so active try/finally/
     // catch run) landed in #526. They double as a cross-mode parity guard.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_Return_RunsFinally_AndReportsValue(ExecutionMode mode)
     {
         // The repro from issue #478: return(v) on a suspended generator resumes it as an
@@ -833,8 +798,7 @@ public class GeneratorTests
         Assert.Equal("1 false\nfinally ran\n99 true\nundefined true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_Throw_CaughtByTryCatch_Continues(ExecutionMode mode)
     {
         // throw(e) injects the error at the yield point; an enclosing catch handles it and
@@ -861,8 +825,7 @@ public class GeneratorTests
         Assert.Equal("1\ncaught boom\n99 false\nundefined true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_Throw_RunsFinally_ThenPropagates(ExecutionMode mode)
     {
         // throw(e) with only a finally (no catch): the finally runs, then the error propagates
@@ -888,8 +851,7 @@ public class GeneratorTests
         Assert.Equal("finally C\nouter caught boomC\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_Return_RunsNestedFinallyInnerToOuter(ExecutionMode mode)
     {
         var source = """
@@ -914,8 +876,7 @@ public class GeneratorTests
         Assert.Equal("inner\nouter\n5 true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_Return_FinallyThatYields_DefersCompletion(ExecutionMode mode)
     {
         // A finally that yields suspends the pending return; the return value is delivered
@@ -940,8 +901,7 @@ public class GeneratorTests
         Assert.Equal("99 false\n5 true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_Return_FinallyReturnOverridesValue(ExecutionMode mode)
     {
         // A finally that returns its own value overrides the value passed to return().
@@ -963,8 +923,7 @@ public class GeneratorTests
         Assert.Equal("7 true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_Return_FinallyThrowOverridesReturn(ExecutionMode mode)
     {
         // A finally that throws overrides the pending return with the thrown error.
@@ -989,8 +948,7 @@ public class GeneratorTests
         Assert.Equal("caught finally-err\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ReturnAndThrow_OnNotStarted_DoNotRunBody(ExecutionMode mode)
     {
         // return()/throw() on a generator that hasn't started close it without running the
@@ -1018,8 +976,7 @@ public class GeneratorTests
         Assert.Equal("8 true\nthrew x\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NextAfterCompletion_ReportsUndefined(ExecutionMode mode)
     {
         // Once a generator finishes, its completion value is delivered exactly once; further
@@ -1041,8 +998,7 @@ public class GeneratorTests
         Assert.Equal("42 true\nundefined true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_UncaughtThrowInBody_PropagatesToNext(ExecutionMode mode)
     {
         // An uncaught throw inside the body surfaces to the next() caller rather than being
@@ -1065,8 +1021,7 @@ public class GeneratorTests
         Assert.Equal("caught bodyboom\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_BareReturn_ReportsUndefinedValue(ExecutionMode mode)
     {
         // A no-argument return() resumes with undefined.
@@ -1093,8 +1048,7 @@ public class GeneratorTests
     // the compiled EmitYieldStar gained the same forwarding (driving the delegate via return()/throw()
     // instead of next()) once the compiled injection landed in #526.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_Return_ForwardsToInnerFinally_ThenOuterReturns(ExecutionMode mode)
     {
         // The repro from #514: return(v) on the outer while suspended inside yield* must run the
@@ -1114,8 +1068,7 @@ public class GeneratorTests
         Assert.Equal("1\ninner finally\n42 true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_Throw_NoInnerCatch_RunsInnerFinally_ThenPropagates(ExecutionMode mode)
     {
         // throw(e) is forwarded to the delegate; with only a finally (no catch) the delegate's
@@ -1133,8 +1086,7 @@ public class GeneratorTests
         Assert.Equal("1\ninner finally\ncaught boom\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_Throw_CaughtByInner_KeepsDelegating(ExecutionMode mode)
     {
         // The delegate catches the injected error and yields again; the outer stays in the
@@ -1153,8 +1105,7 @@ public class GeneratorTests
         Assert.Equal("1\ninner caught boom\n99\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_Throw_CaughtByInnerThenReturns_OuterContinuesNormally(ExecutionMode mode)
     {
         // The delegate catches the error and returns: per §14.4.14 step b.5 the yield* evaluates
@@ -1177,8 +1128,7 @@ public class GeneratorTests
         Assert.Equal("1\nafter yield* recovered\nouter false\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_Return_InnerFinallyYields_DefersCompletion(ExecutionMode mode)
     {
         // The delegate's finally itself yields: the outer suspends there (reporting the
@@ -1205,8 +1155,7 @@ public class GeneratorTests
         Assert.Equal("1\nfrom finally false\nx=7\nundefined true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_Return_InnerFinallyReturnOverridesValue(ExecutionMode mode)
     {
         // A finally in the delegate that returns its own value overrides the value passed to the
@@ -1225,8 +1174,7 @@ public class GeneratorTests
         Assert.Equal("1\n99 true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_Return_RunsInnerThenOuterFinally(ExecutionMode mode)
     {
         // When the outer also wraps the yield* in try/finally, the abrupt return runs the
@@ -1247,8 +1195,7 @@ public class GeneratorTests
         Assert.Equal("1\ninner finally\nouter finally\n5 true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_Nested_Return_ReachesInnermostFinally(ExecutionMode mode)
     {
         // Two levels of delegation (outer → middle → inner): return() must thread through both
@@ -1270,8 +1217,7 @@ public class GeneratorTests
         Assert.Equal("1\ninner finally\nmiddle finally\n3 true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_Nested_Throw_RunsAllFinallys_ThenPropagates(ExecutionMode mode)
     {
         // throw() through two levels of delegation with no catch anywhere: each finally runs
@@ -1292,8 +1238,7 @@ public class GeneratorTests
         Assert.Equal("1\ninner finally\nmiddle finally\ncaught kaboom\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_Return_InnerWithoutFinally_TerminatesCleanly(ExecutionMode mode)
     {
         // return() forwarded to a delegate that has no finally: the delegate just closes, the
@@ -1311,8 +1256,7 @@ public class GeneratorTests
         Assert.Equal("1\n11 true\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_Return_ForwardsIntoGeneratorExpressionDelegate(ExecutionMode mode)
     {
         // The delegate is a generator function EXPRESSION (a distinct runtime type from a
@@ -1331,8 +1275,7 @@ public class GeneratorTests
         Assert.Equal("1\ninner finally\n8 true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_Return_FromGeneratorExpressionOuter(ExecutionMode mode)
     {
         // The OUTER is a generator function expression delegating to a declaration; the suspend
@@ -1360,8 +1303,7 @@ public class GeneratorTests
     // the body ahead of the block-scoped (let/const) bindings it closes over, or the type checker
     // (which checks bodies in source order) rejects the reference as "Undefined variable".
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_ClosesOverOuterLet(ExecutionMode mode)
     {
         // The exact repro from issue #522.
@@ -1375,8 +1317,7 @@ public class GeneratorTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_ClosesOverOuterConst(ExecutionMode mode)
     {
         var source = """
@@ -1389,8 +1330,7 @@ public class GeneratorTests
         Assert.Equal("10\n20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_CapturesVariableNotSnapshot(ExecutionMode mode)
     {
         // The closure binds the variable, so a mutation between definition and iteration is observed.
@@ -1405,8 +1345,7 @@ public class GeneratorTests
         Assert.Equal("99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_NestedInFunction_ClosesOverModuleLet(ExecutionMode mode)
     {
         // A generator expression nested inside another function may still close over module-scope
@@ -1432,8 +1371,7 @@ public class GeneratorTests
     // The GeneratorArrowLifter must descend through the grouped callee so the expression is lifted
     // (otherwise the type checker rejects its `yield` because the generator context is never set).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_IifeCallPosition(ExecutionMode mode)
     {
         // The exact repro from issue #488.
@@ -1445,8 +1383,7 @@ public class GeneratorTests
         Assert.Equal("1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_IifeSpreadIntoArray(ExecutionMode mode)
     {
         var source = """
@@ -1465,8 +1402,7 @@ public class GeneratorTests
     // try-catch-finally / switch / labeled statement bodies, or a generator function expression
     // declared there is never lifted and its `yield` is rejected at type-check time.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_InsideForLoop(ExecutionMode mode)
     {
         // The exact repro from issue #634.
@@ -1480,8 +1416,7 @@ public class GeneratorTests
         Assert.Equal("99\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_InsideForOf(ExecutionMode mode)
     {
         // The generator yields a constant (not the loop variable): #634 is about the lifter reaching
@@ -1497,8 +1432,7 @@ public class GeneratorTests
         Assert.Equal("1\n1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_InsideForIn(ExecutionMode mode)
     {
         var source = """
@@ -1512,8 +1446,7 @@ public class GeneratorTests
         Assert.Equal("2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_InsideLoopClosesOverModuleScope(ExecutionMode mode)
     {
         // A generator expression inside a loop body may still close over a MODULE-scope binding;
@@ -1529,8 +1462,7 @@ public class GeneratorTests
         Assert.Equal("7\n7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_InsideDoWhile(ExecutionMode mode)
     {
         var source = """
@@ -1545,8 +1477,7 @@ public class GeneratorTests
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_InsideTryCatchFinally(ExecutionMode mode)
     {
         var source = """
@@ -1565,8 +1496,7 @@ public class GeneratorTests
         Assert.Equal("1\n3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_InsideSwitchCase(ExecutionMode mode)
     {
         var source = """
@@ -1584,8 +1514,7 @@ public class GeneratorTests
         Assert.Equal("42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_InsideLabeledStatement(ExecutionMode mode)
     {
         var source = """
@@ -1611,8 +1540,7 @@ public class GeneratorTests
     // (this/arguments, rest/default params, self-recursion) instead stay nested and fail cleanly in
     // compiled mode with "Yield not supported in this context", never a miscompile.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_ClosesOverFunctionLocal(ExecutionMode mode)
     {
         // The exact repro from issue #534.
@@ -1628,8 +1556,7 @@ public class GeneratorTests
         Assert.Equal("[5]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_ClosesOverFunctionParameter(ExecutionMode mode)
     {
         var source = """
@@ -1643,8 +1570,7 @@ public class GeneratorTests
         Assert.Equal("[3, 6]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_ClosesOverLocalCapturesByReference(ExecutionMode mode)
     {
         // Closures bind the variable, so a mutation before iteration is observed (not a snapshot). In
@@ -1703,8 +1629,7 @@ public class GeneratorTests
         Assert.Contains("Yield not supported", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_ClosesOverLocal_UsingThis_ThreadsDynamicThis(ExecutionMode mode)
     {
         // #775: a generator function expression that closes over an enclosing-function local AND uses
@@ -1722,8 +1647,7 @@ public class GeneratorTests
         Assert.Equal("2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_ClosesOverLocal_UsingThis_DotCallBindsReceiver(ExecutionMode mode)
     {
         // #775: the generator captures an enclosing-function local (`mult`) AND reads `this` via a bound
@@ -1751,8 +1675,7 @@ public class GeneratorTests
     // reads it LIVE. Class generator-method enclosers (sync/async, static/instance) instead decline
     // cleanly (a compile error, never a stale-value miscompile) — pinned below.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_ClosesOverGeneratorLocal(ExecutionMode mode)
     {
         // The exact repro from issue #945.
@@ -1786,8 +1709,7 @@ public class GeneratorTests
         Assert.Equal("[5]\n", TestHarness.RunCompiled(source));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_ClosesOverGeneratorLocal_CapturesByReference(ExecutionMode mode)
     {
         // The forwarder reads the captured local LIVE through the shared function DC, so a write-capturing
@@ -1806,8 +1728,7 @@ public class GeneratorTests
         Assert.Equal("[31]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_ClosesOverGeneratorLocal_MultipleForwarders(ExecutionMode mode)
     {
         // Two generator expressions each capturing a distinct enclosing-generator local → two DC fields.
@@ -1826,8 +1747,7 @@ public class GeneratorTests
         Assert.Equal("[5, 100]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_ClosesOverGeneratorLocal_NestedInPlainFunction(ExecutionMode mode)
     {
         // The enclosing generator is itself nested in a plain function. NestedFunctionLifter relocates it
@@ -1915,8 +1835,7 @@ public class GeneratorTests
 
     #region Generator function expression / object generator method dynamic `this` — issue #775
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectGeneratorMethod_ReadsThis(ExecutionMode mode)
     {
         // The canonical case from the issue: an object generator method reads instance state via `this`.
@@ -1928,8 +1847,7 @@ public class GeneratorTests
         Assert.Equal("5\n6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorFunctionExpression_DotCallBindsThis(ExecutionMode mode)
     {
         var source = """
@@ -1941,8 +1859,7 @@ public class GeneratorTests
         Assert.Equal("9\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorFunctionExpression_AssignedAsMethod_BindsThis(ExecutionMode mode)
     {
         var source = """
@@ -1954,8 +1871,7 @@ public class GeneratorTests
         Assert.Equal("42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectSymbolIteratorGenerator_ReadsThis(ExecutionMode mode)
     {
         // The canonical MDN iterator pattern: a `[Symbol.iterator]` generator reading `this`.
@@ -1970,8 +1886,7 @@ public class GeneratorTests
         Assert.Equal("10\n20\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedGeneratorFunctionExpression_ReadsThis(ExecutionMode mode)
     {
         var source = """
@@ -1983,8 +1898,7 @@ public class GeneratorTests
         Assert.Equal("100,101\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PlainGeneratorFunctionExpressionCall_ThisIsSloppyGlobal(ExecutionMode mode)
     {
         // A `function*` expression called plainly (no receiver) binds `this` to the sloppy-mode global
@@ -2013,8 +1927,7 @@ public class GeneratorTests
     // local — which is now lambda-lifted and runs in both modes — this cannot be lowered; asserted by
     // the *_CompiledRejectsClearly test).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void GeneratorExpression_CapturesForOfLoopVariable(ExecutionMode mode)
     {
         // The exact repro from issue #678.
@@ -2028,8 +1941,7 @@ public class GeneratorTests
         Assert.Equal("10\n20\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void GeneratorExpression_CapturesNestedBlockLet(ExecutionMode mode)
     {
         // The second repro from issue #678: a let in a nested block within a function.
@@ -2047,8 +1959,7 @@ public class GeneratorTests
         Assert.Equal("[5]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void GeneratorExpression_CapturesForLetLoopVariable(ExecutionMode mode)
     {
         var source = """
@@ -2061,8 +1972,7 @@ public class GeneratorTests
         Assert.Equal("10\n20\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void GeneratorExpression_CapturesForInKey(ExecutionMode mode)
     {
         var source = """
@@ -2076,8 +1986,7 @@ public class GeneratorTests
         Assert.Equal("a\nb\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void GeneratorExpression_CapturesCatchParameter(ExecutionMode mode)
     {
         var source = """
@@ -2092,8 +2001,7 @@ public class GeneratorTests
         Assert.Equal("boom\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void GeneratorExpression_CapturesSwitchCaseBinding(ExecutionMode mode)
     {
         var source = """
@@ -2110,8 +2018,7 @@ public class GeneratorTests
         Assert.Equal("99\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void GeneratorExpression_LoopVariableCapturedPerIteration(ExecutionMode mode)
     {
         // Each iteration's for-of binding is distinct, so a generator created in one iteration captures
@@ -2128,8 +2035,7 @@ public class GeneratorTests
         Assert.Equal("1,2,3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void GeneratorExpression_CapturesBlockScopedAndModuleScoped(ExecutionMode mode)
     {
         // A capture mixing a block-scoped loop variable with a module-scoped const still works: the
@@ -2146,8 +2052,7 @@ public class GeneratorTests
         Assert.Equal("200\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void GeneratorExpression_NamedSelfRecursionCapturingLoopVariable(ExecutionMode mode)
     {
         // #678 + #679 together: a NAMED generator expression that both closes over a loop variable and
@@ -2194,8 +2099,7 @@ public class GeneratorTests
     // Interpreted-only: the compiler has no generator-expression IL path and reports a clear
     // "Yield not supported in this context" error (asserted by the *_CompiledRejectsClearly test).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void AsyncGeneratorExpression_CapturesForOfLoopVariable(ExecutionMode mode)
     {
         // The exact repro from issue #734.
@@ -2214,8 +2118,7 @@ public class GeneratorTests
         Assert.Equal("10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void AsyncGeneratorExpression_CapturesNestedBlockLet(ExecutionMode mode)
     {
         // A let in a nested block captured by an in-place async generator expression, driven by direct
@@ -2235,8 +2138,7 @@ public class GeneratorTests
         Assert.Equal("5,6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void AsyncGeneratorExpression_CapturesLoopVariablePerIteration(ExecutionMode mode)
     {
         // Each iteration's for-of binding is distinct, so an async generator created in one iteration
@@ -2290,8 +2192,7 @@ public class GeneratorTests
     // time, like a plain function), the forwarding binding is HOISTED to the body top so the earlier
     // reference resolves — the async analog of the plain-function #534 hoist. These run in BOTH modes.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGeneratorExpression_ClosesOverAsyncFunctionLocal(ExecutionMode mode)
     {
         // The exact repro from issue #924.
@@ -2310,8 +2211,7 @@ public class GeneratorTests
         Assert.Equal("[5]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGeneratorExpression_ClosesOverAsyncFunctionParameter(ExecutionMode mode)
     {
         var source = """
@@ -2328,8 +2228,7 @@ public class GeneratorTests
         Assert.Equal("[3, 6]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGeneratorExpression_ClosesOverLocalCapturesByReference(ExecutionMode mode)
     {
         // Closures bind the variable, so a mutation before iteration is observed (not a snapshot). In
@@ -2375,8 +2274,7 @@ public class GeneratorTests
         Assert.Equal("[5]\n", TestHarness.RunCompiled(source));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SyncGeneratorExpression_InAsyncFunction_ClosesOverLocal(ExecutionMode mode)
     {
         // A SYNC generator expression closing over a local of an enclosing ASYNC function — the same
@@ -2405,8 +2303,7 @@ public class GeneratorTests
     // the original name, so it injects `const <name> = __genArrow_N;` at the top of the body to keep
     // the self-reference bound (skipped when a parameter or body-level binding shadows the name).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_NamedSelfRecursion(ExecutionMode mode)
     {
         // The exact repro from issue #679.
@@ -2420,8 +2317,7 @@ public class GeneratorTests
         Assert.Equal("[3, 2, 1]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_NamedSelfRecursion_ClosesOverModuleConst(ExecutionMode mode)
     {
         // Self-reference plus a capture of a module-scope binding: both must resolve.
@@ -2436,8 +2332,7 @@ public class GeneratorTests
         Assert.Equal("[3, 2, 1]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_NamedSelfReference_ParameterShadowsName(ExecutionMode mode)
     {
         // A parameter named the same as the function expression shadows the self-name (the self-binding
@@ -2450,8 +2345,7 @@ public class GeneratorTests
         Assert.Equal("[10, 11]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_NamedSelfReference_BodyLetShadowsName(ExecutionMode mode)
     {
         // A body-level `let` of the same name shadows the self-name (no self-binding injected).
@@ -2463,8 +2357,7 @@ public class GeneratorTests
         Assert.Equal("[7]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorExpression_NamedSelfReference_NestedBlockDoesNotShadow(ExecutionMode mode)
     {
         // A nested-block binding of the same name shadows only within that block, so the outer
@@ -2485,8 +2378,7 @@ public class GeneratorTests
 
     #region Block-scope shadowing in compiled generators (#711) and void operator (#712)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NestedBlockConstShadow_DoesNotLeakToOuter(ExecutionMode mode)
     {
         // A const in a nested block that shadows an outer body-level const must get its own slot
@@ -2503,8 +2395,7 @@ public class GeneratorTests
         Assert.Equal("[100]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NestedBlockShadow_LiveAcrossYield_GetsOwnField(ExecutionMode mode)
     {
         // The inner shadow is itself read after a yield, so it must hoist to its OWN field, distinct
@@ -2525,8 +2416,7 @@ public class GeneratorTests
         Assert.Equal("[0, 1, 100]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NestedBlockLetShadow_ReassignedAcrossYield(ExecutionMode mode)
     {
         // A let shadow that is compound-assigned across yields keeps its own value, separate from
@@ -2549,8 +2439,7 @@ public class GeneratorTests
         Assert.Equal("[2, 12, 7]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NestedBlockShadowsParameter(ExecutionMode mode)
     {
         // An inner block const may shadow a (hoisted) parameter without clobbering it (#711).
@@ -2565,8 +2454,7 @@ public class GeneratorTests
         Assert.Equal("[99, 5]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_DeeplyNestedShadows_EachGetOwnSlot(ExecutionMode mode)
     {
         // Each nesting level that re-declares the name resolves to its own binding (#711).
@@ -2582,8 +2470,7 @@ public class GeneratorTests
         Assert.Equal("[3, 2, 1]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_VoidOperator_InBody(ExecutionMode mode)
     {
         // `void expr` inside a compiled generator body must evaluate the operand for its side effects
@@ -2600,8 +2487,7 @@ public class GeneratorTests
         Assert.Equal("[5]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_VoidOperator_WithYieldOperand_Suspends(ExecutionMode mode)
     {
         // `void (yield x)` must still suspend at the inner yield (the operand can suspend), then
@@ -2617,8 +2503,7 @@ public class GeneratorTests
         Assert.Equal("[1, 2]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NestedBlockShadow_CapturedByArrow_DoesNotLeak(ExecutionMode mode)
     {
         // An inner block const that shadows an outer body-level const AND is read by a nested arrow
@@ -2641,8 +2526,7 @@ public class GeneratorTests
         Assert.Equal("[5, 100]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_OuterBindingCapturedByArrow_StaysCorrect(ExecutionMode mode)
     {
         // The arrow captures the OUTER binding (declared before the shadowing block); the inner shadow
@@ -2661,8 +2545,7 @@ public class GeneratorTests
         Assert.Equal("[5, 100]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_TwoArrows_CaptureInnerAndOuterShadows(ExecutionMode mode)
     {
         // Two arrows in distinct scopes each capture a different binding of the same name. Each arrow's
@@ -2685,8 +2568,7 @@ public class GeneratorTests
         Assert.Equal("[2, 1, 1]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NestedBlockShadow_WriteCapturedByArrow_DoesNotLeak(ExecutionMode mode)
     {
         // An inner block let that shadows an outer body-level const AND is WRITTEN by a nested arrow must
@@ -2711,8 +2593,7 @@ public class GeneratorTests
         Assert.Equal("6,6,100\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NestedBlockShadow_WriteCapturedByArrow_IncrementForms(ExecutionMode mode)
     {
         // The arrow mutates the renamed write-shadow through ++ and += (distinct hand-rolled DC store
@@ -2734,8 +2615,7 @@ public class GeneratorTests
         Assert.Equal("8,8,100\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_TwoWriteShadows_CapturedByDistinctArrows(ExecutionMode mode)
     {
         // Two independent nested-block write-shadows, each written by its own arrow, must each get their
@@ -2753,8 +2633,7 @@ public class GeneratorTests
         Assert.Equal("6,6,10,10,100,200\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NonShadowWriteCapture_StillShared(ExecutionMode mode)
     {
         // Regression guard: the classic #674 write-capture WITHOUT shadowing must keep sharing the outer
@@ -2776,8 +2655,7 @@ public class GeneratorTests
 
     #region Optional-chain string-method yield short-circuit parity (#709)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_OptionalChainStringMethod_OnNonString_ShortCircuitsBeforeYield(ExecutionMode mode)
     {
         // o?.substring(...) on a non-string object lacking the method short-circuits to undefined
@@ -2798,8 +2676,7 @@ public class GeneratorTests
         Assert.Equal("undefined true undefined true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_OptionalChainStringMethod_OnString_RunsYield(ExecutionMode mode)
     {
         // On a genuine string receiver the method exists, so the yield argument DOES run and the
@@ -2841,8 +2718,7 @@ public class GeneratorTests
     // The yield*-delegation case doesn't rely on the captured self-reference (the inner generator is
     // created after the outer is assigned), so it runs in both modes from a single source.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Generator_ReentrantNext_ThrowsTypeErrorThenResumes(ExecutionMode mode)
     {
         // The re-entrant next() throws a catchable TypeError; once caught, the generator is still
@@ -2863,8 +2739,7 @@ public class GeneratorTests
         Assert.Equal("true TypeError Generator is already running\n1 false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Generator_ReentrantNext_UncaughtPropagatesToResumingCaller(ExecutionMode mode)
     {
         // An uncaught re-entrant next() completes the generator abnormally and the TypeError
@@ -2881,8 +2756,7 @@ public class GeneratorTests
         Assert.Equal("outer caught Generator is already running\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Generator_ReentrantReturn_ThrowsTypeErrorThenResumes(ExecutionMode mode)
     {
         var source = """
@@ -2901,8 +2775,7 @@ public class GeneratorTests
         Assert.Equal("return -> Generator is already running\n1 false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Generator_ReentrantThrow_ThrowsTypeErrorThenResumes(ExecutionMode mode)
     {
         // The "already running" guard takes precedence over the injected throw(e): the caller's
@@ -2923,8 +2796,7 @@ public class GeneratorTests
         Assert.Equal("throw -> Generator is already running\n1 false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ReentrantThroughYieldStar_ThrowsTypeError(ExecutionMode mode)
     {
         // The outer generator is still `executing` while it delegates via yield*, so an inner
@@ -2947,8 +2819,7 @@ public class GeneratorTests
         Assert.Equal("deleg -> Generator is already running\n5 false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void GeneratorExpression_ReentrantNext_ThrowsTypeError(ExecutionMode mode)
     {
         // A generator function *expression* that closes over a block-scoped binding stays in place and
@@ -2976,8 +2847,7 @@ public class GeneratorTests
     // --- Compiled variants (#521): genuine re-entrancy via a live object-property receiver,
     // so the guard is reached despite the by-value closure capture (#541). ---
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void Generator_ReentrantNext_Compiled_ThrowsTypeErrorThenResumes(ExecutionMode mode)
     {
         // The re-entrant next() throws a catchable TypeError; once caught, the generator is still
@@ -2999,8 +2869,7 @@ public class GeneratorTests
         Assert.Equal("true TypeError Generator is already running\n1 false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void Generator_ReentrantNext_Compiled_UncaughtPropagatesToResumingCaller(ExecutionMode mode)
     {
         // An uncaught re-entrant next() completes the generator abnormally and the TypeError
@@ -3017,8 +2886,7 @@ public class GeneratorTests
         Assert.Equal("true TypeError Generator is already running\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void Generator_ReentrantReturn_Compiled_ThrowsTypeErrorThenResumes(ExecutionMode mode)
     {
         var source = """
@@ -3037,8 +2905,7 @@ public class GeneratorTests
         Assert.Equal("return -> Generator is already running\n1 false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void Generator_ReentrantThrow_Compiled_ThrowsTypeErrorThenResumes(ExecutionMode mode)
     {
         // The "already running" guard takes precedence over the injected throw(e): the caller's
@@ -3059,8 +2926,7 @@ public class GeneratorTests
         Assert.Equal("throw -> Generator is already running\n1 false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void GeneratorExpression_ReentrantNext_Compiled_ThrowsTypeError(ExecutionMode mode)
     {
         // A generator function *expression* uses the same state-machine builder; its guard is

--- a/SharpTS.Tests/SharedTests/GeneratorTryFinallyTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorTryFinallyTests.cs
@@ -23,8 +23,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class GeneratorTryFinallyTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldInTryFinally_RunsFinallyAfterBody(ExecutionMode mode)
     {
         // The exact repro from #477.
@@ -43,8 +42,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("1\n2\nfin\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldThenThrowInTry_CaughtWithValue(ExecutionMode mode)
     {
         // The yield resumes, then a synchronous throw in the same try body is caught — and the
@@ -65,8 +63,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("1\ncaught boom\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldInTry_CatchAndFinally_ThenYieldAfter(ExecutionMode mode)
     {
         var source = """
@@ -86,8 +83,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("1\nfin\n9\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldInTryFinally_InsideLoop_RunsFinallyEachIteration(ExecutionMode mode)
     {
         var source = """
@@ -106,8 +102,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("0\nf0\n1\nf1\n2\nf2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedTryFinally_WithYield_RunsBothFinallysInnerThenOuter(ExecutionMode mode)
     {
         var source = """
@@ -128,8 +123,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("1\ninner\nouter\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStarInTryFinally_DelegatesThenRunsFinally(ExecutionMode mode)
     {
         var source = """
@@ -149,8 +143,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("1\n2\n3\n4\nfin\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FinallyThatYields_IsDriven(ExecutionMode mode)
     {
         var source = """
@@ -168,8 +161,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("1\n2\n3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnInsideTryFinally_RunsFinallyBeforeCompleting(ExecutionMode mode)
     {
         // `return` inside the try must run the finally before the generator completes; the
@@ -190,8 +182,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("1\nfin\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnInsideNestedTryFinally_RunsAllEnclosingFinallys(ExecutionMode mode)
     {
         var source = """
@@ -214,8 +205,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("1\ninner\nouter\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnInTry_WithYieldingFinally_CompletesAfterFinallyYields(ExecutionMode mode)
     {
         // The finally itself yields, suspending MoveNext between the `return` and the completion
@@ -239,8 +229,7 @@ public class GeneratorTryFinallyTests
 
     // ---- #500: non-local exits other than a try-body return must run the enclosing finally ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BreakOutOfTryFinally_RunsFinallyBeforeBreaking(ExecutionMode mode)
     {
         // The exact #500 repro: break leaving the try must run the finally first.
@@ -256,8 +245,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("1\nFIN\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ContinueOutOfTryFinally_RunsFinallyThatIteration(ExecutionMode mode)
     {
         // `continue` from inside the try must run the finally before jumping to the next iteration,
@@ -280,8 +268,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("got0\nafter0\nfin0\ngot1\nfin1\ngot2\nafter2\nfin2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThrowFromCatch_RunsFinallyThenPropagates(ExecutionMode mode)
     {
         // The exact #500 repro: a throw inside the catch must still run the finally before the
@@ -296,8 +283,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("1\nFIN\nouter b\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnFromCatch_RunsFinallyBeforeCompleting(ExecutionMode mode)
     {
         // A `return` from the catch body must run the finally; the yield after the try must not run.
@@ -312,8 +298,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("1\nFIN\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BreakThroughNestedFinallys_RunsInnerThenOuter(ExecutionMode mode)
     {
         // A break that leaves two enclosing trys runs both finallys, innermost first.
@@ -331,8 +316,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v1\ninner\nouter\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledBreakToOuterLoop_RunsInterveningFinally(ExecutionMode mode)
     {
         // A labeled break targeting the outer loop runs the finally of the inner loop's try.
@@ -350,8 +334,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v0\nfin00\nv1\nfin01\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BreakToLoopBetweenTwoTrys_RunsOnlyInnerFinally(ExecutionMode mode)
     {
         // The break targets a loop that sits *between* two trys: only the finally inside that loop
@@ -371,8 +354,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v0\ninner0\nv1\ninner1\nafter-loop\nOUTER\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BreakWithYieldingFinally_DrivesFinallyThenBreaks(ExecutionMode mode)
     {
         // The finally that runs on the break path itself yields; the break completes only after the
@@ -390,8 +372,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v1\nv2\nv3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThrowFromFinally_RunsEnclosingFinallyThenPropagates(ExecutionMode mode)
     {
         // A throw raised inside a finally body must still run the enclosing finally before it
@@ -408,8 +389,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v1\nOUTER\ncaught boom\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BreakOutOfInnerCatchlessTry_RunsOuterFinally(ExecutionMode mode)
     {
         // The break leaves an inner try/catch that has no finally, nested in an outer try-with-
@@ -428,8 +408,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v1\nOUTERFIN\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NextValue_DeliveredToYieldInsideTry(ExecutionMode mode)
     {
         // The value passed to next() must reach a yield expression sitting inside a try.
@@ -450,8 +429,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("got 10\nfin\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HoistedCatchParam_SimplePath_ReceivesThrownValue(ExecutionMode mode)
     {
         // Catch parameter used after a yield is hoisted to a field; the try here has no yield
@@ -478,8 +456,7 @@ public class GeneratorTryFinallyTests
     // finally) rather than an illegal `ret`/`br` — previously these crashed MoveNext with
     // InvalidProgramException (return → ReturnFromTry, break/continue → BranchOutOfTry).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BareReturnInNoYieldTryFinally_RunsFinally(ExecutionMode mode)
     {
         // The exact #554 repro: a yield precedes the try, but the try itself contains no yield.
@@ -491,8 +468,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("0\nf\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ValueReturnInNoYieldTryFinally_RunsFinallyThenCompletesWithValue(ExecutionMode mode)
     {
         // The finally runs on the return path, and the returned value is the completion value.
@@ -507,8 +483,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("0/false\nf\n7/true\nundefined/true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BreakInNoYieldTryFinally_RunsFinallyBeforeBreaking(ExecutionMode mode)
     {
         // The second #554 repro: break leaves a no-yield try, running its finally first.
@@ -520,8 +495,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("0\nf\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ContinueInNoYieldTryFinally_RunsFinallyEachIteration(ExecutionMode mode)
     {
         // The yield sits outside the try, so the try (holding the continue) takes the real-IL path.
@@ -538,8 +512,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v0\nf0\nv1\nf1\nv2\nf2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnInNoYieldTry_NestedInYieldingFinally_RunsAllThenKeepsValue(ExecutionMode mode)
     {
         // The inner try has no yield (real IL block); it is nested in an outer try whose finally
@@ -564,8 +537,7 @@ public class GeneratorTryFinallyTests
 
     // ---- #555: a `return <value>` whose finally yields must keep its completion value ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnValueWithYieldingFinally_RestoresCompletionValue(ExecutionMode mode)
     {
         // The exact #555 repro: the finally yields 9 (overwriting Current), but the final next() must
@@ -582,8 +554,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("9/false\n5/true\nundefined/true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnValueInYieldingTry_NonYieldingFinally_KeepsValue(ExecutionMode mode)
     {
         // Sibling of #555: the try yields (flag-based path) and returns a value; the finally does not
@@ -601,8 +572,7 @@ public class GeneratorTryFinallyTests
 
     // ---- #599: an exception propagating through a YIELDING finally must not be lost ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UncaughtThrow_ThroughYieldingFinally_StillPropagates(ExecutionMode mode)
     {
         // The exact #599 repro: the try throws after a yield, and the (catch-less) finally yields.
@@ -622,8 +592,7 @@ public class GeneratorTryFinallyTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RethrownFromInnerCatch_ThroughYieldingFinally_StillPropagates(ExecutionMode mode)
     {
         // #599's second shape: an inner try/catch (a sync segment of the outer try body) rethrows;
@@ -641,8 +610,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("{\"value\":7,\"done\":false}\ncaught:e2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UncaughtThrow_ThroughNestedYieldingFinally_NotClobbered(ExecutionMode mode)
     {
         // A finally that yields and itself contains a (separate) try/finally that also yields. Each
@@ -662,8 +630,7 @@ public class GeneratorTryFinallyTests
     // None of ret/br/Leave may exit a .NET finally region, so these constructs must take the
     // flag-based path even with no yield (the finally-side analog of #554's try/catch-body fix).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnInsideNoYieldFinally_Completes(ExecutionMode mode)
     {
         // The exact #598 repro: a `return` inside a no-yield finally. The generator has a yield
@@ -681,8 +648,7 @@ public class GeneratorTryFinallyTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BreakInsideNoYieldFinally_ExitsLoop(ExecutionMode mode)
     {
         // #598's break repro: a `break` inside a no-yield finally exits the enclosing loop.
@@ -694,8 +660,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("0\n1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ContinueInsideNoYieldFinally_SkipsRest(ExecutionMode mode)
     {
         var source = """
@@ -711,8 +676,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("body0\nbody2\ny9\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnInNoYieldFinally_OverridesPendingException(ExecutionMode mode)
     {
         // The try throws but the finally returns: per JS semantics the abrupt return overrides the
@@ -729,8 +693,7 @@ public class GeneratorTryFinallyTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledBreakInsideNoYieldFinally_ExitsOuterLoop(ExecutionMode mode)
     {
         var source = """
@@ -745,8 +708,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("0\n1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnInNestedNoYieldFinally_RunsOuterFinally(ExecutionMode mode)
     {
         // A return in an inner finally must still run the enclosing finally before completing.
@@ -773,8 +735,7 @@ public class GeneratorTryFinallyTests
     // a separate, broader representation gap tracked elsewhere — so undefined cases assert via
     // `=== undefined` rather than string form. `throw null` is fully correct.)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThrowNullIntoFlagBasedTryCatch_IsCaught(ExecutionMode mode)
     {
         // The exact #619 repro: throw null after a yield, caught in the same try's catch.
@@ -786,8 +747,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v1\ncaught e=null\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThrowUndefinedIntoFlagBasedTryCatch_IsCaught(ExecutionMode mode)
     {
         // throw undefined likewise reaches the catch (was skipped). Asserted via `=== undefined`
@@ -800,8 +760,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v1\nisUndef=true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FalsyNonNullThrowIntoFlagBasedTryCatch_StillCaught(ExecutionMode mode)
     {
         // Guard the boundary: a falsy-but-non-null thrown value (0 / "" / false box to non-null
@@ -814,8 +773,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v1\ncaught e=0\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThrowNullIntoCatchlessTryFinally_RethrowsAfterFinally(ExecutionMode mode)
     {
         // The catch-less rethrow gate also used value-nullness; a thrown null was dropped instead of
@@ -828,8 +786,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v1\nfin\nouter isNull=true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThrowNullIntoCatchlessTry_WithYieldingFinally_RethrowsAfterFinally(ExecutionMode mode)
     {
         // The present flag must survive a yielding finally (persisted to a field, like the captured
@@ -847,8 +804,7 @@ public class GeneratorTryFinallyTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BareThrowOnSuspendedGenerator_InjectsUndefined(ExecutionMode mode)
     {
         // A bare it.throw() (no argument) injects `undefined` into the suspended yield and engages the
@@ -869,8 +825,7 @@ public class GeneratorTryFinallyTests
     // throw is now routed into the enclosing try's capture local (running the finally(s) inside that try
     // first) and branched to its cleanup, the catch-side analog of the existing finally routing.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RethrowFromCatch_CaughtByEnclosingTryCatch(ExecutionMode mode)
     {
         // The exact #632 repro: an inner catch rethrows; the outer catch must catch the rethrown value.
@@ -887,8 +842,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v0\ninner caught inner\nouter caught rethrown\nv1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThrowFromCatch_WithInterveningFinally_RunsFinallyThenOuterCatch(ExecutionMode mode)
     {
         // The inner try has a finally: a throw escaping the inner catch must run that finally before the
@@ -908,8 +862,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v0\nC1 inner\nF1\nouter rethrown\nv1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UncaughtThrowFromCatchlessTryFinally_CaughtByEnclosingTry(ExecutionMode mode)
     {
         // An uncaught exception leaving a catch-less inner try/finally must, after its finally runs,
@@ -928,8 +881,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v0\nF\nouter x\nv1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThrowFromFinallyBody_CaughtByEnclosingTry(ExecutionMode mode)
     {
         // A throw from a finally body propagates to the enclosing try's catch the same way.
@@ -946,8 +898,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v0\nF1\nouter fromFinally\nv1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RethrowAcrossTwoNestedFinallys_RunsBothBeforeEnclosingCatch(ExecutionMode mode)
     {
         // Two finallys lie between the rethrow and the enclosing catch; both run, innermost first.
@@ -966,8 +917,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v0\nFinner\nCmid deep\nFmid\nouter remid\nv1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExternalThrowAtCatchBodyYield_CaughtByEnclosingTry(ExecutionMode mode)
     {
         // An external it.throw() injected at a yield *inside a catch body* must also propagate to the
@@ -996,8 +946,7 @@ public class GeneratorTryFinallyTests
     // bodies are now emitted through the same sync-segment capture the try body uses, then the captured
     // exception is routed outward like a lexical handler throw.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RealThrowEscapingNestedTryInCatchBody_CaughtByEnclosingTry(ExecutionMode mode)
     {
         // The exact #675 repro: a nested real-IL try/catch inside a flag-based catch body rethrows; the
@@ -1019,8 +968,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v0\nC3 b\nouter c\nv1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RealThrowEscapingNestedTryInFinallyBody_CaughtByEnclosingTry(ExecutionMode mode)
     {
         // The finally-body analog: a nested real-IL try/catch inside a flag-based finally body rethrows.
@@ -1041,8 +989,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v0\nF3 b\nouter c\nv1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RealThrowEscapingNestedTryInCatchBody_RunsOwnFinallyFirst(ExecutionMode mode)
     {
         // The inner try has its own finally: a real exception escaping its catch body must run that
@@ -1065,8 +1012,7 @@ public class GeneratorTryFinallyTests
         Assert.Equal("v0\nC3 b\nT1fin\nouter c\nv1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RuntimeErrorInCatchBody_CaughtByEnclosingTry(ExecutionMode mode)
     {
         // A runtime error (call on undefined) raised at the top of a flag-based catch body is likewise

--- a/SharpTS.Tests/SharedTests/GeneratorUndefinedValueTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorUndefinedValueTests.cs
@@ -21,8 +21,7 @@ public class GeneratorUndefinedValueTests
 {
     // ---- Resumed `yield` value (the issue's primary case) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ResumedYield_ConcatenatedAsString_IsUndefined(ExecutionMode mode)
     {
         // The repro from #443: for…of resumes with no sent value, so `yield 1` evaluates to undefined.
@@ -33,8 +32,7 @@ public class GeneratorUndefinedValueTests
         Assert.Equal("x:undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ResumedYield_StoredInLocal_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -44,8 +42,7 @@ public class GeneratorUndefinedValueTests
         Assert.Equal("r=undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ResumedYield_InArithmetic_IsNaN(ExecutionMode mode)
     {
         // undefined + 10 === NaN; exercises numeric coercion of the resumed sentinel, not just string.
@@ -56,8 +53,7 @@ public class GeneratorUndefinedValueTests
         Assert.Equal("NaN\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultipleResumedYields_AreEachUndefined(ExecutionMode mode)
     {
         var source = """
@@ -69,8 +65,7 @@ public class GeneratorUndefinedValueTests
 
     // ---- `yield*` completion value ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStarOverArray_CompletionIsUndefined(ExecutionMode mode)
     {
         // A plain array has no return value, so the yield* completion value is undefined.
@@ -81,8 +76,7 @@ public class GeneratorUndefinedValueTests
         Assert.Equal("x:undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStarOverString_CompletionIsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -92,8 +86,7 @@ public class GeneratorUndefinedValueTests
         Assert.Equal("x:undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStarOverGeneratorNoReturn_CompletionIsUndefined(ExecutionMode mode)
     {
         // inner runs off the end (no `return`), so the yield* completion value is undefined —
@@ -106,8 +99,7 @@ public class GeneratorUndefinedValueTests
         Assert.Equal("x:undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStarOverGeneratorBareReturn_CompletionIsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -118,8 +110,7 @@ public class GeneratorUndefinedValueTests
         Assert.Equal("x:undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStarOverGeneratorWithReturn_CompletionIsReturnValue(ExecutionMode mode)
     {
         // The fix must not regress the case that already worked: an explicit `return <value>`
@@ -139,8 +130,7 @@ public class GeneratorUndefinedValueTests
     // (#480), fixed by making a bare `return;` produce the `undefined` sentinel at its source
     // (VisitReturn) rather than C# null, while preserving `return null;` as null (see below).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OffEndCompletionValue_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -152,8 +142,7 @@ public class GeneratorUndefinedValueTests
         Assert.Equal("a:1\nb:undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BareReturnCompletionValue_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -165,8 +154,7 @@ public class GeneratorUndefinedValueTests
         Assert.Equal("a:1\nb:undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnNullCompletionValue_IsNull(ExecutionMode mode)
     {
         // `return null;` is distinct from a bare `return;`: the completion value is JS null, not
@@ -190,8 +178,7 @@ public class GeneratorUndefinedValueTests
     // (state == -2 → `_returnFalseLabel`), so `.next()` re-surfaced the last `return`ed or yielded
     // value. The interpreter is already correct for these cases, so they assert cross-mode parity.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NextAfterExplicitReturn_IsUndefined(ExecutionMode mode)
     {
         // `return 42` is surfaced exactly once; the next `.next()` reports undefined, not 42.
@@ -206,8 +193,7 @@ public class GeneratorUndefinedValueTests
         Assert.Equal("a:1\nb:42\nc:undefined\nd:undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NextAfterReturnMethod_IsUndefined(ExecutionMode mode)
     {
         // `gen.return(99)` closes the generator with 99; the next `.next()` reports undefined,
@@ -223,8 +209,7 @@ public class GeneratorUndefinedValueTests
         Assert.Equal("ret:99,true\nafter:undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NextAfterOffEndCompletion_StaysUndefined(ExecutionMode mode)
     {
         // Repeated `.next()` past a no-return completion keeps reporting undefined (never the

--- a/SharpTS.Tests/SharedTests/GeneratorYieldSpillTests.cs
+++ b/SharpTS.Tests/SharedTests/GeneratorYieldSpillTests.cs
@@ -19,8 +19,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class GeneratorYieldSpillTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BinaryConcat_PrefixSurvivesYield(ExecutionMode mode)
     {
         var source = """
@@ -32,8 +31,7 @@ public class GeneratorYieldSpillTests
         Assert.Equal("PFX:undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultipleYields_PrefixSurvives(ExecutionMode mode)
     {
         var source = """
@@ -43,8 +41,7 @@ public class GeneratorYieldSpillTests
         Assert.Equal("TAG:undefined|undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TemplateLiteral_PrefixSurvivesYield(ExecutionMode mode)
     {
         var source = """
@@ -54,8 +51,7 @@ public class GeneratorYieldSpillTests
         Assert.Equal("[head-undefined]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_PrefixSurvivesDelegation(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/GenericsTests.cs
+++ b/SharpTS.Tests/SharedTests/GenericsTests.cs
@@ -10,8 +10,7 @@ public class GenericsTests
 {
     #region Generic Functions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericFunction_TypeInference_Works(ExecutionMode mode)
     {
         var source = """
@@ -26,8 +25,7 @@ public class GenericsTests
         Assert.Equal("42\nhello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericFunction_ExplicitTypeArgument_Works(ExecutionMode mode)
     {
         var source = """
@@ -42,8 +40,7 @@ public class GenericsTests
         Assert.Equal("42\nworld\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericFunction_MultipleTypeParameters_Works(ExecutionMode mode)
     {
         var source = """
@@ -58,8 +55,7 @@ public class GenericsTests
         Assert.Equal("42\nhello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericFunction_WithArrayType_Works(ExecutionMode mode)
     {
         var source = """
@@ -74,8 +70,7 @@ public class GenericsTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericArrowFunction_Works(ExecutionMode mode)
     {
         var source = """
@@ -94,8 +89,7 @@ public class GenericsTests
 
     #region Generic Classes
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericClass_BasicInstantiation_Works(ExecutionMode mode)
     {
         var source = """
@@ -115,8 +109,7 @@ public class GenericsTests
         Assert.Equal("42\nhello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericClass_InferredTypeArguments_Works(ExecutionMode mode)
     {
         // `new Box(5)` relies on type-argument inference from the constructor argument.
@@ -142,8 +135,7 @@ public class GenericsTests
         Assert.Equal("5\nhello\ntrue\nx 42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericClass_WithMethod_Works(ExecutionMode mode)
     {
         var source = """
@@ -164,8 +156,7 @@ public class GenericsTests
         Assert.Equal("99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericClass_MultipleTypeParameters_Works(ExecutionMode mode)
     {
         var source = """
@@ -190,8 +181,7 @@ public class GenericsTests
     // the open generic TypeDef inside the class's own method bodies, which the CLR refuses
     // to load at JIT time (TypeLoadException: Could not load type 'Stack').
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericClass_ArrayFieldAndGetter_Works(ExecutionMode mode)
     {
         var source = """
@@ -224,8 +214,7 @@ public class GenericsTests
         Assert.Equal("3\n30\n30\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericClass_NonGenericFields_Work(ExecutionMode mode)
     {
         var source = """
@@ -250,8 +239,7 @@ public class GenericsTests
         Assert.Equal("lbl:1:42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericClass_MethodCallingOwnMethod_Works(ExecutionMode mode)
     {
         var source = """
@@ -270,8 +258,7 @@ public class GenericsTests
         Assert.Equal("box:generic\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericClass_ExtendedByNonGeneric_InheritedFieldAndSuperCall_Work(ExecutionMode mode)
     {
         var source = """
@@ -303,8 +290,7 @@ public class GenericsTests
         Assert.Equal("14 2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericClass_ExplicitAccessors_Work(ExecutionMode mode)
     {
         var source = """
@@ -330,8 +316,7 @@ public class GenericsTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericClass_AsyncMethodTouchingFields_Works(ExecutionMode mode)
     {
         var source = """
@@ -358,8 +343,7 @@ public class GenericsTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericClass_GeneratorMethodTouchingFields_Works(ExecutionMode mode)
     {
         var source = """
@@ -392,8 +376,7 @@ public class GenericsTests
 
     #region Generic Interfaces
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericInterface_ObjectLiteral_Works(ExecutionMode mode)
     {
         var source = """
@@ -408,8 +391,7 @@ public class GenericsTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericInterface_MultipleTypeParameters_Works(ExecutionMode mode)
     {
         var source = """
@@ -430,8 +412,7 @@ public class GenericsTests
 
     #region Type Constraints
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericFunction_WithConstraint_Works(ExecutionMode mode)
     {
         var source = """
@@ -457,8 +438,7 @@ public class GenericsTests
         Assert.Equal("Rex\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericClass_WithConstraint_Works(ExecutionMode mode)
     {
         var source = """
@@ -489,8 +469,7 @@ public class GenericsTests
         Assert.Equal("Buddy speaks\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericFunction_MixedConstraints_Works(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/GettersSettersTests.cs
+++ b/SharpTS.Tests/SharedTests/GettersSettersTests.cs
@@ -10,8 +10,7 @@ public class GettersSettersTests
 {
     #region Basic Getter/Setter
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Getter_ReturnsValue(ExecutionMode mode)
     {
         var source = """
@@ -32,8 +31,7 @@ public class GettersSettersTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Setter_SetsValue(ExecutionMode mode)
     {
         var source = """
@@ -63,8 +61,7 @@ public class GettersSettersTests
 
     #region Computed Properties
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Getter_ComputedProperty(ExecutionMode mode)
     {
         var source = """
@@ -87,8 +84,7 @@ public class GettersSettersTests
         Assert.Equal("50\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetterOnly_ReadOnlyProperty(ExecutionMode mode)
     {
         var source = """
@@ -117,8 +113,7 @@ public class GettersSettersTests
 
     #region Multiple Properties
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetterSetter_MultipleProperties(ExecutionMode mode)
     {
         var source = """
@@ -157,8 +152,7 @@ public class GettersSettersTests
 
     #region Temperature Conversion
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Getter_TemperatureConversion(ExecutionMode mode)
     {
         var source = """
@@ -190,8 +184,7 @@ public class GettersSettersTests
 
     #region Chained Access
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetterSetter_ChainedAccess(ExecutionMode mode)
     {
         var source = """
@@ -221,8 +214,7 @@ public class GettersSettersTests
 
     #region Constructor Initialization
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Getter_InitializedFromConstructor(ExecutionMode mode)
     {
         var source = """
@@ -243,8 +235,7 @@ public class GettersSettersTests
         Assert.Equal("Alice\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Setter_InvokedViaBracketAssignment(ExecutionMode mode)
     {
         // Regression for #290: bracket assignment `obj["n"] = v` must invoke the declared setter,
@@ -265,8 +256,7 @@ public class GettersSettersTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AccessorBody_ResolvesCapturedTopLevelVariable(ExecutionMode mode)
     {
         // Regression for #300: a getter/setter body referencing a top-level
@@ -291,8 +281,7 @@ public class GettersSettersTests
         Assert.Equal("v5\nv8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetterOnly_BracketWrite_IsNoOp(ExecutionMode mode)
     {
         // Regression for #293: in compiled mode, a bracket write to a getter-only
@@ -316,8 +305,7 @@ public class GettersSettersTests
         Assert.Equal("99\n7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetterWithSetter_BracketWrite_InvokesSetter(ExecutionMode mode)
     {
         // Companion to GetterOnly_BracketWrite_IsNoOp: a property that DOES have a
@@ -342,8 +330,7 @@ public class GettersSettersTests
 
     #region Top-level variable capture (#300)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Getter_ResolvesCapturedTopLevelVariable(ExecutionMode mode)
     {
         // #300: in compiled mode an accessor body that referenced a top-level
@@ -363,8 +350,7 @@ public class GettersSettersTests
         Assert.Equal("v5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetterAndStaticGetter_ResolveCapturedTopLevelVariable(ExecutionMode mode)
     {
         // Cover the setter and static-getter accessor shapes too — all share the

--- a/SharpTS.Tests/SharedTests/GlobalConstantsTests.cs
+++ b/SharpTS.Tests/SharedTests/GlobalConstantsTests.cs
@@ -11,8 +11,7 @@ public class GlobalConstantsTests
 {
     #region NaN Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NaN_OutputsNaN(ExecutionMode mode)
     {
         var source = "console.log(NaN);";
@@ -20,8 +19,7 @@ public class GlobalConstantsTests
         Assert.Equal("NaN\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NaN_TypeOfIsNumber(ExecutionMode mode)
     {
         var source = "console.log(typeof NaN);";
@@ -29,8 +27,7 @@ public class GlobalConstantsTests
         Assert.Equal("number\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NaN_StrictEqualityBehavior(ExecutionMode mode)
     {
         // ECMA-262 7.2.16 IsStrictlyEqual: NaN is never strictly equal to
@@ -41,8 +38,7 @@ public class GlobalConstantsTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NaN_IsNaNReturnsTrue(ExecutionMode mode)
     {
         var source = "console.log(isNaN(NaN));";
@@ -50,8 +46,7 @@ public class GlobalConstantsTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NaN_NumberIsNaNReturnsTrue(ExecutionMode mode)
     {
         var source = "console.log(Number.isNaN(NaN));";
@@ -59,8 +54,7 @@ public class GlobalConstantsTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NaN_ArithmeticProducesNaN(ExecutionMode mode)
     {
         var source = """
@@ -72,8 +66,7 @@ public class GlobalConstantsTests
         Assert.Equal("NaN\nNaN\nNaN\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NaN_ComparisonWithNumbers(ExecutionMode mode)
     {
         // Test NaN comparison behavior
@@ -86,8 +79,7 @@ public class GlobalConstantsTests
         Assert.Equal("false\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NaN_SameAsNumberNaN(ExecutionMode mode)
     {
         // Global NaN should produce same isNaN result as Number.NaN
@@ -103,8 +95,7 @@ public class GlobalConstantsTests
 
     #region Infinity Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Infinity_OutputsInfinity(ExecutionMode mode)
     {
         var source = "console.log(Infinity);";
@@ -112,8 +103,7 @@ public class GlobalConstantsTests
         Assert.Equal("Infinity\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Infinity_NegativeOutputsNegativeInfinity(ExecutionMode mode)
     {
         var source = "console.log(-Infinity);";
@@ -121,8 +111,7 @@ public class GlobalConstantsTests
         Assert.Equal("-Infinity\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Infinity_TypeOfIsNumber(ExecutionMode mode)
     {
         var source = "console.log(typeof Infinity);";
@@ -130,8 +119,7 @@ public class GlobalConstantsTests
         Assert.Equal("number\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Infinity_IsFiniteReturnsFalse(ExecutionMode mode)
     {
         var source = """
@@ -142,8 +130,7 @@ public class GlobalConstantsTests
         Assert.Equal("false\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Infinity_NumberIsFiniteReturnsFalse(ExecutionMode mode)
     {
         var source = """
@@ -154,8 +141,7 @@ public class GlobalConstantsTests
         Assert.Equal("false\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Infinity_EqualsItself(ExecutionMode mode)
     {
         var source = """
@@ -166,8 +152,7 @@ public class GlobalConstantsTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Infinity_Comparisons(ExecutionMode mode)
     {
         var source = """
@@ -179,8 +164,7 @@ public class GlobalConstantsTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Infinity_Arithmetic(ExecutionMode mode)
     {
         var source = """
@@ -193,8 +177,7 @@ public class GlobalConstantsTests
         Assert.Equal("Infinity\nInfinity\n0\nNaN\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Infinity_EqualsNumberPositiveInfinity(ExecutionMode mode)
     {
         var source = "console.log(Infinity === Number.POSITIVE_INFINITY);";
@@ -202,8 +185,7 @@ public class GlobalConstantsTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Infinity_NegativeEqualsNumberNegativeInfinity(ExecutionMode mode)
     {
         var source = "console.log(-Infinity === Number.NEGATIVE_INFINITY);";
@@ -215,8 +197,7 @@ public class GlobalConstantsTests
 
     #region undefined Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_OutputsUndefined(ExecutionMode mode)
     {
         var source = "console.log(undefined);";
@@ -224,8 +205,7 @@ public class GlobalConstantsTests
         Assert.Equal("undefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_TypeOfIsUndefined(ExecutionMode mode)
     {
         var source = "console.log(typeof undefined);";
@@ -233,8 +213,7 @@ public class GlobalConstantsTests
         Assert.Equal("undefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_EqualsItself(ExecutionMode mode)
     {
         var source = "console.log(undefined === undefined);";
@@ -242,8 +221,7 @@ public class GlobalConstantsTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_LooseEqualsNull(ExecutionMode mode)
     {
         var source = "console.log(undefined == null);";
@@ -251,8 +229,7 @@ public class GlobalConstantsTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_StrictNotEqualsNull(ExecutionMode mode)
     {
         var source = "console.log(undefined === null);";
@@ -260,8 +237,7 @@ public class GlobalConstantsTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_IsFalsy(ExecutionMode mode)
     {
         var source = """
@@ -275,8 +251,7 @@ public class GlobalConstantsTests
         Assert.Equal("falsy\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_NullishCoalescingFallsThrough(ExecutionMode mode)
     {
         var source = """
@@ -287,8 +262,7 @@ public class GlobalConstantsTests
         Assert.Equal("default\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_InArrayIsUndefined(ExecutionMode mode)
     {
         // Verify undefined can be stored and retrieved from arrays
@@ -301,8 +275,7 @@ public class GlobalConstantsTests
         Assert.Equal("true\nundefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_StringConcatenation(ExecutionMode mode)
     {
         var source = """
@@ -316,8 +289,7 @@ public class GlobalConstantsTests
 
     #region Combined Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalConstants_AllAccessibleTogether(ExecutionMode mode)
     {
         var source = """
@@ -331,8 +303,7 @@ public class GlobalConstantsTests
         Assert.Equal("4\nnumber\nnumber\nundefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalConstants_CanBePassedToFunctions(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/GroupByTests.cs
+++ b/SharpTS.Tests/SharedTests/GroupByTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class GroupByTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectGroupBy_BasicGrouping(ExecutionMode mode)
     {
         var source = """
@@ -33,8 +32,7 @@ public class GroupByTests
         Assert.Equal("3\n1\n2\n2\nbananas\ncherries\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectGroupBy_EmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -46,8 +44,7 @@ public class GroupByTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectGroupBy_NumericKeys(ExecutionMode mode)
     {
         var source = """
@@ -61,8 +58,7 @@ public class GroupByTests
         Assert.Equal("3\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectGroupBy_CallbackReceivesIndex(ExecutionMode mode)
     {
         var source = """
@@ -78,8 +74,7 @@ public class GroupByTests
         Assert.Equal("2\n2\na\nc\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MapGroupBy_BasicGrouping(ExecutionMode mode)
     {
         var source = """
@@ -99,8 +94,7 @@ public class GroupByTests
         Assert.Equal("1\n2\nbananas\ncherries\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MapGroupBy_EmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -112,8 +106,7 @@ public class GroupByTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MapGroupBy_NullUndefinedKeys(ExecutionMode mode)
     {
         var source = """
@@ -131,8 +124,7 @@ public class GroupByTests
         Assert.Equal("2\n2\n1\n2\n1\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MapGroupBy_MultipleItemsPerGroup(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/HttpAgentPoolTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpAgentPoolTests.cs
@@ -16,17 +16,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </remarks>
 public class HttpAgentPoolTests
 {
-    private static int GetAvailablePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Agent_GetName_FormatsOriginKey(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -43,11 +33,10 @@ public class HttpAgentPoolTests
         Assert.Contains("keepAlive=true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Agent_KeepAlive_PopulatesFreeSockets(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -73,11 +62,10 @@ public class HttpAgentPoolTests
         Assert.Contains("freeOrigins=1", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Agent_NoKeepAlive_LeavesFreeSocketsEmpty(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -104,11 +92,10 @@ public class HttpAgentPoolTests
         Assert.Contains("activeOrigins=0", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Agent_Destroy_ClearsPool(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""

--- a/SharpTS.Tests/SharedTests/HttpAgentTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpAgentTests.cs
@@ -10,8 +10,7 @@ public class HttpAgentTests
 {
     #region globalAgent
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpGlobalAgent_IsObject(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -26,8 +25,7 @@ public class HttpAgentTests
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpGlobalAgent_KeepAlive_IsTrue(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -42,8 +40,7 @@ public class HttpAgentTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpGlobalAgent_MaxSockets_IsInfinity(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -58,8 +55,7 @@ public class HttpAgentTests
         Assert.Equal("Infinity\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpGlobalAgent_AllProperties(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -81,8 +77,7 @@ public class HttpAgentTests
         Assert.Equal("true\n1000\nInfinity\nInfinity\n256\n0\nlifo\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpGlobalAgent_Destroy(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -97,8 +92,7 @@ public class HttpAgentTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpGlobalAgent_GetName(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -114,8 +108,7 @@ public class HttpAgentTests
         Assert.Equal("example.com:443::\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpGlobalAgent_Sockets_IsObject(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -136,8 +129,7 @@ public class HttpAgentTests
 
     #region Agent constructor
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Agent_Constructor_Exists(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -152,8 +144,7 @@ public class HttpAgentTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Agent_Constructor_NoArgs(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -171,8 +162,7 @@ public class HttpAgentTests
         Assert.Equal("object\nfalse\nInfinity\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Agent_Constructor_WithKeepAlive(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -188,8 +178,7 @@ public class HttpAgentTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Agent_Constructor_WithAllOptions(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -221,8 +210,7 @@ public class HttpAgentTests
 
     #region Agent instance methods (interpreter only - use GetMember dispatch)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Agent_GetName_Default(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -238,8 +226,7 @@ public class HttpAgentTests
         Assert.Equal("localhost:80::\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Agent_GetName_WithOptions(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -255,8 +242,7 @@ public class HttpAgentTests
         Assert.Equal("api.example.com:8080::\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Agent_Destroy(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -277,8 +263,7 @@ public class HttpAgentTests
 
     #region Named import
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Agent_NamedImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -299,8 +284,7 @@ public class HttpAgentTests
 
     #region Property mutation
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Agent_PropertyMutation_MaxSockets(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -318,8 +302,7 @@ public class HttpAgentTests
         Assert.Equal("Infinity\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Agent_PropertyMutation_KeepAlive(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -341,8 +324,7 @@ public class HttpAgentTests
 
     #region Agent as request option (compatibility)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Agent_InRequestOptions_DoesNotThrow(ExecutionMode mode)
     {
         // Verify that passing agent in request options doesn't cause errors

--- a/SharpTS.Tests/SharedTests/HttpClientRequestTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpClientRequestTests.cs
@@ -18,20 +18,10 @@ namespace SharpTS.Tests.SharedTests;
 /// </remarks>
 public class HttpClientRequestTests
 {
-    private static int GetAvailablePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void ClientRequest_IsWritable_WithHeaderManipulation(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -69,11 +59,10 @@ public class HttpClientRequestTests
         Assert.Contains("afterRemove=false", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void ClientRequest_PostStreamedBody_ResponseCallback(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -120,11 +109,10 @@ public class HttpClientRequestTests
         Assert.Contains("complete=true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void ClientRequest_ResponseEvent_FiresWithIncomingMessage(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -149,12 +137,11 @@ public class HttpClientRequestTests
         Assert.Contains("got response event 200", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void ClientRequest_ConnectionFailure_EmitsError(ExecutionMode mode)
     {
         // Nothing listening on this port → ECONNREFUSED → 'error' event.
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -171,11 +158,10 @@ public class HttpClientRequestTests
         Assert.Contains("hasCode=true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void ClientRequest_GetHeaders_ReturnsObject(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""

--- a/SharpTS.Tests/SharedTests/HttpEventTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpEventTests.cs
@@ -15,20 +15,10 @@ public class HttpEventTests
     /// <summary>
     /// Gets a random available TCP port.
     /// </summary>
-    private static int GetAvailablePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpServerRequestEvent(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -56,11 +46,10 @@ public class HttpEventTests
         Assert.Contains("function", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpServerResponseWriteHead(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -87,11 +76,10 @@ public class HttpEventTests
         Assert.Contains("xcustom=abc", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpServerSetHeader(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -118,11 +106,10 @@ public class HttpEventTests
         Assert.Contains("false", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpServerResponseStatusCode(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -146,11 +133,10 @@ public class HttpEventTests
         Assert.Contains("true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpRequestDataEvent(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -175,11 +161,10 @@ public class HttpEventTests
         Assert.Contains("request ended", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpRequestHeaders(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -200,11 +185,10 @@ public class HttpEventTests
         Assert.Contains("true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpServerListeningAndCloseEvents(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -228,11 +212,10 @@ public class HttpEventTests
         Assert.Contains("close event", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpServerRequestEventEmitter(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -252,11 +235,10 @@ public class HttpEventTests
         Assert.Contains("request event: GET /test-path", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpResponseWriteMultiple(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -278,11 +260,10 @@ public class HttpEventTests
         Assert.Contains("response sent", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpRequestRawHeaders(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -303,11 +284,10 @@ public class HttpEventTests
         Assert.Contains("true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpResponseWriteHeadStatusMessage(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""

--- a/SharpTS.Tests/SharedTests/HttpIncomingMessageTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpIncomingMessageTests.cs
@@ -13,20 +13,10 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class HttpIncomingMessageTests
 {
-    private static int GetAvailablePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IncomingMessage_VersionSocketAndFields(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -57,11 +47,10 @@ public class HttpIncomingMessageTests
         Assert.Contains("trailers=object", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IncomingMessage_RawHeaders_IsAlternatingArray(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -89,11 +78,10 @@ public class HttpIncomingMessageTests
         Assert.Contains("lowerHost=string", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IncomingMessage_StreamsRequestBody(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""

--- a/SharpTS.Tests/SharedTests/HttpModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpModuleTests.cs
@@ -21,8 +21,7 @@ public class HttpModuleTests : IDisposable
     }
 
     public void Dispose() => _server.Dispose();
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchIsGlobal(ExecutionMode mode)
     {
         // Test that fetch is available as a global
@@ -33,8 +32,7 @@ public class HttpModuleTests : IDisposable
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchReturnsPromise(ExecutionMode mode)
     {
         // Test that fetch returns something with .then. Point at the local server
@@ -49,8 +47,7 @@ public class HttpModuleTests : IDisposable
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpModuleImport(ExecutionMode mode)
     {
         // Test that http module can be imported
@@ -65,8 +62,7 @@ public class HttpModuleTests : IDisposable
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpModuleExports(ExecutionMode mode)
     {
         // Test http module exports - use typeof instead of 'in' operator for compiler compatibility
@@ -84,8 +80,7 @@ public class HttpModuleTests : IDisposable
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpCreateServer(ExecutionMode mode)
     {
         // Test creating a server (without starting it)
@@ -103,8 +98,7 @@ public class HttpModuleTests : IDisposable
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpListenZero_BindsEphemeralPort(ExecutionMode mode)
     {
         // #214: HttpListener has no dynamic-port support, so listen(0) probes
@@ -127,8 +121,7 @@ public class HttpModuleTests : IDisposable
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpStatusCodes(ExecutionMode mode)
     {
         // Test STATUS_CODES constant
@@ -145,8 +138,7 @@ public class HttpModuleTests : IDisposable
         Assert.Equal("OK\nNot Found\nInternal Server Error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpMethods(ExecutionMode mode)
     {
         // Test METHODS constant
@@ -163,8 +155,7 @@ public class HttpModuleTests : IDisposable
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpGlobalAgent(ExecutionMode mode)
     {
         // Test globalAgent object
@@ -180,8 +171,7 @@ public class HttpModuleTests : IDisposable
         Assert.Equal("object\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchResponseProperties(ExecutionMode mode)
     {
         // Test Response properties
@@ -197,8 +187,7 @@ public class HttpModuleTests : IDisposable
         Assert.Equal("true\n200\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchJsonMethod(ExecutionMode mode)
     {
         // Test Response.json() method
@@ -214,8 +203,7 @@ public class HttpModuleTests : IDisposable
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchTextMethod(ExecutionMode mode)
     {
         // Test Response.text() method
@@ -231,8 +219,7 @@ public class HttpModuleTests : IDisposable
         Assert.Equal("string\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FetchWithPost(ExecutionMode mode)
     {
         // Test POST request with body
@@ -254,8 +241,7 @@ public class HttpModuleTests : IDisposable
         Assert.Equal("POST\n123\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThisHasFetch(ExecutionMode mode)
     {
         // Test that fetch is accessible via globalThis and is the same reference
@@ -266,8 +252,7 @@ public class HttpModuleTests : IDisposable
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalThisHasFetch_TypeCheck(ExecutionMode mode)
     {
         // Test that fetch is accessible via globalThis

--- a/SharpTS.Tests/SharedTests/HttpServerAdvancedEventsTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpServerAdvancedEventsTests.cs
@@ -18,21 +18,11 @@ namespace SharpTS.Tests.SharedTests;
 /// </remarks>
 public class HttpServerAdvancedEventsTests
 {
-    private static int GetAvailablePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_AdvancedEventListeners_AreRegistrable(ExecutionMode mode)
     {
         // Registering upgrade/connect/clientError/checkContinue must not break normal serving.
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -57,11 +47,10 @@ public class HttpServerAdvancedEventsTests
         Assert.Contains("handled", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Server_CheckContinue_FiresInsteadOfRequest(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""

--- a/SharpTS.Tests/SharedTests/HttpServerEventTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpServerEventTests.cs
@@ -11,8 +11,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class HttpServerEventTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_On_RegistersListener(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -35,8 +34,7 @@ public class HttpServerEventTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_Once_FiresOnlyOnce(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -66,8 +64,7 @@ public class HttpServerEventTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_Off_RemovesListener(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -96,8 +93,7 @@ public class HttpServerEventTests
         Assert.Equal("1\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_RemoveAllListeners_ClearsAllForEvent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -126,8 +122,7 @@ public class HttpServerEventTests
         Assert.Equal("3\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_ListenerCount_ReturnsCorrectCount(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -153,8 +148,7 @@ public class HttpServerEventTests
         Assert.Equal("0\n1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_EventNames_ReturnsRegisteredEvents(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -179,8 +173,7 @@ public class HttpServerEventTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_MultipleListeners_ReceiveSameEvent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -213,8 +206,7 @@ public class HttpServerEventTests
         Assert.Equal("1,2,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_Emit_CustomEvent_Works(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -241,8 +233,7 @@ public class HttpServerEventTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_Listeners_ReturnsListenerArray(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -269,8 +260,7 @@ public class HttpServerEventTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_SetMaxListeners_Works(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -291,8 +281,7 @@ public class HttpServerEventTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_PrependListener_AddsToFront(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -320,8 +309,7 @@ public class HttpServerEventTests
         Assert.Equal("0,1,2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_AddListener_IsAliasForOn(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -347,8 +335,7 @@ public class HttpServerEventTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_RemoveListener_IsAliasForOff(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -376,8 +363,7 @@ public class HttpServerEventTests
         Assert.Equal("1\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_MethodChaining_Works(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -403,8 +389,7 @@ public class HttpServerEventTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_TypeCheck_EventEmitterMethods(ExecutionMode mode)
     {
         // This test verifies that type checking passes for EventEmitter methods
@@ -435,8 +420,7 @@ public class HttpServerEventTests
         Assert.Equal("type check passed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_Emit_ReturnsBoolean(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -463,8 +447,7 @@ public class HttpServerEventTests
         Assert.Equal("false\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_RawListeners_ReturnsListenerArray(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -488,8 +471,7 @@ public class HttpServerEventTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_PrependOnceListener_AddsOnceListenerToFront(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/HttpServerLifecycleTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpServerLifecycleTests.cs
@@ -17,17 +17,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </remarks>
 public class HttpServerLifecycleTests
 {
-    private static int GetAvailablePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_DefaultConfig_IsReadable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -47,8 +37,7 @@ public class HttpServerLifecycleTests
         Assert.Equal("keepAlive=5000\nheaders=60000\nrequest=300000\ntimeout=0\nmaxHeaders=2000\nmaxReq=0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_LifecycleMethods_AreCallable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -70,11 +59,10 @@ public class HttpServerLifecycleTests
         Assert.Contains("idle-ok", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_CloseAllConnections_StopsServer(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -92,8 +80,7 @@ public class HttpServerLifecycleTests
         Assert.Contains("done", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Server_Config_IsSettable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -113,11 +100,10 @@ public class HttpServerLifecycleTests
         Assert.Equal("1234\n9999\n50\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Server_ConnectionEvent_Fires(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""

--- a/SharpTS.Tests/SharedTests/HttpServerResponseTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpServerResponseTests.cs
@@ -13,20 +13,10 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class HttpServerResponseTests
 {
-    private static int GetAvailablePort()
-    {
-        var listener = new TcpListener(IPAddress.Loopback, 0);
-        listener.Start();
-        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-        listener.Stop();
-        return port;
-    }
-
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ServerResponse_StatusMessage_Writable(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -44,11 +34,10 @@ public class HttpServerResponseTests
         Assert.Contains("msg=Custom OK", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ServerResponse_ExtraMethods_Callable(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -79,11 +68,10 @@ public class HttpServerResponseTests
         Assert.Contains("all-ok", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ServerResponse_Write_ReturnsBoolean(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""
@@ -101,11 +89,10 @@ public class HttpServerResponseTests
         Assert.Contains("writeType=boolean", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ServerResponse_ChunkedStreaming_BodyReceived(ExecutionMode mode)
     {
-        var port = GetAvailablePort();
+        var port = TestPorts.GetAvailablePort();
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = $$"""

--- a/SharpTS.Tests/SharedTests/HttpTypeSurfaceTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpTypeSurfaceTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class HttpTypeSurfaceTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ServerAndClient_TypeCheck(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -34,8 +33,7 @@ public class HttpTypeSurfaceTests
         Assert.Contains("typecheck ok 16384", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpsCreateServerWithTlsOptions_TypeChecks(ExecutionMode mode)
     {
         var (certPem, keyPem) = TlsModuleTestsCertHelper.GenerateSelfSignedCert();

--- a/SharpTS.Tests/SharedTests/HttpUtilitiesTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpUtilitiesTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class HttpUtilitiesTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MaxHeaderSize_Is16384(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -25,8 +24,7 @@ public class HttpUtilitiesTests
         Assert.Equal("16384\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ValidateHeaderName_AcceptsValid_RejectsInvalid(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -49,8 +47,7 @@ public class HttpUtilitiesTests
         Assert.DoesNotContain("NO-THROW", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ValidateHeaderValue_AcceptsValid_RejectsInvalid(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -73,8 +70,7 @@ public class HttpUtilitiesTests
         Assert.DoesNotContain("NO-THROW", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Methods_IncludesFullList(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -92,8 +88,7 @@ public class HttpUtilitiesTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetMaxIdleHTTPParsers_IsCallable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -108,8 +103,7 @@ public class HttpUtilitiesTests
         Assert.Equal("ok\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Https_MirrorsUtilities(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/HttpsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/HttpsModuleTests.cs
@@ -15,8 +15,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </remarks>
 public class HttpsModuleTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Https_Exports_Exist(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -32,8 +31,7 @@ public class HttpsModuleTests
         Assert.Equal("function\nfunction\nfunction\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Https_ServerClient_RoundTrip(ExecutionMode mode)
     {
         var (certPem, keyPem) = TlsModuleTestsCertHelper.GenerateSelfSignedCert();
@@ -66,8 +64,7 @@ public class HttpsModuleTests
         Assert.Contains("body=secure:/hello", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Https_ServerClient_PostBody(ExecutionMode mode)
     {
         var (certPem, keyPem) = TlsModuleTestsCertHelper.GenerateSelfSignedCert();

--- a/SharpTS.Tests/SharedTests/ImportAliasTests.cs
+++ b/SharpTS.Tests/SharedTests/ImportAliasTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ImportAliasTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BasicFunctionAlias(ExecutionMode mode)
     {
         var code = @"
@@ -23,8 +22,7 @@ public class ImportAliasTests
         Assert.Equal("Hello\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BasicVariableAlias(ExecutionMode mode)
     {
         var code = @"
@@ -37,8 +35,7 @@ public class ImportAliasTests
         Assert.Equal("3.14\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassAlias(ExecutionMode mode)
     {
         var code = @"
@@ -57,8 +54,7 @@ public class ImportAliasTests
         Assert.Equal("Alice\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedNamespacePath(ExecutionMode mode)
     {
         var code = @"
@@ -75,8 +71,7 @@ public class ImportAliasTests
         Assert.Equal("42\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedNamespacePathFunction(ExecutionMode mode)
     {
         var code = @"
@@ -91,8 +86,7 @@ public class ImportAliasTests
         Assert.Equal("100\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InterfaceAlias_TypeOnly(ExecutionMode mode)
     {
         var code = @"
@@ -110,8 +104,7 @@ public class ImportAliasTests
         Assert.Equal("Bob\n30\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EnumAlias(ExecutionMode mode)
     {
         var code = @"
@@ -125,8 +118,7 @@ public class ImportAliasTests
         Assert.Equal("1\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ImportAliasInsideNamespace(ExecutionMode mode)
     {
         var code = @"
@@ -142,8 +134,7 @@ public class ImportAliasTests
         Assert.Equal("999\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportedImportAlias(ExecutionMode mode)
     {
         var code = @"
@@ -158,8 +149,7 @@ public class ImportAliasTests
         Assert.Equal("helped\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultipleAliases(ExecutionMode mode)
     {
         var code = @"
@@ -178,8 +168,7 @@ public class ImportAliasTests
         Assert.Equal("15\n5\n3.14159\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AliasNestedNamespace(ExecutionMode mode)
     {
         var code = @"
@@ -194,8 +183,7 @@ public class ImportAliasTests
         Assert.Equal("leaf value\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericClassAlias(ExecutionMode mode)
     {
         var code = @"
@@ -218,8 +206,7 @@ public class ImportAliasTests
 
     #region Error Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_InvalidNamespace(ExecutionMode mode)
     {
         var code = @"
@@ -229,8 +216,7 @@ public class ImportAliasTests
         Assert.Contains("Namespace 'NonExistent' is not defined", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_InvalidMember(ExecutionMode mode)
     {
         var code = @"
@@ -243,8 +229,7 @@ public class ImportAliasTests
         Assert.Contains("does not exist in namespace", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Error_IntermediateNotNamespace(ExecutionMode mode)
     {
         var code = @"

--- a/SharpTS.Tests/SharedTests/ImportMetaTests.cs
+++ b/SharpTS.Tests/SharedTests/ImportMetaTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ImportMetaTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ImportMeta_UrlProperty_ReturnsString(ExecutionMode mode)
     {
         var source = """
@@ -21,8 +20,7 @@ public class ImportMetaTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ImportMeta_DirectAccess_Works(ExecutionMode mode)
     {
         var source = """
@@ -34,8 +32,7 @@ public class ImportMetaTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ImportMeta_DirnameProperty_ReturnsString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -51,8 +48,7 @@ public class ImportMetaTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ImportMeta_FilenameProperty_ReturnsString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -68,8 +64,7 @@ public class ImportMetaTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ImportMeta_AllProperties_AreConsistent(ExecutionMode mode)
     {
         // All import.meta properties should be accessible and consistent
@@ -89,8 +84,7 @@ public class ImportMetaTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ImportMeta_UrlStartsWithFile_InSingleFileMode(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/IndexSignatureTests.cs
+++ b/SharpTS.Tests/SharedTests/IndexSignatureTests.cs
@@ -10,8 +10,7 @@ public class IndexSignatureTests
 {
     #region String Index Signatures
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringIndex_BasicGetSet_Works(ExecutionMode mode)
     {
         var source = """
@@ -29,8 +28,7 @@ public class IndexSignatureTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringIndex_WithExplicitProperties_Works(ExecutionMode mode)
     {
         var source = """
@@ -48,8 +46,7 @@ public class IndexSignatureTests
         Assert.Equal("app\n1.0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringIndex_DynamicKeyAccess_Works(ExecutionMode mode)
     {
         var source = """
@@ -70,8 +67,7 @@ public class IndexSignatureTests
 
     #region Number Index Signatures
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumberIndex_BasicGetSet_Works(ExecutionMode mode)
     {
         var source = """
@@ -89,8 +85,7 @@ public class IndexSignatureTests
         Assert.Equal("zero\none\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumberIndex_WithExplicitProperties_Works(ExecutionMode mode)
     {
         var source = """
@@ -114,8 +109,7 @@ public class IndexSignatureTests
 
     #region Symbol Index Signatures
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SymbolIndex_BasicGetSet_Works(ExecutionMode mode)
     {
         var source = """
@@ -132,8 +126,7 @@ public class IndexSignatureTests
         Assert.Equal("value\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SymbolIndex_MultipleSymbols_Works(ExecutionMode mode)
     {
         var source = """
@@ -157,8 +150,7 @@ public class IndexSignatureTests
 
     #region Mixed Index Signatures
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MixedIndex_StringAndNumber_Works(ExecutionMode mode)
     {
         var source = """
@@ -181,8 +173,7 @@ public class IndexSignatureTests
 
     #region Plain Object Bracket Notation
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PlainObject_BracketNotation_Works(ExecutionMode mode)
     {
         var source = """
@@ -195,8 +186,7 @@ public class IndexSignatureTests
         Assert.Equal("test\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PlainObject_DynamicKeyAccess_Works(ExecutionMode mode)
     {
         var source = """
@@ -209,8 +199,7 @@ public class IndexSignatureTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PlainObject_SetWithBracket_Works(ExecutionMode mode)
     {
         var source = """
@@ -230,8 +219,7 @@ public class IndexSignatureTests
 
     #region Class Instance Bracket Notation
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassInstance_BracketNotation_Works(ExecutionMode mode)
     {
         var source = """
@@ -252,8 +240,7 @@ public class IndexSignatureTests
         Assert.Equal("Alice\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassInstance_SymbolKey_Works(ExecutionMode mode)
     {
         var source = """
@@ -278,8 +265,7 @@ public class IndexSignatureTests
 
     #region Inline Type Index Signature
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InlineType_IndexSignature_Works(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/InnerFunctionArrowCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/InnerFunctionArrowCaptureTests.cs
@@ -17,8 +17,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class InnerFunctionArrowCaptureTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionDecl_InArrow_ReadsConstAssignedAfterHoist(ExecutionMode mode)
     {
         // Minimal repro from #307: bgt is hoisted before `const Obj = 42` runs.
@@ -35,8 +34,7 @@ public class InnerFunctionArrowCaptureTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionDecl_GrandparentArrowCapture_ThroughIntermediateArrow(ExecutionMode mode)
     {
         var source = """
@@ -55,8 +53,7 @@ public class InnerFunctionArrowCaptureTests
         Assert.Equal("grand\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionDecl_GrandparentArrowCapture_ThroughIntermediateFunctionDecl(ExecutionMode mode)
     {
         // The intermediate scope is a function DECLARATION: the live reference
@@ -77,8 +74,7 @@ public class InnerFunctionArrowCaptureTests
         Assert.Equal("grand2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionDecl_InArrow_MutationsVisibleBothWays(ExecutionMode mode)
     {
         // Writes from the arrow body must be visible inside the function
@@ -99,8 +95,7 @@ public class InnerFunctionArrowCaptureTests
         Assert.Equal("12\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionDecls_InFunctionExpression_PeerReferences(ExecutionMode mode)
     {
         // lodash idiom: hoisted peers referencing each other before their
@@ -119,8 +114,7 @@ public class InnerFunctionArrowCaptureTests
         Assert.Equal("99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionDecl_HoistedBeforeVarAssignment_CalledAfter(ExecutionMode mode)
     {
         var source = """
@@ -137,8 +131,7 @@ public class InnerFunctionArrowCaptureTests
         Assert.Equal("assigned-later\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Closure_CapturesFromTwoAncestorArrowScopes(ExecutionMode mode)
     {
         // lodash shortOut shape: the returned closure captures `tag` from the
@@ -170,8 +163,7 @@ public class InnerFunctionArrowCaptureTests
         Assert.Equal("v7/T\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CapturedParameter_ReassignedInBody_ReadsStayCurrent(ExecutionMode mode)
     {
         // lodash runInContext shape: a captured parameter is reassigned at the
@@ -191,8 +183,7 @@ public class InnerFunctionArrowCaptureTests
         Assert.Equal("real/real\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ValueForm_ObjectCall_Coerces(ExecutionMode mode)
     {
         // lodash overArg(Object.keys, Object): `Object` held as a value and
@@ -209,8 +200,7 @@ public class InnerFunctionArrowCaptureTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ValueForm_ObjectCreate_SingleArg(ExecutionMode mode)
     {
         // Value-form Object.create(proto) under-application: the padded props
@@ -227,8 +217,7 @@ public class InnerFunctionArrowCaptureTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ValueForm_DateNow_AsValue(ExecutionMode mode)
     {
         // lodash: `var nativeNow = Date.now;` then nativeNow() — value-form
@@ -249,8 +238,7 @@ public class InnerFunctionArrowCaptureTests
     // the arg slot before the DC, so a DC-only store leaves the direct read
     // seeing the stale original argument while the closure read sees the new
     // value. Mirrors the assignment-path dual-write from #307/#313.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CapturedParam_PostfixIncrement_SyncsArgSlotAndDC(ExecutionMode mode)
     {
         var source = """
@@ -269,8 +257,7 @@ public class InnerFunctionArrowCaptureTests
         Assert.Equal("8008\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CapturedParam_PrefixDecrement_SyncsArgSlotAndDC(ExecutionMode mode)
     {
         // Prefix form + decrement + arrow parameter (arrow scope DC branch).
@@ -287,8 +274,7 @@ public class InnerFunctionArrowCaptureTests
         Assert.Equal("6006\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CapturedUntypedParam_PostfixIncrement_SyncsArgSlotAndDC(ExecutionMode mode)
     {
         // Untyped (any) parameter: arg slot is object, so the dual-write must
@@ -312,8 +298,7 @@ public class InnerFunctionArrowCaptureTests
     // saw the stale/previous value — null on the first loop iteration. The
     // declaration now writes the freshly-assigned value back into the closure's
     // DC field after the store, while keeping per-iteration fresh-binding.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SelfReferentialConst_SingleDeclaration_ClosureSeesValue(ExecutionMode mode)
     {
         var source = """
@@ -327,8 +312,7 @@ public class InnerFunctionArrowCaptureTests
         Assert.Equal("true\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SelfReferentialConst_InLoop_EachClosureSeesOwnBinding(ExecutionMode mode)
     {
         // The first iteration's closure captured null (snapshot before the

--- a/SharpTS.Tests/SharedTests/InnerFunctionInBlockTests.cs
+++ b/SharpTS.Tests/SharedTests/InnerFunctionInBlockTests.cs
@@ -25,8 +25,7 @@ public class InnerFunctionInBlockTests
 {
     // ---- The headline #1230 repro: inner function in a loop body capturing a loop-body const ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LoopBody_InnerFunction_CapturesBodyConst_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -46,8 +45,7 @@ public class InnerFunctionInBlockTests
 
     // ---- Capturing the loop VARIABLE directly (needs the value boxed into the closure field) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LoopBody_InnerFunction_CapturesLoopVariable_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -66,8 +64,7 @@ public class InnerFunctionInBlockTests
 
     // ---- Non-capturing inner function in a plain block (was also unreferenceable) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PlainBlock_NonCapturingInnerFunction_IsReferenceable(ExecutionMode mode)
     {
         var source = """
@@ -86,8 +83,7 @@ public class InnerFunctionInBlockTests
 
     // ---- Inner function in an if-branch inside a function ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IfBranch_InnerFunction_IsReferenceable(ExecutionMode mode)
     {
         var source = """
@@ -105,8 +101,7 @@ public class InnerFunctionInBlockTests
 
     // ---- Two block-levels deep: function nested in an if inside a loop ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LoopThenIf_InnerFunction_CapturesLoopVariable_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -127,8 +122,7 @@ public class InnerFunctionInBlockTests
 
     // ---- Inner function capturing an enclosing parameter ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Block_InnerFunction_CapturesParameter(ExecutionMode mode)
     {
         var source = """
@@ -145,8 +139,7 @@ public class InnerFunctionInBlockTests
 
     // ---- Recursive inner function declared in a block ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Block_RecursiveInnerFunction(ExecutionMode mode)
     {
         var source = """
@@ -163,8 +156,7 @@ public class InnerFunctionInBlockTests
 
     // ---- Sibling inner functions in a block: a later one calls an earlier one ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Block_SiblingInnerFunctions_CallEarlierSibling(ExecutionMode mode)
     {
         var source = """
@@ -182,8 +174,7 @@ public class InnerFunctionInBlockTests
 
     // ---- while-loop body ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WhileLoopBody_InnerFunction_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -205,8 +196,7 @@ public class InnerFunctionInBlockTests
 
     // ---- for-of loop body: inner function captures the loop variable ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOfLoopBody_InnerFunction_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -225,8 +215,7 @@ public class InnerFunctionInBlockTests
 
     // ---- An arrow created in the same block captures the block-scoped inner function's value ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Block_ArrowCapturesInnerFunctionValue(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/InnerFunctionInMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/InnerFunctionInMethodTests.cs
@@ -28,8 +28,7 @@ public class InnerFunctionInMethodTests
 {
     // ---- The headline #1237 repro: non-capturing inner function in an instance method ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethod_NonCapturingInnerFunction_IsReferenceable(ExecutionMode mode)
     {
         var source = """
@@ -46,8 +45,7 @@ public class InnerFunctionInMethodTests
 
     // ---- Capturing a method-local const (was "Undefined variable", then a null capture pre-fix) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethod_CapturingInnerFunction_SeesMethodLocal(ExecutionMode mode)
     {
         var source = """
@@ -65,8 +63,7 @@ public class InnerFunctionInMethodTests
 
     // ---- Capturing a method parameter (value-type double must be boxed into the closure field) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethod_InnerFunction_CapturesParameter(ExecutionMode mode)
     {
         var source = """
@@ -83,8 +80,7 @@ public class InnerFunctionInMethodTests
 
     // ---- Capturing a value-type method-local (boxing on the local fallback path) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethod_InnerFunction_CapturesNumericLocal(ExecutionMode mode)
     {
         var source = """
@@ -102,8 +98,7 @@ public class InnerFunctionInMethodTests
 
     // ---- Self-recursion (own name resolved via direct dispatch, not a captured local) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethod_InnerFunction_SelfRecursion(ExecutionMode mode)
     {
         var source = """
@@ -120,8 +115,7 @@ public class InnerFunctionInMethodTests
 
     // ---- Two inner functions sharing a captured method-local ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethod_TwoInnerFunctions_ShareCapture(ExecutionMode mode)
     {
         var source = """
@@ -140,8 +134,7 @@ public class InnerFunctionInMethodTests
 
     // ---- Capturing a module top-level variable from inside a method (routes via entry-point DC) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceMethod_InnerFunction_CapturesTopLevelVar(ExecutionMode mode)
     {
         var source = """
@@ -159,8 +152,7 @@ public class InnerFunctionInMethodTests
 
     // ---- Block-nested inner function inside a method (composes with #1230 in-place path) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Method_LoopBody_InnerFunction_CapturesLoopVariable_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -179,8 +171,7 @@ public class InnerFunctionInMethodTests
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Method_IfBlock_InnerFunction_CapturesBlockConst(ExecutionMode mode)
     {
         var source = """
@@ -202,8 +193,7 @@ public class InnerFunctionInMethodTests
 
     // ---- Static method ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticMethod_InnerFunction_IsReferenceable(ExecutionMode mode)
     {
         var source = """
@@ -221,8 +211,7 @@ public class InnerFunctionInMethodTests
 
     // ---- Private method (ES2022 #member) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateMethod_InnerFunction_IsReferenceable(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/InnerFunctionScopeDisplayClassTests.cs
+++ b/SharpTS.Tests/SharedTests/InnerFunctionScopeDisplayClassTests.cs
@@ -16,8 +16,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class InnerFunctionScopeDisplayClassTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SiblingClosures_ShareInnerFunctionLocal(ExecutionMode mode)
     {
         // Minimal repro from #313: get() must see inc()'s mutations.
@@ -41,8 +40,7 @@ public class InnerFunctionScopeDisplayClassTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EachInvocation_GetsFreshScope(ExecutionMode mode)
     {
         var source = """
@@ -66,8 +64,7 @@ public class InnerFunctionScopeDisplayClassTests
         Assert.Equal("31\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CapturedParameter_ReassignedAndMutatedBySiblings(ExecutionMode mode)
     {
         // Captured typed parameter: reassignment in the function body must be
@@ -91,8 +88,7 @@ public class InnerFunctionScopeDisplayClassTests
         Assert.Equal("106\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedInnerFunction_OwnsItsOwnScope(ExecutionMode mode)
     {
         // The scope-owning function is itself nested inside another inner
@@ -119,8 +115,7 @@ public class InnerFunctionScopeDisplayClassTests
         Assert.Equal("4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Closure_CapturesInnerFunctionScopeAndAncestorArrowScope(ExecutionMode mode)
     {
         // One closure captures from TWO scopes: the inner function's own
@@ -145,8 +140,7 @@ public class InnerFunctionScopeDisplayClassTests
         Assert.Equal("110\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HoistedSiblingFunctions_ShareInnerFunctionLocal(ExecutionMode mode)
     {
         // The sibling closures are hoisted function declarations, not arrows —
@@ -170,8 +164,7 @@ public class InnerFunctionScopeDisplayClassTests
         Assert.Equal("21\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunctionInTopLevelFunction_SiblingsShare(ExecutionMode mode)
     {
         // Enclosing callable is a top-level function declaration, not an arrow.
@@ -194,8 +187,7 @@ public class InnerFunctionScopeDisplayClassTests
         Assert.Equal("4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EscapedClosures_MutateAfterReturn(ExecutionMode mode)
     {
         // Closures escape the inner function and mutate later — storage is

--- a/SharpTS.Tests/SharedTests/InnerFunctionTests.cs
+++ b/SharpTS.Tests/SharedTests/InnerFunctionTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class InnerFunctionTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_Basic(ExecutionMode mode)
     {
         var source = """
@@ -27,8 +26,7 @@ public class InnerFunctionTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_WithParameters(ExecutionMode mode)
     {
         var source = """
@@ -45,8 +43,7 @@ public class InnerFunctionTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_Recursive(ExecutionMode mode)
     {
         var source = """
@@ -64,8 +61,7 @@ public class InnerFunctionTests
         Assert.Equal("120\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_CapturingOuterVariable(ExecutionMode mode)
     {
         var source = """
@@ -83,8 +79,7 @@ public class InnerFunctionTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_ModifyingCapturedVariable(ExecutionMode mode)
     {
         var source = """
@@ -105,8 +100,7 @@ public class InnerFunctionTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_MultipleInnerFunctions(ExecutionMode mode)
     {
         var source = """
@@ -127,8 +121,7 @@ public class InnerFunctionTests
         Assert.Equal("Hello, Alice\nGoodbye, Bob\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_DeclaredBeforeUse(ExecutionMode mode)
     {
         // Inner function declared before first call (standard order)
@@ -146,8 +139,7 @@ public class InnerFunctionTests
         Assert.Equal("declared first\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_CapturingParameter(ExecutionMode mode)
     {
         var source = """
@@ -164,8 +156,7 @@ public class InnerFunctionTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_ReturnedAsValue(ExecutionMode mode)
     {
         // Inner function used as a closure factory
@@ -188,8 +179,7 @@ public class InnerFunctionTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_SimpleRecursion(ExecutionMode mode)
     {
         // Simplest possible recursive inner function - no typed params, string result
@@ -208,8 +198,7 @@ public class InnerFunctionTests
         Assert.Equal("3,2,1,done\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_SingleSelfCall(ExecutionMode mode)
     {
         // Just one self-call to isolate the most basic recursive behavior
@@ -228,8 +217,7 @@ public class InnerFunctionTests
         Assert.Equal("base\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_SelfRefCheck(ExecutionMode mode)
     {
         // Check that the self-reference local is accessible as a function
@@ -248,8 +236,7 @@ public class InnerFunctionTests
         Assert.Equal("ok\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_NestedInnerFunctions(ExecutionMode mode)
     {
         // Function inside function inside function
@@ -270,8 +257,7 @@ public class InnerFunctionTests
         Assert.Equal("deep\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_ForwardReferenceHoisted(ExecutionMode mode)
     {
         // Reduced repro of issue #40: an earlier-declared hoisted function
@@ -291,8 +277,7 @@ public class InnerFunctionTests
         Assert.Equal("forward\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_MutualRecursion(ExecutionMode mode)
     {
         // Two hoisted functions reference each other. Before the two-pass
@@ -317,8 +302,7 @@ public class InnerFunctionTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_ThreeWayForwardReferenceCycle(ExecutionMode mode)
     {
         // Three-way cycle, all forward references.
@@ -336,8 +320,7 @@ public class InnerFunctionTests
         Assert.Equal("a->b->c\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_ForwardReferenceInArrowBody(ExecutionMode mode)
     {
         // Exact shape from issue #40: hoisted forward-reference inside an
@@ -360,8 +343,7 @@ public class InnerFunctionTests
         Assert.Equal("wrapped:x\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_NewOnPeerHoistedFunction(ExecutionMode mode)
     {
         // Issue #59: `new X()` inside an inner function where X is a peer
@@ -382,8 +364,7 @@ public class InnerFunctionTests
         Assert.Equal("a-object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_NewInsideLogicalFallback(ExecutionMode mode)
     {
         // Issue #59, lodash shape: `new (x || MapCache)` — MapCache as the
@@ -406,8 +387,7 @@ public class InnerFunctionTests
         Assert.Equal("map\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BuiltIn_ArrayIsArray_AsValue(ExecutionMode mode)
     {
         // Regression: `var f = Array.isArray` previously stored the boolean
@@ -429,8 +409,7 @@ public class InnerFunctionTests
         Assert.Equal("function\ntrue\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void BuiltIn_ClassNameProperty_Preserved(ExecutionMode mode)
     {
         // Compiled-only: regression guard that closing the Type-reflection
@@ -450,8 +429,7 @@ public class InnerFunctionTests
         Assert.Equal("MyClass\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BuiltIn_MathMethods_AsValues(ExecutionMode mode)
     {
         // Issue #60: `var f = Math.floor; f(x)` must resolve to the Math.floor
@@ -478,8 +456,7 @@ public class InnerFunctionTests
         Assert.Equal("function function function\n2 3 5\n4 1\n3 0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BuiltIn_NumberMethods_AsValues(ExecutionMode mode)
     {
         // Issue #60: Number.isInteger / isFinite / isInteger / isSafeInteger
@@ -497,8 +474,7 @@ public class InnerFunctionTests
         Assert.Equal("function true false false\nfunction true false false\nfunction true false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BuiltIn_StringFromCharCode_AsValue(ExecutionMode mode)
     {
         // Issue #60: String.fromCharCode as a stored value. $Runtime's
@@ -515,8 +491,7 @@ public class InnerFunctionTests
         Assert.Equal("function\nA\nHi!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void BuiltIn_MathMaxMin_Variadic_WithCoercion(ExecutionMode mode)
     {
         // Compiled-only: verifies that the Math.max/min adapters coerce
@@ -537,8 +512,7 @@ public class InnerFunctionTests
         Assert.Equal("3\n2\n-Infinity\nInfinity\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BuiltIn_ArrayConstructor_AllForms(ExecutionMode mode)
     {
         // Issue #61: `new Array(n)` / `Array(n)` / `new Array(a, b, c)` must
@@ -559,8 +533,7 @@ public class InnerFunctionTests
         Assert.Equal("3\n3\n[1, 2, 3]\n[hello]\n[]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void BuiltIn_ArrayConstructor_AsValue_CallForm(ExecutionMode mode)
     {
         // Issue #61: calling an Array reference stored in a variable — the
@@ -584,8 +557,7 @@ public class InnerFunctionTests
         Assert.Equal("2 undefined undefined\n2 x y\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BuiltIn_NumberStringBoolean_BareIdentifiers(ExecutionMode mode)
     {
         // Issue #62: bare `Number` / `String` / `Boolean` must resolve to
@@ -604,8 +576,7 @@ public class InnerFunctionTests
         Assert.Equal("function function function\nfunction function function\ntrue true true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void BuiltIn_StoredTypeToken_StaticMemberDispatch(ExecutionMode mode)
     {
         // Issue #63: when a built-in type constructor is stored in a variable
@@ -631,8 +602,7 @@ public class InnerFunctionTests
         Assert.Equal("function function function\ntrue false\ntrue false\nHi\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void BuiltIn_ClassUnknownStaticProperty_IsUndefined(ExecutionMode mode)
     {
         // Compiled-only: `ClassName.nonexistentProp` must return undefined

--- a/SharpTS.Tests/SharedTests/InstanceConstructorTests.cs
+++ b/SharpTS.Tests/SharedTests/InstanceConstructorTests.cs
@@ -17,8 +17,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class InstanceConstructorTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceConstructor_IsTheClass(ExecutionMode mode)
     {
         var source = """
@@ -29,8 +28,7 @@ public class InstanceConstructorTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceConstructor_Name(ExecutionMode mode)
     {
         var source = """
@@ -41,8 +39,7 @@ public class InstanceConstructorTests
         Assert.Equal("Animal\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceConstructor_ReadsStaticMember(ExecutionMode mode)
     {
         var source = """
@@ -53,8 +50,7 @@ public class InstanceConstructorTests
         Assert.Equal("mammal\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceConstructor_SubclassResolvesToSubclass(ExecutionMode mode)
     {
         // The most-derived class is reported — each class's GetProperty returns its
@@ -68,8 +64,7 @@ public class InstanceConstructorTests
         Assert.Equal("true false\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceConstructor_OwnDataPropertyShadows(ExecutionMode mode)
     {
         // An own data property named `constructor` shadows the class (JS semantics):

--- a/SharpTS.Tests/SharedTests/InterfaceFieldAssignmentTests.cs
+++ b/SharpTS.Tests/SharedTests/InterfaceFieldAssignmentTests.cs
@@ -18,8 +18,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </remarks>
 public class InterfaceFieldAssignmentTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AssignPrimitiveField_OnInterface(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -37,8 +36,7 @@ public class InterfaceFieldAssignmentTests
         Assert.Equal("hello 42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AssignArrayField_ThenPush_PreservesElementType(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -57,8 +55,7 @@ public class InterfaceFieldAssignmentTests
         Assert.Equal("2 a b string\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AssignField_InsideSwitchStateMachine(ExecutionMode mode)
     {
         // Exactly the WHATWG URL parser pattern: interface param, switch-heavy

--- a/SharpTS.Tests/SharedTests/InterfaceTests.cs
+++ b/SharpTS.Tests/SharedTests/InterfaceTests.cs
@@ -11,8 +11,7 @@ public class InterfaceTests
 {
     #region Structural Typing
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_ObjectLiteralMatches_Works(ExecutionMode mode)
     {
         var source = """
@@ -29,8 +28,7 @@ public class InterfaceTests
         Assert.Equal("10\n20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_ExcessProperties_FreshLiteral_Rejected(ExecutionMode mode)
     {
         var source = """
@@ -42,8 +40,7 @@ public class InterfaceTests
         Assert.Contains("Excess property: 'extra'", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_ExcessProperties_NonFreshLiteral_Allowed(ExecutionMode mode)
     {
         var source = """
@@ -57,8 +54,7 @@ public class InterfaceTests
         Assert.Equal("test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_AsParameter_Works(ExecutionMode mode)
     {
         var source = """
@@ -79,8 +75,7 @@ public class InterfaceTests
 
     #region Implements Clause
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Implements_SingleInterface_Works(ExecutionMode mode)
     {
         var source = """
@@ -101,8 +96,7 @@ public class InterfaceTests
         Assert.Equal("Alice\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Implements_MultipleInterfaces_Works(ExecutionMode mode)
     {
         var source = """
@@ -129,8 +123,7 @@ public class InterfaceTests
         Assert.Equal("Bob\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Implements_WithExtends_Works(ExecutionMode mode)
     {
         var source = """
@@ -159,8 +152,7 @@ public class InterfaceTests
         Assert.Equal("1\nA product\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Implements_GetterSatisfiesProperty_Works(ExecutionMode mode)
     {
         var source = """
@@ -184,8 +176,7 @@ public class InterfaceTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_WithMethods_Works(ExecutionMode mode)
     {
         var source = """
@@ -205,8 +196,7 @@ public class InterfaceTests
         Assert.Equal("Hello!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_PolymorphicUse_Works(ExecutionMode mode)
     {
         var source = """
@@ -238,8 +228,7 @@ public class InterfaceTests
 
     #region Optional Interface Members
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_OptionalProperty_Works(ExecutionMode mode)
     {
         var source = """
@@ -262,8 +251,7 @@ public class InterfaceTests
 
     #region Interface-to-Interface Compatibility
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_ToInterface_SameStructure_Compatible(ExecutionMode mode)
     {
         var source = """
@@ -284,8 +272,7 @@ public class InterfaceTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_ToInterface_ReturnedFromFunction_Compatible(ExecutionMode mode)
     {
         var source = """
@@ -306,8 +293,7 @@ public class InterfaceTests
         Assert.Equal("test.txt\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interface_ToInterface_WithArrayPush_Compatible(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/IntersectionTests.cs
+++ b/SharpTS.Tests/SharedTests/IntersectionTests.cs
@@ -12,8 +12,7 @@ public class IntersectionTests
 {
     #region Basic Intersection of Interfaces
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_ObjectTypes_MergesProperties(ExecutionMode mode)
     {
         var source = """
@@ -29,8 +28,7 @@ public class IntersectionTests
         Assert.Equal("Alice\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_RequiresAllProperties(ExecutionMode mode)
     {
         var source = """
@@ -46,8 +44,7 @@ public class IntersectionTests
         Assert.Equal("1\nhello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_MissingProperty_TypeError(ExecutionMode mode)
     {
         var source = """
@@ -65,8 +62,7 @@ public class IntersectionTests
 
     #region Multiple Intersections
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_MultipleTypes_Works(ExecutionMode mode)
     {
         var source = """
@@ -88,8 +84,7 @@ public class IntersectionTests
 
     #region Type Alias with Intersection
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_TypeAlias_Works(ExecutionMode mode)
     {
         var source = """
@@ -110,8 +105,7 @@ public class IntersectionTests
 
     #region Compatible Property Merge
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_CompatibleProperties_Merges(ExecutionMode mode)
     {
         var source = """
@@ -132,8 +126,7 @@ public class IntersectionTests
 
     #region Precedence Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_BindsTighterThanUnion_MatchesFirst(ExecutionMode mode)
     {
         var source = """
@@ -150,8 +143,7 @@ public class IntersectionTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_BindsTighterThanUnion_MatchesSecond(ExecutionMode mode)
     {
         var source = """
@@ -173,8 +165,7 @@ public class IntersectionTests
 
     #region Special Types
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_WithUnknown_ProducesOtherType(ExecutionMode mode)
     {
         var source = """
@@ -187,8 +178,7 @@ public class IntersectionTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_WithAny_ProducesAny(ExecutionMode mode)
     {
         var source = """
@@ -201,8 +191,7 @@ public class IntersectionTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_WithNever_ProducesNever(ExecutionMode mode)
     {
         var source = """
@@ -218,8 +207,7 @@ public class IntersectionTests
 
     #region Primitive Intersections
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_ConflictingPrimitives_ProducesNever(ExecutionMode mode)
     {
         var source = """
@@ -235,8 +223,7 @@ public class IntersectionTests
 
     #region Property Conflicts
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_ConflictingPropertyTypes_PropertyBecomesNever(ExecutionMode mode)
     {
         var source = """
@@ -255,8 +242,7 @@ public class IntersectionTests
 
     #region Function Parameter
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_AsFunctionParameter(ExecutionMode mode)
     {
         var source = """
@@ -279,8 +265,7 @@ public class IntersectionTests
 
     #region Nested Intersection in Union
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_NestedInUnion_Works(ExecutionMode mode)
     {
         var source = """
@@ -299,8 +284,7 @@ public class IntersectionTests
         Assert.Equal("1\ntest\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_NestedInUnion_MatchesSecondBranch(ExecutionMode mode)
     {
         var source = """
@@ -322,8 +306,7 @@ public class IntersectionTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_ClassWithInterface_Works(ExecutionMode mode)
     {
         var source = """
@@ -346,8 +329,7 @@ public class IntersectionTests
         Assert.Equal("Report\nContent here\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_TwoInterfaces_WithMethods(ExecutionMode mode)
     {
         var source = """
@@ -372,8 +354,7 @@ public class IntersectionTests
         Assert.Equal("Hello\nGoodbye\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_ArrayOfIntersection_Works(ExecutionMode mode)
     {
         var source = """
@@ -395,8 +376,7 @@ public class IntersectionTests
         Assert.Equal("Alice\n30\nBob\n25\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_ArrayOfIntersection_MissingProperty_TypeError(ExecutionMode mode)
     {
         var source = """
@@ -413,8 +393,7 @@ public class IntersectionTests
         Assert.Contains("Type Error", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_GenericConstraint_Works(ExecutionMode mode)
     {
         var source = """
@@ -433,8 +412,7 @@ public class IntersectionTests
         Assert.Equal("Alice\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_GenericConstraint_MissingProperty_TypeError(ExecutionMode mode)
     {
         var source = """
@@ -452,8 +430,7 @@ public class IntersectionTests
         Assert.Contains("Type Error", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_AsReturnType_Works(ExecutionMode mode)
     {
         var source = """
@@ -473,8 +450,7 @@ public class IntersectionTests
         Assert.Equal("Alice\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_WithOptionalProperties_Works(ExecutionMode mode)
     {
         var source = """
@@ -490,8 +466,7 @@ public class IntersectionTests
         Assert.Equal("1\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_WithOptionalProperties_AllProvided(ExecutionMode mode)
     {
         var source = """
@@ -508,8 +483,7 @@ public class IntersectionTests
         Assert.Equal("1\nhello\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_DeeplyNested_Works(ExecutionMode mode)
     {
         var source = """
@@ -531,8 +505,7 @@ public class IntersectionTests
         Assert.Equal("1\ntwo\ntrue\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_InUnionWithNull_Works(ExecutionMode mode)
     {
         // Test intersection type with null in union - requires null check before property access
@@ -551,8 +524,7 @@ public class IntersectionTests
         Assert.Equal("Alice\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_InUnionWithNull_NullValue(ExecutionMode mode)
     {
         var source = """
@@ -567,8 +539,7 @@ public class IntersectionTests
         Assert.Equal("null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_SamePropertySameType_Merges(ExecutionMode mode)
     {
         var source = """
@@ -585,8 +556,7 @@ public class IntersectionTests
         Assert.Equal("common\n1\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intersection_WithLiteralType_Works(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/IntlCollatorTests.cs
+++ b/SharpTS.Tests/SharedTests/IntlCollatorTests.cs
@@ -11,8 +11,7 @@ public class IntlCollatorTests
 {
     // ========== Basic Comparison ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlCollator_BasicCompare(ExecutionMode mode)
     {
         var source = @"
@@ -27,8 +26,7 @@ public class IntlCollatorTests
 
     // ========== Case Sensitivity ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlCollator_CaseInsensitive(ExecutionMode mode)
     {
         var source = @"
@@ -39,8 +37,7 @@ public class IntlCollatorTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlCollator_CaseSensitive(ExecutionMode mode)
     {
         var source = @"
@@ -54,8 +51,7 @@ public class IntlCollatorTests
 
     // ========== Accent Sensitivity ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlCollator_AccentInsensitive(ExecutionMode mode)
     {
         var source = @"
@@ -66,8 +62,7 @@ public class IntlCollatorTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlCollator_AccentSensitive(ExecutionMode mode)
     {
         var source = @"
@@ -81,8 +76,7 @@ public class IntlCollatorTests
 
     // ========== Resolved Options ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlCollator_ResolvedOptions(ExecutionMode mode)
     {
         var source = @"
@@ -97,8 +91,7 @@ public class IntlCollatorTests
 
     // ========== Sorting ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlCollator_SortArray(ExecutionMode mode)
     {
         var source = @"
@@ -113,8 +106,7 @@ public class IntlCollatorTests
 
     // ========== Default (No Arguments) ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlCollator_DefaultNoArgs(ExecutionMode mode)
     {
         var source = @"
@@ -128,8 +120,7 @@ public class IntlCollatorTests
 
     // ========== Ignore Punctuation ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlCollator_IgnorePunctuation(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/IntlDateTimeFormatTests.cs
+++ b/SharpTS.Tests/SharedTests/IntlDateTimeFormatTests.cs
@@ -12,8 +12,7 @@ public class IntlDateTimeFormatTests
 {
     // ========== Basic Date Formatting ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_DateStyleShort(ExecutionMode mode)
     {
         var source = @"
@@ -25,8 +24,7 @@ public class IntlDateTimeFormatTests
         Assert.Contains("1/15/2024", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_DateStyleLong(ExecutionMode mode)
     {
         var source = @"
@@ -42,8 +40,7 @@ public class IntlDateTimeFormatTests
 
     // ========== Time Formatting ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_TimeStyleShort(ExecutionMode mode)
     {
         var source = @"
@@ -56,8 +53,7 @@ public class IntlDateTimeFormatTests
         Assert.Contains("30", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_TimeStyleLong(ExecutionMode mode)
     {
         var source = @"
@@ -72,8 +68,7 @@ public class IntlDateTimeFormatTests
 
     // ========== Combined Date + Time ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_DateAndTimeStyle(ExecutionMode mode)
     {
         var source = @"
@@ -89,8 +84,7 @@ public class IntlDateTimeFormatTests
 
     // ========== Individual Component Options ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_YearMonthDay(ExecutionMode mode)
     {
         var source = @"
@@ -104,8 +98,7 @@ public class IntlDateTimeFormatTests
         Assert.Contains("15", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_TwoDigitYear(ExecutionMode mode)
     {
         var source = @"
@@ -121,8 +114,7 @@ public class IntlDateTimeFormatTests
 
     // ========== Weekday ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_WeekdayLong(ExecutionMode mode)
     {
         var source = @"
@@ -135,8 +127,7 @@ public class IntlDateTimeFormatTests
         Assert.Contains("Monday", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_WeekdayShort(ExecutionMode mode)
     {
         var source = @"
@@ -150,8 +141,7 @@ public class IntlDateTimeFormatTests
 
     // ========== Weekday Narrow (Bug Fix) ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_WeekdayNarrow(ExecutionMode mode)
     {
         var source = @"
@@ -166,8 +156,7 @@ public class IntlDateTimeFormatTests
 
     // ========== Month Narrow (Bug Fix) ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_MonthNarrow(ExecutionMode mode)
     {
         var source = @"
@@ -182,8 +171,7 @@ public class IntlDateTimeFormatTests
 
     // ========== dateStyle full/long differentiation ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_DateStyleFull_IncludesWeekday(ExecutionMode mode)
     {
         var source = @"
@@ -196,8 +184,7 @@ public class IntlDateTimeFormatTests
         Assert.Contains("January", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_DateStyleLong_NoWeekday(ExecutionMode mode)
     {
         var source = @"
@@ -213,8 +200,7 @@ public class IntlDateTimeFormatTests
 
     // ========== timeStyle medium/short differentiation ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_TimeStyleMedium_HasSeconds(ExecutionMode mode)
     {
         var source = @"
@@ -226,8 +212,7 @@ public class IntlDateTimeFormatTests
         Assert.Contains(":45", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_TimeStyleShort_NoSeconds(ExecutionMode mode)
     {
         var source = @"
@@ -242,8 +227,7 @@ public class IntlDateTimeFormatTests
 
     // ========== dateStyle medium ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_DateStyleMedium(ExecutionMode mode)
     {
         var source = @"
@@ -260,8 +244,7 @@ public class IntlDateTimeFormatTests
 
     // ========== Hour12 ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_Hour12(ExecutionMode mode)
     {
         var source = @"
@@ -277,8 +260,7 @@ public class IntlDateTimeFormatTests
 
     // ========== Resolved Options ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_ResolvedOptions(ExecutionMode mode)
     {
         var source = @"
@@ -291,8 +273,7 @@ public class IntlDateTimeFormatTests
         Assert.Equal("short\ngregory\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_ResolvedOptions_ReflectsCalendarAndNumbering(ExecutionMode mode)
     {
         var source = @"
@@ -308,8 +289,7 @@ public class IntlDateTimeFormatTests
 
     // ========== Default (No Arguments) ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_DefaultNoArgs(ExecutionMode mode)
     {
         var source = @"
@@ -324,8 +304,7 @@ public class IntlDateTimeFormatTests
 
     // ========== No-argument constructor ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_LocaleOnly(ExecutionMode mode)
     {
         var source = @"
@@ -340,8 +319,7 @@ public class IntlDateTimeFormatTests
 
     // ========== Month Short ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_MonthShort(ExecutionMode mode)
     {
         var source = @"
@@ -357,8 +335,7 @@ public class IntlDateTimeFormatTests
 
     // ========== formatToParts ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_FormatToParts_ReturnsArray(ExecutionMode mode)
     {
         var source = @"
@@ -387,8 +364,7 @@ public class IntlDateTimeFormatTests
     // commits 696bdbc and cfc667b document the original workarounds.
     // ========================================================================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_FormatToParts_HasTypeAndValue(ExecutionMode mode)
     {
         var source = @"
@@ -404,8 +380,7 @@ public class IntlDateTimeFormatTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_FormatToParts_ContainsLiterals(ExecutionMode mode)
     {
         var source = @"
@@ -421,8 +396,7 @@ public class IntlDateTimeFormatTests
 
     // ========== formatRange ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_FormatRange_SameDate(ExecutionMode mode)
     {
         var source = @"
@@ -436,8 +410,7 @@ public class IntlDateTimeFormatTests
         Assert.Equal("string\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_FormatRange_DifferentDates(ExecutionMode mode)
     {
         var source = @"
@@ -451,8 +424,7 @@ public class IntlDateTimeFormatTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_FormatRange_DifferentMonths(ExecutionMode mode)
     {
         var source = @"
@@ -469,8 +441,7 @@ public class IntlDateTimeFormatTests
 
     // ========== formatRangeToParts ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_FormatRangeToParts_HasSourceField(ExecutionMode mode)
     {
         var source = @"
@@ -487,8 +458,7 @@ public class IntlDateTimeFormatTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_FormatRangeToParts_SameDateIsShared(ExecutionMode mode)
     {
         var source = @"
@@ -504,8 +474,7 @@ public class IntlDateTimeFormatTests
 
     // ========== BCP 47 Extensions ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_HourCycleExtension_H23(ExecutionMode mode)
     {
         var source = @"
@@ -518,8 +487,7 @@ public class IntlDateTimeFormatTests
         Assert.Equal("h23\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_CalendarOption(ExecutionMode mode)
     {
         var source = @"
@@ -531,8 +499,7 @@ public class IntlDateTimeFormatTests
         Assert.Equal("buddhist\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_NumberingSystemOption(ExecutionMode mode)
     {
         var source = @"
@@ -546,8 +513,7 @@ public class IntlDateTimeFormatTests
 
     // ========== Timezone ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_TimeZoneUTC(ExecutionMode mode)
     {
         var source = @"
@@ -560,8 +526,7 @@ public class IntlDateTimeFormatTests
         Assert.Equal("string\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_TimeZoneNameLong_UTC(ExecutionMode mode)
     {
         var source = @"
@@ -574,8 +539,7 @@ public class IntlDateTimeFormatTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlDateTimeFormat_TimeZoneNameShort_UTC(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/IntlDisplayNamesTests.cs
+++ b/SharpTS.Tests/SharedTests/IntlDisplayNamesTests.cs
@@ -11,8 +11,7 @@ public class IntlDisplayNamesTests
 {
     // ========== Language Display Names ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DisplayNames_LanguageFrench(ExecutionMode mode)
     {
         var source = @"
@@ -23,8 +22,7 @@ public class IntlDisplayNamesTests
         Assert.Contains("French", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DisplayNames_LanguageEnglish(ExecutionMode mode)
     {
         var source = @"
@@ -37,8 +35,7 @@ public class IntlDisplayNamesTests
 
     // ========== Region Display Names ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DisplayNames_RegionUS(ExecutionMode mode)
     {
         var source = @"
@@ -49,8 +46,7 @@ public class IntlDisplayNamesTests
         Assert.Contains("United States", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DisplayNames_RegionGB(ExecutionMode mode)
     {
         var source = @"
@@ -63,8 +59,7 @@ public class IntlDisplayNamesTests
 
     // ========== Script Display Names ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DisplayNames_ScriptLatin(ExecutionMode mode)
     {
         var source = @"
@@ -77,8 +72,7 @@ public class IntlDisplayNamesTests
 
     // ========== Currency Display Names ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DisplayNames_CurrencyUSD(ExecutionMode mode)
     {
         var source = @"
@@ -89,8 +83,7 @@ public class IntlDisplayNamesTests
         Assert.Contains("Dollar", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DisplayNames_CurrencyEUR(ExecutionMode mode)
     {
         var source = @"
@@ -103,8 +96,7 @@ public class IntlDisplayNamesTests
 
     // ========== Calendar Display Names ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DisplayNames_CalendarGregory(ExecutionMode mode)
     {
         var source = @"
@@ -117,8 +109,7 @@ public class IntlDisplayNamesTests
 
     // ========== DateTimeField Display Names ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DisplayNames_DateTimeFieldYear(ExecutionMode mode)
     {
         var source = @"
@@ -131,8 +122,7 @@ public class IntlDisplayNamesTests
 
     // ========== Fallback Behavior ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DisplayNames_FallbackCode(ExecutionMode mode)
     {
         var source = @"
@@ -143,8 +133,7 @@ public class IntlDisplayNamesTests
         Assert.Equal("ZZZ\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DisplayNames_FallbackNone(ExecutionMode mode)
     {
         var source = @"
@@ -158,8 +147,7 @@ public class IntlDisplayNamesTests
 
     // ========== Resolved Options ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DisplayNames_ResolvedOptions(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/IntlListFormatTests.cs
+++ b/SharpTS.Tests/SharedTests/IntlListFormatTests.cs
@@ -11,8 +11,7 @@ public class IntlListFormatTests
 {
     // ========== Conjunction (default) ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlListFormat_ConjunctionThreeItems(ExecutionMode mode)
     {
         var source = @"
@@ -23,8 +22,7 @@ public class IntlListFormatTests
         Assert.Equal("Apple, Banana, and Cherry\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlListFormat_ConjunctionTwoItems(ExecutionMode mode)
     {
         var source = @"
@@ -35,8 +33,7 @@ public class IntlListFormatTests
         Assert.Equal("Alice and Bob\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlListFormat_ConjunctionOneItem(ExecutionMode mode)
     {
         var source = @"
@@ -47,8 +44,7 @@ public class IntlListFormatTests
         Assert.Equal("Solo\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlListFormat_ConjunctionEmpty(ExecutionMode mode)
     {
         var source = @"
@@ -61,8 +57,7 @@ public class IntlListFormatTests
 
     // ========== Disjunction ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlListFormat_DisjunctionThreeItems(ExecutionMode mode)
     {
         var source = @"
@@ -73,8 +68,7 @@ public class IntlListFormatTests
         Assert.Equal("Apple, Banana, or Cherry\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlListFormat_DisjunctionTwoItems(ExecutionMode mode)
     {
         var source = @"
@@ -87,8 +81,7 @@ public class IntlListFormatTests
 
     // ========== Unit ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlListFormat_UnitShort(ExecutionMode mode)
     {
         var source = @"
@@ -99,8 +92,7 @@ public class IntlListFormatTests
         Assert.Equal("6 hours, 30 minutes\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlListFormat_UnitNarrow(ExecutionMode mode)
     {
         var source = @"
@@ -113,8 +105,7 @@ public class IntlListFormatTests
 
     // ========== Resolved Options ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlListFormat_ResolvedOptions(ExecutionMode mode)
     {
         var source = @"
@@ -129,8 +120,7 @@ public class IntlListFormatTests
 
     // ========== Format To Parts ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlListFormat_FormatToParts(ExecutionMode mode)
     {
         var source = @"
@@ -146,8 +136,7 @@ public class IntlListFormatTests
         Assert.Contains("element:B", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlListFormat_FormatToPartsReturnsArray(ExecutionMode mode)
     {
         var source = @"
@@ -161,8 +150,7 @@ public class IntlListFormatTests
 
     // ========== Default (No Arguments) ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlListFormat_DefaultNoArgs(ExecutionMode mode)
     {
         var source = @"
@@ -176,8 +164,7 @@ public class IntlListFormatTests
 
     // ========== Four+ Items ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlListFormat_FourItems(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/IntlNumberFormatTests.cs
+++ b/SharpTS.Tests/SharedTests/IntlNumberFormatTests.cs
@@ -11,8 +11,7 @@ public class IntlNumberFormatTests
 {
     // ========== Basic Decimal Formatting ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlNumberFormat_BasicDecimal(ExecutionMode mode)
     {
         var source = @"
@@ -25,8 +24,7 @@ public class IntlNumberFormatTests
 
     // ========== Currency Formatting ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlNumberFormat_CurrencyUSD(ExecutionMode mode)
     {
         var source = @"
@@ -37,8 +35,7 @@ public class IntlNumberFormatTests
         Assert.Equal("$1,234.50\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlNumberFormat_CurrencyEUR(ExecutionMode mode)
     {
         var source = @"
@@ -52,8 +49,7 @@ public class IntlNumberFormatTests
 
     // ========== Percent Formatting ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlNumberFormat_Percent(ExecutionMode mode)
     {
         var source = @"
@@ -68,8 +64,7 @@ public class IntlNumberFormatTests
 
     // ========== Fraction Digits ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlNumberFormat_FractionDigits(ExecutionMode mode)
     {
         var source = @"
@@ -82,8 +77,7 @@ public class IntlNumberFormatTests
 
     // ========== No Grouping ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlNumberFormat_NoGrouping(ExecutionMode mode)
     {
         var source = @"
@@ -96,8 +90,7 @@ public class IntlNumberFormatTests
 
     // ========== Resolved Options ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlNumberFormat_ResolvedOptions(ExecutionMode mode)
     {
         var source = @"
@@ -112,8 +105,7 @@ public class IntlNumberFormatTests
 
     // ========== Minimum Integer Digits ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlNumberFormat_MinimumIntegerDigits(ExecutionMode mode)
     {
         var source = @"
@@ -126,8 +118,7 @@ public class IntlNumberFormatTests
 
     // ========== Default (No Arguments) ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlNumberFormat_DefaultNoArgs(ExecutionMode mode)
     {
         var source = @"
@@ -142,8 +133,7 @@ public class IntlNumberFormatTests
 
     // ========== Integer Formatting ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlNumberFormat_Integer(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/IntlPluralRulesTests.cs
+++ b/SharpTS.Tests/SharedTests/IntlPluralRulesTests.cs
@@ -11,8 +11,7 @@ public class IntlPluralRulesTests
 {
     // ========== English Cardinal ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlPluralRules_EnglishCardinal_One(ExecutionMode mode)
     {
         var source = @"
@@ -23,8 +22,7 @@ public class IntlPluralRulesTests
         Assert.Equal("one\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlPluralRules_EnglishCardinal_Other(ExecutionMode mode)
     {
         var source = @"
@@ -40,8 +38,7 @@ public class IntlPluralRulesTests
 
     // ========== English Ordinal ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlPluralRules_EnglishOrdinal(ExecutionMode mode)
     {
         var source = @"
@@ -59,8 +56,7 @@ public class IntlPluralRulesTests
 
     // ========== French Cardinal ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlPluralRules_FrenchCardinal(ExecutionMode mode)
     {
         var source = @"
@@ -76,8 +72,7 @@ public class IntlPluralRulesTests
 
     // ========== Arabic Cardinal ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlPluralRules_ArabicCardinal(ExecutionMode mode)
     {
         var source = @"
@@ -95,8 +90,7 @@ public class IntlPluralRulesTests
 
     // ========== Resolved Options ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlPluralRules_ResolvedOptions(ExecutionMode mode)
     {
         var source = @"
@@ -110,8 +104,7 @@ public class IntlPluralRulesTests
 
     // ========== Default (No Arguments) ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlPluralRules_DefaultNoArgs(ExecutionMode mode)
     {
         var source = @"
@@ -125,8 +118,7 @@ public class IntlPluralRulesTests
 
     // ========== Decimal Numbers ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlPluralRules_DecimalNumber(ExecutionMode mode)
     {
         var source = @"
@@ -140,8 +132,7 @@ public class IntlPluralRulesTests
 
     // ========== Suffix Helper ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlPluralRules_OrdinalSuffixHelper(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/IntlRelativeTimeFormatTests.cs
+++ b/SharpTS.Tests/SharedTests/IntlRelativeTimeFormatTests.cs
@@ -11,8 +11,7 @@ public class IntlRelativeTimeFormatTests
 {
     // ========== Past Formatting ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlRelativeTimeFormat_PastDays(ExecutionMode mode)
     {
         var source = @"
@@ -23,8 +22,7 @@ public class IntlRelativeTimeFormatTests
         Assert.Equal("3 days ago\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlRelativeTimeFormat_PastSingular(ExecutionMode mode)
     {
         var source = @"
@@ -37,8 +35,7 @@ public class IntlRelativeTimeFormatTests
 
     // ========== Future Formatting ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlRelativeTimeFormat_FutureHours(ExecutionMode mode)
     {
         var source = @"
@@ -49,8 +46,7 @@ public class IntlRelativeTimeFormatTests
         Assert.Equal("in 2 hours\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlRelativeTimeFormat_FutureMonths(ExecutionMode mode)
     {
         var source = @"
@@ -63,8 +59,7 @@ public class IntlRelativeTimeFormatTests
 
     // ========== Auto Numeric ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlRelativeTimeFormat_AutoYesterday(ExecutionMode mode)
     {
         var source = @"
@@ -75,8 +70,7 @@ public class IntlRelativeTimeFormatTests
         Assert.Equal("yesterday\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlRelativeTimeFormat_AutoTomorrow(ExecutionMode mode)
     {
         var source = @"
@@ -87,8 +81,7 @@ public class IntlRelativeTimeFormatTests
         Assert.Equal("tomorrow\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlRelativeTimeFormat_AutoLastYear(ExecutionMode mode)
     {
         var source = @"
@@ -99,8 +92,7 @@ public class IntlRelativeTimeFormatTests
         Assert.Equal("last year\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlRelativeTimeFormat_AutoNextMonth(ExecutionMode mode)
     {
         var source = @"
@@ -113,8 +105,7 @@ public class IntlRelativeTimeFormatTests
 
     // ========== Different Units ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlRelativeTimeFormat_VariousUnits(ExecutionMode mode)
     {
         var source = @"
@@ -129,8 +120,7 @@ public class IntlRelativeTimeFormatTests
 
     // ========== Resolved Options ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlRelativeTimeFormat_ResolvedOptions(ExecutionMode mode)
     {
         var source = @"
@@ -145,8 +135,7 @@ public class IntlRelativeTimeFormatTests
 
     // ========== Default (No Arguments) ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlRelativeTimeFormat_DefaultNoArgs(ExecutionMode mode)
     {
         var source = @"
@@ -160,8 +149,7 @@ public class IntlRelativeTimeFormatTests
 
     // ========== Plural Unit Names ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IntlRelativeTimeFormat_PluralUnitNames(ExecutionMode mode)
     {
         // Should accept both singular and plural unit names

--- a/SharpTS.Tests/SharedTests/IntlSegmenterTests.cs
+++ b/SharpTS.Tests/SharedTests/IntlSegmenterTests.cs
@@ -11,8 +11,7 @@ public class IntlSegmenterTests
 {
     // ========== Grapheme Segmentation ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Segmenter_GraphemeBasic(ExecutionMode mode)
     {
         var source = @"
@@ -26,8 +25,7 @@ public class IntlSegmenterTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Segmenter_GraphemeSpread(ExecutionMode mode)
     {
         var source = @"
@@ -39,8 +37,7 @@ public class IntlSegmenterTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Segmenter_GraphemeSegmentProperties(ExecutionMode mode)
     {
         var source = @"
@@ -57,8 +54,7 @@ public class IntlSegmenterTests
 
     // ========== Word Segmentation ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Segmenter_WordBasic(ExecutionMode mode)
     {
         var source = @"
@@ -70,8 +66,7 @@ public class IntlSegmenterTests
         Assert.Equal("3\n", output); // "Hello", " ", "World"
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Segmenter_WordIsWordLike(ExecutionMode mode)
     {
         var source = @"
@@ -87,8 +82,7 @@ public class IntlSegmenterTests
 
     // ========== Sentence Segmentation ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Segmenter_SentenceBasic(ExecutionMode mode)
     {
         var source = @"
@@ -103,8 +97,7 @@ public class IntlSegmenterTests
 
     // ========== Resolved Options ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Segmenter_ResolvedOptions(ExecutionMode mode)
     {
         var source = @"
@@ -116,8 +109,7 @@ public class IntlSegmenterTests
         Assert.Equal("word\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Segmenter_DefaultGranularity(ExecutionMode mode)
     {
         var source = @"
@@ -131,8 +123,7 @@ public class IntlSegmenterTests
 
     // ========== Segment Index Values ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Segmenter_SegmentIndex(ExecutionMode mode)
     {
         var source = @"
@@ -148,8 +139,7 @@ public class IntlSegmenterTests
 
     // ========== Containing Method ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Segmenter_ContainingBasic(ExecutionMode mode)
     {
         var source = @"
@@ -162,8 +152,7 @@ public class IntlSegmenterTests
         Assert.Equal("H\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Segmenter_ContainingMiddle(ExecutionMode mode)
     {
         var source = @"
@@ -178,8 +167,7 @@ public class IntlSegmenterTests
 
     // ========== Empty String ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Segmenter_EmptyString(ExecutionMode mode)
     {
         var source = @"
@@ -193,8 +181,7 @@ public class IntlSegmenterTests
 
     // ========== For-Of Iteration ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Segmenter_ForOf(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/IteratorHelpersTests.cs
+++ b/SharpTS.Tests/SharedTests/IteratorHelpersTests.cs
@@ -12,8 +12,7 @@ public class IteratorHelpersTests
 {
     #region map
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_Map_TransformsElements(ExecutionMode mode)
     {
         var source = @"
@@ -31,8 +30,7 @@ public class IteratorHelpersTests
 
     #region filter
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_Filter_SelectsMatchingElements(ExecutionMode mode)
     {
         var source = @"
@@ -49,8 +47,7 @@ public class IteratorHelpersTests
 
     #region take
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_Take_LimitsElements(ExecutionMode mode)
     {
         var source = @"
@@ -68,8 +65,7 @@ public class IteratorHelpersTests
 
     #region drop
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_Drop_SkipsElements(ExecutionMode mode)
     {
         var source = @"
@@ -87,8 +83,7 @@ public class IteratorHelpersTests
 
     #region flatMap
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_FlatMap_FlattensResults(ExecutionMode mode)
     {
         var source = @"
@@ -109,8 +104,7 @@ public class IteratorHelpersTests
 
     #region reduce
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_Reduce_WithInitialValue(ExecutionMode mode)
     {
         var source = @"
@@ -121,8 +115,7 @@ public class IteratorHelpersTests
         Assert.Equal("6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_Reduce_WithoutInitialValue(ExecutionMode mode)
     {
         var source = @"
@@ -137,8 +130,7 @@ public class IteratorHelpersTests
 
     #region forEach
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_ForEach_CallsForEachElement(ExecutionMode mode)
     {
         var source = @"
@@ -152,8 +144,7 @@ public class IteratorHelpersTests
 
     #region some
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_Some_TruthyCase(ExecutionMode mode)
     {
         var source = @"
@@ -164,8 +155,7 @@ public class IteratorHelpersTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_Some_FalsyCase(ExecutionMode mode)
     {
         var source = @"
@@ -180,8 +170,7 @@ public class IteratorHelpersTests
 
     #region every
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_Every_TruthyCase(ExecutionMode mode)
     {
         var source = @"
@@ -192,8 +181,7 @@ public class IteratorHelpersTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_Every_FalsyCase(ExecutionMode mode)
     {
         var source = @"
@@ -208,8 +196,7 @@ public class IteratorHelpersTests
 
     #region find
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_Find_FoundCase(ExecutionMode mode)
     {
         var source = @"
@@ -220,8 +207,7 @@ public class IteratorHelpersTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_Find_NotFoundCase(ExecutionMode mode)
     {
         var source = @"
@@ -237,8 +223,7 @@ public class IteratorHelpersTests
 
     #region toArray
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_ToArray_CollectsElements(ExecutionMode mode)
     {
         var source = @"
@@ -256,8 +241,7 @@ public class IteratorHelpersTests
 
     #region Chaining
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_Chaining_MapFilterTake(ExecutionMode mode)
     {
         var source = @"
@@ -280,8 +264,7 @@ public class IteratorHelpersTests
 
     #region Generator + iterator helpers
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_GeneratorWithTake_IsLazy(ExecutionMode mode)
     {
         // Both modes support lazy generators:
@@ -307,8 +290,7 @@ public class IteratorHelpersTests
         Assert.Equal("1\n2\n3\n4\n5\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_GeneratorMapFilter(ExecutionMode mode)
     {
         var source = @"
@@ -337,8 +319,7 @@ public class IteratorHelpersTests
 
     #region Map/Set iterators
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_MapKeys_WithHelpers(ExecutionMode mode)
     {
         var source = @"
@@ -357,8 +338,7 @@ public class IteratorHelpersTests
 
     #region Iterator.from
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_From_Array(ExecutionMode mode)
     {
         var source = @"
@@ -376,8 +356,7 @@ public class IteratorHelpersTests
 
     #region next() protocol
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_Next_ManualProtocol(ExecutionMode mode)
     {
         var source = @"
@@ -402,8 +381,7 @@ public class IteratorHelpersTests
 
     #region for...of on helper result
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_ForOf_OnMapResult(ExecutionMode mode)
     {
         var source = @"
@@ -415,8 +393,7 @@ public class IteratorHelpersTests
         Assert.Equal("11\n12\n13\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_ForOf_OnFilterResult(ExecutionMode mode)
     {
         var source = @"
@@ -432,8 +409,7 @@ public class IteratorHelpersTests
 
     #region drop + take combined
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Iterator_DropAndTake_SlicesBehavior(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/IteratorProtocolTests.cs
+++ b/SharpTS.Tests/SharedTests/IteratorProtocolTests.cs
@@ -12,8 +12,7 @@ public class IteratorProtocolTests
 {
     #region Sync Iterator Protocol (Symbol.iterator)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CustomIterator_BasicObject_IteratesValues(ExecutionMode mode)
     {
         var source = """
@@ -47,8 +46,7 @@ public class IteratorProtocolTests
         Assert.Equal("60\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CustomIterator_EmptyIterator_NoIterations(ExecutionMode mode)
     {
         var source = """
@@ -74,8 +72,7 @@ public class IteratorProtocolTests
         Assert.Equal("count: 0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CustomIterator_SingleValue_IteratesOnce(ExecutionMode mode)
     {
         var source = """
@@ -104,8 +101,7 @@ public class IteratorProtocolTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CustomIterator_WithBreak_StopsEarly(ExecutionMode mode)
     {
         var source = """
@@ -136,8 +132,7 @@ public class IteratorProtocolTests
         Assert.Equal("1\n2\n3\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CustomIterator_WithContinue_SkipsValues(ExecutionMode mode)
     {
         var source = """
@@ -167,8 +162,7 @@ public class IteratorProtocolTests
         Assert.Equal("1\n3\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CustomIterator_YieldingNull_Works(ExecutionMode mode)
     {
         var source = """
@@ -197,8 +191,7 @@ public class IteratorProtocolTests
         Assert.Equal("null\n42\nnull\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CustomIterator_MultipleIterations_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -237,8 +230,7 @@ public class IteratorProtocolTests
 
     #region Async Iterator Protocol (Symbol.asyncIterator)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CustomAsyncIterator_BasicObject_IteratesValues(ExecutionMode mode)
     {
         var source = """
@@ -276,8 +268,7 @@ public class IteratorProtocolTests
         Assert.Equal("600\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CustomAsyncIterator_EmptyIterator_NoIterations(ExecutionMode mode)
     {
         var source = """
@@ -307,8 +298,7 @@ public class IteratorProtocolTests
         Assert.Equal("count: 0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CustomAsyncIterator_WithBreak_StopsEarly(ExecutionMode mode)
     {
         var source = """
@@ -343,8 +333,7 @@ public class IteratorProtocolTests
         Assert.Equal("1\n2\n3\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CustomAsyncIterator_WithContinue_SkipsValues(ExecutionMode mode)
     {
         var source = """
@@ -382,8 +371,7 @@ public class IteratorProtocolTests
 
     #region Fallback to Built-in Iteration
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayWithoutSymbolIterator_StillIterates(ExecutionMode mode)
     {
         var source = """
@@ -399,8 +387,7 @@ public class IteratorProtocolTests
         Assert.Equal("6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PlainObject_UsesIndexBasedIteration(ExecutionMode mode)
     {
         var source = """
@@ -418,8 +405,7 @@ public class IteratorProtocolTests
 
     #region Spread with Custom Iterator
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadCustomIterator_InArrayLiteral_CollectsAllValues(ExecutionMode mode)
     {
         var source = """
@@ -455,8 +441,7 @@ public class IteratorProtocolTests
         Assert.Equal("5\n1\n10\n20\n30\n100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadEmptyIterator_InArrayLiteral_AddsNothing(ExecutionMode mode)
     {
         var source = """
@@ -481,8 +466,7 @@ public class IteratorProtocolTests
         Assert.Equal("2\n1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadCustomIterator_InFunctionCall_ExpandsArguments(ExecutionMode mode)
     {
         var source = """
@@ -520,8 +504,7 @@ public class IteratorProtocolTests
         Assert.Equal("161\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadGenerator_InArrayLiteral_CollectsAllValues(ExecutionMode mode)
     {
         var source = """
@@ -547,8 +530,7 @@ public class IteratorProtocolTests
 
     #region Yield* with Custom Iterator
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_CustomIterator_DelegatesAllValues(ExecutionMode mode)
     {
         var source = """
@@ -586,8 +568,7 @@ public class IteratorProtocolTests
         Assert.Equal("1\n10\n20\n30\n100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_EmptyIterator_YieldsNothing(ExecutionMode mode)
     {
         var source = """
@@ -617,8 +598,7 @@ public class IteratorProtocolTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_Generator_DelegatesAllValues(ExecutionMode mode)
     {
         var source = """
@@ -647,8 +627,7 @@ public class IteratorProtocolTests
 
     #region Generator Variable Capture
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_CapturesOuterVariable_ReadsCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -666,8 +645,7 @@ public class IteratorProtocolTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_CapturesOuterObject_AccessesProperty(ExecutionMode mode)
     {
         var source = """
@@ -685,8 +663,7 @@ public class IteratorProtocolTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_CapturesMultipleVariables_AllAccessible(ExecutionMode mode)
     {
         var source = """
@@ -710,8 +687,7 @@ public class IteratorProtocolTests
         Assert.Equal("60\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_CapturesVariable_UsedMultipleTimes(ExecutionMode mode)
     {
         var source = """
@@ -731,8 +707,7 @@ public class IteratorProtocolTests
         Assert.Equal("10\n20\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_CapturesArrayFromOuter_AccessesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -753,8 +728,7 @@ public class IteratorProtocolTests
         Assert.Equal("3\n10\n20\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_CapturesAndUsesParameter_BothWork(ExecutionMode mode)
     {
         var source = """
@@ -778,8 +752,7 @@ public class IteratorProtocolTests
 
     #region For...Of with Yield Inside Generators
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOfWithYield_BasicLoop_IteratesAllValues(ExecutionMode mode)
     {
         var source = """
@@ -798,8 +771,7 @@ public class IteratorProtocolTests
         Assert.Equal("2\n4\n6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOfWithYield_ParameterArray_IteratesAllValues(ExecutionMode mode)
     {
         var source = """
@@ -818,8 +790,7 @@ public class IteratorProtocolTests
         Assert.Equal("10\n20\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOfWithYield_CapturedArray_IteratesAllValues(ExecutionMode mode)
     {
         var source = """
@@ -839,8 +810,7 @@ public class IteratorProtocolTests
         Assert.Equal("5\n10\n15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOfWithYield_NestedLoops_IteratesAllCombinations(ExecutionMode mode)
     {
         var source = """
@@ -861,8 +831,7 @@ public class IteratorProtocolTests
         Assert.Equal("11\n21\n12\n22\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOfWithYield_MultipleLoops_IteratesAllSequentially(ExecutionMode mode)
     {
         var source = """
@@ -884,8 +853,7 @@ public class IteratorProtocolTests
         Assert.Equal("1\n2\n10\n20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOfWithYield_WithBreak_StopsEarly(ExecutionMode mode)
     {
         var source = """
@@ -906,8 +874,7 @@ public class IteratorProtocolTests
         Assert.Equal("1\n2\n3\n100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOfWithYield_WithContinue_SkipsValues(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/JSONProxyTests.cs
+++ b/SharpTS.Tests/SharedTests/JSONProxyTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class JSONProxyTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void JSON_Stringify_ProxyWithGetTrap(ExecutionMode mode)
     {
         var source = """
@@ -25,8 +24,7 @@ public class JSONProxyTests
         Assert.Equal("{\"a\":10,\"b\":20}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void JSON_Stringify_ProxyWithOwnKeysTrap(ExecutionMode mode)
     {
         var source = """
@@ -41,8 +39,7 @@ public class JSONProxyTests
         Assert.Equal("{\"a\":1,\"c\":3}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void JSON_Stringify_RevokedProxy_Throws(ExecutionMode mode)
     {
         var source = """
@@ -61,8 +58,7 @@ public class JSONProxyTests
         Assert.Equal("threw\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void Object_Keys_Proxy_DispatchesOwnKeysTrap(ExecutionMode mode)
     {
         var source = """
@@ -77,8 +73,7 @@ public class JSONProxyTests
         Assert.Equal("x,y\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void Object_GetOwnPropertyNames_Proxy_DispatchesOwnKeysTrap(ExecutionMode mode)
     {
         var source = """
@@ -93,8 +88,7 @@ public class JSONProxyTests
         Assert.Equal("p,q,r\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void Object_Keys_RevokedProxy_Throws(ExecutionMode mode)
     {
         var source = """
@@ -121,8 +115,7 @@ public class JSONProxyTests
     // OwnKeys / Get operations dispatch to the proxy's traps. The tests below
     // pin the spec-required behavior in both interpreter and compiled modes.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Parse_Reviver_ReceivesHolderAsThis(ExecutionMode mode)
     {
         // Reviver mutates `this` while walking — only possible if `this` is
@@ -148,8 +141,7 @@ public class JSONProxyTests
         Assert.Equal("99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Parse_Reviver_ArrayIndexKeyIsString(ExecutionMode mode)
     {
         // ECMA-262 step 2.b.iii.1: the reviver receives ToString(F(I)) for
@@ -169,8 +161,7 @@ public class JSONProxyTests
         Assert.Equal("string,string,string,\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Parse_Reviver_UndefinedRemovesObjectKey(ExecutionMode mode)
     {
         var source = """
@@ -185,8 +176,7 @@ public class JSONProxyTests
         Assert.Equal("{\"a\":1,\"c\":3}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void JSON_Parse_Reviver_DispatchesProxyTraps(ExecutionMode mode)
     {
         // Reviver inserts a Proxy as a sibling value; the walker continues
@@ -231,8 +221,7 @@ public class JSONProxyTests
         Assert.Contains("set:y=200;", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Parse_Reviver_WithNullValue(ExecutionMode mode)
     {
         // Pins the null-guard in the IL ApplyReviver: when the parsed value
@@ -250,8 +239,7 @@ public class JSONProxyTests
         Assert.Equal("was-null,2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void JSON_Parse_RevokedProxyDuringReviver_Throws(ExecutionMode mode)
     {
         // A revoked Proxy reached during the walk must throw. The trap

--- a/SharpTS.Tests/SharedTests/JSONTests.cs
+++ b/SharpTS.Tests/SharedTests/JSONTests.cs
@@ -10,8 +10,7 @@ public class JSONTests
 {
     #region JSON.parse basic tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Parse_Number(ExecutionMode mode)
     {
         var source = """
@@ -23,8 +22,7 @@ public class JSONTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Parse_String(ExecutionMode mode)
     {
         var source = """
@@ -36,8 +34,7 @@ public class JSONTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Parse_Boolean(ExecutionMode mode)
     {
         var source = """
@@ -49,8 +46,7 @@ public class JSONTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Parse_Null(ExecutionMode mode)
     {
         var source = """
@@ -62,8 +58,7 @@ public class JSONTests
         Assert.Equal("null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Parse_Object(ExecutionMode mode)
     {
         var source = """
@@ -76,8 +71,7 @@ public class JSONTests
         Assert.Equal("Alice\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Parse_Array(ExecutionMode mode)
     {
         var source = """
@@ -92,8 +86,7 @@ public class JSONTests
         Assert.Equal("3\n1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Parse_NestedObject(ExecutionMode mode)
     {
         var source = """
@@ -105,8 +98,7 @@ public class JSONTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Parse_WithReviver(ExecutionMode mode)
     {
         var source = """
@@ -128,8 +120,7 @@ public class JSONTests
 
     #region JSON.stringify basic tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_Number(ExecutionMode mode)
     {
         var source = """
@@ -141,8 +132,7 @@ public class JSONTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_String(ExecutionMode mode)
     {
         var source = """
@@ -154,8 +144,7 @@ public class JSONTests
         Assert.Equal("\"hello\"\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_Boolean(ExecutionMode mode)
     {
         var source = """
@@ -167,8 +156,7 @@ public class JSONTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_Null(ExecutionMode mode)
     {
         var source = """
@@ -180,8 +168,7 @@ public class JSONTests
         Assert.Equal("null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_Undefined_ReturnsUndefinedNotNull(ExecutionMode mode)
     {
         // ECMA-262 25.5.2.1 step 12: a top-level undefined makes
@@ -199,8 +186,7 @@ public class JSONTests
         Assert.Equal("undefined\nundefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_Function_ReturnsUndefined(ExecutionMode mode)
     {
         // ECMA-262 25.5.2.3 step 9: a top-level callable serializes to the JS
@@ -214,8 +200,7 @@ public class JSONTests
         Assert.Equal("undefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_Object(ExecutionMode mode)
     {
         var source = """
@@ -228,8 +213,7 @@ public class JSONTests
         Assert.Equal("{\"a\":1,\"b\":2}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_Array(ExecutionMode mode)
     {
         var source = """
@@ -242,8 +226,7 @@ public class JSONTests
         Assert.Equal("[1,2,3]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_WithIndent(ExecutionMode mode)
     {
         var source = """
@@ -256,8 +239,7 @@ public class JSONTests
         Assert.Equal("{\n  \"a\": 1\n}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_WithReplacerArray(ExecutionMode mode)
     {
         var source = """
@@ -270,8 +252,7 @@ public class JSONTests
         Assert.Equal("{\"a\":1,\"c\":3}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_EmptyObject(ExecutionMode mode)
     {
         var source = """
@@ -284,8 +265,7 @@ public class JSONTests
         Assert.Equal("{}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_EmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -298,8 +278,7 @@ public class JSONTests
         Assert.Equal("[]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Roundtrip(ExecutionMode mode)
     {
         var source = """
@@ -318,8 +297,7 @@ public class JSONTests
 
     #region Enhanced JSON.stringify tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_ClassInstance(ExecutionMode mode)
     {
         var source = """
@@ -340,8 +318,7 @@ public class JSONTests
         Assert.Equal("{\"name\":\"Bob\",\"age\":25}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_ClassInstance_ToJSON(ExecutionMode mode)
     {
         var source = """
@@ -363,8 +340,7 @@ public class JSONTests
         Assert.Equal("{\"custom\":50}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_ObjectWithToJSON(ExecutionMode mode)
     {
         var source = """
@@ -382,8 +358,7 @@ public class JSONTests
         Assert.Equal("\"custom\"\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void JSON_Stringify_ToJSON_ReceivesPropertyKey(ExecutionMode mode)
     {
         // ECMA-262 25.5.2.3 SerializeJSONProperty step 2.b.i: toJSON is invoked
@@ -404,8 +379,7 @@ public class JSONTests
         Assert.Equal("{\"a\":\"k=a\",\"b\":[\"i=0\",\"i=1\"]}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void JSON_Stringify_Replacer_ReceivesPropertyKey(ExecutionMode mode)
     {
         // ECMA-262 25.5.2.3 step 3.a: replacer is called with (key, value).
@@ -426,8 +400,7 @@ public class JSONTests
         Assert.Equal("|x|y|0|1\n{\"x\":1,\"y\":[10,20]}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_BigInt_Throws(ExecutionMode mode)
     {
         var source = """
@@ -443,8 +416,7 @@ public class JSONTests
         Assert.Equal("caught error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_StringIndent_Tab(ExecutionMode mode)
     {
         var source = """
@@ -457,8 +429,7 @@ public class JSONTests
         Assert.Equal("{\n\t\"a\": 1\n}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_StringIndent_Custom(ExecutionMode mode)
     {
         var source = """
@@ -471,8 +442,7 @@ public class JSONTests
         Assert.Equal("{\n>>>\"a\": 1\n}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_NestedClassInstance(ExecutionMode mode)
     {
         var source = """
@@ -497,8 +467,7 @@ public class JSONTests
         Assert.Equal("{\"inner\":{\"value\":42}}\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_ClassInstanceWithIndent(ExecutionMode mode)
     {
         var source = """
@@ -528,8 +497,7 @@ public class JSONTests
     // previously emitted the wrapper's __primitiveType/__primitiveValue marker fields; compiled
     // mode was already correct, so these run in both modes as a parity check.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_BoxedPrimitives_TopLevel(ExecutionMode mode)
     {
         var source = """
@@ -540,8 +508,7 @@ public class JSONTests
         Assert.Equal("5\n\"hi\"\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_BoxedPrimitives_AsObjectProperties(ExecutionMode mode)
     {
         var source = """
@@ -550,8 +517,7 @@ public class JSONTests
         Assert.Equal("{\"a\":5,\"b\":\"x\",\"c\":false}\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_BoxedPrimitives_AsArrayElements(ExecutionMode mode)
     {
         var source = """
@@ -560,8 +526,7 @@ public class JSONTests
         Assert.Equal("[1,\"y\",false]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_BoxedNumber_AsSpace_Indents(ExecutionMode mode)
     {
         // ECMA-262 25.5.2.1 step 5: a boxed Number `space` contributes its primitive value (2 → 2
@@ -572,8 +537,7 @@ public class JSONTests
         Assert.Equal("[\n  7\n]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_BoxedString_AsSpace_Indents(ExecutionMode mode)
     {
         // A boxed String `space` contributes its primitive value as the literal indent string.
@@ -583,8 +547,7 @@ public class JSONTests
         Assert.Equal("{\n--\"k\": 1\n}\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_PlainObjectWithPrimitiveValueField_NotUnwrapped(ExecutionMode mode)
     {
         // An ordinary object that merely has a __primitiveValue field (but no __primitiveType) is
@@ -596,8 +559,7 @@ public class JSONTests
         Assert.Equal("{\"__primitiveValue\":7}\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_PlainObjectWithPrimitiveValueField_WithSpace_NotUnwrapped(ExecutionMode mode)
     {
         // Same as above but exercises the StringifyFull code path (replacer/space present).
@@ -615,8 +577,7 @@ public class JSONTests
     // ToNumber/ToString, which go through OrdinaryToPrimitive and so honor a user-
     // overridden own valueOf/toString — not the raw [[PrimitiveValue]] slot.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_BoxedNumber_Value_HonorsValueOfOverride(ExecutionMode mode)
     {
         // value-number-object.js: a replacer returns a new Number whose own valueOf
@@ -636,8 +597,7 @@ public class JSONTests
         Assert.Equal("[2]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_BoxedString_Value_HonorsToStringOverride(ExecutionMode mode)
     {
         // value-string-object.js: a String wrapper with an own toString override
@@ -650,8 +610,7 @@ public class JSONTests
         Assert.Equal("\"OVERRIDE\"\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_BoxedNumber_Space_HonorsValueOfOverride(ExecutionMode mode)
     {
         // space-number-object.js: space = new Number(1) with valueOf → 3 indents by 3.
@@ -664,8 +623,7 @@ public class JSONTests
         Assert.Equal("{\n   \"k\": 1\n}\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_BoxedString_Space_HonorsToStringOverride(ExecutionMode mode)
     {
         // space-string-object.js: space = new String with toString override is the indent.
@@ -677,8 +635,7 @@ public class JSONTests
         Assert.Equal("{\n>>\"k\": 1\n}\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_ReplacerArray_BoxedNumber_UsesToString(ExecutionMode mode)
     {
         // replacer-array-number-object.js: a Number wrapper in the replacer array is a
@@ -693,8 +650,7 @@ public class JSONTests
         Assert.Equal("{\"toString\":2}\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_ReplacerArray_BoxedString_UsedAsKey(ExecutionMode mode)
     {
         // replacer-array-string-object.js: a String wrapper element selects that key.
@@ -705,8 +661,7 @@ public class JSONTests
         Assert.Equal("{\"z\":1}\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_ReplacerArray_PlainNumber_CoercedToKey(ExecutionMode mode)
     {
         // ECMA-262 25.5.2.1 step 4.b: a plain Number element coerces to its ToString key.
@@ -716,8 +671,7 @@ public class JSONTests
         Assert.Equal("{\"a\":1,\"2\":2,\"c\":3}\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JSON_Stringify_BoxedNumber_AbruptValueOf_Propagates(ExecutionMode mode)
     {
         // value-number-object.js abrupt case: a throwing valueOf/toString must propagate.

--- a/SharpTS.Tests/SharedTests/KeyOfIndexSignatureBuiltInTests.cs
+++ b/SharpTS.Tests/SharedTests/KeyOfIndexSignatureBuiltInTests.cs
@@ -16,8 +16,7 @@ public class KeyOfIndexSignatureBuiltInTests
 {
     // ----- keyof string -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_String_AcceptsPropertyName(ExecutionMode mode)
     {
         var source = """
@@ -27,8 +26,7 @@ public class KeyOfIndexSignatureBuiltInTests
         Assert.Equal("length\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_String_AcceptsMethodName(ExecutionMode mode)
     {
         var source = """
@@ -38,8 +36,7 @@ public class KeyOfIndexSignatureBuiltInTests
         Assert.Equal("charAt\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_String_AcceptsNumberIndex(ExecutionMode mode)
     {
         // string carries a numeric index signature, so `number` is a valid key.
@@ -50,8 +47,7 @@ public class KeyOfIndexSignatureBuiltInTests
         Assert.Equal("5\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_String_RejectsNonMember(ExecutionMode mode)
     {
         var source = """
@@ -62,8 +58,7 @@ public class KeyOfIndexSignatureBuiltInTests
 
     // ----- keyof T[] -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_Array_AcceptsMethodName(ExecutionMode mode)
     {
         var source = """
@@ -73,8 +68,7 @@ public class KeyOfIndexSignatureBuiltInTests
         Assert.Equal("push\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_Array_AcceptsLengthAndNumberIndex(ExecutionMode mode)
     {
         var source = """
@@ -85,8 +79,7 @@ public class KeyOfIndexSignatureBuiltInTests
         Assert.Equal("length 0\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_Array_RejectsNonMember(ExecutionMode mode)
     {
         var source = """
@@ -97,8 +90,7 @@ public class KeyOfIndexSignatureBuiltInTests
 
     // ----- keyof [tuple] -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_Tuple_AcceptsLiteralIndex(ExecutionMode mode)
     {
         // A tuple is an Array subtype: keyof includes the literal element indices "0" | "1".
@@ -109,8 +101,7 @@ public class KeyOfIndexSignatureBuiltInTests
         Assert.Equal("1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_Tuple_AcceptsArrayMemberAndNumberIndex(ExecutionMode mode)
     {
         var source = """
@@ -121,8 +112,7 @@ public class KeyOfIndexSignatureBuiltInTests
         Assert.Equal("length 0\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_Tuple_RejectsOutOfRangeLiteralIndex(ExecutionMode mode)
     {
         // [a, b] has indices "0" and "1" only; "2" is not a literal key (and "2" is a string, so the
@@ -135,8 +125,7 @@ public class KeyOfIndexSignatureBuiltInTests
 
     // ----- keyof feeding a mapped type over an index-signature built-in -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MappedType_OverKeyOfArray_TypeChecks(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/KeyOfTypeOfTests.cs
+++ b/SharpTS.Tests/SharedTests/KeyOfTypeOfTests.cs
@@ -12,8 +12,7 @@ public class KeyOfTypeOfTests
 {
     #region keyof Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_InterfaceExtractsKeysAsUnion(ExecutionMode mode)
     {
         var source = """
@@ -26,8 +25,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("name\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_InterfaceAgeKey(ExecutionMode mode)
     {
         var source = """
@@ -40,8 +38,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("age\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_WithTypeAlias(ExecutionMode mode)
     {
         var source = """
@@ -54,8 +51,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("host\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_InvalidKeyAssignment_Throws(ExecutionMode mode)
     {
         var source = """
@@ -67,8 +63,7 @@ public class KeyOfTypeOfTests
         Assert.Contains("Type Error", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_InlineObjectType(ExecutionMode mode)
     {
         var source = """
@@ -80,8 +75,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("x\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_EmptyInterface_NeverType(ExecutionMode mode)
     {
         // keyof {} should be never, so no value can be assigned
@@ -95,8 +89,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("ok\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_WithOptionalProperties(ExecutionMode mode)
     {
         var source = """
@@ -115,8 +108,7 @@ public class KeyOfTypeOfTests
 
     #region typeof Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_SimpleVariable(ExecutionMode mode)
     {
         var source = """
@@ -129,8 +121,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_NumberVariable(ExecutionMode mode)
     {
         var source = """
@@ -143,8 +134,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_ObjectVariable(ExecutionMode mode)
     {
         var source = """
@@ -158,8 +148,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("example.com\n443\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_Function(ExecutionMode mode)
     {
         var source = """
@@ -174,8 +163,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("Hi, World\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_PropertyAccess(ExecutionMode mode)
     {
         var source = """
@@ -188,8 +176,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_NestedProperty(ExecutionMode mode)
     {
         var source = """
@@ -202,8 +189,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("Bob\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_ArrayElement(ExecutionMode mode)
     {
         var source = """
@@ -216,8 +202,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_TupleElement(ExecutionMode mode)
     {
         var source = """
@@ -233,8 +218,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("world\n100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_ObjectIndexAccess(ExecutionMode mode)
     {
         var source = """
@@ -247,8 +231,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("another value\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_UndefinedVariable_Throws(ExecutionMode mode)
     {
         // Type aliases are lazily evaluated, so we need to use T to trigger the error
@@ -260,8 +243,7 @@ public class KeyOfTypeOfTests
         Assert.Contains("undefinedVar", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_ClassInstance(ExecutionMode mode)
     {
         var source = """
@@ -286,8 +268,7 @@ public class KeyOfTypeOfTests
 
     #region keyof typeof Combined Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOfTypeOf_ObjectLiteral(ExecutionMode mode)
     {
         var source = """
@@ -300,8 +281,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("host\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOfTypeOf_AllKeys(ExecutionMode mode)
     {
         var source = """
@@ -316,8 +296,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("theme\nfontSize\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOfTypeOf_InvalidKey_Throws(ExecutionMode mode)
     {
         var source = """
@@ -329,8 +308,7 @@ public class KeyOfTypeOfTests
         Assert.Contains("Type Error", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOfTypeOf_NestedObject(ExecutionMode mode)
     {
         var source = """
@@ -347,8 +325,7 @@ public class KeyOfTypeOfTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_WithArrayMethods(ExecutionMode mode)
     {
         var source = """
@@ -361,8 +338,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_WithIndexSignature(ExecutionMode mode)
     {
         var source = """
@@ -375,8 +351,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("ok\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_MultipleLevelDeepAccess(ExecutionMode mode)
     {
         var source = """
@@ -389,8 +364,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void KeyOf_Interface_UseInFunction(ExecutionMode mode)
     {
         var source = """
@@ -415,8 +389,7 @@ public class KeyOfTypeOfTests
 
     #region Runtime typeof on Undeclared Variables
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_UndeclaredVariable_ReturnsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -426,8 +399,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("undefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_UndeclaredVariable_InComparison(ExecutionMode mode)
     {
         var source = """
@@ -441,8 +413,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("not defined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_DeclaredVariable_StillWorks(ExecutionMode mode)
     {
         var source = """
@@ -461,8 +432,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("number\nstring\nboolean\nundefined\nobject\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_UndeclaredVariable_MultipleChecks(ExecutionMode mode)
     {
         var source = """
@@ -482,8 +452,7 @@ public class KeyOfTypeOfTests
     // `typeof a & typeof b`) handed the whole "a & typeof b" string to the custom typeof-path
     // parser, which spun forever on the first '&'/'|'. These exercise both composites end to end.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_IntersectionOfTwoTypeOf(ExecutionMode mode)
     {
         var source = """
@@ -498,8 +467,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_UnionWithNull(ExecutionMode mode)
     {
         // Resolving `typeof a | null` to a real union (rather than hanging) means null is a genuine
@@ -516,8 +484,7 @@ public class KeyOfTypeOfTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypeOf_IntersectionEnforcesBothMembers(ExecutionMode mode)
     {
         // The intersection must require members from BOTH operands — a value missing `y` is invalid.

--- a/SharpTS.Tests/SharedTests/LabeledForAwaitTests.cs
+++ b/SharpTS.Tests/SharedTests/LabeledForAwaitTests.cs
@@ -18,8 +18,7 @@ public class LabeledForAwaitTests
 {
     private const string Gen = "async function* g() { yield 1; yield 2; yield 3; yield 4; }\n";
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledForAwait_ContinueOuter(ExecutionMode mode)
     {
         // The exact #728 repro.
@@ -38,8 +37,7 @@ public class LabeledForAwaitTests
         Assert.Equal("8\n", TestHarness.Run(source, mode));  // 1 + 3 + 4 (2 skipped)
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledForAwait_BreakOuter(ExecutionMode mode)
     {
         var source = Gen + """
@@ -57,8 +55,7 @@ public class LabeledForAwaitTests
         Assert.Equal("3\n", TestHarness.Run(source, mode));  // 1 + 2, then break at 3
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledForAwait_ContinueOuterFromInnerLoop(ExecutionMode mode)
     {
         // `continue outer` from a regular loop nested in the for-await body resumes the for-await.
@@ -79,8 +76,7 @@ public class LabeledForAwaitTests
         Assert.Equal("1:0,2:0,3:0,4:0,\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForAwaitAsInnerLoop_BreakToOuterFor(ExecutionMode mode)
     {
         // A for-await nested inside a labeled regular `for`; `break outer` from inside the for-await.

--- a/SharpTS.Tests/SharedTests/LabeledStatementTests.cs
+++ b/SharpTS.Tests/SharedTests/LabeledStatementTests.cs
@@ -11,8 +11,7 @@ public class LabeledStatementTests
 {
     #region Basic Labeled Loop Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledWhile_Break_ExitsLoop(ExecutionMode mode)
     {
         var source = """
@@ -30,8 +29,7 @@ public class LabeledStatementTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledWhile_Continue_RestartsLoop(ExecutionMode mode)
     {
         var source = """
@@ -51,8 +49,7 @@ public class LabeledStatementTests
         Assert.Equal("12\n", output);  // 1 + 2 + 4 + 5 = 12 (skips 3)
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledForOf_Break_ExitsLoop(ExecutionMode mode)
     {
         var source = """
@@ -69,8 +66,7 @@ public class LabeledStatementTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledDoWhile_Break_ExitsLoop(ExecutionMode mode)
     {
         var source = """
@@ -93,8 +89,7 @@ public class LabeledStatementTests
 
     #region Nested Loop Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedLoops_BreakOuter_ExitsBoth(ExecutionMode mode)
     {
         var source = """
@@ -112,8 +107,7 @@ public class LabeledStatementTests
         Assert.Equal("inner\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedLoops_ContinueOuter_SkipsInner(ExecutionMode mode)
     {
         var source = """
@@ -135,8 +129,7 @@ public class LabeledStatementTests
         Assert.Equal("1\n1\n1\n", output);  // Only prints 1 from inner loop each time
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedLoops_BreakInner_OnlyExitsInner(ExecutionMode mode)
     {
         var source = """
@@ -158,8 +151,7 @@ public class LabeledStatementTests
         Assert.Equal("1\n2\n1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThreeLevelNesting_BreakMiddle(ExecutionMode mode)
     {
         var source = """
@@ -191,8 +183,7 @@ public class LabeledStatementTests
     // non-loop label and escaped). These pin the correct behavior: continue runs the loop's own
     // step. Note the pre-existing suite only exercised labeled while/for-of/do-while continue.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledFor_ContinueOuter_RunsIncrementNotInitializer(ExecutionMode mode)
     {
         // The exact #558 repro: continue to the outer `for` must advance i (not reset it).
@@ -212,8 +203,7 @@ public class LabeledStatementTests
         Assert.Equal("0,10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledFor_ContinueSelf_SkipsIteration(ExecutionMode mode)
     {
         var source = """
@@ -229,8 +219,7 @@ public class LabeledStatementTests
         Assert.Equal("013\n", output);  // skips 2, but keeps advancing
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledFor_BreakOuter_ExitsBoth(ExecutionMode mode)
     {
         var source = """
@@ -248,8 +237,7 @@ public class LabeledStatementTests
         Assert.Equal("13\n", output);  // 0+1+2 (i=0) + 10 (i=1,j=0), then break
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledForOf_ContinueOuter_SkipsRestOfInner(ExecutionMode mode)
     {
         var source = """
@@ -267,8 +255,7 @@ public class LabeledStatementTests
         Assert.Equal("11;12;13;\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledForIn_ContinueOuter_SkipsRestOfInner(ExecutionMode mode)
     {
         var source = """
@@ -287,8 +274,7 @@ public class LabeledStatementTests
         Assert.Equal("aa;ba;\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledDoWhile_ContinueOuter_RetestsCondition(ExecutionMode mode)
     {
         var source = """
@@ -310,8 +296,7 @@ public class LabeledStatementTests
         Assert.Equal("11;21;31;\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_LabeledContinueOuterFor_YieldsAcrossIterations(ExecutionMode mode)
     {
         // #558 generator repro: the yield suspends inside the inner loop; continue outer must
@@ -335,8 +320,7 @@ public class LabeledStatementTests
         Assert.Equal("0;10;\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ChainedLabels_While_ContinueOuter(ExecutionMode mode)
     {
         // Both labels wrap the same while; `continue a` re-tests the outer condition.
@@ -359,8 +343,7 @@ public class LabeledStatementTests
         Assert.Equal("63\n", output);  // 11 + 21 + 31
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ChainedLabels_For_ContinueOuter(ExecutionMode mode)
     {
         // A chain of labels on a `for` (p: q: for) — `continue p` to the OUTER label of the chain
@@ -382,8 +365,7 @@ public class LabeledStatementTests
         Assert.Equal("30\n", output);  // 0 + 10 + 20
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Async_ChainedLabels_For_ContinueOuter(ExecutionMode mode)
     {
         // #704 repro: a chain of labels on a `for` inside an async function — `continue p` (the OUTER
@@ -407,8 +389,7 @@ public class LabeledStatementTests
         Assert.Equal("30\n", TestHarness.Run(source, mode));  // 0 + 10 + 20
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ChainedLabels_For_ContinueInner(ExecutionMode mode)
     {
         // `continue q` to the INNER label of the chain targets the same for — same result as the
@@ -428,8 +409,7 @@ public class LabeledStatementTests
         Assert.Equal("30\n", output);  // 0 + 10 + 20
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Async_ChainedLabels_For_BreakOuter(ExecutionMode mode)
     {
         // `break a` to the outer label of a chain inside an async function must exit the outer for.
@@ -450,8 +430,7 @@ public class LabeledStatementTests
         Assert.Equal("4\n", TestHarness.Run(source, mode));  // x=0: 3 iters; x=1: 1 iter then break
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ChainedLabels_For_BreakOuter(ExecutionMode mode)
     {
         // `break a` to the outer label of a chain on a `for` exits the loop entirely.
@@ -470,8 +449,7 @@ public class LabeledStatementTests
         Assert.Equal("00;01;02;10;\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Async_ChainedLabels_While_ContinueOuter(ExecutionMode mode)
     {
         // Chained labels on a `while` inside an async function — `continue a` re-tests the outer
@@ -497,8 +475,7 @@ public class LabeledStatementTests
         Assert.Equal("63\n", TestHarness.Run(source, mode));  // 11 + 21 + 31
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ChainedLabels_For_TripleChain_ContinueOutermost(ExecutionMode mode)
     {
         // Three labels on one `for`; `continue a` to the outermost resolves to the loop's increment.
@@ -517,8 +494,7 @@ public class LabeledStatementTests
         Assert.Equal("30\n", output);  // 0 + 10 + 20
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Async_ChainedLabels_ForOf_ContinueOuter(ExecutionMode mode)
     {
         // Chained labels on a (synchronous) `for…of` inside an async function — `continue p` must
@@ -540,8 +516,7 @@ public class LabeledStatementTests
         Assert.Equal("30\n", TestHarness.Run(source, mode));  // 0 + 10 + 20
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ChainedLabels_ForOf_ContinueOuter(ExecutionMode mode)
     {
         // A chain on a `for-of`; `continue m` to the outer label advances the outer iterator.
@@ -564,8 +539,7 @@ public class LabeledStatementTests
 
     #region Labeled Block Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledBlock_Break_ExitsBlock(ExecutionMode mode)
     {
         var source = """
@@ -582,8 +556,7 @@ public class LabeledStatementTests
         Assert.Equal("before\nin block\nafter\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledBlock_Nested_BreakOuter(ExecutionMode mode)
     {
         var source = """
@@ -603,8 +576,7 @@ public class LabeledStatementTests
         Assert.Equal("outer start\ninner start\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledBlock_InLoop_BreakBlockNotLoop(ExecutionMode mode)
     {
         var source = """
@@ -628,8 +600,7 @@ public class LabeledStatementTests
 
     #region Switch Nesting Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SwitchInLoop_BreakLabel_ExitsLoop(ExecutionMode mode)
     {
         var source = """
@@ -649,8 +620,7 @@ public class LabeledStatementTests
         Assert.Equal("case 1\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SwitchInLoop_UnlabeledBreak_ExitsSwitch(ExecutionMode mode)
     {
         var source = """
@@ -673,8 +643,7 @@ public class LabeledStatementTests
         Assert.Equal("case 1\nafter switch\ncase 2\nafter switch\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SwitchInLoop_ContinueLabel_ContinuesLoop(ExecutionMode mode)
     {
         var source = """
@@ -697,8 +666,7 @@ public class LabeledStatementTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabeledEmptyStatement_Allowed(ExecutionMode mode)
     {
         var source = """
@@ -711,8 +679,7 @@ public class LabeledStatementTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultipleLabels_DifferentStatements(ExecutionMode mode)
     {
         var source = """
@@ -736,8 +703,7 @@ public class LabeledStatementTests
 
     #region Error Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Break_NonexistentLabel_ThrowsError(ExecutionMode mode)
     {
         var source = """
@@ -750,8 +716,7 @@ public class LabeledStatementTests
         Assert.Contains("Label 'missing' not found", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Continue_NonexistentLabel_ThrowsError(ExecutionMode mode)
     {
         var source = """
@@ -764,8 +729,7 @@ public class LabeledStatementTests
         Assert.Contains("Label 'missing' not found", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Continue_ToNonLoopLabel_ThrowsError(ExecutionMode mode)
     {
         var source = """
@@ -778,8 +742,7 @@ public class LabeledStatementTests
         Assert.Contains("Cannot continue to non-loop label", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LabelShadowing_ThrowsError(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/LexicalForwardReferenceTests.cs
+++ b/SharpTS.Tests/SharedTests/LexicalForwardReferenceTests.cs
@@ -16,8 +16,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class LexicalForwardReferenceTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionDeclaration_ReferencesLaterLet(ExecutionMode mode)
     {
         var source = """
@@ -29,8 +28,7 @@ public class LexicalForwardReferenceTests
         Assert.Equal("1", TestHarness.Run(source, mode).Trim());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionDeclaration_ReferencesLaterConst(ExecutionMode mode)
     {
         var source = """
@@ -42,8 +40,7 @@ public class LexicalForwardReferenceTests
         Assert.Equal("5", TestHarness.Run(source, mode).Trim());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_ReferencesLaterLet(ExecutionMode mode)
     {
         // The exact second repro from the issue (a generator declared before its let binding).
@@ -56,8 +53,7 @@ public class LexicalForwardReferenceTests
         Assert.Equal("1,2", TestHarness.Run(source, mode).Trim());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowConst_ReferencesLaterLet(ExecutionMode mode)
     {
         var source = """
@@ -69,8 +65,7 @@ public class LexicalForwardReferenceTests
         Assert.Equal("42", TestHarness.Run(source, mode).Trim());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AnnotatedLet_ForwardReferenced_TypeChecks(ExecutionMode mode)
     {
         var source = """
@@ -82,8 +77,7 @@ public class LexicalForwardReferenceTests
         Assert.Equal("hi", TestHarness.Run(source, mode).Trim());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InnerFunction_ReferencesLaterLet_InEnclosingBody(ExecutionMode mode)
     {
         // The forward binding lives in the enclosing FUNCTION body, not module scope.
@@ -99,8 +93,7 @@ public class LexicalForwardReferenceTests
         Assert.Equal("99", TestHarness.Run(source, mode).Trim());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ShadowingConst_BindsToInnerDeclaration(ExecutionMode mode)
     {
         // The inner `const x` shadows the outer one throughout `wrapper`, including in f's closure.
@@ -122,8 +115,7 @@ public class LexicalForwardReferenceTests
         Assert.Equal("shadow", TestHarness.Run(source, mode).Trim());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ShadowingConst_DoesNotClobberOuterModuleBinding(ExecutionMode mode)
     {
         // The companion to #562: the function-local shadow must not write through to the module
@@ -141,8 +133,7 @@ public class LexicalForwardReferenceTests
         Assert.Equal("inner outer", TestHarness.Run(source, mode).Trim());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MutualRecursion_ViaConstArrows_StillWorks(ExecutionMode mode)
     {
         // Guards that hoisting let/const as `any` does not clobber the precise function type that
@@ -157,8 +148,7 @@ public class LexicalForwardReferenceTests
         Assert.Equal("true true", TestHarness.Run(source, mode).Trim());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceMemberFunction_ReferencesLaterConst(ExecutionMode mode)
     {
         // A namespace member function declared before a namespace-level const type-checks the same way

--- a/SharpTS.Tests/SharedTests/LiteralAfterPrimitiveTests.cs
+++ b/SharpTS.Tests/SharedTests/LiteralAfterPrimitiveTests.cs
@@ -20,8 +20,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </remarks>
 public class LiteralAfterPrimitiveTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EmptyObject_AfterNumericConst_IsObject(ExecutionMode mode)
     {
         var source = @"
@@ -36,8 +35,7 @@ public class LiteralAfterPrimitiveTests
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EmptyObject_AfterBooleanConst_IsObject(ExecutionMode mode)
     {
         // Parallel check for the Boolean arm of the stack-type tracker.
@@ -53,8 +51,7 @@ public class LiteralAfterPrimitiveTests
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EmptyArray_AfterNumericConst_IsArray(ExecutionMode mode)
     {
         var source = @"
@@ -69,8 +66,7 @@ public class LiteralAfterPrimitiveTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EmptyObject_AfterLetNumber_IsObject(ExecutionMode mode)
     {
         // `let i = 0;` is the pattern that surfaced this in util.parseArgs —
@@ -90,8 +86,7 @@ public class LiteralAfterPrimitiveTests
         Assert.Equal("object\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EmptyObject_UsedAsMapAfterLoop_BehavesAsDictionary(ExecutionMode mode)
     {
         var source = @"
@@ -112,8 +107,7 @@ public class LiteralAfterPrimitiveTests
         Assert.Equal("3\n1\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonEmptyObject_AfterNumericConst_StillWorks(ExecutionMode mode)
     {
         // Baseline — non-empty literals already worked; make sure we didn't break them.

--- a/SharpTS.Tests/SharedTests/LogicalAssignmentTests.cs
+++ b/SharpTS.Tests/SharedTests/LogicalAssignmentTests.cs
@@ -10,8 +10,7 @@ public class LogicalAssignmentTests
 {
     #region &&= Operator
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AndAssign_TruthyValue_AssignsNewValue(ExecutionMode mode)
     {
         var source = """
@@ -24,8 +23,7 @@ public class LogicalAssignmentTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AndAssign_FalsyValue_KeepsOriginal(ExecutionMode mode)
     {
         var source = """
@@ -38,8 +36,7 @@ public class LogicalAssignmentTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AndAssign_NullValue_KeepsNull(ExecutionMode mode)
     {
         var source = """
@@ -52,8 +49,7 @@ public class LogicalAssignmentTests
         Assert.Equal("null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AndAssign_ShortCircuit_DoesNotEvaluateRight(ExecutionMode mode)
     {
         var source = """
@@ -73,8 +69,7 @@ public class LogicalAssignmentTests
 
     #region ||= Operator
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OrAssign_FalsyValue_AssignsNewValue(ExecutionMode mode)
     {
         var source = """
@@ -87,8 +82,7 @@ public class LogicalAssignmentTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OrAssign_TruthyValue_KeepsOriginal(ExecutionMode mode)
     {
         var source = """
@@ -101,8 +95,7 @@ public class LogicalAssignmentTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OrAssign_NullValue_AssignsNewValue(ExecutionMode mode)
     {
         var source = """
@@ -115,8 +108,7 @@ public class LogicalAssignmentTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OrAssign_ShortCircuit_DoesNotEvaluateRight(ExecutionMode mode)
     {
         var source = """
@@ -136,8 +128,7 @@ public class LogicalAssignmentTests
 
     #region ??= Operator
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullishAssign_NullValue_AssignsNewValue(ExecutionMode mode)
     {
         var source = """
@@ -150,8 +141,7 @@ public class LogicalAssignmentTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullishAssign_UndefinedValue_AssignsNewValue(ExecutionMode mode)
     {
         var source = """
@@ -164,8 +154,7 @@ public class LogicalAssignmentTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullishAssign_ZeroValue_KeepsOriginal(ExecutionMode mode)
     {
         var source = """
@@ -178,8 +167,7 @@ public class LogicalAssignmentTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullishAssign_EmptyString_KeepsOriginal(ExecutionMode mode)
     {
         var source = """
@@ -192,8 +180,7 @@ public class LogicalAssignmentTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullishAssign_ShortCircuit_DoesNotEvaluateRight(ExecutionMode mode)
     {
         var source = """
@@ -213,8 +200,7 @@ public class LogicalAssignmentTests
 
     #region Object Property Access
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AndAssign_ObjectProperty_Works(ExecutionMode mode)
     {
         var source = """
@@ -227,8 +213,7 @@ public class LogicalAssignmentTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OrAssign_ObjectProperty_Works(ExecutionMode mode)
     {
         var source = """
@@ -241,8 +226,7 @@ public class LogicalAssignmentTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullishAssign_ObjectProperty_Works(ExecutionMode mode)
     {
         var source = """
@@ -259,8 +243,7 @@ public class LogicalAssignmentTests
 
     #region Array Index Access
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AndAssign_ArrayIndex_Works(ExecutionMode mode)
     {
         var source = """
@@ -273,8 +256,7 @@ public class LogicalAssignmentTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OrAssign_ArrayIndex_Works(ExecutionMode mode)
     {
         var source = """
@@ -287,8 +269,7 @@ public class LogicalAssignmentTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullishAssign_ArrayIndex_Works(ExecutionMode mode)
     {
         var source = """
@@ -305,8 +286,7 @@ public class LogicalAssignmentTests
 
     #region Return Value
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LogicalAssign_ReturnsResultValue(ExecutionMode mode)
     {
         var source = """
@@ -319,8 +299,7 @@ public class LogicalAssignmentTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LogicalAssign_ReturnsOriginalWhenNotAssigned(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/LoopBodyBlockScopeCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/LoopBodyBlockScopeCaptureTests.cs
@@ -33,8 +33,7 @@ public class LoopBodyBlockScopeCaptureTests
 {
     // ---- Headline #1223 shape: body const captured inside an arrow ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowBody_ForLoopBodyConst_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -51,8 +50,7 @@ public class LoopBodyBlockScopeCaptureTests
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionBody_ForLoopBodyConst_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -73,8 +71,7 @@ public class LoopBodyBlockScopeCaptureTests
     // The closure captures BOTH a module-level mutable counter (stays on the entry-point DC)
     // and the per-iteration body const; each handler must destroy ITS OWN object.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MixedCapture_ModuleCounterPlusBodyConst_DestroysOwnObject(ExecutionMode mode)
     {
         var source = """
@@ -97,8 +94,7 @@ public class LoopBodyBlockScopeCaptureTests
 
     // ---- Other loop kinds ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WhileLoopBodyConst_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -117,8 +113,7 @@ public class LoopBodyBlockScopeCaptureTests
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DoWhileLoopBodyConst_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -137,8 +132,7 @@ public class LoopBodyBlockScopeCaptureTests
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOfLoopVariable_CapturedInFunction_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -154,8 +148,7 @@ public class LoopBodyBlockScopeCaptureTests
         Assert.Equal("10,20,30\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForInLoopVariable_CapturedInFunction_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -171,8 +164,7 @@ public class LoopBodyBlockScopeCaptureTests
         Assert.Equal("a,b\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOfBodyConst_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -191,8 +183,7 @@ public class LoopBodyBlockScopeCaptureTests
 
     // ---- State machines: async function and generator bodies ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunctionLoopBodyConst_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -213,8 +204,7 @@ public class LoopBodyBlockScopeCaptureTests
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorLoopBodyConst_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -234,8 +224,7 @@ public class LoopBodyBlockScopeCaptureTests
 
     // ---- Nested loops: body const of the inner loop sees both indices ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedLoopBodyConst_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -258,8 +247,7 @@ public class LoopBodyBlockScopeCaptureTests
 
     // A `let` the closure itself mutates must keep shared mutation visibility
     // within the iteration (the closure's writes reach the outer read).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WriteCapturedBodyLet_MutationVisibleWithinIteration(ExecutionMode mode)
     {
         var source = """
@@ -280,8 +268,7 @@ public class LoopBodyBlockScopeCaptureTests
 
     // A body const shadow-adjacent to a function-level binding: the outer binding
     // keeps its shared slot; the body binding is still per-iteration.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BodyConstNextToFunctionLevelCapture_BothCorrect(ExecutionMode mode)
     {
         var source = """
@@ -303,8 +290,7 @@ public class LoopBodyBlockScopeCaptureTests
 
     // Same name declared BOTH as a function-level local and in a loop body of a
     // sibling function: per-function tracking keeps them independent.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SameNameAcrossSiblingFunctions_Independent(ExecutionMode mode)
     {
         var source = """
@@ -332,8 +318,7 @@ public class LoopBodyBlockScopeCaptureTests
     // closure read null (top-level / for-initializer) or the fused last value (function body).
 
     // Top-level loop-body const through a two-arrow chain (#1231 shape 1).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TopLevel_LoopBodyConst_ChainedCapture_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -348,8 +333,7 @@ public class LoopBodyBlockScopeCaptureTests
     }
 
     // Top-level for-initializer binding through a chain (#1231 shape 2 / #649 exclusion).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TopLevel_ForInitializer_ChainedCapture_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -363,8 +347,7 @@ public class LoopBodyBlockScopeCaptureTests
     }
 
     // Function-local loop-body const through a chain (was fused to the last iteration).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionBody_LoopBodyConst_ChainedCapture_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -382,8 +365,7 @@ public class LoopBodyBlockScopeCaptureTests
     }
 
     // Function-local for-initializer binding through a chain (was null compiled).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionBody_ForInitializer_ChainedCapture_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -402,8 +384,7 @@ public class LoopBodyBlockScopeCaptureTests
     // A binding captured BOTH directly and through a chain in the same loop: both closures
     // must observe the same per-iteration value (previously the chained capture forced even
     // the direct one onto the shared fused slot).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DirectAndChainedCapture_SameLoop_BothPerIteration(ExecutionMode mode)
     {
         var source = """
@@ -422,8 +403,7 @@ public class LoopBodyBlockScopeCaptureTests
     }
 
     // Deeper chain (four arrows) still forwards the per-iteration value all the way in.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TopLevel_LoopBodyConst_DeepChain_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -438,8 +418,7 @@ public class LoopBodyBlockScopeCaptureTests
     }
 
     // Top-level for-of loop variable through a chain.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TopLevel_ForOfVariable_ChainedCapture_PerIteration(ExecutionMode mode)
     {
         var source = """
@@ -454,8 +433,7 @@ public class LoopBodyBlockScopeCaptureTests
 
     // A chained capture that also references the enclosing class `this`: the per-iteration
     // binding forwards by value while `this` still relays through the arrow chain.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ChainedCapture_WithThis_PerIteration(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/MapSetDuckTypingTests.cs
+++ b/SharpTS.Tests/SharedTests/MapSetDuckTypingTests.cs
@@ -20,8 +20,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </remarks>
 public class MapSetDuckTypingTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_TypeofMethodsIsFunction(ExecutionMode mode)
     {
         var source = @"
@@ -43,8 +42,7 @@ public class MapSetDuckTypingTests
             output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_TypeofMethodsIsFunction(ExecutionMode mode)
     {
         var source = @"
@@ -65,8 +63,7 @@ public class MapSetDuckTypingTests
             output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_SizeIsNumber(ExecutionMode mode)
     {
         var source = @"
@@ -80,8 +77,7 @@ public class MapSetDuckTypingTests
         Assert.Equal("number\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_SizeIsNumber(ExecutionMode mode)
     {
         var source = @"
@@ -95,8 +91,7 @@ public class MapSetDuckTypingTests
         Assert.Equal("number\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_CapturedMethodDirectInvocation(ExecutionMode mode)
     {
         var source = @"
@@ -111,8 +106,7 @@ public class MapSetDuckTypingTests
         Assert.Equal("42\n7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_CapturedMethodDirectInvocation(ExecutionMode mode)
     {
         var source = @"
@@ -127,8 +121,7 @@ public class MapSetDuckTypingTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_CrossModule_DuckTypingCheck(ExecutionMode mode)
     {
         // The util.types.isMap polyfill pattern — exactly what the util migration
@@ -164,8 +157,7 @@ public class MapSetDuckTypingTests
         Assert.Equal("true\nfalse\nfalse\n1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_CrossModule_DuckTypingCheck(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -199,8 +191,7 @@ public class MapSetDuckTypingTests
         Assert.Equal("true\nfalse\nfalse\ntrue\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_CrossModule_DynamicMethodAccess(ExecutionMode mode)
     {
         // Receiving a Map typed as `unknown` / `any` must still allow dynamic
@@ -231,8 +222,7 @@ public class MapSetDuckTypingTests
         Assert.Equal("99\ntrue\nfalse\n2\nfalse\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_CrossModule_DynamicMethodAccess(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/MapSetTests.cs
+++ b/SharpTS.Tests/SharedTests/MapSetTests.cs
@@ -10,8 +10,7 @@ public class MapSetTests
 {
     #region Map Constructor Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_EmptyConstructor_CreatesEmptyMap(ExecutionMode mode)
     {
         var source = @"
@@ -22,8 +21,7 @@ public class MapSetTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_FromEntries_CreatesMapWithValues(ExecutionMode mode)
     {
         var source = @"
@@ -41,8 +39,7 @@ public class MapSetTests
 
     #region Map Basic Operations
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_SetAndGet_WorksCorrectly(ExecutionMode mode)
     {
         var source = @"
@@ -56,8 +53,7 @@ public class MapSetTests
         Assert.Equal("100\n200\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_Has_ChecksKeyExistence(ExecutionMode mode)
     {
         var source = @"
@@ -70,8 +66,7 @@ public class MapSetTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_Delete_RemovesKey(ExecutionMode mode)
     {
         var source = @"
@@ -86,8 +81,7 @@ public class MapSetTests
         Assert.Equal("true\ntrue\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_Clear_RemovesAllEntries(ExecutionMode mode)
     {
         var source = @"
@@ -102,8 +96,7 @@ public class MapSetTests
         Assert.Equal("2\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_Set_ReturnsMapForChaining(ExecutionMode mode)
     {
         var source = @"
@@ -123,8 +116,7 @@ public class MapSetTests
     // previously collapsed both onto a single null-sentinel, so set(undefined) overwrote
     // set(null) and size was undercounted. These run in both modes to pin parity.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_NullAndUndefinedKeys_AreDistinct(ExecutionMode mode)
     {
         // Exact repro from issue #960.
@@ -140,8 +132,7 @@ public class MapSetTests
         Assert.Equal("2\n9\n8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_NullAndUndefinedKeys_HasAndDeleteIndependently(ExecutionMode mode)
     {
         var source = @"
@@ -159,8 +150,7 @@ public class MapSetTests
         Assert.Equal("true\ntrue\ntrue\nfalse\ntrue\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_NullAndUndefinedKeys_ConstructorAndIteration(ExecutionMode mode)
     {
         // Guards the entries-constructor (CreateMapFromEntries) and the
@@ -180,8 +170,7 @@ public class MapSetTests
 
     #region Map Iteration
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_ForEach_IteratesAllEntries(ExecutionMode mode)
     {
         var source = @"
@@ -197,8 +186,7 @@ public class MapSetTests
         Assert.Contains("b: 2", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_ForOf_IteratesEntries(ExecutionMode mode)
     {
         var source = @"
@@ -214,8 +202,7 @@ public class MapSetTests
         Assert.Contains("y=20", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_Keys_ReturnsKeyIterator(ExecutionMode mode)
     {
         var source = @"
@@ -231,8 +218,7 @@ public class MapSetTests
         Assert.Contains("second", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_Values_ReturnsValueIterator(ExecutionMode mode)
     {
         var source = @"
@@ -248,8 +234,7 @@ public class MapSetTests
         Assert.Contains("200", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_Entries_ReturnsEntryIterator(ExecutionMode mode)
     {
         var source = @"
@@ -269,8 +254,7 @@ public class MapSetTests
 
     #region Map Object Key Reference Equality
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_ObjectKeys_UseReferenceEquality(ExecutionMode mode)
     {
         var source = @"
@@ -286,8 +270,7 @@ public class MapSetTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_StringKeys_UseValueEquality(ExecutionMode mode)
     {
         var source = @"
@@ -307,8 +290,7 @@ public class MapSetTests
 
     #region Set Constructor Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_EmptyConstructor_CreatesEmptySet(ExecutionMode mode)
     {
         var source = @"
@@ -319,8 +301,7 @@ public class MapSetTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_FromArray_CreatesSetWithValues(ExecutionMode mode)
     {
         var source = @"
@@ -335,8 +316,7 @@ public class MapSetTests
 
     #region Set Basic Operations
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Add_InsertsValues(ExecutionMode mode)
     {
         var source = @"
@@ -351,8 +331,7 @@ public class MapSetTests
         Assert.Equal("2\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Add_IgnoresDuplicates(ExecutionMode mode)
     {
         var source = @"
@@ -367,8 +346,7 @@ public class MapSetTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Delete_RemovesValue(ExecutionMode mode)
     {
         var source = @"
@@ -382,8 +360,7 @@ public class MapSetTests
         Assert.Equal("true\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Clear_RemovesAllValues(ExecutionMode mode)
     {
         var source = @"
@@ -399,8 +376,7 @@ public class MapSetTests
         Assert.Equal("3\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Add_ReturnsSetForChaining(ExecutionMode mode)
     {
         var source = @"
@@ -416,8 +392,7 @@ public class MapSetTests
 
     #region Set Iteration
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_ForEach_IteratesAllValues(ExecutionMode mode)
     {
         var source = @"
@@ -435,8 +410,7 @@ public class MapSetTests
         Assert.Contains("30", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_ForOf_IteratesValues(ExecutionMode mode)
     {
         var source = @"
@@ -454,8 +428,7 @@ public class MapSetTests
         Assert.Contains("c", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Values_ReturnsValueIterator(ExecutionMode mode)
     {
         var source = @"
@@ -471,8 +444,7 @@ public class MapSetTests
         Assert.Contains("10", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Keys_IsSameAsValues(ExecutionMode mode)
     {
         var source = @"
@@ -488,8 +460,7 @@ public class MapSetTests
         Assert.Contains("2", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Entries_ReturnsPairs(ExecutionMode mode)
     {
         var source = @"
@@ -509,8 +480,7 @@ public class MapSetTests
 
     #region Set Object Reference Equality
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_ObjectValues_UseReferenceEquality(ExecutionMode mode)
     {
         var source = @"
@@ -530,8 +500,7 @@ public class MapSetTests
 
     #region Type Inference Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Map_WithoutTypeArgs_DefaultsToAny(ExecutionMode mode)
     {
         var source = @"
@@ -544,8 +513,7 @@ public class MapSetTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_WithoutTypeArgs_DefaultsToAny(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/MathBuiltInTests.cs
+++ b/SharpTS.Tests/SharedTests/MathBuiltInTests.cs
@@ -10,8 +10,7 @@ public class MathBuiltInTests
 {
     #region Math Constants
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_PI_ReturnsCorrectValue(ExecutionMode mode)
     {
         var source = """
@@ -23,8 +22,7 @@ public class MathBuiltInTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_E_ReturnsCorrectValue(ExecutionMode mode)
     {
         var source = """
@@ -40,8 +38,7 @@ public class MathBuiltInTests
 
     #region Math Functions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Abs_ReturnsAbsoluteValue(ExecutionMode mode)
     {
         var source = """
@@ -54,8 +51,7 @@ public class MathBuiltInTests
         Assert.Equal("5\n5\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Floor_RoundsDown(ExecutionMode mode)
     {
         var source = """
@@ -68,8 +64,7 @@ public class MathBuiltInTests
         Assert.Equal("4\n4\n-5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Ceil_RoundsUp(ExecutionMode mode)
     {
         var source = """
@@ -82,8 +77,7 @@ public class MathBuiltInTests
         Assert.Equal("5\n5\n-4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Round_RoundsToNearest(ExecutionMode mode)
     {
         var source = """
@@ -96,8 +90,7 @@ public class MathBuiltInTests
         Assert.Equal("4\n5\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Round_JSParity_NegativeHalfValues(ExecutionMode mode)
     {
         // JavaScript rounds half-values toward +infinity
@@ -116,8 +109,7 @@ public class MathBuiltInTests
         Assert.Equal("3\n-2\n2\n-1\n1\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Sqrt_ReturnsSquareRoot(ExecutionMode mode)
     {
         var source = """
@@ -130,8 +122,7 @@ public class MathBuiltInTests
         Assert.Equal("4\n3\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Pow_ReturnsPower(ExecutionMode mode)
     {
         var source = """
@@ -144,8 +135,7 @@ public class MathBuiltInTests
         Assert.Equal("8\n9\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Min_ReturnsMinimum(ExecutionMode mode)
     {
         var source = """
@@ -158,8 +148,7 @@ public class MathBuiltInTests
         Assert.Equal("1\n2\n-5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Max_ReturnsMaximum(ExecutionMode mode)
     {
         var source = """
@@ -172,8 +161,7 @@ public class MathBuiltInTests
         Assert.Equal("3\n8\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Sign_ReturnsSign(ExecutionMode mode)
     {
         var source = """
@@ -186,8 +174,7 @@ public class MathBuiltInTests
         Assert.Equal("-1\n0\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Trunc_RemovesDecimal(ExecutionMode mode)
     {
         var source = """
@@ -204,8 +191,7 @@ public class MathBuiltInTests
 
     #region Trigonometric Functions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Sin_ReturnsCorrectValue(ExecutionMode mode)
     {
         var source = """
@@ -216,8 +202,7 @@ public class MathBuiltInTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Cos_ReturnsCorrectValue(ExecutionMode mode)
     {
         var source = """
@@ -228,8 +213,7 @@ public class MathBuiltInTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Tan_ReturnsCorrectValue(ExecutionMode mode)
     {
         var source = """
@@ -244,8 +228,7 @@ public class MathBuiltInTests
 
     #region Exponential and Logarithmic Functions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Log_ReturnsNaturalLog(ExecutionMode mode)
     {
         var source = """
@@ -256,8 +239,7 @@ public class MathBuiltInTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Exp_ReturnsExponential(ExecutionMode mode)
     {
         var source = """
@@ -272,8 +254,7 @@ public class MathBuiltInTests
 
     #region Random
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Random_ReturnsValueInRange(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/MathSpreadArgumentTests.cs
+++ b/SharpTS.Tests/SharedTests/MathSpreadArgumentTests.cs
@@ -15,8 +15,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class MathSpreadArgumentTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Max_Min_Hypot_BasicSpread(ExecutionMode mode)
     {
         var source = @"
@@ -28,8 +27,7 @@ public class MathSpreadArgumentTests
         Assert.Equal("3\n1\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Spread_MixedWithRegularArgs(ExecutionMode mode)
     {
         var source = @"
@@ -41,8 +39,7 @@ public class MathSpreadArgumentTests
         Assert.Equal("5\n13\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Spread_EmptyArray(ExecutionMode mode)
     {
         // Spreading an empty array yields the no-argument result: max → -Infinity,
@@ -56,8 +53,7 @@ public class MathSpreadArgumentTests
         Assert.Equal("-Infinity\nInfinity\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Spread_BoxedAnyArray(ExecutionMode mode)
     {
         // A spread of an `any[]` (boxed-element representation) must expand the
@@ -71,8 +67,7 @@ public class MathSpreadArgumentTests
         Assert.Equal("20\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Spread_NaNAndInfinitySemantics(ExecutionMode mode)
     {
         // max/min short-circuit to NaN on any NaN; hypot's Infinity check fires
@@ -86,8 +81,7 @@ public class MathSpreadArgumentTests
         Assert.Equal("NaN\nNaN\nInfinity\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Math_Spread_InsideAsyncFunction(ExecutionMode mode)
     {
         // Exercises the async built-in call path (CallBuiltInWithPooledArgs /

--- a/SharpTS.Tests/SharedTests/MemberIncrementCoercionTests.cs
+++ b/SharpTS.Tests/SharedTests/MemberIncrementCoercionTests.cs
@@ -16,8 +16,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class MemberIncrementCoercionTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PostfixIncrement_NumericStringMember_ReturnsOldNumber_StoresIncremented(ExecutionMode mode)
     {
         // o.x = "5": (o.x++) is ToNumber("5") === 5; o.x becomes 6.
@@ -29,8 +28,7 @@ public class MemberIncrementCoercionTests
         Assert.Equal("5|6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PostfixIncrement_UndefinedMember_IsNaN(ExecutionMode mode)
     {
         // ToNumber(undefined) is NaN; NaN + 1 is NaN (no longer throws).
@@ -42,8 +40,7 @@ public class MemberIncrementCoercionTests
         Assert.Equal("NaN\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrefixIncrement_NumericStringMember_ReturnsNewNumber(ExecutionMode mode)
     {
         var source = """
@@ -54,8 +51,7 @@ public class MemberIncrementCoercionTests
         Assert.Equal("6|6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PostfixDecrement_NumericStringMember_Coerces(ExecutionMode mode)
     {
         var source = """
@@ -66,8 +62,7 @@ public class MemberIncrementCoercionTests
         Assert.Equal("4\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PostfixIncrement_NumericStringElement_Coerces(ExecutionMode mode)
     {
         // arr[i]++ has the identical divergence as o.x++.
@@ -79,8 +74,7 @@ public class MemberIncrementCoercionTests
         Assert.Equal("7|8\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PostfixIncrement_NumericStringVariable_Coerces(ExecutionMode mode)
     {
         // The variable l-value path shared the same latent gap (it asserted a boxed double via

--- a/SharpTS.Tests/SharedTests/MethodCompletionValueTests.cs
+++ b/SharpTS.Tests/SharedTests/MethodCompletionValueTests.cs
@@ -29,8 +29,7 @@ public class MethodCompletionValueTests
     // ---- Off-the-end instance / static methods (the issue's primary repro) ----
     // The interpreter is already correct (CallV2), so these assert cross-mode parity.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OffEndInstanceMethod_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -40,8 +39,7 @@ public class MethodCompletionValueTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OffEndStaticMethod_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -51,8 +49,7 @@ public class MethodCompletionValueTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OffEndInstanceMethod_StrictlyEqualsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -62,8 +59,7 @@ public class MethodCompletionValueTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OffEndInstanceMethod_InArithmetic_IsNaN(ExecutionMode mode)
     {
         // undefined + 10 === NaN, but null + 10 === 10 — this distinguishes the
@@ -80,8 +76,7 @@ public class MethodCompletionValueTests
 
     // A method that reaches the epilogue after a conditional branch (real body, still
     // falls off the end on the taken path) — exercises the epilogue, not a bare return.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MethodFallingOffEndAfterBranch_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -96,8 +91,7 @@ public class MethodCompletionValueTests
     // ---- Class-expression methods (separate emit path) ----
     // Interpreter invokes these via CallV2 too, so cross-mode parity holds.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OffEndClassExpressionInstanceMethod_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -107,8 +101,7 @@ public class MethodCompletionValueTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OffEndClassExpressionStaticMethod_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -121,8 +114,7 @@ public class MethodCompletionValueTests
     // ---- Regression: explicit returns must NOT be rewritten to undefined ----
     // These go through EmitReturn (untouched by the fix); asserts cross-mode parity.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExplicitReturnNull_StaysNull(ExecutionMode mode)
     {
         // `return null` is observably distinct from `undefined` — it must be preserved.
@@ -134,8 +126,7 @@ public class MethodCompletionValueTests
         Assert.Equal("object\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExplicitReturnValue_IsPreserved(ExecutionMode mode)
     {
         var source = """
@@ -151,8 +142,7 @@ public class MethodCompletionValueTests
         Assert.Equal("5\n7\nhi\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BranchedExplicitReturns_StillWork(ExecutionMode mode)
     {
         var source = """
@@ -172,8 +162,7 @@ public class MethodCompletionValueTests
     // The setter's CLR return value is discarded; the assignment side effect and the
     // value of the assignment expression (the RHS, per JS) must be unaffected.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetterOffEnd_StillAppliesEffect(ExecutionMode mode)
     {
         var source = """
@@ -194,8 +183,7 @@ public class MethodCompletionValueTests
     // epilogue; #603 fixed the interpreter's boxed `Call` to return the `undefined` sentinel
     // off the end, so these now assert cross-mode parity (previously compiled-only).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OffEndGetter_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -205,8 +193,7 @@ public class MethodCompletionValueTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OffEndStaticGetter_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -216,8 +203,7 @@ public class MethodCompletionValueTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetterFallingOffEndAfterBranch_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -230,8 +216,7 @@ public class MethodCompletionValueTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OffEndPrivateMethod_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -244,8 +229,7 @@ public class MethodCompletionValueTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OffEndPrivateStaticMethod_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -258,8 +242,7 @@ public class MethodCompletionValueTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OffEndClassExpressionGetter_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -272,8 +255,7 @@ public class MethodCompletionValueTests
     // Off-the-end getter/private completion must be `undefined`, not CLR `null` — assert via
     // arithmetic (undefined + 10 === NaN, but null + 10 === 10) so it can't pass by `typeof`
     // coincidence. This is the #603 distinguisher on the interpreter's boxed `Call` path.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OffEndGetter_InArithmetic_IsNaN(ExecutionMode mode)
     {
         var source = """
@@ -283,8 +265,7 @@ public class MethodCompletionValueTests
         Assert.Equal("NaN\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OffEndPrivateMethod_StrictlyEqualsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -300,8 +281,7 @@ public class MethodCompletionValueTests
     // Regression for #603: only the *off-the-end* completion becomes `undefined`. A getter with
     // an explicit `return null` must still observe CLR `null` (boxed `Call` returns via the
     // Return branch, untouched by the fix).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetterExplicitReturnNull_StaysNull(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/MicrotaskTests.cs
+++ b/SharpTS.Tests/SharedTests/MicrotaskTests.cs
@@ -12,8 +12,7 @@ public class MicrotaskTests
 {
     #region Basic Functionality Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void QueueMicrotask_ExecutesCallback(ExecutionMode mode)
     {
         // queueMicrotask should execute the callback
@@ -29,8 +28,7 @@ public class MicrotaskTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void QueueMicrotask_ExecutesCallbackWithConsoleLog(ExecutionMode mode)
     {
         // queueMicrotask should execute callback that logs output
@@ -46,8 +44,7 @@ public class MicrotaskTests
         Assert.Contains("done", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void QueueMicrotask_ReturnsUndefined(ExecutionMode mode)
     {
         // queueMicrotask should return undefined
@@ -63,8 +60,7 @@ public class MicrotaskTests
 
     #region Ordering Tests - Microtasks Before Macrotasks
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void QueueMicrotask_ExecutesBeforeSetTimeout(ExecutionMode mode)
     {
         // Microtasks should execute before macrotasks (setTimeout with 0 delay)
@@ -81,8 +77,7 @@ public class MicrotaskTests
         Assert.Equal("microtask,timeout\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void QueueMicrotask_ExecutesInFIFOOrder(ExecutionMode mode)
     {
         // Multiple microtasks should execute in FIFO order
@@ -100,8 +95,7 @@ public class MicrotaskTests
         Assert.Equal("first,second,third\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void QueueMicrotask_NestedMicrotasksExecuteBeforeMacrotasks(ExecutionMode mode)
     {
         // Microtasks queued from within microtasks should still execute before macrotasks
@@ -126,8 +120,7 @@ public class MicrotaskTests
 
     #region Type Checking Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void QueueMicrotask_RequiresCallback(ExecutionMode mode)
     {
         // queueMicrotask without callback should fail type checking
@@ -138,8 +131,7 @@ public class MicrotaskTests
         Assert.Contains("queueMicrotask", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void QueueMicrotask_CallbackMustBeFunction(ExecutionMode mode)
     {
         // queueMicrotask with non-function callback should fail type checking
@@ -154,8 +146,7 @@ public class MicrotaskTests
 
     #region Variable Capture Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void QueueMicrotask_CapturesClosureVariables(ExecutionMode mode)
     {
         // Callback should capture closure variables correctly
@@ -172,8 +163,7 @@ public class MicrotaskTests
         Assert.Equal("captured\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void QueueMicrotask_MutatesClosureVariables(ExecutionMode mode)
     {
         // Callback should be able to mutate closure variables

--- a/SharpTS.Tests/SharedTests/ModuleAugmentationTests.cs
+++ b/SharpTS.Tests/SharedTests/ModuleAugmentationTests.cs
@@ -11,8 +11,7 @@ public class ModuleAugmentationTests
 {
     #region Parser Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeclareModule_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -26,8 +25,7 @@ public class ModuleAugmentationTests
         Assert.Equal("parsed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeclareGlobal_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -47,8 +45,7 @@ public class ModuleAugmentationTests
 
     #region Global Augmentation Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeclareGlobal_DefinesNewInterface(ExecutionMode mode)
     {
         var source = """
@@ -69,8 +66,7 @@ public class ModuleAugmentationTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeclareGlobal_WithExport_DefinesInterface(ExecutionMode mode)
     {
         var source = """
@@ -95,8 +91,7 @@ public class ModuleAugmentationTests
 
     #region Ambient Module Declaration Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AmbientModule_IsTypeOnly(ExecutionMode mode)
     {
         var source = """
@@ -114,8 +109,7 @@ public class ModuleAugmentationTests
         Assert.Equal("ambient declaration works\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AmbientModule_MultipleDeclarations(ExecutionMode mode)
     {
         var source = """
@@ -138,8 +132,7 @@ public class ModuleAugmentationTests
 
     #region Module Augmentation Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ModuleAugmentation_AddsNewInterface(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -171,8 +164,7 @@ public class ModuleAugmentationTests
 
     #region Type Alias in Declare Block Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeclareModule_WithTypeAlias(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ModuleGlobalsTests.cs
+++ b/SharpTS.Tests/SharedTests/ModuleGlobalsTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ModuleGlobalsTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dirname_ReturnsString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -24,8 +23,7 @@ public class ModuleGlobalsTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Filename_ReturnsString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -39,8 +37,7 @@ public class ModuleGlobalsTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dirname_ContainsPath(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -54,8 +51,7 @@ public class ModuleGlobalsTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Filename_EndsWithTs(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -69,8 +65,7 @@ public class ModuleGlobalsTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Filename_ContainsMainTs(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -84,8 +79,7 @@ public class ModuleGlobalsTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Dirname_MatchesImportMetaDirname(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -99,8 +93,7 @@ public class ModuleGlobalsTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Filename_MatchesImportMetaFilename(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/ModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/ModuleTests.cs
@@ -12,8 +12,7 @@ public class ModuleTests
 {
     #region Named Exports and Imports
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedExport_SingleVariable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -31,8 +30,7 @@ public class ModuleTests
         Assert.Equal("3.14159\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedExport_MultipleVariables(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -52,8 +50,7 @@ public class ModuleTests
         Assert.Equal("60\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedExport_Function(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -81,8 +78,7 @@ public class ModuleTests
     // case — the broader gap #417 also fixed — is covered by ExportSyncFunction_SingleFile below.
     // Compiled cross-module execution of these exports is additionally covered by the
     // *_CrossModule tests further down (#395).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportAsyncFunction_Parses(ExecutionMode mode)
     {
         // Regression: `export async function` previously failed to parse
@@ -98,8 +94,7 @@ public class ModuleTests
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportGeneratorFunction_Parses(ExecutionMode mode)
     {
         // Regression: `export function*` previously failed to parse ("Expect
@@ -115,8 +110,7 @@ public class ModuleTests
         Assert.Equal("1\n2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportAsyncGeneratorFunction_Parses(ExecutionMode mode)
     {
         // Regression: `export async function*` shares the same export dispatcher
@@ -133,8 +127,7 @@ public class ModuleTests
         Assert.Equal("1\n2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportSyncFunction_SingleFile(ExecutionMode mode)
     {
         // Regression for #417: a plain `export function` in a single-file (script-mode)
@@ -159,8 +152,7 @@ public class ModuleTests
     // interpreter (which was already correct). The CLI routes any file with import/export through
     // the module path, so no production program hit this — only the in-process single-file harness.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportConst_SingleFile(ExecutionMode mode)
     {
         // The canonical #424 repro: a non-captured exported const must still be
@@ -173,8 +165,7 @@ public class ModuleTests
         Assert.Equal("5\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportLet_SingleFile(ExecutionMode mode)
     {
         // `export let` is mutable — exercises the Stmt.Var arm and a later reassignment.
@@ -187,8 +178,7 @@ public class ModuleTests
         Assert.Equal("8\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportVar_SingleFile(ExecutionMode mode)
     {
         var source = """
@@ -199,8 +189,7 @@ public class ModuleTests
         Assert.Equal("hi\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportConst_CapturedByClosure_SingleFile(ExecutionMode mode)
     {
         // When a function (a separate compiled method) reads the exported binding, the
@@ -217,8 +206,7 @@ public class ModuleTests
         Assert.Equal("15\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportConst_MultiDeclarator_SingleFile(ExecutionMode mode)
     {
         // `export const a = 1, b = 2` desugars to Stmt.Export { Declaration: Stmt.Sequence };
@@ -238,8 +226,7 @@ public class ModuleTests
     // type-checker/interpreter export helpers (GetDeclarationName / GetDeclaredType /
     // GetDeclaredName / GetDeclaredValue) gained the Stmt.Const arm they previously lacked.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportConst_Reassignment_IsTypeError(ExecutionMode mode)
     {
         // The canonical #428 repro: reassigning an `export const` must be rejected, just like
@@ -253,8 +240,7 @@ public class ModuleTests
         Assert.Contains("'y'", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportConst_LiteralTypeNarrowed(ExecutionMode mode)
     {
         // `export const x = 5` must infer the literal type `5`, not the widened `number`.
@@ -268,8 +254,7 @@ public class ModuleTests
         Assert.Equal("5\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportConst_NarrowedType_FlowsCrossModule(ExecutionMode mode)
     {
         // The narrowed literal type of an exported const must survive import into another
@@ -289,8 +274,7 @@ public class ModuleTests
         Assert.Equal("100\n", TestHarness.RunModules(files, "./main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportConst_CrossModule_Runs(ExecutionMode mode)
     {
         // A plain exported const imported and used across modules still binds and runs
@@ -318,8 +302,7 @@ public class ModuleTests
     // simple name) — the import field stayed null and the call threw "object is not a function".
     // They run in BOTH modes to pin the fix and guard the interpreter.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedExport_AsyncFunction_CrossModule(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -339,8 +322,7 @@ public class ModuleTests
         Assert.Equal("7\n", TestHarness.RunModules(files, "./main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedExport_GeneratorFunction_CrossModule(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -361,8 +343,7 @@ public class ModuleTests
         Assert.Equal("1\n2\n3\n", TestHarness.RunModules(files, "./main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedExport_AsyncGeneratorFunction_CrossModule(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -385,8 +366,7 @@ public class ModuleTests
         Assert.Equal("10\n20\n", TestHarness.RunModules(files, "./main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedListExport_StateMachineFunctions_CrossModule(ExecutionMode mode)
     {
         // The `export { a, b, c }` list form is a distinct export-store branch from the
@@ -413,8 +393,7 @@ public class ModuleTests
         Assert.Equal("15\n7\n8\n99\n", TestHarness.RunModules(files, "./main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultExport_AsyncFunction_CrossModule(ExecutionMode mode)
     {
         // `export default async function` / `export default function*` additionally required a
@@ -436,8 +415,7 @@ public class ModuleTests
         Assert.Equal("42\n", TestHarness.RunModules(files, "./main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultExport_GeneratorFunction_CrossModule(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -454,8 +432,7 @@ public class ModuleTests
         Assert.Equal("5\n6\n", TestHarness.RunModules(files, "./main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultExport_AsyncGeneratorFunction_CrossModule(ExecutionMode mode)
     {
         // Guards the `async`+`*` combination in the `export default` parser branch.
@@ -474,8 +451,7 @@ public class ModuleTests
         Assert.Equal("1\n2\n", TestHarness.RunModules(files, "./main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultExport_AsyncArrow_StillParsesAsExpression(ExecutionMode mode)
     {
         // Guard: the `export default async function` parser branch must NOT swallow
@@ -497,8 +473,7 @@ public class ModuleTests
         Assert.Equal("42\n", TestHarness.RunModules(files, "./main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedExport_Class(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -525,8 +500,7 @@ public class ModuleTests
         Assert.Equal("Hello, Alice\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedImport_WithAlias(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -544,8 +518,7 @@ public class ModuleTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedExport_List(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -566,8 +539,7 @@ public class ModuleTests
         Assert.Equal("6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedExport_ListWithAlias(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -590,8 +562,7 @@ public class ModuleTests
 
     #region Default Exports and Imports
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultExport_Expression(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -609,8 +580,7 @@ public class ModuleTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultExport_Function(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -630,8 +600,7 @@ public class ModuleTests
         Assert.Equal("Hello, World\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultExport_Class(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -660,8 +629,7 @@ public class ModuleTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultExport_ArrowFunction(ExecutionMode mode)
     {
         // Note: anonymous function export default not supported, use arrow function
@@ -685,8 +653,7 @@ public class ModuleTests
 
     #region Combined Imports
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CombinedImport_DefaultAndNamed(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -710,8 +677,7 @@ public class ModuleTests
 
     #region Namespace Imports
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceImport_AllExports(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -739,8 +705,7 @@ public class ModuleTests
 
     #region Re-exports
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReExport_Named(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -761,8 +726,7 @@ public class ModuleTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReExport_NamedWithAlias(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -783,8 +747,7 @@ public class ModuleTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReExport_All(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -810,8 +773,7 @@ public class ModuleTests
 
     #region Multi-Level Dependencies
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultiLevel_ThreeModules(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -833,8 +795,7 @@ public class ModuleTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultiLevel_DiamondDependency(ExecutionMode mode)
     {
         // a -> b -> d
@@ -875,8 +836,7 @@ public class ModuleTests
 
     #region Circular Dependency Detection
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CircularDependency_ThrowsError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -901,8 +861,7 @@ public class ModuleTests
             $"Expected circular or module error, got: {ex.Message}");
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CircularDependency_IndirectCycle(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -935,8 +894,7 @@ public class ModuleTests
 
     #region Side-Effect Imports
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SideEffectImport_ExecutesModule(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -954,8 +912,7 @@ public class ModuleTests
         Assert.Equal("Side effect executed\nMain executed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecutionOrder_MultipleModules(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -981,8 +938,7 @@ public class ModuleTests
 
     #region Module Execution Order
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecutionOrder_DependenciesFirst(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1011,8 +967,7 @@ public class ModuleTests
 
     #region Path Resolution
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PathResolution_OmittedExtension(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1030,8 +985,7 @@ public class ModuleTests
         Assert.Equal("Helping!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PathResolution_WithExtension(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1049,8 +1003,7 @@ public class ModuleTests
         Assert.Equal("Helping!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PathResolution_NestedDirectories(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1074,8 +1027,7 @@ public class ModuleTests
 
     #region Export Types (Interface, Type Alias, Enum)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Export_InterfaceWithFactory(ExecutionMode mode)
     {
         // Note: Interfaces are type-only exports (erased at runtime).
@@ -1103,8 +1055,7 @@ public class ModuleTests
         Assert.Equal("Alice\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Export_TypeAliasUsedLocally(ExecutionMode mode)
     {
         // Note: Type aliases are type-only exports (erased at runtime).
@@ -1127,8 +1078,7 @@ public class ModuleTests
         Assert.Equal("42000\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Export_Enum(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1155,8 +1105,7 @@ public class ModuleTests
 
     #region Complex Scenarios
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Complex_MultipleExportsAndImports(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1188,8 +1137,7 @@ public class ModuleTests
         Assert.Equal("3.14159\n5\n20\n15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Complex_ClassInheritanceAcrossModules(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1227,8 +1175,7 @@ public class ModuleTests
         Assert.Equal("Rex barks\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Complex_FunctionUsingImportedClass(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1266,8 +1213,7 @@ public class ModuleTests
     /// Tests that two different modules can each define a class with the same name,
     /// and they should be treated as separate types.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DuplicateClassNames_AcrossModules_ShouldBeDistinct(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1302,8 +1248,7 @@ public class ModuleTests
     /// Tests that two different modules can each define a function with the same name,
     /// and they should be treated as separate functions.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DuplicateFunctionNames_AcrossModules_ShouldBeDistinct(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1335,8 +1280,7 @@ public class ModuleTests
     /// Tests that two different modules can each define an enum with the same name,
     /// and they should be treated as separate enums.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DuplicateEnumNames_AcrossModules_ShouldBeDistinct(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1372,8 +1316,7 @@ public class ModuleTests
     /// Tests that a class exported from one module can be imported, instantiated,
     /// and have its methods called from another module.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CrossModule_ClassInstantiationAndMethodCall(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1416,8 +1359,7 @@ public class ModuleTests
     /// Tests that a function exported from one module can be imported and called
     /// from another module with arguments and return values.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CrossModule_FunctionCall(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1453,8 +1395,7 @@ public class ModuleTests
     /// Tests that an enum exported from one module can be imported and its
     /// members accessed from another module.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CrossModule_EnumAccess(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1491,8 +1432,7 @@ public class ModuleTests
     /// Tests that multiple modules can import from the same shared module,
     /// and each gets the correct types without interference.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CrossModule_SharedDependency(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1552,8 +1492,7 @@ public class ModuleTests
     /// Tests a complex scenario with classes, functions, and enums all being
     /// imported and used across modules.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CrossModule_MixedTypes(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/ModuloParityTests.cs
+++ b/SharpTS.Tests/SharedTests/ModuloParityTests.cs
@@ -18,8 +18,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ModuloParityTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AscendingCounter_BasicDivisor(ExecutionMode mode)
     {
         var source = """
@@ -30,8 +29,7 @@ public class ModuloParityTests
         Assert.Equal("0,1,2,0,1,2,0,1,2,0,\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CounterPlusMinusLiteral_Dividend(ExecutionMode mode)
     {
         // `(i + k) % m` and `(i - k) % m` — the counter±literal dividend shapes the fast path recognizes.
@@ -43,8 +41,7 @@ public class ModuloParityTests
         Assert.Equal("1:-2 2:-1 3:0 0:1 1:2 2:3 3:4 0:0 \n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DescendingCounter_NegativeDividend_AndNegativeDivisor(ExecutionMode mode)
     {
         // Truncated remainder: the result takes the dividend's sign; a negative divisor does not
@@ -57,8 +54,7 @@ public class ModuloParityTests
         Assert.Equal("0/0 2/2 1/1 0/0 -1/-1 -2/-2 0/0 \n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DivisorOne_AlwaysZero(ExecutionMode mode)
     {
         var source = """
@@ -69,8 +65,7 @@ public class ModuloParityTests
         Assert.Equal("0,0,0,0,0,\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DivisorZero_FallsBackToNaN_DoesNotThrow(ExecutionMode mode)
     {
         // `i % 0` is NaN in JS (fmod(x, 0)). The fast path explicitly declines divisor 0 so it never
@@ -83,8 +78,7 @@ public class ModuloParityTests
         Assert.Equal("NaN,NaN,NaN,\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonCounterDividend_FallsBackToDoublePath(ExecutionMode mode)
     {
         // `(i * 2) % 5` — the dividend is a multiply, not a recognized counter expression, so the
@@ -97,8 +91,7 @@ public class ModuloParityTests
         Assert.Equal("0,2,4,1,3,0,\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ModuloInFloat64WriteKernel(ExecutionMode mode)
     {
         // The real kernel shape: a modulo embedded in a mixed-double store expression into a
@@ -113,8 +106,7 @@ public class ModuloParityTests
         Assert.Equal("342\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ModuloInInt32WriteKernel_ToInt32Truncation(ExecutionMode mode)
     {
         // Int32Array store path: the int64 modulo result feeds a store that ToInt32-truncates.

--- a/SharpTS.Tests/SharedTests/NamedBuiltInImportTests.cs
+++ b/SharpTS.Tests/SharedTests/NamedBuiltInImportTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class NamedBuiltInImportTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_NamedImport_ExistsSync_Works(ExecutionMode mode)
     {
         var testFile = Path.GetTempFileName();
@@ -33,8 +32,7 @@ public class NamedBuiltInImportTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_NamedImport_WriteFileSync_ReadFileSync_Works(ExecutionMode mode)
     {
         var testFile = Path.Combine(Path.GetTempPath(), $"sharptstest_{Guid.NewGuid()}.txt");
@@ -60,8 +58,7 @@ public class NamedBuiltInImportTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fs_NamedImport_MultipleImports_Work(ExecutionMode mode)
     {
         var testFile = Path.Combine(Path.GetTempPath(), $"sharptstest_{Guid.NewGuid()}.txt");
@@ -91,8 +88,7 @@ public class NamedBuiltInImportTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_NamedImport_Basename_Works(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -107,8 +103,7 @@ public class NamedBuiltInImportTests
         Assert.Equal("baz.txt", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_NamedImport_Dirname_Works(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -125,8 +120,7 @@ public class NamedBuiltInImportTests
         Assert.Contains("bar", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_NamedImport_Extname_Works(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -141,8 +135,7 @@ public class NamedBuiltInImportTests
         Assert.Equal(".ts", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_NamedImport_Join_Works(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -163,8 +156,7 @@ public class NamedBuiltInImportTests
         Assert.Equal(["true", "true", "true"], lines);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_NamedImport_IsAbsolute_Works(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -179,8 +171,7 @@ public class NamedBuiltInImportTests
         Assert.Equal("false", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Path_NamedImport_MultipleImports_Work(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -200,8 +191,7 @@ public class NamedBuiltInImportTests
         Assert.Equal(".ts", lines[1]);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceImports_StillWork(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/NamedFunctionExpressionTests.cs
+++ b/SharpTS.Tests/SharedTests/NamedFunctionExpressionTests.cs
@@ -12,8 +12,7 @@ public class NamedFunctionExpressionTests
 {
     #region Basic NFE Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedFunctionExpression_BasicRecursion_Works(ExecutionMode mode)
     {
         var source = """
@@ -28,8 +27,7 @@ public class NamedFunctionExpressionTests
         Assert.Equal("120\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedFunctionExpression_NameNotVisibleOutside(ExecutionMode mode)
     {
         // The function name is only visible inside the function body, not outside
@@ -45,8 +43,7 @@ public class NamedFunctionExpressionTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedFunctionExpression_ParameterShadowsName(ExecutionMode mode)
     {
         // If a parameter has the same name as the function, parameter wins
@@ -65,8 +62,7 @@ public class NamedFunctionExpressionTests
 
     #region Nested Functions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedFunctionExpression_NestedFunctions(ExecutionMode mode)
     {
         var source = """
@@ -88,8 +84,7 @@ public class NamedFunctionExpressionTests
 
     #region Object Literals
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedFunctionExpression_InObjectLiteral(ExecutionMode mode)
     {
         var source = """
@@ -110,8 +105,7 @@ public class NamedFunctionExpressionTests
 
     #region Callback Arguments
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedFunctionExpression_AsCallbackArgument(ExecutionMode mode)
     {
         var source = """
@@ -134,8 +128,7 @@ public class NamedFunctionExpressionTests
 
     #region Recursion Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedFunctionExpression_FibonacciRecursion(ExecutionMode mode)
     {
         var source = """
@@ -150,8 +143,7 @@ public class NamedFunctionExpressionTests
         Assert.Equal("55\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedFunctionExpression_MutualRecursionWithClosure(ExecutionMode mode)
     {
         var source = """
@@ -177,8 +169,7 @@ public class NamedFunctionExpressionTests
 
     #region Default Parameters
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedFunctionExpression_WithDefaultParameters(ExecutionMode mode)
     {
         var source = """
@@ -197,8 +188,7 @@ public class NamedFunctionExpressionTests
 
     #region Anonymous Function Expressions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedFunctionExpression_Anonymous_StillWorks(ExecutionMode mode)
     {
         // Anonymous function expressions should still work
@@ -217,8 +207,7 @@ public class NamedFunctionExpressionTests
 
     #region Closure Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedFunctionExpression_ClosureCapture(ExecutionMode mode)
     {
         var source = """
@@ -244,8 +233,7 @@ public class NamedFunctionExpressionTests
 
     #region IIFE Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedFunctionExpression_ImmediatelyInvoked(ExecutionMode mode)
     {
         // IIFE (Immediately Invoked Function Expression) with name
@@ -265,8 +253,7 @@ public class NamedFunctionExpressionTests
 
     #region Rest Parameters
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedFunctionExpression_WithRestParameters(ExecutionMode mode)
     {
         var source = """
@@ -285,8 +272,7 @@ public class NamedFunctionExpressionTests
 
     #region Can Log Function
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamedFunctionExpression_CanLogFunction(ExecutionMode mode)
     {
         // Named function expressions have their name in the string representation

--- a/SharpTS.Tests/SharedTests/NamespaceGlobalBindingTests.cs
+++ b/SharpTS.Tests/SharedTests/NamespaceGlobalBindingTests.cs
@@ -13,8 +13,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class NamespaceGlobalBindingTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_StaticAbort_Resolves(ExecutionMode mode)
     {
         var source = """
@@ -27,8 +26,7 @@ public class NamespaceGlobalBindingTests
         Assert.Equal("true\nwhy\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AbortSignal_DirectConstruction_Throws(ExecutionMode mode)
     {
         var source = """
@@ -43,8 +41,7 @@ public class NamespaceGlobalBindingTests
         Assert.Equal("threw\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Intl_ValuePosition_AndMemberConstruction(ExecutionMode mode)
     {
         var source = """
@@ -57,8 +54,7 @@ public class NamespaceGlobalBindingTests
         Assert.Equal("1,234.5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WebStreamConstructors_ValuePosition_AndInstanceof(ExecutionMode mode)
     {
         var source = """
@@ -76,8 +72,7 @@ public class NamespaceGlobalBindingTests
     // ReadableStream.from(iterable) eagerly drains the iterable into a closed
     // stream (#269). Both modes are covered now that compiled mode emits a
     // $ReadableStream.from static (interp uses SharpTSWebStreamsConstructors).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WebStreamConstructors_From(ExecutionMode mode)
     {
         var source = """
@@ -91,8 +86,7 @@ public class NamespaceGlobalBindingTests
 
     // #269: the produced stream yields each element of the iterable followed by
     // done — verified by draining it through a reader.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WebStreamConstructors_From_DrainsIterable(ExecutionMode mode)
     {
         var source = """
@@ -113,8 +107,7 @@ public class NamespaceGlobalBindingTests
         Assert.Equal("a false\nb false\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MessageChannel_ValuePosition(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/NamespaceInModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/NamespaceInModuleTests.cs
@@ -14,8 +14,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class NamespaceInModuleTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Namespace_WithImportAfter_ExportedConst(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -33,8 +32,7 @@ public class NamespaceInModuleTests
         Assert.Equal("1\nfunction\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Namespace_WithImportBefore_ExportedFunction(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -52,8 +50,7 @@ public class NamespaceInModuleTests
         Assert.Equal("hi\nfunction\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedNamespace_WithImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -75,8 +72,7 @@ public class NamespaceInModuleTests
         Assert.Equal("10\n42\nfunction\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Namespace_WithSiblingModuleImport_ClassAndEnumMembers(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/NamespaceTests.cs
+++ b/SharpTS.Tests/SharedTests/NamespaceTests.cs
@@ -17,8 +17,7 @@ public class NamespaceTests
     // to the member function body, throwing "Undefined variable". The fix also backs each with a static
     // field surfaced to the function's resolver. These pin every variant from the issue.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceFunction_ReadsNamespaceConst(ExecutionMode mode)
     {
         var code = @"
@@ -28,8 +27,7 @@ public class NamespaceTests
         Assert.Equal("7\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceFunction_ReadsNamespaceLet(ExecutionMode mode)
     {
         var code = @"
@@ -39,8 +37,7 @@ public class NamespaceTests
         Assert.Equal("7\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceFunction_ReadsNamespaceVar(ExecutionMode mode)
     {
         var code = @"
@@ -50,8 +47,7 @@ public class NamespaceTests
         Assert.Equal("7\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceFunction_ReadsExportedConst_AndExternalAccessStillWorks(ExecutionMode mode)
     {
         var code = @"
@@ -61,8 +57,7 @@ public class NamespaceTests
         Assert.Equal("7,7\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedNamespaceFunction_ReadsOuterAndInnerVars(ExecutionMode mode)
     {
         var code = @"
@@ -86,8 +81,7 @@ public class NamespaceTests
     // resolve a namespace var by bare name — silently returning undefined (state machines)
     // or throwing "Undefined variable" (class members). These pin each path.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceGenerator_ReadsNamespaceVar(ExecutionMode mode)
     {
         var code = @"
@@ -97,8 +91,7 @@ public class NamespaceTests
         Assert.Equal("4\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceAsyncFunction_ReadsNamespaceVar(ExecutionMode mode)
     {
         var code = @"
@@ -108,8 +101,7 @@ public class NamespaceTests
         Assert.Equal("7\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceClassMethod_ReadsNamespaceVar(ExecutionMode mode)
     {
         var code = @"
@@ -119,8 +111,7 @@ public class NamespaceTests
         Assert.Equal("3\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceClassStaticMethod_ReadsNamespaceVar(ExecutionMode mode)
     {
         var code = @"
@@ -130,8 +121,7 @@ public class NamespaceTests
         Assert.Equal("5\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceClassAccessor_ReadsNamespaceVar(ExecutionMode mode)
     {
         var code = @"
@@ -141,8 +131,7 @@ public class NamespaceTests
         Assert.Equal("8\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceClassConstructor_ReadsNamespaceVar(ExecutionMode mode)
     {
         var code = @"
@@ -152,8 +141,7 @@ public class NamespaceTests
         Assert.Equal("6\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedNamespaceGenerator_ReadsOuterNamespaceVar(ExecutionMode mode)
     {
         var code = @"
@@ -180,8 +168,7 @@ public class NamespaceTests
     // write), instead of the namespace object's declaration-time member. const members never
     // change, so their external value is unaffected.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MutableExportedLet_MutationVisibleViaExternalAccess(ExecutionMode mode)
     {
         var code = @"
@@ -198,8 +185,7 @@ public class NamespaceTests
         Assert.Equal("2\n2\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MutableExportedVar_MutationVisibleViaExternalAccess(ExecutionMode mode)
     {
         var code = @"
@@ -215,8 +201,7 @@ public class NamespaceTests
         Assert.Equal("3\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MutableExportedLet_ExternalAccessReflectsEachMutation(ExecutionMode mode)
     {
         var code = @"
@@ -233,8 +218,7 @@ public class NamespaceTests
         Assert.Equal("1\n10\n20\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstExportedMember_ExternalAccessUnaffected(ExecutionMode mode)
     {
         var code = @"
@@ -248,8 +232,7 @@ public class NamespaceTests
         Assert.Equal("5\n5\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedNamespace_MutableExport_LiveViaExternalAccess(ExecutionMode mode)
     {
         var code = @"
@@ -270,8 +253,7 @@ public class NamespaceTests
 
     #region Basic Namespace Features (Both Modes)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BasicNamespaceWithFunction(ExecutionMode mode)
     {
         var code = @"
@@ -283,8 +265,7 @@ public class NamespaceTests
         Assert.Equal("42\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceWithVariable(ExecutionMode mode)
     {
         var code = @"
@@ -296,8 +277,7 @@ public class NamespaceTests
         Assert.Equal("3.14159\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedNamespace(ExecutionMode mode)
     {
         var code = @"
@@ -311,8 +291,7 @@ public class NamespaceTests
         Assert.Equal("Hello\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DottedNamespaceSyntax(ExecutionMode mode)
     {
         var code = @"
@@ -324,8 +303,7 @@ public class NamespaceTests
         Assert.Equal("123\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeclarationMerging(ExecutionMode mode)
     {
         var code = @"
@@ -340,8 +318,7 @@ public class NamespaceTests
         Assert.Equal("3\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceMultipleFunctions(ExecutionMode mode)
     {
         var code = @"
@@ -355,8 +332,7 @@ public class NamespaceTests
         Assert.Equal("5\n20\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeeplyNestedDottedNamespace(ExecutionMode mode)
     {
         var code = @"
@@ -368,8 +344,7 @@ public class NamespaceTests
         Assert.Equal("1.0.0\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceMergingWithDottedSyntax(ExecutionMode mode)
     {
         var code = @"
@@ -388,8 +363,7 @@ public class NamespaceTests
 
     #region Namespace with Classes (Both Modes)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceWithClass(ExecutionMode mode)
     {
         var code = @"
@@ -409,8 +383,7 @@ public class NamespaceTests
         Assert.StartsWith("12.566", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeepNestedNamespaceClass(ExecutionMode mode)
     {
         var code = @"
@@ -426,8 +399,7 @@ public class NamespaceTests
         Assert.Equal("Click me\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceWithGenericClass(ExecutionMode mode)
     {
         var code = @"
@@ -445,8 +417,7 @@ public class NamespaceTests
         Assert.Equal("42\nhello\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceClassInheritance(ExecutionMode mode)
     {
         var code = @"
@@ -470,8 +441,7 @@ public class NamespaceTests
 
     #region Namespace with Enums (Both Modes)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceWithEnum(ExecutionMode mode)
     {
         var code = @"
@@ -491,8 +461,7 @@ public class NamespaceTests
     // Compiled mode previously only carried the namespace static field on a subset of emission
     // contexts, so a top-level function reading `N.c` threw "Undefined variable 'N'".
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Namespace_ResolvableByBareName_FromTopLevelFunction(ExecutionMode mode)
     {
         var code = @"
@@ -503,8 +472,7 @@ public class NamespaceTests
         Assert.Equal("5\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Namespace_MemberCall_FromTopLevelFunction(ExecutionMode mode)
     {
         var code = @"
@@ -515,8 +483,7 @@ public class NamespaceTests
         Assert.Equal("9\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Namespace_ExportedVar_IsLiveBinding_FromAsyncFunctionBody(ExecutionMode mode)
     {
         // The async function reads N.count AFTER two mutations; it must observe the live
@@ -534,8 +501,7 @@ public class NamespaceTests
     // #657 — namespace var/function members must not collide with module-level or
     // sibling-namespace bindings of the same name.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceVar_DoesNotClobber_ModuleVar(ExecutionMode mode)
     {
         var code = @"
@@ -546,8 +512,7 @@ public class NamespaceTests
         Assert.Equal("100 5\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SiblingNamespaceFunctions_SameName_DoNotCollide(ExecutionMode mode)
     {
         var code = @"
@@ -558,8 +523,7 @@ public class NamespaceTests
         Assert.Equal("1 2\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceFunction_CallsNonExportedSibling(ExecutionMode mode)
     {
         var code = @"
@@ -569,8 +533,7 @@ public class NamespaceTests
         Assert.Equal("42\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceFunction_Recursive(ExecutionMode mode)
     {
         var code = @"
@@ -580,8 +543,7 @@ public class NamespaceTests
         Assert.Equal("55\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceFunction_FallsBackToTopLevelFunction(ExecutionMode mode)
     {
         var code = @"
@@ -592,8 +554,7 @@ public class NamespaceTests
         Assert.Equal("9\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceFunction_ShadowsTopLevelFunctionOfSameName(ExecutionMode mode)
     {
         // A namespace member function with the same simple name as a top-level function must
@@ -609,8 +570,7 @@ public class NamespaceTests
 
     // #659 — arrow-function and async-generator namespace members must be callable via N.member.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowFunctionNamespaceMember_IsCallable(ExecutionMode mode)
     {
         var code = @"
@@ -620,8 +580,7 @@ public class NamespaceTests
         Assert.Equal("42\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGeneratorNamespaceMember_IsCallableAndIterable(ExecutionMode mode)
     {
         // The async-generator member is callable and iterable via `for await` inside an async
@@ -637,8 +596,7 @@ public class NamespaceTests
 
     // #660 — a nested function declaration inside a namespace member function must be callable.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedFunctionDeclaration_InsideNamespaceMemberFunction(ExecutionMode mode)
     {
         var code = @"
@@ -656,8 +614,7 @@ public class NamespaceTests
     // #467 — a namespace-scoped `export const` parses as Stmt.Const, so it carries the narrowed
     // literal type (and reassignment is rejected), matching tsc and the module-export fix #428.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NamespaceExportConst_HasLiteralType(ExecutionMode mode)
     {
         // Before #467 this raised TS2322 ("Type 'number' is not assignable to type '5'") because
@@ -690,8 +647,7 @@ public class NamespaceTests
     // nested namespace is fully checked during the enclosing namespace's first pass, before its
     // sibling functions were registered; CheckNamespace now hoists function declarations first.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedNamespaceFunction_CallsNonExportedEnclosingFunction(ExecutionMode mode)
     {
         // The exact issue repro: O.I.f() reaches O's non-exported helper by bare name.
@@ -707,8 +663,7 @@ public class NamespaceTests
         Assert.Equal("7\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedNamespaceFunction_ForwardReferencesEnclosingFunction(ExecutionMode mode)
     {
         // The enclosing helper is declared AFTER the nested namespace — function hoisting makes it
@@ -725,8 +680,7 @@ public class NamespaceTests
         Assert.Equal("7\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedNamespaceFunction_ReferencesEnclosingClassByBareName(ExecutionMode mode)
     {
         var code = @"
@@ -741,8 +695,7 @@ public class NamespaceTests
         Assert.Equal("42\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedNamespaceFunction_ReferencesSiblingNamespaceByBareName(ExecutionMode mode)
     {
         // B.f names sibling namespace A by its simple name (A is a member of the enclosing O). The
@@ -759,8 +712,7 @@ public class NamespaceTests
         Assert.Equal("5\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeeplyNestedNamespaceFunction_ReferencesOutermostFunction(ExecutionMode mode)
     {
         var code = @"
@@ -777,8 +729,7 @@ public class NamespaceTests
         Assert.Equal("1\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedNamespaceFunction_OwnHelperShadowsEnclosingOfSameName(ExecutionMode mode)
     {
         // The nested namespace declares its own `help`; the bare reference resolves to the inner
@@ -796,8 +747,7 @@ public class NamespaceTests
         Assert.Equal("2\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedNamespace_ShadowsSameNamedTopLevelNamespace(ExecutionMode mode)
     {
         // Nested O.A shadows the top-level A for bare references from sibling O.B.
@@ -829,8 +779,7 @@ public class NamespaceTests
     // the own dotted name; an enclosing function/var by the namespace's own name (`O.outerFunc()`)
     // is not covered — its bare form works via #665.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedNamespace_ReferencesEnclosingNamespaceByOwnDottedName(ExecutionMode mode)
     {
         // The exact issue repro: O.B.f names O by its own name to reach O.A.g.
@@ -844,8 +793,7 @@ public class NamespaceTests
         Assert.Equal("5\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeeplyNested_ReferencesOutermostNamespaceByDottedName(ExecutionMode mode)
     {
         // A three-level-deep member names the outermost namespace by its own dotted name.
@@ -863,8 +811,7 @@ public class NamespaceTests
         Assert.Equal("9\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedNamespace_BareAndOwnDottedNameCoexist(ExecutionMode mode)
     {
         // The same body uses both the bare sibling form (A.g(), #665) and the own dotted name
@@ -879,8 +826,7 @@ public class NamespaceTests
         Assert.Equal("10\n", TestHarness.Run(code, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedNamespace_OwnDottedNameIsUnambiguousVsSameNamedTopLevel(ExecutionMode mode)
     {
         // A top-level A exists, but the dotted path O.A is unambiguous: it resolves the nested

--- a/SharpTS.Tests/SharedTests/NestedFunctionLiftingTests.cs
+++ b/SharpTS.Tests/SharedTests/NestedFunctionLiftingTests.cs
@@ -15,8 +15,7 @@ public class NestedFunctionLiftingTests
 {
     // ── #470: a plain function declared inside a state-machine body ──────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PlainFunction_NestedInGeneratorBody_IsCallable(ExecutionMode mode)
     {
         var source = """
@@ -29,8 +28,7 @@ public class NestedFunctionLiftingTests
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PlainFunction_NestedInAsyncBody_IsCallable(ExecutionMode mode)
     {
         var source = """
@@ -45,8 +43,7 @@ public class NestedFunctionLiftingTests
 
     // ── #501: a nested generator/async function declaration ──────────────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NestedInPlainFunction_IsCallable(ExecutionMode mode)
     {
         var source = """
@@ -59,8 +56,7 @@ public class NestedFunctionLiftingTests
         Assert.Equal("[42]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_NestedInGeneratorBody_NonCapturing_IsCallable(ExecutionMode mode)
     {
         var source = """
@@ -74,8 +70,7 @@ public class NestedFunctionLiftingTests
         Assert.Equal("[1,2,3]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncFunction_NestedInPlainFunction_IsCallable(ExecutionMode mode)
     {
         var source = """
@@ -90,8 +85,7 @@ public class NestedFunctionLiftingTests
 
     // ── Recursion: self-reference must resolve to the relocated declaration ───────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RecursiveNestedFunction_InGeneratorBody(ExecutionMode mode)
     {
         var source = """
@@ -104,8 +98,7 @@ public class NestedFunctionLiftingTests
         Assert.Equal("120\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RecursiveNestedGenerator_InPlainFunction(ExecutionMode mode)
     {
         var source = """
@@ -122,8 +115,7 @@ public class NestedFunctionLiftingTests
 
     // ── Multiple siblings and name independence across scopes ────────────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultipleIndependentNestedHelpers(ExecutionMode mode)
     {
         var source = """
@@ -138,8 +130,7 @@ public class NestedFunctionLiftingTests
         Assert.Equal("[1,2]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SameNamedNestedHelpers_InDifferentFunctions_StayIndependent(ExecutionMode mode)
     {
         // Each relocated declaration gets a fresh unique top-level name, so two generators that both
@@ -152,8 +143,7 @@ public class NestedFunctionLiftingTests
         Assert.Equal("[1] [2]\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LiftedHelper_DoesNotHijack_SameNamedBindingElsewhere(ExecutionMode mode)
     {
         // `a`'s nested `h` is relocated; `b`'s own (unrelated) nested `h` must keep returning 20.
@@ -166,8 +156,7 @@ public class NestedFunctionLiftingTests
         Assert.Equal("[10] 20\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedGenerator_NameCollidesWithTopLevelFunction_IsLifted(ExecutionMode mode)
     {
         // The nested generator `a3` shares a name with a top-level function. It is relocated under a
@@ -184,8 +173,7 @@ public class NestedFunctionLiftingTests
 
     // ── Deep nesting ─────────────────────────────────────────────────────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeeplyNestedGenerators(ExecutionMode mode)
     {
         var source = """
@@ -204,8 +192,7 @@ public class NestedFunctionLiftingTests
 
     // ── Generator value-references to a top-level function (the lift's alias relies on this) ──────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TopLevelFunction_ReferencedAsValueInsideGenerator(ExecutionMode mode)
     {
         // A top-level function used as a value (not a direct call) inside a generator body must
@@ -222,8 +209,7 @@ public class NestedFunctionLiftingTests
         Assert.Equal("function\n7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedHelper_YieldedAsValue_IsCallable(ExecutionMode mode)
     {
         var source = """
@@ -242,8 +228,7 @@ public class NestedFunctionLiftingTests
     // the inner-function pass and previously threw "Undefined variable" in compiled mode. The lifter
     // now relocates the non-capturing ones to the module top level.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PlainFunction_InTopLevelBlock_IsCallable(ExecutionMode mode)
     {
         var source = """
@@ -252,8 +237,7 @@ public class NestedFunctionLiftingTests
         Assert.Equal("1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_InTopLevelBlock_IsCallable(ExecutionMode mode)
     {
         var source = """
@@ -262,8 +246,7 @@ public class NestedFunctionLiftingTests
         Assert.Equal("1,2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BlockFunction_ReferencingModuleBinding_IsCallable(ExecutionMode mode)
     {
         // A block function that references a module-level binding (not a block/loop-scoped one) is
@@ -276,8 +259,7 @@ public class NestedFunctionLiftingTests
         Assert.Equal("15\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RecursiveBlockFunction_IsCallable(ExecutionMode mode)
     {
         var source = """
@@ -286,8 +268,7 @@ public class NestedFunctionLiftingTests
         Assert.Equal("120\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_InTopLevelIfBlock_IsCallable(ExecutionMode mode)
     {
         var source = """
@@ -303,8 +284,7 @@ public class NestedFunctionLiftingTests
     // only route that lowers a capturing GENERATOR/ASYNC (the compiler cannot emit one as a capturing
     // closure directly). Previously these threw "ReferenceError: Undefined variable" in compiled mode.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BlockFunction_CapturingBlockConst_IsCallable(ExecutionMode mode)
     {
         var source = """
@@ -313,8 +293,7 @@ public class NestedFunctionLiftingTests
         Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BlockFunction_CapturingMultipleBlockBindings_IsCallable(ExecutionMode mode)
     {
         var source = """
@@ -323,8 +302,7 @@ public class NestedFunctionLiftingTests
         Assert.Equal("12\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BlockAsyncFunction_CapturingBlockConst_IsCallable(ExecutionMode mode)
     {
         var source = """
@@ -333,8 +311,7 @@ public class NestedFunctionLiftingTests
         Assert.Equal("y\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RecursiveBlockGenerator_CapturingBlockConst_IsCallable(ExecutionMode mode)
     {
         // The function's own name is forwarded too, so the relocated body's self-calls resolve to
@@ -373,8 +350,7 @@ public class NestedFunctionLiftingTests
     // Only a GENERATOR encloser snapshots its captures at creation, so its forward-reference form stays
     // unsupported and fails cleanly rather than miscompiling.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CapturingNestedGenerator_ForwardReference_IsLifted(ExecutionMode mode)
     {
         var source = """
@@ -393,8 +369,7 @@ public class NestedFunctionLiftingTests
     // #924: function declarations hoist inside an ASYNC function body just as in a sync body, so a
     // forward reference to a function declared later resolves. Previously the interpreter raised
     // "Undefined variable" (ExecuteBlockAsync never ran the hoisting pass).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PlainFunctionDeclaration_ForwardReference_InAsyncFunction_IsHoisted(ExecutionMode mode)
     {
         var source = """
@@ -411,8 +386,7 @@ public class NestedFunctionLiftingTests
     // #924: a capturing generator declaration whose forward reference precedes it, inside an ASYNC
     // (non-generator) function. The interpreter hoists it; the compiler hoists its forwarding binding
     // (the async encloser reads captures live at call time, unlike a generator encloser).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CapturingGeneratorDeclaration_ForwardReference_InAsyncFunction_IsLifted(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/NestedGenericsParsingTests.cs
+++ b/SharpTS.Tests/SharedTests/NestedGenericsParsingTests.cs
@@ -13,8 +13,7 @@ public class NestedGenericsParsingTests
 {
     #region Double Nested Generics (>> token splitting)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DoubleNested_VariableDeclaration(ExecutionMode mode)
     {
         var source = """
@@ -26,8 +25,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DoubleNested_FunctionParameter(ExecutionMode mode)
     {
         var source = """
@@ -42,8 +40,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("test\ndefault\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DoubleNested_FunctionReturnType(ExecutionMode mode)
     {
         var source = """
@@ -58,8 +55,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DoubleNested_GenericClassInstantiation(ExecutionMode mode)
     {
         var source = """
@@ -76,8 +72,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DoubleNested_MultipleTypeArguments(ExecutionMode mode)
     {
         var source = """
@@ -89,8 +84,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DoubleNested_MultipleVariables(ExecutionMode mode)
     {
         // Tests multiple nested generic declarations in sequence
@@ -106,8 +100,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("Alice\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DoubleNested_InFunctionCall(ExecutionMode mode)
     {
         var source = """
@@ -126,8 +119,7 @@ public class NestedGenericsParsingTests
 
     #region Triple Nested Generics (>>> token splitting)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TripleNested_VariableDeclaration(ExecutionMode mode)
     {
         var source = """
@@ -139,8 +131,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TripleNested_FunctionParameter(ExecutionMode mode)
     {
         var source = """
@@ -154,8 +145,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TripleNested_MultipleVariables(ExecutionMode mode)
     {
         var source = """
@@ -170,8 +160,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("1\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TripleNested_GenericClass(ExecutionMode mode)
     {
         var source = """
@@ -191,8 +180,7 @@ public class NestedGenericsParsingTests
 
     #region Quadruple+ Nested Generics (multiple splits)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void QuadrupleNested_VariableDeclaration(ExecutionMode mode)
     {
         var source = """
@@ -204,8 +192,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("999\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DeeplyNested_FiveLevel(ExecutionMode mode)
     {
         var source = """
@@ -221,8 +208,7 @@ public class NestedGenericsParsingTests
 
     #region Mixed Contexts
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MixedNesting_DifferentLevels(ExecutionMode mode)
     {
         var source = """
@@ -237,8 +223,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("1\ntest\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedGenerics_InClassField(ExecutionMode mode)
     {
         var source = """
@@ -256,8 +241,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedGenerics_InMethodParameter(ExecutionMode mode)
     {
         var source = """
@@ -275,8 +259,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("42\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedGenerics_InMethodReturnType(ExecutionMode mode)
     {
         var source = """
@@ -293,8 +276,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedGenerics_InArrowFunction(ExecutionMode mode)
     {
         var source = """
@@ -307,8 +289,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("123\n-1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedGenerics_InTypeAssertion(ExecutionMode mode)
     {
         var source = """
@@ -325,8 +306,7 @@ public class NestedGenericsParsingTests
 
     #region Regression: Right-Shift Operators Still Work
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RightShift_InExpression(ExecutionMode mode)
     {
         var source = """
@@ -337,8 +317,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UnsignedRightShift_InExpression(ExecutionMode mode)
     {
         var source = """
@@ -349,8 +328,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RightShift_NegativeNumber(ExecutionMode mode)
     {
         var source = """
@@ -361,8 +339,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("-4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RightShift_WithParentheses(ExecutionMode mode)
     {
         var source = """
@@ -374,8 +351,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RightShift_InComparison(ExecutionMode mode)
     {
         var source = """
@@ -387,8 +363,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MixedContext_TypeAndShiftOperator(ExecutionMode mode)
     {
         // Tests that >> works as shift in expressions while also having nested generics
@@ -407,8 +382,7 @@ public class NestedGenericsParsingTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedGenerics_EmptyTypeArgs(ExecutionMode mode)
     {
         // Generic with nested generic that has its own empty case
@@ -421,8 +395,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("ok\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedGenerics_WithOptionalProperties(ExecutionMode mode)
     {
         var source = """
@@ -437,8 +410,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedGenerics_ConsecutiveDeclarations(ExecutionMode mode)
     {
         var source = """
@@ -456,8 +428,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("1\ntwo\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedGenerics_InConditionalReturn(ExecutionMode mode)
     {
         var source = """
@@ -475,8 +446,7 @@ public class NestedGenericsParsingTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedGenerics_Record_With_NestedType(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/NetModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/NetModuleTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class NetModuleTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NetModuleImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -23,8 +22,7 @@ public class NetModuleTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NetModuleNodePrefix(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -38,8 +36,7 @@ public class NetModuleTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NetModuleExports(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -58,8 +55,7 @@ public class NetModuleTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NetIsIPv4(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -79,8 +75,7 @@ public class NetModuleTests
         Assert.Equal("4\n6\n0\ntrue\nfalse\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NetCreateServerReturnsServer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -99,8 +94,7 @@ public class NetModuleTests
         Assert.Equal("false\nfunction\nfunction\nfunction\nfunction\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NetServerListenAndClose(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -124,8 +118,7 @@ public class NetModuleTests
         Assert.Equal("listening\ntrue\ntrue\nclosed\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NetServerListeningEvent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -148,8 +141,7 @@ public class NetModuleTests
         Assert.Contains("close event fired", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NetServerConnectionEvent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -173,8 +165,7 @@ public class NetModuleTests
         Assert.Contains("true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NetConnectPositionalPortHostCallback(ExecutionMode mode)
     {
         // Node signature: net.connect(port[, host][, connectListener]) — the
@@ -200,8 +191,7 @@ public class NetModuleTests
         Assert.Contains("connect listener fired", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NetSocketWriteAndReceive(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -232,8 +222,7 @@ public class NetModuleTests
         Assert.Contains("received: hello", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NetSocketCloseEmittedOnceWhenDestroyedAfterEnd(ExecutionMode mode)
     {
         // Node emits 'close' exactly once per socket lifetime. Calling destroy()
@@ -265,8 +254,7 @@ public class NetModuleTests
         Assert.Contains("close events: 1", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NetSocketProperties(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -293,8 +281,7 @@ public class NetModuleTests
         Assert.Contains("false", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NetServerGetConnections(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -328,8 +315,7 @@ public class NetModuleTests
         return OperatingSystem.IsWindows() ? pipeName : $"/tmp/{pipeName}.sock";
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IpcSocket_PipeBasic(ExecutionMode mode)
     {
         var pipePath = GetIpcPath();
@@ -361,8 +347,7 @@ public class NetModuleTests
         Assert.Contains("received: pong", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IpcSocket_ConnectionEvent(ExecutionMode mode)
     {
         var pipePath = GetIpcPath();
@@ -386,8 +371,7 @@ public class NetModuleTests
         Assert.Contains("connection event fired", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IpcSocket_MultipleClients(ExecutionMode mode)
     {
         var pipePath = GetIpcPath();
@@ -418,8 +402,7 @@ public class NetModuleTests
         Assert.Contains("connection 2", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IpcSocket_OptionsObject(ExecutionMode mode)
     {
         var pipePath = GetIpcPath();
@@ -442,8 +425,7 @@ public class NetModuleTests
         Assert.Contains("connected via options", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IpcSocket_Properties(ExecutionMode mode)
     {
         var pipePath = GetIpcPath();
@@ -468,8 +450,7 @@ public class NetModuleTests
         Assert.Contains("readyState: open", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IpcSocket_ServerAddress(ExecutionMode mode)
     {
         var pipePath = GetIpcPath();
@@ -496,8 +477,7 @@ public class NetModuleTests
         Assert.Contains($"addr: {pipePath}", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IpcSocket_BidirectionalEcho(ExecutionMode mode)
     {
         var pipePath = GetIpcPath();
@@ -530,8 +510,7 @@ public class NetModuleTests
         Assert.Contains("echo:hello", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
     public void IpcSocket_ConnectErrorCode(ExecutionMode mode)
     {
@@ -561,8 +540,7 @@ public class NetModuleTests
         Assert.Contains("code: E", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IpcSocket_ServerListenErrorEvent(ExecutionMode mode)
     {
         var pipePath = GetIpcPath();
@@ -594,8 +572,7 @@ public class NetModuleTests
         Assert.Contains("listening", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IpcSocket_NetConnect(ExecutionMode mode)
     {
         // Test net.connect() as alias for net.createConnection() with IPC
@@ -625,8 +602,7 @@ public class NetModuleTests
 
     #endregion
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HttpsModuleImport(ExecutionMode mode)
     {
         // Test that https module can be imported (delegates to http)

--- a/SharpTS.Tests/SharedTests/NetTransportParityTests.cs
+++ b/SharpTS.Tests/SharedTests/NetTransportParityTests.cs
@@ -13,8 +13,7 @@ public class NetTransportParityTests
 {
     #region #1068 — write backpressure + drain
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Socket_Write_PastHighWaterMark_ReturnsFalse_ThenDrains(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -50,8 +49,7 @@ public class NetTransportParityTests
         Assert.Equal("hwm 4\nwrite false\nneedDrain true\ndrain 0 false\nserver got 10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Socket_Write_BelowHighWaterMark_ReturnsTrue_DefaultHwm(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -78,8 +76,7 @@ public class NetTransportParityTests
         Assert.Equal("default hwm 16384\nsmall write true\nneedDrain false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Socket_WriteCallback_FiresAfterFlush_BeforeDrain(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -107,8 +104,7 @@ public class NetTransportParityTests
         Assert.Equal("write cb\ndrain\nend cb\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_HighWaterMarkOption_AppliesToAcceptedSockets(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -136,8 +132,7 @@ public class NetTransportParityTests
         Assert.Equal("accepted hwm 8\nserver write false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Socket_EndWithData_FlushesQueuedWritesBeforeFin(ExecutionMode mode)
     {
         // end(data, cb) must flush pending writes, then the final chunk, then FIN —
@@ -175,8 +170,7 @@ public class NetTransportParityTests
 
     #region #1069 — net.BlockList + net.SocketAddress
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BlockList_AddressRangeSubnet_CheckAndRules(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -212,8 +206,7 @@ public class NetTransportParityTests
             output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SocketAddress_DefaultsAndOptions(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -236,8 +229,7 @@ public class NetTransportParityTests
         Assert.Equal("1.2.3.4 ipv4 80 0\n:: ipv6\n127.0.0.1 ipv4 0\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BlockList_InvalidInputs_ThrowOrFalse(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -256,8 +248,7 @@ public class NetTransportParityTests
         Assert.Equal("addAddress threw\naddRange threw\naddSubnet threw\nfalse\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_BlockList_RejectsBlockedPeerSilently(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -285,8 +276,7 @@ public class NetTransportParityTests
         Assert.Equal("blocked client closed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_AllowHalfOpen_KeepsWritableSideAfterFin(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -329,8 +319,7 @@ public class NetTransportParityTests
             output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Server_Drop_FiresPastMaxConnections(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -366,8 +355,7 @@ public class NetTransportParityTests
         Assert.Equal("drop string number IPv4\nc2 closed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Net_AutoSelectFamilyDefaults_GetAndSet(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -388,8 +376,7 @@ public class NetTransportParityTests
         Assert.Equal("true\n250\nfalse\n500\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BlockList_NamedImport_Constructible(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/NonCallableInvocationTests.cs
+++ b/SharpTS.Tests/SharedTests/NonCallableInvocationTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class NonCallableInvocationTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullCallee_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """
@@ -28,8 +27,7 @@ public class NonCallableInvocationTests
         Assert.Equal("true object is not a function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UndefinedAndMissingMethod_ThrowTypeError(ExecutionMode mode)
     {
         var source = """
@@ -53,8 +51,7 @@ public class NonCallableInvocationTests
             output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonCallablePrimitive_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """
@@ -67,8 +64,7 @@ public class NonCallableInvocationTests
         Assert.Equal("true number is not a function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalCall_OfNullish_ReturnsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -82,8 +78,7 @@ public class NonCallableInvocationTests
         Assert.Equal("undefined\nundefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalChainMethodCall_ShortCircuitsWholeChain(ExecutionMode mode)
     {
         // ECMA-262 §13.3: a.b?.m(x) yields undefined when a.b is nullish — the
@@ -103,8 +98,7 @@ public class NonCallableInvocationTests
         Assert.Equal("undefined\n/x/\nundefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonCallableMember_EvaluatesArgsBeforeCallabilityCheck(ExecutionMode mode)
     {
         // ECMA-262 §13.3.6.1: ArgumentListEvaluation (step 2) runs before the
@@ -122,8 +116,7 @@ public class NonCallableInvocationTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MemberAccessOnUndefinedCallee_ThrowsBeforeArgs(ExecutionMode mode)
     {
         // ECMA-262 §13.3.2.1: evaluating the callee `o.bar.gar` calls
@@ -142,8 +135,7 @@ public class NonCallableInvocationTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SloppyThisMethodCall_EvaluatesArgs(ExecutionMode mode)
     {
         // `this.bar(se())` in a function called without a receiver: sloppy-mode
@@ -163,8 +155,7 @@ public class NonCallableInvocationTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForAwaitBreak_WithoutIteratorReturn_DoesNotThrow(ExecutionMode mode)
     {
         // iterator.return() is optional per the iterator protocol; the for-await

--- a/SharpTS.Tests/SharedTests/NonNullAssertionTests.cs
+++ b/SharpTS.Tests/SharedTests/NonNullAssertionTests.cs
@@ -11,8 +11,7 @@ public class NonNullAssertionTests
 {
     #region Basic Syntax
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_OnVariable(ExecutionMode mode)
     {
         var source = """
@@ -24,8 +23,7 @@ public class NonNullAssertionTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_OnNullableString(ExecutionMode mode)
     {
         var source = """
@@ -37,8 +35,7 @@ public class NonNullAssertionTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_OnPropertyAccess(ExecutionMode mode)
     {
         var source = """
@@ -51,8 +48,7 @@ public class NonNullAssertionTests
         Assert.Equal("Bob\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_OnMethodResult(ExecutionMode mode)
     {
         var source = """
@@ -70,8 +66,7 @@ public class NonNullAssertionTests
 
     #region Chained Operations
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_ChainedPropertyAccess(ExecutionMode mode)
     {
         var source = """
@@ -85,8 +80,7 @@ public class NonNullAssertionTests
         Assert.Equal("Charlie\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_ChainedMethodCall(ExecutionMode mode)
     {
         var source = """
@@ -98,8 +92,7 @@ public class NonNullAssertionTests
         Assert.Equal("HELLO\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_MultipleInChain(ExecutionMode mode)
     {
         var source = """
@@ -118,8 +111,7 @@ public class NonNullAssertionTests
 
     #region Array Operations
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_ArrayElement(ExecutionMode mode)
     {
         var source = """
@@ -131,8 +123,7 @@ public class NonNullAssertionTests
         Assert.Equal("b\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_ArrayElement_WithMethodCall(ExecutionMode mode)
     {
         var source = """
@@ -148,8 +139,7 @@ public class NonNullAssertionTests
 
     #region Object Literal
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_InObjectProperty(ExecutionMode mode)
     {
         var source = """
@@ -165,8 +155,7 @@ public class NonNullAssertionTests
 
     #region Function Arguments
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_InFunctionArgument(ExecutionMode mode)
     {
         var source = """
@@ -180,8 +169,7 @@ public class NonNullAssertionTests
         Assert.Equal("Hello, World\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_MultipleArguments(ExecutionMode mode)
     {
         var source = """
@@ -200,8 +188,7 @@ public class NonNullAssertionTests
 
     #region Class Methods and Properties
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_OnClassProperty(ExecutionMode mode)
     {
         var source = """
@@ -218,8 +205,7 @@ public class NonNullAssertionTests
         Assert.Equal("test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_OnClassMethodResult(ExecutionMode mode)
     {
         var source = """
@@ -239,8 +225,7 @@ public class NonNullAssertionTests
 
     #region Arithmetic Operations
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_InArithmeticExpression(ExecutionMode mode)
     {
         var source = """
@@ -253,8 +238,7 @@ public class NonNullAssertionTests
         Assert.Equal("8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_InComparison(ExecutionMode mode)
     {
         var source = """
@@ -270,8 +254,7 @@ public class NonNullAssertionTests
 
     #region Combined with Other Operators
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_BeforeTernary(ExecutionMode mode)
     {
         var source = """
@@ -283,8 +266,7 @@ public class NonNullAssertionTests
         Assert.Equal("big\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_AfterOptionalChaining(ExecutionMode mode)
     {
         var source = """
@@ -297,8 +279,7 @@ public class NonNullAssertionTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_InStringConcatenation(ExecutionMode mode)
     {
         var source = """
@@ -314,8 +295,7 @@ public class NonNullAssertionTests
 
     #region Type Narrowing
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_NarrowsUnionType(ExecutionMode mode)
     {
         var source = """
@@ -327,8 +307,7 @@ public class NonNullAssertionTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_OnMultiTypeUnion(ExecutionMode mode)
     {
         var source = """
@@ -340,8 +319,7 @@ public class NonNullAssertionTests
         Assert.Equal("string\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_OnAlreadyNonNull(ExecutionMode mode)
     {
         var source = """
@@ -357,8 +335,7 @@ public class NonNullAssertionTests
 
     #region Nested Expressions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_InNestedExpression(ExecutionMode mode)
     {
         var source = """
@@ -371,8 +348,7 @@ public class NonNullAssertionTests
         Assert.Equal("60\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_OnGroupedExpression(ExecutionMode mode)
     {
         var source = """
@@ -388,8 +364,7 @@ public class NonNullAssertionTests
 
     #region Template Literals
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_InTemplateLiteral(ExecutionMode mode)
     {
         var source = """
@@ -405,8 +380,7 @@ public class NonNullAssertionTests
 
     #region Arrow Functions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_InArrowFunction(ExecutionMode mode)
     {
         var source = """
@@ -417,8 +391,7 @@ public class NonNullAssertionTests
         Assert.Equal("TEST\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_InArrowFunctionReturn(ExecutionMode mode)
     {
         var source = """
@@ -432,8 +405,7 @@ public class NonNullAssertionTests
         Assert.Equal("HELLO\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_SingleParamArrowWithoutParens(ExecutionMode mode)
     {
         // Single-parameter arrow function without parentheses
@@ -446,8 +418,7 @@ public class NonNullAssertionTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_SingleParamArrowWithBinaryOp(ExecutionMode mode)
     {
         // Single-parameter arrow with non-null assertion followed by comparison
@@ -460,8 +431,7 @@ public class NonNullAssertionTests
         Assert.Equal("[3, 4, 5]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_SingleParamArrowWithArithmetic(ExecutionMode mode)
     {
         // Single-parameter arrow with non-null assertion followed by arithmetic
@@ -474,8 +444,7 @@ public class NonNullAssertionTests
         Assert.Equal("[2, 4, 6]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_ChainedSingleParamArrows(ExecutionMode mode)
     {
         // Chained array methods with single-parameter arrows
@@ -492,8 +461,7 @@ public class NonNullAssertionTests
 
     #region With Type Assertions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_CombinedWithTypeAssertion(ExecutionMode mode)
     {
         var source = """
@@ -509,8 +477,7 @@ public class NonNullAssertionTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_OnNumberZero(ExecutionMode mode)
     {
         // Zero is falsy but not null - assertion should pass
@@ -522,8 +489,7 @@ public class NonNullAssertionTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_OnEmptyString(ExecutionMode mode)
     {
         // Empty string is falsy but not null - assertion should pass
@@ -535,8 +501,7 @@ public class NonNullAssertionTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_OnBoolean(ExecutionMode mode)
     {
         var source = """
@@ -547,8 +512,7 @@ public class NonNullAssertionTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullAssertion_Consecutive(ExecutionMode mode)
     {
         // Multiple ! in a row (redundant but valid)

--- a/SharpTS.Tests/SharedTests/NullishEqualityFastPathTests.cs
+++ b/SharpTS.Tests/SharedTests/NullishEqualityFastPathTests.cs
@@ -18,8 +18,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class NullishEqualityFastPathTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StrictNull_DistinguishesUndefined(ExecutionMode mode)
     {
         var source = """
@@ -37,8 +36,7 @@ public class NullishEqualityFastPathTests
         Assert.Equal("true,false\nfalse,true\nfalse,true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StrictUndefined_DistinguishesNull(ExecutionMode mode)
     {
         var source = """
@@ -55,8 +53,7 @@ public class NullishEqualityFastPathTests
         Assert.Equal("false,true\ntrue,false\nfalse,true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LooseNullish_NullAndUndefinedInterchangeable(ExecutionMode mode)
     {
         var source = """
@@ -77,8 +74,7 @@ public class NullishEqualityFastPathTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NaN_IsNotNullish(ExecutionMode mode)
     {
         // A NaN value operand must compare unequal to null/undefined (and the fast path
@@ -90,8 +86,7 @@ public class NullishEqualityFastPathTests
         Assert.Equal("false false false\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullVsUndefinedLiterals(ExecutionMode mode)
     {
         // Both-literal comparisons (handled by the fall-through boxed path, not the fast
@@ -104,8 +99,7 @@ public class NullishEqualityFastPathTests
         Assert.Equal("true true\nfalse true\ntrue false\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReversedOperandOrder(ExecutionMode mode)
     {
         // The literal may be on either side.
@@ -117,8 +111,7 @@ public class NullishEqualityFastPathTests
         Assert.Equal("false false true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullGuardedTreeTraversal(ExecutionMode mode)
     {
         // The binary-trees idiom: `node === null` driving recursion. Exercises the fast

--- a/SharpTS.Tests/SharedTests/NullishMemberAccessTests.cs
+++ b/SharpTS.Tests/SharedTests/NullishMemberAccessTests.cs
@@ -35,8 +35,7 @@ public class NullishMemberAccessTests
 
     // ----- undefined receiver: dot read (#676 / #701 core) -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UndefinedDotRead_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -49,8 +48,7 @@ public class NullishMemberAccessTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UndefinedBracketRead_StringKey_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -63,8 +61,7 @@ public class NullishMemberAccessTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UndefinedBracketRead_NumericKey_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -79,8 +76,7 @@ public class NullishMemberAccessTests
 
     // ----- null receiver: dot + bracket read (#735) -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullDotRead_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -93,8 +89,7 @@ public class NullishMemberAccessTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullBracketRead_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -109,8 +104,7 @@ public class NullishMemberAccessTests
 
     // ----- null/undefined receiver: method call (the #676 repro shape) -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UndefinedMethodCall_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -121,8 +115,7 @@ public class NullishMemberAccessTests
         Assert.Equal("object true TypeError\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullMethodCall_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -135,8 +128,7 @@ public class NullishMemberAccessTests
 
     // ----- writes on null/undefined (#733) -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UndefinedDotWrite_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -149,8 +141,7 @@ public class NullishMemberAccessTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullDotWrite_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -163,8 +154,7 @@ public class NullishMemberAccessTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullBracketWrite_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -178,8 +168,7 @@ public class NullishMemberAccessTests
     }
 
     // PutValue follows RHS evaluation: the RHS side effect must run before the throw.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullWrite_RHS_SideEffect_Runs_BeforeThrow(ExecutionMode mode)
     {
         var source = """
@@ -195,8 +184,7 @@ public class NullishMemberAccessTests
     // These read the property first (GetValue), so per spec they throw the
     // *read*-worded message, NOT the "setting" wording of a plain `o.x = v`.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UndefinedDotCompound_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -209,8 +197,7 @@ public class NullishMemberAccessTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullDotCompound_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -223,8 +210,7 @@ public class NullishMemberAccessTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UndefinedDotLogicalNullish_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -237,8 +223,7 @@ public class NullishMemberAccessTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullDotLogicalOr_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -251,8 +236,7 @@ public class NullishMemberAccessTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UndefinedIndexCompound_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -265,8 +249,7 @@ public class NullishMemberAccessTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullIndexLogicalNullish_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -280,8 +263,7 @@ public class NullishMemberAccessTests
     }
 
     // Exercises the base (state-machine) compound/logical emitter + EvaluateLogicalSetAsync.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UndefinedDotLogical_InsideAsync_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -298,8 +280,7 @@ public class NullishMemberAccessTests
     }
 
     // Regression: compound/logical assignment on a real receiver still works.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefinedReceiver_CompoundAndLogical_StillWork(ExecutionMode mode)
     {
         var source = """
@@ -314,8 +295,7 @@ public class NullishMemberAccessTests
 
     // ----- async context exercises the base (state-machine) emitter -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UndefinedDotRead_InsideAsync_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -331,8 +311,7 @@ public class NullishMemberAccessTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullDotRead_InsideAsync_ThrowsTypeError(ExecutionMode mode)
     {
         var source = $$"""
@@ -354,8 +333,7 @@ public class NullishMemberAccessTests
     // the new null/undefined guard, and writes via `this.x = v` round-trip through
     // the global object.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SloppyThis_Read_DoesNotThrow(ExecutionMode mode)
     {
         var source = """
@@ -365,8 +343,7 @@ public class NullishMemberAccessTests
         Assert.Equal("ok-undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SloppyThis_Write_RoutesToGlobalThis(ExecutionMode mode)
     {
         var source = """
@@ -394,8 +371,7 @@ public class NullishMemberAccessTests
 
     // ----- regression: optional chaining still short-circuits (does NOT throw) -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalDotChain_OnUndefined_ReturnsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -406,8 +382,7 @@ public class NullishMemberAccessTests
         Assert.Equal("undefined-ok\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalBracketChain_OnUndefined_ReturnsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -418,8 +393,7 @@ public class NullishMemberAccessTests
         Assert.Equal("undefined-ok\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalDotChain_OnNull_ReturnsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -430,8 +404,7 @@ public class NullishMemberAccessTests
         Assert.Equal("undefined-ok\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalDotChain_OnUndefined_InsideAsync_ReturnsUndefined(ExecutionMode mode)
     {
         // Exercises the base EmitGet optional short-circuit added for the
@@ -449,8 +422,7 @@ public class NullishMemberAccessTests
 
     // ----- regression: real reads still work after the guard -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefinedReceiver_DotAndBracketRead_StillWork(ExecutionMode mode)
     {
         var source = """
@@ -460,8 +432,7 @@ public class NullishMemberAccessTests
         Assert.Equal("42 42 one\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefinedReceiver_DotWrite_StillWorks(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/NumberFormattingParityTests.cs
+++ b/SharpTS.Tests/SharedTests/NumberFormattingParityTests.cs
@@ -13,8 +13,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class NumberFormattingParityTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConsoleLog_PrecisionAndThresholds(ExecutionMode mode)
     {
         var source = """
@@ -33,8 +32,7 @@ public class NumberFormattingParityTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringAndToString(ExecutionMode mode)
     {
         var source = """
@@ -47,8 +45,7 @@ public class NumberFormattingParityTests
         Assert.Equal("0.30000000000000004\n1e+21\n0.30000000000000004\n1e+21\n1e+21\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConcatTemplateJoinAndPropertyKey(ExecutionMode mode)
     {
         var source = """
@@ -64,8 +61,7 @@ public class NumberFormattingParityTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void JsonStringify_PrecisionAndSpecials(ExecutionMode mode)
     {
         // NaN/Infinity serialize as null; everything else uses Number::toString.
@@ -78,8 +74,7 @@ public class NumberFormattingParityTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LargeIntegers_ShortestRoundTrip(ExecutionMode mode)
     {
         // At/above 2^53 the double loses integer precision; ECMA-262 uses the shortest
@@ -92,8 +87,7 @@ public class NumberFormattingParityTests
         Assert.Equal("1234567890123456800\n9007199254740992\n9007199254740992\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpecialValuesAndRadix(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/NumberLocalCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/NumberLocalCaptureTests.cs
@@ -15,8 +15,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class NumberLocalCaptureTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumberLoopLocal_CapturedByArrow(ExecutionMode mode)
     {
         // The #431 repro: a per-iteration number const captured by an arrow.
@@ -28,8 +27,7 @@ public class NumberLocalCaptureTests
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumberBlockConst_CapturedByArrow(ExecutionMode mode)
     {
         var source = """
@@ -38,8 +36,7 @@ public class NumberLocalCaptureTests
         Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumberLoopVar_CapturedByArrow_IsPerIteration(ExecutionMode mode)
     {
         // Capturing the `let` loop binding itself (not a fresh per-iteration const). Both modes

--- a/SharpTS.Tests/SharedTests/NumberTests.cs
+++ b/SharpTS.Tests/SharedTests/NumberTests.cs
@@ -10,8 +10,7 @@ public class NumberTests
 {
     #region Static Properties
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_MAX_VALUE_ReturnsLargeNumber(ExecutionMode mode)
     {
         // Use a comparison that doesn't require scientific notation parsing
@@ -20,8 +19,7 @@ public class NumberTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_MIN_VALUE_ReturnsSmallPositive(ExecutionMode mode)
     {
         // MIN_VALUE is the smallest positive number (like double.Epsilon)
@@ -30,8 +28,7 @@ public class NumberTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_NaN_IsNaN(ExecutionMode mode)
     {
         var source = "console.log(Number.isNaN(Number.NaN));";
@@ -39,8 +36,7 @@ public class NumberTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_POSITIVE_INFINITY_IsInfinity(ExecutionMode mode)
     {
         var source = "console.log(Number.POSITIVE_INFINITY > Number.MAX_VALUE);";
@@ -48,8 +44,7 @@ public class NumberTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_NEGATIVE_INFINITY_IsNegativeInfinity(ExecutionMode mode)
     {
         // Verify NEGATIVE_INFINITY is less than any large negative number
@@ -58,8 +53,7 @@ public class NumberTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_MAX_SAFE_INTEGER_HasCorrectValue(ExecutionMode mode)
     {
         var source = "console.log(Number.MAX_SAFE_INTEGER === 9007199254740991);";
@@ -67,8 +61,7 @@ public class NumberTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_MIN_SAFE_INTEGER_HasCorrectValue(ExecutionMode mode)
     {
         var source = "console.log(Number.MIN_SAFE_INTEGER === -9007199254740991);";
@@ -76,8 +69,7 @@ public class NumberTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_EPSILON_IsSmallPositive(ExecutionMode mode)
     {
         // EPSILON is 2^-52, a very small positive number
@@ -90,8 +82,7 @@ public class NumberTests
 
     #region Static Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_parseInt_ParsesIntegers(ExecutionMode mode)
     {
         var source = """
@@ -102,8 +93,7 @@ public class NumberTests
         Assert.Equal("42\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_parseInt_WithRadix(ExecutionMode mode)
     {
         var source = """
@@ -115,8 +105,7 @@ public class NumberTests
         Assert.Equal("255\n5\n63\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_parseFloat_ParsesFloats(ExecutionMode mode)
     {
         var source = """
@@ -128,8 +117,7 @@ public class NumberTests
         Assert.Equal("3.14\n42\n3.14\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_isNaN_StrictBehavior(ExecutionMode mode)
     {
         var source = """
@@ -141,8 +129,7 @@ public class NumberTests
         Assert.Equal("true\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_isFinite_StrictBehavior(ExecutionMode mode)
     {
         var source = """
@@ -155,8 +142,7 @@ public class NumberTests
         Assert.Equal("true\nfalse\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_isInteger_DetectsIntegers(ExecutionMode mode)
     {
         var source = """
@@ -169,8 +155,7 @@ public class NumberTests
         Assert.Equal("true\ntrue\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_isSafeInteger_DetectsSafeIntegers(ExecutionMode mode)
     {
         var source = """
@@ -187,8 +172,7 @@ public class NumberTests
 
     #region Instance Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_toFixed_FormatsDecimals(ExecutionMode mode)
     {
         var source = """
@@ -201,8 +185,7 @@ public class NumberTests
         Assert.Equal("3.14\n42.00\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_toPrecision_FormatsPrecision(ExecutionMode mode)
     {
         var source = """
@@ -213,8 +196,7 @@ public class NumberTests
         Assert.Contains("123.5", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_toExponential_FormatsExponential(ExecutionMode mode)
     {
         var source = """
@@ -225,8 +207,7 @@ public class NumberTests
         Assert.Contains("e+", output.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_toString_WithRadix(ExecutionMode mode)
     {
         var source = """
@@ -242,8 +223,7 @@ public class NumberTests
 
     #region Global Functions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Global_parseInt_Works(ExecutionMode mode)
     {
         var source = """
@@ -254,8 +234,7 @@ public class NumberTests
         Assert.Equal("42\n255\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Global_parseFloat_Works(ExecutionMode mode)
     {
         var source = """
@@ -266,8 +245,7 @@ public class NumberTests
         Assert.Equal("3.14\n42.5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Global_isNaN_CoercesBehavior(ExecutionMode mode)
     {
         var source = """
@@ -280,8 +258,7 @@ public class NumberTests
         Assert.Equal("true\nfalse\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Global_isFinite_CoercesBehavior(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/NumericEqualityFastPathTests.cs
+++ b/SharpTS.Tests/SharedTests/NumericEqualityFastPathTests.cs
@@ -18,8 +18,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class NumericEqualityFastPathTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RuntimeNaN_NeverEqual(ExecutionMode mode)
     {
         // NaN from a runtime computation (not the literal) — must never equal itself.
@@ -34,8 +33,7 @@ public class NumericEqualityFastPathTests
         Assert.Equal("false\ntrue\nfalse\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RuntimeSignedZero_ComparesEqual(ExecutionMode mode)
     {
         // +0 === -0 is true per ===, even though Object.is would say false.
@@ -49,8 +47,7 @@ public class NumericEqualityFastPathTests
         Assert.Equal("true\ntrue\nfalse\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RuntimeInfinity_Equality(ExecutionMode mode)
     {
         var source = """
@@ -63,8 +60,7 @@ public class NumericEqualityFastPathTests
         Assert.Equal("true\nfalse\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OrdinaryNumberEquality(ExecutionMode mode)
     {
         // Variables defeat constant folding; covers strict + loose + negated forms.
@@ -83,8 +79,7 @@ public class NumericEqualityFastPathTests
         Assert.Equal("true\nfalse\ntrue\nfalse\ntrue\nfalse\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DispatchChain_LikeBrainfuck(ExecutionMode mode)
     {
         // The shape the fast path was built for: a tight loop whose control flow is driven by
@@ -108,8 +103,7 @@ public class NumericEqualityFastPathTests
         Assert.Equal("300\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CharCodeEquality(ExecutionMode mode)
     {
         // charCodeAt returns number; comparing it against numeric literals is the brainfuck idiom.

--- a/SharpTS.Tests/SharedTests/NumericSeparatorTests.cs
+++ b/SharpTS.Tests/SharedTests/NumericSeparatorTests.cs
@@ -10,8 +10,7 @@ public class NumericSeparatorTests
 {
     #region Valid Numeric Separators
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericSeparator_IntegerLiteral_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -23,8 +22,7 @@ public class NumericSeparatorTests
         Assert.Equal("1000000\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericSeparator_DecimalLiteral_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -36,8 +34,7 @@ public class NumericSeparatorTests
         Assert.Equal("1234.56789\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericSeparator_MultipleSeparators_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -49,8 +46,7 @@ public class NumericSeparatorTests
         Assert.Equal("12345\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericSeparator_BigInt_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -62,8 +58,7 @@ public class NumericSeparatorTests
         Assert.Equal("1000000n\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericSeparator_Arithmetic_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -76,8 +71,7 @@ public class NumericSeparatorTests
         Assert.Equal("3000\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericSeparator_InExpression_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -93,8 +87,7 @@ public class NumericSeparatorTests
 
     #region Invalid Numeric Separators
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericSeparator_LeadingUnderscore_ThrowsError(ExecutionMode mode)
     {
         var source = """
@@ -107,8 +100,7 @@ public class NumericSeparatorTests
         Assert.ThrowsAny<Exception>(() => TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericSeparator_TrailingUnderscore_ThrowsError(ExecutionMode mode)
     {
         var source = """
@@ -119,8 +111,7 @@ public class NumericSeparatorTests
         Assert.ThrowsAny<Exception>(() => TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericSeparator_AdjacentUnderscores_ThrowsError(ExecutionMode mode)
     {
         var source = """
@@ -131,8 +122,7 @@ public class NumericSeparatorTests
         Assert.ThrowsAny<Exception>(() => TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericSeparator_BeforeDecimalPoint_ThrowsError(ExecutionMode mode)
     {
         var source = """
@@ -143,8 +133,7 @@ public class NumericSeparatorTests
         Assert.ThrowsAny<Exception>(() => TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericSeparator_AfterDecimalPoint_ThrowsError(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ObjectAccessorTests.cs
+++ b/SharpTS.Tests/SharedTests/ObjectAccessorTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ObjectAccessorTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Getter_ReturnsValue(ExecutionMode mode)
     {
         var source = """
@@ -27,8 +26,7 @@ public class ObjectAccessorTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Setter_SetsValue(ExecutionMode mode)
     {
         var source = """
@@ -50,8 +48,7 @@ public class ObjectAccessorTests
         Assert.Equal("100\n100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Getter_BindsThis(ExecutionMode mode)
     {
         var source = """
@@ -68,8 +65,7 @@ public class ObjectAccessorTests
         Assert.Equal("Hello, test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Setter_BindsThis(ExecutionMode mode)
     {
         var source = """
@@ -91,8 +87,7 @@ public class ObjectAccessorTests
         Assert.Equal("John\nDoe\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Getter_ComputedValue(ExecutionMode mode)
     {
         var source = """
@@ -109,8 +104,7 @@ public class ObjectAccessorTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetterWithoutSetter_IsReadOnly(ExecutionMode mode)
     {
         var source = """
@@ -130,8 +124,7 @@ public class ObjectAccessorTests
         Assert.Equal("10\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MixedAccessorsAndRegularProperties(ExecutionMode mode)
     {
         var source = """
@@ -155,8 +148,7 @@ public class ObjectAccessorTests
         Assert.Equal("regular\n10\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Getter_WithMethod(ExecutionMode mode)
     {
         var source = """
@@ -179,8 +171,7 @@ public class ObjectAccessorTests
         Assert.Equal("0\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultipleGetters(ExecutionMode mode)
     {
         var source = """
@@ -202,8 +193,7 @@ public class ObjectAccessorTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadWithGetter_MergesProperties(ExecutionMode mode)
     {
         var source = """
@@ -224,8 +214,7 @@ public class ObjectAccessorTests
         Assert.Equal("1\n2\n20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadWithGetterAndSetter_MergesProperties(ExecutionMode mode)
     {
         var source = """
@@ -251,8 +240,7 @@ public class ObjectAccessorTests
         Assert.Equal("100\n200\n110\n150\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadFromObjectWithAccessor_CopiesDataProperties(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ObjectCreateTests.cs
+++ b/SharpTS.Tests/SharedTests/ObjectCreateTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests;
 public class ObjectCreateTests
 {
     // Basic Object.create with null prototype
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_NullPrototype_ReturnsEmptyObject(ExecutionMode mode)
     {
         var source = """
@@ -25,8 +24,7 @@ public class ObjectCreateTests
     }
 
     // Object.create with object prototype copies properties
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_WithPrototype_CopiesProperties(ExecutionMode mode)
     {
         var source = """
@@ -41,8 +39,7 @@ public class ObjectCreateTests
     }
 
     // Object.create with prototype - new object is independent
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_NewObjectIsIndependent(ExecutionMode mode)
     {
         var source = """
@@ -61,8 +58,7 @@ public class ObjectCreateTests
     }
 
     // Object.create with properties object (second argument)
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_WithPropertiesObject(ExecutionMode mode)
     {
         var source = """
@@ -79,8 +75,7 @@ public class ObjectCreateTests
     }
 
     // Object.create with both prototype and properties
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_WithPrototypeAndProperties(ExecutionMode mode)
     {
         var source = """
@@ -97,8 +92,7 @@ public class ObjectCreateTests
     }
 
     // Object.create with non-writable property
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_NonWritableProperty(ExecutionMode mode)
     {
         var source = """
@@ -115,8 +109,7 @@ public class ObjectCreateTests
     }
 
     // Object.create with accessor property (getter)
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_WithGetter(ExecutionMode mode)
     {
         var source = """
@@ -136,8 +129,7 @@ public class ObjectCreateTests
     }
 
     // Object.create with accessor property (getter and setter)
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_WithGetterAndSetter(ExecutionMode mode)
     {
         var source = """
@@ -160,8 +152,7 @@ public class ObjectCreateTests
     }
 
     // Object.create returns object type
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_ReturnsObjectType(ExecutionMode mode)
     {
         var source = """
@@ -174,8 +165,7 @@ public class ObjectCreateTests
     }
 
     // Object.create with empty prototype
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_WithEmptyPrototype(ExecutionMode mode)
     {
         var source = """
@@ -190,8 +180,7 @@ public class ObjectCreateTests
     }
 
     // Object.create with nested object in prototype
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_WithNestedPrototype(ExecutionMode mode)
     {
         var source = """
@@ -205,8 +194,7 @@ public class ObjectCreateTests
     }
 
     // Object.create multiple objects from same prototype
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_MultipleObjectsFromSamePrototype(ExecutionMode mode)
     {
         var source = """
@@ -225,8 +213,7 @@ public class ObjectCreateTests
     }
 
     // Object.create with method in prototype
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_WithMethodInPrototype(ExecutionMode mode)
     {
         var source = """
@@ -245,8 +232,7 @@ public class ObjectCreateTests
     }
 
     // Object.create - properties object overrides prototype properties
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_PropertiesOverridePrototype(ExecutionMode mode)
     {
         var source = """
@@ -262,8 +248,7 @@ public class ObjectCreateTests
     }
 
     // Object.create with class instance as prototype
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_WithClassInstancePrototype(ExecutionMode mode)
     {
         var source = """
@@ -286,8 +271,7 @@ public class ObjectCreateTests
     }
 
     // Object.create with array values in prototype
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_WithArrayInPrototype(ExecutionMode mode)
     {
         var source = """
@@ -302,8 +286,7 @@ public class ObjectCreateTests
     }
 
     // Object.create - verify Object.keys works on created object
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_ObjectKeysWorks(ExecutionMode mode)
     {
         var source = """
@@ -325,8 +308,7 @@ public class ObjectCreateTests
     }
 
     // Object.create with undefined second argument (same as not passing it)
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_UndefinedPropertiesObject(ExecutionMode mode)
     {
         var source = """
@@ -340,8 +322,7 @@ public class ObjectCreateTests
     }
 
     // Object.create with mixed property types
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_MixedPropertyTypes(ExecutionMode mode)
     {
         var source = """
@@ -365,8 +346,7 @@ public class ObjectCreateTests
     }
 
     // ECMA-262 §20.1.2.2 step 1: prototype must be Object or null (#104).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Create_NonObjectPrototype_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ObjectFeatureTests.cs
+++ b/SharpTS.Tests/SharedTests/ObjectFeatureTests.cs
@@ -11,8 +11,7 @@ namespace SharpTS.Tests.SharedTests;
 public class ObjectFeatureTests
 {
     // Property Shorthand
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_PropertyShorthand_Works(ExecutionMode mode)
     {
         var source = """
@@ -27,8 +26,7 @@ public class ObjectFeatureTests
         Assert.Equal("Alice\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_MixedShorthandAndExplicit_Works(ExecutionMode mode)
     {
         var source = """
@@ -43,8 +41,7 @@ public class ObjectFeatureTests
     }
 
     // Method Shorthand
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_MethodShorthand_Works(ExecutionMode mode)
     {
         var source = """
@@ -60,8 +57,7 @@ public class ObjectFeatureTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_MethodWithDefaultParams_Works(ExecutionMode mode)
     {
         var source = """
@@ -78,8 +74,7 @@ public class ObjectFeatureTests
     }
 
     // Object Rest Pattern
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_RestPattern_Works(ExecutionMode mode)
     {
         var source = """
@@ -94,8 +89,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_RestPattern_MultipleExtracted_Works(ExecutionMode mode)
     {
         var source = """
@@ -112,8 +106,7 @@ public class ObjectFeatureTests
     }
 
     // Object.keys
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Keys_ReturnsPropertyNames(ExecutionMode mode)
     {
         var source = """
@@ -127,8 +120,7 @@ public class ObjectFeatureTests
     }
 
     // Object.values
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Values_ReturnsPropertyValues(ExecutionMode mode)
     {
         var source = """
@@ -144,8 +136,7 @@ public class ObjectFeatureTests
         Assert.Equal("3\n1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Values_WithMixedTypes(ExecutionMode mode)
     {
         var source = """
@@ -159,8 +150,7 @@ public class ObjectFeatureTests
     }
 
     // Object.entries
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Entries_ReturnsKeyValuePairs(ExecutionMode mode)
     {
         var source = """
@@ -178,8 +168,7 @@ public class ObjectFeatureTests
     }
 
     // Object.keys on class instance
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Keys_OnClassInstance(ExecutionMode mode)
     {
         var source = """
@@ -201,8 +190,7 @@ public class ObjectFeatureTests
     }
 
     // Object.values on class instance
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Values_OnClassInstance(ExecutionMode mode)
     {
         var source = """
@@ -224,8 +212,7 @@ public class ObjectFeatureTests
     }
 
     // Object.entries on class instance
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Entries_OnClassInstance(ExecutionMode mode)
     {
         var source = """
@@ -247,8 +234,7 @@ public class ObjectFeatureTests
     }
 
     // Empty Object
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Empty_Works(ExecutionMode mode)
     {
         var source = """
@@ -261,8 +247,7 @@ public class ObjectFeatureTests
     }
 
     // Nested Object Literals
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Nested_Works(ExecutionMode mode)
     {
         var source = """
@@ -275,8 +260,7 @@ public class ObjectFeatureTests
     }
 
     // Object Property Assignment
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_PropertyAssignment_Works(ExecutionMode mode)
     {
         var source = """
@@ -290,8 +274,7 @@ public class ObjectFeatureTests
     }
 
     // Object with Array Property
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_WithArrayProperty_Works(ExecutionMode mode)
     {
         var source = """
@@ -305,8 +288,7 @@ public class ObjectFeatureTests
     }
 
     // Computed Property Names
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_ComputedPropertyName_VariableKey(ExecutionMode mode)
     {
         var source = """
@@ -319,8 +301,7 @@ public class ObjectFeatureTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_ComputedPropertyName_StringConcatenation(ExecutionMode mode)
     {
         var source = """
@@ -334,8 +315,7 @@ public class ObjectFeatureTests
         Assert.Equal("one\ntwo\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_StringLiteralKey(ExecutionMode mode)
     {
         var source = """
@@ -348,8 +328,7 @@ public class ObjectFeatureTests
         Assert.Equal("hello\nworld\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_NumberLiteralKey(ExecutionMode mode)
     {
         var source = """
@@ -362,8 +341,7 @@ public class ObjectFeatureTests
         Assert.Equal("numeric key\nanother\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_MixedStaticAndComputedKeys(ExecutionMode mode)
     {
         var source = """
@@ -378,8 +356,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_ComputedPropertyName_NumberKey(ExecutionMode mode)
     {
         var source = """
@@ -392,8 +369,7 @@ public class ObjectFeatureTests
         Assert.Equal("value at 42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_ComputedPropertyName_SymbolKey(ExecutionMode mode)
     {
         var source = """
@@ -406,8 +382,7 @@ public class ObjectFeatureTests
         Assert.Equal("symbol value\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_ComputedPropertyName_WithSpread(ExecutionMode mode)
     {
         var source = """
@@ -423,8 +398,7 @@ public class ObjectFeatureTests
     }
 
     // Object Method This Binding
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_MethodShorthand_ThisBinding_SingleProperty(ExecutionMode mode)
     {
         var source = """
@@ -441,8 +415,7 @@ public class ObjectFeatureTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_MethodShorthand_ThisBinding_MultipleProperties(ExecutionMode mode)
     {
         var source = """
@@ -460,8 +433,7 @@ public class ObjectFeatureTests
         Assert.Equal("30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_MethodShorthand_ThisBinding_NestedObject(ExecutionMode mode)
     {
         var source = """
@@ -484,8 +456,7 @@ public class ObjectFeatureTests
     // otherwise the resolver's scope distances don't match the runtime chain and
     // outer-variable captures read as undefined. Originally surfaced as
     // PerformanceObserver's callback seeing `[undefined]` from `list.getEntries()`.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_MethodShorthand_CapturesEnclosingVariable(ExecutionMode mode)
     {
         var source = """
@@ -504,8 +475,7 @@ public class ObjectFeatureTests
         Assert.Equal("m:42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_MethodShorthand_ClosureAndThisCoexist(ExecutionMode mode)
     {
         var source = """
@@ -525,8 +495,7 @@ public class ObjectFeatureTests
     // Constructor-function pattern: `new F()` on a runtime $TSFunction value must
     // run the body with a fresh `this` and propagate property writes. Fixed for both
     // modes in #54.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_ConstructorPattern_CapturesEnclosingVariable(ExecutionMode mode)
     {
         var source = """
@@ -545,8 +514,7 @@ public class ObjectFeatureTests
         Assert.Equal("Hello World\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_New_On_Returned_Ctor_MinimalClosure(ExecutionMode mode)
     {
         // The minimal-closure variant from #54 — ctor returned from a factory with
@@ -565,8 +533,7 @@ public class ObjectFeatureTests
         Assert.Equal("Fixed W\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_New_On_Inline_Callee_Expression(ExecutionMode mode)
     {
         // Inline form: `new (factory() as any)(args)` with no intermediate local.
@@ -586,8 +553,7 @@ public class ObjectFeatureTests
         Assert.Equal("Inline W\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_New_ArrowCapturesConstructedThis_DirectNew(ExecutionMode mode)
     {
         // #399: an arrow declared inside a plain `function` invoked with `new` must
@@ -609,8 +575,7 @@ public class ObjectFeatureTests
         Assert.Equal("arrow: cap\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_New_ArrowCapturesConstructedThis_DynamicNewViaValue(ExecutionMode mode)
     {
         // #399, dynamic-new form: the callee is a runtime value (`new C(...)`), so the
@@ -630,8 +595,7 @@ public class ObjectFeatureTests
         Assert.Equal("arrow: cap\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_New_NestedArrowsCaptureConstructedThis(ExecutionMode mode)
     {
         // #399, deep nesting: an arrow inside an arrow inside a function-as-constructor.
@@ -654,8 +618,7 @@ public class ObjectFeatureTests
         Assert.Equal("inner: deep\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_New_ArrowOnInstanceEscapesAndKeepsThis(ExecutionMode mode)
     {
         // #399, escaping arrow: the arrow is stored on the instance and invoked AFTER
@@ -674,8 +637,7 @@ public class ObjectFeatureTests
         Assert.Equal("escaped: X\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_New_ClassMethodArrowThis_StillWorks(ExecutionMode mode)
     {
         // #399 regression guard: routing captured-`this` through LoadThis() must not
@@ -697,8 +659,7 @@ public class ObjectFeatureTests
         Assert.Equal("P:a,P:b | P:c\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_Call_RoutesPropertyWritesToTarget(ExecutionMode mode)
     {
         // `Fn.call(target, ...)` must mutate `target`. Compiled path needed
@@ -720,8 +681,7 @@ public class ObjectFeatureTests
         Assert.Equal("99\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_Apply_RoutesPropertyWritesToTarget(ExecutionMode mode)
     {
         // .apply walks the same InvokeWithThis path as .call (compiled) and the
@@ -737,8 +697,7 @@ public class ObjectFeatureTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_New_Respects_Explicit_Object_Return(ExecutionMode mode)
     {
         // Per JS semantics: if a constructor returns a non-null object, `new` yields
@@ -760,8 +719,7 @@ public class ObjectFeatureTests
         Assert.Equal("explicit\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_New_Primitive_Return_Is_Ignored(ExecutionMode mode)
     {
         // Per JS semantics: if a constructor returns a primitive, `new` yields the
@@ -783,8 +741,7 @@ public class ObjectFeatureTests
         Assert.Equal("from this\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_MethodShorthand_ThisBinding_MultipleMethods(ExecutionMode mode)
     {
         var source = """
@@ -805,8 +762,7 @@ public class ObjectFeatureTests
         Assert.Equal("10\n15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_MethodShorthand_ThisBinding_WithParameters(ExecutionMode mode)
     {
         var source = """
@@ -825,8 +781,7 @@ public class ObjectFeatureTests
     }
 
     // Object.fromEntries tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_FromEntries_BasicArray(ExecutionMode mode)
     {
         var source = """
@@ -841,8 +796,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_FromEntries_EmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -855,8 +809,7 @@ public class ObjectFeatureTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_FromEntries_DuplicateKeys(ExecutionMode mode)
     {
         var source = """
@@ -869,8 +822,7 @@ public class ObjectFeatureTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_FromEntries_RoundTrip(ExecutionMode mode)
     {
         var source = """
@@ -886,8 +838,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_FromEntries_MixedValueTypes(ExecutionMode mode)
     {
         var source = """
@@ -902,8 +853,7 @@ public class ObjectFeatureTests
         Assert.Equal("Alice\n30\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_FromEntries_WithMapEntries(ExecutionMode mode)
     {
         var source = """
@@ -920,8 +870,7 @@ public class ObjectFeatureTests
     }
 
     // Object.hasOwn tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_HasOwn_ReturnsTrueForOwnProperty(ExecutionMode mode)
     {
         var source = """
@@ -934,8 +883,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_HasOwn_ReturnsFalseForMissingProperty(ExecutionMode mode)
     {
         var source = """
@@ -948,8 +896,7 @@ public class ObjectFeatureTests
         Assert.Equal("false\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_HasOwn_EmptyObject(ExecutionMode mode)
     {
         var source = """
@@ -961,8 +908,7 @@ public class ObjectFeatureTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_HasOwn_ClassInstanceField(ExecutionMode mode)
     {
         var source = """
@@ -986,8 +932,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_HasOwn_ClassInstanceMethod(ExecutionMode mode)
     {
         var source = """
@@ -1008,8 +953,7 @@ public class ObjectFeatureTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_HasOwn_WithNumberKey(ExecutionMode mode)
     {
         var source = """
@@ -1022,8 +966,7 @@ public class ObjectFeatureTests
     }
 
     // Object.assign tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Assign_BasicMerge(ExecutionMode mode)
     {
         var source = """
@@ -1038,8 +981,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Assign_ModifiesTarget(ExecutionMode mode)
     {
         var source = """
@@ -1053,8 +995,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Assign_MultipleSources(ExecutionMode mode)
     {
         var source = """
@@ -1071,8 +1012,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Assign_OverridesProperties(ExecutionMode mode)
     {
         var source = """
@@ -1085,8 +1025,7 @@ public class ObjectFeatureTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Assign_LaterSourceWins(ExecutionMode mode)
     {
         var source = """
@@ -1099,8 +1038,7 @@ public class ObjectFeatureTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Assign_ReturnsTarget(ExecutionMode mode)
     {
         var source = """
@@ -1113,8 +1051,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Assign_EmptySource(ExecutionMode mode)
     {
         var source = """
@@ -1127,8 +1064,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Assign_EmptyTarget(ExecutionMode mode)
     {
         var source = """
@@ -1142,8 +1078,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Assign_MixedTypes(ExecutionMode mode)
     {
         var source = """
@@ -1158,8 +1093,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\nhello\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Assign_NestedObjects(ExecutionMode mode)
     {
         var source = """
@@ -1174,8 +1108,7 @@ public class ObjectFeatureTests
     }
 
     // Object.freeze tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Freeze_ReturnsTheSameObject(ExecutionMode mode)
     {
         var source = """
@@ -1188,8 +1121,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Freeze_PreventsMutation(ExecutionMode mode)
     {
         var source = """
@@ -1203,8 +1135,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Freeze_PreventsAddingProperties(ExecutionMode mode)
     {
         var source = """
@@ -1219,8 +1150,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_IsFrozen_ReturnsTrueForFrozenObject(ExecutionMode mode)
     {
         var source = """
@@ -1233,8 +1163,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_IsFrozen_ReturnsFalseForNonFrozenObject(ExecutionMode mode)
     {
         var source = """
@@ -1246,8 +1175,7 @@ public class ObjectFeatureTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_IsFrozen_ReturnsTrueForPrimitives(ExecutionMode mode)
     {
         var source = """
@@ -1261,8 +1189,7 @@ public class ObjectFeatureTests
     }
 
     // Object.seal tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Seal_ReturnsTheSameObject(ExecutionMode mode)
     {
         var source = """
@@ -1275,8 +1202,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Seal_AllowsPropertyModification(ExecutionMode mode)
     {
         var source = """
@@ -1290,8 +1216,7 @@ public class ObjectFeatureTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Seal_PreventsAddingProperties(ExecutionMode mode)
     {
         var source = """
@@ -1306,8 +1231,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_IsSealed_ReturnsTrueForSealedObject(ExecutionMode mode)
     {
         var source = """
@@ -1320,8 +1244,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_IsSealed_ReturnsFalseForNonSealedObject(ExecutionMode mode)
     {
         var source = """
@@ -1333,8 +1256,7 @@ public class ObjectFeatureTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_IsSealed_ReturnsTrueForFrozenObject(ExecutionMode mode)
     {
         var source = """
@@ -1348,8 +1270,7 @@ public class ObjectFeatureTests
     }
 
     // Array freeze/seal tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Freeze_ArrayPreventsModification(ExecutionMode mode)
     {
         var source = """
@@ -1363,8 +1284,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Freeze_ArrayPreventsPush(ExecutionMode mode)
     {
         var source = """
@@ -1378,8 +1298,7 @@ public class ObjectFeatureTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Seal_ArrayAllowsModification(ExecutionMode mode)
     {
         var source = """
@@ -1393,8 +1312,7 @@ public class ObjectFeatureTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Seal_ArrayPreventsPush(ExecutionMode mode)
     {
         var source = """
@@ -1408,8 +1326,7 @@ public class ObjectFeatureTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_IsFrozen_ArrayReturnsTrueForFrozen(ExecutionMode mode)
     {
         var source = """
@@ -1423,8 +1340,7 @@ public class ObjectFeatureTests
     }
 
     // Class instance freeze/seal tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Freeze_ClassInstancePreventsModification(ExecutionMode mode)
     {
         var source = """
@@ -1447,8 +1363,7 @@ public class ObjectFeatureTests
         Assert.Equal("10\n20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Seal_ClassInstanceAllowsModification(ExecutionMode mode)
     {
         var source = """
@@ -1471,8 +1386,7 @@ public class ObjectFeatureTests
         Assert.Equal("100\n20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_IsFrozen_ClassInstanceReturnsTrueForFrozen(ExecutionMode mode)
     {
         var source = """
@@ -1492,8 +1406,7 @@ public class ObjectFeatureTests
     }
 
     // Shallow freeze tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Freeze_IsShallow(ExecutionMode mode)
     {
         var source = """
@@ -1507,8 +1420,7 @@ public class ObjectFeatureTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Freeze_ArrayReverseFails(ExecutionMode mode)
     {
         var source = """
@@ -1523,8 +1435,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Seal_ArrayReverseSucceeds(ExecutionMode mode)
     {
         var source = """
@@ -1540,8 +1451,7 @@ public class ObjectFeatureTests
     }
 
     // Object.is tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Is_SameNumbers(ExecutionMode mode)
     {
         var source = """
@@ -1554,8 +1464,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Is_DifferentNumbers(ExecutionMode mode)
     {
         var source = """
@@ -1567,8 +1476,7 @@ public class ObjectFeatureTests
         Assert.Equal("false\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Is_NaN_ReturnsTrue(ExecutionMode mode)
     {
         // Object.is(NaN, NaN) should be true (this differs from === in standard JavaScript)
@@ -1582,8 +1490,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Is_PositiveAndNegativeZero_ReturnsFalse(ExecutionMode mode)
     {
         // Unlike ===, Object.is(+0, -0) should be false
@@ -1597,8 +1504,7 @@ public class ObjectFeatureTests
         Assert.Equal("false\nfalse\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Is_SameZeros(ExecutionMode mode)
     {
         var source = """
@@ -1610,8 +1516,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Is_NullComparison(ExecutionMode mode)
     {
         var source = """
@@ -1624,8 +1529,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Is_UndefinedComparison(ExecutionMode mode)
     {
         var source = """
@@ -1638,8 +1542,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Is_StringComparison(ExecutionMode mode)
     {
         var source = """
@@ -1652,8 +1555,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\nfalse\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Is_BooleanComparison(ExecutionMode mode)
     {
         var source = """
@@ -1666,8 +1568,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Is_ObjectReferenceEquality(ExecutionMode mode)
     {
         var source = """
@@ -1683,8 +1584,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\nfalse\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Is_ArrayReferenceEquality(ExecutionMode mode)
     {
         var source = """
@@ -1700,8 +1600,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\nfalse\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Is_MixedTypes(ExecutionMode mode)
     {
         var source = """
@@ -1715,8 +1614,7 @@ public class ObjectFeatureTests
         Assert.Equal("false\nfalse\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Is_Infinity(ExecutionMode mode)
     {
         var source = """
@@ -1730,8 +1628,7 @@ public class ObjectFeatureTests
     }
 
     // Object.defineProperty tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_BasicDataProperty(ExecutionMode mode)
     {
         var source = """
@@ -1744,8 +1641,7 @@ public class ObjectFeatureTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_ReturnsTheObject(ExecutionMode mode)
     {
         var source = """
@@ -1758,8 +1654,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_NonWritableProperty(ExecutionMode mode)
     {
         var source = """
@@ -1773,8 +1668,7 @@ public class ObjectFeatureTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_WritableProperty(ExecutionMode mode)
     {
         var source = """
@@ -1788,8 +1682,7 @@ public class ObjectFeatureTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_MultipleProperties(ExecutionMode mode)
     {
         var source = """
@@ -1804,8 +1697,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_OverwriteExistingProperty(ExecutionMode mode)
     {
         var source = """
@@ -1818,8 +1710,7 @@ public class ObjectFeatureTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_OnClassInstance(ExecutionMode mode)
     {
         var source = """
@@ -1839,8 +1730,7 @@ public class ObjectFeatureTests
         Assert.Equal("10\n20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_OnArray(ExecutionMode mode)
     {
         var source = """
@@ -1855,8 +1745,7 @@ public class ObjectFeatureTests
     }
 
     // Object.getOwnPropertyDescriptor tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyDescriptor_BasicProperty(ExecutionMode mode)
     {
         var source = """
@@ -1872,8 +1761,7 @@ public class ObjectFeatureTests
         Assert.Equal("42\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyDescriptor_NonExistentProperty(ExecutionMode mode)
     {
         var source = """
@@ -1886,8 +1774,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyDescriptor_DefinedProperty(ExecutionMode mode)
     {
         var source = """
@@ -1904,8 +1791,7 @@ public class ObjectFeatureTests
         Assert.Equal("42\nfalse\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyDescriptor_ArrayLength(ExecutionMode mode)
     {
         var source = """
@@ -1921,8 +1807,7 @@ public class ObjectFeatureTests
         Assert.Equal("3\ntrue\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyDescriptor_ArrayElement(ExecutionMode mode)
     {
         var source = """
@@ -1938,8 +1823,7 @@ public class ObjectFeatureTests
         Assert.Equal("20\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyDescriptor_ClassInstance(ExecutionMode mode)
     {
         var source = """
@@ -1959,8 +1843,7 @@ public class ObjectFeatureTests
         Assert.Equal("42\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_ThenGetDescriptor_Roundtrip(ExecutionMode mode)
     {
         var source = """
@@ -1982,8 +1865,7 @@ public class ObjectFeatureTests
         Assert.Equal("Alice\ntrue\nfalse\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_WithGetter(ExecutionMode mode)
     {
         var source = """
@@ -2000,8 +1882,7 @@ public class ObjectFeatureTests
         Assert.Equal("200\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_WithGetterAndSetter(ExecutionMode mode)
     {
         var source = """
@@ -2021,8 +1902,7 @@ public class ObjectFeatureTests
         Assert.Equal("10\n50\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyDescriptor_AccessorProperty(ExecutionMode mode)
     {
         var source = """
@@ -2042,8 +1922,7 @@ public class ObjectFeatureTests
         Assert.Equal("function\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_FrozenObjectFails(ExecutionMode mode)
     {
         // When object is frozen, defineProperty should throw
@@ -2063,8 +1942,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_SealedObjectNewPropertyFails(ExecutionMode mode)
     {
         // When object is sealed, adding new property should throw
@@ -2085,8 +1963,7 @@ public class ObjectFeatureTests
     }
 
     // Object.getOwnPropertyNames tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyNames_BasicObject(ExecutionMode mode)
     {
         var source = """
@@ -2099,8 +1976,7 @@ public class ObjectFeatureTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyNames_EmptyObject(ExecutionMode mode)
     {
         var source = """
@@ -2113,8 +1989,7 @@ public class ObjectFeatureTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyNames_Array(ExecutionMode mode)
     {
         var source = """
@@ -2131,8 +2006,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyNames_ClassInstance(ExecutionMode mode)
     {
         var source = """
@@ -2153,8 +2027,7 @@ public class ObjectFeatureTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyNames_ReturnsStrings(ExecutionMode mode)
     {
         var source = """
@@ -2168,8 +2041,7 @@ public class ObjectFeatureTests
         Assert.Equal("string\nx\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyNames_WithMixedTypes(ExecutionMode mode)
     {
         var source = """
@@ -2182,8 +2054,7 @@ public class ObjectFeatureTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyNames_IncludesNonEnumerableProperties(ExecutionMode mode)
     {
         // Unlike Object.keys(), getOwnPropertyNames should include non-enumerable properties
@@ -2200,8 +2071,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyNames_DoesNotIncludeMethods(ExecutionMode mode)
     {
         // Methods defined on the class should NOT appear in getOwnPropertyNames
@@ -2227,8 +2097,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyNames_IncludesDefinedProperties(ExecutionMode mode)
     {
         // Both getOwnPropertyNames and keys include properties added via defineProperty
@@ -2246,8 +2115,7 @@ public class ObjectFeatureTests
         Assert.Equal("2\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_WithBoundGetterSetter(ExecutionMode mode)
     {
         // Regression: accessors stored as bound/wrapper callables must be invocable
@@ -2270,8 +2138,7 @@ public class ObjectFeatureTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_WithArrowGetterSetter(ExecutionMode mode)
     {
         // Regression: arrow function accessors via defineProperty
@@ -2293,8 +2160,7 @@ public class ObjectFeatureTests
         Assert.Equal("10\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_ReadsInheritedValueViaSetterOnlyAccessor(ExecutionMode mode)
     {
         // #801: ECMA-262 §6.2.5.5 ToPropertyDescriptor reads `value` via HasProperty/Get,
@@ -2316,8 +2182,7 @@ public class ObjectFeatureTests
         Assert.Equal("undefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperty_AttributeOnlyRedefinePreservesValue(ExecutionMode mode)
     {
         // #801: an attribute-only descriptor (no `value` key) must preserve the existing
@@ -2332,8 +2197,7 @@ public class ObjectFeatureTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Object_DefineProperty_ReadsInheritedEnumerableFromRegExpPrototype(ExecutionMode mode)
     {
         // #801: a descriptor's INHERITED `enumerable` (here via a user-set
@@ -2355,8 +2219,7 @@ public class ObjectFeatureTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.InterpretedOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, InterpretedOnlyData]
     public void Object_RegExp_InheritsUserSetPrototypeProperty(ExecutionMode mode)
     {
         // #801/#474-adjacent: a plain user property set on RegExp.prototype is visible
@@ -2374,8 +2237,7 @@ public class ObjectFeatureTests
     // Object.defineProperties
     // ========================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperties_BasicDataProperties(ExecutionMode mode)
     {
         var source = """
@@ -2391,8 +2253,7 @@ public class ObjectFeatureTests
         Assert.Equal("Alice\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperties_WithAccessors(ExecutionMode mode)
     {
         var source = """
@@ -2413,8 +2274,7 @@ public class ObjectFeatureTests
         Assert.Equal("10\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_DefineProperties_ReturnsTarget(ExecutionMode mode)
     {
         var source = """
@@ -2433,8 +2293,7 @@ public class ObjectFeatureTests
     // Object.getOwnPropertyDescriptors
     // ================================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyDescriptors_BasicObject(ExecutionMode mode)
     {
         var source = """
@@ -2450,8 +2309,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\n2\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyDescriptors_WithDefinedProperties(ExecutionMode mode)
     {
         var source = """
@@ -2466,8 +2324,7 @@ public class ObjectFeatureTests
         Assert.Equal("test\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyDescriptors_RoundTrip(ExecutionMode mode)
     {
         var source = """
@@ -2481,8 +2338,7 @@ public class ObjectFeatureTests
         Assert.Equal("1\nhello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_GetOwnPropertyDescriptors_EmptyObject(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ObjectLocalPromotionTests.cs
+++ b/SharpTS.Tests/SharedTests/ObjectLocalPromotionTests.cs
@@ -20,8 +20,7 @@ public class ObjectLocalPromotionTests
 {
     // ── Positive cases: promotable shapes ──────────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_NumberRecord_ReadFieldsInLoop(ExecutionMode mode)
     {
         // The benchmark shape (objectWork): a fresh per-iteration record read by field.
@@ -41,8 +40,7 @@ public class ObjectLocalPromotionTests
         Assert.Equal("10000\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_FieldWrite_MutatesThenReads(ExecutionMode mode)
     {
         // `const o` binds the slot but its fields stay mutable.
@@ -58,8 +56,7 @@ public class ObjectLocalPromotionTests
         Assert.Equal("12\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_FieldWrite_ReturnsAssignedValue(ExecutionMode mode)
     {
         // `o.x = v` is an expression whose value is the assigned RHS.
@@ -75,8 +72,7 @@ public class ObjectLocalPromotionTests
         Assert.Equal("84\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_BooleanAndNumberFields(ExecutionMode mode)
     {
         var source = """
@@ -91,8 +87,7 @@ public class ObjectLocalPromotionTests
         Assert.Equal("5\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_StringFields_Concat(ExecutionMode mode)
     {
         var source = """
@@ -106,8 +101,7 @@ public class ObjectLocalPromotionTests
         Assert.Equal("ab\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_MixedPrimitiveFields(ExecutionMode mode)
     {
         // number + string + boolean fields in one shape, with a string-typed result mixing kinds.
@@ -124,8 +118,7 @@ public class ObjectLocalPromotionTests
         Assert.Equal("x3!\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_MultipleObjects_Independent(ExecutionMode mode)
     {
         var source = """
@@ -142,8 +135,7 @@ public class ObjectLocalPromotionTests
         Assert.Equal("132\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_FieldWrittenFromComputedNumber(ExecutionMode mode)
     {
         var source = """
@@ -162,8 +154,7 @@ public class ObjectLocalPromotionTests
 
     // ── Escape cases: must fall back, must stay correct ────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Escape_PassedToFunction(ExecutionMode mode)
     {
         var source = """
@@ -178,8 +169,7 @@ public class ObjectLocalPromotionTests
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Escape_Returned(ExecutionMode mode)
     {
         var source = """
@@ -194,8 +184,7 @@ public class ObjectLocalPromotionTests
         Assert.Equal("15\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Escape_Spread(ExecutionMode mode)
     {
         var source = """
@@ -210,8 +199,7 @@ public class ObjectLocalPromotionTests
         Assert.Equal("6\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Escape_ForInEnumeration(ExecutionMode mode)
     {
         var source = """
@@ -227,8 +215,7 @@ public class ObjectLocalPromotionTests
         Assert.Equal("3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Escape_StrictEquality(ExecutionMode mode)
     {
         // Object identity comparison — a promoted struct local has no stable reference, so this must
@@ -245,8 +232,7 @@ public class ObjectLocalPromotionTests
         Assert.Equal("0\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Escape_CapturedByClosure(ExecutionMode mode)
     {
         var source = """
@@ -261,8 +247,7 @@ public class ObjectLocalPromotionTests
         Assert.Equal("11\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Escape_CompoundFieldAssign(ExecutionMode mode)
     {
         // `o.x += v` is intentionally not promoted in the first cut → falls back, must stay correct.
@@ -278,8 +263,7 @@ public class ObjectLocalPromotionTests
         Assert.Equal("13\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Escape_NestedObjectField(ExecutionMode mode)
     {
         // A non-primitive (nested object) field disqualifies the shape → falls back.
@@ -294,8 +278,7 @@ public class ObjectLocalPromotionTests
         Assert.Equal("3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Escape_DynamicBracketRead(ExecutionMode mode)
     {
         // Bracket access (even with a literal key) is a dynamic index → disqualifies → falls back.

--- a/SharpTS.Tests/SharedTests/ObjectPrototypeTests.cs
+++ b/SharpTS.Tests/SharedTests/ObjectPrototypeTests.cs
@@ -13,8 +13,7 @@ public class ObjectPrototypeTests
 {
     // === preventExtensions ===
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PreventExtensions_BlocksNewProperties(ExecutionMode mode)
     {
         var source = """
@@ -26,8 +25,7 @@ public class ObjectPrototypeTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PreventExtensions_AllowsModifyingExisting(ExecutionMode mode)
     {
         var source = """
@@ -39,8 +37,7 @@ public class ObjectPrototypeTests
         Assert.Equal("100\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PreventExtensions_AllowsDeleting(ExecutionMode mode)
     {
         // Delete operator support varies by mode
@@ -53,8 +50,7 @@ public class ObjectPrototypeTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PreventExtensions_ReturnsTheObject(ExecutionMode mode)
     {
         var source = """
@@ -65,8 +61,7 @@ public class ObjectPrototypeTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PreventExtensions_OnArray(ExecutionMode mode)
     {
         var source = """
@@ -78,8 +73,7 @@ public class ObjectPrototypeTests
         Assert.Equal("3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PreventExtensions_ArrayAllowsModification(ExecutionMode mode)
     {
         var source = """
@@ -93,8 +87,7 @@ public class ObjectPrototypeTests
 
     // === isExtensible ===
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsExtensible_TrueForNormalObject(ExecutionMode mode)
     {
         var source = """
@@ -103,8 +96,7 @@ public class ObjectPrototypeTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsExtensible_FalseAfterPreventExtensions(ExecutionMode mode)
     {
         var source = """
@@ -115,8 +107,7 @@ public class ObjectPrototypeTests
         Assert.Equal("false\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsExtensible_FalseForFrozenObject(ExecutionMode mode)
     {
         var source = """
@@ -126,8 +117,7 @@ public class ObjectPrototypeTests
         Assert.Equal("false\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsExtensible_FalseForSealedObject(ExecutionMode mode)
     {
         var source = """
@@ -137,8 +127,7 @@ public class ObjectPrototypeTests
         Assert.Equal("false\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsExtensible_FalseForPrimitives(ExecutionMode mode)
     {
         var source = """
@@ -148,8 +137,7 @@ public class ObjectPrototypeTests
         Assert.Equal("false\nfalse\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsExtensible_TrueForArray(ExecutionMode mode)
     {
         var source = """
@@ -159,8 +147,7 @@ public class ObjectPrototypeTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsExtensible_FalseAfterPreventExtensionsOnArray(ExecutionMode mode)
     {
         var source = """
@@ -173,8 +160,7 @@ public class ObjectPrototypeTests
 
     // === getOwnPropertySymbols ===
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetOwnPropertySymbols_ReturnsSymbolKeys(ExecutionMode mode)
     {
         var source = """
@@ -187,8 +173,7 @@ public class ObjectPrototypeTests
         Assert.Equal("2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetOwnPropertySymbols_EmptyForNoSymbols(ExecutionMode mode)
     {
         var source = """
@@ -198,8 +183,7 @@ public class ObjectPrototypeTests
         Assert.Equal("0\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetOwnPropertySymbols_ReturnsArray(ExecutionMode mode)
     {
         var source = """
@@ -211,8 +195,7 @@ public class ObjectPrototypeTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetOwnPropertySymbols_SymbolsAreUsable(ExecutionMode mode)
     {
         var source = """
@@ -226,8 +209,7 @@ public class ObjectPrototypeTests
 
     // === getPrototypeOf ===
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetPrototypeOf_ReturnsPrototypeFromCreate(ExecutionMode mode)
     {
         var source = """
@@ -238,8 +220,7 @@ public class ObjectPrototypeTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetPrototypeOf_ReturnsNullForNullPrototype(ExecutionMode mode)
     {
         var source = """
@@ -249,8 +230,7 @@ public class ObjectPrototypeTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetPrototypeOf_PlainObjectIsNotUndefined(ExecutionMode mode)
     {
         // The two modes diverge here: compiled returns %Object.prototype% (spec-
@@ -267,8 +247,7 @@ public class ObjectPrototypeTests
 
     // === setPrototypeOf ===
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetPrototypeOf_ChangesPrototype(ExecutionMode mode)
     {
         var source = """
@@ -281,8 +260,7 @@ public class ObjectPrototypeTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetPrototypeOf_ReturnsTheObject(ExecutionMode mode)
     {
         var source = """
@@ -293,8 +271,7 @@ public class ObjectPrototypeTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetPrototypeOf_CopiesPropertiesFromNewPrototype(ExecutionMode mode)
     {
         var source = """
@@ -307,8 +284,7 @@ public class ObjectPrototypeTests
         Assert.Equal("42\n100\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetPrototypeOf_ToNull(ExecutionMode mode)
     {
         var source = """
@@ -320,8 +296,7 @@ public class ObjectPrototypeTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetPrototypeOf_ThrowsOnNonExtensible(ExecutionMode mode)
     {
         var source = """
@@ -338,8 +313,7 @@ public class ObjectPrototypeTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetPrototypeOf_ThrowsOnClassInstance(ExecutionMode mode)
     {
         var source = """
@@ -360,8 +334,7 @@ public class ObjectPrototypeTests
 
     // === Edge cases and interactions ===
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PreventExtensions_DifferentFromFreeze(ExecutionMode mode)
     {
         // preventExtensions allows modification but not addition
@@ -379,8 +352,7 @@ public class ObjectPrototypeTests
         Assert.Equal("100\n1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PreventExtensions_DifferentFromSeal_AllowsDelete(ExecutionMode mode)
     {
         // preventExtensions allows delete, seal does not
@@ -399,8 +371,7 @@ public class ObjectPrototypeTests
         Assert.Equal("10\n10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassInstance_IsExtensible(ExecutionMode mode)
     {
         var source = """
@@ -416,8 +387,7 @@ public class ObjectPrototypeTests
         Assert.Equal("true\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassInstance_PreventExtensions(ExecutionMode mode)
     {
         var source = """
@@ -436,8 +406,7 @@ public class ObjectPrototypeTests
         Assert.Equal("false\ntrue\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassInstance_GetOwnPropertySymbols(ExecutionMode mode)
     {
         var source = """
@@ -455,8 +424,7 @@ public class ObjectPrototypeTests
 
     // ECMA-262 §20.1.3.4 Object.prototype.isPrototypeOf — was stubbed to
     // always return false (#104).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IsPrototypeOf_WalksPrototypeChain(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ObjectToStringTagTests.cs
+++ b/SharpTS.Tests/SharedTests/ObjectToStringTagTests.cs
@@ -13,8 +13,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ObjectToStringTagTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BuiltInConstructors_TagAsFunction(ExecutionMode mode)
     {
         var source = """
@@ -33,8 +32,7 @@ public class ObjectToStringTagTests
             output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UserFunctions_TagAsFunction(ExecutionMode mode)
     {
         var source = """
@@ -50,8 +48,7 @@ public class ObjectToStringTagTests
         Assert.Equal("[object Function]\n[object Function]\n[object Function]\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonFunctions_KeepTheirTags(ExecutionMode mode)
     {
         var source = """
@@ -70,8 +67,7 @@ public class ObjectToStringTagTests
             output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectKeys_OnFunction_ReturnsExpandoProps(ExecutionMode mode)
     {
         // ECMA-262: Object.keys does ToObject — functions are objects, and

--- a/SharpTS.Tests/SharedTests/OperatorTests.cs
+++ b/SharpTS.Tests/SharedTests/OperatorTests.cs
@@ -11,8 +11,7 @@ public class OperatorTests
 {
     #region Bitwise Operators
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BitwiseAnd_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -23,8 +22,7 @@ public class OperatorTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BitwiseOr_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -35,8 +33,7 @@ public class OperatorTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BitwiseXor_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -47,8 +44,7 @@ public class OperatorTests
         Assert.Equal("6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BitwiseNot_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -59,8 +55,7 @@ public class OperatorTests
         Assert.Equal("-6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LeftShift_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -71,8 +66,7 @@ public class OperatorTests
         Assert.Equal("8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RightShift_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -83,8 +77,7 @@ public class OperatorTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UnsignedRightShift_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -97,8 +90,7 @@ public class OperatorTests
 
     // ECMA-262 ToInt32/ToUint32 wraps operands modulo 2^32 before bitwise ops.
     // Regression for uuid.parse() which uses `v >>> 24 & 0xff` on a 48-bit number.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UnsignedRightShift_OperandAbove2Pow32_UsesLow32Bits(ExecutionMode mode)
     {
         var source = """
@@ -113,8 +105,7 @@ public class OperatorTests
         Assert.Equal("86\n120\n154\n188\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BitwiseOr_OperandAbove2Pow32_WrapsModulo(ExecutionMode mode)
     {
         var source = """
@@ -126,8 +117,7 @@ public class OperatorTests
         Assert.Equal("5\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BitwiseOr_NonFiniteOperand_ReturnsZero(ExecutionMode mode)
     {
         var source = """
@@ -140,8 +130,7 @@ public class OperatorTests
         Assert.Equal("0\n0\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UnsignedRightShiftCompound_OperandAbove2Pow32_UsesLow32Bits(ExecutionMode mode)
     {
         var source = """
@@ -158,8 +147,7 @@ public class OperatorTests
 
     #region Nullish Coalescing
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullishCoalescing_WithNull_ReturnsDefault(ExecutionMode mode)
     {
         var source = """
@@ -171,8 +159,7 @@ public class OperatorTests
         Assert.Equal("default\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullishCoalescing_WithValue_ReturnsValue(ExecutionMode mode)
     {
         var source = """
@@ -184,8 +171,7 @@ public class OperatorTests
         Assert.Equal("value\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullishCoalescing_WithZero_ReturnsZero(ExecutionMode mode)
     {
         var source = """
@@ -197,8 +183,7 @@ public class OperatorTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullishCoalescing_WithEmptyString_ReturnsEmptyString(ExecutionMode mode)
     {
         var source = """
@@ -211,8 +196,7 @@ public class OperatorTests
         Assert.Equal("\ndone\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullishCoalescing_Chained_ReturnsFirstNonNull(ExecutionMode mode)
     {
         var source = """
@@ -230,8 +214,7 @@ public class OperatorTests
 
     #region Optional Chaining
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalChaining_WithValue_ReturnsProperty(ExecutionMode mode)
     {
         var source = """
@@ -243,8 +226,7 @@ public class OperatorTests
         Assert.Equal("test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalChaining_WithNull_ReturnsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -256,8 +238,7 @@ public class OperatorTests
         Assert.Equal("undefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalChaining_Nested_ReturnsValue(ExecutionMode mode)
     {
         var source = """
@@ -269,8 +250,7 @@ public class OperatorTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalChaining_CombinedWithNullish_ReturnsDefault(ExecutionMode mode)
     {
         var source = """
@@ -286,8 +266,7 @@ public class OperatorTests
 
     #region Ternary Operator
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Ternary_TrueCondition_ReturnsTrueValue(ExecutionMode mode)
     {
         var source = """
@@ -298,8 +277,7 @@ public class OperatorTests
         Assert.Equal("yes\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Ternary_FalseCondition_ReturnsFalseValue(ExecutionMode mode)
     {
         var source = """
@@ -310,8 +288,7 @@ public class OperatorTests
         Assert.Equal("no\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Ternary_WithComparison_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -323,8 +300,7 @@ public class OperatorTests
         Assert.Equal("big\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Ternary_Nested_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -341,8 +317,7 @@ public class OperatorTests
 
     #region Increment/Decrement Operators
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrefixIncrement_ReturnsNewValue(ExecutionMode mode)
     {
         var source = """
@@ -355,8 +330,7 @@ public class OperatorTests
         Assert.Equal("6\n6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PostfixIncrement_ReturnsOldValue(ExecutionMode mode)
     {
         var source = """
@@ -369,8 +343,7 @@ public class OperatorTests
         Assert.Equal("5\n6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrefixDecrement_ReturnsNewValue(ExecutionMode mode)
     {
         var source = """
@@ -383,8 +356,7 @@ public class OperatorTests
         Assert.Equal("4\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PostfixDecrement_ReturnsOldValue(ExecutionMode mode)
     {
         var source = """
@@ -397,8 +369,7 @@ public class OperatorTests
         Assert.Equal("5\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IncrementInExpression_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -414,8 +385,7 @@ public class OperatorTests
 
     #region Compound Assignment Operators
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssignment_Add_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -428,8 +398,7 @@ public class OperatorTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssignment_Subtract_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -442,8 +411,7 @@ public class OperatorTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssignment_Multiply_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -456,8 +424,7 @@ public class OperatorTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssignment_Divide_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -470,8 +437,7 @@ public class OperatorTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssignment_Modulo_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -484,8 +450,7 @@ public class OperatorTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssignment_StringConcat_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -498,8 +463,7 @@ public class OperatorTests
         Assert.Equal("Hello World\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssignment_OnArrayElement_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -512,8 +476,7 @@ public class OperatorTests
         Assert.Equal("12\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssignment_OnObjectProperty_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -530,8 +493,7 @@ public class OperatorTests
 
     #region Bitwise Compound Assignment
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssignment_BitwiseAnd_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -544,8 +506,7 @@ public class OperatorTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssignment_BitwiseOr_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -558,8 +519,7 @@ public class OperatorTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssignment_LeftShift_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -572,8 +532,7 @@ public class OperatorTests
         Assert.Equal("8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssignment_RightShift_ReturnsCorrectResult(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/OverloadTests.cs
+++ b/SharpTS.Tests/SharedTests/OverloadTests.cs
@@ -10,8 +10,7 @@ public class OverloadTests
 {
     #region Function Overloads
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_Overload_ArityBased(ExecutionMode mode)
     {
         var source = """
@@ -31,8 +30,7 @@ public class OverloadTests
         Assert.Equal("Hello Alice\nBob is 30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_Overload_TypeBased(ExecutionMode mode)
     {
         var source = """
@@ -56,8 +54,7 @@ public class OverloadTests
 
     #region Method Overloads
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Method_Overload_Basic(ExecutionMode mode)
     {
         var source = """
@@ -80,8 +77,7 @@ public class OverloadTests
         Assert.Equal("6\n15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Method_Overload_ThreeSignatures(ExecutionMode mode)
     {
         var source = """
@@ -114,8 +110,7 @@ public class OverloadTests
 
     #region Constructor Overloads
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Constructor_Overload(ExecutionMode mode)
     {
         var source = """
@@ -148,8 +143,7 @@ public class OverloadTests
 
     #region Static Method Overloads
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticMethod_Overload(ExecutionMode mode)
     {
         var source = """
@@ -175,8 +169,7 @@ public class OverloadTests
 
     #region Overload with Inheritance
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Overload_WithInheritance(ExecutionMode mode)
     {
         var source = """
@@ -209,8 +202,7 @@ public class OverloadTests
 
     #region Method Chaining with Overloads
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Overload_MethodChaining(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/OverrideKeywordTests.cs
+++ b/SharpTS.Tests/SharedTests/OverrideKeywordTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class OverrideKeywordTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_BasicMethod_Works(ExecutionMode mode)
     {
         var source = """
@@ -28,8 +27,7 @@ public class OverrideKeywordTests
         Assert.Equal("Woof\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_WithAccessModifier_Works(ExecutionMode mode)
     {
         var source = """
@@ -46,8 +44,7 @@ public class OverrideKeywordTests
         Assert.Equal("Woof\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_ProtectedMethod_Works(ExecutionMode mode)
     {
         var source = """
@@ -65,8 +62,7 @@ public class OverrideKeywordTests
         Assert.Equal("Woof\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_AbstractMethod_Works(ExecutionMode mode)
     {
         var source = """
@@ -88,8 +84,7 @@ public class OverrideKeywordTests
         Assert.Equal("300\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_MultiLevelInheritance_Works(ExecutionMode mode)
     {
         var source = """
@@ -109,8 +104,7 @@ public class OverrideKeywordTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_SkipLevel_Works(ExecutionMode mode)
     {
         // Override grandparent method, parent doesn't override
@@ -130,8 +124,7 @@ public class OverrideKeywordTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_Getter_Works(ExecutionMode mode)
     {
         var source = """
@@ -148,8 +141,7 @@ public class OverrideKeywordTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_Setter_Works(ExecutionMode mode)
     {
         var source = """
@@ -171,8 +163,7 @@ public class OverrideKeywordTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_WithoutKeyword_StillWorks(ExecutionMode mode)
     {
         // Implicit override still works (override keyword is optional)
@@ -190,8 +181,7 @@ public class OverrideKeywordTests
         Assert.Equal("Woof\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_WithOverloads_Works(ExecutionMode mode)
     {
         var source = """
@@ -225,8 +215,7 @@ public class OverrideKeywordTests
 
     // Error cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_NoParentMethod_Errors(ExecutionMode mode)
     {
         var source = """
@@ -242,8 +231,7 @@ public class OverrideKeywordTests
         Assert.Contains("speak", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_NoSuperclass_Errors(ExecutionMode mode)
     {
         var source = """
@@ -256,8 +244,7 @@ public class OverrideKeywordTests
         Assert.Contains("override", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_StaticMethod_Errors(ExecutionMode mode)
     {
         var source = """
@@ -273,8 +260,7 @@ public class OverrideKeywordTests
         Assert.Contains("Static", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_Constructor_Errors(ExecutionMode mode)
     {
         var source = """
@@ -290,8 +276,7 @@ public class OverrideKeywordTests
         Assert.Contains("constructor", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_NoParentGetter_Errors(ExecutionMode mode)
     {
         var source = """
@@ -307,8 +292,7 @@ public class OverrideKeywordTests
         Assert.Contains("value", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Override_NoParentSetter_Errors(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/PackageExportsTests.cs
+++ b/SharpTS.Tests/SharedTests/PackageExportsTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class PackageExportsTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SimpleStringExports(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -30,8 +29,7 @@ public class PackageExportsTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConditionalExports_Import(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -53,8 +51,7 @@ public class PackageExportsTests
         Assert.Equal("esm\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SubpathExports(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -78,8 +75,7 @@ public class PackageExportsTests
         Assert.Equal("main\nhelped\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WildcardExports(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -98,8 +94,7 @@ public class PackageExportsTests
         Assert.Equal("foo-value\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullRestriction_Throws(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -120,8 +115,7 @@ public class PackageExportsTests
         Assert.ThrowsAny<Exception>(() => TestHarness.RunModules(files, "./main.ts", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MainFieldFallback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -140,8 +134,7 @@ public class PackageExportsTests
         Assert.Equal("99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtensionMapping_JsToTs(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -160,8 +153,7 @@ public class PackageExportsTests
         Assert.Equal("mapped-from-ts\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScopedPackage(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -180,8 +172,7 @@ public class PackageExportsTests
         Assert.Equal("scoped-value\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScopedPackageSubpath(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -203,8 +194,7 @@ public class PackageExportsTests
         Assert.Equal("util-value\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NoPackageJson_LegacyIndexTs(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -222,8 +212,7 @@ public class PackageExportsTests
         Assert.Equal("legacy-value\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SelfReferencing(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -245,8 +234,7 @@ public class PackageExportsTests
         Assert.Equal("hello from utils\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SubpathImports_HashPrefix(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -265,8 +253,7 @@ public class PackageExportsTests
         Assert.Equal("import-mapped\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedConditionalWithSubpath(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/PrimitiveStringTypeTests.cs
+++ b/SharpTS.Tests/SharedTests/PrimitiveStringTypeTests.cs
@@ -56,8 +56,7 @@ public class PrimitiveStringTypeTests
         Assert.Equal("string\n", result);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringFieldObjectLocal_PromotesAndRoundTrips(ExecutionMode mode)
     {
         // The compiled ObjectLocalPromotionAnalyzer classifies a string field by TypeInfo.String now

--- a/SharpTS.Tests/SharedTests/PrimitiveWrapperTests.cs
+++ b/SharpTS.Tests/SharedTests/PrimitiveWrapperTests.cs
@@ -12,24 +12,21 @@ public class PrimitiveWrapperTests
 {
     // ── typeof ───────────────────────────────────────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_NewWrapper_TypeofIsObject(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log(typeof new Number(5));", mode);
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_NewWrapper_TypeofIsObject(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log(typeof new String('x'));", mode);
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Boolean_NewWrapper_TypeofIsObject(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log(typeof new Boolean(true));", mode);
@@ -38,24 +35,21 @@ public class PrimitiveWrapperTests
 
     // ── instanceof Object ────────────────────────────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_NewWrapper_InstanceofObject(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log(new Number(5) instanceof Object);", mode);
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_NewWrapper_InstanceofObject(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log(new String('x') instanceof Object);", mode);
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Boolean_NewWrapper_InstanceofObject(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log(new Boolean(true) instanceof Object);", mode);
@@ -64,24 +58,21 @@ public class PrimitiveWrapperTests
 
     // ── instanceof own constructor ───────────────────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_NewWrapper_InstanceofNumber(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log(new Number(5) instanceof Number);", mode);
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_NewWrapper_InstanceofString(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log(new String('x') instanceof String);", mode);
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Boolean_NewWrapper_InstanceofBoolean(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log(new Boolean(false) instanceof Boolean);", mode);
@@ -93,24 +84,21 @@ public class PrimitiveWrapperTests
     // its wrapper constructor; only boxed `new Number(5)` wrappers are. Both modes
     // now agree (#360 interp, #375 compiled).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_Bare_NotInstanceofNumber(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log((5 as any) instanceof Number);", mode);
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Bare_NotInstanceofString(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log(('x' as any) instanceof String);", mode);
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Boolean_Bare_NotInstanceofBoolean(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log((true as any) instanceof Boolean);", mode);
@@ -121,16 +109,14 @@ public class PrimitiveWrapperTests
     // Symbol has no `new` form, so its only boxed form is `Object(Symbol())`.
     // A bare symbol primitive is NOT an instance; the boxed wrapper IS.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_Bare_NotInstanceofSymbol(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log((Symbol('s') as any) instanceof Symbol);", mode);
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_Boxed_InstanceofSymbol(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log((Object(Symbol('s')) as any) instanceof Symbol);", mode);
@@ -139,24 +125,21 @@ public class PrimitiveWrapperTests
 
     // ── call form still coerces (no wrapper) ────────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_CallForm_ReturnsPrimitive(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log(typeof Number('42'));", mode);
         Assert.Equal("number\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_CallForm_ReturnsPrimitive(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log(typeof String(42));", mode);
         Assert.Equal("string\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Boolean_CallForm_ReturnsPrimitive(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log(typeof Boolean(1));", mode);
@@ -165,24 +148,21 @@ public class PrimitiveWrapperTests
 
     // ── wrapper primitive value / conversion ─────────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_NoArg_WrapsZero(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log(new Number() instanceof Number);", mode);
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Length_MatchesPrimitive(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log(new String('hello').length);", mode);
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_IndexedAccess_ReturnsChar(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log((new String('hi') as any)[0]);", mode);
@@ -191,24 +171,21 @@ public class PrimitiveWrapperTests
 
     // ── method dispatch on wrappers ──────────────────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_ToFixed_WorksOnWrapper(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log((new Number(5) as any).toFixed(2));", mode);
         Assert.Equal("5.00\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_ToUpperCase_WorksOnWrapper(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log((new String('hello') as any).toUpperCase());", mode);
         Assert.Equal("HELLO\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Boolean_ToString_WorksOnWrapper(ExecutionMode mode)
     {
         var output = TestHarness.Run("console.log((new Boolean(true) as any).toString());", mode);
@@ -219,8 +196,7 @@ public class PrimitiveWrapperTests
     // ECMA-262 7.1.1: `+` and `==` ToPrimitive (default hint) an object operand,
     // which calls an own valueOf override before reading the wrapper's slot.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_ValueOfOverride_HonoredInAddition(ExecutionMode mode)
     {
         var source = """
@@ -231,8 +207,7 @@ public class PrimitiveWrapperTests
         Assert.Equal("10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_ValueOfOverride_HonoredInLooseEquality(ExecutionMode mode)
     {
         var source = """
@@ -250,15 +225,13 @@ public class PrimitiveWrapperTests
     // string coercion; an own toString override does. Interpreter and compiled
     // must agree (the divergence these tests pin down).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_Wrapper_TemplateLiteral_UsesPrimitive(ExecutionMode mode)
     {
         Assert.Equal("v:1\n", TestHarness.Run("const n: any = new Number(1); console.log(`v:${n}`);", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_Wrapper_TemplateLiteral_IgnoresValueOfOverride(ExecutionMode mode)
     {
         // String hint resolves toString first (inherited → primitive), so a
@@ -271,8 +244,7 @@ public class PrimitiveWrapperTests
         Assert.Equal("v:1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Number_Wrapper_TemplateLiteral_HonorsToStringOverride(ExecutionMode mode)
     {
         var source = """
@@ -283,22 +255,19 @@ public class PrimitiveWrapperTests
         Assert.Equal("v:NUM\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Wrapper_TemplateLiteral_UsesPrimitive(ExecutionMode mode)
     {
         Assert.Equal("v:x\n", TestHarness.Run("const s: any = new String(\"x\"); console.log(`v:${s}`);", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_CallForm_CoercesBoxedNumber(ExecutionMode mode)
     {
         Assert.Equal("1\n", TestHarness.Run("console.log(String(new Number(1)));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_CallForm_BoxedNumber_IgnoresValueOfOverride(ExecutionMode mode)
     {
         var source = """
@@ -309,8 +278,7 @@ public class PrimitiveWrapperTests
         Assert.Equal("1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_CallForm_BoxedString_HonorsToStringOverride(ExecutionMode mode)
     {
         var source = """
@@ -321,8 +289,7 @@ public class PrimitiveWrapperTests
         Assert.Equal("STR\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_CallForm_CoercesBoxedBoolean(ExecutionMode mode)
     {
         Assert.Equal("true\n", TestHarness.Run("console.log(String(new Boolean(true)));", mode));

--- a/SharpTS.Tests/SharedTests/PrivateAsyncGeneratorMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/PrivateAsyncGeneratorMethodTests.cs
@@ -18,8 +18,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class PrivateAsyncGeneratorMethodTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncPrivateMethod_Instance(ExecutionMode mode)
     {
         // The exact #720 async repro.
@@ -34,8 +33,7 @@ public class PrivateAsyncGeneratorMethodTests
         Assert.Equal("5\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorPrivateMethod_Instance(ExecutionMode mode)
     {
         // The exact #720 generator repro.
@@ -50,8 +48,7 @@ public class PrivateAsyncGeneratorMethodTests
         Assert.Equal("11\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGeneratorPrivateMethod_Instance(ExecutionMode mode)
     {
         var source = """
@@ -65,8 +62,7 @@ public class PrivateAsyncGeneratorMethodTests
         Assert.Equal("11\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticAsyncPrivateMethod(ExecutionMode mode)
     {
         var source = """
@@ -80,8 +76,7 @@ public class PrivateAsyncGeneratorMethodTests
         Assert.Equal("10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncPrivateMethod_AwaitsAndReachesOtherPrivateMembers(ExecutionMode mode)
     {
         // The async private method awaits, reads a private field, and calls another private method —
@@ -126,8 +121,7 @@ public class PrivateAsyncGeneratorMethodTests
         Assert.Empty(errors);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticGeneratorPrivateMethod(ExecutionMode mode)
     {
         // Static generator support landed in #692; the static private form routes through the same

--- a/SharpTS.Tests/SharedTests/PrivateFieldAsyncTests.cs
+++ b/SharpTS.Tests/SharedTests/PrivateFieldAsyncTests.cs
@@ -12,8 +12,7 @@ public class PrivateFieldAsyncTests
 {
     #region Async Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_CanReadPrivateField(ExecutionMode mode)
     {
         var source = """
@@ -34,8 +33,7 @@ public class PrivateFieldAsyncTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_CanWritePrivateField(ExecutionMode mode)
     {
         var source = """
@@ -64,8 +62,7 @@ public class PrivateFieldAsyncTests
         Assert.Equal("1\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_CanCallPrivateMethod(ExecutionMode mode)
     {
         var source = """
@@ -88,8 +85,7 @@ public class PrivateFieldAsyncTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_MultipleAwaitsWithPrivateField(ExecutionMode mode)
     {
         var source = """
@@ -117,8 +113,7 @@ public class PrivateFieldAsyncTests
 
     #region Generators
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_CanReadPrivateField(ExecutionMode mode)
     {
         var source = """
@@ -142,8 +137,7 @@ public class PrivateFieldAsyncTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_CanWritePrivateField(ExecutionMode mode)
     {
         var source = """
@@ -173,8 +167,7 @@ public class PrivateFieldAsyncTests
         Assert.Equal("1\n2\n3\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_CanCallPrivateMethod(ExecutionMode mode)
     {
         var source = """
@@ -207,8 +200,7 @@ public class PrivateFieldAsyncTests
     // NOTE: Async generator class methods work in compiled mode. The interpreter needs
     // additional support for recognizing async generator class methods as async iterables.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_CanReadPrivateField(ExecutionMode mode)
     {
         var source = """
@@ -236,8 +228,7 @@ public class PrivateFieldAsyncTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_CanWritePrivateField(ExecutionMode mode)
     {
         var source = """
@@ -275,8 +266,7 @@ public class PrivateFieldAsyncTests
 
     #region Async Arrow Functions (in class methods)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_CanReadPrivateField(ExecutionMode mode)
     {
         var source = """
@@ -300,8 +290,7 @@ public class PrivateFieldAsyncTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_CanWritePrivateField(ExecutionMode mode)
     {
         var source = """
@@ -333,8 +322,7 @@ public class PrivateFieldAsyncTests
         Assert.Equal("1\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_CanCallPrivateMethod(ExecutionMode mode)
     {
         var source = """
@@ -364,8 +352,7 @@ public class PrivateFieldAsyncTests
 
     #region Static Private Fields in Async Contexts
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_StaticPrivateField(ExecutionMode mode)
     {
         var source = """
@@ -401,8 +388,7 @@ public class PrivateFieldAsyncTests
 
     #region Complex Scenarios
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_PrivateFieldWithMultipleInstances(ExecutionMode mode)
     {
         var source = """
@@ -436,8 +422,7 @@ public class PrivateFieldAsyncTests
         Assert.Equal("1\n101\n2\n102\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncMethod_MixedPublicAndPrivateFields(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/PrivateFieldTests.cs
+++ b/SharpTS.Tests/SharedTests/PrivateFieldTests.cs
@@ -11,8 +11,7 @@ public class PrivateFieldTests
 {
     #region Instance Private Fields
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateField_GetAndSet(ExecutionMode mode)
     {
         var source = """
@@ -40,8 +39,7 @@ public class PrivateFieldTests
         Assert.Equal("0\n1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateField_WithInitializer(ExecutionMode mode)
     {
         var source = """
@@ -61,8 +59,7 @@ public class PrivateFieldTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateField_MultipleInstances(ExecutionMode mode)
     {
         var source = """
@@ -93,8 +90,7 @@ public class PrivateFieldTests
         Assert.Equal("2\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateField_CoexistsWithPublicField(ExecutionMode mode)
     {
         var source = """
@@ -128,8 +124,7 @@ public class PrivateFieldTests
 
     #region Static Private Fields
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticPrivateField_GetAndSet(ExecutionMode mode)
     {
         var source = """
@@ -158,8 +153,7 @@ public class PrivateFieldTests
         Assert.Equal("0\n1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticPrivateField_WithInitializer(ExecutionMode mode)
     {
         var source = """
@@ -182,8 +176,7 @@ public class PrivateFieldTests
 
     #region Private Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateMethod_CalledFromPublicMethod(ExecutionMode mode)
     {
         var source = """
@@ -205,8 +198,7 @@ public class PrivateFieldTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateMethod_AccessesPrivateField(ExecutionMode mode)
     {
         var source = """
@@ -233,8 +225,7 @@ public class PrivateFieldTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateMethod_WithParameters(ExecutionMode mode)
     {
         var source = """
@@ -256,8 +247,7 @@ public class PrivateFieldTests
         Assert.Equal("$42.00\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateMethod_MultipleOptionalParameters_PartialApplication(ExecutionMode mode)
     {
         // #696: several optional parameters, only some supplied. Omitted trailing arguments read
@@ -274,8 +264,7 @@ public class PrivateFieldTests
         Assert.Equal("15\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateMethod_DefaultParameter_FiresWhenOmitted(ExecutionMode mode)
     {
         // #696: a defaulted private-method parameter fires its default when the argument is omitted,
@@ -317,8 +306,7 @@ public class PrivateFieldTests
 
     #region Static Private Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticPrivateMethod_CalledFromStaticPublicMethod(ExecutionMode mode)
     {
         var source = """
@@ -339,8 +327,7 @@ public class PrivateFieldTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticPrivateMethod_OptionalParameter_Omitted(ExecutionMode mode)
     {
         // #696: optional parameter on a *static* private method, invoked with no argument.
@@ -354,8 +341,7 @@ public class PrivateFieldTests
         Assert.Equal("default\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticPrivateMethod_AccessesStaticPrivateField(ExecutionMode mode)
     {
         var source = """
@@ -385,8 +371,7 @@ public class PrivateFieldTests
 
     #region Combined Features
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateElements_FullExample(ExecutionMode mode)
     {
         var source = """
@@ -430,8 +415,7 @@ public class PrivateFieldTests
         Assert.Equal("1\n2\n2\n1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateField_MultiplePrivateFields(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/PromiseMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseMethodTests.cs
@@ -12,8 +12,7 @@ public class PromiseMethodTests
 {
     #region Promise.then() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Then_BasicChaining(ExecutionMode mode)
     {
         var source = """
@@ -32,8 +31,7 @@ public class PromiseMethodTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Then_MultipleChains(ExecutionMode mode)
     {
         var source = """
@@ -54,8 +52,7 @@ public class PromiseMethodTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Then_ReturnsPromise_Flattens(ExecutionMode mode)
     {
         var source = """
@@ -76,8 +73,7 @@ public class PromiseMethodTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Then_WithOnRejected(ExecutionMode mode)
     {
         var source = """
@@ -96,8 +92,7 @@ public class PromiseMethodTests
         Assert.Equal("caught: error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Then_PassesValueThrough(ExecutionMode mode)
     {
         var source = """
@@ -117,8 +112,7 @@ public class PromiseMethodTests
     // (then/catch) or no-op (finally). Previously the interpreter registered
     // these with minArity 1 and threw "expects 1-2 arguments but got 0" (#382).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Then_ZeroArgs_PassesValueThrough(ExecutionMode mode)
     {
         var source = """
@@ -133,8 +127,7 @@ public class PromiseMethodTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Catch_ZeroArgs_PassesValueThrough(ExecutionMode mode)
     {
         var source = """
@@ -149,8 +142,7 @@ public class PromiseMethodTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_ZeroArgs_PassesValueThrough(ExecutionMode mode)
     {
         var source = """
@@ -169,8 +161,7 @@ public class PromiseMethodTests
 
     #region Promise.catch() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Catch_HandlesRejection(ExecutionMode mode)
     {
         var source = """
@@ -186,8 +177,7 @@ public class PromiseMethodTests
         Assert.Equal("handled: something went wrong\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Catch_PassesThroughResolved(ExecutionMode mode)
     {
         var source = """
@@ -203,8 +193,7 @@ public class PromiseMethodTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Catch_AfterThen(ExecutionMode mode)
     {
         var source = """
@@ -226,8 +215,7 @@ public class PromiseMethodTests
 
     #region Promise.finally() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_RunsOnResolved(ExecutionMode mode)
     {
         var source = """
@@ -246,8 +234,7 @@ public class PromiseMethodTests
         Assert.Equal("42\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Finally_DoesNotAlterValue(ExecutionMode mode)
     {
         var source = """
@@ -268,8 +255,7 @@ public class PromiseMethodTests
 
     #region Promise.all() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void All_ResolvesAllPromises(ExecutionMode mode)
     {
         var source = """
@@ -289,8 +275,7 @@ public class PromiseMethodTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void All_EmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -305,8 +290,7 @@ public class PromiseMethodTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void All_WithNonPromises(ExecutionMode mode)
     {
         var source = """
@@ -325,8 +309,7 @@ public class PromiseMethodTests
 
     #region Promise.race() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Race_FirstResolvedWins(ExecutionMode mode)
     {
         var source = """
@@ -343,8 +326,7 @@ public class PromiseMethodTests
         Assert.Equal("first\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Race_NonPromiseWins(ExecutionMode mode)
     {
         var source = """
@@ -366,8 +348,7 @@ public class PromiseMethodTests
 
     #region Promise.resolve() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolve_WrapsValue(ExecutionMode mode)
     {
         var source = """
@@ -383,8 +364,7 @@ public class PromiseMethodTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolve_NoDoubleWrap(ExecutionMode mode)
     {
         var source = """
@@ -404,8 +384,7 @@ public class PromiseMethodTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolve_NoArgs(ExecutionMode mode)
     {
         var source = """
@@ -426,8 +405,7 @@ public class PromiseMethodTests
     /// Previously, this caused double-wrapping: Promise(Task(Promise(Task(value))))
     /// which led to infinite loops in async iterators.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolve_NestedPromiseResolve_Flattens(ExecutionMode mode)
     {
         var source = """
@@ -447,8 +425,7 @@ public class PromiseMethodTests
     /// <summary>
     /// Regression test: Triple-nested Promise.resolve must flatten correctly.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolve_TripleNestedPromise_Flattens(ExecutionMode mode)
     {
         var source = """
@@ -471,8 +448,7 @@ public class PromiseMethodTests
     /// This is the exact pattern that caused infinite loops in async iterators
     /// when the iterator result object was double-wrapped.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolve_IteratorResultObject_NotDoubleWrapped(ExecutionMode mode)
     {
         var source = """
@@ -493,8 +469,7 @@ public class PromiseMethodTests
     /// <summary>
     /// Regression test: Async function returning Promise.resolve should not double-wrap.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Resolve_FromAsyncFunction_NotDoubleWrapped(ExecutionMode mode)
     {
         var source = """
@@ -516,8 +491,7 @@ public class PromiseMethodTests
 
     #region Promise.reject() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reject_CreatesRejectedPromise(ExecutionMode mode)
     {
         var source = """
@@ -541,8 +515,7 @@ public class PromiseMethodTests
 
     #region Complex Scenarios
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Chaining_ThenCatchFinally(ExecutionMode mode)
     {
         var source = """
@@ -574,8 +547,7 @@ public class PromiseMethodTests
         Assert.Equal("25\nthen1 then2 finally\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultipleThenOnSamePromise(ExecutionMode mode)
     {
         var source = """
@@ -597,8 +569,7 @@ public class PromiseMethodTests
 
     #region Promise.allSettled() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AllSettled_AllResolve(ExecutionMode mode)
     {
         var source = """
@@ -618,8 +589,7 @@ public class PromiseMethodTests
         Assert.Equal("fulfilled\n1\nfulfilled\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AllSettled_SomeReject(ExecutionMode mode)
     {
         var source = """
@@ -642,8 +612,7 @@ public class PromiseMethodTests
         Assert.Equal("fulfilled\n1\nrejected\nerror\nfulfilled\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AllSettled_EmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -658,8 +627,7 @@ public class PromiseMethodTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AllSettled_WithNonPromises(ExecutionMode mode)
     {
         var source = """
@@ -681,8 +649,7 @@ public class PromiseMethodTests
 
     #region Promise.any() Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Any_FirstResolves(ExecutionMode mode)
     {
         var source = """
@@ -699,8 +666,7 @@ public class PromiseMethodTests
         Assert.Equal("first\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Any_NonPromiseWins(ExecutionMode mode)
     {
         var source = """
@@ -718,8 +684,7 @@ public class PromiseMethodTests
         Assert.Equal("immediate\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Any_FirstFulfilledAfterRejection(ExecutionMode mode)
     {
         var source = """
@@ -737,8 +702,7 @@ public class PromiseMethodTests
         Assert.Equal("success\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Any_AllReject_ThrowsAggregateError(ExecutionMode mode)
     {
         var source = """
@@ -760,8 +724,7 @@ public class PromiseMethodTests
         Assert.Equal("caught\nAggregateError\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Any_EmptyArray_ThrowsAggregateError(ExecutionMode mode)
     {
         // ECMA-262 §27.2.4.3: empty iterable rejects with an AggregateError
@@ -785,8 +748,7 @@ public class PromiseMethodTests
         Assert.Equal("caught\nAggregateError\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Any_RejectionIsInstanceofAggregateError(ExecutionMode mode)
     {
         // #232: the combinator's rejection must be the same representation
@@ -812,8 +774,7 @@ public class PromiseMethodTests
         Assert.Equal("true\ntrue\ntrue true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Any_ErrorsCarryGuestRejectionValues(ExecutionMode mode)
     {
         // #232: e.errors must hold what each promise rejected with — the
@@ -838,8 +799,7 @@ public class PromiseMethodTests
         Assert.Equal("2\ntrue t1\ntrue boom\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AllSettled_ReasonCarriesGuestValue(ExecutionMode mode)
     {
         // #232 (adjacent): allSettled's rejected outcome must carry the guest
@@ -860,8 +820,7 @@ public class PromiseMethodTests
         Assert.Equal("rejected\ntrue r1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void InstanceofError_InsideAsyncFunction(ExecutionMode mode)
     {
         // #232 root cause in compiled mode: state-machine bodies (async
@@ -889,8 +848,7 @@ public class PromiseMethodTests
 
     #region Promise Executor Constructor Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecutorConstructor_ImmediateResolve(ExecutionMode mode)
     {
         var source = """
@@ -908,8 +866,7 @@ public class PromiseMethodTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecutorConstructor_ImmediateReject(ExecutionMode mode)
     {
         var source = """
@@ -931,8 +888,7 @@ public class PromiseMethodTests
         Assert.Equal("caught\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecutorConstructor_ResolveWithObject(ExecutionMode mode)
     {
         var source = """
@@ -950,8 +906,7 @@ public class PromiseMethodTests
         Assert.Equal("test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecutorConstructor_ResolveWithUndefined(ExecutionMode mode)
     {
         var source = """
@@ -969,8 +924,7 @@ public class PromiseMethodTests
         Assert.Equal("null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecutorConstructor_ExecutorThrows(ExecutionMode mode)
     {
         var source = """
@@ -992,8 +946,7 @@ public class PromiseMethodTests
         Assert.Equal("caught executor error\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecutorConstructor_OnlyFirstSettlementCounts(ExecutionMode mode)
     {
         var source = """
@@ -1013,8 +966,7 @@ public class PromiseMethodTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecutorConstructor_ChainWithThen(ExecutionMode mode)
     {
         var source = """
@@ -1032,8 +984,7 @@ public class PromiseMethodTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecutorConstructor_ChainWithCatch(ExecutionMode mode)
     {
         var source = """
@@ -1051,8 +1002,7 @@ public class PromiseMethodTests
         Assert.Equal("99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecutorConstructor_UseInPromiseAll(ExecutionMode mode)
     {
         var source = """
@@ -1070,8 +1020,7 @@ public class PromiseMethodTests
         Assert.Equal("6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecutorConstructor_UseInPromiseRace(ExecutionMode mode)
     {
         var source = """
@@ -1099,8 +1048,7 @@ public class PromiseMethodTests
     /// dispatch itself stays unobservable until guest classes can subclass
     /// Promise (#233) and Symbol is a first-class value (#234).
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PromiseConstructorProperty_IsPromiseGlobal(ExecutionMode mode)
     {
         var source = """
@@ -1126,8 +1074,7 @@ public class PromiseMethodTests
     /// new Exception(reason.ToString()), so catch handlers saw a host string
     /// ("Error: nope") instead of the rejected error object (#232 family).
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExecutorReject_PreservesGuestReason(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseSubclassTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class PromiseSubclassTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsPromise_ExecutorConstructionAndBrand(ExecutionMode mode)
     {
         var source = """
@@ -28,8 +27,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\ntrue\n41\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsPromise_MethodsAndFields(ExecutionMode mode)
     {
         var source = """
@@ -51,8 +49,7 @@ public class PromiseSubclassTests
         Assert.Equal("mine\nMyPromise:mine\nMyPromise:updated\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsPromise_StaticSideInheritance_Resolve(ExecutionMode mode)
     {
         var source = """
@@ -70,8 +67,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\ntrue\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsPromise_ThenReturnsSubclass(ExecutionMode mode)
     {
         var source = """
@@ -89,8 +85,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsPromise_RejectAndCatch(ExecutionMode mode)
     {
         var source = """
@@ -107,8 +102,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\ncaught:boom\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsPromise_UserConstructorWithSuper(ExecutionMode mode)
     {
         var source = """
@@ -132,8 +126,7 @@ public class PromiseSubclassTests
         Assert.Equal("yes\ntrue true\nv\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsPromise_TransitiveSubclass(ExecutionMode mode)
     {
         var source = """
@@ -156,8 +149,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\n7\ntrue\ntrue\ntrue\nx\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsPromise_Combinators(ExecutionMode mode)
     {
         var source = """
@@ -178,8 +170,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\n7\ntrue\nfirst\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsPromise_WithResolvers(ExecutionMode mode)
     {
         var source = """
@@ -196,8 +187,7 @@ public class PromiseSubclassTests
         Assert.Equal("9\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsPromise_DynamicDispatch_ThenKeepsBrand(ExecutionMode mode)
     {
         var source = """
@@ -215,8 +205,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsPromise_BasePromiseUnaffected(ExecutionMode mode)
     {
         var source = """
@@ -234,8 +223,7 @@ public class PromiseSubclassTests
         Assert.Equal("false\ntrue\n14\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsPromise_TopLevelStaticThen(ExecutionMode mode)
     {
         // #309: the exact repro — inherited static + derived `then` dispatched
@@ -253,8 +241,7 @@ public class PromiseSubclassTests
         Assert.Equal("got 1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsPromise_TopLevelRejectCatch(ExecutionMode mode)
     {
         // #309 sibling: reject/catch on a non-generic subclass from the
@@ -268,8 +255,7 @@ public class PromiseSubclassTests
         Assert.Equal("caught boom\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsPromise_ConstructorIdentity(ExecutionMode mode)
     {
         // ECMA-262 §27.2.5.1 / #221: subclass instances report the subclass
@@ -292,8 +278,7 @@ public class PromiseSubclassTests
 
     #region SpeciesConstructor (#221) — then/catch/finally consult @@species
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_ThenRedirectsToPlainPromise(ExecutionMode mode)
     {
         // ECMA-262 §27.2.5.4 / §7.3.22: then builds its result through
@@ -317,8 +302,7 @@ public class PromiseSubclassTests
         Assert.Equal("false\ntrue\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_DefaultIsReceiverClass(ExecutionMode mode)
     {
         // No @@species override: the inherited Promise[@@species] returns the
@@ -337,8 +321,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_ThenRedirectsToOtherSubclass(ExecutionMode mode)
     {
         // @@species may name a different Promise subclass; then constructs
@@ -361,8 +344,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\nfalse\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_UndefinedFallsBackToPromise(ExecutionMode mode)
     {
         // SpeciesConstructor: an @@species of undefined/null defaults to
@@ -383,8 +365,7 @@ public class PromiseSubclassTests
         Assert.Equal("false\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_CatchAndFinallyFollowSpecies(ExecutionMode mode)
     {
         // catch (= then(undefined, onRejected)) and finally also route their
@@ -407,8 +388,7 @@ public class PromiseSubclassTests
         Assert.Equal("false\nfalse\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_CombinatorsUseReceiverConstructorDirectly(ExecutionMode mode)
     {
         // Static methods (resolve/all/race) build through the receiver
@@ -430,8 +410,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_GenericSubclassOverride(ExecutionMode mode)
     {
         // A GENERIC Promise subclass with a @@species override resolves in both
@@ -454,8 +433,7 @@ public class PromiseSubclassTests
         Assert.Equal("false\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_GenericSubclassRedirectsToOtherGenericSubclass(ExecutionMode mode)
     {
         // A generic subclass whose @@species names ANOTHER generic Promise
@@ -480,8 +458,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\nfalse\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_GenericSubclassStaticReadResolvesOverride(ExecutionMode mode)
     {
         // The guest-visible static read `(MyP as any)[Symbol.species]` of a
@@ -499,8 +476,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_ExpandoOverrideRedirectsToPlainPromise(ExecutionMode mode)
     {
         // A dynamically-assigned static @@species ((C as any)[Symbol.species] =
@@ -524,8 +500,7 @@ public class PromiseSubclassTests
         Assert.Equal("false\ntrue\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_ExpandoOverrideRedirectsToOtherSubclass(ExecutionMode mode)
     {
         // The expando @@species may name another Promise subclass; then must
@@ -547,8 +522,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\nfalse\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_ExpandoOverrideInheritedThroughSubclass(ExecutionMode mode)
     {
         // An expando @@species set on a base class is visible on a subclass
@@ -573,8 +547,7 @@ public class PromiseSubclassTests
         Assert.Equal("false\nfalse\ntrue\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_ExpandoOverrideOnGenericSubclass(ExecutionMode mode)
     {
         // An expando @@species on a GENERIC subclass: the assignment keys the
@@ -602,8 +575,7 @@ public class PromiseSubclassTests
 
     #region General NewPromiseCapability (#349) — non-Promise species + thenable await
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_NonPromiseConstructor_BuildsThroughIt(ExecutionMode mode)
     {
         // ECMA-262 §27.2.5.4 step 7 / §27.2.4.5: when @@species resolves to a
@@ -642,8 +614,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\nfalse\n11\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_NonPromiseConstructor_AdoptsRejection(ExecutionMode mode)
     {
         // The captured capability's reject is driven when the source task faults
@@ -669,8 +640,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\nrethrow:boom undefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_ExpandoNonPromiseConstructor_BuildsThroughIt(ExecutionMode mode)
     {
         // The general NewPromiseCapability path is reached through an EXPANDO
@@ -703,8 +673,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\nfalse\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Await_AdoptsPlainThenable(ExecutionMode mode)
     {
         // `await` on an ordinary object whose `then` is callable adopts it
@@ -727,8 +696,7 @@ public class PromiseSubclassTests
         Assert.Equal("hello\ncaught:nope\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Await_NonThenableObjectPassesThrough(ExecutionMode mode)
     {
         // An object WITHOUT a callable `then` is not a thenable: `await` returns
@@ -751,8 +719,7 @@ public class PromiseSubclassTests
 
     #region SpeciesConstructor IsConstructor (#390) — non-constructor throws, function species constructs
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_NonConstructor_ThrowsTypeErrorSynchronously(ExecutionMode mode)
     {
         // ECMA-262 §7.3.22 SpeciesConstructor step 5: if C[@@species] is neither
@@ -778,8 +745,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_ExpandoNonConstructor_ThrowsTypeError(ExecutionMode mode)
     {
         // The IsConstructor check applies to an expando @@species
@@ -802,8 +768,7 @@ public class PromiseSubclassTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Species_PlainFunctionConstructor_BuildsThroughNewProtocol(ExecutionMode mode)
     {
         // A @@species that resolves to a plain FUNCTION (constructible via the
@@ -853,8 +818,7 @@ public class PromiseSubclassTests
 
     #region Poisoned constructor getter (#350) — then/catch/finally throw synchronously
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PoisonedConstructor_ThenThrowsSynchronously(ExecutionMode mode)
     {
         // ECMA-262 §27.2.5.4 step 3 resolves SpeciesConstructor(promise, %Promise%)
@@ -882,8 +846,7 @@ public class PromiseSubclassTests
         Assert.Equal("poisoned\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PoisonedConstructor_CatchThrowsSynchronously(ExecutionMode mode)
     {
         // catch delegates to then, so the same synchronous SpeciesConstructor
@@ -907,8 +870,7 @@ public class PromiseSubclassTests
         Assert.Equal("poisoned-catch\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PoisonedConstructor_FinallyThrowsSynchronously(ExecutionMode mode)
     {
         // finally also resolves SpeciesConstructor for its result promise.
@@ -931,8 +893,7 @@ public class PromiseSubclassTests
         Assert.Equal("poisoned-finally\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PoisonedConstructor_DoesNotAffectNormalThen(ExecutionMode mode)
     {
         // Regression guard: a promise WITHOUT a poisoned `constructor` accessor
@@ -949,8 +910,7 @@ public class PromiseSubclassTests
         Assert.Equal("11\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PoisonedConstructor_OwnAccessorWinsOverSubclassConstructor(ExecutionMode mode)
     {
         // An own `constructor` accessor on a Promise SUBCLASS instance shadows the

--- a/SharpTS.Tests/SharedTests/PromiseWithResolversTests.cs
+++ b/SharpTS.Tests/SharedTests/PromiseWithResolversTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class PromiseWithResolversTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WithResolvers_BasicResolve(ExecutionMode mode)
     {
         var source = """
@@ -26,8 +25,7 @@ public class PromiseWithResolversTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WithResolvers_BasicReject(ExecutionMode mode)
     {
         var source = """
@@ -47,8 +45,7 @@ public class PromiseWithResolversTests
         Assert.Equal("caught\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WithResolvers_ResolveWithString(ExecutionMode mode)
     {
         var source = """
@@ -65,8 +62,7 @@ public class PromiseWithResolversTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WithResolvers_HasAllProperties(ExecutionMode mode)
     {
         var source = """
@@ -83,8 +79,7 @@ public class PromiseWithResolversTests
         Assert.Equal("object\nfunction\nfunction\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WithResolvers_ResolveWithNumber(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ProxyTests.cs
+++ b/SharpTS.Tests/SharedTests/ProxyTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ProxyTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Proxy_GetTrap(ExecutionMode mode)
     {
         var source = @"
@@ -28,8 +27,7 @@ public class ProxyTests
         Assert.Equal("intercepted\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Proxy_SetTrap(ExecutionMode mode)
     {
         var source = @"
@@ -48,8 +46,7 @@ public class ProxyTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Proxy_HasTrap(ExecutionMode mode)
     {
         var source = @"
@@ -69,8 +66,7 @@ public class ProxyTests
         Assert.Equal("true\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Proxy_DeletePropertyTrap(ExecutionMode mode)
     {
         var source = @"
@@ -92,8 +88,7 @@ public class ProxyTests
         Assert.Equal("x\nundefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Proxy_DefaultForwarding_Get(ExecutionMode mode)
     {
         var source = @"
@@ -106,8 +101,7 @@ public class ProxyTests
         Assert.Equal("original\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Proxy_DefaultForwarding_Set(ExecutionMode mode)
     {
         var source = @"
@@ -121,8 +115,7 @@ public class ProxyTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Proxy_Typeof(ExecutionMode mode)
     {
         var source = @"
@@ -135,8 +128,7 @@ public class ProxyTests
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Proxy_ApplyTrap(ExecutionMode mode)
     {
         var source = @"
@@ -155,8 +147,7 @@ public class ProxyTests
         Assert.Equal("Hello, World!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Proxy_TypeofFunction(ExecutionMode mode)
     {
         var source = @"
@@ -169,8 +160,7 @@ public class ProxyTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Proxy_HasTrap_TruthyCoercion(ExecutionMode mode)
     {
         var source = @"
@@ -193,8 +183,7 @@ public class ProxyTests
         Assert.Equal("true\nfalse\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Proxy_Revocable(ExecutionMode mode)
     {
         var source = @"
@@ -214,8 +203,7 @@ public class ProxyTests
         Assert.Equal("42\nrevoked\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Proxy_RevokedThrows(ExecutionMode mode)
     {
         var source = @"
@@ -236,8 +224,7 @@ public class ProxyTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Proxy_GetTrap_MultipleProperties(ExecutionMode mode)
     {
         var source = @"
@@ -258,8 +245,7 @@ public class ProxyTests
         Assert.Equal("a,b\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Proxy_SetTrap_ReturnsValue(ExecutionMode mode)
     {
         var source = @"
@@ -278,8 +264,7 @@ public class ProxyTests
         Assert.Equal("11\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Proxy_NestedTraps(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/RealmIsolationTests.cs
+++ b/SharpTS.Tests/SharedTests/RealmIsolationTests.cs
@@ -21,8 +21,7 @@ public class RealmIsolationTests
     /// round-trips a registered symbol while returning <c>undefined</c> for an
     /// unregistered one.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SymbolFor_WithinRealm_IsIdempotentAndRoundTrips(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ReflectApiTests.cs
+++ b/SharpTS.Tests/SharedTests/ReflectApiTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class ReflectApiTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_Has_ChecksPropertyExistence(ExecutionMode mode)
     {
         var source = """
@@ -23,8 +22,7 @@ public class ReflectApiTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_Has_ArrayIndex(ExecutionMode mode)
     {
         var source = """
@@ -39,8 +37,7 @@ public class ReflectApiTests
         Assert.Equal("true\ntrue\nfalse\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_Has_InheritedProperty(ExecutionMode mode)
     {
         var source = """
@@ -60,8 +57,7 @@ public class ReflectApiTests
         Assert.Equal("true\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_DeleteProperty_RemovesProperty(ExecutionMode mode)
     {
         var source = """
@@ -75,8 +71,7 @@ public class ReflectApiTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_DeleteProperty_MissingProperty_ReturnsTrue(ExecutionMode mode)
     {
         var source = """
@@ -89,8 +84,7 @@ public class ReflectApiTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_DeleteProperty_FrozenObject_ReturnsFalse(ExecutionMode mode)
     {
         var source = """
@@ -104,8 +98,7 @@ public class ReflectApiTests
         Assert.Equal("false\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_DeleteProperty_SealedObject_ReturnsFalse(ExecutionMode mode)
     {
         var source = """
@@ -119,8 +112,7 @@ public class ReflectApiTests
         Assert.Equal("false\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_Get_ReadsProperty(ExecutionMode mode)
     {
         var source = """
@@ -133,8 +125,7 @@ public class ReflectApiTests
         Assert.Equal("hello\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_Get_MissingProperty_ReturnsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -146,8 +137,7 @@ public class ReflectApiTests
         Assert.Equal("undefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_Set_SetsProperty(ExecutionMode mode)
     {
         var source = """
@@ -161,8 +151,7 @@ public class ReflectApiTests
         Assert.Equal("true\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_Set_FrozenObject_ReturnsFalse(ExecutionMode mode)
     {
         var source = """
@@ -177,8 +166,7 @@ public class ReflectApiTests
         Assert.Equal("false\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_OwnKeys_ReturnsAllKeys(ExecutionMode mode)
     {
         var source = """
@@ -194,8 +182,7 @@ public class ReflectApiTests
         Assert.Equal("3\na\nb\nc\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_GetPrototypeOf_ReturnsPrototype(ExecutionMode mode)
     {
         var source = """
@@ -209,8 +196,7 @@ public class ReflectApiTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_SetPrototypeOf_SetsPrototype(ExecutionMode mode)
     {
         var source = """
@@ -224,8 +210,7 @@ public class ReflectApiTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_SetPrototypeOf_NonExtensible_ReturnsFalse(ExecutionMode mode)
     {
         var source = """
@@ -239,8 +224,7 @@ public class ReflectApiTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_IsExtensible_ReturnsTrueByDefault(ExecutionMode mode)
     {
         var source = """
@@ -252,8 +236,7 @@ public class ReflectApiTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_PreventExtensions_ReturnsTrueAndPrevents(ExecutionMode mode)
     {
         var source = """
@@ -267,8 +250,7 @@ public class ReflectApiTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_GetOwnPropertyDescriptor_ReturnsDescriptor(ExecutionMode mode)
     {
         var source = """
@@ -284,8 +266,7 @@ public class ReflectApiTests
         Assert.Equal("42\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_GetOwnPropertyDescriptor_MissingProperty_ReturnsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -298,8 +279,7 @@ public class ReflectApiTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_DefineProperty_DefinesProperty(ExecutionMode mode)
     {
         var source = """
@@ -313,8 +293,7 @@ public class ReflectApiTests
         Assert.Equal("true\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_Apply_CallsFunction(ExecutionMode mode)
     {
         var source = """
@@ -329,8 +308,7 @@ public class ReflectApiTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reflect_Construct_CreatesInstance(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/RegExpFlagPropertyTests.cs
+++ b/SharpTS.Tests/SharedTests/RegExpFlagPropertyTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class RegExpFlagPropertyTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FlagProperties_SetFlags_ReadTrue(ExecutionMode mode)
     {
         var source = """
@@ -25,8 +24,7 @@ public class RegExpFlagPropertyTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FlagProperties_UnsetFlags_ReadFalse(ExecutionMode mode)
     {
         var source = """
@@ -41,8 +39,7 @@ public class RegExpFlagPropertyTests
         Assert.Equal("false\nfalse\nfalse\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FlagsString_IncludesHasIndicesAndSticky(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/RegExpLiteralHoistingTests.cs
+++ b/SharpTS.Tests/SharedTests/RegExpLiteralHoistingTests.cs
@@ -16,8 +16,7 @@ public class RegExpLiteralHoistingTests
     // shared instance would advance lastIndex across evaluations. Fresh-per-eval
     // resets lastIndex each call, so every test of "aaa" matches → all true. A
     // shared instance would walk 0,1,2 then fail on the 4th.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GlobalTestInLoop_NotHoisted_ResetsEachEvaluation(ExecutionMode mode)
     {
         var source = """
@@ -33,8 +32,7 @@ public class RegExpLiteralHoistingTests
 
     // A non-global, non-sticky literal as a `.test` receiver in a loop IS hoisted;
     // result must be unchanged (lastIndex is irrelevant without g/y).
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PlainTestInLoop_Hoisted_CountsCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -55,8 +53,7 @@ public class RegExpLiteralHoistingTests
     // Stateless String.prototype consumers (match/replace/search/split) scan from
     // 0 and never read instance lastIndex, so the literal arg is hoisted even with
     // g — repeated calls must give identical results.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StatelessStringConsumersInLoop_Hoisted_StableResults(ExecutionMode mode)
     {
         var source = """
@@ -77,8 +74,7 @@ public class RegExpLiteralHoistingTests
     // independent instance (the analyzer keys by node identity, not value). Here
     // `/a/` is hoisted via `.test`; the value-equal `const r = /a/` is mutated and
     // must keep its own lastIndex.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EscapingLiteral_ValueEqualToHoisted_StaysIndependent(ExecutionMode mode)
     {
         var source = """
@@ -96,8 +92,7 @@ public class RegExpLiteralHoistingTests
     // Two evaluations of the same source literal are distinct objects (===
     // false). The literals appear in === position (not a consuming position), so
     // they are never hoisted — identity is preserved.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RegexLiteralIdentity_NotHoistedInComparison(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/RegExpNamedCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/RegExpNamedCaptureTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class RegExpNamedCaptureTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exec_NamedGroups_PopulatesGroupsObject(ExecutionMode mode)
     {
         var source = """
@@ -24,8 +23,7 @@ public class RegExpNamedCaptureTests
         Assert.Equal("2024\n03\n15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exec_NamedGroups_IndexAndInput(ExecutionMode mode)
     {
         var source = """
@@ -40,8 +38,7 @@ public class RegExpNamedCaptureTests
         Assert.Equal("hello\n0\nhello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exec_NoNamedGroups_GroupsIsNull(ExecutionMode mode)
     {
         var source = """
@@ -54,8 +51,7 @@ public class RegExpNamedCaptureTests
         Assert.Equal("null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Match_NamedGroups_NonGlobal(ExecutionMode mode)
     {
         var source = """
@@ -69,8 +65,7 @@ public class RegExpNamedCaptureTests
         Assert.Equal("2024\n03\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MatchAll_NamedGroups(ExecutionMode mode)
     {
         var source = """
@@ -87,8 +82,7 @@ public class RegExpNamedCaptureTests
         Assert.Equal("2\n2024\n03\n2025\n12\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exec_NoMatch_ReturnsNull(ExecutionMode mode)
     {
         var source = """
@@ -101,8 +95,7 @@ public class RegExpNamedCaptureTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exec_MixedNamedAndUnnamed(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/RequestResponseTests.cs
+++ b/SharpTS.Tests/SharedTests/RequestResponseTests.cs
@@ -11,8 +11,7 @@ public class RequestResponseTests
 {
     // ========== Response Constructor Tests ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Response_DefaultConstructor(ExecutionMode mode)
     {
         var source = @"
@@ -24,8 +23,7 @@ public class RequestResponseTests
         Assert.Equal("200\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Response_StringBody(ExecutionMode mode)
     {
         var source = @"
@@ -40,8 +38,7 @@ public class RequestResponseTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Response_NullBody(ExecutionMode mode)
     {
         var source = @"
@@ -56,8 +53,7 @@ public class RequestResponseTests
         Assert.Equal("\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Response_CustomStatus(ExecutionMode mode)
     {
         var source = @"
@@ -70,8 +66,7 @@ public class RequestResponseTests
         Assert.Equal("404\nNot Found\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Response_CustomHeaders(ExecutionMode mode)
     {
         var source = @"
@@ -82,8 +77,7 @@ public class RequestResponseTests
         Assert.Equal("val\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Response_BodyUsed(ExecutionMode mode)
     {
         var source = @"
@@ -99,8 +93,7 @@ public class RequestResponseTests
         Assert.Equal("false\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Response_Json(ExecutionMode mode)
     {
         var source = @"
@@ -115,8 +108,7 @@ public class RequestResponseTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Response_ArrayBuffer(ExecutionMode mode)
     {
         var source = @"
@@ -131,8 +123,7 @@ public class RequestResponseTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Response_Clone(ExecutionMode mode)
     {
         var source = @"
@@ -152,8 +143,7 @@ public class RequestResponseTests
 
     // ========== Response Static Method Tests ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Response_Json_Static(ExecutionMode mode)
     {
         var source = @"
@@ -170,8 +160,7 @@ public class RequestResponseTests
         Assert.Equal("200\napplication/json\nvalue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Response_Json_WithInit(ExecutionMode mode)
     {
         var source = @"
@@ -182,8 +171,7 @@ public class RequestResponseTests
         Assert.Equal("201\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Response_Redirect(ExecutionMode mode)
     {
         var source = @"
@@ -195,8 +183,7 @@ public class RequestResponseTests
         Assert.Equal("302\nhttps://example.com\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Response_Redirect_CustomStatus(ExecutionMode mode)
     {
         var source = @"
@@ -207,8 +194,7 @@ public class RequestResponseTests
         Assert.Equal("301\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Response_Error(ExecutionMode mode)
     {
         var source = @"
@@ -222,8 +208,7 @@ public class RequestResponseTests
 
     // ========== Request Constructor Tests ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Request_BasicGet(ExecutionMode mode)
     {
         var source = @"
@@ -235,8 +220,7 @@ public class RequestResponseTests
         Assert.Equal("GET\nhttps://example.com\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Request_PostMethod(ExecutionMode mode)
     {
         var source = @"
@@ -247,8 +231,7 @@ public class RequestResponseTests
         Assert.Equal("POST\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Request_CustomHeaders(ExecutionMode mode)
     {
         var source = @"
@@ -261,8 +244,7 @@ public class RequestResponseTests
         Assert.Equal("Bearer token123\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Request_Body(ExecutionMode mode)
     {
         var source = @"
@@ -280,8 +262,7 @@ public class RequestResponseTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Request_Clone(ExecutionMode mode)
     {
         var source = @"
@@ -294,8 +275,7 @@ public class RequestResponseTests
         Assert.Equal("POST\nhttps://example.com\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Request_Properties(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/SatisfiesTests.cs
+++ b/SharpTS.Tests/SharedTests/SatisfiesTests.cs
@@ -11,8 +11,7 @@ public class SatisfiesTests
 {
     #region Basic Pass-Through
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Satisfies_BasicNumber(ExecutionMode mode)
     {
         var source = """
@@ -24,8 +23,7 @@ public class SatisfiesTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Satisfies_BasicString(ExecutionMode mode)
     {
         var source = """
@@ -37,8 +35,7 @@ public class SatisfiesTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Satisfies_ObjectLiteral(ExecutionMode mode)
     {
         var source = """
@@ -55,8 +52,7 @@ public class SatisfiesTests
 
     #region Union Constraints
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Satisfies_UnionConstraint(ExecutionMode mode)
     {
         var source = """
@@ -74,8 +70,7 @@ public class SatisfiesTests
 
     #region Array Constraints
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Satisfies_ArrayConstraint(ExecutionMode mode)
     {
         var source = """
@@ -92,8 +87,7 @@ public class SatisfiesTests
 
     #region Escape Hatches
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Satisfies_AnyConstraint(ExecutionMode mode)
     {
         var source = """
@@ -106,8 +100,7 @@ public class SatisfiesTests
         Assert.Equal("1\ntwo\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Satisfies_UnknownConstraint(ExecutionMode mode)
     {
         var source = """
@@ -123,8 +116,7 @@ public class SatisfiesTests
 
     #region Chaining
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Satisfies_Chained(ExecutionMode mode)
     {
         var source = """
@@ -140,8 +132,7 @@ public class SatisfiesTests
 
     #region Excess Properties
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Satisfies_ExcessProperties(ExecutionMode mode)
     {
         var source = """
@@ -159,8 +150,7 @@ public class SatisfiesTests
 
     #region With Arrow Functions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Satisfies_InArrowFunction(ExecutionMode mode)
     {
         var source = """
@@ -175,8 +165,7 @@ public class SatisfiesTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Satisfies_ArrowReturnsSatisfies(ExecutionMode mode)
     {
         var source = """
@@ -192,8 +181,7 @@ public class SatisfiesTests
 
     #region Async Functions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Satisfies_InAsyncFunction(ExecutionMode mode)
     {
         var source = """
@@ -216,8 +204,7 @@ public class SatisfiesTests
 
     #region With as const
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Satisfies_WithAsConst(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/ScriptLikeModuleTopLevelCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/ScriptLikeModuleTopLevelCaptureTests.cs
@@ -47,8 +47,7 @@ public class ScriptLikeModuleTopLevelCaptureTests
     private static string Normalize(string s) =>
         string.Join("\n", s.Replace("\r\n", "\n").Split('\n').Select(l => l.TrimEnd())).Trim();
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionDeclaration_ReadsTopLevelLet(ExecutionMode mode)
     {
         // Previously: ReferenceError: Undefined variable 'v'.
@@ -59,8 +58,7 @@ public class ScriptLikeModuleTopLevelCaptureTests
             """, "v=7", mode);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionDeclaration_MutatesTopLevelLet(ExecutionMode mode)
     {
         // Previously: InvalidProgramException, for each of the three write forms.
@@ -75,8 +73,7 @@ public class ScriptLikeModuleTopLevelCaptureTests
             """, "2,4,6", mode);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionDeclaration_MutatesTopLevelVarAndString(ExecutionMode mode)
     {
         Expect("""
@@ -94,8 +91,7 @@ public class ScriptLikeModuleTopLevelCaptureTests
     /// Function declarations hoist, so a function defined above the binding it captures
     /// still has to resolve to the same storage once called.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void HoistedFunction_CapturesLaterDeclaredTopLevelLet(ExecutionMode mode)
     {
         Expect("""
@@ -108,8 +104,7 @@ public class ScriptLikeModuleTopLevelCaptureTests
             """, "count=3", mode);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassMethod_CapturesTopLevelLet(ExecutionMode mode)
     {
         Expect("""
@@ -130,8 +125,7 @@ public class ScriptLikeModuleTopLevelCaptureTests
     /// (it never enters the shared bucket). Both are kept so a future change to the
     /// normalization can't fix one shape by breaking another.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowAndRealModule_StillCaptureTopLevelLet(ExecutionMode mode)
     {
         Expect("""
@@ -154,8 +148,7 @@ public class ScriptLikeModuleTopLevelCaptureTests
     /// Two script-like modules genuinely share one global scope, so a function in the
     /// entry file must see a binding the imported-by-side-effect script declared.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionDeclaration_MutatesAcrossScriptMergedFiles(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/SetOperationsTests.cs
+++ b/SharpTS.Tests/SharedTests/SetOperationsTests.cs
@@ -11,8 +11,7 @@ public class SetOperationsTests
 {
     #region Union Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Union_CombinesTwoSets(ExecutionMode mode)
     {
         var source = @"
@@ -30,8 +29,7 @@ public class SetOperationsTests
         Assert.Equal("5\ntrue\ntrue\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Union_WithEmptySet(ExecutionMode mode)
     {
         var source = @"
@@ -44,8 +42,7 @@ public class SetOperationsTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Union_DoesNotMutateOriginal(ExecutionMode mode)
     {
         var source = @"
@@ -64,8 +61,7 @@ public class SetOperationsTests
 
     #region Intersection Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Intersection_ReturnsCommonElements(ExecutionMode mode)
     {
         var source = @"
@@ -82,8 +78,7 @@ public class SetOperationsTests
         Assert.Equal("2\ntrue\ntrue\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Intersection_NoCommonElements(ExecutionMode mode)
     {
         var source = @"
@@ -96,8 +91,7 @@ public class SetOperationsTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Intersection_WithEmptySet(ExecutionMode mode)
     {
         var source = @"
@@ -114,8 +108,7 @@ public class SetOperationsTests
 
     #region Difference Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Difference_ReturnsElementsOnlyInFirst(ExecutionMode mode)
     {
         var source = @"
@@ -131,8 +124,7 @@ public class SetOperationsTests
         Assert.Equal("2\ntrue\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Difference_WithEmptySet(ExecutionMode mode)
     {
         var source = @"
@@ -145,8 +137,7 @@ public class SetOperationsTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Difference_FromEmptySet(ExecutionMode mode)
     {
         var source = @"
@@ -163,8 +154,7 @@ public class SetOperationsTests
 
     #region Symmetric Difference Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_SymmetricDifference_ReturnsElementsInEitherButNotBoth(ExecutionMode mode)
     {
         var source = @"
@@ -181,8 +171,7 @@ public class SetOperationsTests
         Assert.Equal("2\ntrue\ntrue\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_SymmetricDifference_IdenticalSets(ExecutionMode mode)
     {
         var source = @"
@@ -195,8 +184,7 @@ public class SetOperationsTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_SymmetricDifference_DisjointSets(ExecutionMode mode)
     {
         var source = @"
@@ -213,8 +201,7 @@ public class SetOperationsTests
 
     #region IsSubsetOf Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_IsSubsetOf_ReturnsTrueForSubset(ExecutionMode mode)
     {
         var source = @"
@@ -226,8 +213,7 @@ public class SetOperationsTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_IsSubsetOf_ReturnsFalseForNonSubset(ExecutionMode mode)
     {
         var source = @"
@@ -239,8 +225,7 @@ public class SetOperationsTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_IsSubsetOf_EmptySetIsSubsetOfAll(ExecutionMode mode)
     {
         var source = @"
@@ -252,8 +237,7 @@ public class SetOperationsTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_IsSubsetOf_SetIsSubsetOfItself(ExecutionMode mode)
     {
         var source = @"
@@ -268,8 +252,7 @@ public class SetOperationsTests
 
     #region IsSupersetOf Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_IsSupersetOf_ReturnsTrueForSuperset(ExecutionMode mode)
     {
         var source = @"
@@ -281,8 +264,7 @@ public class SetOperationsTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_IsSupersetOf_ReturnsFalseForNonSuperset(ExecutionMode mode)
     {
         var source = @"
@@ -294,8 +276,7 @@ public class SetOperationsTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_IsSupersetOf_AllAreSupersetOfEmpty(ExecutionMode mode)
     {
         var source = @"
@@ -311,8 +292,7 @@ public class SetOperationsTests
 
     #region IsDisjointFrom Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_IsDisjointFrom_ReturnsTrueForDisjointSets(ExecutionMode mode)
     {
         var source = @"
@@ -324,8 +304,7 @@ public class SetOperationsTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_IsDisjointFrom_ReturnsFalseForOverlappingSets(ExecutionMode mode)
     {
         var source = @"
@@ -337,8 +316,7 @@ public class SetOperationsTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_IsDisjointFrom_EmptySetIsDisjointFromAll(ExecutionMode mode)
     {
         var source = @"
@@ -355,8 +333,7 @@ public class SetOperationsTests
 
     #region String Set Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Operations_WithStrings(ExecutionMode mode)
     {
         var source = @"
@@ -380,8 +357,7 @@ public class SetOperationsTests
 
     #region Chaining Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_Operations_CanBeChained(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/SpreadIntoRestParameterTests.cs
+++ b/SharpTS.Tests/SharedTests/SpreadIntoRestParameterTests.cs
@@ -46,8 +46,7 @@ public class SpreadIntoRestParameterTests
     /// Every callable shape that can declare a rest parameter, each called three ways:
     /// plain args, a bare spread, and a leading arg followed by a spread.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadIntoRest_AllCallableShapes(ExecutionMode mode)
     {
         AssertLines("""
@@ -82,8 +81,7 @@ public class SpreadIntoRestParameterTests
     /// The rest parameter's declared element type must not change dispatch. Before the
     /// fix <c>...p: string[]</c> worked by accident and <c>...p: any[]</c> did not.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadIntoRest_ElementTypeDoesNotChangeDispatch(ExecutionMode mode)
     {
         AssertLines("""
@@ -113,8 +111,7 @@ public class SpreadIntoRestParameterTests
     /// follows, an empty spread must contribute nothing, and a spread may also supply
     /// the leading parameters.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadIntoRest_RegularParamsAndEmptySpread(ExecutionMode mode)
     {
         AssertLines("""
@@ -150,8 +147,7 @@ public class SpreadIntoRestParameterTests
     /// rejected tuples, and typed arrays/Buffers were missing from the interpreter's
     /// iterable switch even though the compiled path expanded them.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadIntoRest_AcceptsEveryIterableKind(ExecutionMode mode)
     {
         AssertLines("""
@@ -200,8 +196,7 @@ public class SpreadIntoRestParameterTests
     /// A genuinely non-iterable spread operand must still be rejected — the fix widened the
     /// check to "iterable", not "anything".
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadIntoRest_RejectsNonIterable(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -223,8 +218,7 @@ public class SpreadIntoRestParameterTests
     /// the IL stack), so they get their own coverage — including a spread that follows
     /// an awaited leading argument.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadIntoRest_InsideAsyncBody(ExecutionMode mode)
     {
         AssertLines("""
@@ -256,8 +250,7 @@ public class SpreadIntoRestParameterTests
     /// stdlib object-literal namespace method with a rest parameter, and the spread
     /// form crashed compiled output with an InvalidCastException.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadIntoRest_StdlibNamespaceMethod(ExecutionMode mode)
     {
         AssertLines("""

--- a/SharpTS.Tests/SharedTests/StateMachineUndefinedEqualityTests.cs
+++ b/SharpTS.Tests/SharedTests/StateMachineUndefinedEqualityTests.cs
@@ -11,8 +11,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class StateMachineUndefinedEqualityTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Async_AwaitNullResolvedPromise_IsNotUndefined(ExecutionMode mode)
     {
         // The exact repro from #600: awaiting a promise that resolves null must yield a value that is
@@ -32,8 +31,7 @@ public class StateMachineUndefinedEqualityTests
         Assert.Equal("object\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Async_UndefinedLiteralAndStrictEquality(ExecutionMode mode)
     {
         var source = """
@@ -51,8 +49,7 @@ public class StateMachineUndefinedEqualityTests
         Assert.Equal("undefined\nundefined\nfalse\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Async_ReturnNull_ResolvesNullNotUndefined(ExecutionMode mode)
     {
         // `return null` in an async function still resolves with null (distinct from undefined).
@@ -69,8 +66,7 @@ public class StateMachineUndefinedEqualityTests
         Assert.Equal("object null true false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Async_ThrowUndefined_StringifiesAsUndefined(ExecutionMode mode)
     {
         // #629: the undefined literal was Ldnull in state machines, so a caught `throw undefined`
@@ -87,8 +83,7 @@ public class StateMachineUndefinedEqualityTests
         Assert.Equal("u=undefined isUndef=true\nn=null isNull=true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_UndefinedLiteralAndStrictEquality(ExecutionMode mode)
     {
         var source = """
@@ -104,8 +99,7 @@ public class StateMachineUndefinedEqualityTests
         Assert.Equal("undefined\nfalse\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncArrow_UndefinedLiteralAndStrictEquality(ExecutionMode mode)
     {
         var source = """
@@ -120,8 +114,7 @@ public class StateMachineUndefinedEqualityTests
         Assert.Equal("undefined\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGenerator_UndefinedLiteralAndStrictEquality(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/StaticBlockTests.cs
+++ b/SharpTS.Tests/SharedTests/StaticBlockTests.cs
@@ -14,8 +14,7 @@ public class StaticBlockTests
 {
     // ============== BASIC FUNCTIONALITY ==============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_ExecutesOnClassDeclaration(ExecutionMode mode)
     {
         var source = """
@@ -27,8 +26,7 @@ public class StaticBlockTests
         Assert.Equal("block executed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_MultipleBlocksExecuteInOrder(ExecutionMode mode)
     {
         var source = """
@@ -42,8 +40,7 @@ public class StaticBlockTests
         Assert.Equal("first\nsecond\nthird\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_CanAccessStaticField(ExecutionMode mode)
     {
         var source = """
@@ -56,8 +53,7 @@ public class StaticBlockTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_CanModifyStaticField(ExecutionMode mode)
     {
         var source = """
@@ -71,8 +67,7 @@ public class StaticBlockTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_InterleavedWithFieldsInOrder(ExecutionMode mode)
     {
         var source = """
@@ -89,8 +84,7 @@ public class StaticBlockTests
 
     // ============== THIS BINDING ==============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_ThisRefersToClass(ExecutionMode mode)
     {
         var source = """
@@ -103,8 +97,7 @@ public class StaticBlockTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_ThisCanModifyStaticProperty(ExecutionMode mode)
     {
         var source = """
@@ -118,8 +111,7 @@ public class StaticBlockTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_ThisCanCallStaticMethod(ExecutionMode mode)
     {
         var source = """
@@ -132,8 +124,7 @@ public class StaticBlockTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_CanCallStaticMethod(ExecutionMode mode)
     {
         // Using class name directly works in both interpreter and compiler
@@ -149,8 +140,7 @@ public class StaticBlockTests
 
     // ============== INHERITANCE ==============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_SubclassBlockRunsAfterSuperclass(ExecutionMode mode)
     {
         var source = """
@@ -165,8 +155,7 @@ public class StaticBlockTests
         Assert.Equal("parent\nchild\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_CanAccessInheritedStaticField(ExecutionMode mode)
     {
         var source = """
@@ -183,8 +172,7 @@ public class StaticBlockTests
 
     // ============== CLASS EXPRESSIONS ==============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_InAnonymousClassExpression(ExecutionMode mode)
     {
         var source = """
@@ -198,8 +186,7 @@ public class StaticBlockTests
         Assert.Equal("99\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_InNamedClassExpression(ExecutionMode mode)
     {
         var source = """
@@ -213,8 +200,7 @@ public class StaticBlockTests
 
     // ============== CONTROL FLOW ==============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_WithIfElse(ExecutionMode mode)
     {
         var source = """
@@ -234,8 +220,7 @@ public class StaticBlockTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_WithForLoop(ExecutionMode mode)
     {
         var source = """
@@ -253,8 +238,7 @@ public class StaticBlockTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_WithTryCatch(ExecutionMode mode)
     {
         var source = """
@@ -274,8 +258,7 @@ public class StaticBlockTests
         Assert.Equal("caught\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_BreakInLoop(ExecutionMode mode)
     {
         var source = """
@@ -296,8 +279,7 @@ public class StaticBlockTests
 
     // ============== EDGE CASES ==============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_Empty(ExecutionMode mode)
     {
         var source = """
@@ -310,8 +292,7 @@ public class StaticBlockTests
         Assert.Equal("ok\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_InGenericClass(ExecutionMode mode)
     {
         var source = """
@@ -325,8 +306,7 @@ public class StaticBlockTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_InAbstractClass(ExecutionMode mode)
     {
         var source = """
@@ -340,8 +320,7 @@ public class StaticBlockTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_ThrowPropagates(ExecutionMode mode)
     {
         var source = """
@@ -354,8 +333,7 @@ public class StaticBlockTests
 
     // ============== ERROR VALIDATION ==============
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_ReturnStatementNotAllowed(ExecutionMode mode)
     {
         var source = """
@@ -367,8 +345,7 @@ public class StaticBlockTests
         Assert.Contains("Return statements are not allowed in static blocks", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_ReturnValueNotAllowed(ExecutionMode mode)
     {
         var source = """
@@ -380,8 +357,7 @@ public class StaticBlockTests
         Assert.Contains("Return statements are not allowed in static blocks", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticBlock_NoAccessModifiersAllowed(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/StaticDispatchBoxingTests.cs
+++ b/SharpTS.Tests/SharedTests/StaticDispatchBoxingTests.cs
@@ -15,8 +15,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class StaticDispatchBoxingTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticMethod_BoxedPrimitiveArgs_SyncTopLevel(ExecutionMode mode)
     {
         var source = """
@@ -33,8 +32,7 @@ public class StaticDispatchBoxingTests
         Assert.Equal("number\nnumber\nboolean\nboolean\nstring\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticMethod_BoxedPrimitiveArgs_InsideAsync(ExecutionMode mode)
     {
         var source = """
@@ -54,8 +52,7 @@ public class StaticDispatchBoxingTests
         Assert.Equal("number\nnumber\nboolean\nnumber\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PromiseSubclassStatic_InsideAsync(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/StaticGeneratorMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/StaticGeneratorMethodTests.cs
@@ -10,8 +10,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class StaticGeneratorMethodTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticGenerator_SingleYield_Works(ExecutionMode mode)
     {
         var source = """
@@ -22,8 +21,7 @@ public class StaticGeneratorMethodTests
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticGenerator_WithParameter_Works(ExecutionMode mode)
     {
         var source = """
@@ -35,8 +33,7 @@ public class StaticGeneratorMethodTests
         Assert.Equal("0,2,4\n0\n2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticGenerator_ReadsStaticField_Works(ExecutionMode mode)
     {
         var source = """
@@ -50,8 +47,7 @@ public class StaticGeneratorMethodTests
         Assert.Equal("0,1,2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticGenerator_ExplicitReturnType_Works(ExecutionMode mode)
     {
         // Per #692: an explicit Generator<T> return type doesn't change the lowering path.
@@ -63,8 +59,7 @@ public class StaticGeneratorMethodTests
         Assert.Equal("3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceGenerator_StillWorks(ExecutionMode mode)
     {
         // Regression guard: the instance form (the path #692 did not touch) keeps working.
@@ -76,8 +71,7 @@ public class StaticGeneratorMethodTests
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticAsyncGenerator_ForAwait_Works(ExecutionMode mode)
     {
         // #778: a static async generator (static async *m()) was emitted as a plain async method, so
@@ -92,8 +86,7 @@ public class StaticGeneratorMethodTests
         Assert.Equal("1\n2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticAsyncGenerator_ParameterAndAwait_Works(ExecutionMode mode)
     {
         // Reads a parameter (in a yield, not a for-condition — see the CompiledOnly test below) and
@@ -107,8 +100,7 @@ public class StaticGeneratorMethodTests
         Assert.Equal("5\n10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticAsyncGenerator_DefaultParamLoopAndAwait_Works(ExecutionMode mode)
     {
         // Exercises a default value-type parameter, a C-style for loop whose bound reads that

--- a/SharpTS.Tests/SharedTests/StaticMembersTests.cs
+++ b/SharpTS.Tests/SharedTests/StaticMembersTests.cs
@@ -10,8 +10,7 @@ public class StaticMembersTests
 {
     #region Static Fields
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticField_InitializedCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -25,8 +24,7 @@ public class StaticMembersTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticField_StringInitializer(ExecutionMode mode)
     {
         var source = """
@@ -40,8 +38,7 @@ public class StaticMembersTests
         Assert.Equal("SharpTS\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticField_ModificationPersists(ExecutionMode mode)
     {
         var source = """
@@ -61,8 +58,7 @@ public class StaticMembersTests
 
     #region Static Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticMethod_CanBeCalled(ExecutionMode mode)
     {
         var source = """
@@ -78,8 +74,7 @@ public class StaticMembersTests
         Assert.Equal("25\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticMethod_CallsOtherStatic(ExecutionMode mode)
     {
         var source = """
@@ -98,8 +93,7 @@ public class StaticMembersTests
         Assert.Equal("27\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticMethod_ModifiesStaticField(ExecutionMode mode)
     {
         var source = """
@@ -119,8 +113,7 @@ public class StaticMembersTests
         Assert.Equal("1\n2\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticMethod_WithParameters(ExecutionMode mode)
     {
         var source = """
@@ -144,8 +137,7 @@ public class StaticMembersTests
 
     #region Static and Instance Separation
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticAndInstance_AreSeparate(ExecutionMode mode)
     {
         var source = """
@@ -179,8 +171,7 @@ public class StaticMembersTests
     // call returned null. Babel-transpiled CJS (minimatch, uuid, many others)
     // hits this through `const mod = require('./submodule'); mod.AST.fromGlob(...)`.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticMethod_ThroughLocalAlias(ExecutionMode mode)
     {
         var source = """
@@ -196,8 +187,7 @@ public class StaticMembersTests
         Assert.Equal("function\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticMethod_ThroughObjectProperty(ExecutionMode mode)
     {
         var source = """
@@ -215,8 +205,7 @@ public class StaticMembersTests
         Assert.Equal("function\n42\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticField_ThroughLocalAlias(ExecutionMode mode)
     {
         var source = """
@@ -293,8 +282,7 @@ public class StaticMembersTests
     // Static members declared on a base user class are inherited by subclasses. In compiled mode the
     // .NET token references the *declaring* class, so resolution walks the superclass chain (#332).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStatic_Method(ExecutionMode mode)
     {
         var source = """
@@ -308,8 +296,7 @@ public class StaticMembersTests
         Assert.Equal("hi\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStatic_Field(ExecutionMode mode)
     {
         var source = """
@@ -323,8 +310,7 @@ public class StaticMembersTests
         Assert.Equal("5\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStatic_Getter(ExecutionMode mode)
     {
         var source = """
@@ -338,8 +324,7 @@ public class StaticMembersTests
         Assert.Equal("L\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStatic_MultiLevelChain(ExecutionMode mode)
     {
         var source = """
@@ -356,8 +341,7 @@ public class StaticMembersTests
         Assert.Equal("A\na\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStatic_SubclassShadowWins(ExecutionMode mode)
     {
         var source = """
@@ -374,8 +358,7 @@ public class StaticMembersTests
         Assert.Equal("Child\nParent\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStatic_FromGenericBase(ExecutionMode mode)
     {
         var source = """
@@ -393,8 +376,7 @@ public class StaticMembersTests
         Assert.Equal("made\nbox\nT\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStatic_FieldWriteDoesNotCorruptBase(ExecutionMode mode)
     {
         // A static-field write through the subclass must not mutate the base's storage.
@@ -410,8 +392,7 @@ public class StaticMembersTests
         Assert.Equal("1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStatic_FieldWriteCreatesOwnShadow(ExecutionMode mode)
     {
         // Writing an inherited static field through a subclass creates a per-subclass own shadow:
@@ -427,8 +408,7 @@ public class StaticMembersTests
         Assert.Equal("1\n42\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStatic_ShadowReadBeforeWriteSeesBase(ExecutionMode mode)
     {
         // Before a subclass write, an inherited-field read resolves the live base value; after the
@@ -449,8 +429,7 @@ public class StaticMembersTests
         Assert.Equal("1\n7\n42\n42\n9\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStatic_ShadowNearestAncestorWins(ExecutionMode mode)
     {
         // A shadow on an intermediate ancestor is visible to a deeper subclass until that subclass
@@ -470,8 +449,7 @@ public class StaticMembersTests
         Assert.Equal("b\nc\nb\na\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStatic_ShadowSiblingsAreIsolated(ExecutionMode mode)
     {
         // Each subclass owns its shadow; a write through one sibling is invisible to the other and
@@ -489,8 +467,7 @@ public class StaticMembersTests
         Assert.Equal("1\n0\n0\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStatic_ShadowFromGenericBase(ExecutionMode mode)
     {
         // Writing an inherited static declared on a generic base creates the subclass shadow without
@@ -506,8 +483,7 @@ public class StaticMembersTests
         Assert.Equal("intbox\nbox\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StaticField_OwnCompoundAndIncrementViaClassName(ExecutionMode mode)
     {
         // Read-modify-write of an own static field accessed as `Class.field` must land on the field
@@ -526,8 +502,7 @@ public class StaticMembersTests
         Assert.Equal("13\n14\n14\n15\n14\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStatic_CompoundAndIncrementCreateShadow(ExecutionMode mode)
     {
         // Read-modify-write through a subclass reads the inherited value, then writes the result to
@@ -558,8 +533,7 @@ public class StaticMembersTests
     // subclass's own declared statics and ancestor expando shadows — never an ancestor's *declared*
     // static (#358). The interpreter was already correct.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStaticAsValue_DeclaredFieldPreShadow(ExecutionMode mode)
     {
         var source = """
@@ -572,8 +546,7 @@ public class StaticMembersTests
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStaticAsValue_DeclaredMethod(ExecutionMode mode)
     {
         var source = """
@@ -586,8 +559,7 @@ public class StaticMembersTests
         Assert.Equal("hi\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStaticAsValue_MultiLevelChain(ExecutionMode mode)
     {
         var source = """
@@ -602,8 +574,7 @@ public class StaticMembersTests
         Assert.Equal("7\nhi\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStaticAsValue_OwnShadowWinsOverDeclared(ExecutionMode mode)
     {
         // Once a per-subclass own shadow exists, the dynamic read returns it, not the base value.
@@ -618,8 +589,7 @@ public class StaticMembersTests
         Assert.Equal("99\n10\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InheritedStaticAsValue_AncestorExpandoWinsOverDeclared(ExecutionMode mode)
     {
         // An expando shadow written on an ancestor (shadow-before-declared) is seen through the
@@ -643,8 +613,7 @@ public class StaticMembersTests
     // these reads come through an `any`/value position. Compiled mode was already correct; the
     // interpreter previously threw "Static member 'x' does not exist on class 'y'." (#398).
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MissingStaticAsValue_OnSubclass(ExecutionMode mode)
     {
         var source = """
@@ -657,8 +626,7 @@ public class StaticMembersTests
         Assert.Equal("undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MissingStaticAsValue_OnPlainClass(ExecutionMode mode)
     {
         var source = """
@@ -671,8 +639,7 @@ public class StaticMembersTests
         Assert.Equal("1\nundefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MissingStaticAsValue_UsedInExpression(ExecutionMode mode)
     {
         // A missing read yielding `undefined` participates in normal coercion rather than aborting.

--- a/SharpTS.Tests/SharedTests/StaticMethodAccessTests.cs
+++ b/SharpTS.Tests/SharedTests/StaticMethodAccessTests.cs
@@ -14,8 +14,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class StaticMethodAccessTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateStaticMethod_ExternalAccess_Errors(ExecutionMode mode)
     {
         var source = """
@@ -28,8 +27,7 @@ public class StaticMethodAccessTests
         Assert.Contains("is private", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateStaticMethod_InternalAccess_Allowed(ExecutionMode mode)
     {
         var source = """
@@ -43,8 +41,7 @@ public class StaticMethodAccessTests
         Assert.Equal("s\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProtectedStaticMethod_FromSubclass_Allowed(ExecutionMode mode)
     {
         var source = """
@@ -60,8 +57,7 @@ public class StaticMethodAccessTests
         Assert.Equal("base\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProtectedStaticMethod_ExternalAccess_Errors(ExecutionMode mode)
     {
         var source = """
@@ -74,8 +70,7 @@ public class StaticMethodAccessTests
         Assert.Contains("is protected", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateInstanceMethod_NotMaskedByPublicStaticTwin(ExecutionMode mode)
     {
         // Issue #722 collision: a public `static run` must not overwrite the
@@ -92,8 +87,7 @@ public class StaticMethodAccessTests
         Assert.Contains("is private", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PublicStaticTwin_StillAccessible_WhenInstanceTwinIsPrivate(ExecutionMode mode)
     {
         // The mirror of the above: the public static `run` remains accessible
@@ -111,8 +105,7 @@ public class StaticMethodAccessTests
 
     // --- Static fields (same StaticFieldAccess treatment as static methods) ---
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateStaticField_ExternalRead_Errors(ExecutionMode mode)
     {
         var source = """
@@ -125,8 +118,7 @@ public class StaticMethodAccessTests
         Assert.Contains("is private", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateStaticField_ExternalAssignment_Errors(ExecutionMode mode)
     {
         var source = """
@@ -139,8 +131,7 @@ public class StaticMethodAccessTests
         Assert.Contains("is private", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateStaticField_InternalRead_Allowed(ExecutionMode mode)
     {
         var source = """
@@ -154,8 +145,7 @@ public class StaticMethodAccessTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ProtectedStaticField_FromSubclass_Allowed(ExecutionMode mode)
     {
         var source = """
@@ -169,8 +159,7 @@ public class StaticMethodAccessTests
         Assert.Equal("9\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateInstanceField_NotMaskedByPublicStaticTwin(ExecutionMode mode)
     {
         // Field collision mirror of issue #722: a public `static x` must not
@@ -186,8 +175,7 @@ public class StaticMethodAccessTests
         Assert.Contains("is private", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PublicStaticField_ExternalRead_Allowed(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/StdlibClosureCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/StdlibClosureCaptureTests.cs
@@ -28,8 +28,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </remarks>
 public class StdlibClosureCaptureTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SiblingFunctions_SameParamName_CapturedByClosures(ExecutionMode mode)
     {
         // Minimal repro: two module-level functions with `fn` params, each
@@ -64,8 +63,7 @@ public class StdlibClosureCaptureTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedArrow_CapturesParentArrowRestParam(ExecutionMode mode)
     {
         // Second-order repro: a Promise-executor pattern where the innermost
@@ -96,8 +94,7 @@ public class StdlibClosureCaptureTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThreeSiblings_SameParamName_AllClosuresWork(ExecutionMode mode)
     {
         // Extends the two-sibling case to three, verifying the resolver still

--- a/SharpTS.Tests/SharedTests/StrictModeTests.cs
+++ b/SharpTS.Tests/SharedTests/StrictModeTests.cs
@@ -7,8 +7,7 @@ namespace SharpTS.Tests.SharedTests;
 public class StrictModeTests
 {
     // Basic directive parsing
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_DirectiveIsParsed(ExecutionMode mode)
     {
         var source = """
@@ -21,8 +20,7 @@ public class StrictModeTests
     }
 
     // Frozen object tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_FrozenObject_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """
@@ -36,8 +34,7 @@ public class StrictModeTests
         Assert.Contains("Cannot assign to read only property", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NoUseStrict_FrozenObject_SilentlyFails(ExecutionMode mode)
     {
         var source = """
@@ -51,8 +48,7 @@ public class StrictModeTests
     }
 
     // Sealed object tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_SealedObject_AddProperty_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """
@@ -66,8 +62,7 @@ public class StrictModeTests
         Assert.Contains("Cannot add property", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_SealedObject_ModifyExisting_Works(ExecutionMode mode)
     {
         var source = """
@@ -81,8 +76,7 @@ public class StrictModeTests
         Assert.Equal("2\n", output); // Sealed objects allow modifying existing properties
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NoUseStrict_SealedObject_AddProperty_SilentlyFails(ExecutionMode mode)
     {
         var source = """
@@ -97,8 +91,7 @@ public class StrictModeTests
     }
 
     // Frozen array tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_FrozenArray_SetElement_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """
@@ -111,8 +104,7 @@ public class StrictModeTests
         Assert.Contains("TypeError", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NoUseStrict_FrozenArray_SetElement_SilentlyFails(ExecutionMode mode)
     {
         var source = """
@@ -126,8 +118,7 @@ public class StrictModeTests
     }
 
     // Function-level strict mode
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_FunctionLevel_AffectsOnlyFunction(ExecutionMode mode)
     {
         var source = """
@@ -147,8 +138,7 @@ public class StrictModeTests
         Assert.Equal("1\n", output); // Global modification silently ignored
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_FunctionLevel_ThrowsInFunction(ExecutionMode mode)
     {
         var source = """
@@ -165,8 +155,7 @@ public class StrictModeTests
     }
 
     // Strict mode inheritance to nested functions (uses arrow functions for compiler compatibility)
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_InheritsToNestedFunctions(ExecutionMode mode)
     {
         var source = """
@@ -187,8 +176,7 @@ public class StrictModeTests
     }
 
     // Multiple directives
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_OtherDirectivesAllowed(ExecutionMode mode)
     {
         var source = """
@@ -202,8 +190,7 @@ public class StrictModeTests
     }
 
     // Directive must be at the start
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_AfterStatements_NotDirective(ExecutionMode mode)
     {
         var source = """
@@ -219,8 +206,7 @@ public class StrictModeTests
     }
 
     // Class instance frozen
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_FrozenClassInstance_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """
@@ -242,8 +228,7 @@ public class StrictModeTests
     }
 
     // Delete variable tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_DeleteVariable_ThrowsSyntaxError(ExecutionMode mode)
     {
         var source = """
@@ -257,8 +242,7 @@ public class StrictModeTests
         Assert.Contains("Delete of unqualified identifier", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SloppyMode_DeleteVariable_ReturnsFalse(ExecutionMode mode)
     {
         var source = """
@@ -275,8 +259,7 @@ public class StrictModeTests
     }
 
     // Duplicate parameter tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_DuplicateParameters_ThrowsSyntaxError(ExecutionMode mode)
     {
         var source = """
@@ -291,8 +274,7 @@ public class StrictModeTests
         Assert.Contains("Duplicate parameter name", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_FunctionLevelStrict_DuplicateParameters_ThrowsSyntaxError(ExecutionMode mode)
     {
         // Function with "use strict" directive inside should detect duplicate params
@@ -311,8 +293,7 @@ public class StrictModeTests
     // eval/arguments assignment tests
     // Note: In strict mode, 'eval' and 'arguments' cannot be used as assignment targets
     // This is checked during parsing when we see `eval = ...` or `arguments = ...`
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_AssignToEval_ThrowsSyntaxError(ExecutionMode mode)
     {
         // Need to have eval as a variable first, then reassign it
@@ -327,8 +308,7 @@ public class StrictModeTests
         Assert.Contains("eval or arguments", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_AssignToArguments_ThrowsSyntaxError(ExecutionMode mode)
     {
         var source = """
@@ -343,8 +323,7 @@ public class StrictModeTests
     }
 
     // Legacy octal literal tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LegacyOctalLiteral_ThrowsSyntaxError(ExecutionMode mode)
     {
         var source = """
@@ -356,8 +335,7 @@ public class StrictModeTests
         Assert.Contains("Legacy octal literals are not allowed", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ModernOctalLiteral_Works(ExecutionMode mode)
     {
         var source = """
@@ -370,8 +348,7 @@ public class StrictModeTests
     }
 
     // Octal escape sequence tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OctalEscapeSequence_ThrowsSyntaxError(ExecutionMode mode)
     {
         // \1 is an octal escape - not allowed
@@ -382,8 +359,7 @@ public class StrictModeTests
         Assert.Contains("Octal escape sequences are not allowed", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullEscape_WithoutFollowingDigit_Works(ExecutionMode mode)
     {
         // \0 is allowed when not followed by a digit
@@ -397,8 +373,7 @@ public class StrictModeTests
     }
 
     // Getter-only property tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_WriteToGetterOnly_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """
@@ -413,8 +388,7 @@ public class StrictModeTests
         Assert.Contains("getter", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SloppyMode_WriteToGetterOnly_SilentlyFails(ExecutionMode mode)
     {
         var source = """
@@ -430,8 +404,7 @@ public class StrictModeTests
     }
 
     // Delete from frozen/sealed object tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_DeleteFromFrozen_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """
@@ -445,8 +418,7 @@ public class StrictModeTests
         Assert.Contains("Cannot delete property", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SloppyMode_DeleteFromFrozen_ReturnsFalse(ExecutionMode mode)
     {
         var source = """
@@ -462,8 +434,7 @@ public class StrictModeTests
     }
 
     // Strict mode inheritance tests
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UseStrict_ArrowFunction_InheritsStrictMode(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/StringAccumulatorPromotionTests.cs
+++ b/SharpTS.Tests/SharedTests/StringAccumulatorPromotionTests.cs
@@ -19,8 +19,7 @@ public class StringAccumulatorPromotionTests
 {
     // ── Positive cases: promotable shapes ──────────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_BuildThenScan_CharCodeSum(ExecutionMode mode)
     {
         // The stringWork shape: append in a loop, then sweep length + charCodeAt.
@@ -39,8 +38,7 @@ public class StringAccumulatorPromotionTests
         Assert.Equal("585\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_CompoundAppend_Length(ExecutionMode mode)
     {
         var source = """
@@ -56,8 +54,7 @@ public class StringAccumulatorPromotionTests
         Assert.Equal("4\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_CharCodeAt_OutOfRange_IsNaN(ExecutionMode mode)
     {
         var source = """
@@ -73,8 +70,7 @@ public class StringAccumulatorPromotionTests
         Assert.Equal("NaN\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promoted_PerScope_NameCollisionDoesNotPoison(ExecutionMode mode)
     {
         // `s` in build() is a clean append-only accumulator and must promote even though an
@@ -101,8 +97,7 @@ public class StringAccumulatorPromotionTests
 
     // ── Non-promotable cases: must fall back and stay correct ───────────────
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NotPromoted_Returned_StillCorrect(ExecutionMode mode)
     {
         // `return s` escapes the accumulator (a StringBuilder slot can't be returned as a string
@@ -119,8 +114,7 @@ public class StringAccumulatorPromotionTests
         Assert.Equal("zzz\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NotPromoted_Reassigned_StillCorrect(ExecutionMode mode)
     {
         // `s = "b"` is a non-append reassignment → disqualified.
@@ -137,8 +131,7 @@ public class StringAccumulatorPromotionTests
         Assert.Equal("bc\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NotPromoted_Captured_StillCorrect(ExecutionMode mode)
     {
         // `s` is captured by a closure → routed to an object display-class field, never a
@@ -156,8 +149,7 @@ public class StringAccumulatorPromotionTests
         Assert.Equal("3\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NotPromoted_NonStringAppend_StillCorrect(ExecutionMode mode)
     {
         // `s = s + i` appends a number — not statically string, so not the promotable shape;

--- a/SharpTS.Tests/SharedTests/StringIndexByNumberTests.cs
+++ b/SharpTS.Tests/SharedTests/StringIndexByNumberTests.cs
@@ -11,8 +11,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class StringIndexByNumberTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IndexString_ByNumber_ReturnsCharacter(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/StringMatchAllTests.cs
+++ b/SharpTS.Tests/SharedTests/StringMatchAllTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class StringMatchAllTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MatchAll_BasicGlobalRegex_ReturnsAllMatches(ExecutionMode mode)
     {
         var source = """
@@ -28,8 +27,7 @@ public class StringMatchAllTests
         Assert.Equal("3\ntest1\ntest2\ntest3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MatchAll_AccessIndexProperty(ExecutionMode mode)
     {
         var source = """
@@ -43,8 +41,7 @@ public class StringMatchAllTests
         Assert.Equal("0\n6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MatchAll_AccessInputProperty(ExecutionMode mode)
     {
         var source = """
@@ -57,8 +54,7 @@ public class StringMatchAllTests
         Assert.Equal("abc 123\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MatchAll_CaptureGroups(ExecutionMode mode)
     {
         var source = """
@@ -77,8 +73,7 @@ public class StringMatchAllTests
         Assert.Equal("2\n12-ab\n12\nab\n34-cd\n34\ncd\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MatchAll_NoMatches_ReturnsEmptyArray(ExecutionMode mode)
     {
         var source = """
@@ -91,8 +86,7 @@ public class StringMatchAllTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MatchAll_NonGlobalRegex_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """
@@ -108,8 +102,7 @@ public class StringMatchAllTests
         Assert.Contains("non-global", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MatchAll_ForOfIteration(ExecutionMode mode)
     {
         var source = """
@@ -125,8 +118,7 @@ public class StringMatchAllTests
         Assert.Equal("a1,b2,c3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MatchAll_StringPattern_MatchesLiterally(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/StringMethodRegexParamTests.cs
+++ b/SharpTS.Tests/SharedTests/StringMethodRegexParamTests.cs
@@ -11,8 +11,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class StringMethodRegexParamTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Replace_WithRegex(ExecutionMode mode)
     {
         var source = @"
@@ -23,8 +22,7 @@ public class StringMethodRegexParamTests
         Assert.Equal("hellX wXrld\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReplaceAll_WithRegex(ExecutionMode mode)
     {
         var source = @"
@@ -35,8 +33,7 @@ public class StringMethodRegexParamTests
         Assert.Equal("a-b-c\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Split_WithRegex(ExecutionMode mode)
     {
         var source = @"
@@ -51,8 +48,7 @@ public class StringMethodRegexParamTests
         Assert.Equal("3\none\ntwo\nthree\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Replace_StringSecondArg_StillWorks(ExecutionMode mode)
     {
         // Make sure the widened signature didn't break the plain string form.

--- a/SharpTS.Tests/SharedTests/StringMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/StringMethodTests.cs
@@ -10,8 +10,7 @@ public class StringMethodTests
 {
     #region String Properties
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Length_ReturnsCorrectValue(ExecutionMode mode)
     {
         var source = """
@@ -28,8 +27,7 @@ public class StringMethodTests
 
     #region Basic String Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_CharAt_ReturnsCharacter(ExecutionMode mode)
     {
         var source = """
@@ -42,8 +40,7 @@ public class StringMethodTests
         Assert.Equal("h\ne\no\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Substring_WithStartAndEnd_ReturnsSubstring(ExecutionMode mode)
     {
         var source = """
@@ -55,8 +52,7 @@ public class StringMethodTests
         Assert.Equal("ell\nhe\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Substring_WithStartOnly_ReturnsToEnd(ExecutionMode mode)
     {
         var source = """
@@ -68,8 +64,7 @@ public class StringMethodTests
         Assert.Equal("llo\nhello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_IndexOf_ReturnsIndex(ExecutionMode mode)
     {
         var source = """
@@ -82,8 +77,7 @@ public class StringMethodTests
         Assert.Equal("2\n4\n-1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_ToUpperCase_ReturnsUpperCase(ExecutionMode mode)
     {
         var source = """
@@ -95,8 +89,7 @@ public class StringMethodTests
         Assert.Equal("HELLO\nHELLO WORLD\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_ToLowerCase_ReturnsLowerCase(ExecutionMode mode)
     {
         var source = """
@@ -108,8 +101,7 @@ public class StringMethodTests
         Assert.Equal("hello\nhello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Trim_RemovesWhitespace(ExecutionMode mode)
     {
         var source = """
@@ -121,8 +113,7 @@ public class StringMethodTests
         Assert.Equal("hello\nno space\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Replace_ReplacesFirstOccurrence(ExecutionMode mode)
     {
         var source = """
@@ -134,8 +125,7 @@ public class StringMethodTests
         Assert.Equal("hexlo\nhell0 world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Split_ReturnsArray(ExecutionMode mode)
     {
         var source = """
@@ -150,8 +140,7 @@ public class StringMethodTests
         Assert.Equal("3\na\nb\nc\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Split_WithEmptyDelimiter_SplitsChars(ExecutionMode mode)
     {
         var source = """
@@ -166,8 +155,7 @@ public class StringMethodTests
         Assert.Equal("3\na\nb\nc\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Includes_ReturnsBoolean(ExecutionMode mode)
     {
         var source = """
@@ -179,8 +167,7 @@ public class StringMethodTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_StartsWith_ReturnsBoolean(ExecutionMode mode)
     {
         var source = """
@@ -192,8 +179,7 @@ public class StringMethodTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_EndsWith_ReturnsBoolean(ExecutionMode mode)
     {
         var source = """
@@ -209,8 +195,7 @@ public class StringMethodTests
 
     #region String with Variables
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_MethodsOnVariable_Work(ExecutionMode mode)
     {
         var source = """
@@ -224,8 +209,7 @@ public class StringMethodTests
         Assert.Equal("11\nHELLO WORLD\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_ChainedMethods_Work(ExecutionMode mode)
     {
         var source = """
@@ -240,8 +224,7 @@ public class StringMethodTests
 
     #region Slice Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Slice_BasicUsage(ExecutionMode mode)
     {
         var source = """
@@ -253,8 +236,7 @@ public class StringMethodTests
         Assert.Equal("ell\nllo\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Slice_NegativeIndices(ExecutionMode mode)
     {
         var source = """
@@ -267,8 +249,7 @@ public class StringMethodTests
         Assert.Equal("llo\nell\nell\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Slice_EdgeCases(ExecutionMode mode)
     {
         var source = """
@@ -285,8 +266,7 @@ public class StringMethodTests
 
     #region Repeat Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Repeat_BasicUsage(ExecutionMode mode)
     {
         var source = """
@@ -298,8 +278,7 @@ public class StringMethodTests
         Assert.Equal("ababab\nxxxxx\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Repeat_EdgeCases(ExecutionMode mode)
     {
         var source = """
@@ -316,8 +295,7 @@ public class StringMethodTests
 
     #region Pad Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_PadStart_BasicUsage(ExecutionMode mode)
     {
         var source = """
@@ -330,8 +308,7 @@ public class StringMethodTests
         Assert.Equal("005\n123abc\n     hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_PadStart_EdgeCases(ExecutionMode mode)
     {
         var source = """
@@ -343,8 +320,7 @@ public class StringMethodTests
         Assert.Equal("hello\nhi\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_PadEnd_BasicUsage(ExecutionMode mode)
     {
         var source = """
@@ -357,8 +333,7 @@ public class StringMethodTests
         Assert.Equal("500\nabc123\nhello     \n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_PadEnd_EdgeCases(ExecutionMode mode)
     {
         var source = """
@@ -374,8 +349,7 @@ public class StringMethodTests
 
     #region CharCodeAt Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_CharCodeAt_BasicUsage(ExecutionMode mode)
     {
         var source = """
@@ -388,8 +362,7 @@ public class StringMethodTests
         Assert.Equal("65\n66\n111\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_CharCodeAt_OutOfRange(ExecutionMode mode)
     {
         var source = """
@@ -405,8 +378,7 @@ public class StringMethodTests
 
     #region Concat Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Concat_BasicUsage(ExecutionMode mode)
     {
         var source = """
@@ -423,8 +395,7 @@ public class StringMethodTests
 
     #region LastIndexOf Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_LastIndexOf_BasicUsage(ExecutionMode mode)
     {
         var source = """
@@ -441,8 +412,7 @@ public class StringMethodTests
 
     #region Trim Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_TrimStart_BasicUsage(ExecutionMode mode)
     {
         var source = """
@@ -454,8 +424,7 @@ public class StringMethodTests
         Assert.Equal("hello  \nhello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_TrimEnd_BasicUsage(ExecutionMode mode)
     {
         var source = """
@@ -471,8 +440,7 @@ public class StringMethodTests
 
     #region ReplaceAll Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_ReplaceAll_BasicUsage(ExecutionMode mode)
     {
         var source = """
@@ -485,8 +453,7 @@ public class StringMethodTests
         Assert.Equal("hexxo\nbbb\nhell0 w0rld\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_ReplaceAll_EdgeCases(ExecutionMode mode)
     {
         // ECMA-262 22.1.3.20: empty search inserts replacement at every
@@ -505,8 +472,7 @@ public class StringMethodTests
 
     #region At Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_At_BasicUsage(ExecutionMode mode)
     {
         var source = """
@@ -520,8 +486,7 @@ public class StringMethodTests
         Assert.Equal("h\nl\no\nl\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_At_OutOfRange(ExecutionMode mode)
     {
         var source = """
@@ -537,8 +502,7 @@ public class StringMethodTests
 
     #region String.fromCharCode Static Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_FromCharCode_BasicUsage(ExecutionMode mode)
     {
         var source = """
@@ -551,8 +515,7 @@ public class StringMethodTests
         Assert.Equal("Hello\nA\nWorld\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_FromCharCode_NoArguments(ExecutionMode mode)
     {
         var source = """
@@ -564,8 +527,7 @@ public class StringMethodTests
         Assert.Equal("\nempty:\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_FromCharCode_SingleCharacter(ExecutionMode mode)
     {
         var source = """
@@ -578,8 +540,7 @@ public class StringMethodTests
         Assert.Equal("A\na\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_FromCharCode_SpecialCharacters(ExecutionMode mode)
     {
         var source = """
@@ -592,8 +553,7 @@ public class StringMethodTests
         Assert.Equal("\n\n\t\n \n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_FromCharCode_WithVariables(ExecutionMode mode)
     {
         var source = """
@@ -608,8 +568,7 @@ public class StringMethodTests
         Assert.Equal("Hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_FromCharCode_RoundTripWithCharCodeAt(ExecutionMode mode)
     {
         var source = """
@@ -627,8 +586,7 @@ public class StringMethodTests
         Assert.Equal("Test\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_FromCharCode_LargeCodePoints(ExecutionMode mode)
     {
         // Values > 65535 should be truncated to 16-bit (& 0xFFFF)
@@ -649,8 +607,7 @@ public class StringMethodTests
 
     #region String.fromCodePoint Static Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_FromCodePoint_InvalidCodePoint_MessageIncludesValue(ExecutionMode mode)
     {
         // #731: the RangeError message must carry the offending code-point value
@@ -664,8 +621,7 @@ public class StringMethodTests
         Assert.Equal("Invalid code point -1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_FromCodePoint_BasicBMP(ExecutionMode mode)
     {
         var source = """
@@ -677,8 +633,7 @@ public class StringMethodTests
         Assert.Equal("Hello\nA\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_FromCodePoint_NoArguments(ExecutionMode mode)
     {
         var source = """
@@ -689,8 +644,7 @@ public class StringMethodTests
         Assert.Equal("><\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_FromCodePoint_SupplementaryCharacters(ExecutionMode mode)
     {
         // U+1F600 = 128512 (Grinning Face emoji)
@@ -707,8 +661,7 @@ public class StringMethodTests
         Assert.Equal("2\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_FromCodePoint_MixedBMPAndSupplementary(ExecutionMode mode)
     {
         var source = """
@@ -723,8 +676,7 @@ public class StringMethodTests
         Assert.Equal("4\n65\n66\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_FromCodePoint_WithVariables(ExecutionMode mode)
     {
         var source = """
@@ -737,8 +689,7 @@ public class StringMethodTests
         Assert.Equal("9731\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_FromCodePoint_LoneSurrogates(ExecutionMode mode)
     {
         // ECMA-262 §22.1.2.2 + §11.1.3 UTF16EncodeCodePoint: lone surrogates
@@ -762,8 +713,7 @@ public class StringMethodTests
 
     #region String.prototype.codePointAt
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_CodePointAt_BasicBMP(ExecutionMode mode)
     {
         var source = """
@@ -776,8 +726,7 @@ public class StringMethodTests
         Assert.Equal("65\n66\n67\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_CodePointAt_OutOfRange(ExecutionMode mode)
     {
         var source = """
@@ -789,8 +738,7 @@ public class StringMethodTests
         Assert.Equal("undefined\nundefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_CodePointAt_SurrogatePair(ExecutionMode mode)
     {
         // Create a string with a supplementary character and read it back
@@ -803,8 +751,7 @@ public class StringMethodTests
         Assert.Equal("128512\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_CodePointAt_SecondSurrogate(ExecutionMode mode)
     {
         // Accessing index 1 of a surrogate pair should return the low surrogate's code unit value
@@ -823,8 +770,7 @@ public class StringMethodTests
         Assert.Equal("true", lines[2]);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_CodePointAt_RoundTrip(ExecutionMode mode)
     {
         var source = """
@@ -840,8 +786,7 @@ public class StringMethodTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_CodePointAt_MatchesCharCodeAtForBMP(ExecutionMode mode)
     {
         var source = """
@@ -863,8 +808,7 @@ public class StringMethodTests
 
     #region New Methods on Variable and Chained
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_NewMethods_OnVariable(ExecutionMode mode)
     {
         var source = """
@@ -878,8 +822,7 @@ public class StringMethodTests
         Assert.Equal("Hello\nHello WorldHello World\n7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_NewMethods_Chained(ExecutionMode mode)
     {
         var source = """
@@ -895,8 +838,7 @@ public class StringMethodTests
 
     #region Normalize Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Normalize_DefaultNFC(ExecutionMode mode)
     {
         // \u00e9 is precomposed é (NFC), e\u0301 is decomposed e + combining accent (NFD)
@@ -914,8 +856,7 @@ public class StringMethodTests
         Assert.Equal("1\n2\n1\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Normalize_NFD(ExecutionMode mode)
     {
         var source = """
@@ -929,8 +870,7 @@ public class StringMethodTests
         Assert.Equal("2\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Normalize_AllForms(ExecutionMode mode)
     {
         var source = """
@@ -945,8 +885,7 @@ public class StringMethodTests
         Assert.Equal("1\n2\n1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_Normalize_AlreadyNormalized(ExecutionMode mode)
     {
         var source = """
@@ -963,8 +902,7 @@ public class StringMethodTests
 
     #region LocaleCompare Method
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_LocaleCompare_Equal(ExecutionMode mode)
     {
         var source = """
@@ -975,8 +913,7 @@ public class StringMethodTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_LocaleCompare_LessThan(ExecutionMode mode)
     {
         var source = """
@@ -987,8 +924,7 @@ public class StringMethodTests
         Assert.Equal("-1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_LocaleCompare_GreaterThan(ExecutionMode mode)
     {
         var source = """
@@ -999,8 +935,7 @@ public class StringMethodTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void String_LocaleCompare_WithVariables(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/StringRelationalComparisonTests.cs
+++ b/SharpTS.Tests/SharedTests/StringRelationalComparisonTests.cs
@@ -11,8 +11,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class StringRelationalComparisonTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LessThan_Strings(ExecutionMode mode)
     {
         var source = """
@@ -25,8 +24,7 @@ public class StringRelationalComparisonTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GreaterThan_Strings(ExecutionMode mode)
     {
         var source = """
@@ -39,8 +37,7 @@ public class StringRelationalComparisonTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LessEqual_Strings_Equal(ExecutionMode mode)
     {
         var source = """
@@ -53,8 +50,7 @@ public class StringRelationalComparisonTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GreaterEqual_Strings(ExecutionMode mode)
     {
         var source = """
@@ -67,8 +63,7 @@ public class StringRelationalComparisonTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EmptyString_LessThan_NonEmpty(ExecutionMode mode)
     {
         var source = """
@@ -79,8 +74,7 @@ public class StringRelationalComparisonTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringLiteral_Compare(ExecutionMode mode)
     {
         var source = """
@@ -91,8 +85,7 @@ public class StringRelationalComparisonTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InsertionSort_UsingStringCompare(ExecutionMode mode)
     {
         // Mirrors the pattern used by stdlib/node/url.ts URLSearchParams.sort.

--- a/SharpTS.Tests/SharedTests/SymbolTests.cs
+++ b/SharpTS.Tests/SharedTests/SymbolTests.cs
@@ -10,8 +10,7 @@ public class SymbolTests
 {
     #region Basic Symbol Creation
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_CreateWithoutDescription_Works(ExecutionMode mode)
     {
         var source = """
@@ -23,8 +22,7 @@ public class SymbolTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_CreateWithDescription_Works(ExecutionMode mode)
     {
         var source = """
@@ -36,8 +34,7 @@ public class SymbolTests
         Assert.Equal("Symbol(mySymbol)\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_Uniqueness_Works(ExecutionMode mode)
     {
         var source = """
@@ -55,8 +52,7 @@ public class SymbolTests
 
     #region Symbol as Object Key
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_AsObjectKey_Works(ExecutionMode mode)
     {
         var source = """
@@ -70,8 +66,7 @@ public class SymbolTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_MultipleSymbolKeys_Works(ExecutionMode mode)
     {
         var source = """
@@ -88,8 +83,7 @@ public class SymbolTests
         Assert.Equal("10\n20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_ObjectKey_OverwriteValue(ExecutionMode mode)
     {
         var source = """
@@ -104,8 +98,7 @@ public class SymbolTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_ObjectKey_CoexistsWithStringKey(ExecutionMode mode)
     {
         var source = """
@@ -125,8 +118,7 @@ public class SymbolTests
 
     #region Symbol Type Annotation
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_TypeAnnotation_Works(ExecutionMode mode)
     {
         var source = """
@@ -138,8 +130,7 @@ public class SymbolTests
         Assert.Equal("Symbol(typed)\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_InFunction_Works(ExecutionMode mode)
     {
         var source = """
@@ -158,8 +149,7 @@ public class SymbolTests
 
     #region Well-Known Symbols
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_Iterator_Exists(ExecutionMode mode)
     {
         var source = """
@@ -171,8 +161,7 @@ public class SymbolTests
         Assert.Equal("symbol\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_AsyncIterator_Exists(ExecutionMode mode)
     {
         var source = """
@@ -184,8 +173,7 @@ public class SymbolTests
         Assert.Equal("symbol\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_ToStringTag_Exists(ExecutionMode mode)
     {
         var source = """
@@ -197,8 +185,7 @@ public class SymbolTests
         Assert.Equal("symbol\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_HasInstance_Exists(ExecutionMode mode)
     {
         var source = """
@@ -209,8 +196,7 @@ public class SymbolTests
         Assert.Equal("symbol\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_ToPrimitive_Exists(ExecutionMode mode)
     {
         var source = """
@@ -221,8 +207,7 @@ public class SymbolTests
         Assert.Equal("symbol\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_WellKnown_AreUnique(ExecutionMode mode)
     {
         var source = """
@@ -239,8 +224,7 @@ public class SymbolTests
 
     #region Symbol Identity and Equality
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_SameSymbolEqualsItself(ExecutionMode mode)
     {
         var source = """
@@ -252,8 +236,7 @@ public class SymbolTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_StoredInVariable_MaintainsIdentity(ExecutionMode mode)
     {
         var source = """
@@ -266,8 +249,7 @@ public class SymbolTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_PassedToFunction_MaintainsIdentity(ExecutionMode mode)
     {
         var source = """
@@ -286,8 +268,7 @@ public class SymbolTests
 
     #region Symbol.for() and Symbol.keyFor() - Global Registry
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SymbolFor_ReturnsSameSymbolForSameKey(ExecutionMode mode)
     {
         var source = """
@@ -300,8 +281,7 @@ public class SymbolTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SymbolFor_ReturnsDifferentSymbolsForDifferentKeys(ExecutionMode mode)
     {
         var source = """
@@ -314,8 +294,7 @@ public class SymbolTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SymbolFor_DifferentFromRegularSymbol(ExecutionMode mode)
     {
         var source = """
@@ -328,8 +307,7 @@ public class SymbolTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SymbolKeyFor_ReturnsKeyForGlobalSymbol(ExecutionMode mode)
     {
         var source = """
@@ -341,8 +319,7 @@ public class SymbolTests
         Assert.Equal("myKey\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SymbolKeyFor_ReturnsUndefinedForLocalSymbol(ExecutionMode mode)
     {
         var source = """
@@ -355,8 +332,7 @@ public class SymbolTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SymbolKeyFor_WellKnownSymbolsNotInRegistry(ExecutionMode mode)
     {
         var source = """
@@ -372,8 +348,7 @@ public class SymbolTests
 
     #region Symbol Description Property
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_Description_ReturnsDescription(ExecutionMode mode)
     {
         var source = """
@@ -385,8 +360,7 @@ public class SymbolTests
         Assert.Equal("myDesc\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_Description_UndefinedWhenNoDescription(ExecutionMode mode)
     {
         var source = """
@@ -402,8 +376,7 @@ public class SymbolTests
 
     #region Symbol Object Property Operations (Not Yet Implemented)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_ObjectKey_DeleteProperty(ExecutionMode mode)
     {
         var source = """
@@ -419,8 +392,7 @@ public class SymbolTests
         Assert.Equal("value\nundefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_InOperator_Works(ExecutionMode mode)
     {
         var source = """
@@ -442,8 +414,7 @@ public class SymbolTests
     /// <summary>
     /// Tests computed property names with symbols in class fields.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_AsClassPropertyKey(ExecutionMode mode)
     {
         var source = """
@@ -475,8 +446,7 @@ public class SymbolTests
 
     #region Symbol.prototype Surface (#237)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_ToString_ReturnsDescriptiveString(ExecutionMode mode)
     {
         var source = """
@@ -490,8 +460,7 @@ public class SymbolTests
         Assert.Equal("Symbol(d)\nSymbol()\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_ValueOf_ReturnsSelf(ExecutionMode mode)
     {
         var source = """
@@ -503,8 +472,7 @@ public class SymbolTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_StringCallForm_ReturnsDescriptiveString(ExecutionMode mode)
     {
         // ECMA-262 §22.1.1.1: the String() call form is exempt from ToString's
@@ -518,8 +486,7 @@ public class SymbolTests
         Assert.Equal("Symbol(d)\nSymbol()\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_AnyTyped_PrototypeMembers_Work(ExecutionMode mode)
     {
         // Dynamic-dispatch path (receiver statically `any`) must resolve the
@@ -539,8 +506,7 @@ public class SymbolTests
 
     #region Implicit Symbol-to-String Coercion Throws (#245)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_TemplateLiteralInterpolation_ThrowsTypeError(ExecutionMode mode)
     {
         // ECMA-262 §7.1.17 ToString: implicit coercion of a Symbol throws.
@@ -558,8 +524,7 @@ public class SymbolTests
         Assert.Equal("true Cannot convert a Symbol value to a string\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_StringPlusConcat_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """
@@ -584,8 +549,7 @@ public class SymbolTests
             "true Cannot convert a Symbol value to a string\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_PlusEqualConcat_ThrowsTypeError(ExecutionMode mode)
     {
         var source = """
@@ -603,8 +567,7 @@ public class SymbolTests
         Assert.Equal("true Cannot convert a Symbol value to a string\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_TemplateLiteralInAsyncFunction_ThrowsTypeError(ExecutionMode mode)
     {
         // The async/generator state-machine emitters build template literals
@@ -629,8 +592,7 @@ public class SymbolTests
         Assert.Equal("true Cannot convert a Symbol value to a string\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_ExplicitForms_StillStringify(ExecutionMode mode)
     {
         // Only implicit coercion throws: String(sym), sym.toString(), and
@@ -650,8 +612,7 @@ public class SymbolTests
 
     #region Symbol as First-Class Global (#234)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_TypeofGlobal_IsFunction(ExecutionMode mode)
     {
         var source = """
@@ -662,8 +623,7 @@ public class SymbolTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_TypeofCallResult_IsSymbol(ExecutionMode mode)
     {
         var source = """
@@ -675,8 +635,7 @@ public class SymbolTests
         Assert.Equal("symbol\nsymbol\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_Aliased_CallCreatesSymbol(ExecutionMode mode)
     {
         var source = """
@@ -690,8 +649,7 @@ public class SymbolTests
         Assert.Equal("symbol\naliased\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_Aliased_WellKnownIdentity(ExecutionMode mode)
     {
         var source = """
@@ -705,8 +663,7 @@ public class SymbolTests
         Assert.Equal("true\ntrue\nsymbol\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_Aliased_ForAndKeyFor(ExecutionMode mode)
     {
         var source = """
@@ -720,8 +677,7 @@ public class SymbolTests
         Assert.Equal("true\nregistry-key\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Symbol_CastExpression_MemberAccess(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/SyncAsyncEquivalenceTests.cs
+++ b/SharpTS.Tests/SharedTests/SyncAsyncEquivalenceTests.cs
@@ -15,8 +15,7 @@ public class SyncAsyncEquivalenceTests
 {
     // ===================== Basic Expressions =====================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Binary_Expression_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -31,8 +30,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("8 6 42 5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Binary_Expression_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -50,8 +48,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("8 6 42 5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Logical_Expression_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -65,8 +62,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("false true default\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Logical_Expression_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -83,8 +79,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("false true default\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Ternary_Expression_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -97,8 +92,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("yes no\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Ternary_Expression_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -116,8 +110,7 @@ public class SyncAsyncEquivalenceTests
 
     // ===================== Object and Array Literals =====================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Literal_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -129,8 +122,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("test 42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Object_Literal_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -145,8 +137,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("test 42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Literal_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -158,8 +149,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("1 2 3 3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Array_Literal_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -174,8 +164,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("1 2 3 3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spread_In_Object_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -188,8 +177,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("1 2 3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spread_In_Object_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -205,8 +193,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("1 2 3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spread_In_Array_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -219,8 +206,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("1,2,3,4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Spread_In_Array_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -238,8 +224,7 @@ public class SyncAsyncEquivalenceTests
 
     // ===================== Function Calls =====================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_Call_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -253,8 +238,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Function_Call_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -271,8 +255,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Method_Call_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -289,8 +272,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Method_Call_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -312,8 +294,7 @@ public class SyncAsyncEquivalenceTests
 
     // ===================== Class Instantiation (EvaluateNew) =====================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void New_Expression_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -331,8 +312,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("Alice\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void New_Expression_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -353,8 +333,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("Alice\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void New_BuiltIn_Date_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -366,8 +345,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("2023\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void New_BuiltIn_Date_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -384,8 +362,7 @@ public class SyncAsyncEquivalenceTests
 
     // ===================== Switch Statement =====================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Switch_Statement_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -403,8 +380,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("one two other\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Switch_Statement_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -428,8 +404,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("one two other\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Switch_FallThrough_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -454,8 +429,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("ab b c\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Switch_FallThrough_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -488,8 +462,7 @@ public class SyncAsyncEquivalenceTests
 
     // ===================== Try/Catch/Finally =====================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryCatch_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -507,8 +480,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("caught: error!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryCatch_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -529,8 +501,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("caught: error!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryCatchFinally_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -554,8 +525,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("result try,catch,finally\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryCatchFinally_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -584,8 +554,7 @@ public class SyncAsyncEquivalenceTests
 
     // ===================== For...of Loop =====================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_Array_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -601,8 +570,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_Array_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -621,8 +589,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_String_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -638,8 +605,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("a,b,c,\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_String_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -660,8 +626,7 @@ public class SyncAsyncEquivalenceTests
 
     // ===================== Property Access (EvaluateGet) =====================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PropertyAccess_Instance_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -676,8 +641,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PropertyAccess_Instance_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -695,8 +659,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PropertyAccess_Static_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -710,8 +673,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("1.0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PropertyAccess_Static_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -728,8 +690,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("1.0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PropertyAccess_BuiltIn_Number_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -742,8 +703,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PropertyAccess_BuiltIn_Number_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -759,8 +719,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PropertyAccess_BuiltIn_Math_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -773,8 +732,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("true\n3\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PropertyAccess_BuiltIn_Math_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -792,8 +750,7 @@ public class SyncAsyncEquivalenceTests
 
     // ===================== Compound Assignment =====================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssign_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -808,8 +765,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("24\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssign_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -829,8 +785,7 @@ public class SyncAsyncEquivalenceTests
 
     // ===================== Logical Assignment =====================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LogicalAssign_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -849,8 +804,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("default value default\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LogicalAssign_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -874,8 +828,7 @@ public class SyncAsyncEquivalenceTests
 
     // ===================== Compound/Logical Assignment on Captured Top-Level Vars =====================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssign_CapturedTopLevel_AsyncArrow(ExecutionMode mode)
     {
         var source = """
@@ -893,8 +846,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("39\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LogicalAssign_CapturedTopLevel_AsyncArrow(ExecutionMode mode)
     {
         var source = """
@@ -912,8 +864,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("filled existing\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAssign_CapturedTopLevel_AsyncFunction(ExecutionMode mode)
     {
         var source = """
@@ -932,8 +883,7 @@ public class SyncAsyncEquivalenceTests
 
     // ===================== Template Literals =====================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TemplateLiteral_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -946,8 +896,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("Hello, World!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TemplateLiteral_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -965,8 +914,7 @@ public class SyncAsyncEquivalenceTests
 
     // ===================== Index Operations =====================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IndexGet_Array_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -978,8 +926,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("10 20 30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IndexGet_Array_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -994,8 +941,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("10 20 30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IndexSet_Array_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -1008,8 +954,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("1,99,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IndexSet_Array_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -1025,8 +970,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("1,99,3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IndexGet_Object_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -1038,8 +982,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("1 2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IndexGet_Object_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -1056,8 +999,7 @@ public class SyncAsyncEquivalenceTests
 
     // ===================== Class Inheritance =====================
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassInheritance_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -1083,8 +1025,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("Rex barks\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassInheritance_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -1113,8 +1054,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("Rex barks\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SuperCall_SyncPath(ExecutionMode mode)
     {
         var source = """
@@ -1137,8 +1077,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SuperCall_AsyncPath(ExecutionMode mode)
     {
         var source = """
@@ -1164,8 +1103,7 @@ public class SyncAsyncEquivalenceTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClosureMutation_InsideAsyncFunction(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/TaggedTemplateLiteralTests.cs
+++ b/SharpTS.Tests/SharedTests/TaggedTemplateLiteralTests.cs
@@ -11,8 +11,7 @@ public class TaggedTemplateLiteralTests
 {
     #region Basic Tagged Templates
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Basic_TaggedTemplate_CallsTagFunction(ExecutionMode mode)
     {
         var code = """
@@ -30,8 +29,7 @@ public class TaggedTemplateLiteralTests
         Assert.Equal("tagged\n1\nhello", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Basic_TaggedTemplate_WithInterpolation(ExecutionMode mode)
     {
         var code = """
@@ -46,8 +44,7 @@ public class TaggedTemplateLiteralTests
         Assert.Equal("hello _!:world", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Basic_TaggedTemplate_MultipleInterpolations(ExecutionMode mode)
     {
         var code = """
@@ -75,8 +72,7 @@ public class TaggedTemplateLiteralTests
 
     #region Raw Strings
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Raw_Property_PreservesBackslashes(ExecutionMode mode)
     {
         var code = """
@@ -90,8 +86,7 @@ public class TaggedTemplateLiteralTests
         Assert.Equal("hello\\nworld", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Cooked_Vs_Raw_Difference(ExecutionMode mode)
     {
         var code = """
@@ -107,8 +102,7 @@ public class TaggedTemplateLiteralTests
         Assert.Equal("different", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Raw_Property_WithMultipleParts(ExecutionMode mode)
     {
         var code = """
@@ -127,8 +121,7 @@ public class TaggedTemplateLiteralTests
 
     #region String.raw
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringRaw_PreservesRawStrings(ExecutionMode mode)
     {
         var code = """
@@ -139,8 +132,7 @@ public class TaggedTemplateLiteralTests
         Assert.Equal("hello\\nworld", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringRaw_WithInterpolation(ExecutionMode mode)
     {
         var code = """
@@ -152,8 +144,7 @@ public class TaggedTemplateLiteralTests
         Assert.Equal("C:\\Users\\test\\path", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StringRaw_MultipleInterpolations(ExecutionMode mode)
     {
         var code = """
@@ -170,8 +161,7 @@ public class TaggedTemplateLiteralTests
 
     #region Tag Function Return Types
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Tag_ReturnsNumber(ExecutionMode mode)
     {
         var code = """
@@ -186,8 +176,7 @@ public class TaggedTemplateLiteralTests
         Assert.Equal("3", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Tag_ReturnsArray(ExecutionMode mode)
     {
         var code = """
@@ -202,8 +191,7 @@ public class TaggedTemplateLiteralTests
         Assert.Equal("3", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Tag_ReturnsObject(ExecutionMode mode)
     {
         var code = """
@@ -221,8 +209,7 @@ public class TaggedTemplateLiteralTests
 
     #region Arrow Functions as Tags
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowFunction_AsTag(ExecutionMode mode)
     {
         var code = """
@@ -234,8 +221,7 @@ public class TaggedTemplateLiteralTests
         Assert.Equal("a-b-c", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowFunction_ReturnsString(ExecutionMode mode)
     {
         var code = """
@@ -258,8 +244,7 @@ public class TaggedTemplateLiteralTests
 
     #region Method as Tag
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectMethod_AsTag(ExecutionMode mode)
     {
         var code = """
@@ -282,8 +267,7 @@ public class TaggedTemplateLiteralTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NoInterpolations_EmptyTag(ExecutionMode mode)
     {
         var code = """
@@ -297,8 +281,7 @@ public class TaggedTemplateLiteralTests
         Assert.Equal("1:0", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AllInterpolations_NoLiteralText(ExecutionMode mode)
     {
         var code = """
@@ -312,8 +295,7 @@ public class TaggedTemplateLiteralTests
         Assert.Equal("|||:1,2,3", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedTemplates(ExecutionMode mode)
     {
         var code = """
@@ -330,8 +312,7 @@ public class TaggedTemplateLiteralTests
         Assert.Equal("outer:inner:hello", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExpressionAsValue(ExecutionMode mode)
     {
         var code = """
@@ -345,8 +326,7 @@ public class TaggedTemplateLiteralTests
         Assert.Equal("number,boolean,string,object", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArraysFrozen(ExecutionMode mode)
     {
         var code = """

--- a/SharpTS.Tests/SharedTests/TemplateLiteralTests.cs
+++ b/SharpTS.Tests/SharedTests/TemplateLiteralTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class TemplateLiteralTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Template_SimpleString_Works(ExecutionMode mode)
     {
         var source = """
@@ -20,8 +19,7 @@ public class TemplateLiteralTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Template_SingleInterpolation_Works(ExecutionMode mode)
     {
         var source = """
@@ -33,8 +31,7 @@ public class TemplateLiteralTests
         Assert.Equal("Hello, World!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Template_MultipleInterpolations_Works(ExecutionMode mode)
     {
         var source = """
@@ -47,8 +44,7 @@ public class TemplateLiteralTests
         Assert.Equal("5 + 3 = 8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Template_ExpressionEvaluation_Works(ExecutionMode mode)
     {
         var source = """
@@ -59,8 +55,7 @@ public class TemplateLiteralTests
         Assert.Equal("Double of 5 is 10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Template_PropertyAccess_Works(ExecutionMode mode)
     {
         var source = """
@@ -72,8 +67,7 @@ public class TemplateLiteralTests
         Assert.Equal("Name: Alice\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Template_FunctionCall_Works(ExecutionMode mode)
     {
         var source = """
@@ -87,8 +81,7 @@ public class TemplateLiteralTests
         Assert.Equal("Result: Hello, Bob\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Template_NumberCoercion_Works(ExecutionMode mode)
     {
         var source = """
@@ -100,8 +93,7 @@ public class TemplateLiteralTests
         Assert.Equal("The answer is 42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Template_BooleanCoercion_Works(ExecutionMode mode)
     {
         var source = """
@@ -113,8 +105,7 @@ public class TemplateLiteralTests
         Assert.Equal("Value is true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Template_NestedInterpolation_Works(ExecutionMode mode)
     {
         var source = """
@@ -127,8 +118,7 @@ public class TemplateLiteralTests
         Assert.Equal("Result: 6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Template_EmptyInterpolation_Works(ExecutionMode mode)
     {
         var source = """
@@ -140,8 +130,7 @@ public class TemplateLiteralTests
         Assert.Equal("beforeafter\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Template_ConditionalExpression_Works(ExecutionMode mode)
     {
         var source = """
@@ -153,8 +142,7 @@ public class TemplateLiteralTests
         Assert.Equal("x is big\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Template_MultilineInReturn_DoesNotTriggerAsi(ExecutionMode mode)
     {
         // Regression for issue #44: a multi-line template literal started on
@@ -172,8 +160,7 @@ public class TemplateLiteralTests
         Assert.Equal("a\nb\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Template_MultilineInYield_DoesNotTriggerAsi(ExecutionMode mode)
     {
         // Same restricted production as `return`: `yield [no LT here] Expression`.

--- a/SharpTS.Tests/SharedTests/ThisParameterTests.cs
+++ b/SharpTS.Tests/SharedTests/ThisParameterTests.cs
@@ -11,8 +11,7 @@ public class ThisParameterTests
 {
     #region Basic Function Parsing
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisParameter_BasicFunction_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -26,8 +25,7 @@ public class ThisParameterTests
         Assert.Equal("parsed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisParameter_WithOtherParams_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -41,8 +39,7 @@ public class ThisParameterTests
         Assert.Equal("parsed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisParameter_OnlyThisParam_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -60,8 +57,7 @@ public class ThisParameterTests
 
     #region Interface and Type Alias
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisParameter_InInterface_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -74,8 +70,7 @@ public class ThisParameterTests
         Assert.Equal("parsed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisParameter_InTypeAlias_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -87,8 +82,7 @@ public class ThisParameterTests
         Assert.Equal("parsed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisParameter_FunctionTypeAnnotation_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -104,8 +98,7 @@ public class ThisParameterTests
 
     #region Class Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisParameter_InAbstractMethod_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -124,8 +117,7 @@ public class ThisParameterTests
         Assert.Equal("parsed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisParameter_ClassMethod_ParsesCorrectly(ExecutionMode mode)
     {
         // This test focuses on parsing - the this parameter allows explicit this type annotation
@@ -152,8 +144,7 @@ public class ThisParameterTests
 
     #region Object Literal Methods
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisParameter_ObjectLiteralMethod_ParsesCorrectly(ExecutionMode mode)
     {
         // This test focuses on parsing - the this parameter is a compile-time annotation
@@ -175,8 +166,7 @@ public class ThisParameterTests
 
     #region With Other Parameter Types
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisParameter_WithRestParams_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -190,8 +180,7 @@ public class ThisParameterTests
         Assert.Equal("parsed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisParameter_WithDefaultParams_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -209,8 +198,7 @@ public class ThisParameterTests
 
     #region Generic Functions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisParameter_GenericFunction_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -228,8 +216,7 @@ public class ThisParameterTests
 
     #region Overloaded Functions
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisParameter_OverloadedFunction_ParsesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -249,8 +236,7 @@ public class ThisParameterTests
 
     #region Type Checking
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisParameter_TypeChecksThisAccess(ExecutionMode mode)
     {
         // This test verifies that accessing properties on 'this' is type-checked
@@ -269,8 +255,7 @@ public class ThisParameterTests
         Assert.Equal("type checked\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisParameter_ValidThisPropertyAccess_TypeChecks(ExecutionMode mode)
     {
         // Verify that accessing valid properties on the declared this type works

--- a/SharpTS.Tests/SharedTests/TimerTests.cs
+++ b/SharpTS.Tests/SharedTests/TimerTests.cs
@@ -23,8 +23,7 @@ public class TimerTests
 {
     #region setTimeout Basic Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetTimeout_ReturnsTimeout(ExecutionMode mode)
     {
         // setTimeout should return a Timeout object
@@ -37,8 +36,7 @@ public class TimerTests
         Assert.Equal("object\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetTimeout_ZeroDelay_ExecutesCallback_Interpreted(ExecutionMode mode)
     {
         // setTimeout with 0 delay should still execute (interpreted: check variable)
@@ -54,8 +52,7 @@ public class TimerTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetTimeout_ZeroDelay_ExecutesCallback_Compiled(ExecutionMode mode)
     {
         // setTimeout with 0 delay should execute callback (compiled: check console output)
@@ -72,8 +69,7 @@ public class TimerTests
         Assert.Contains("done", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetTimeout_DefaultDelay_IsZero_Interpreted(ExecutionMode mode)
     {
         // setTimeout without delay should default to 0 (interpreted)
@@ -88,8 +84,7 @@ public class TimerTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetTimeout_DefaultDelay_ExecutesCallback_Compiled(ExecutionMode mode)
     {
         // setTimeout without delay should default to 0 and execute (compiled)
@@ -105,8 +100,7 @@ public class TimerTests
         Assert.Contains("done", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetTimeout_KeepsEventLoopAlive(ExecutionMode mode)
     {
         // In interpreted mode, the event loop should stay alive for timers by default
@@ -117,8 +111,7 @@ public class TimerTests
         Assert.Equal("executed\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetTimeout_Unref_AllowsExit_Interpreted(ExecutionMode mode)
     {
         // unref() drops a timer's hold on the event loop: the program exits once
@@ -147,8 +140,7 @@ public class TimerTests
 
     #region clearTimeout Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClearTimeout_PreventsExecution_Interpreted(ExecutionMode mode)
     {
         // clearTimeout should prevent callback from executing (interpreted: check variable)
@@ -165,8 +157,7 @@ public class TimerTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClearTimeout_PreventsExecution_Compiled(ExecutionMode mode)
     {
         // clearTimeout should prevent callback from executing (compiled: check console output)
@@ -183,8 +174,7 @@ public class TimerTests
         Assert.Contains("done", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClearTimeout_Null_DoesNotThrow(ExecutionMode mode)
     {
         // clearTimeout(null) should not throw
@@ -196,8 +186,7 @@ public class TimerTests
         Assert.Equal("ok\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClearTimeout_Undefined_DoesNotThrow(ExecutionMode mode)
     {
         // clearTimeout(undefined) should not throw
@@ -209,8 +198,7 @@ public class TimerTests
         Assert.Equal("ok\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClearTimeout_NoArgs_DoesNotThrow(ExecutionMode mode)
     {
         // clearTimeout() with no args should not throw
@@ -226,8 +214,7 @@ public class TimerTests
 
     #region ref/unref Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timeout_Ref_ReturnsSameObject(ExecutionMode mode)
     {
         // ref() should return the same Timeout object for chaining
@@ -240,8 +227,7 @@ public class TimerTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timeout_Unref_ReturnsSameObject(ExecutionMode mode)
     {
         // unref() should return the same Timeout object for chaining
@@ -254,8 +240,7 @@ public class TimerTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timeout_HasRef_DefaultsToTrue(ExecutionMode mode)
     {
         // hasRef should default to true
@@ -267,8 +252,7 @@ public class TimerTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timeout_Unref_SetsHasRefFalse(ExecutionMode mode)
     {
         // unref() should set hasRef to false
@@ -281,8 +265,7 @@ public class TimerTests
         Assert.Equal("false\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timeout_RefAfterUnref_SetsHasRefTrue(ExecutionMode mode)
     {
         // ref() after unref() should set hasRef back to true
@@ -296,8 +279,7 @@ public class TimerTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Timeout_MethodChaining(ExecutionMode mode)
     {
         // ref/unref should support method chaining
@@ -313,8 +295,7 @@ public class TimerTests
 
     #region setTimeout with Arguments Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetTimeout_PassesArgsToCallback_Interpreted(ExecutionMode mode)
     {
         // Additional args should be passed to callback (interpreted: captured variable)
@@ -329,8 +310,7 @@ public class TimerTests
         Assert.Equal("helloworld\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetTimeout_PassesArgsToCallback_Compiled(ExecutionMode mode)
     {
         // Additional args should be passed to callback (compiled: console.log)
@@ -348,8 +328,7 @@ public class TimerTests
 
     #region Type Checking Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetTimeout_RequiresCallback(ExecutionMode mode)
     {
         // setTimeout without callback should fail type checking
@@ -360,8 +339,7 @@ public class TimerTests
         Assert.Contains("setTimeout", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetTimeout_CallbackMustBeFunction(ExecutionMode mode)
     {
         // setTimeout with non-function callback should fail type checking
@@ -372,8 +350,7 @@ public class TimerTests
         Assert.Contains("function", ex.Message.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetTimeout_DelayMustBeNumber(ExecutionMode mode)
     {
         // setTimeout with non-number delay should fail type checking
@@ -388,8 +365,7 @@ public class TimerTests
 
     #region setInterval Basic Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetInterval_ReturnsTimeout(ExecutionMode mode)
     {
         // setInterval should return a Timeout object (same as setTimeout)
@@ -403,8 +379,7 @@ public class TimerTests
         Assert.Equal("object\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetInterval_ExecutesMultipleTimes_Interpreted(ExecutionMode mode)
     {
         // setInterval should execute multiple times (interpreted: count variable)
@@ -421,8 +396,7 @@ public class TimerTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetInterval_ExecutesCallback_Compiled(ExecutionMode mode)
     {
         // setInterval should execute callback (compiled: console.log and self-clear)
@@ -447,8 +421,7 @@ public class TimerTests
             "Expected 'done' to appear after 'tick' in output");
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClearInterval_StopsExecution_Interpreted(ExecutionMode mode)
     {
         // clearInterval should stop the interval (interpreted: count variable)
@@ -467,8 +440,7 @@ public class TimerTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClearInterval_StopsExecution_Compiled(ExecutionMode mode)
     {
         // clearInterval should stop the interval from executing (compiled: console.log)
@@ -484,8 +456,7 @@ public class TimerTests
         Assert.Contains("done", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetInterval_PassesArgsToCallback_Interpreted(ExecutionMode mode)
     {
         // Additional args should be passed to callback (interpreted: captured variable)
@@ -501,8 +472,7 @@ public class TimerTests
         Assert.Equal("helloworld\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetInterval_PassesArgsToCallback_Compiled(ExecutionMode mode)
     {
         // Additional args should be passed to callback (compiled: console.log)
@@ -517,8 +487,7 @@ public class TimerTests
         Assert.Contains("helloworld", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetInterval_DefaultDelay_Interpreted(ExecutionMode mode)
     {
         // setInterval without delay should default to 0 (interpreted)
@@ -534,8 +503,7 @@ public class TimerTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetInterval_DefaultDelay_Compiled(ExecutionMode mode)
     {
         // setInterval without delay should default to 0 and execute (compiled)
@@ -556,8 +524,7 @@ public class TimerTests
 
     #region clearInterval Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClearInterval_Null_DoesNotThrow(ExecutionMode mode)
     {
         // clearInterval(null) should not throw
@@ -569,8 +536,7 @@ public class TimerTests
         Assert.Equal("ok\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClearInterval_Undefined_DoesNotThrow(ExecutionMode mode)
     {
         // clearInterval(undefined) should not throw
@@ -582,8 +548,7 @@ public class TimerTests
         Assert.Equal("ok\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClearInterval_NoArgs_DoesNotThrow(ExecutionMode mode)
     {
         // clearInterval() with no args should not throw
@@ -599,8 +564,7 @@ public class TimerTests
 
     #region setInterval ref/unref Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interval_Ref_ReturnsSameObject(ExecutionMode mode)
     {
         // ref() should return the same object for chaining
@@ -614,8 +578,7 @@ public class TimerTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interval_Unref_ReturnsSameObject(ExecutionMode mode)
     {
         // unref() should return the same object for chaining
@@ -629,8 +592,7 @@ public class TimerTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Interval_HasRef_DefaultsToTrue(ExecutionMode mode)
     {
         // hasRef should default to true
@@ -647,8 +609,7 @@ public class TimerTests
 
     #region setInterval Type Checking Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetInterval_RequiresCallback(ExecutionMode mode)
     {
         // setInterval without callback should fail type checking
@@ -659,8 +620,7 @@ public class TimerTests
         Assert.Contains("setInterval", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetInterval_CallbackMustBeFunction(ExecutionMode mode)
     {
         // setInterval with non-function callback should fail type checking
@@ -671,8 +631,7 @@ public class TimerTests
         Assert.Contains("function", ex.Message.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SetInterval_DelayMustBeNumber(ExecutionMode mode)
     {
         // setInterval with non-number delay should fail type checking
@@ -687,8 +646,7 @@ public class TimerTests
 
     #region Promise + setTimeout Integration Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Await_Promise_SetTimeout_ResolvesCallback(ExecutionMode mode)
     {
         // await new Promise(r => setTimeout(r, N)) — the canonical delay-async pattern
@@ -707,8 +665,7 @@ public class TimerTests
         Assert.Contains("top-end", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Await_Promise_SetTimeout_ZeroDelay(ExecutionMode mode)
     {
         // await new Promise(r => setTimeout(r, 0)) — zero-delay variant

--- a/SharpTS.Tests/SharedTests/TlsCheckIdentityTests.cs
+++ b/SharpTS.Tests/SharedTests/TlsCheckIdentityTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class TlsCheckIdentityTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CheckServerIdentity_SanMatch(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -25,8 +24,7 @@ public class TlsCheckIdentityTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CheckServerIdentity_Mismatch(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -44,8 +42,7 @@ public class TlsCheckIdentityTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CheckServerIdentity_Wildcard(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -62,8 +59,7 @@ public class TlsCheckIdentityTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CheckServerIdentity_CnFallback(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/TlsModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/TlsModuleTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class TlsModuleTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsModuleImport(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -23,8 +22,7 @@ public class TlsModuleTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsModuleNodePrefix(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -38,8 +36,7 @@ public class TlsModuleTests
         Assert.Equal("function\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsModuleExports(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -57,8 +54,7 @@ public class TlsModuleTests
         Assert.Equal("true\ntrue\ntrue\nTLSv1.2\nTLSv1.3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsModuleConstants(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -73,8 +69,7 @@ public class TlsModuleTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsCreateServerReturnsServer(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -108,8 +103,7 @@ public class TlsModuleTests
         Assert.Equal("function\nfunction\nfunction\nfunction\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsConnectReturnsSocket(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -128,8 +122,7 @@ public class TlsModuleTests
         Assert.Equal("function\nfunction\nfunction\nfunction\nfunction\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsSocketProperties(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -145,8 +138,7 @@ public class TlsModuleTests
         Assert.Equal("false\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsCreateSecureContext(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -369,8 +361,7 @@ public class TlsModuleTests
 
     #region ALPN and SNI Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsSocket_Servername_Property(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -385,8 +376,7 @@ public class TlsModuleTests
         Assert.Contains("true", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsConnect_ALPNProtocols(ExecutionMode mode)
     {
         var (certPem, keyPem) = GenerateSelfSignedCert();
@@ -416,8 +406,7 @@ public class TlsModuleTests
         Assert.Contains("alpn:h2", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsServer_ALPNProtocols(ExecutionMode mode)
     {
         var (certPem, keyPem) = GenerateSelfSignedCert();
@@ -447,8 +436,7 @@ public class TlsModuleTests
         Assert.Contains("server-alpn:http/1.1", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsClient_AlpnProtocol_Exposed(ExecutionMode mode)
     {
         // The client sends ALPNProtocols and exposes the negotiated client.alpnProtocol — both modes.
@@ -479,8 +467,7 @@ public class TlsModuleTests
         Assert.Contains("client-alpn:h2", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsServer_SNICallback_Accepted(ExecutionMode mode)
     {
         var (certPem, keyPem) = GenerateSelfSignedCert();
@@ -507,8 +494,7 @@ public class TlsModuleTests
 
     #region rejectUnauthorized parity (#1040)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsRejectUnauthorized_Parity(ExecutionMode mode)
     {
         // rejectUnauthorized:true against a self-signed peer fails the handshake ('error'),
@@ -533,8 +519,7 @@ public class TlsModuleTests
         Assert.Equal("rejected\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsRoundTrip_ServerToClientData_Parity(ExecutionMode mode)
     {
         // Full client↔server round trip: server writes, client receives, identical in both modes.
@@ -568,8 +553,7 @@ public class TlsModuleTests
 
     #region Introspection parity (#1034)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsSocket_Introspection_Parity(ExecutionMode mode)
     {
         // After a real handshake, getCipher/getProtocol/getPeerCertificate/authorized/encrypted
@@ -609,8 +593,7 @@ public class TlsModuleTests
             output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsSocket_PeerCertSubjectAltName_Parity(ExecutionMode mode)
     {
         // getPeerCertificate().subjectaltname is formatted "DNS:…, IP Address:…" identically in
@@ -645,8 +628,7 @@ public class TlsModuleTests
 
     #region I/O + renegotiate parity (#1035)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TlsSocket_WriteEchoAndClose_Parity(ExecutionMode mode)
     {
         // Bidirectional write-through over the negotiated SslStream + close lifecycle,

--- a/SharpTS.Tests/SharedTests/TlsSecureContextTests.cs
+++ b/SharpTS.Tests/SharedTests/TlsSecureContextTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class TlsSecureContextTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GetCiphers(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -27,8 +26,7 @@ public class TlsSecureContextTests
         Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RootCertificates(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -45,8 +43,7 @@ public class TlsSecureContextTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SecureContext_ServerHandshake(ExecutionMode mode)
     {
         var (certPem, keyPem) = TlsModuleTestsCertHelper.GenerateSelfSignedCert();

--- a/SharpTS.Tests/SharedTests/TlsUnsupportedApiTests.cs
+++ b/SharpTS.Tests/SharedTests/TlsUnsupportedApiTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class TlsUnsupportedApiTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UnsupportedApis_Throw(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/TopLevelBlockScopeCaptureTests.cs
+++ b/SharpTS.Tests/SharedTests/TopLevelBlockScopeCaptureTests.cs
@@ -17,8 +17,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class TopLevelBlockScopeCaptureTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BlockScopedCapture_ClosureInLoopInClosure_SharesEnvironment(ExecutionMode mode)
     {
         // The issue's minimal repro: closures created in a loop inside another closure,
@@ -43,8 +42,7 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("set=1 n=1\nset=2 n=2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BlockScopedCapture_RelayedThroughIntermediateClosure_NoLoop(ExecutionMode mode)
     {
         // No loop involved: the intermediate closure doesn't reference the captured
@@ -67,8 +65,7 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("set=1 n=1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BlockScopedCapture_MutationsSharedBothWays(ExecutionMode mode)
     {
         // Two-way sharing between the block body and a closure: block writes after
@@ -87,8 +84,7 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("11\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TopLevelLoopBody_Capture_StaysPerIteration(ExecutionMode mode)
     {
         // Bindings declared inside a top-level loop body are per-iteration and must
@@ -106,8 +102,7 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("0,10,20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BlockInsideTopLevelLoop_Capture_StaysPerIteration(ExecutionMode mode)
     {
         // A block nested inside a loop is still loop territory: its bindings are
@@ -126,8 +121,7 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("iter0,iter1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SiblingBlocks_SameName_EachClosureReadsOwnBinding(ExecutionMode mode)
     {
         // Same name declared in two sibling blocks fails the declared-exactly-once
@@ -149,8 +143,7 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("first\nsecond\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SwitchCase_BlockScopedCapture_Relayed(ExecutionMode mode)
     {
         var source = """
@@ -171,8 +164,7 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("size=1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TryBlock_BlockScopedCapture_Relayed(ExecutionMode mode)
     {
         var source = """
@@ -193,8 +185,7 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("size=2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BlockScopedCapture_InImportedModule(ExecutionMode mode)
     {
         // Module-init methods reach the entry-point display class through its static
@@ -234,8 +225,7 @@ public class TopLevelBlockScopeCaptureTests
     // that local — before the fix, name-keyed routing sent the capture to the module
     // binding's entry-point-DC field, so compiled closures read the OUTER value.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ShadowedModuleBinding_ClosureCapturesBlockLocal(ExecutionMode mode)
     {
         // The issue's exact reproducer: compiled printed "outer\nouter".
@@ -253,8 +243,7 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("inner\nouter\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ShadowedModuleBinding_AsyncArrowReadsShadow(ExecutionMode mode)
     {
         // Standalone async arrows deliberately read captured top-level names LIVE from
@@ -274,8 +263,7 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("async=inner\nmodule=outer\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ShadowedModuleBinding_AsyncArrowWriteDoesNotClobberModule(ExecutionMode mode)
     {
         // A write to the shadow inside the async arrow must land on the arrow's
@@ -294,8 +282,7 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("ret=clobbered\nmodule=outer\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ShadowedModuleBinding_IncrementAndCompoundTargetShadow(ExecutionMode mode)
     {
         // ++ and += store-backs resolved the entry-DC field before locals, so they
@@ -316,8 +303,7 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("block=4,4\nmodule=100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ShadowedModuleBinding_FunctionDeclarationInBlock(ExecutionMode mode)
     {
         // Function DECLARATIONS in top-level blocks are lambda-lifted with by-value
@@ -337,8 +323,7 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("inner\nouter\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ShadowedModuleBinding_InImportedModule(ExecutionMode mode)
     {
         // Module-init methods reach the entry-point DC through its static field;
@@ -367,8 +352,7 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("lib=inner\nmain=outer\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportedArrow_CapturingExportedLet_IsCallableCrossModule(ExecutionMode mode)
     {
         // #1229: an `export const` arrow capturing an `export let` from the same module.
@@ -392,8 +376,7 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("main=outer\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExportedArrow_WithParam_CapturingExportedLet_IsCallableCrossModule(ExecutionMode mode)
     {
         // #1229 variant: a capturing exported arrow that also takes a parameter, exported via a
@@ -414,8 +397,7 @@ public class TopLevelBlockScopeCaptureTests
         Assert.Equal("add=15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void BlockScopedCapture_FunctionExpression_SharesEnvironment(ExecutionMode mode)
     {
         // Function EXPRESSIONS route through the arrow display-class machinery and

--- a/SharpTS.Tests/SharedTests/TripleSlashReferenceTests.cs
+++ b/SharpTS.Tests/SharedTests/TripleSlashReferenceTests.cs
@@ -10,8 +10,7 @@ public class TripleSlashReferenceTests
 {
     #region Basic Path References
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PathReference_FunctionFromReferencedScript(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -31,8 +30,7 @@ public class TripleSlashReferenceTests
         Assert.Equal("Hello, World\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PathReference_VariableFromReferencedScript(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -52,8 +50,7 @@ public class TripleSlashReferenceTests
         Assert.Equal("3.14159\n2.71828\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PathReference_ClassFromReferencedScript(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -84,8 +81,7 @@ public class TripleSlashReferenceTests
 
     #region Multiple References
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PathReference_MultipleReferences(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -115,8 +111,7 @@ public class TripleSlashReferenceTests
 
     #region Nested References
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PathReference_NestedReferences(ExecutionMode mode)
     {
         // A references B, B references C
@@ -140,8 +135,7 @@ public class TripleSlashReferenceTests
         Assert.Equal("5\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PathReference_DiamondReferences(ExecutionMode mode)
     {
         // A references B and C, both B and C reference D
@@ -178,8 +172,7 @@ public class TripleSlashReferenceTests
 
     #region Execution Order
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PathReference_ExecutionOrder_ReferencesFirst(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -205,8 +198,7 @@ public class TripleSlashReferenceTests
 
     #region Path Resolution
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PathReference_WithoutExtension(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -224,8 +216,7 @@ public class TripleSlashReferenceTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PathReference_NestedDirectory(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -249,8 +240,7 @@ public class TripleSlashReferenceTests
 
     #region Error Cases (Interpreter only - error messages differ)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PathReference_NotFoundFile_ThrowsError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -266,8 +256,7 @@ public class TripleSlashReferenceTests
         Assert.Contains("not found", ex.Message.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PathReference_InModuleFile_ThrowsError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -286,8 +275,7 @@ public class TripleSlashReferenceTests
         Assert.Contains("script", ex.Message.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PathReference_ToModuleFile_ThrowsError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -306,8 +294,7 @@ public class TripleSlashReferenceTests
         Assert.Contains("module", ex.Message.ToLower());
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PathReference_Circular_ThrowsError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -331,8 +318,7 @@ public class TripleSlashReferenceTests
 
     #region Script Detection
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScriptDetection_FileWithNoImportExport_IsScript(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -348,8 +334,7 @@ public class TripleSlashReferenceTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScriptDetection_FileWithImport_IsModule(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/TypedArrayBulkMethodTests.cs
+++ b/SharpTS.Tests/SharedTests/TypedArrayBulkMethodTests.cs
@@ -20,8 +20,7 @@ public class TypedArrayBulkMethodTests
 
     // ----- fill -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fill_WholeArray(ExecutionMode mode)
     {
         Assert.Equal("2.5,2.5,2.5,2.5\n", Run(@"
@@ -30,8 +29,7 @@ public class TypedArrayBulkMethodTests
             console.log(a.join(','));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fill_Range_LeavesOthersZero(ExecutionMode mode)
     {
         Assert.Equal("0,7,7,7,0\n", Run(@"
@@ -40,8 +38,7 @@ public class TypedArrayBulkMethodTests
             console.log(a.join(','));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fill_Int32_TruncatesTowardZero(ExecutionMode mode)
     {
         Assert.Equal("3,3,3\n", Run(@"
@@ -50,8 +47,7 @@ public class TypedArrayBulkMethodTests
             console.log(a.join(','));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fill_Uint8Clamped_ClampsHigh(ExecutionMode mode)
     {
         Assert.Equal("255,255,255\n", Run(@"
@@ -60,8 +56,7 @@ public class TypedArrayBulkMethodTests
             console.log(a.join(','));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Fill_Uint8Clamped_ClampsLow(ExecutionMode mode)
     {
         Assert.Equal("0,0,0\n", Run(@"
@@ -72,8 +67,7 @@ public class TypedArrayBulkMethodTests
 
     // ----- set -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_SameType_AtOffset(ExecutionMode mode)
     {
         // Same element type → Buffer.BlockCopy fast path.
@@ -85,8 +79,7 @@ public class TypedArrayBulkMethodTests
             console.log(b.join(','));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_CrossType_ConvertsPerElement(ExecutionMode mode)
     {
         // Different element type → value-converting element-wise path (truncates to int8).
@@ -98,8 +91,7 @@ public class TypedArrayBulkMethodTests
             console.log(i.join(','));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_FromRegularArray(ExecutionMode mode)
     {
         Assert.Equal("10,20,30\n", Run(@"
@@ -108,8 +100,7 @@ public class TypedArrayBulkMethodTests
             console.log(a.join(','));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_SameType_NegativeOffset_Throws(ExecutionMode mode)
     {
         // The same-type fast path must NOT silently accept a negative offset — it falls
@@ -122,8 +113,7 @@ public class TypedArrayBulkMethodTests
             catch (e) { console.log('threw'); }", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Set_SameType_TooLarge_Throws(ExecutionMode mode)
     {
         Assert.Equal("threw\n", Run(@"
@@ -135,8 +125,7 @@ public class TypedArrayBulkMethodTests
 
     // ----- copyWithin -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CopyWithin_Forward(ExecutionMode mode)
     {
         Assert.Equal("3,4,2,3,4\n", Run(@"
@@ -146,8 +135,7 @@ public class TypedArrayBulkMethodTests
             console.log(a.join(','));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CopyWithin_OverlappingRegions(ExecutionMode mode)
     {
         // src [0..3) copied onto [2..5): overlapping; memmove must read-before-overwrite.
@@ -160,8 +148,7 @@ public class TypedArrayBulkMethodTests
 
     // ----- reverse -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reverse_EvenLength(ExecutionMode mode)
     {
         Assert.Equal("4,3,2,1\n", Run(@"
@@ -171,8 +158,7 @@ public class TypedArrayBulkMethodTests
             console.log(a.join(','));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reverse_OddLength_MiddleFixed(ExecutionMode mode)
     {
         Assert.Equal("3,2,1\n", Run(@"
@@ -182,8 +168,7 @@ public class TypedArrayBulkMethodTests
             console.log(a.join(','));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Reverse_Float64_PreservesValues(ExecutionMode mode)
     {
         Assert.Equal("3.5,2.5,1.5\n", Run(@"
@@ -195,8 +180,7 @@ public class TypedArrayBulkMethodTests
 
     // ----- slice -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Slice_Range(ExecutionMode mode)
     {
         Assert.Equal("1,2,3\n", Run(@"
@@ -205,8 +189,7 @@ public class TypedArrayBulkMethodTests
             console.log(a.slice(1, 4).join(','));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Slice_NegativeBegin(ExecutionMode mode)
     {
         Assert.Equal("3,4\n", Run(@"
@@ -215,8 +198,7 @@ public class TypedArrayBulkMethodTests
             console.log(a.slice(-2).join(','));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Slice_IsIndependentCopy(ExecutionMode mode)
     {
         // Mutating the slice must not affect the source (slice copies, subarray would alias).
@@ -230,8 +212,7 @@ public class TypedArrayBulkMethodTests
 
     // ----- subarray -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subarray_AliasesBackingBuffer(ExecutionMode mode)
     {
         // subarray returns a VIEW over the same buffer: mutating it is visible in the parent.
@@ -243,8 +224,7 @@ public class TypedArrayBulkMethodTests
             console.log(a.join(',') + '|' + s.join(','));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Subarray_NegativeBegin(ExecutionMode mode)
     {
         Assert.Equal("3,4\n", Run(@"
@@ -255,8 +235,7 @@ public class TypedArrayBulkMethodTests
 
     // ----- indexOf / lastIndexOf / includes -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IndexOf_FoundMissingAndFromIndex(ExecutionMode mode)
     {
         // found=1, missing=-1, and fromIndex skips earlier matches.
@@ -266,8 +245,7 @@ public class TypedArrayBulkMethodTests
             console.log(a.indexOf(6) + ',' + a.indexOf(42) + ',' + a.indexOf(5, 1));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LastIndexOf_ScansBackward(ExecutionMode mode)
     {
         Assert.Equal("2,1,-1\n", Run(@"
@@ -276,8 +254,7 @@ public class TypedArrayBulkMethodTests
             console.log(a.lastIndexOf(1) + ',' + a.lastIndexOf(2) + ',' + a.lastIndexOf(9));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Includes_TrueAndFalse(ExecutionMode mode)
     {
         Assert.Equal("true,false\n", Run(@"
@@ -286,8 +263,7 @@ public class TypedArrayBulkMethodTests
             console.log(a.includes(2) + ',' + a.includes(9));", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Includes_NaN_SameValueZero(ExecutionMode mode)
     {
         // includes uses SameValueZero, so NaN matches NaN (unlike indexOf strict equality).
@@ -299,8 +275,7 @@ public class TypedArrayBulkMethodTests
 
     // ----- join / toString -----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Join_CustomAndDefaultSeparator(ExecutionMode mode)
     {
         Assert.Equal("1-2-3 1,2,3\n", Run(@"
@@ -309,8 +284,7 @@ public class TypedArrayBulkMethodTests
             console.log(a.join('-') + ' ' + a.join());", mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ToString_CommaSeparated(ExecutionMode mode)
     {
         Assert.Equal("1,2,3\n", Run(@"

--- a/SharpTS.Tests/SharedTests/TypedArrayIterationParityTests.cs
+++ b/SharpTS.Tests/SharedTests/TypedArrayIterationParityTests.cs
@@ -34,8 +34,7 @@ public class TypedArrayIterationParityTests
     private static string Normalize(string s) =>
         string.Join("\n", s.Replace("\r\n", "\n").Split('\n').Select(l => l.TrimEnd())).Trim();
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOf_OverTypedArrayAndBuffer(ExecutionMode mode)
     {
         // Previously (interpreted): "for...of requires an iterable (array, Map, Set, or iterator)."
@@ -63,8 +62,7 @@ public class TypedArrayIterationParityTests
             """, mode);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayLiteralSpread_OfTypedArrayAndBuffer(ExecutionMode mode)
     {
         Expect("""
@@ -81,8 +79,7 @@ public class TypedArrayIterationParityTests
             """, mode);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForAwaitOf_OverTypedArrayAndBuffer(ExecutionMode mode)
     {
         Expect("""
@@ -97,8 +94,7 @@ public class TypedArrayIterationParityTests
             """, "[1,2,-1,300,4,5]", mode);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void YieldStar_OverTypedArrayAndBuffer(ExecutionMode mode)
     {
         Expect("""
@@ -119,8 +115,7 @@ public class TypedArrayIterationParityTests
             "[0,1,2,-1,300,4,5]", mode);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGeneratorYieldStar_OverTypedArrayAndBuffer(ExecutionMode mode)
     {
         Expect("""
@@ -151,8 +146,7 @@ public class TypedArrayIterationParityTests
     /// back undefined and <c>ToLength(undefined)</c> made the result empty — a silent
     /// <c>[]</c> rather than an error.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayFrom_OverTypedArrayAndBuffer(ExecutionMode mode)
     {
         Expect("""
@@ -170,8 +164,7 @@ public class TypedArrayIterationParityTests
     /// <summary>
     /// A zero-length typed array contributes nothing rather than throwing.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EmptyTypedArray_IteratesToNothing(ExecutionMode mode)
     {
         Expect("""

--- a/SharpTS.Tests/SharedTests/UnboxedArithmeticTests.cs
+++ b/SharpTS.Tests/SharedTests/UnboxedArithmeticTests.cs
@@ -12,8 +12,7 @@ public class UnboxedArithmeticTests
 {
     #region Numeric Chain Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericChain_NoIntermediateBoxing(ExecutionMode mode)
     {
         var source = """
@@ -25,8 +24,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedLocal_StaysUnboxed(ExecutionMode mode)
     {
         var source = """
@@ -40,8 +38,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MultipleArithmeticOps_ComplexExpression(ExecutionMode mode)
     {
         var source = """
@@ -53,8 +50,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("29\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LongChain_AllOperators(ExecutionMode mode)
     {
         var source = """
@@ -70,8 +66,7 @@ public class UnboxedArithmeticTests
 
     #region Typed Local Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExplicitNumberType_UsesUnboxedLocal(ExecutionMode mode)
     {
         var source = """
@@ -83,8 +78,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InferredType_FallsBackToObject(ExecutionMode mode)
     {
         var source = """
@@ -99,8 +93,7 @@ public class UnboxedArithmeticTests
     // CompiledOnly: Uninitialized `let x: number` defaults to 0 in compiled mode
     // (.NET value type default) but produces `undefined` in the interpreter (correct per JS spec).
     // This is a CLR platform constraint — .NET locals of value types are zero-initialized.
-    [Theory]
-    [MemberData(nameof(ExecutionModes.CompiledOnly), MemberType = typeof(ExecutionModes))]
+    [Theory, CompiledOnlyData]
     public void UninitializedNumberLocal_DefaultsToZero(ExecutionMode mode)
     {
         var source = """
@@ -112,8 +105,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedLocal_ReassignmentWorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -131,8 +123,7 @@ public class UnboxedArithmeticTests
 
     #region Boxing Boundary Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionCallWithNumericArg_BoxesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -146,8 +137,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnNumericValue_BoxesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -161,8 +151,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PropertySetWithNumeric_BoxesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -178,8 +167,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrayElementWithNumeric_BoxesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -192,8 +180,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("9\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConsoleLogWithNumericExpr_BoxesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -208,8 +195,7 @@ public class UnboxedArithmeticTests
 
     #region Mixed Type Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MixedAnyAndNumber_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -222,8 +208,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ObjectLocalWithNumber_FallsBackToBoxing(ExecutionMode mode)
     {
         var source = """
@@ -236,8 +221,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("11\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumberAndStringConcatenation_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -254,8 +238,7 @@ public class UnboxedArithmeticTests
 
     #region Control Flow Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TernaryWithNumericBranches_ProducesCorrectResult(ExecutionMode mode)
     {
         var source = """
@@ -267,8 +250,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TernaryWithNumericBranches_FalseBranch(ExecutionMode mode)
     {
         var source = """
@@ -280,8 +262,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IfElseWithNumericAssignment_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -298,8 +279,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void LoopWithNumericAccumulator_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -316,8 +296,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ForOfWithNumericSum_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -337,8 +316,7 @@ public class UnboxedArithmeticTests
 
     #region Compound Assignment Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundAddWithTypedLocal_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -351,8 +329,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("8\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundSubtractWithTypedLocal_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -365,8 +342,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundMultiplyWithTypedLocal_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -379,8 +355,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void CompoundDivideWithTypedLocal_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -393,8 +368,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IncrementTypedLocal_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -407,8 +381,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DecrementTypedLocal_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -421,8 +394,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrefixIncrementTypedLocal_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -434,8 +406,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrefixDecrementTypedLocal_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -451,8 +422,7 @@ public class UnboxedArithmeticTests
 
     #region Comparison Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NumericComparison_ProducesBoolean(ExecutionMode mode)
     {
         var source = """
@@ -465,8 +435,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ComparisonInCondition_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -480,8 +449,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("yes\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ChainedComparisons_WorkCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -495,8 +463,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ComparisonWithArithmetic_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -513,8 +480,7 @@ public class UnboxedArithmeticTests
 
     #region Function with Numeric Locals Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FunctionWithTypedLocals_ComputesCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -530,8 +496,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("22\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RecursiveFunctionWithNumbers_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -548,8 +513,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("120\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedFunctionCalls_WorkCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -570,8 +534,7 @@ public class UnboxedArithmeticTests
 
     #region Class Method Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassMethodWithNumericComputation_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -597,8 +560,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ClassWithNumericField_ArithmeticWorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -628,8 +590,7 @@ public class UnboxedArithmeticTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ZeroOperations_WorkCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -643,8 +604,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NegativeNumbers_WorkCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -658,8 +618,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FloatingPointOperations_WorkCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -672,8 +631,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DivisionBySmallNumber_WorksCorrectly(ExecutionMode mode)
     {
         var source = """
@@ -690,8 +648,7 @@ public class UnboxedArithmeticTests
 
     #region Typed Return Value Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReturn_FibonacciRecursion_WorksCorrectly(ExecutionMode mode)
     {
         // Tests recursive typed returns with multiple return points
@@ -709,8 +666,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("55\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReturn_MutualRecursion_WorksCorrectly(ExecutionMode mode)
     {
         // Tests mutually recursive functions with typed returns
@@ -731,8 +687,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReturn_DeepNesting_WorksCorrectly(ExecutionMode mode)
     {
         // Tests deeply nested function calls with typed returns
@@ -751,8 +706,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("9.5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReturn_ChainedInExpression_WorksCorrectly(ExecutionMode mode)
     {
         // Tests using typed return values in complex expressions
@@ -768,8 +722,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("13\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReturn_InTernaryCondition_WorksCorrectly(ExecutionMode mode)
     {
         // Tests typed return values used in ternary expressions
@@ -784,8 +737,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("above\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReturn_BooleanFunction_WorksCorrectly(ExecutionMode mode)
     {
         // Tests functions with boolean return type
@@ -805,8 +757,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("true\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReturn_StringFunction_WorksCorrectly(ExecutionMode mode)
     {
         // Tests functions with string return type
@@ -821,8 +772,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("Hello, World!\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReturn_UsedAsArgument_WorksCorrectly(ExecutionMode mode)
     {
         // Tests passing typed return values directly as arguments
@@ -837,8 +787,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("14\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReturn_InWhileCondition_WorksCorrectly(ExecutionMode mode)
     {
         // Tests typed boolean return in loop condition
@@ -857,8 +806,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("1\n2\n3\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReturn_InIfCondition_WorksCorrectly(ExecutionMode mode)
     {
         // Tests typed boolean return in if condition
@@ -882,8 +830,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("greater\nless\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReturn_MultipleReturnPaths_WorksCorrectly(ExecutionMode mode)
     {
         // Tests function with multiple return statements
@@ -910,8 +857,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("negative\nzero\nsmall\nlarge\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReturn_InArrayMap_WorksCorrectly(ExecutionMode mode)
     {
         // Tests typed return with array operations
@@ -928,8 +874,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("2,4,6,8,10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReturn_ClassMethodReturningNumber_WorksCorrectly(ExecutionMode mode)
     {
         // Tests class methods with typed returns
@@ -956,8 +901,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("1\n2\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReturn_ClassMethodChaining_WorksCorrectly(ExecutionMode mode)
     {
         // Tests chaining calls on class methods with typed returns
@@ -978,8 +922,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("64\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReturn_WithDefaultParameter_WorksCorrectly(ExecutionMode mode)
     {
         // Tests typed return with default parameters
@@ -995,8 +938,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("10\n15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedReturn_TailRecursion_WorksCorrectly(ExecutionMode mode)
     {
         // Tests tail-recursive function with typed return
@@ -1019,8 +961,7 @@ public class UnboxedArithmeticTests
 
     #region Arrow Function Typed Return Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowTypedReturn_ExpressionBody_Number(ExecutionMode mode)
     {
         // Tests arrow function with expression body returning number
@@ -1033,8 +974,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowTypedReturn_ExpressionBody_Boolean(ExecutionMode mode)
     {
         // Tests arrow function with expression body returning boolean
@@ -1048,8 +988,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowTypedReturn_ExpressionBody_String(ExecutionMode mode)
     {
         // Tests arrow function with expression body returning string
@@ -1062,8 +1001,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("Hello, World\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowTypedReturn_BlockBody_Number(ExecutionMode mode)
     {
         // Tests arrow function with block body returning number
@@ -1079,8 +1017,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("49\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowTypedReturn_BlockBody_MultipleReturns(ExecutionMode mode)
     {
         // Tests arrow function with multiple return paths
@@ -1099,8 +1036,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("5\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowTypedReturn_NestedArrows(ExecutionMode mode)
     {
         // Tests nested arrow functions with typed returns
@@ -1117,8 +1053,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("11\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowTypedReturn_ArrayMap(ExecutionMode mode)
     {
         // Tests arrow function typed return with array map
@@ -1132,8 +1067,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("2,4,6,8,10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowTypedReturn_ArrayFilter(ExecutionMode mode)
     {
         // Tests arrow function typed return with array filter
@@ -1147,8 +1081,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("2,4,6\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowTypedReturn_ArrayReduce(ExecutionMode mode)
     {
         // Tests arrow function typed return with array reduce
@@ -1162,8 +1095,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowTypedReturn_ChainedCalls(ExecutionMode mode)
     {
         // Tests chaining calls on arrow functions with typed returns
@@ -1179,8 +1111,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("37\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowTypedReturn_WithClosure(ExecutionMode mode)
     {
         // Tests arrow function with closure and typed return
@@ -1196,8 +1127,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("12\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowTypedReturn_VoidExpression_NoError(ExecutionMode mode)
     {
         // Tests arrow function with void expression body (like console.log)
@@ -1211,8 +1141,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("Hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowTypedReturn_InTernary(ExecutionMode mode)
     {
         // Tests arrow function typed return used in ternary expression
@@ -1226,8 +1155,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("10\n20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowTypedReturn_RecursiveArrow(ExecutionMode mode)
     {
         // Tests recursive arrow function with typed return (using let for self-reference)
@@ -1241,8 +1169,7 @@ public class UnboxedArithmeticTests
         Assert.Equal("120\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ArrowTypedReturn_AsMethodCallback(ExecutionMode mode)
     {
         // Tests arrow function with typed return as method callback

--- a/SharpTS.Tests/SharedTests/UndefinedTests.cs
+++ b/SharpTS.Tests/SharedTests/UndefinedTests.cs
@@ -10,8 +10,7 @@ public class UndefinedTests
 {
     #region Basic Undefined Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_TypeOf_ReturnsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -22,8 +21,7 @@ public class UndefinedTests
         Assert.Equal("undefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_GlobalVariable_Accessible(ExecutionMode mode)
     {
         var source = """
@@ -37,8 +35,7 @@ public class UndefinedTests
 
     #region Equality Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_LooseEquality_WithUndefined(ExecutionMode mode)
     {
         var source = """
@@ -48,8 +45,7 @@ public class UndefinedTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_LooseEquality_WithNull(ExecutionMode mode)
     {
         var source = """
@@ -60,8 +56,7 @@ public class UndefinedTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_StrictEquality_WithUndefined(ExecutionMode mode)
     {
         var source = """
@@ -71,8 +66,7 @@ public class UndefinedTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_StrictEquality_WithNull_ReturnsFalse(ExecutionMode mode)
     {
         var source = """
@@ -83,8 +77,7 @@ public class UndefinedTests
         Assert.Equal("false\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_NotEqualToFalsyValues(ExecutionMode mode)
     {
         var source = """
@@ -100,8 +93,7 @@ public class UndefinedTests
 
     #region Truthiness Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_IsFalsy(ExecutionMode mode)
     {
         var source = """
@@ -119,8 +111,7 @@ public class UndefinedTests
 
     #region String Conversion Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_Stringify(ExecutionMode mode)
     {
         var source = """
@@ -135,8 +126,7 @@ public class UndefinedTests
 
     #region Nullish Coalescing Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullishCoalescing_WithUndefined_ReturnsDefault(ExecutionMode mode)
     {
         var source = """
@@ -147,8 +137,7 @@ public class UndefinedTests
         Assert.Equal("default\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullishCoalescing_WithNull_ReturnsDefault(ExecutionMode mode)
     {
         var source = """
@@ -159,8 +148,7 @@ public class UndefinedTests
         Assert.Equal("default\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NullishCoalescing_WithValue_ReturnsValue(ExecutionMode mode)
     {
         var source = """
@@ -175,8 +163,7 @@ public class UndefinedTests
 
     #region Optional Chaining Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalChaining_WithUndefined_ReturnsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -187,8 +174,7 @@ public class UndefinedTests
         Assert.Equal("undefined\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalChaining_WithValue_ReturnsProperty(ExecutionMode mode)
     {
         var source = """
@@ -203,8 +189,7 @@ public class UndefinedTests
 
     #region Type Annotation Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Undefined_TypeAnnotation_Works(ExecutionMode mode)
     {
         var source = """
@@ -222,8 +207,7 @@ public class UndefinedTests
 
     #region Uninitialized Variable Tests (Issue #17)
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UninitializedLet_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -236,8 +220,7 @@ public class UndefinedTests
         Assert.Equal("undefined\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UninitializedVar_IsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -250,8 +233,7 @@ public class UndefinedTests
         Assert.Equal("undefined\ntrue\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalParam_NoDefault_IsUndefined(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/UnionArrayLiteralTests.cs
+++ b/SharpTS.Tests/SharedTests/UnionArrayLiteralTests.cs
@@ -16,8 +16,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class UnionArrayLiteralTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void IssueRepro_ArrowReturningArrayMixingFreeFnCallAndParam(ExecutionMode mode)
     {
         // Exact issue repro: array literal mixing a free-function call (number[]) and the
@@ -30,8 +29,7 @@ public class UnionArrayLiteralTests
         Assert.Equal("2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MapCallback_ArrayMixingFreeFnCallAndParam(ExecutionMode mode)
     {
         var source = """
@@ -41,8 +39,7 @@ public class UnionArrayLiteralTests
         Assert.Equal("2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void FlatMapCallback_ArrayMixingFreeFnCallAndParam(ExecutionMode mode)
     {
         var source = """
@@ -52,8 +49,7 @@ public class UnionArrayLiteralTests
         Assert.Equal("4\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ScalarUnionArrayLiteral(ExecutionMode mode)
     {
         // No collection member, but number | string still generates a Union_* struct, so the
@@ -65,8 +61,7 @@ public class UnionArrayLiteralTests
         Assert.Equal("2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PromiseUnionReturn(ExecutionMode mode)
     {
         // Promise<number | string> maps to Task<Union_*> — the analogous choke point.
@@ -82,8 +77,7 @@ public class UnionArrayLiteralTests
         Assert.Equal("number\n5\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MapWithUnionValueType(ExecutionMode mode)
     {
         // Map<string, number[] | number> exercises MapMapTypeStrict's value element via the
@@ -98,8 +92,7 @@ public class UnionArrayLiteralTests
         Assert.Equal("2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Control_HomogeneousNestedNumberArray(ExecutionMode mode)
     {
         // No union (number[][]) — must remain unaffected by the fix.
@@ -111,8 +104,7 @@ public class UnionArrayLiteralTests
         Assert.Equal("1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Control_HomogeneousNumberArray(ExecutionMode mode)
     {
         // No union (number[]) — must remain unaffected by the fix.

--- a/SharpTS.Tests/SharedTests/UriGlobalsTests.cs
+++ b/SharpTS.Tests/SharedTests/UriGlobalsTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class UriGlobalsTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EncodeURIComponent_EncodesSpaces(ExecutionMode mode)
     {
         var source = "console.log(encodeURIComponent('hello world'));";
@@ -18,8 +17,7 @@ public class UriGlobalsTests
         Assert.Equal("hello%20world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EncodeURIComponent_EncodesReservedChars(ExecutionMode mode)
     {
         // & / ? = # are all reserved and must be encoded
@@ -28,8 +26,7 @@ public class UriGlobalsTests
         Assert.Equal("a%3Db%26c%2Fd%3Fe%23f\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EncodeURIComponent_PassesThroughUnreserved(ExecutionMode mode)
     {
         // A-Z a-z 0-9 - _ . ~ pass through per RFC 3986
@@ -38,8 +35,7 @@ public class UriGlobalsTests
         Assert.Equal("abcABC123-_.~\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DecodeURIComponent_DecodesPercentEncoded(ExecutionMode mode)
     {
         var source = "console.log(decodeURIComponent('hello%20world'));";
@@ -47,8 +43,7 @@ public class UriGlobalsTests
         Assert.Equal("hello world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DecodeURIComponent_RoundTripPreservesString(ExecutionMode mode)
     {
         var source = """
@@ -61,8 +56,7 @@ public class UriGlobalsTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EncodeURIComponent_CoercesNonString(ExecutionMode mode)
     {
         var source = "console.log(encodeURIComponent(42));";

--- a/SharpTS.Tests/SharedTests/UrlTests.cs
+++ b/SharpTS.Tests/SharedTests/UrlTests.cs
@@ -25,8 +25,7 @@ public class UrlTests
 
     // ========== URL Constructor ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URL_Constructor_ParsesFullUrl(ExecutionMode mode)
     {
         var body = @"
@@ -37,8 +36,7 @@ public class UrlTests
         Assert.Equal("https://example.com/path?q=1#hash\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URL_Constructor_WithBase(ExecutionMode mode)
     {
         var body = @"
@@ -51,8 +49,7 @@ public class UrlTests
 
     // ========== URL Properties ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URL_Protocol(ExecutionMode mode)
     {
         var body = @"
@@ -63,8 +60,7 @@ public class UrlTests
         Assert.Equal("https:\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URL_Host_DefaultPort(ExecutionMode mode)
     {
         var body = @"
@@ -75,8 +71,7 @@ public class UrlTests
         Assert.Equal("example.com\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URL_Host_NonDefaultPort(ExecutionMode mode)
     {
         var body = @"
@@ -87,8 +82,7 @@ public class UrlTests
         Assert.Equal("example.com:8080\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URL_Hostname(ExecutionMode mode)
     {
         var body = @"
@@ -99,8 +93,7 @@ public class UrlTests
         Assert.Equal("example.com\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URL_Port_NonDefault(ExecutionMode mode)
     {
         var body = @"
@@ -111,8 +104,7 @@ public class UrlTests
         Assert.Equal("8080\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URL_Port_Default_Empty(ExecutionMode mode)
     {
         var body = @"
@@ -123,8 +115,7 @@ public class UrlTests
         Assert.Equal("\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URL_Pathname(ExecutionMode mode)
     {
         var body = @"
@@ -135,8 +126,7 @@ public class UrlTests
         Assert.Equal("/path/to/resource\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URL_Search(ExecutionMode mode)
     {
         var body = @"
@@ -147,8 +137,7 @@ public class UrlTests
         Assert.Equal("?q=1&r=2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URL_Hash(ExecutionMode mode)
     {
         var body = @"
@@ -159,8 +148,7 @@ public class UrlTests
         Assert.Equal("#section\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URL_Origin(ExecutionMode mode)
     {
         var body = @"
@@ -173,8 +161,7 @@ public class UrlTests
 
     // ========== URL Methods ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URL_ToString(ExecutionMode mode)
     {
         var body = @"
@@ -185,8 +172,7 @@ public class UrlTests
         Assert.Equal("https://example.com/path\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URL_ToJSON(ExecutionMode mode)
     {
         var body = @"
@@ -199,8 +185,7 @@ public class UrlTests
 
     // ========== URL.searchParams ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URL_SearchParams_Get(ExecutionMode mode)
     {
         var body = @"
@@ -214,8 +199,7 @@ public class UrlTests
 
     // ========== URLSearchParams Constructor ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URLSearchParams_Constructor_Empty(ExecutionMode mode)
     {
         var body = @"
@@ -226,8 +210,7 @@ public class UrlTests
         Assert.Equal("\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URLSearchParams_Constructor_String(ExecutionMode mode)
     {
         var body = @"
@@ -238,8 +221,7 @@ public class UrlTests
         Assert.Equal("a=1&b=2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URLSearchParams_Constructor_Object(ExecutionMode mode)
     {
         var body = @"
@@ -253,8 +235,7 @@ public class UrlTests
 
     // ========== URLSearchParams Methods ==========
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URLSearchParams_Get_ReturnsNull(ExecutionMode mode)
     {
         var body = @"
@@ -265,8 +246,7 @@ public class UrlTests
         Assert.Equal("null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URLSearchParams_Has(ExecutionMode mode)
     {
         var body = @"
@@ -278,8 +258,7 @@ public class UrlTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URLSearchParams_Set(ExecutionMode mode)
     {
         var body = @"
@@ -291,8 +270,7 @@ public class UrlTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URLSearchParams_Append(ExecutionMode mode)
     {
         var body = @"
@@ -305,8 +283,7 @@ public class UrlTests
         Assert.Equal("a=1&a=2&b=3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URLSearchParams_Delete(ExecutionMode mode)
     {
         var body = @"
@@ -318,8 +295,7 @@ public class UrlTests
         Assert.Equal("b=2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URLSearchParams_GetAll(ExecutionMode mode)
     {
         var body = @"
@@ -333,8 +309,7 @@ public class UrlTests
         Assert.Equal("2\n1\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URLSearchParams_Sort(ExecutionMode mode)
     {
         var body = @"
@@ -346,8 +321,7 @@ public class UrlTests
         Assert.Equal("a=1&b=2&c=3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URLSearchParams_Size(ExecutionMode mode)
     {
         var body = @"
@@ -358,8 +332,7 @@ public class UrlTests
         Assert.Equal("3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void URLSearchParams_ToString(ExecutionMode mode)
     {
         var body = @"
@@ -381,8 +354,7 @@ public class UrlTests
         return TestHarness.RunModules(files, "main.ts", mode);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Parse_RelativeUrl_SplitsQueryString(ExecutionMode mode)
     {
         // Regression for #47: parse('/api/echo?k=v') used to return
@@ -403,8 +375,7 @@ public class UrlTests
             output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Parse_RelativeUrl_SplitsFragment(ExecutionMode mode)
     {
         var body = @"
@@ -417,8 +388,7 @@ public class UrlTests
         Assert.Equal("pathname: /a/b\nhash: #frag\nsearch: null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Parse_RelativeUrl_SplitsBothQueryAndFragment(ExecutionMode mode)
     {
         var body = @"
@@ -432,8 +402,7 @@ public class UrlTests
         Assert.Equal("pathname: /a\nsearch: ?x=1\nquery: x=1\nhash: #f\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Parse_RelativeUrl_HashBeforeQuestionMarkIsFragment(ExecutionMode mode)
     {
         // Split order matters: a '?' inside a fragment is literal.
@@ -447,8 +416,7 @@ public class UrlTests
         Assert.Equal("pathname: /a\nhash: #frag?not-a-query\nsearch: null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Parse_EmptyString_DegenerateCase(ExecutionMode mode)
     {
         var body = @"
@@ -461,8 +429,7 @@ public class UrlTests
         Assert.Equal("pathname: \nsearch: null\nhash: null\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Parse_AbsoluteUrl_StillSplitsCorrectly(ExecutionMode mode)
     {
         // Regression guard: the absolute-URL path must be unchanged.

--- a/SharpTS.Tests/SharedTests/UsingDeclarationTests.cs
+++ b/SharpTS.Tests/SharedTests/UsingDeclarationTests.cs
@@ -9,8 +9,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class UsingDeclarationTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Using_CallsDisposeAtBlockEnd(ExecutionMode mode)
     {
         var source = """
@@ -30,8 +29,7 @@ public class UsingDeclarationTests
         Assert.Equal("inside block\ndisposed: true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Using_SkipsNullValues(ExecutionMode mode)
     {
         var source = """
@@ -48,8 +46,7 @@ public class UsingDeclarationTests
         Assert.Equal("inside block, after block\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Using_DisposesInReverseOrder(ExecutionMode mode)
     {
         var source = """
@@ -66,8 +63,7 @@ public class UsingDeclarationTests
         Assert.Equal("c, b, a\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Using_DisposesOnException(ExecutionMode mode)
     {
         var source = """
@@ -91,8 +87,7 @@ public class UsingDeclarationTests
         Assert.Equal("disposed: true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Using_DisposesOnReturn(ExecutionMode mode)
     {
         var source = """
@@ -116,8 +111,7 @@ public class UsingDeclarationTests
         Assert.Equal("result: 42\ndisposed: true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Using_CommaSeparated_DisposesAll(ExecutionMode mode)
     {
         var source = """
@@ -134,8 +128,7 @@ public class UsingDeclarationTests
         Assert.Equal("b, a\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Using_VariableAccessible_InsideBlock(ExecutionMode mode)
     {
         var source = """
@@ -152,8 +145,7 @@ public class UsingDeclarationTests
         Assert.Equal("value: 42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Using_WithTypeAnnotation(ExecutionMode mode)
     {
         var source = """
@@ -178,8 +170,7 @@ public class UsingDeclarationTests
         Assert.Equal("value: 100\ndisposed: true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Using_NestedBlocks_DisposeInCorrectOrder(ExecutionMode mode)
     {
         var source = """
@@ -198,8 +189,7 @@ public class UsingDeclarationTests
         Assert.Equal("inner, between, outer\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Using_DisposeReceivesCorrectThis(ExecutionMode mode)
     {
         var source = """
@@ -219,8 +209,7 @@ public class UsingDeclarationTests
         Assert.Equal("test-resource\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Using_DisposeThrows_CatchesError(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/UtilityTypesTests.cs
+++ b/SharpTS.Tests/SharedTests/UtilityTypesTests.cs
@@ -11,8 +11,7 @@ public class UtilityTypesTests
 {
     #region Partial<T>
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Partial_AllPropertiesOptional_EmptyObjectValid(ExecutionMode mode)
     {
         var source = """
@@ -24,8 +23,7 @@ public class UtilityTypesTests
         Assert.Equal("ok\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Partial_SomePropertiesProvided(ExecutionMode mode)
     {
         var source = """
@@ -37,8 +35,7 @@ public class UtilityTypesTests
         Assert.Equal("Alice\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Partial_AllPropertiesProvided(ExecutionMode mode)
     {
         var source = """
@@ -51,8 +48,7 @@ public class UtilityTypesTests
         Assert.Equal("Bob\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Partial_WrongArgCount_Throws(ExecutionMode mode)
     {
         var source = """
@@ -62,8 +58,7 @@ public class UtilityTypesTests
         Assert.Contains("Partial<T> requires exactly 1 type argument", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Partial_OnRecord(ExecutionMode mode)
     {
         var source = """
@@ -79,8 +74,7 @@ public class UtilityTypesTests
 
     #region Required<T>
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Required_AllPropertiesRequired(ExecutionMode mode)
     {
         var source = """
@@ -93,8 +87,7 @@ public class UtilityTypesTests
         Assert.Equal("app\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Required_MissingProperty_Throws(ExecutionMode mode)
     {
         var source = """
@@ -105,8 +98,7 @@ public class UtilityTypesTests
         Assert.Contains("debug", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Required_WrongArgCount_Throws(ExecutionMode mode)
     {
         var source = """
@@ -120,8 +112,7 @@ public class UtilityTypesTests
 
     #region Readonly<T>
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readonly_PropertiesAccessible(ExecutionMode mode)
     {
         var source = """
@@ -134,8 +125,7 @@ public class UtilityTypesTests
         Assert.Equal("10\n20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readonly_PreservesOptionalProperties(ExecutionMode mode)
     {
         var source = """
@@ -147,8 +137,7 @@ public class UtilityTypesTests
         Assert.Equal("app\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readonly_WrongArgCount_Throws(ExecutionMode mode)
     {
         var source = """
@@ -162,8 +151,7 @@ public class UtilityTypesTests
 
     #region Record<K, V>
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Record_StringLiteralKeys(ExecutionMode mode)
     {
         var source = """
@@ -176,8 +164,7 @@ public class UtilityTypesTests
         Assert.Equal("1\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Record_SingleStringLiteral(ExecutionMode mode)
     {
         // Use type alias to avoid parser issue with string literal in generic type argument
@@ -190,8 +177,7 @@ public class UtilityTypesTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Record_StringIndexSignature(ExecutionMode mode)
     {
         var source = """
@@ -203,8 +189,7 @@ public class UtilityTypesTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Record_WrongArgCount_Throws(ExecutionMode mode)
     {
         var source = """
@@ -214,8 +199,7 @@ public class UtilityTypesTests
         Assert.Contains("Record<K, V> requires exactly 2 type arguments", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Record_MissingKey_Throws(ExecutionMode mode)
     {
         var source = """
@@ -230,8 +214,7 @@ public class UtilityTypesTests
 
     #region Pick<T, K>
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pick_SelectsSingleKey(ExecutionMode mode)
     {
         var source = """
@@ -243,8 +226,7 @@ public class UtilityTypesTests
         Assert.Equal("Bob\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pick_SelectsMultipleKeys(ExecutionMode mode)
     {
         var source = """
@@ -257,8 +239,7 @@ public class UtilityTypesTests
         Assert.Equal("Bob\n25\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pick_ExtraProperty_Throws(ExecutionMode mode)
     {
         var source = """
@@ -269,8 +250,7 @@ public class UtilityTypesTests
         Assert.Contains("age", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pick_PreservesOptional(ExecutionMode mode)
     {
         var source = """
@@ -282,8 +262,7 @@ public class UtilityTypesTests
         Assert.Equal("app\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pick_WrongArgCount_Throws(ExecutionMode mode)
     {
         var source = """
@@ -297,8 +276,7 @@ public class UtilityTypesTests
 
     #region Omit<T, K>
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Omit_ExcludesSingleKey(ExecutionMode mode)
     {
         var source = """
@@ -311,8 +289,7 @@ public class UtilityTypesTests
         Assert.Equal("Bob\n25\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Omit_ExcludesMultipleKeys(ExecutionMode mode)
     {
         var source = """
@@ -325,8 +302,7 @@ public class UtilityTypesTests
         Assert.Equal("Bob\n25\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Omit_ExcludedKeyNotAllowed(ExecutionMode mode)
     {
         var source = """
@@ -337,8 +313,7 @@ public class UtilityTypesTests
         Assert.Contains("email", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Omit_MissingRequiredKey_Throws(ExecutionMode mode)
     {
         var source = """
@@ -349,8 +324,7 @@ public class UtilityTypesTests
         Assert.Contains("age", ex.Message);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Omit_PreservesOptional(ExecutionMode mode)
     {
         var source = """
@@ -362,8 +336,7 @@ public class UtilityTypesTests
         Assert.Equal("app\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Omit_WrongArgCount_Throws(ExecutionMode mode)
     {
         var source = """
@@ -377,8 +350,7 @@ public class UtilityTypesTests
 
     #region Composition
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Partial_Readonly_Composed(ExecutionMode mode)
     {
         var source = """
@@ -390,8 +362,7 @@ public class UtilityTypesTests
         Assert.Equal("Test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readonly_Partial_Composed(ExecutionMode mode)
     {
         var source = """
@@ -403,8 +374,7 @@ public class UtilityTypesTests
         Assert.Equal("25\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pick_Then_Partial(ExecutionMode mode)
     {
         var source = """
@@ -416,8 +386,7 @@ public class UtilityTypesTests
         Assert.Equal("Alice\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Omit_Then_Required(ExecutionMode mode)
     {
         var source = """
@@ -430,8 +399,7 @@ public class UtilityTypesTests
         Assert.Equal("app\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TripleNestedGenerics_ClosingBrackets(ExecutionMode mode)
     {
         // Tests parsing of >>> which the lexer tokenizes as a single GREATER_GREATER_GREATER token
@@ -448,8 +416,7 @@ public class UtilityTypesTests
 
     #region With Classes
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Partial_FromClass(ExecutionMode mode)
     {
         var source = """
@@ -468,8 +435,7 @@ public class UtilityTypesTests
         Assert.Equal("Alice\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pick_FromClass(ExecutionMode mode)
     {
         var source = """
@@ -490,8 +456,7 @@ public class UtilityTypesTests
         Assert.Equal("Alice\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Omit_FromClass(ExecutionMode mode)
     {
         var source = """
@@ -516,8 +481,7 @@ public class UtilityTypesTests
 
     #region Edge Cases
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Partial_EmptyInterface(ExecutionMode mode)
     {
         var source = """
@@ -529,8 +493,7 @@ public class UtilityTypesTests
         Assert.Equal("ok\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Record_WithObjectValue(ExecutionMode mode)
     {
         var source = """
@@ -546,8 +509,7 @@ public class UtilityTypesTests
         Assert.Equal("Alice\nBob\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pick_KeyofPattern(ExecutionMode mode)
     {
         var source = """
@@ -564,8 +526,7 @@ public class UtilityTypesTests
 
     #region Array Suffix
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Partial_WithArraySuffix(ExecutionMode mode)
     {
         var source = """
@@ -582,8 +543,7 @@ public class UtilityTypesTests
         Assert.Equal("3\nfirst\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Partial_WithMultiDimensionalArray(ExecutionMode mode)
     {
         var source = """
@@ -600,8 +560,7 @@ public class UtilityTypesTests
         Assert.Equal("2\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedUtilityType_WithArraySuffix(ExecutionMode mode)
     {
         var source = """
@@ -617,8 +576,7 @@ public class UtilityTypesTests
         Assert.Equal("2\nlocalhost\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Promise_WithArraySuffix(ExecutionMode mode)
     {
         var source = """
@@ -632,8 +590,7 @@ public class UtilityTypesTests
         Assert.Equal("2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void UserDefinedGeneric_WithArraySuffix(ExecutionMode mode)
     {
         var source = """
@@ -650,8 +607,7 @@ public class UtilityTypesTests
         Assert.Equal("3\n1\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Record_WithArraySuffix(ExecutionMode mode)
     {
         var source = """
@@ -668,8 +624,7 @@ public class UtilityTypesTests
         Assert.Equal("2\n1\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Pick_WithArraySuffix(ExecutionMode mode)
     {
         var source = """
@@ -685,8 +640,7 @@ public class UtilityTypesTests
         Assert.Equal("2\nBob\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Omit_WithArraySuffix(ExecutionMode mode)
     {
         var source = """
@@ -703,8 +657,7 @@ public class UtilityTypesTests
         Assert.Equal("2\nAlice\n25\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Required_WithArraySuffix(ExecutionMode mode)
     {
         var source = """
@@ -721,8 +674,7 @@ public class UtilityTypesTests
         Assert.Equal("2\napp1\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Readonly_WithArraySuffix(ExecutionMode mode)
     {
         var source = """
@@ -739,8 +691,7 @@ public class UtilityTypesTests
         Assert.Equal("2\n1\n4\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GenericArray_TypeErrorStillDetected(ExecutionMode mode)
     {
         var source = """
@@ -755,8 +706,7 @@ public class UtilityTypesTests
 
     #region ReturnType<T>
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnType_ExtractsFromSimpleFunction(ExecutionMode mode)
     {
         var source = """
@@ -769,8 +719,7 @@ public class UtilityTypesTests
         Assert.Equal("world\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnType_ExtractsFromFunctionType(ExecutionMode mode)
     {
         var source = """
@@ -783,8 +732,7 @@ public class UtilityTypesTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnType_ExtractsFromArrowFunction(ExecutionMode mode)
     {
         var source = """
@@ -797,8 +745,7 @@ public class UtilityTypesTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReturnType_WrongArgCount_Throws(ExecutionMode mode)
     {
         var source = """
@@ -812,8 +759,7 @@ public class UtilityTypesTests
 
     #region Parameters<T>
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Parameters_ExtractsFromSimpleFunction(ExecutionMode mode)
     {
         var source = """
@@ -827,8 +773,7 @@ public class UtilityTypesTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Parameters_ExtractsFromFunctionType(ExecutionMode mode)
     {
         var source = """
@@ -842,8 +787,7 @@ public class UtilityTypesTests
         Assert.Equal("Alice\n30\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Parameters_EmptyForNoArgs(ExecutionMode mode)
     {
         var source = """
@@ -856,8 +800,7 @@ public class UtilityTypesTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Parameters_WrongArgCount_Throws(ExecutionMode mode)
     {
         var source = """
@@ -871,8 +814,7 @@ public class UtilityTypesTests
 
     #region ConstructorParameters<T>
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstructorParameters_ExtractsFromClass(ExecutionMode mode)
     {
         var source = """
@@ -888,8 +830,7 @@ public class UtilityTypesTests
         Assert.Equal("Bob\n25\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstructorParameters_EmptyForNoArgs(ExecutionMode mode)
     {
         var source = """
@@ -902,8 +843,7 @@ public class UtilityTypesTests
         Assert.Equal("0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstructorParameters_WrongArgCount_Throws(ExecutionMode mode)
     {
         var source = """
@@ -917,8 +857,7 @@ public class UtilityTypesTests
 
     #region InstanceType<T>
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceType_ExtractsFromClass(ExecutionMode mode)
     {
         var source = """
@@ -934,8 +873,7 @@ public class UtilityTypesTests
         Assert.Equal("unknown\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void InstanceType_WrongArgCount_Throws(ExecutionMode mode)
     {
         var source = """
@@ -949,8 +887,7 @@ public class UtilityTypesTests
 
     #region ThisType<T>
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisType_AcceptsType(ExecutionMode mode)
     {
         // ThisType<T> is a marker type that just returns T
@@ -963,8 +900,7 @@ public class UtilityTypesTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ThisType_WrongArgCount_Throws(ExecutionMode mode)
     {
         var source = """
@@ -978,8 +914,7 @@ public class UtilityTypesTests
 
     #region Awaited<T>
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Awaited_UnwrapsPromise(ExecutionMode mode)
     {
         var source = """
@@ -991,8 +926,7 @@ public class UtilityTypesTests
         Assert.Equal("resolved\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Awaited_UnwrapsNestedPromise(ExecutionMode mode)
     {
         var source = """
@@ -1004,8 +938,7 @@ public class UtilityTypesTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Awaited_PassesThroughNonPromise(ExecutionMode mode)
     {
         var source = """
@@ -1017,8 +950,7 @@ public class UtilityTypesTests
         Assert.Equal("direct\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Awaited_WrongArgCount_Throws(ExecutionMode mode)
     {
         var source = """
@@ -1032,8 +964,7 @@ public class UtilityTypesTests
 
     #region NonNullable<T>
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullable_RemovesNull(ExecutionMode mode)
     {
         var source = """
@@ -1045,8 +976,7 @@ public class UtilityTypesTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullable_RemovesUndefined(ExecutionMode mode)
     {
         var source = """
@@ -1058,8 +988,7 @@ public class UtilityTypesTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullable_RemovesBothNullAndUndefined(ExecutionMode mode)
     {
         var source = """
@@ -1071,8 +1000,7 @@ public class UtilityTypesTests
         Assert.Equal("test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullable_PassesThroughNonNullable(ExecutionMode mode)
     {
         var source = """
@@ -1084,8 +1012,7 @@ public class UtilityTypesTests
         Assert.Equal("direct\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullable_WrongArgCount_Throws(ExecutionMode mode)
     {
         var source = """
@@ -1099,8 +1026,7 @@ public class UtilityTypesTests
 
     #region Extract<T, U>
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Extract_FiltersByType(ExecutionMode mode)
     {
         var source = """
@@ -1112,8 +1038,7 @@ public class UtilityTypesTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Extract_FiltersByLiteral(ExecutionMode mode)
     {
         var source = """
@@ -1126,8 +1051,7 @@ public class UtilityTypesTests
         Assert.Equal("success\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Extract_CanExtractBoolean(ExecutionMode mode)
     {
         var source = """
@@ -1139,8 +1063,7 @@ public class UtilityTypesTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Extract_WrongArgCount_Throws(ExecutionMode mode)
     {
         var source = """
@@ -1154,8 +1077,7 @@ public class UtilityTypesTests
 
     #region Exclude<T, U>
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exclude_RemovesByType(ExecutionMode mode)
     {
         var source = """
@@ -1167,8 +1089,7 @@ public class UtilityTypesTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exclude_RemovesByLiteral(ExecutionMode mode)
     {
         var source = """
@@ -1181,8 +1102,7 @@ public class UtilityTypesTests
         Assert.Equal("pending\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exclude_RemovesNull(ExecutionMode mode)
     {
         var source = """
@@ -1194,8 +1114,7 @@ public class UtilityTypesTests
         Assert.Equal("test\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exclude_WrongArgCount_Throws(ExecutionMode mode)
     {
         var source = """
@@ -1209,8 +1128,7 @@ public class UtilityTypesTests
 
     #region Utility Type Composition
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NonNullable_Extract_Composed(ExecutionMode mode)
     {
         var source = """
@@ -1223,8 +1141,7 @@ public class UtilityTypesTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Exclude_NonNullable_Composed(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/VoidFunctionEarlyReturnTests.cs
+++ b/SharpTS.Tests/SharedTests/VoidFunctionEarlyReturnTests.cs
@@ -16,8 +16,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </remarks>
 public class VoidFunctionEarlyReturnTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EarlyReturn_InVoidFunction_WithInterfaceParam(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -37,8 +36,7 @@ public class VoidFunctionEarlyReturnTests
         Assert.Equal("2 a b\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EarlyReturn_InVoidFunction_WithArrayParam(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/SharedTests/VoidOperatorTests.cs
+++ b/SharpTS.Tests/SharedTests/VoidOperatorTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class VoidOperatorTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Void_ReturnsUndefined(ExecutionMode mode)
     {
         var source = """
@@ -20,8 +19,7 @@ public class VoidOperatorTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Void_EvaluatesExpressionForSideEffects(ExecutionMode mode)
     {
         var source = """
@@ -34,8 +32,7 @@ public class VoidOperatorTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Void_WithFunctionCall(ExecutionMode mode)
     {
         var source = """
@@ -52,8 +49,7 @@ public class VoidOperatorTests
         Assert.Equal("true\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Void_WithNumber(ExecutionMode mode)
     {
         var source = """
@@ -64,8 +60,7 @@ public class VoidOperatorTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Void_WithExpression(ExecutionMode mode)
     {
         var source = """
@@ -76,8 +71,7 @@ public class VoidOperatorTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Void_InConditional(ExecutionMode mode)
     {
         var source = """

--- a/SharpTS.Tests/SharedTests/WeakMapSetTests.cs
+++ b/SharpTS.Tests/SharedTests/WeakMapSetTests.cs
@@ -10,8 +10,7 @@ public class WeakMapSetTests
 {
     #region WeakMap Basic Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakMap_CreateEmpty(ExecutionMode mode)
     {
         var source = @"
@@ -22,8 +21,7 @@ public class WeakMapSetTests
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakMap_SetAndGet(ExecutionMode mode)
     {
         var source = @"
@@ -36,8 +34,7 @@ public class WeakMapSetTests
         Assert.Equal("value1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakMap_Has(ExecutionMode mode)
     {
         var source = @"
@@ -52,8 +49,7 @@ public class WeakMapSetTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakMap_Delete(ExecutionMode mode)
     {
         var source = @"
@@ -69,8 +65,7 @@ public class WeakMapSetTests
         Assert.Equal("true\ntrue\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakMap_SetReturnsWeakMap(ExecutionMode mode)
     {
         var source = @"
@@ -83,8 +78,7 @@ public class WeakMapSetTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakMap_ChainedSet(ExecutionMode mode)
     {
         var source = @"
@@ -101,8 +95,7 @@ public class WeakMapSetTests
         Assert.Equal("1\n2\n3\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakMap_GetNonExistentKeyReturnsNull(ExecutionMode mode)
     {
         var source = @"
@@ -114,8 +107,7 @@ public class WeakMapSetTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakMap_UpdateExistingKey(ExecutionMode mode)
     {
         var source = @"
@@ -130,8 +122,7 @@ public class WeakMapSetTests
         Assert.Equal("100\n200\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakMap_MultipleKeys(ExecutionMode mode)
     {
         var source = @"
@@ -154,8 +145,7 @@ public class WeakMapSetTests
 
     #region WeakSet Basic Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakSet_CreateEmpty(ExecutionMode mode)
     {
         var source = @"
@@ -166,8 +156,7 @@ public class WeakMapSetTests
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakSet_Add(ExecutionMode mode)
     {
         var source = @"
@@ -180,8 +169,7 @@ public class WeakMapSetTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakSet_Has(ExecutionMode mode)
     {
         var source = @"
@@ -196,8 +184,7 @@ public class WeakMapSetTests
         Assert.Equal("true\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakSet_Delete(ExecutionMode mode)
     {
         var source = @"
@@ -213,8 +200,7 @@ public class WeakMapSetTests
         Assert.Equal("true\ntrue\nfalse\nfalse\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakSet_AddReturnsWeakSet(ExecutionMode mode)
     {
         var source = @"
@@ -227,8 +213,7 @@ public class WeakMapSetTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakSet_ChainedAdd(ExecutionMode mode)
     {
         var source = @"
@@ -245,8 +230,7 @@ public class WeakMapSetTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakSet_AddDuplicate(ExecutionMode mode)
     {
         var source = @"
@@ -260,8 +244,7 @@ public class WeakMapSetTests
         Assert.Equal("true\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakSet_MultipleObjects(ExecutionMode mode)
     {
         var source = @"
@@ -284,8 +267,7 @@ public class WeakMapSetTests
 
     #region WeakMap with Class Keys
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakMap_WithClassInstanceKeys(ExecutionMode mode)
     {
         var source = @"
@@ -308,8 +290,7 @@ public class WeakMapSetTests
 
     #region WeakSet with Class Instances
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakSet_WithClassInstances(ExecutionMode mode)
     {
         var source = @"
@@ -331,8 +312,7 @@ public class WeakMapSetTests
 
     #region WeakMap with Array Keys
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakMap_WithArrayKeys(ExecutionMode mode)
     {
         var source = @"
@@ -352,8 +332,7 @@ public class WeakMapSetTests
 
     #region WeakSet with Array Elements
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakSet_WithArrayElements(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/WeakRefTests.cs
+++ b/SharpTS.Tests/SharedTests/WeakRefTests.cs
@@ -8,8 +8,7 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class WeakRefTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakRef_CreateAndDeref(ExecutionMode mode)
     {
         var source = @"
@@ -22,8 +21,7 @@ public class WeakRefTests
         Assert.Equal("hello\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakRef_Typeof(ExecutionMode mode)
     {
         var source = @"
@@ -35,8 +33,7 @@ public class WeakRefTests
         Assert.Equal("object\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakRef_DerefWithClassInstance(ExecutionMode mode)
     {
         var source = @"
@@ -52,8 +49,7 @@ public class WeakRefTests
         Assert.Equal("Alice\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakRef_DerefReturnsCorrectValue(ExecutionMode mode)
     {
         var source = @"
@@ -67,8 +63,7 @@ public class WeakRefTests
         Assert.Equal("10\n20\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakRef_WithArrayTarget(ExecutionMode mode)
     {
         var source = @"
@@ -82,8 +77,7 @@ public class WeakRefTests
         Assert.Equal("3\n1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakRef_MultipleRefs(ExecutionMode mode)
     {
         var source = @"
@@ -98,8 +92,7 @@ public class WeakRefTests
         Assert.Equal("1\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void WeakRef_WithTypeArgument(ExecutionMode mode)
     {
         var source = @"

--- a/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -11,8 +11,7 @@ public class WorkerThreadsTests
 {
     #region SharedArrayBuffer Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SharedArrayBuffer_Constructor_CreatesBufferWithSize(ExecutionMode mode)
     {
         var source = @"
@@ -23,8 +22,7 @@ public class WorkerThreadsTests
         Assert.Equal("16\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SharedArrayBuffer_Slice_CreatesNewBuffer(ExecutionMode mode)
     {
         var source = @"
@@ -40,8 +38,7 @@ public class WorkerThreadsTests
 
     #region TypedArray over SharedArrayBuffer Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Int32Array_OverSharedArrayBuffer_SharesMemory(ExecutionMode mode)
     {
         var source = @"
@@ -55,8 +52,7 @@ public class WorkerThreadsTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedArray_WithByteOffset_CreatesCorrectView(ExecutionMode mode)
     {
         var source = @"
@@ -69,8 +65,7 @@ public class WorkerThreadsTests
         Assert.Equal("4\n2\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Uint8Array_OverSharedArrayBuffer_WorksCorrectly(ExecutionMode mode)
     {
         var source = @"
@@ -85,8 +80,7 @@ public class WorkerThreadsTests
         Assert.Equal("255\n128\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void TypedArray_FromLength_CreatesArray(ExecutionMode mode)
     {
         var source = @"
@@ -107,8 +101,7 @@ public class WorkerThreadsTests
 
     #region Atomics Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Atomics_Load_ReadsValue(ExecutionMode mode)
     {
         var source = @"
@@ -121,8 +114,7 @@ public class WorkerThreadsTests
         Assert.Equal("42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Atomics_Store_WritesValue(ExecutionMode mode)
     {
         var source = @"
@@ -135,8 +127,7 @@ public class WorkerThreadsTests
         Assert.Equal("100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Atomics_Add_AddsAndReturnsOldValue(ExecutionMode mode)
     {
         var source = @"
@@ -151,8 +142,7 @@ public class WorkerThreadsTests
         Assert.Equal("10\n15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Atomics_Sub_SubtractsAndReturnsOldValue(ExecutionMode mode)
     {
         var source = @"
@@ -167,8 +157,7 @@ public class WorkerThreadsTests
         Assert.Equal("10\n7\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Atomics_Exchange_SwapsValues(ExecutionMode mode)
     {
         var source = @"
@@ -183,8 +172,7 @@ public class WorkerThreadsTests
         Assert.Equal("42\n100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Atomics_CompareExchange_Success(ExecutionMode mode)
     {
         var source = @"
@@ -199,8 +187,7 @@ public class WorkerThreadsTests
         Assert.Equal("42\n100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Atomics_CompareExchange_Failure(ExecutionMode mode)
     {
         var source = @"
@@ -215,8 +202,7 @@ public class WorkerThreadsTests
         Assert.Equal("42\n42\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Atomics_And_PerformsBitwiseAnd(ExecutionMode mode)
     {
         var source = @"
@@ -231,8 +217,7 @@ public class WorkerThreadsTests
         Assert.Equal("15\n5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Atomics_Or_PerformsBitwiseOr(ExecutionMode mode)
     {
         var source = @"
@@ -247,8 +232,7 @@ public class WorkerThreadsTests
         Assert.Equal("10\n15\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Atomics_Xor_PerformsBitwiseXor(ExecutionMode mode)
     {
         var source = @"
@@ -263,8 +247,7 @@ public class WorkerThreadsTests
         Assert.Equal("15\n10\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Atomics_IsLockFree_ReturnsBooleanForSize(ExecutionMode mode)
     {
         var source = @"
@@ -279,8 +262,7 @@ public class WorkerThreadsTests
 
     #region MessageChannel Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MessageChannel_Constructor_CreatesTwoPorts(ExecutionMode mode)
     {
         var source = @"
@@ -293,8 +275,7 @@ public class WorkerThreadsTests
         Assert.Equal("true\ntrue\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MessageChannel_PortOnMessage_ReceivesPostedValue(ExecutionMode mode)
     {
         // #209 (interpreter) / #222 (compiled $MessagePort): port.on() must
@@ -315,8 +296,7 @@ public class WorkerThreadsTests
         Assert.Contains("received: hello", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MessageChannel_MessagesPostedBeforeListener_DeliveredInOrderAfterImplicitStart(ExecutionMode mode)
     {
         // #222: messages posted before any listener exists must queue and be
@@ -338,8 +318,7 @@ public class WorkerThreadsTests
         Assert.Contains("got: first\ngot: second", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MessageChannel_UnclosedPort_DoesNotHangProcess(ExecutionMode mode)
     {
         // #1254: a plain in-process MessageChannel (neither port ever transferred to a
@@ -362,8 +341,7 @@ public class WorkerThreadsTests
 
     #region StructuredClone Tests
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StructuredClone_ClonesObject(ExecutionMode mode)
     {
         var source = @"
@@ -377,8 +355,7 @@ public class WorkerThreadsTests
         Assert.Equal("1\n999\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StructuredClone_ClonesNestedObjects(ExecutionMode mode)
     {
         var source = @"
@@ -392,8 +369,7 @@ public class WorkerThreadsTests
         Assert.Equal("42\n100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StructuredClone_ClonesArrays(ExecutionMode mode)
     {
         var source = @"
@@ -407,8 +383,7 @@ public class WorkerThreadsTests
         Assert.Equal("1\n999\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StructuredClone_SharesSharedArrayBuffer(ExecutionMode mode)
     {
         var source = @"
@@ -428,8 +403,7 @@ public class WorkerThreadsTests
         Assert.Equal("42\n100\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StructuredClone_ClonesMap(ExecutionMode mode)
     {
         var source = @"
@@ -443,8 +417,7 @@ public class WorkerThreadsTests
         Assert.Equal("1\n999\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StructuredClone_ClonesSet(ExecutionMode mode)
     {
         var source = @"
@@ -464,8 +437,7 @@ public class WorkerThreadsTests
     /// affect the clone. Before the fix, compiled mode's <c>$Runtime.StructuredClone</c>
     /// aliased all of these by reference (only List/Dictionary/Set were deep-cloned).
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StructuredClone_ClonesDateIndependently(ExecutionMode mode)
     {
         var source = @"
@@ -478,8 +450,7 @@ public class WorkerThreadsTests
         Assert.Equal("1000\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StructuredClone_ClonesRegExpSourceAndFlags(ExecutionMode mode)
     {
         var source = @"
@@ -493,8 +464,7 @@ public class WorkerThreadsTests
         Assert.Equal("abc\ngi\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StructuredClone_ClonesTypedArrayIndependently(ExecutionMode mode)
     {
         var source = @"
@@ -507,8 +477,7 @@ public class WorkerThreadsTests
         Assert.Equal("5\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StructuredClone_ClonesBufferIndependently(ExecutionMode mode)
     {
         var source = @"
@@ -521,8 +490,7 @@ public class WorkerThreadsTests
         Assert.Equal("1\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StructuredClone_ClonesErrorPreservingNameAndMessage(ExecutionMode mode)
     {
         var source = @"
@@ -542,8 +510,7 @@ public class WorkerThreadsTests
     /// Before the fix, compiled mode's shallow fallback aliased these by reference instead
     /// of throwing.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StructuredClone_ThrowsForFunction(ExecutionMode mode)
     {
         // Dual-mode parity check: a non-guest-throw exception's catch value is the raw
@@ -562,8 +529,7 @@ public class WorkerThreadsTests
         Assert.Equal("threw:string\ntrue\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StructuredClone_ThrowsForNestedFunction(ExecutionMode mode)
     {
         var source = @"
@@ -578,8 +544,7 @@ public class WorkerThreadsTests
         Assert.Equal("threw\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StructuredClone_ThrowsForSymbol(ExecutionMode mode)
     {
         var source = @"
@@ -594,8 +559,7 @@ public class WorkerThreadsTests
         Assert.Equal("threw\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StructuredClone_ThrowsForClassInstance(ExecutionMode mode)
     {
         var source = @"
@@ -635,8 +599,7 @@ public class WorkerThreadsTests
     /// the Ref keeps the loop alive for it, so the test cannot flake the way a
     /// wall-clock window would.
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_Terminate_KeepsEventLoopAliveUntilSettled(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -674,8 +637,7 @@ public class WorkerThreadsTests
     /// the parked wait. A still-leaked thread would never produce it. <c>"survived"</c> after
     /// the wait must never be delivered — termination is not catchable by guest code.
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_Terminate_WakesAtomicsWaitAndEmitsExitCode1(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -719,8 +681,7 @@ public class WorkerThreadsTests
     /// hardcoded 0 and nothing stopped the loop early, so a terminated worker either reported
     /// 0 or waited out the 5s join.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_Terminate_StopsCooperativeEventLoopWorkerWithExitCode1(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -760,8 +721,7 @@ public class WorkerThreadsTests
     /// before any <c>'message'</c> it posts. SharpTS emitted no such event. The worker posts
     /// a message at the top of its script; the parent must see <c>'online'</c> first.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_Online_FiresBeforeFirstMessage(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -796,8 +756,7 @@ public class WorkerThreadsTests
     /// is detached by the time <c>new Worker</c> returns. Dual-mode: the Worker uses the C#
     /// <c>StructuredClone</c> in both interpreter and compiled parents.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_ArrayBufferInTransferList_DetachesSource(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -827,8 +786,7 @@ public class WorkerThreadsTests
     /// the fix the interpreter had no ArrayBuffer clone arm and threw "Cannot clone value of
     /// type SharpTSArrayBuffer", so the worker failed to spawn. Dual-mode.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_NonTransferredArrayBufferWorkerData_IsCopiedNotDetached(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -894,8 +852,7 @@ public class WorkerThreadsTests
     /// parent's set routes to the shared C# store in both modes (compiled via a reflection
     /// helper); the worker reads it through the interpreter.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_EnvironmentData_VisibleInWorker_NotInProcessEnv(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -924,8 +881,7 @@ public class WorkerThreadsTests
     /// dual-mode by <see cref="Worker_ReceiveMessageOnPort_OnTransferredPort"/> (driven through
     /// the interpreter inside the worker).
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReceiveMessageOnPort_EmptyPort_IsUndefined(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -949,8 +905,7 @@ public class WorkerThreadsTests
     /// emitted <c>$MessagePort</c> queue directly (it was previously a stub that always returned
     /// <c>undefined</c>).
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ReceiveMessageOnPort_QueuedMessage_ReturnsMessageThenUndefined(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -982,8 +937,7 @@ public class WorkerThreadsTests
     /// <c>{ idle, active, utilization }</c> object (SharpTS has no precise idle/active loop
     /// accounting). Dual-mode.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_Performance_EventLoopUtilization_ReturnsShape(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1009,8 +963,7 @@ public class WorkerThreadsTests
     /// #1004: <c>worker.getHeapSnapshot()</c> throws a clear "not supported" error — a
     /// V8-format heap snapshot has no .NET equivalent (epic ceiling). Dual-mode.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_GetHeapSnapshot_ThrowsClearError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1072,8 +1025,7 @@ public class WorkerThreadsTests
     /// <c>worker.resourceLimits</c> (cosmetic — .NET cannot enforce V8 heap/stack sizing).
     /// Dual-mode.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_ResourceLimits_EchoedBack(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1102,8 +1054,7 @@ public class WorkerThreadsTests
     /// Console into a per-worker Readable <c>worker.stdout</c>; the parent reads it via
     /// 'data'/'end'. Each chunk is marshalled onto the parent loop before delivery. Dual-mode.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_StdoutTrue_CapturesWorkerConsoleOutput(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1136,8 +1087,7 @@ public class WorkerThreadsTests
     /// the worker always interprets; a compiled parent reaches <c>worker.stdin</c> via runtime
     /// dispatch on the C# SharpTSWorker (like worker.stdout).
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_StdinTrue_ParentWriteReadableInWorker(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1168,8 +1118,7 @@ public class WorkerThreadsTests
     /// worker accumulates each chunk and, on 'end', posts the concatenation — verifying both
     /// ordering and that end() flushes after the last chunk. Dual-mode.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_StdinTrue_MultipleWritesPreserveOrder(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1201,8 +1150,7 @@ public class WorkerThreadsTests
     /// (its GetMember convention for stdout/stderr too), which is falsy like Node's <c>null</c>,
     /// so <c>!w.stdin</c> holds. Dual-mode.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_StdinWithoutOption_IsAbsent(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1234,8 +1182,7 @@ public class WorkerThreadsTests
     /// <c>StructuredClone</c> registry (compiled via a reflection helper), and the Worker
     /// transferList clone honors it in both modes.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_MarkAsUntransferable_BufferIsClonedNotDetached(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1269,8 +1216,7 @@ public class WorkerThreadsTests
     /// postMessage. Dual-mode: the worker always interprets and posts through the C#
     /// <c>SharpTSWorker</c>, whose clone throws DataCloneError for a function in both modes.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_PostUncloneableToParent_FiresMessageError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1297,8 +1243,7 @@ public class WorkerThreadsTests
     /// <c>parentPort</c> fires <c>'messageerror'</c>. The worker echoes which event it saw.
     /// Dual-mode (parent posts through the C# <c>SharpTSWorker</c>).
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_ParentPostsUncloneable_WorkerParentPortFiresMessageError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1334,8 +1279,7 @@ public class WorkerThreadsTests
     /// <c>'messageerror'</c>, matching the interpreter's receiver-side model (previously
     /// compiled returned the function by reference and fired <c>'message'</c>).
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MessageChannelPort_PostUncloneable_FiresMessageError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1364,8 +1308,7 @@ public class WorkerThreadsTests
     /// unknown values by reference, so a nested function silently passed through as
     /// <c>'message'</c> in compiled mode.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MessageChannelPort_PostNestedUncloneable_FiresMessageError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1406,8 +1349,7 @@ public class WorkerThreadsTests
     /// and the running-Ref keeps the parent alive until it does, so the test cannot
     /// flake the way a wall-clock window would.
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_RunningWorker_KeepsParentLoopAliveUntilMessage(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1437,8 +1379,7 @@ public class WorkerThreadsTests
     /// <c>ref()</c> after an <c>unref()</c> restores the keep-alive so a later
     /// delayed message is still delivered (positive, load-independent assertion).
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_UnrefThenRef_RestoresKeepAlive(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1477,8 +1418,7 @@ public class WorkerThreadsTests
     /// passed as an object, not an array — the shape that always yielded null under
     /// the old <c>as SharpTSArray</c> read, confirming the bag no longer trips on it.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_StdioAndResourceLimitsOptions_AreHonored(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1528,8 +1468,7 @@ public class WorkerThreadsTests
     /// <c>__dirname</c> routes the harness through the real-disk path so the worker
     /// can load its script.
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_WorkerData_PrimitiveIsVisibleInWorker(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1557,8 +1496,7 @@ public class WorkerThreadsTests
     /// <c>Dictionary&lt;string, object?&gt;</c> clone path as well as the interpreter
     /// <c>SharpTSObject</c> path.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_WorkerData_ObjectIsClonedAndVisibleInWorker(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1611,8 +1549,7 @@ public class WorkerThreadsTests
     /// output-present check — so it cannot flake under load.
     /// </para>
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_TransferredMessagePort_RoundTripsBetweenParentAndWorker(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1651,8 +1588,7 @@ public class WorkerThreadsTests
     /// compiled <c>Dictionary&lt;string, object?&gt;</c> clone path through the bridge
     /// as well as the interpreter <c>SharpTSObject</c> path).
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_TransferredMessagePort_StructuredClonesObjectPayloads(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1694,8 +1630,7 @@ public class WorkerThreadsTests
     /// an object carrying <c>message</c>. The guest reads <c>e.message</c> with a string
     /// fallback so the rejection text is observable either way.
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_MessagePortInWorkerDataWithoutTransfer_IsRejected(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1733,8 +1668,7 @@ public class WorkerThreadsTests
     /// only after the previous reply, so each delivery happens while the worker is
     /// otherwise quiescent.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_TransferredMessagePort_MultipleRoundTripsWhileIdle(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1780,8 +1714,7 @@ public class WorkerThreadsTests
     /// compiled <c>CompiledMessagePortBridge.ReceiveMessageSync</c> as well as the
     /// interpreter <c>SharpTSMessagePort</c> path.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_ReceiveMessageOnPort_OnTransferredPort(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1823,8 +1756,7 @@ public class WorkerThreadsTests
     /// In interpreter mode the cross-thread <c>SharpTSMessagePort</c> delivery handles
     /// both ends.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_SplitChannel_WorkersCanCommunicateDirectly(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1875,8 +1807,7 @@ public class WorkerThreadsTests
     /// the parent can log them on the main thread (worker console.log is not guaranteed
     /// to reach the captured output before the harness returns).
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_SplitChannel_MultipleRoundTrips(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1944,8 +1875,7 @@ public class WorkerThreadsTests
     /// <c>__dirname</c> routes the harness through the real-disk path so the worker can
     /// load its script. Load-independent positive assertion (output present).
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_ImportFromWorkerThreads_ResolvesInModuleMode(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -1972,8 +1902,7 @@ public class WorkerThreadsTests
     /// case for <c>worker_threads</c>. Here the worker imports a relative helper and a
     /// worker_threads binding together.
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_ImportRelativeModule_WorksInModuleMode(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -2016,8 +1945,7 @@ public class WorkerThreadsTests
     /// hold in BOTH modes (previously asserted only for the interpreter, which #464
     /// targeted).
     /// </remarks>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Worker_UncloneableWorkerData_RejectsWithErrorObjectNotString(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -2062,8 +1990,7 @@ public class WorkerThreadsTests
     /// so the compiled path is only ever reached on the main thread. This locks in that both modes agree
     /// and that the canonical <c>if (parentPort)</c> main-thread guard keeps working (not a throw).
     /// </summary>
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ParentPort_OnMainThread_IsNull(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/SharpTS.Tests/TypeCheckerTests/ConstInitializerWideningTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/ConstInitializerWideningTests.cs
@@ -16,8 +16,7 @@ public class ConstInitializerWideningTests
 {
     // --- The headline bug: property/element reassignment on a const object/array literal ---
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstObjectLiteral_PropertyReassign_Allowed(ExecutionMode mode)
     {
         // `const o = { n: 1 }` has type `{ n: number }`, so `o.n = 9` is legal TypeScript.
@@ -110,8 +109,7 @@ public class ConstInitializerWideningTests
             TestHarness.RunInterpreted("const o = { p: { n: 1 } as const }; o.p.n = 9;"));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ConstObjectLiteral_MixedPlainAndAsConstMembers(ExecutionMode mode)
     {
         // In the same object literal, a plain member widens (`o.b.m = 5` is allowed) while an
@@ -123,8 +121,7 @@ public class ConstInitializerWideningTests
     // --- #493: `as const` literal types survive `const`-initializer widening regardless of the
     // nesting position (array element, spread member), and `as const` members model readonly. ---
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsConstArrayElement_KeepsLiteralType(ExecutionMode mode)
     {
         // `as const` on an *array element* inside a fresh array literal is no longer widened away:
@@ -133,8 +130,7 @@ public class ConstInitializerWideningTests
         Assert.Equal("1\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadOfAsConstObject_KeepsLiteralType(ExecutionMode mode)
     {
         // Spreading an `as const` object into a fresh object literal preserves the (already-fixed)
@@ -189,8 +185,7 @@ public class ConstInitializerWideningTests
         Assert.Equal("TS2322", ex.Diagnostic.TsCode);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void SpreadOfFreshObjectLiteral_Widens(ExecutionMode mode)
     {
         // Spreading a *fresh* inline object literal still widens its members (unlike an `as const`
@@ -199,8 +194,7 @@ public class ConstInitializerWideningTests
         Assert.Equal("2\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void MixedSpread_PlainSourceWidens_AsConstSourcePreserved(ExecutionMode mode)
     {
         // A plain spread member widens (`o.a` is `number`, writable) while a later `as const` spread

--- a/SharpTS.Tests/TypeCheckerTests/DedicatedContainerTypeReferenceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/DedicatedContainerTypeReferenceTests.cs
@@ -370,8 +370,7 @@ public class DedicatedContainerTypeReferenceTests
 
     // ---- regression guard: ordinary use of these annotations type-checks and runs in BOTH modes ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AnnotatedIterator_IteratesCorrectly(ExecutionMode mode)
     {
         // The annotation is type-level only; it must not perturb interpretation or IL codegen.

--- a/SharpTS.Tests/TypeCheckerTests/DisjunctionEarlyReturnNarrowingTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/DisjunctionEarlyReturnNarrowingTests.cs
@@ -13,8 +13,7 @@ namespace SharpTS.Tests.TypeCheckerTests;
 /// </summary>
 public class DisjunctionEarlyReturnNarrowingTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DisjunctionNullGuard_EarlyReturn_NarrowsAfter(ExecutionMode mode)
     {
         var source = """
@@ -31,8 +30,7 @@ public class DisjunctionEarlyReturnNarrowingTests
         Assert.Equal("2\n0\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedDisjunctionGuard_EarlyReturn_NarrowsAll(ExecutionMode mode)
     {
         var source = """
@@ -48,8 +46,7 @@ public class DisjunctionEarlyReturnNarrowingTests
         Assert.Equal("3\n0\n", output);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void EventsModuleImport_TypeChecksAndRuns(ExecutionMode mode)
     {
         // The original #216 repro: importing EventEmitter triggered a

--- a/SharpTS.Tests/TypeCheckerTests/GeneratorYieldInferenceTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/GeneratorYieldInferenceTests.cs
@@ -107,8 +107,7 @@ public class GeneratorYieldInferenceTests
         Assert.ThrowsAny<TypeCheckException>(() => TestHarness.RunInterpreted(source));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_InferredYield_IteratesInBothModes(ExecutionMode mode)
     {
         // Type-level change must not perturb interpretation or IL codegen.
@@ -121,8 +120,7 @@ public class GeneratorYieldInferenceTests
         Assert.Equal("60\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void Generator_EmptyYieldsNever_RunsInBothModes(ExecutionMode mode)
     {
         // An empty generator infers Generator<never>; spreading it yields an empty array. The never element
@@ -137,8 +135,7 @@ public class GeneratorYieldInferenceTests
 
     // ---- #532: nested generator declaration infers its yield type (compiled no longer System.Void) ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void NestedGenerator_InfersYieldType_RunsInBothModes(ExecutionMode mode)
     {
         // The nested generator's yield type is inferred (number), so the outer function returns number[]
@@ -169,8 +166,7 @@ public class GeneratorYieldInferenceTests
     // CheckClassBody computes the inferred (un-annotated) method return type during the body pass and
     // re-publishes the frozen class afterwards, so `new C().m()` no longer reads the `<inferred>` placeholder.
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorMethod_InferredYield_IsIterable_RunsInBothModes(ExecutionMode mode)
     {
         // The #661 headline (also reported as #687): spreading a generator method with no explicit
@@ -196,8 +192,7 @@ public class GeneratorYieldInferenceTests
         Assert.Equal("TS2322", ex.Diagnostic.TsCode);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void GeneratorMethod_InferredYield_ForOf_RunsInBothModes(ExecutionMode mode)
     {
         var source = """
@@ -209,8 +204,7 @@ public class GeneratorYieldInferenceTests
         Assert.Equal("30\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void AsyncGeneratorMethod_InferredYield_RunsInBothModes(ExecutionMode mode)
     {
         // The inferred async generator method computes AsyncGenerator<number> (its yield type), so
@@ -255,8 +249,7 @@ public class GeneratorYieldInferenceTests
         Assert.Equal("TS2322", ex.Diagnostic.TsCode);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OrdinaryMethod_InferredReturn_CorrectUse_RunsInBothModes(ExecutionMode mode)
     {
         // The same propagation must not over-reject: a correctly-typed consumer of the inferred return runs.

--- a/SharpTS.Tests/TypeCheckerTests/HarnessModuleDiagnosticGateTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/HarnessModuleDiagnosticGateTests.cs
@@ -20,8 +20,7 @@ public class HarnessModuleDiagnosticGateTests
         ["main.ts"] = "export {};\nconst x: number = \"not a number\";\nconsole.log(1);\n",
     };
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RunModules_ThrowsOnTypeError(ExecutionMode mode)
     {
         var ex = Assert.Throws<TypeCheckDiagnosticException>(
@@ -29,8 +28,7 @@ public class HarnessModuleDiagnosticGateTests
         Assert.NotEmpty(ex.Diagnostics);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void RunModules_AllowTypeErrors_RunsIllTypedProgram(ExecutionMode mode)
     {
         // Opt-out escape hatch for tests that intentionally exercise ill-typed programs.

--- a/SharpTS.Tests/TypeCheckerTests/OptionalParamUndefinedArgTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/OptionalParamUndefinedArgTests.cs
@@ -11,8 +11,7 @@ namespace SharpTS.Tests.TypeCheckerTests;
 /// </summary>
 public class OptionalParamUndefinedArgTests
 {
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void OptionalParameter_AcceptsExplicitUndefined(ExecutionMode mode)
     {
         var source = """
@@ -22,8 +21,7 @@ public class OptionalParamUndefinedArgTests
         Assert.Equal("Hi undefined\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void DefaultParameter_AcceptsExplicitUndefined_FiresDefault(ExecutionMode mode)
     {
         var source = """
@@ -72,8 +70,7 @@ public class OptionalParamUndefinedArgTests
         Assert.Equal("undefined\n", TestHarness.RunInterpreted(source));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateMethodDefaultParameter_AcceptsUndefined(ExecutionMode mode)
     {
         // #668 private-method argument-compatibility path. Runs in BOTH modes: unlike free
@@ -90,8 +87,7 @@ public class OptionalParamUndefinedArgTests
         Assert.Equal("8\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateMethodOptionalParameter_AcceptsExplicitUndefined(ExecutionMode mode)
     {
         // #668 path that #696 unblocked: an *optional* (`b?: T`) private-method parameter could
@@ -107,8 +103,7 @@ public class OptionalParamUndefinedArgTests
         Assert.Equal("x_\n", TestHarness.Run(source, mode));
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void PrivateMethodOptionalParameter_OmittedArgument(ExecutionMode mode)
     {
         // The minimal #696 scenario end-to-end: a private method with a sole optional parameter

--- a/SharpTS.Tests/TypeCheckerTests/StructuralIterableTypingTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/StructuralIterableTypingTests.cs
@@ -454,8 +454,7 @@ public class StructuralIterableTypingTests
 
     // ---- Runtime regression guard: the new type modeling does not perturb execution in either mode ----
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void StructuralIterable_IteratesAndSpreads(ExecutionMode mode)
     {
         var source = """
@@ -536,8 +535,7 @@ public class StructuralIterableTypingTests
         TestHarness.RunInterpreted(source);
     }
 
-    [Theory]
-    [MemberData(nameof(ExecutionModes.All), MemberType = typeof(ExecutionModes))]
+    [Theory, ModeData]
     public void ExtendsArray_ForOf_BindsElementType_RunsInBothModes(ExecutionMode mode)
     {
         // The inherited element type is number (recovered from the dropped `extends Array<number>` arg), and


### PR DESCRIPTION
Fifth tier of the cleanup audit (stacked on #1297). Test-project only.

- **~6,000 lines of attribute scaffolding gone:** `[Theory, ModeData]` (a `DataAttribute` over the existing `ExecutionModes`) replaces the two-line MemberData pair at **6,070 sites in 342 files**. Test count verified unchanged: **15,747 → 15,747**, full suite green.
- Shared `TestPorts.GetAvailablePort` (×7 copies), `RepoPaths.FindRepoRoot` (×4), `TestHarness.ParseOrThrow` (×10) replace byte-identical private helpers.
- `[Collection("ScriptArgs")]` finally gets a real `CollectionDefinition` with `DisableParallelization` — it was silently binding to an implicit parallelizable collection while mutating process-level argv.
- `VerifyILBytes` → private; stale `CrossModuleChainedLogicalOrTests` remark rewritten as a regression note.
- **Fixes an ordering-dependent leak in the tier-2 tests this stack added:** `process.exit(7)` publishes `Environment.ExitCode` before the intercepting handler runs; without a reset it poisoned later `ProcessLifecycleTests` runs depending on scheduling. Caught by this branch's repeated full-suite gate; the fix rides here since the stack merges in order.

Deliberately deferred (low value / npm-gated): theory-izing `RealPackageSmokeTests`' 16 hand-written mode pairs; extracting the shared RSA test key PEM.