### PR TITLE
refactor: first consolidation clusters (directive prologue, weak errors, module list)

### DIFF
--- a/Compilation/ILCompiler.Async.cs
+++ b/Compilation/ILCompiler.Async.cs
@@ -718,7 +718,7 @@ public partial class ILCompiler
             ctx.CommonJsExportFields = _modules.CommonJsExportFields;
             ctx.CommonJsGetExportsMethods = _modules.CommonJsGetExportsMethods;
             // Check for function-level "use strict" directive
-            ctx.IsStrictMode = _isStrictMode || CheckForUseStrict(func.Body);
+            ctx.IsStrictMode = _isStrictMode || Parsing.DirectivePrologue.HasUseStrict(func.Body);
             // Entry-point display class for captured top-level variables
             ApplyCapturedTopLevelVariableAccess(ctx);
             ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;

--- a/Compilation/ILCompiler.AsyncGenerators.cs
+++ b/Compilation/ILCompiler.AsyncGenerators.cs
@@ -204,7 +204,7 @@ public partial class ILCompiler
         var ctx = CreateModuleMemberContext(il);
         ctx.FieldsField = fieldsField;
         ctx.IsInstanceMethod = isInstanceMethod;
-        ctx.IsStrictMode = _isStrictMode || CheckForUseStrict(method.Body);
+        ctx.IsStrictMode = _isStrictMode || Parsing.DirectivePrologue.HasUseStrict(method.Body);
         // ES2022 Private Class Elements support for async generator methods (a private async
         // generator threads its QUALIFIED class name so nested private member access resolves — #720).
         ctx.CurrentClassName = currentClassName ?? methodBuilder.DeclaringType?.Name;

--- a/Compilation/ILCompiler.Classes.Methods.cs
+++ b/Compilation/ILCompiler.Classes.Methods.cs
@@ -973,7 +973,7 @@ public partial class ILCompiler
         ctx.AsyncArrowParentBuilders = _async.ArrowParentBuilders;
         ApplyLockDecoratorFields(ctx);
         // Check for method-level "use strict" directive
-        ctx.IsStrictMode = _isStrictMode || CheckForUseStrict(method.Body);
+        ctx.IsStrictMode = _isStrictMode || Parsing.DirectivePrologue.HasUseStrict(method.Body);
         // ES2022 Private Class Elements support
         ctx.CurrentClassName = typeBuilder.Name;
         ctx.CurrentClassBuilder = typeBuilder;

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -354,7 +354,7 @@ public partial class ILCompiler
         ApplyCommonJsModuleAccess(ctx);
         ctx.UnionGenerator = _unionGenerator;
         // Check for function-level "use strict" directive
-        ctx.IsStrictMode = _isStrictMode || CheckForUseStrict(funcStmt.Body);
+        ctx.IsStrictMode = _isStrictMode || Parsing.DirectivePrologue.HasUseStrict(funcStmt.Body);
         // Entry-point display class for captured top-level variables. TopLevelStaticVars uses
         // the pre-computed per-function map rather than the module-wide default.
         ApplyCapturedTopLevelVariableAccess(ctx);
@@ -1302,7 +1302,7 @@ public partial class ILCompiler
             var il = overload.GetILGenerator();
 
             // Create a minimal context just for emitting default value expressions
-            var ctx = CreateOverloadDefaultsContext(il, _isStrictMode || CheckForUseStrict(funcStmt.Body));
+            var ctx = CreateOverloadDefaultsContext(il, _isStrictMode || Parsing.DirectivePrologue.HasUseStrict(funcStmt.Body));
             var emitter = new ILEmitter(ctx);
 
             // Make the provided parameters resolvable so a default value that references an

--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -383,7 +383,7 @@ public partial class ILCompiler
         var il = smBuilder.MoveNextMethod.GetILGenerator();
         var ctx = CreateModuleMemberContext(il);
         // Check for function-level "use strict" directive
-        ctx.IsStrictMode = _isStrictMode || CheckForUseStrict(funcStmt.Body);
+        ctx.IsStrictMode = _isStrictMode || Parsing.DirectivePrologue.HasUseStrict(funcStmt.Body);
         // Captured outer variables are read live (by reference) rather than snapshotted (#541).
         // These mirror the async-generator MoveNext context so reads/writes of top-level
         // variables go straight to their backing storage instead of a stale state-machine field.
@@ -451,7 +451,7 @@ public partial class ILCompiler
         var ctx = CreateModuleMemberContext(il);
         ctx.FieldsField = fieldsField;
         ctx.IsInstanceMethod = isInstanceMethod;
-        ctx.IsStrictMode = _isStrictMode || CheckForUseStrict(method.Body);
+        ctx.IsStrictMode = _isStrictMode || Parsing.DirectivePrologue.HasUseStrict(method.Body);
         // ES2022 Private Class Elements support for generator methods (a private generator threads
         // its QUALIFIED class name so nested private member access resolves under modules — #720).
         ctx.CurrentClassName = currentClassName ?? methodBuilder.DeclaringType?.Name;

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -407,7 +407,7 @@ public partial class ILCompiler
         _deadCodeInfo = deadCodeInfo;
 
         // Check for "use strict" directive at file level
-        _isStrictMode = CheckForUseStrict(statements);
+        _isStrictMode = Parsing.DirectivePrologue.HasUseStrict(statements);
 
         // Relocate non-capturing nested generator/async/state-machine-nested function declarations
         // to the module top level so the mature top-level state-machine pipeline can lower them
@@ -440,33 +440,6 @@ public partial class ILCompiler
     }
 
     #region Compile Phases
-
-    /// <summary>
-    /// Checks if the statements begin with a "use strict" directive.
-    /// </summary>
-    /// <param name="statements">The list of statements to check.</param>
-    /// <returns>True if "use strict" directive is found at the beginning.</returns>
-    private static bool CheckForUseStrict(List<Stmt>? statements)
-    {
-        if (statements == null) return false;
-        foreach (var stmt in statements)
-        {
-            if (stmt is Stmt.Directive directive)
-            {
-                if (directive.Value == "use strict")
-                {
-                    return true;
-                }
-                // Continue checking other directives at the start
-            }
-            else
-            {
-                // Non-directive statement encountered, stop checking
-                break;
-            }
-        }
-        return false;
-    }
 
     /// <summary>
     /// Phase 0: Extract .NET namespace from @Namespace file directive.

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -1130,7 +1130,7 @@ public partial class Interpreter : IDisposable
         try
         {
             // Check for "use strict" directive at file level
-            bool isStrict = CheckForUseStrict(statements);
+            bool isStrict = Parsing.DirectivePrologue.HasUseStrict(statements);
             if (isStrict)
             {
                 // Wrap the current environment with strict mode enabled
@@ -1389,7 +1389,7 @@ public partial class Interpreter : IDisposable
         using (PushScriptContext(scriptEnv, script))
         {
             // Check for "use strict" directive
-            bool isStrict = CheckForUseStrict(script.Statements);
+            bool isStrict = Parsing.DirectivePrologue.HasUseStrict(script.Statements);
             if (isStrict && !_environment.IsStrictMode)
             {
                 _environment = new RuntimeEnvironment(_environment, strictMode: true);
@@ -1930,32 +1930,6 @@ public partial class Interpreter : IDisposable
         }
 
         return ExecutionResult.Success();
-    }
-
-    /// <summary>
-    /// Checks if the statements begin with a "use strict" directive.
-    /// </summary>
-    /// <param name="statements">The list of statements to check.</param>
-    /// <returns>True if "use strict" directive is found at the beginning.</returns>
-    private static bool CheckForUseStrict(List<Stmt> statements)
-    {
-        foreach (var stmt in statements)
-        {
-            if (stmt is Stmt.Directive directive)
-            {
-                if (directive.Value == "use strict")
-                {
-                    return true;
-                }
-                // Continue checking other directives at the start
-            }
-            else
-            {
-                // Non-directive statement encountered, stop checking
-                break;
-            }
-        }
-        return false;
     }
 
     /// <summary>

--- a/Parsing/DirectivePrologue.cs
+++ b/Parsing/DirectivePrologue.cs
@@ -1,0 +1,37 @@
+namespace SharpTS.Parsing;
+
+/// <summary>
+/// Directive-prologue queries shared by every phase (ECMA-262 §11.2.1: the
+/// prologue is the longest leading run of directive statements). One
+/// implementation replaces the four per-phase CheckForUseStrict copies
+/// (Interpreter, SharpTSFunction, SharpTSArrowFunction, ILCompiler) so strict
+/// -mode detection cannot drift between phases (2026-07 cleanup).
+/// </summary>
+public static class DirectivePrologue
+{
+    /// <summary>
+    /// True when the directive prologue of <paramref name="statements"/>
+    /// contains the "use strict" directive.
+    /// </summary>
+    public static bool HasUseStrict(List<Stmt>? statements)
+    {
+        if (statements == null) return false;
+        foreach (var stmt in statements)
+        {
+            if (stmt is Stmt.Directive directive)
+            {
+                if (directive.Value == "use strict")
+                {
+                    return true;
+                }
+                // Keep scanning the rest of the directive prologue.
+            }
+            else
+            {
+                // First non-directive statement ends the prologue.
+                break;
+            }
+        }
+        return false;
+    }
+}

--- a/Runtime/BuiltIns/Modules/Interpreter/BuiltInModuleValues.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/BuiltInModuleValues.cs
@@ -85,10 +85,8 @@ public static class BuiltInModuleValues
     /// </summary>
     public static bool HasInterpreterSupport(string moduleName)
     {
-        return moduleName is
-            "crypto" or "child_process" or "buffer"
-            or "stream" or "stream/promises" or "stream/web"
-            or "http" or "worker_threads" or "dns" or "dns/promises" or "net" or "https" or "tls"
-            or "dgram" or "cluster" or "vm";
+        // Single source of truth: the registry's module set (previously a third
+        // hand-maintained copy of the same 16-entry list — 2026-07 cleanup).
+        return BuiltInModuleRegistry.IsBuiltIn(moduleName);
     }
 }

--- a/Runtime/Types/CollectionInspect.cs
+++ b/Runtime/Types/CollectionInspect.cs
@@ -1,0 +1,19 @@
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Shared inspect-style value formatting for collection ToString output.
+/// One implementation replaces the byte-identical FormatValue copies in
+/// SharpTSMap / SharpTSSet (2026-07 cleanup).
+/// </summary>
+internal static class CollectionInspect
+{
+    public static string FormatValue(object? value) => value switch
+    {
+        null => "undefined",
+        string s => $"\"{s}\"",
+        bool b => b ? "true" : "false",
+        SharpTSArray arr => arr.ToString(),
+        SharpTSObject obj => obj.ToString(),
+        _ => value.ToString() ?? "undefined"
+    };
+}

--- a/Runtime/Types/SharpTSFunction.cs
+++ b/Runtime/Types/SharpTSFunction.cs
@@ -193,7 +193,7 @@ public class SharpTSFunction : ISharpTSCallable, ITypeCategorized
         }
 
         // Check for function-level "use strict" directive
-        bool functionStrict = CheckForUseStrict(_declaration.Body);
+        bool functionStrict = Parsing.DirectivePrologue.HasUseStrict(_declaration.Body);
         RuntimeEnvironment environment = functionStrict
             ? new RuntimeEnvironment(_closure, strictMode: true)
             : new RuntimeEnvironment(_closure);
@@ -245,28 +245,6 @@ public class SharpTSFunction : ISharpTSCallable, ITypeCategorized
         return SharpTSUndefined.Instance;
     }
 
-    /// <summary>
-    /// Checks if the statements begin with a "use strict" directive.
-    /// </summary>
-    private static bool CheckForUseStrict(List<Stmt> statements)
-    {
-        foreach (var stmt in statements)
-        {
-            if (stmt is Stmt.Directive directive)
-            {
-                if (directive.Value == "use strict")
-                {
-                    return true;
-                }
-            }
-            else
-            {
-                break;
-            }
-        }
-        return false;
-    }
-
     public SharpTSFunction Bind(SharpTSInstance instance)
     {
         RuntimeEnvironment environment = new(_closure);
@@ -316,7 +294,7 @@ public class SharpTSFunction : ISharpTSCallable, ITypeCategorized
             throw new Exception($"Cannot invoke abstract method '{_declaration.Name.Lexeme}'.");
         }
 
-        bool functionStrict = CheckForUseStrict(_declaration.Body);
+        bool functionStrict = Parsing.DirectivePrologue.HasUseStrict(_declaration.Body);
         RuntimeEnvironment environment = functionStrict
             ? new RuntimeEnvironment(_closure, strictMode: true)
             : new RuntimeEnvironment(_closure);
@@ -513,7 +491,7 @@ public class SharpTSArrowFunction : ISharpTSCallable, ITypeCategorized
     public object? Call(Interpreter interpreter, List<object?> arguments)
     {
         // Check for function-level "use strict" directive in block body
-        bool functionStrict = _declaration.BlockBody != null && CheckForUseStrict(_declaration.BlockBody);
+        bool functionStrict = _declaration.BlockBody != null && Parsing.DirectivePrologue.HasUseStrict(_declaration.BlockBody);
         RuntimeEnvironment environment = functionStrict
             ? new RuntimeEnvironment(_closure, strictMode: true)
             : new RuntimeEnvironment(_closure);
@@ -599,7 +577,7 @@ public class SharpTSArrowFunction : ISharpTSCallable, ITypeCategorized
     /// </summary>
     public RuntimeValue CallV2(Interpreter interpreter, ReadOnlySpan<RuntimeValue> arguments)
     {
-        bool functionStrict = _declaration.BlockBody != null && CheckForUseStrict(_declaration.BlockBody);
+        bool functionStrict = _declaration.BlockBody != null && Parsing.DirectivePrologue.HasUseStrict(_declaration.BlockBody);
         RuntimeEnvironment environment = functionStrict
             ? new RuntimeEnvironment(_closure, strictMode: true)
             : new RuntimeEnvironment(_closure);
@@ -667,28 +645,6 @@ public class SharpTSArrowFunction : ISharpTSCallable, ITypeCategorized
         }
 
         return RuntimeValue.Undefined;
-    }
-
-    /// <summary>
-    /// Checks if the statements begin with a "use strict" directive.
-    /// </summary>
-    private static bool CheckForUseStrict(List<Stmt> statements)
-    {
-        foreach (var stmt in statements)
-        {
-            if (stmt is Stmt.Directive directive)
-            {
-                if (directive.Value == "use strict")
-                {
-                    return true;
-                }
-            }
-            else
-            {
-                break;
-            }
-        }
-        return false;
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSMap.cs
+++ b/Runtime/Types/SharpTSMap.cs
@@ -172,17 +172,8 @@ public class SharpTSMap : ITypeCategorized, IEnumerable<object?>
     public override string ToString()
     {
         var entries = _map.Select(kvp =>
-            $"{FormatValue(DenormalizeKey(kvp.Key))} => {FormatValue(kvp.Value)}");
+            $"{CollectionInspect.FormatValue(DenormalizeKey(kvp.Key))} => {CollectionInspect.FormatValue(kvp.Value)}");
         return $"Map({_map.Count}) {{ {string.Join(", ", entries)} }}";
     }
 
-    private static string FormatValue(object? value) => value switch
-    {
-        null => "undefined",
-        string s => $"\"{s}\"",
-        bool b => b ? "true" : "false",
-        SharpTSArray arr => arr.ToString(),
-        SharpTSObject obj => obj.ToString(),
-        _ => value.ToString() ?? "undefined"
-    };
 }

--- a/Runtime/Types/SharpTSSet.cs
+++ b/Runtime/Types/SharpTSSet.cs
@@ -279,17 +279,8 @@ public class SharpTSSet : ITypeCategorized, IEnumerable<object?>
 
     public override string ToString()
     {
-        var values = _set.Select(FormatValue);
+        var values = _set.Select(CollectionInspect.FormatValue);
         return $"Set({_set.Count}) {{ {string.Join(", ", values)} }}";
     }
 
-    private static string FormatValue(object? value) => value switch
-    {
-        null => "undefined",
-        string s => $"\"{s}\"",
-        bool b => b ? "true" : "false",
-        SharpTSArray arr => arr.ToString(),
-        SharpTSObject obj => obj.ToString(),
-        _ => value.ToString() ?? "undefined"
-    };
 }

--- a/Runtime/Types/SharpTSWeakMap.cs
+++ b/Runtime/Types/SharpTSWeakMap.cs
@@ -71,17 +71,9 @@ public class SharpTSWeakMap : ITypeCategorized
         // Check for primitive types that cannot be WeakMap keys
         if (key is string or double or bool or int or long or float or decimal)
         {
-            throw new Exception($"Runtime Error: Invalid value used as weak map key. WeakMap keys must be objects, not '{GetTypeName(key)}'.");
+            throw new Exception($"Runtime Error: Invalid value used as weak map key. WeakMap keys must be objects, not '{WeakTargetErrors.TypeNameOf(key)}'.");
         }
     }
-
-    private static string GetTypeName(object value) => value switch
-    {
-        string => "string",
-        double or int or long or float or decimal => "number",
-        bool => "boolean",
-        _ => value.GetType().Name
-    };
 
     public override string ToString() => "WeakMap { <items unknown> }";
 }

--- a/Runtime/Types/SharpTSWeakRef.cs
+++ b/Runtime/Types/SharpTSWeakRef.cs
@@ -43,17 +43,9 @@ public class SharpTSWeakRef : ITypeCategorized
 
         if (target is string or double or bool or int or long or float or decimal)
         {
-            throw new Exception($"Runtime Error: Invalid value used as weak reference target. WeakRef target must be an object, not '{GetTypeName(target)}'.");
+            throw new Exception($"Runtime Error: Invalid value used as weak reference target. WeakRef target must be an object, not '{WeakTargetErrors.TypeNameOf(target)}'.");
         }
     }
-
-    private static string GetTypeName(object value) => value switch
-    {
-        string => "string",
-        double or int or long or float or decimal => "number",
-        bool => "boolean",
-        _ => value.GetType().Name
-    };
 
     public override string ToString() => "WeakRef {}";
 }

--- a/Runtime/Types/SharpTSWeakSet.cs
+++ b/Runtime/Types/SharpTSWeakSet.cs
@@ -62,17 +62,9 @@ public class SharpTSWeakSet : ITypeCategorized
         // Check for primitive types that cannot be WeakSet values
         if (value is string or double or bool or int or long or float or decimal)
         {
-            throw new Exception($"Runtime Error: Invalid value used in weak set. WeakSet values must be objects, not '{GetTypeName(value)}'.");
+            throw new Exception($"Runtime Error: Invalid value used in weak set. WeakSet values must be objects, not '{WeakTargetErrors.TypeNameOf(value)}'.");
         }
     }
-
-    private static string GetTypeName(object value) => value switch
-    {
-        string => "string",
-        double or int or long or float or decimal => "number",
-        bool => "boolean",
-        _ => value.GetType().Name
-    };
 
     public override string ToString() => "WeakSet { <items unknown> }";
 }

--- a/Runtime/Types/WeakTargetErrors.cs
+++ b/Runtime/Types/WeakTargetErrors.cs
@@ -1,0 +1,19 @@
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Shared helpers for weak-collection error messages. One implementation
+/// replaces the byte-identical GetTypeName copies in SharpTSWeakMap /
+/// SharpTSWeakSet / SharpTSWeakRef (2026-07 cleanup) so a future Symbol/BigInt
+/// conformance fix cannot drift across the weak constructs.
+/// </summary>
+internal static class WeakTargetErrors
+{
+    /// <summary>JS-flavored type name for "must be an object" error messages.</summary>
+    public static string TypeNameOf(object value) => value switch
+    {
+        string => "string",
+        double or int or long or float or decimal => "number",
+        bool => "boolean",
+        _ => value.GetType().Name
+    };
+}

--- a/TypeSystem/TypeChecker.Validation.cs
+++ b/TypeSystem/TypeChecker.Validation.cs
@@ -10,7 +10,7 @@ namespace SharpTS.TypeSystem;
 /// Contains validation methods:
 /// ValidateInterfaceImplementation, ValidateAbstractMemberImplementation,
 /// IsMethodImplemented, IsGetterImplemented, IsSetterImplemented,
-/// FindMemberInClass, ValidateOverrideMembers,
+/// FindMemberInBaseChain, ValidateOverrideMembers,
 /// HasParentMethod, HasParentGetter, HasParentSetter.
 /// </remarks>
 public partial class TypeChecker
@@ -51,7 +51,7 @@ public partial class TypeChecker
             bool isOptional = interfaceType.OptionalMembers.Contains(memberName);
 
             // Check: field, getter, or method (including inheritance chain)
-            TypeInfo? actualType = FindMemberInClass(classType, memberName);
+            TypeInfo? actualType = FindMemberInBaseChain(classType, memberName);
 
             if (actualType == null && !isOptional)
             {
@@ -339,21 +339,6 @@ public partial class TypeChecker
         return false;
     }
 
-    private TypeInfo? FindMemberInClass(TypeInfo.Class classType, string name)
-    {
-        TypeInfo? current = classType;
-        while (current != null)
-        {
-            var fieldTypes = GetFieldTypes(current);
-            var getters = GetGetters(current);
-            var methods = GetMethods(current);
-            if (fieldTypes != null && fieldTypes.TryGetValue(name, out var ft)) return ft;
-            if (getters != null && getters.TryGetValue(name, out var gt)) return gt;
-            if (methods != null && methods.TryGetValue(name, out var mt)) return mt;
-            current = GetSuperclass(current);
-        }
-        return null;
-    }
 
     /// <summary>
     /// Validates that a class's own members are compatible with the members it overrides from its


### PR DESCRIPTION
Sixth tier of the cleanup audit stack (on #1299) — the first, lowest-risk slice of the consolidation backlog: four clusters where the copies were byte-identical (or provably equivalent) and the extraction is mechanical. Full suite 15,747/15,747 green.

**Remaining consolidation backlog** (documented in the audit; each is a #1293-style one-cluster-per-commit refactor deserving fresh-session focus with full gates — several touch semantics-bearing paths):
- Interpreter: `EvaluateNew` sync/async/Construct triplication (~344 lines; the `IEvaluationContext` pattern 12 other operations already use); class-declaration vs class-expression duplication (~250 lines); the 17-argument `SharpTSClass` constructor ×4
- Parser: `ClassExpression` ≈ `ClassDeclaration` (~380 lines → shared `ParseClassBody`); `TryParseTypeArguments` pair; residual parameter-list preambles
- TypeChecker: `CheckSet` re-implements the read-side member dispatch (~360 lines → `CheckSetOnType`); null-strip idiom ×5 with divergent empty-cases; `Expand{Partial,Required,Readonly}` skeleton; interface pre-register/check pair; the 4× check-entry hoist preamble (verify the `HoistClassDeclarations` divergence while there); a TS-code/message factory
- Runtime: object integrity state ×3 + the 11 receiver switches (`IntegrityOps`); `TcpServerBase` for Net/Tls (+ the address formatter ×4); `FunctionObjectProperties` extraction (~272 lines); the rebind cascade via widened `IReceiverBindable`; fs/crypto/dns async-callback scaffolds (~450-600 lines)
- Compilation: `ILEmitter.Calls.*` → the existing `EmitArgsArray`/`EmitBoxedArgumentOrNull` helpers (~300 lines); `Arrays.Iterators` scaffold ×11; `EmitReflectionCall` instance variant ×13; private-field emit ×3; class-expr property body; thread `ctx.Runtime` into the 4 state-machine helper constructions and delete the divergent comparison fallback; hoist a `const` for the 5 `Ldstr "Call"` reflection-contract literals
- Plumbing: `ProcessBuiltIns` diagnostics/report → `CreateV2`; `BuiltInAsyncMethod` V2 support + shared `Bind`/validation base; delete the 20 V2→boxed shims; migrate the ~11 hot boxed-only `ISharpTSCallable` implementors
- Cross-runtime constants: the RFC MODP prime tables duplicated between `SharpTSDiffieHellman` and `RuntimeEmitter.TSDH` (safe to share — `Ldstr` embeds the value, no assembly-reference leak)