### PR TITLE
Add first-class TypeScript project-system support

### DIFF
--- a/Cli/CommandLineParser.cs
+++ b/Cli/CommandLineParser.cs
@@ -54,6 +54,9 @@ namespace SharpTS.Cli;
 /// <c>--showConfig</c>: print the resolved configuration, with the source of each value, then
 /// exit 0.
 /// </param>
+/// <param name="Watch">Recheck a project when its inputs change.</param>
+/// <param name="Incremental">Reuse SharpTS project build state when inputs are unchanged.</param>
+/// <param name="Force">Ignore build state and check every project.</param>
 public record GlobalOptions(
     DecoratorMode DecoratorMode = DecoratorMode.Stage3,
     bool EmitDecoratorMetadata = false,
@@ -63,7 +66,10 @@ public record GlobalOptions(
     bool NoEmit = false,
     string? ProjectPath = null,
     bool NoTsConfig = false,
-    bool ShowConfig = false
+    bool ShowConfig = false,
+    bool Watch = false,
+    bool Incremental = false,
+    bool Force = false
 )
 {
     public IReadOnlyList<string> References { get; init; } = References ?? [];
@@ -137,6 +143,12 @@ public abstract record ParsedCommand
     /// <param name="Options">Global options for the session</param>
     public sealed record Repl(GlobalOptions Options) : ParsedCommand;
 
+    /// <summary>Type-check every root selected by a tsconfig project.</summary>
+    public sealed record Project(GlobalOptions Options) : ParsedCommand;
+
+    /// <summary>Type-check one or more project-reference graphs in dependency order.</summary>
+    public sealed record Build(IReadOnlyList<string> ProjectPaths, GlobalOptions Options) : ParsedCommand;
+
     /// <summary>Execute a TypeScript file with optional arguments.</summary>
     /// <param name="ScriptPath">Path to the TypeScript file</param>
     /// <param name="ScriptArgs">Arguments passed to the script (process.argv)</param>
@@ -204,10 +216,42 @@ public class CommandLineParser
         var (globalOptions, remainingArgs, scriptArgs, globalError) = ParseGlobalOptions(args);
         if (globalError is not null)
             return globalError;
+        if (globalOptions.ProjectPath is not null && globalOptions.NoTsConfig)
+        {
+            return new ParsedCommand.Error(
+                "Error: --project cannot be combined with --no-tsconfig.",
+                64);
+        }
 
         if (remainingArgs.Length == 0)
         {
+            if (globalOptions.ProjectPath is not null)
+                return new ParsedCommand.Project(globalOptions);
+            if (globalOptions.Watch || globalOptions.Incremental || globalOptions.Force)
+            {
+                return new ParsedCommand.Error(
+                    "Error: --watch, --incremental, and --force require -p/--project or --build.",
+                    64);
+            }
             return new ParsedCommand.Repl(globalOptions);
+        }
+
+        // Handle project-reference build mode.
+        if (remainingArgs[0] is "--build" or "-b")
+        {
+            if (globalOptions.ProjectPath is not null)
+                return new ParsedCommand.Error("Error: --build cannot be combined with --project.", 64);
+            var projects = remainingArgs.Skip(1).ToArray();
+            if (projects.Any(path => path.StartsWith('-')))
+                return new ParsedCommand.Error($"Error: Unknown build option '{projects.First(path => path.StartsWith('-'))}'.", 64);
+            return new ParsedCommand.Build(projects.Length == 0 ? ["."] : projects, globalOptions);
+        }
+
+        if (globalOptions.Watch || globalOptions.Incremental || globalOptions.Force)
+        {
+            return new ParsedCommand.Error(
+                "Error: --watch, --incremental, and --force apply to a project command or --build, not a script/compile command.",
+                64);
         }
 
         // Handle --compile / -c
@@ -294,6 +338,9 @@ public class CommandLineParser
         var noEmit = false;
         var noTsConfig = false;
         var showConfig = false;
+        var watch = false;
+        var incremental = false;
+        var force = false;
         string? projectPath = null;
         var strictness = new StrictnessOptions();
         List<string> references = [];
@@ -373,6 +420,19 @@ public class CommandLineParser
                     if (!TryParseFlagBool(value, out flag)) return (default!, [], [], BadBool(name, value));
                     showConfig = flag;
                     break;
+                case "-w":
+                case "--watch":
+                    if (!TryParseFlagBool(value, out flag)) return (default!, [], [], BadBool(name, value));
+                    watch = flag;
+                    break;
+                case "--incremental":
+                    if (!TryParseFlagBool(value, out flag)) return (default!, [], [], BadBool(name, value));
+                    incremental = flag;
+                    break;
+                case "--force":
+                    if (!TryParseFlagBool(value, out flag)) return (default!, [], [], BadBool(name, value));
+                    force = flag;
+                    break;
                 case "-p" or "--project" when value is not null:
                     projectPath = value;
                     break;
@@ -397,7 +457,7 @@ public class CommandLineParser
 
         var options = new GlobalOptions(
             decoratorMode, emitDecoratorMetadata, checkJs, references, strictness, noEmit,
-            projectPath, noTsConfig, showConfig);
+            projectPath, noTsConfig, showConfig, watch, incremental, force);
         return (options, remaining.ToArray(), scriptArgs.ToArray(), null);
     }
 

--- a/Configuration/ModuleResolutionOptions.cs
+++ b/Configuration/ModuleResolutionOptions.cs
@@ -1,0 +1,39 @@
+namespace SharpTS.Configuration;
+
+/// <summary>
+/// TypeScript module resolution strategies understood by SharpTS.
+/// </summary>
+public enum ModuleResolutionMode
+{
+    /// <summary>TypeScript's pre-Node resolver. Bare names resolve only through paths/baseUrl.</summary>
+    Classic,
+
+    /// <summary>Legacy Node resolution. Package exports/imports maps are not consulted.</summary>
+    Node10,
+
+    /// <summary>Node's dual ESM/CommonJS resolver, including package exports/imports.</summary>
+    Node16,
+
+    /// <summary>Node16 behavior with the modern NodeNext spelling.</summary>
+    NodeNext,
+
+    /// <summary>Bundler-oriented resolution with paths and package exports/imports.</summary>
+    Bundler,
+}
+
+/// <summary>
+/// Fully resolved, path-absolute module resolution configuration.
+/// </summary>
+public sealed record ModuleResolutionOptions(
+    ModuleResolutionMode Mode,
+    string? BaseUrl,
+    IReadOnlyDictionary<string, IReadOnlyList<string>> Paths,
+    IReadOnlyList<string>? TypeRoots = null)
+{
+    public static ModuleResolutionOptions Default { get; } =
+        new(ModuleResolutionMode.Node16, null,
+            new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal));
+
+    public bool UsesPackageMaps =>
+        Mode is ModuleResolutionMode.Node16 or ModuleResolutionMode.NodeNext or ModuleResolutionMode.Bundler;
+}

--- a/Configuration/TsConfigDeclarationResolver.cs
+++ b/Configuration/TsConfigDeclarationResolver.cs
@@ -1,0 +1,177 @@
+using System.Text.Json;
+
+namespace SharpTS.Configuration;
+
+/// <summary>Resolves explicitly selected TypeScript libs and visible <c>@types</c> packages.</summary>
+internal static class TsConfigDeclarationResolver
+{
+    public static IReadOnlyList<string> Resolve(
+        string configDirectory,
+        IReadOnlyList<string>? libs,
+        IReadOnlyList<string>? types,
+        IReadOnlyList<string>? typeRoots)
+    {
+        var comparer = OperatingSystem.IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+        var result = new HashSet<string>(comparer);
+
+        if (libs is not null)
+        {
+            foreach (string lib in libs)
+                result.Add(ResolveLib(configDirectory, lib));
+        }
+
+        var roots = typeRoots?.ToArray() ?? FindVisibleTypeRoots(configDirectory).ToArray();
+        if (types is not null)
+        {
+            foreach (string type in types)
+                result.Add(ResolveTypePackage(type, roots));
+        }
+        else
+        {
+            foreach (string root in roots)
+            {
+                if (!Directory.Exists(root))
+                    continue;
+                foreach (string directory in Directory.EnumerateDirectories(root))
+                {
+                    string name = Path.GetFileName(directory);
+                    if (name.StartsWith('.'))
+                        continue;
+                    string? entry = TryFindDeclarationEntry(directory);
+                    if (entry is not null)
+                        result.Add(entry);
+                }
+            }
+        }
+
+        return result.OrderBy(p => p, comparer).ToArray();
+    }
+
+    public static string ResolveLibReference(string containingFile, string name) =>
+        ResolveLib(Path.GetDirectoryName(Path.GetFullPath(containingFile))!, name);
+
+    public static string ResolveTypeReference(
+        string containingFile,
+        string name,
+        IReadOnlyList<string>? typeRoots)
+    {
+        string directory = Path.GetDirectoryName(Path.GetFullPath(containingFile))!;
+        var roots = typeRoots?.ToArray() ?? FindVisibleTypeRoots(directory).ToArray();
+        return ResolveTypePackage(name, roots);
+    }
+
+    private static string ResolveLib(string configDirectory, string name)
+    {
+        string fileName = name.StartsWith("lib.", StringComparison.OrdinalIgnoreCase)
+            ? name
+            : $"lib.{name}";
+        if (!fileName.EndsWith(".d.ts", StringComparison.OrdinalIgnoreCase))
+            fileName += ".d.ts";
+
+        foreach (string directory in Ancestors(configDirectory))
+        {
+            string candidate = Path.Combine(directory, "node_modules", "typescript", "lib", fileName);
+            if (File.Exists(candidate))
+                return Path.GetFullPath(candidate);
+        }
+
+        throw new Exception(
+            $"Error: tsconfig.json: cannot resolve lib '{name}'. Install the 'typescript' package " +
+            $"so '{fileName}' is available under node_modules/typescript/lib.");
+    }
+
+    private static string ResolveTypePackage(string type, IReadOnlyList<string> roots)
+    {
+        string packageDirectoryName = type.StartsWith('@')
+            ? type[1..].Replace("/", "__", StringComparison.Ordinal)
+            : type;
+
+        foreach (string root in roots)
+        {
+            string directory = Path.Combine(root, packageDirectoryName);
+            string? entry = TryFindDeclarationEntry(directory);
+            if (entry is not null)
+                return entry;
+        }
+
+        throw new Exception(
+            $"Error: tsconfig.json: cannot find type definition package '{type}' in: " +
+            string.Join(", ", roots));
+    }
+
+    private static string? TryFindDeclarationEntry(string packageDirectory)
+    {
+        if (!Directory.Exists(packageDirectory))
+            return null;
+
+        string packageJson = Path.Combine(packageDirectory, "package.json");
+        if (File.Exists(packageJson))
+        {
+            try
+            {
+                using var document = JsonDocument.Parse(
+                    File.ReadAllText(packageJson),
+                    new JsonDocumentOptions { AllowTrailingCommas = true, CommentHandling = JsonCommentHandling.Skip });
+                var root = document.RootElement;
+                foreach (string key in new[] { "types", "typings" })
+                {
+                    if (root.TryGetProperty(key, out var property) &&
+                        property.ValueKind == JsonValueKind.String)
+                    {
+                        string candidate = Path.GetFullPath(
+                            Path.Combine(packageDirectory, property.GetString()!));
+                        if (File.Exists(candidate))
+                            return candidate;
+                    }
+                }
+            }
+            catch (JsonException)
+            {
+                // Module loading will produce the actionable package error if this package is imported.
+            }
+        }
+
+        string index = Path.Combine(packageDirectory, "index.d.ts");
+        return File.Exists(index) ? Path.GetFullPath(index) : null;
+    }
+
+    private static IEnumerable<string> FindVisibleTypeRoots(string startDirectory)
+    {
+        string[] ceilings =
+            new[]
+            {
+                Path.GetTempPath(),
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            }
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar))
+            .ToArray();
+        bool isStartDirectory = true;
+        foreach (string directory in Ancestors(startDirectory))
+        {
+            string normalized = directory.TrimEnd(Path.DirectorySeparatorChar);
+            if (!isStartDirectory && ceilings.Any(ceiling =>
+                    string.Equals(normalized, ceiling, StringComparison.OrdinalIgnoreCase)))
+            {
+                yield break;
+            }
+
+            string root = Path.Combine(directory, "node_modules", "@types");
+            if (Directory.Exists(root))
+                yield return Path.GetFullPath(root);
+            isStartDirectory = false;
+        }
+    }
+
+    private static IEnumerable<string> Ancestors(string startDirectory)
+    {
+        string? directory = Path.GetFullPath(startDirectory);
+        while (directory is not null)
+        {
+            yield return directory;
+            directory = Path.GetDirectoryName(directory);
+        }
+    }
+}

--- a/Configuration/TsConfigFileMatcher.cs
+++ b/Configuration/TsConfigFileMatcher.cs
@@ -1,0 +1,198 @@
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace SharpTS.Configuration;
+
+/// <summary>
+/// Expands a tsconfig's <c>files</c>/<c>include</c>/<c>exclude</c> fields into root files.
+/// Imported files are intentionally not filtered here; the module resolver adds those later.
+/// </summary>
+internal static class TsConfigFileMatcher
+{
+    public static IReadOnlyList<string> Resolve(
+        IReadOnlyList<string>? files,
+        IReadOnlyList<string>? includes,
+        IReadOnlyList<string>? excludes,
+        string configDirectory,
+        string? outDir,
+        bool allowJs)
+    {
+        var comparer = OperatingSystem.IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+        var roots = new HashSet<string>(comparer);
+
+        // `files` entries are never filtered by `exclude`.
+        if (files is not null)
+        {
+            foreach (string file in files)
+            {
+                string full = Path.GetFullPath(file);
+                if (!File.Exists(full))
+                    throw new Exception($"Error: tsconfig.json: file '{full}' listed in 'files' does not exist.");
+                if (IsSupportedSource(full, allowJs))
+                    roots.Add(full);
+            }
+        }
+
+        // An explicit `files: []` with no include means exactly no roots. When neither field
+        // appears, TypeScript's implicit include is **/*.
+        IReadOnlyList<string> effectiveIncludes = includes
+            ?? (files is null ? [Path.Combine(configDirectory, "**", "*")] : []);
+
+        var effectiveExcludes = excludes is null
+            ? new List<string>
+            {
+                Path.Combine(configDirectory, "node_modules"),
+                Path.Combine(configDirectory, "bower_components"),
+                Path.Combine(configDirectory, "jspm_packages"),
+            }
+            : [.. excludes];
+        if (excludes is null && outDir is not null)
+            effectiveExcludes.Add(outDir);
+
+        var excludeMatchers = effectiveExcludes
+            .Select(pattern => CreateMatcher(pattern, matchDirectoryDescendants: true))
+            .ToArray();
+        foreach (string include in effectiveIncludes)
+        {
+            string pattern = NormalizeInclude(include);
+            foreach (string candidate in EnumerateCandidates(pattern))
+            {
+                string full = Path.GetFullPath(candidate);
+                if (!IsSupportedSource(full, allowJs))
+                    continue;
+                if (excludeMatchers.Any(m => m(full)))
+                    continue;
+                roots.Add(full);
+            }
+        }
+
+        return roots.OrderBy(p => p, comparer).ToArray();
+    }
+
+    private static bool IsSupportedSource(string path, bool allowJs)
+    {
+        string normalized = path.Replace('\\', '/');
+        if (normalized.EndsWith(".d.ts", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        string extension = Path.GetExtension(path).ToLowerInvariant();
+        if (extension is ".ts" or ".tsx" or ".mts" or ".cts")
+            return true;
+        return allowJs && extension is ".js" or ".jsx" or ".mjs" or ".cjs";
+    }
+
+    private static string NormalizeInclude(string include)
+    {
+        string full = Path.GetFullPath(include);
+        if (ContainsWildcard(full))
+            return full;
+        if (File.Exists(full) || Path.HasExtension(full))
+            return full;
+        return Path.Combine(full, "**", "*");
+    }
+
+    private static IEnumerable<string> EnumerateCandidates(string pattern)
+    {
+        if (!ContainsWildcard(pattern))
+        {
+            if (File.Exists(pattern))
+                yield return pattern;
+            yield break;
+        }
+
+        string root = SearchRoot(pattern);
+        if (!Directory.Exists(root))
+            yield break;
+
+        var matches = CreateMatcher(pattern);
+        var enumeration = new EnumerationOptions
+        {
+            RecurseSubdirectories = true,
+            IgnoreInaccessible = true,
+            AttributesToSkip = FileAttributes.ReparsePoint,
+        };
+        foreach (string file in Directory.EnumerateFiles(root, "*", enumeration))
+        {
+            if (matches(file))
+                yield return file;
+        }
+    }
+
+    private static string SearchRoot(string pattern)
+    {
+        int wildcard = pattern.IndexOfAny(['*', '?']);
+        string prefix = wildcard < 0 ? pattern : pattern[..wildcard];
+        bool endsAtDirectoryBoundary =
+            prefix.EndsWith(Path.DirectorySeparatorChar) ||
+            prefix.EndsWith(Path.AltDirectorySeparatorChar);
+        if (endsAtDirectoryBoundary)
+            return Path.GetFullPath(prefix);
+
+        string trimmed = prefix.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        string? root = Path.GetDirectoryName(trimmed);
+        if (string.IsNullOrEmpty(root))
+            root = Path.GetPathRoot(Path.GetFullPath(pattern));
+        return root ?? Directory.GetCurrentDirectory();
+    }
+
+    private static Func<string, bool> CreateMatcher(
+        string pattern,
+        bool matchDirectoryDescendants = false)
+    {
+        string full = Path.GetFullPath(pattern);
+        string finalSegment = Path.GetFileName(full);
+        if (matchDirectoryDescendants &&
+            !Path.HasExtension(finalSegment) &&
+            !ContainsWildcard(finalSegment))
+        {
+            full = Path.Combine(full, "**", "*");
+        }
+        if (!ContainsWildcard(full) && !Path.HasExtension(full))
+            full = Path.Combine(full, "**", "*");
+
+        string normalized = full.Replace('\\', '/').TrimEnd('/');
+        var regex = new StringBuilder("^");
+        for (int i = 0; i < normalized.Length; i++)
+        {
+            char c = normalized[i];
+            if (c == '*' && i + 1 < normalized.Length && normalized[i + 1] == '*')
+            {
+                i++;
+                if (i + 1 < normalized.Length && normalized[i + 1] == '/')
+                {
+                    i++;
+                    regex.Append("(?:.*/)?");
+                }
+                else
+                {
+                    regex.Append(".*");
+                }
+            }
+            else if (c == '*')
+            {
+                regex.Append("[^/]*");
+            }
+            else if (c == '?')
+            {
+                regex.Append("[^/]");
+            }
+            else
+            {
+                regex.Append(Regex.Escape(c.ToString()));
+            }
+        }
+
+        regex.Append('$');
+
+        var options = RegexOptions.CultureInvariant | RegexOptions.Compiled;
+        if (OperatingSystem.IsWindows())
+            options |= RegexOptions.IgnoreCase;
+        var matcher = new Regex(regex.ToString(), options);
+        return path => matcher.IsMatch(Path.GetFullPath(path).Replace('\\', '/').TrimEnd('/'));
+    }
+
+    private static bool ContainsWildcard(string value) =>
+        value.IndexOfAny(['*', '?']) >= 0;
+}

--- a/Configuration/TsConfigJson.Cli.cs
+++ b/Configuration/TsConfigJson.Cli.cs
@@ -26,6 +26,9 @@ internal sealed partial class TsConfigJson
     [JsonPropertyName("exclude")]
     public string[]? Exclude { get; set; }
 
+    [JsonPropertyName("references")]
+    public TsConfigProjectReference[]? References { get; set; }
+
     /// <summary>
     /// Top-level keys SharpTS did not bind. Drives the "unknown key / did you mean" warnings;
     /// keys keep the casing the user wrote so the message can echo it back.
@@ -51,6 +54,36 @@ internal sealed partial class TsConfigCompilerOptions
     [JsonPropertyName("checkJs")]
     public bool? CheckJs { get; set; }
 
+    [JsonPropertyName("allowJs")]
+    public bool? AllowJs { get; set; }
+
+    [JsonPropertyName("baseUrl")]
+    public string? BaseUrl { get; set; }
+
+    [JsonPropertyName("paths")]
+    public Dictionary<string, string[]>? Paths { get; set; }
+
+    [JsonPropertyName("moduleResolution")]
+    public string? ModuleResolution { get; set; }
+
+    [JsonPropertyName("lib")]
+    public string[]? Lib { get; set; }
+
+    [JsonPropertyName("types")]
+    public string[]? Types { get; set; }
+
+    [JsonPropertyName("typeRoots")]
+    public string[]? TypeRoots { get; set; }
+
+    [JsonPropertyName("incremental")]
+    public bool? Incremental { get; set; }
+
+    [JsonPropertyName("composite")]
+    public bool? Composite { get; set; }
+
+    [JsonPropertyName("tsBuildInfoFile")]
+    public string? TsBuildInfoFile { get; set; }
+
     /// <summary>See <see cref="TsConfigJson.UnknownKeys"/>.</summary>
     [JsonExtensionData]
     public Dictionary<string, JsonElement>? UnknownKeys { get; set; }
@@ -63,4 +96,10 @@ internal sealed partial class TsConfigCompilerOptions
         StrictFunctionTypes = StrictFunctionTypes,
         NoImplicitAny = NoImplicitAny,
     };
+}
+
+internal sealed class TsConfigProjectReference
+{
+    [JsonPropertyName("path")]
+    public string? Path { get; set; }
 }

--- a/Configuration/TsConfigKeyCatalog.cs
+++ b/Configuration/TsConfigKeyCatalog.cs
@@ -30,7 +30,8 @@ internal static class TsConfigKeyCatalog
     [
         "strict", "strictNullChecks", "strictFunctionTypes", "noImplicitAny", "checkJs",
         "preserveConstEnums", "experimentalDecorators", "decorators", "emitDecoratorMetadata",
-        "rootDir", "outDir",
+        "rootDir", "outDir", "allowJs", "moduleResolution", "lib", "baseUrl", "paths",
+        "typeRoots", "types", "incremental", "composite", "tsBuildInfoFile",
     ];
 
     /// <summary>
@@ -39,13 +40,12 @@ internal static class TsConfigKeyCatalog
     /// </summary>
     private static readonly HashSet<string> EmitOptions = new(StringComparer.OrdinalIgnoreCase)
     {
-        "target", "module", "moduleResolution", "moduleDetection", "lib", "jsx", "jsxFactory",
+        "target", "module", "moduleDetection", "jsx", "jsxFactory",
         "jsxFragmentFactory", "jsxImportSource", "declaration", "declarationMap", "declarationDir",
         "sourceMap", "inlineSourceMap", "inlineSources", "sourceRoot", "mapRoot", "outFile", "out",
         "removeComments", "importHelpers", "downlevelIteration", "isolatedModules",
         "verbatimModuleSyntax", "esModuleInterop", "allowSyntheticDefaultImports",
-        "resolveJsonModule", "allowJs", "baseUrl", "paths", "typeRoots", "types", "incremental",
-        "composite", "tsBuildInfoFile", "skipLibCheck", "skipDefaultLibCheck", "noEmit",
+        "resolveJsonModule", "skipLibCheck", "skipDefaultLibCheck", "noEmit",
         "noEmitOnError", "noEmitHelpers", "newLine", "pretty", "plugins", "noResolve",
         "preserveSymlinks", "forceConsistentCasingInFileNames", "useDefineForClassFields",
         "emitBOM", "charset", "watchOptions", "allowImportingTsExtensions", "allowArbitraryExtensions",
@@ -62,10 +62,10 @@ internal static class TsConfigKeyCatalog
     };
 
     private static readonly string[] AppliedTopLevel =
-        ["compilerOptions", "files", "include", "exclude", "extends"];
+        ["compilerOptions", "files", "include", "exclude", "extends", "references"];
 
     private static readonly HashSet<string> KnownTopLevel = new(StringComparer.OrdinalIgnoreCase)
-        { "references", "compileOnSave", "typeAcquisition", "ts-node", "watchOptions", "$schema" };
+        { "compileOnSave", "typeAcquisition", "ts-node", "watchOptions", "$schema" };
 
     /// <summary>Formats every note for one file in an extends chain.</summary>
     public static IEnumerable<string> Diagnose(string configPath, TsConfigJson json)

--- a/Configuration/TsConfigLoader.cs
+++ b/Configuration/TsConfigLoader.cs
@@ -190,9 +190,16 @@ public static class TsConfigLoader
     private static TsConfigResult Fold(List<(string Path, TsConfigJson Json)> chain)
     {
         var strictness = new StrictnessOptions();
-        bool? checkJs = null, preserveConstEnums = null, emitDecoratorMetadata = null;
+        bool? checkJs = null, allowJs = null, preserveConstEnums = null, emitDecoratorMetadata = null;
+        bool? incremental = null, composite = null;
         DecoratorMode? decoratorMode = null;
-        string? outDir = null, entryFile = null;
+        string? rootDir = null, outDir = null, baseUrl = null, buildInfoFile = null;
+        IReadOnlyList<string>? files = null, includes = null, excludes = null;
+        IReadOnlyList<string>? libs = null, types = null, typeRoots = null;
+        IReadOnlyDictionary<string, IReadOnlyList<string>> paths =
+            new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
+        // Preserve SharpTS's pre-project-system resolver behavior (package exports/imports).
+        ModuleResolutionMode resolutionMode = ModuleResolutionMode.Node16;
         var warnings = new List<string>();
 
         foreach (var (path, json) in chain)
@@ -213,8 +220,11 @@ public static class TsConfigLoader
                 };
 
                 checkJs = opts.CheckJs ?? checkJs;
+                allowJs = opts.AllowJs ?? allowJs;
                 preserveConstEnums = opts.PreserveConstEnums ?? preserveConstEnums;
                 emitDecoratorMetadata = opts.EmitDecoratorMetadata ?? emitDecoratorMetadata;
+                incremental = opts.Incremental ?? incremental;
+                composite = opts.Composite ?? composite;
 
                 // `decorators` (Stage 3) wins over `experimentalDecorators` (Legacy) when both
                 // are set — the same precedence the CLI's last-wins switch gives the arguments
@@ -222,16 +232,57 @@ public static class TsConfigLoader
                 if (opts.ExperimentalDecorators == true) decoratorMode = Parsing.DecoratorMode.Legacy;
                 if (opts.Decorators == true) decoratorMode = Parsing.DecoratorMode.Stage3;
 
+                if (!string.IsNullOrWhiteSpace(opts.RootDir))
+                    rootDir = Path.GetFullPath(Path.Combine(dir, opts.RootDir!));
                 if (!string.IsNullOrWhiteSpace(opts.OutDir))
                     outDir = Path.GetFullPath(Path.Combine(dir, opts.OutDir!));
+                if (!string.IsNullOrWhiteSpace(opts.BaseUrl))
+                    baseUrl = Path.GetFullPath(Path.Combine(dir, opts.BaseUrl!));
+                if (!string.IsNullOrWhiteSpace(opts.TsBuildInfoFile))
+                    buildInfoFile = Path.GetFullPath(Path.Combine(dir, opts.TsBuildInfoFile!));
+
+                if (!string.IsNullOrWhiteSpace(opts.ModuleResolution))
+                    resolutionMode = ParseModuleResolution(opts.ModuleResolution!, path);
+
+                if (opts.Paths is not null)
+                {
+                    string pathsBase = baseUrl ?? dir;
+                    paths = opts.Paths.ToDictionary(
+                        pair => pair.Key,
+                        pair => (IReadOnlyList<string>)pair.Value
+                            .Select(value => Path.GetFullPath(Path.Combine(pathsBase, value)))
+                            .ToArray(),
+                        StringComparer.Ordinal);
+                }
+
+                if (opts.Lib is not null)
+                    libs = opts.Lib.ToArray();
+                if (opts.Types is not null)
+                    types = opts.Types.ToArray();
+                if (opts.TypeRoots is not null)
+                    typeRoots = opts.TypeRoots
+                        .Select(value => Path.GetFullPath(Path.Combine(dir, value)))
+                        .ToArray();
             }
 
             // `files`/`include`/`exclude` replace rather than merge (tsc's rule).
-            if (json.Files is { Length: > 0 })
-                entryFile = Path.GetFullPath(Path.Combine(dir, json.Files[0]));
+            if (json.Files is not null)
+                files = json.Files.Select(value => Path.GetFullPath(Path.Combine(dir, value))).ToArray();
+            if (json.Include is not null)
+                includes = json.Include.Select(value => Path.GetFullPath(Path.Combine(dir, value))).ToArray();
+            if (json.Exclude is not null)
+                excludes = json.Exclude.Select(value => Path.GetFullPath(Path.Combine(dir, value))).ToArray();
         }
 
         var leaf = chain[^1];
+        string configDirectory = Path.GetDirectoryName(leaf.Path)!;
+        bool effectiveAllowJs = allowJs == true || checkJs == true;
+        var rootFiles = TsConfigFileMatcher.Resolve(
+            files, includes, excludes, configDirectory, outDir, effectiveAllowJs);
+        var declarationFiles = TsConfigDeclarationResolver.Resolve(
+            configDirectory, libs, types, typeRoots);
+        var references = ResolveProjectReferences(leaf.Json.References, configDirectory, leaf.Path);
+
         return new TsConfigResult(
             ConfigPath: leaf.Path,
             ExtendsChain: chain.Select(c => c.Path).ToArray(),
@@ -240,9 +291,62 @@ public static class TsConfigLoader
             PreserveConstEnums: preserveConstEnums,
             DecoratorMode: decoratorMode,
             EmitDecoratorMetadata: emitDecoratorMetadata,
+            RootDir: rootDir,
             OutDir: outDir,
-            EntryFile: entryFile,
+            EntryFile: files?.FirstOrDefault(),
+            RootFiles: rootFiles,
+            DeclarationFiles: declarationFiles,
+            ProjectReferences: references,
+            ModuleResolution: new ModuleResolutionOptions(resolutionMode, baseUrl, paths, typeRoots),
+            Lib: libs,
+            Types: types,
+            TypeRoots: typeRoots,
+            Incremental: incremental,
+            Composite: composite,
+            BuildInfoFile: ResolveBuildInfoFile(buildInfoFile, outDir, leaf.Path),
             Warnings: warnings);
+    }
+
+    private static ModuleResolutionMode ParseModuleResolution(string value, string configPath) =>
+        value.ToLowerInvariant() switch
+        {
+            "classic" => ModuleResolutionMode.Classic,
+            "node" or "node10" => ModuleResolutionMode.Node10,
+            "node16" => ModuleResolutionMode.Node16,
+            "nodenext" => ModuleResolutionMode.NodeNext,
+            "bundler" => ModuleResolutionMode.Bundler,
+            _ => throw new Exception(
+                $"Error: {FileName} ('{configPath}'): unsupported moduleResolution '{value}'. " +
+                "Use classic, node10, node16, nodenext, or bundler."),
+        };
+
+    private static IReadOnlyList<string> ResolveProjectReferences(
+        IReadOnlyList<TsConfigProjectReference>? references,
+        string configDirectory,
+        string configPath)
+    {
+        if (references is null)
+            return [];
+
+        var result = new List<string>();
+        foreach (var reference in references)
+        {
+            if (string.IsNullOrWhiteSpace(reference.Path))
+                throw new Exception($"Error: {FileName} ('{configPath}'): every project reference requires a 'path'.");
+            string candidate = Path.GetFullPath(Path.Combine(configDirectory, reference.Path));
+            result.Add(ResolveProjectPath(candidate));
+        }
+        return result;
+    }
+
+    private static string ResolveBuildInfoFile(string? configured, string? outDir, string configPath)
+    {
+        // SharpTS build-state data is deliberately kept separate from tsc's incompatible
+        // .tsbuildinfo format, even when both tools share tsBuildInfoFile.
+        if (configured is not null)
+            return configured + ".sharpts";
+        string directory = outDir ?? Path.GetDirectoryName(configPath)!;
+        return Path.Combine(directory, Path.GetFileNameWithoutExtension(configPath) + ".sharptsbuildinfo");
     }
 
     private static StringComparison PathComparison =>
@@ -256,8 +360,8 @@ public static class TsConfigLoader
 /// <param name="ConfigPath">Absolute path of the tsconfig.json that was loaded.</param>
 /// <param name="ExtendsChain">Every file in the chain, base first, ending with <paramref name="ConfigPath"/>.</param>
 /// <param name="EntryFile">
-/// <c>files[0]</c>, absolute. Used as the entry point only for <c>-p</c>/<c>--project</c> with no
-/// script argument — mirroring <c>ReadTsConfigTask</c> so the CLI and MSBuild pick the same file.
+/// <c>files[0]</c>, absolute. Retained as the default runtime entry point for the MSBuild SDK;
+/// project checks use every file in <see cref="TsConfigResult.RootFiles"/>.
 /// </param>
 /// <param name="Warnings">Unknown/inapplicable-key notes, already formatted for display.</param>
 public sealed record TsConfigResult(
@@ -268,6 +372,17 @@ public sealed record TsConfigResult(
     bool? PreserveConstEnums,
     DecoratorMode? DecoratorMode,
     bool? EmitDecoratorMetadata,
+    string? RootDir,
     string? OutDir,
     string? EntryFile,
+    IReadOnlyList<string> RootFiles,
+    IReadOnlyList<string> DeclarationFiles,
+    IReadOnlyList<string> ProjectReferences,
+    ModuleResolutionOptions ModuleResolution,
+    IReadOnlyList<string>? Lib,
+    IReadOnlyList<string>? Types,
+    IReadOnlyList<string>? TypeRoots,
+    bool? Incremental,
+    bool? Composite,
+    string BuildInfoFile,
     IReadOnlyList<string> Warnings);

--- a/Modules/ModuleResolver.cs
+++ b/Modules/ModuleResolver.cs
@@ -1,4 +1,5 @@
 using System.Collections.Frozen;
+using SharpTS.Configuration;
 using SharpTS.Modules.Stdlib;
 using SharpTS.Modules.Stdlib.Providers;
 using SharpTS.Parsing;
@@ -32,11 +33,14 @@ public enum ResolutionKind
 /// </remarks>
 public class ModuleResolver
 {
+    private const string AmbientModulePrefix = "ambient:";
     private readonly string _basePath;
+    private readonly ModuleResolutionOptions _resolutionOptions;
     private readonly Dictionary<string, ParsedModule> _moduleCache = [];
     private readonly HashSet<string> _loadingModules = [];  // For circular detection
     private readonly HashSet<string> _loadingScriptRefs = [];  // For circular script reference detection
     private readonly Dictionary<string, ModulePackageJson?> _packageJsonCache = [];
+    private readonly Dictionary<string, string> _ambientModulePaths = new(StringComparer.Ordinal);
     private readonly StdlibProviderChain _stdlibChain;
     /// <summary>
     /// Optional in-memory virtual file system. When non-null, all file existence checks and
@@ -52,7 +56,7 @@ public class ModuleResolver
     /// Creates a new module resolver rooted at the given path.
     /// </summary>
     /// <param name="basePath">Entry point file path or base directory</param>
-    public ModuleResolver(string basePath) : this(basePath, virtualFiles: null) { }
+    public ModuleResolver(string basePath) : this(basePath, ModuleResolutionOptions.Default, virtualFiles: null) { }
 
     /// <summary>
     /// Creates a new module resolver with an optional in-memory virtual file system.
@@ -65,8 +69,18 @@ public class ModuleResolver
     /// <param name="virtualFiles">If non-null, an in-memory file system. Keys must be
     /// absolute paths; normalization happens internally.</param>
     public ModuleResolver(string basePath, IReadOnlyDictionary<string, string>? virtualFiles)
+        : this(basePath, ModuleResolutionOptions.Default, virtualFiles)
+    {
+    }
+
+    /// <summary>Creates a resolver using project-selected module resolution behavior.</summary>
+    public ModuleResolver(
+        string basePath,
+        ModuleResolutionOptions resolutionOptions,
+        IReadOnlyDictionary<string, string>? virtualFiles = null)
     {
         _basePath = Path.GetDirectoryName(Path.GetFullPath(basePath)) ?? ".";
+        _resolutionOptions = resolutionOptions;
         _stdlibChain = new StdlibProviderChain(
         [
             new PrimitiveProvider(),
@@ -140,6 +154,9 @@ public class ModuleResolver
             return specifier;
         }
 
+        if (_ambientModulePaths.TryGetValue(specifier, out string? ambientPath))
+            return ambientPath;
+
         if (specifier.StartsWith("./") || specifier.StartsWith("../") ||
             specifier.StartsWith(".\\") || specifier.StartsWith("..\\"))
         {
@@ -152,8 +169,15 @@ public class ModuleResolver
             // Absolute path
             return AddExtensionIfNeeded(specifier);
         }
+        else if (TryResolvePaths(specifier, out string? mapped))
+        {
+            return mapped!;
+        }
         else if (specifier.StartsWith('#'))
         {
+            if (!_resolutionOptions.UsesPackageMaps)
+                throw new Exception(
+                    $"Module Error: '{specifier}' requires node16, nodenext, or bundler module resolution.");
             // Subpath imports (#-prefixed) — resolve through nearest package.json "imports" field
             string? result = TryResolveSubpathImport(specifier, currentDir, kind);
             if (result != null)
@@ -189,8 +213,24 @@ public class ModuleResolver
                 return stdlibModule.VirtualPath;
             }
 
+            if (_resolutionOptions.BaseUrl is not null)
+            {
+                string? baseUrlResult = TryAddExtension(
+                    Path.GetFullPath(Path.Combine(_resolutionOptions.BaseUrl, specifier)));
+                if (baseUrlResult is not null)
+                    return baseUrlResult;
+            }
+
+            if (_resolutionOptions.Mode == ModuleResolutionMode.Classic)
+            {
+                throw new Exception(
+                    $"Module Error: Cannot resolve bare specifier '{specifier}' with classic module resolution.");
+            }
+
             // Try self-referencing: if nearest package.json has "name" matching the specifier
-            string? selfRef = TryResolveSelfReference(specifier, currentDir, kind);
+            string? selfRef = _resolutionOptions.UsesPackageMaps
+                ? TryResolveSelfReference(specifier, currentDir, kind)
+                : null;
             if (selfRef != null)
                 return selfRef;
 
@@ -204,6 +244,52 @@ public class ModuleResolver
             throw new Exception($"Module Error: Cannot resolve bare specifier '{specifier}'. " +
                                 "Bare imports require a node_modules directory with the package installed.");
         }
+    }
+
+    private bool TryResolvePaths(string specifier, out string? resolved)
+    {
+        resolved = null;
+        if (_resolutionOptions.Paths.Count == 0)
+            return false;
+
+        var matches = new List<(int PrefixLength, string? Capture, IReadOnlyList<string> Targets)>();
+        foreach (var (pattern, targets) in _resolutionOptions.Paths)
+        {
+            int star = pattern.IndexOf('*');
+            if (star < 0)
+            {
+                if (string.Equals(pattern, specifier, StringComparison.Ordinal))
+                    matches.Add((int.MaxValue, null, targets));
+                continue;
+            }
+
+            string prefix = pattern[..star];
+            string suffix = pattern[(star + 1)..];
+            if (specifier.StartsWith(prefix, StringComparison.Ordinal) &&
+                specifier.EndsWith(suffix, StringComparison.Ordinal) &&
+                specifier.Length >= prefix.Length + suffix.Length)
+            {
+                string capture = specifier.Substring(
+                    prefix.Length, specifier.Length - prefix.Length - suffix.Length);
+                matches.Add((prefix.Length, capture, targets));
+            }
+        }
+
+        foreach (var match in matches.OrderByDescending(m => m.PrefixLength))
+        {
+            foreach (string target in match.Targets)
+            {
+                string candidate = match.Capture is null
+                    ? target
+                    : target.Replace("*", match.Capture, StringComparison.Ordinal);
+                resolved = TryAddExtension(candidate);
+                if (resolved is not null)
+                    return true;
+            }
+        }
+
+        resolved = null;
+        return false;
     }
 
     /// <summary>
@@ -252,7 +338,7 @@ public class ModuleResolver
         string packageJsonPath = Path.Combine(packageDir, "package.json");
         var pkg = LoadPackageJson(packageJsonPath);
 
-        if (pkg?.Exports != null)
+        if (_resolutionOptions.UsesPackageMaps && pkg?.Exports != null)
         {
             // Use exports field
             var resolved = ExportsResolver.ResolvePackageExports(
@@ -302,48 +388,7 @@ public class ModuleResolver
         // Strip leading "./" and combine with package dir
         string relPath = resolvedRelative.StartsWith("./") ? resolvedRelative[2..] : resolvedRelative;
         string fullPath = Path.GetFullPath(Path.Combine(packageDir, relPath));
-
-        // If path exists as-is, use it
-        if (ResolverFileExists(fullPath))
-            return fullPath;
-
-        // Extension mapping: .js → .ts, .tsx
-        if (fullPath.EndsWith(".js", StringComparison.OrdinalIgnoreCase))
-        {
-            string tsPath = fullPath[..^3] + ".ts";
-            if (ResolverFileExists(tsPath)) return tsPath;
-            string tsxPath = fullPath[..^3] + ".tsx";
-            if (ResolverFileExists(tsxPath)) return tsxPath;
-        }
-        else if (fullPath.EndsWith(".mjs", StringComparison.OrdinalIgnoreCase))
-        {
-            string mtsPath = fullPath[..^4] + ".mts";
-            if (ResolverFileExists(mtsPath)) return mtsPath;
-        }
-        else if (fullPath.EndsWith(".cjs", StringComparison.OrdinalIgnoreCase))
-        {
-            string ctsPath = fullPath[..^4] + ".cts";
-            if (ResolverFileExists(ctsPath)) return ctsPath;
-        }
-
-        // Try appending each known extension
-        foreach (var ext in SourceExtensions)
-        {
-            string candidate = fullPath + ext;
-            if (ResolverFileExists(candidate)) return candidate;
-        }
-
-        // Try as directory with index.* file
-        if (ResolverDirectoryExists(fullPath))
-        {
-            foreach (var ext in SourceExtensions)
-            {
-                string indexPath = Path.Combine(fullPath, "index" + ext);
-                if (ResolverFileExists(indexPath)) return indexPath;
-            }
-        }
-
-        return null;
+        return TryAddExtension(fullPath);
     }
 
     /// <summary>
@@ -351,6 +396,7 @@ public class ModuleResolver
     /// </summary>
     private string? TryAddExtension(string path)
     {
+        path = Path.GetFullPath(path);
         if (ResolverFileExists(path))
             return path;
 
@@ -360,11 +406,25 @@ public class ModuleResolver
             if (ResolverFileExists(candidate)) return candidate;
         }
 
-        // .js → .ts (TS-source-for-JS-spec)
-        if (path.EndsWith(".js", StringComparison.OrdinalIgnoreCase))
+        // TypeScript source substitution for JavaScript-flavoured specifiers.
+        string[] substitutions = path.ToLowerInvariant() switch
         {
-            string tsPath = path[..^3] + ".ts";
-            if (ResolverFileExists(tsPath)) return tsPath;
+            var value when value.EndsWith(".mjs") => [".mts", ".d.mts"],
+            var value when value.EndsWith(".cjs") => [".cts", ".d.cts"],
+            var value when value.EndsWith(".jsx") => [".tsx", ".ts", ".d.ts"],
+            var value when value.EndsWith(".js") => [".ts", ".tsx", ".d.ts"],
+            _ => [],
+        };
+        if (substitutions.Length > 0)
+        {
+            int extensionLength = Path.GetExtension(path).Length;
+            string stem = path[..^extensionLength];
+            foreach (string extension in substitutions)
+            {
+                string candidate = stem + extension;
+                if (ResolverFileExists(candidate))
+                    return candidate;
+            }
         }
 
         if (ResolverDirectoryExists(path))
@@ -460,11 +520,19 @@ public class ModuleResolver
         return null;
     }
 
-    private static string[] ConditionsFor(ResolutionKind kind) => kind switch
+    private string[] ConditionsFor(ResolutionKind kind)
     {
-        ResolutionKind.Cjs => ExportsResolver.CjsConditions,
-        _ => ExportsResolver.EsmConditions,
-    };
+        if (_resolutionOptions.Mode == ModuleResolutionMode.Bundler)
+            return kind == ResolutionKind.Cjs
+                ? ["require", "default"]
+                : ["import", "default"];
+
+        return kind switch
+        {
+            ResolutionKind.Cjs => ExportsResolver.CjsConditions,
+            _ => ExportsResolver.EsmConditions,
+        };
+    }
 
     /// <summary>
     /// Loads a package.json with caching.
@@ -486,54 +554,13 @@ public class ModuleResolver
         return pkg;
     }
 
-    private static readonly string[] SourceExtensions = [".ts", ".tsx", ".cts", ".mts", ".js", ".jsx", ".cjs", ".mjs"];
+    private static readonly string[] SourceExtensions =
+        [".ts", ".tsx", ".d.ts", ".cts", ".d.cts", ".mts", ".d.mts", ".js", ".jsx", ".cjs", ".mjs"];
 
     private string AddExtensionIfNeeded(string path)
     {
-        // If path already has a known extension and exists, use it
-        if (HasKnownSourceExtension(path) && ResolverFileExists(path))
-        {
-            return path;
-        }
-
-        // Try each known extension
-        foreach (var ext in SourceExtensions)
-        {
-            string candidate = path + ext;
-            if (ResolverFileExists(candidate))
-                return candidate;
-        }
-
-        // Try path as-is as a directory with index.* file
-        if (ResolverDirectoryExists(path))
-        {
-            foreach (var ext in SourceExtensions)
-            {
-                string indexPath = Path.Combine(path, "index" + ext);
-                if (ResolverFileExists(indexPath))
-                    return indexPath;
-            }
-        }
-
-        // If original path exists (e.g. an unusual extension), use it
-        if (ResolverFileExists(path))
-        {
-            return path;
-        }
-
-        throw new Exception($"Module Error: Cannot resolve module '{path}'. File not found.");
-    }
-
-    private static bool HasKnownSourceExtension(string path)
-    {
-        var ext = Path.GetExtension(path);
-        if (string.IsNullOrEmpty(ext)) return false;
-        foreach (var known in SourceExtensions)
-        {
-            if (string.Equals(ext, known, StringComparison.OrdinalIgnoreCase))
-                return true;
-        }
-        return false;
+        return TryAddExtension(path)
+            ?? throw new Exception($"Module Error: Cannot resolve module '{path}'. File not found.");
     }
 
     /// <summary>
@@ -608,6 +635,13 @@ public class ModuleResolver
     /// <exception cref="Exception">If a circular dependency is detected</exception>
     public ParsedModule LoadModule(string absolutePath, DecoratorMode decoratorMode = DecoratorMode.None)
     {
+        if (absolutePath.StartsWith(AmbientModulePrefix, StringComparison.Ordinal))
+        {
+            return _moduleCache.TryGetValue(absolutePath, out var ambient)
+                ? ambient
+                : throw new Exception($"Module Error: Unknown ambient module '{absolutePath}'.");
+        }
+
         // Embedded stdlib TypeScript module — compile from resource instead of filesystem.
         if (absolutePath.StartsWith(EmbeddedStdlibProvider.VirtualPathPrefix, StringComparison.Ordinal))
         {
@@ -728,10 +762,11 @@ public class ModuleResolver
             // NOTE: Process BEFORE caching to properly detect circular references
             var directives = lexer.TripleSlashDirectives;
             var pathRefs = directives.Where(d => d.Type == TripleSlashReferenceType.Path).ToList();
+            bool isDeclarationFile = absolutePath.EndsWith(".d.ts", StringComparison.OrdinalIgnoreCase);
 
             if (pathRefs.Count > 0)
             {
-                if (!module.IsScript)
+                if (!module.IsScript && !isDeclarationFile)
                 {
                     throw new Exception($"Type Error: /// <reference path=\"...\"> is only valid in script files (files without import/export). File '{absolutePath}' is a module.");
                 }
@@ -742,14 +777,34 @@ public class ModuleResolver
                     string refPath = ResolveReferencePath(pathRef.Value, absolutePath);
                     var refModule = LoadScriptReference(refPath, decoratorMode, absolutePath);
 
-                    if (!refModule.IsScript)
+                    bool referencedDeclaration =
+                        refPath.EndsWith(".d.ts", StringComparison.OrdinalIgnoreCase);
+                    if (!refModule.IsScript && !referencedDeclaration)
                     {
                         throw new Exception($"Type Error: /// <reference path=\"{pathRef.Value}\"> cannot reference a module file. Referenced file '{refPath}' contains import/export statements.");
                     }
 
                     module.PathReferences.Add(pathRef);
-                    module.ReferencedScripts.Add(refModule);
+                    if (module.IsScript && refModule.IsScript)
+                        module.ReferencedScripts.Add(refModule);
+                    else if (!module.Dependencies.Contains(refModule))
+                        module.Dependencies.Add(refModule);
                 }
+            }
+
+            // Type/lib references are declaration dependencies. Unlike `path`, they are valid
+            // in both scripts and modules and never participate in runtime execution.
+            foreach (var directive in directives.Where(
+                         d => d.Type is TripleSlashReferenceType.Types or TripleSlashReferenceType.Lib))
+            {
+                string declarationPath = directive.Type == TripleSlashReferenceType.Lib
+                    ? TsConfigDeclarationResolver.ResolveLibReference(absolutePath, directive.Value)
+                    : TsConfigDeclarationResolver.ResolveTypeReference(
+                        absolutePath, directive.Value, _resolutionOptions.TypeRoots);
+                var declarationModule = LoadModule(declarationPath, decoratorMode);
+                RegisterAmbientModuleDeclarations([declarationModule]);
+                if (!module.Dependencies.Contains(declarationModule))
+                    module.Dependencies.Add(declarationModule);
             }
 
             // Cache AFTER processing path references to properly detect circular references
@@ -1014,6 +1069,42 @@ public class ModuleResolver
     /// <param name="entryPoint">The entry point module</param>
     /// <returns>List of modules in dependency order</returns>
     public List<ParsedModule> GetModulesInOrder(ParsedModule entryPoint)
+        => GetModulesInOrder([entryPoint]);
+
+    /// <summary>
+    /// Registers <c>declare module "name"</c> blocks from declaration roots as synthetic
+    /// type-only modules, allowing imports to resolve without a runtime package.
+    /// </summary>
+    public void RegisterAmbientModuleDeclarations(IEnumerable<ParsedModule> declarationModules)
+    {
+        foreach (var declarationFile in declarationModules)
+        {
+            foreach (var statement in declarationFile.Statements)
+            {
+                if (statement is not Stmt.DeclareModule declaration ||
+                    declaration.ModulePath.StartsWith("./", StringComparison.Ordinal) ||
+                    declaration.ModulePath.StartsWith("../", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                string virtualPath = AmbientModulePrefix + declaration.ModulePath;
+                if (!_moduleCache.TryGetValue(virtualPath, out var module))
+                {
+                    module = new ParsedModule(virtualPath, [])
+                    {
+                        IsScript = false,
+                    };
+                    _moduleCache[virtualPath] = module;
+                    _ambientModulePaths[declaration.ModulePath] = virtualPath;
+                }
+                module.Statements.AddRange(declaration.Members);
+            }
+        }
+    }
+
+    /// <summary>Returns the union of several root graphs in dependency order.</summary>
+    public List<ParsedModule> GetModulesInOrder(IEnumerable<ParsedModule> entryPoints)
     {
         List<ParsedModule> result = [];
         HashSet<string> visited = [];
@@ -1042,9 +1133,17 @@ public class ModuleResolver
             result.Add(module);
         }
 
-        Visit(entryPoint);
+        foreach (var entryPoint in entryPoints)
+            Visit(entryPoint);
         return result;
     }
+
+    /// <summary>Real source files currently present in the resolver cache.</summary>
+    public IReadOnlyList<string> LoadedFilePaths =>
+        _moduleCache.Keys
+            .Where(File.Exists)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
 
     /// <summary>
     /// Gets a cached module by its absolute path.
@@ -1055,6 +1154,7 @@ public class ModuleResolver
         // interop modules, primitive: C# interop modules — none resolve to a real filesystem path).
         if (!absolutePath.StartsWith(BuiltInModuleRegistry.BuiltInPrefix)
             && !absolutePath.StartsWith(EmbeddedStdlibProvider.VirtualPathPrefix, StringComparison.Ordinal)
+            && !absolutePath.StartsWith(AmbientModulePrefix, StringComparison.Ordinal)
             && !DotNetImports.IsDotNetSpecifier(absolutePath)
             && !absolutePath.StartsWith(PrimitiveRegistry.Prefix, StringComparison.Ordinal))
         {
@@ -1069,6 +1169,7 @@ public class ModuleResolver
     public void ClearCache()
     {
         _moduleCache.Clear();
+        _ambientModulePaths.Clear();
     }
 
     /// <summary>

--- a/Parsing/TripleSlashDirective.cs
+++ b/Parsing/TripleSlashDirective.cs
@@ -11,17 +11,17 @@ public enum TripleSlashReferenceType
     Path,
 
     /// <summary>
-    /// /// &lt;reference types="..." /&gt; - references type declarations (future).
+    /// /// &lt;reference types="..." /&gt; - references a visible declaration package.
     /// </summary>
     Types,
 
     /// <summary>
-    /// /// &lt;reference lib="..." /&gt; - references built-in lib declarations (future).
+    /// /// &lt;reference lib="..." /&gt; - references an installed TypeScript lib declaration.
     /// </summary>
     Lib,
 
     /// <summary>
-    /// /// &lt;reference no-default-lib="true" /&gt; - excludes default lib (future).
+    /// /// &lt;reference no-default-lib="true" /&gt; - excludes TypeScript's default lib set.
     /// </summary>
     NoDefaultLib
 }

--- a/Program.cs
+++ b/Program.cs
@@ -50,6 +50,7 @@ using SharpTS.Execution;
 using SharpTS.Modules;
 using SharpTS.Packaging;
 using SharpTS.Parsing;
+using SharpTS.Projects;
 using SharpTS.References;
 using SharpTS.TypeSystem;
 
@@ -75,6 +76,49 @@ switch (command)
         if (error.ShowCompileUsage)
             PrintCompileUsage();
         Environment.Exit(error.ExitCode);
+        break;
+
+    case ParsedCommand.Project project:
+        try
+        {
+            string projectPath = TsConfigLoader.ResolveProjectPath(project.Options.ProjectPath!);
+            var projectConfig = TsConfigLoader.Load(projectPath);
+            if (project.Options.ShowConfig)
+            {
+                var (resolvedOptions, _) = ApplyTsConfig(
+                    project.Options, Path.GetDirectoryName(projectPath) ?? ".");
+                PrintResolvedConfig(resolvedOptions, project.Options.Strictness, projectConfig);
+                return;
+            }
+
+            Environment.ExitCode = project.Options.Watch
+                ? ProjectCommandRunner.Watch([projectPath], project.Options, buildMode: false)
+                : ProjectCommandRunner.Run(
+                    [projectPath], project.Options, buildMode: false, force: project.Options.Force);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.Message);
+            Environment.ExitCode = 1;
+        }
+        break;
+
+    case ParsedCommand.Build build:
+        try
+        {
+            var projectPaths = build.ProjectPaths
+                .Select(TsConfigLoader.ResolveProjectPath)
+                .ToArray();
+            Environment.ExitCode = build.Options.Watch
+                ? ProjectCommandRunner.Watch(projectPaths, build.Options, buildMode: true)
+                : ProjectCommandRunner.Run(
+                    projectPaths, build.Options, buildMode: true, force: build.Options.Force);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.Message);
+            Environment.ExitCode = 1;
+        }
         break;
 
     case ParsedCommand.Repl repl:
@@ -103,7 +147,7 @@ switch (command)
             PrintResolvedConfig(scriptOptions, script.Options.Strictness, scriptConfig);
             return;
         }
-        RunFile(script.ScriptPath, scriptOptions, script.ScriptArgs);
+        RunFile(script.ScriptPath, scriptOptions, script.ScriptArgs, scriptConfig);
         break;
 
     case ParsedCommand.Compile compile:
@@ -129,7 +173,8 @@ switch (command)
             compile.CompileOptions.References,
             compile.CompileOptions.Target,
             compile.CompileOptions.Bundler,
-            compileOptions
+            compileOptions,
+            compileConfig
         );
         break;
 
@@ -248,6 +293,18 @@ static void PrintResolvedConfig(GlobalOptions options, StrictnessOptions cliStri
             ["decoratorMode"] = options.DecoratorMode.ToString(),
             ["entryPoint"] = config?.EntryFile,
             ["outDir"] = config?.OutDir,
+            ["rootFiles"] = config?.RootFiles ?? [],
+            ["declarationFiles"] = config?.DeclarationFiles ?? [],
+            ["projectReferences"] = config?.ProjectReferences ?? [],
+            ["moduleResolution"] = config?.ModuleResolution.Mode.ToString(),
+            ["baseUrl"] = config?.ModuleResolution.BaseUrl,
+            ["paths"] = config?.ModuleResolution.Paths,
+            ["lib"] = config?.Lib,
+            ["types"] = config?.Types,
+            ["typeRoots"] = config?.TypeRoots,
+            ["incremental"] = options.Incremental || config?.Incremental == true,
+            ["composite"] = config?.Composite,
+            ["buildInfoFile"] = config?.BuildInfoFile,
             ["provenance"] = new Dictionary<string, object?>
             {
                 ["strictNullChecks"] = OriginVia(cliLayer.StrictNullChecks, configLayer.StrictNullChecks),
@@ -281,7 +338,11 @@ static ReferenceSet LoadDotNetReferences(string startDirectory, IReadOnlyList<st
     }
 }
 
-static void RunFile(string path, GlobalOptions options, string[]? scriptArgs = null)
+static void RunFile(
+    string path,
+    GlobalOptions options,
+    string[]? scriptArgs = null,
+    TsConfigResult? project = null)
 {
     string absolutePath = Path.GetFullPath(path);
     string source = File.ReadAllText(absolutePath);
@@ -305,9 +366,10 @@ static void RunFile(string path, GlobalOptions options, string[]? scriptArgs = n
         && (source.Contains("require(") || source.Contains("module.exports") || source.Contains("exports."));
 
     // Check if the file contains imports/exports or path references - if so, use module mode
-    if (hasPathReferences || source.Contains("import ") || source.Contains("export ") || isCjsFile)
+    if (hasPathReferences || source.Contains("import ") || source.Contains("export ") || isCjsFile ||
+        project?.DeclarationFiles.Count > 0)
     {
-        RunModuleFile(absolutePath, options, scriptArgs);
+        RunModuleFile(absolutePath, options, scriptArgs, project);
     }
     else
     {
@@ -316,15 +378,26 @@ static void RunFile(string path, GlobalOptions options, string[]? scriptArgs = n
     }
 }
 
-static void RunModuleFile(string absolutePath, GlobalOptions options, string[]? scriptArgs = null)
+static void RunModuleFile(
+    string absolutePath,
+    GlobalOptions options,
+    string[]? scriptArgs = null,
+    TsConfigResult? project = null)
 {
     var decoratorMode = options.DecoratorMode;
     try
     {
         // Load the entry module and all dependencies
-        var resolver = new ModuleResolver(absolutePath);
+        var resolver = project is null
+            ? new ModuleResolver(absolutePath)
+            : new ModuleResolver(absolutePath, project.ModuleResolution);
+        var declarationModules = (project?.DeclarationFiles ?? [])
+            .Select(path => resolver.LoadModule(path, decoratorMode))
+            .ToArray();
+        resolver.RegisterAmbientModuleDeclarations(declarationModules);
         var entryModule = resolver.LoadModule(absolutePath, decoratorMode);
-        var allModules = resolver.GetModulesInOrder(entryModule);
+        var runtimeModules = resolver.GetModulesInOrder(entryModule);
+        var allModules = resolver.GetModulesInOrder(declarationModules.Append(entryModule));
 
         // Type checking across all modules (still uses Check-style API for modules)
         // Module type checking has its own error handling
@@ -362,13 +435,13 @@ static void RunModuleFile(string absolutePath, GlobalOptions options, string[]? 
 
         // Variable Resolution Phase (enables O(1) lookups)
         var varResolver = new VariableResolver(interpreter);
-        foreach (var module in allModules)
+        foreach (var module in runtimeModules)
         {
             if (!module.IsBuiltIn)
                 varResolver.Resolve(module.Statements);
         }
 
-        interpreter.InterpretModules(allModules, resolver, typeMap);
+        interpreter.InterpretModules(runtimeModules, resolver, typeMap);
 
         // Node default: an unhandled promise rejection makes the process
         // exit nonzero. The rejection itself was already reported to stderr
@@ -488,7 +561,7 @@ static void Run(string source, DecoratorMode decoratorMode, bool emitDecoratorMe
     }
 }
 
-static void CompileFile(string inputPath, string outputPath, bool preserveConstEnums, bool useReferenceAssemblies, string? sdkPath, bool verifyIL, DecoratorMode decoratorMode, bool emitDecoratorMetadata, PackOptions packOptions, OutputOptions outputOptions, IReadOnlyList<string> references, OutputTarget target, BundlerMode bundlerMode, GlobalOptions globalOptions)
+static void CompileFile(string inputPath, string outputPath, bool preserveConstEnums, bool useReferenceAssemblies, string? sdkPath, bool verifyIL, DecoratorMode decoratorMode, bool emitDecoratorMetadata, PackOptions packOptions, OutputOptions outputOptions, IReadOnlyList<string> references, OutputTarget target, BundlerMode bundlerMode, GlobalOptions globalOptions, TsConfigResult? project = null)
 {
     try
     {
@@ -568,7 +641,9 @@ static void CompileFile(string inputPath, string outputPath, bool preserveConstE
 
         // Check AST for import/export statements or path references
         // Include ImportRequire for CommonJS-style: import X = require('./module')
-        bool hasModules = hasPathReferences || statements.Any(s => s is Stmt.Import or Stmt.Export or Stmt.ImportRequire);
+        bool hasModules = hasPathReferences ||
+            statements.Any(s => s is Stmt.Import or Stmt.Export or Stmt.ImportRequire) ||
+            project?.DeclarationFiles.Count > 0;
 
         // CommonJS files (.cjs, or .js classified as CJS) also need module-mode compilation
         // because they use the CJS module pipeline (per-file class with $exports field).
@@ -585,7 +660,7 @@ static void CompileFile(string inputPath, string outputPath, bool preserveConstE
 
         if (hasModules)
         {
-            CompileModuleFile(absolutePath, outputPath, preserveConstEnums, useReferenceAssemblies, sdkPath, verifyIL, decoratorMode, outputOptions, metadata, references, target, bundlerMode, externalRefs, globalOptions);
+            CompileModuleFile(absolutePath, outputPath, preserveConstEnums, useReferenceAssemblies, sdkPath, verifyIL, decoratorMode, outputOptions, metadata, references, target, bundlerMode, externalRefs, globalOptions, project);
         }
         else
         {
@@ -622,17 +697,24 @@ static void CompileFile(string inputPath, string outputPath, bool preserveConstE
     }
 }
 
-static void CompileModuleFile(string absolutePath, string outputPath, bool preserveConstEnums, bool useReferenceAssemblies, string? sdkPath, bool verifyIL, DecoratorMode decoratorMode, OutputOptions outputOptions, AssemblyMetadata? metadata, IReadOnlyList<string> references, OutputTarget target, BundlerMode bundlerMode, ReferenceSet externalRefs, GlobalOptions globalOptions)
+static void CompileModuleFile(string absolutePath, string outputPath, bool preserveConstEnums, bool useReferenceAssemblies, string? sdkPath, bool verifyIL, DecoratorMode decoratorMode, OutputOptions outputOptions, AssemblyMetadata? metadata, IReadOnlyList<string> references, OutputTarget target, BundlerMode bundlerMode, ReferenceSet externalRefs, GlobalOptions globalOptions, TsConfigResult? project = null)
 {
     // Phase 1: Load all static dependencies via ModuleResolver
-    var resolver = new ModuleResolver(absolutePath);
+    var resolver = project is null
+        ? new ModuleResolver(absolutePath)
+        : new ModuleResolver(absolutePath, project.ModuleResolution);
+    var declarationModules = (project?.DeclarationFiles ?? [])
+        .Select(path => resolver.LoadModule(path, decoratorMode))
+        .ToArray();
+    resolver.RegisterAmbientModuleDeclarations(declarationModules);
     var entryModule = resolver.LoadModule(absolutePath, decoratorMode);
     var allModules = resolver.GetModulesInOrder(entryModule);
+    var typeModules = resolver.GetModulesInOrder(declarationModules.Append(entryModule));
 
     // Phase 2: Initial type checking to discover dynamic import paths
     var checker = new TypeChecker(globalOptions.TypeCheckerOptions);
     checker.SetDecoratorMode(decoratorMode);
-    var typeMap = checker.CheckModules(allModules, resolver);
+    var typeMap = checker.CheckModules(typeModules, resolver);
 
     // Phase 3: Load modules discovered through dynamic import string literals
     // These modules aren't in the static dependency graph but need to be compiled
@@ -645,10 +727,11 @@ static void CompileModuleFile(string absolutePath, string outputPath, bool prese
         {
             // Re-get the module list to include newly discovered modules
             allModules = resolver.GetModulesInOrder(entryModule);
+            typeModules = resolver.GetModulesInOrder(declarationModules.Append(entryModule));
 
             // Re-run type checking with the expanded module list
             // (CheckModules is incremental - only checks newly added modules)
-            typeMap = checker.CheckModules(allModules, resolver);
+            typeMap = checker.CheckModules(typeModules, resolver);
         }
     }
 
@@ -1182,6 +1265,8 @@ static void PrintHelp()
     Console.WriteLine("Usage:");
     Console.WriteLine("  sharpts [options] [script.ts] [args...]");
     Console.WriteLine("  sharpts [options] script.ts -- [script-args...]");
+    Console.WriteLine("  sharpts -p <tsconfig> [--watch] [--incremental]");
+    Console.WriteLine("  sharpts --build [project ...] [--watch] [--force]");
     Console.WriteLine("  sharpts --compile <script.ts> [compile-options]");
     Console.WriteLine("  sharpts --gen-decl <TypeName|Namespace|AssemblyPath> [--json] [-o output.txt]");
     Console.WriteLine();
@@ -1207,17 +1292,22 @@ static void PrintHelp()
     Console.WriteLine();
     Console.WriteLine("Configuration (tsconfig.json):");
     Console.WriteLine("  -p, --project <path>          Use this tsconfig.json (file or directory)");
+    Console.WriteLine("  -b, --build [project ...]     Check project references in dependency order");
+    Console.WriteLine("  -w, --watch                   Recheck a project graph when inputs change");
+    Console.WriteLine("  --incremental                 Reuse SharpTS build state when inputs are unchanged");
+    Console.WriteLine("  --force                       Ignore build state and check every project");
     Console.WriteLine("  --no-tsconfig                 Skip tsconfig.json discovery entirely");
     Console.WriteLine("  --showConfig                  Print the resolved config as JSON and exit");
     Console.WriteLine();
     Console.WriteLine("  A tsconfig.json next to (or above) the entry script is discovered");
     Console.WriteLine("  automatically. Command-line flags win over it. 'extends' chains are");
-    Console.WriteLine("  followed. SharpTS reads the strictness options, checkJs, the decorator");
-    Console.WriteLine("  options, preserveConstEnums, outDir, and files[0]; emit options such as");
-    Console.WriteLine("  target/module/jsx do not apply because SharpTS compiles to .NET IL.");
+    Console.WriteLine("  followed. With no script, -p checks the roots selected by files/include/");
+    Console.WriteLine("  exclude. Project references, incremental/watch builds, lib/types/typeRoots,");
+    Console.WriteLine("  baseUrl/paths, and classic/node10/node16/nodenext/bundler resolution are");
+    Console.WriteLine("  supported. target/module/jsx do not apply to .NET IL output.");
     Console.WriteLine("  Set SHARPTS_TSCONFIG_VERBOSE=1 to list every option that was ignored.");
-    Console.WriteLine("  SharpTS compiles the entry file and everything it imports; include/exclude");
-    Console.WriteLine("  do not select inputs.");
+    Console.WriteLine("  Script and --compile commands still use their named file as the runtime");
+    Console.WriteLine("  entry point; project commands are type-check-only.");
     Console.WriteLine();
     Console.WriteLine(".NET References:");
     Console.WriteLine("  A sharpts.json next to (or above) the entry script supplies project-level");
@@ -1256,6 +1346,9 @@ static void PrintHelp()
     Console.WriteLine("  sharpts script.ts arg1 arg2       Run script with arguments");
     Console.WriteLine("  sharpts script.ts -- --flag val   Pass flags to script (use -- separator)");
     Console.WriteLine("  sharpts --compile app.ts          Compile to app.dll");
+    Console.WriteLine("  sharpts -p .                      Check every tsconfig project root");
+    Console.WriteLine("  sharpts --build                   Check referenced projects incrementally");
+    Console.WriteLine("  sharpts --build --watch           Keep the project graph up to date");
     Console.WriteLine("  sharpts --compile app.ts -t exe   Compile to executable");
     Console.WriteLine("  sharpts --compile app.ts --pack   Compile and create NuGet package");
     Console.WriteLine("  sharpts --gen-decl System.Text.StringBuilder   Inspect a .NET type for interop");

--- a/Projects/ProjectBuildState.cs
+++ b/Projects/ProjectBuildState.cs
@@ -1,0 +1,94 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using SharpTS.Configuration;
+
+namespace SharpTS.Projects;
+
+/// <summary>SharpTS-owned incremental project state. The format is intentionally not tsc's.</summary>
+internal static class ProjectBuildState
+{
+    private const int FormatVersion = 1;
+
+    private static readonly string ToolVersion =
+        typeof(ProjectBuildState).Assembly.GetName().Version?.ToString() ?? "unknown";
+
+    private sealed record State(
+        int Version,
+        string ToolVersion,
+        string ConfigPath,
+        string OptionsKey,
+        Dictionary<string, string> Inputs);
+
+    public static bool IsUpToDate(TsConfigResult project, string optionsKey)
+    {
+        if (!File.Exists(project.BuildInfoFile))
+            return false;
+
+        try
+        {
+            var state = JsonSerializer.Deserialize<State>(File.ReadAllText(project.BuildInfoFile));
+            if (state is null ||
+                state.Version != FormatVersion ||
+                !string.Equals(state.ToolVersion, ToolVersion, StringComparison.Ordinal) ||
+                !string.Equals(state.OptionsKey, optionsKey, StringComparison.Ordinal) ||
+                !PathEquals(state.ConfigPath, project.ConfigPath))
+            {
+                return false;
+            }
+
+            foreach (string currentRoot in project.RootFiles.Concat(project.DeclarationFiles))
+            {
+                if (!state.Inputs.Keys.Any(path => PathEquals(path, currentRoot)))
+                    return false;
+            }
+
+            foreach (var (path, expectedHash) in state.Inputs)
+            {
+                if (!File.Exists(path) || !string.Equals(Hash(path), expectedHash, StringComparison.Ordinal))
+                    return false;
+            }
+            return true;
+        }
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    public static void Write(
+        TsConfigResult project,
+        string optionsKey,
+        IEnumerable<string> inputPaths)
+    {
+        var comparer = OperatingSystem.IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+        var inputs = inputPaths
+            .Where(File.Exists)
+            .Append(project.ConfigPath)
+            .Concat(project.ExtendsChain)
+            .Distinct(comparer)
+            .ToDictionary(path => Path.GetFullPath(path), Hash, comparer);
+
+        string? directory = Path.GetDirectoryName(project.BuildInfoFile);
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
+
+        var state = new State(FormatVersion, ToolVersion, project.ConfigPath, optionsKey, inputs);
+        File.WriteAllText(
+            project.BuildInfoFile,
+            JsonSerializer.Serialize(state, new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private static string Hash(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexString(SHA256.HashData(stream));
+    }
+
+    private static bool PathEquals(string left, string right) =>
+        string.Equals(
+            Path.GetFullPath(left),
+            Path.GetFullPath(right),
+            OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+}

--- a/Projects/ProjectCommandRunner.cs
+++ b/Projects/ProjectCommandRunner.cs
@@ -1,0 +1,271 @@
+using SharpTS.Cli;
+using SharpTS.Configuration;
+using SharpTS.Diagnostics;
+using SharpTS.Modules;
+using SharpTS.Parsing;
+using SharpTS.References;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Projects;
+
+/// <summary>Runs project checks, build graphs, incremental checks, and watch sessions.</summary>
+public static class ProjectCommandRunner
+{
+    public static int Run(
+        IReadOnlyList<string> rootConfigPaths,
+        GlobalOptions cliOptions,
+        bool buildMode,
+        bool force = false)
+    {
+        try
+        {
+            var graph = ProjectGraph.Load(rootConfigPaths);
+            foreach (var project in graph.Projects)
+            {
+                string optionsKey = BuildOptionsKey(cliOptions);
+                bool useIncremental = buildMode || cliOptions.Incremental ||
+                    project.Incremental == true || project.Composite == true;
+                if (useIncremental && !force && ProjectBuildState.IsUpToDate(project, optionsKey))
+                {
+                    Console.WriteLine($"{project.ConfigPath}: up to date");
+                    continue;
+                }
+
+                if (!CheckProject(project, cliOptions, out var inputs))
+                {
+                    return 1;
+                }
+
+                if (useIncremental)
+                    ProjectBuildState.Write(project, optionsKey, inputs);
+                Console.WriteLine($"{project.ConfigPath}: checked {project.RootFiles.Count} root file(s)");
+            }
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex.Message);
+            return 1;
+        }
+    }
+
+    public static int Watch(
+        IReadOnlyList<string> rootConfigPaths,
+        GlobalOptions options,
+        bool buildMode)
+    {
+        int exitCode = Run(rootConfigPaths, options, buildMode, force: options.Force);
+        var graph = ProjectGraph.Load(rootConfigPaths);
+        var directories = CollapseWatchDirectories(graph.Projects.SelectMany(WatchDirectories));
+
+        using var changed = new AutoResetEvent(false);
+        using var cancelled = new ManualResetEvent(false);
+        var watchers = new List<FileSystemWatcher>();
+        ConsoleCancelEventHandler cancelHandler = (_, args) =>
+        {
+            args.Cancel = true;
+            cancelled.Set();
+            changed.Set();
+        };
+        Console.CancelKeyPress += cancelHandler;
+
+        try
+        {
+            foreach (string directory in directories)
+            {
+                var watcher = new FileSystemWatcher(directory)
+                {
+                    IncludeSubdirectories = true,
+                    NotifyFilter = NotifyFilters.FileName | NotifyFilters.LastWrite |
+                                   NotifyFilters.DirectoryName,
+                    EnableRaisingEvents = true,
+                };
+                FileSystemEventHandler onChange = (_, args) =>
+                {
+                    if (IsProjectInput(args.FullPath))
+                        changed.Set();
+                };
+                RenamedEventHandler onRename = (_, args) =>
+                {
+                    if (IsProjectInput(args.FullPath) || IsProjectInput(args.OldFullPath))
+                        changed.Set();
+                };
+                watcher.Changed += onChange;
+                watcher.Created += onChange;
+                watcher.Deleted += onChange;
+                watcher.Renamed += onRename;
+                watchers.Add(watcher);
+            }
+
+            Console.WriteLine("Watching for project changes. Press Ctrl+C to stop.");
+            while (true)
+            {
+                changed.WaitOne();
+                if (cancelled.WaitOne(0))
+                    break;
+
+                // Coalesce the burst of write/rename notifications produced by one save.
+                Thread.Sleep(100);
+                while (changed.WaitOne(0)) { }
+                Console.WriteLine($"[{DateTime.Now:T}] Change detected. Rechecking...");
+                exitCode = Run(rootConfigPaths, options, buildMode);
+            }
+        }
+        finally
+        {
+            Console.CancelKeyPress -= cancelHandler;
+            foreach (var watcher in watchers)
+                watcher.Dispose();
+        }
+
+        return exitCode;
+    }
+
+    private static bool CheckProject(
+        TsConfigResult project,
+        GlobalOptions cliOptions,
+        out IReadOnlyList<string> inputs)
+    {
+        inputs = [];
+        foreach (string warning in project.Warnings)
+            Console.WriteLine(warning);
+
+        if (project.RootFiles.Count == 0 && project.DeclarationFiles.Count == 0)
+        {
+            Console.WriteLine(
+                $"Error: tsconfig.json ('{project.ConfigPath}'): no inputs were found. " +
+                "Check 'files', 'include', and 'exclude'.");
+            return false;
+        }
+
+        string projectDirectory = Path.GetDirectoryName(project.ConfigPath)!;
+        DotNetReferences.Load(projectDirectory, cliOptions.References);
+
+        var options = MergeOptions(cliOptions, project);
+        var resolver = new ModuleResolver(project.ConfigPath, project.ModuleResolution);
+        var declarationRoots = project.DeclarationFiles
+            .Select(path => resolver.LoadModule(path, options.DecoratorMode))
+            .ToArray();
+        resolver.RegisterAmbientModuleDeclarations(declarationRoots);
+
+        var sourceRoots = project.RootFiles
+            .Where(path => !project.DeclarationFiles.Contains(path, PathComparer))
+            .Select(path => resolver.LoadModule(path, options.DecoratorMode))
+            .ToArray();
+        var modules = resolver.GetModulesInOrder(declarationRoots.Concat(sourceRoots));
+
+        var checker = new TypeChecker(options.TypeCheckerOptions);
+        checker.SetDecoratorMode(options.DecoratorMode);
+        checker.CheckModules(modules, resolver);
+
+        var errors = checker.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToArray();
+        foreach (var diagnostic in errors)
+            Console.WriteLine($"Error: {diagnostic}");
+
+        inputs = resolver.LoadedFilePaths;
+        return errors.Length == 0;
+    }
+
+    private static GlobalOptions MergeOptions(GlobalOptions cli, TsConfigResult project) =>
+        cli with
+        {
+            Strictness = new StrictnessOptions
+            {
+                Strict = cli.Strictness.Strict ?? project.Strictness.Strict,
+                StrictNullChecks = cli.Strictness.StrictNullChecks ?? project.Strictness.StrictNullChecks,
+                StrictFunctionTypes = cli.Strictness.StrictFunctionTypes ?? project.Strictness.StrictFunctionTypes,
+                NoImplicitAny = cli.Strictness.NoImplicitAny ?? project.Strictness.NoImplicitAny,
+            },
+            CheckJs = cli.CheckJs || project.CheckJs == true,
+            EmitDecoratorMetadata = cli.EmitDecoratorMetadata || project.EmitDecoratorMetadata == true,
+            DecoratorMode = cli.DecoratorMode == DecoratorMode.Stage3 && project.DecoratorMode is { } configured
+                ? configured
+                : cli.DecoratorMode,
+        };
+
+    private static IReadOnlyList<string> CollapseWatchDirectories(IEnumerable<string> directories)
+    {
+        var comparer = PathComparer;
+        var ordered = directories
+            .Select(Path.GetFullPath)
+            .Distinct(comparer)
+            .OrderBy(path => path.Length)
+            .ToList();
+        var result = new List<string>();
+        foreach (string candidate in ordered)
+        {
+            if (!result.Any(parent => IsUnder(candidate, parent)))
+                result.Add(candidate);
+        }
+        return result;
+    }
+
+    private static bool IsProjectInput(string path)
+    {
+        string fileName = Path.GetFileName(path);
+        return fileName.EndsWith(".json", StringComparison.OrdinalIgnoreCase) ||
+               fileName.EndsWith(".ts", StringComparison.OrdinalIgnoreCase) ||
+               fileName.EndsWith(".tsx", StringComparison.OrdinalIgnoreCase) ||
+               fileName.EndsWith(".mts", StringComparison.OrdinalIgnoreCase) ||
+               fileName.EndsWith(".cts", StringComparison.OrdinalIgnoreCase) ||
+               fileName.EndsWith(".js", StringComparison.OrdinalIgnoreCase) ||
+               fileName.EndsWith(".jsx", StringComparison.OrdinalIgnoreCase) ||
+               fileName.EndsWith(".mjs", StringComparison.OrdinalIgnoreCase) ||
+               fileName.EndsWith(".cjs", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IEnumerable<string> WatchDirectories(TsConfigResult project)
+    {
+        yield return Path.GetDirectoryName(project.ConfigPath)!;
+
+        foreach (string file in project.RootFiles.Concat(project.DeclarationFiles))
+            yield return Path.GetDirectoryName(file)!;
+
+        if (project.ModuleResolution.BaseUrl is { } baseUrl && Directory.Exists(baseUrl))
+            yield return baseUrl;
+
+        foreach (string target in project.ModuleResolution.Paths.Values.SelectMany(value => value))
+        {
+            int wildcard = target.IndexOfAny(['*', '?']);
+            string prefix = wildcard < 0 ? target : target[..wildcard];
+            string? directory = Directory.Exists(prefix)
+                ? prefix
+                : Path.GetDirectoryName(prefix.TrimEnd(
+                    Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+            if (directory is not null && Directory.Exists(directory))
+                yield return directory;
+        }
+    }
+
+    private static string BuildOptionsKey(GlobalOptions options)
+    {
+        string[] values =
+        [
+            options.Strictness.Strict?.ToString() ?? "",
+            options.Strictness.StrictNullChecks?.ToString() ?? "",
+            options.Strictness.StrictFunctionTypes?.ToString() ?? "",
+            options.Strictness.NoImplicitAny?.ToString() ?? "",
+            options.CheckJs.ToString(),
+            options.DecoratorMode.ToString(),
+            options.EmitDecoratorMetadata.ToString(),
+            .. options.References
+                .Select(Path.GetFullPath)
+                .OrderBy(path => path, PathComparer),
+        ];
+        return string.Join("|", values);
+    }
+
+    private static bool IsUnder(string candidate, string parent)
+    {
+        string relative = Path.GetRelativePath(parent, candidate);
+        return relative == "." ||
+               (!relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) &&
+                relative != ".." &&
+                !Path.IsPathRooted(relative));
+    }
+
+    private static StringComparer PathComparer =>
+        OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+}

--- a/Projects/ProjectGraph.cs
+++ b/Projects/ProjectGraph.cs
@@ -1,0 +1,68 @@
+using SharpTS.Configuration;
+
+namespace SharpTS.Projects;
+
+/// <summary>A validated, dependency-first graph of referenced tsconfig projects.</summary>
+public sealed class ProjectGraph
+{
+    private ProjectGraph(IReadOnlyList<TsConfigResult> projects)
+    {
+        Projects = projects;
+    }
+
+    public IReadOnlyList<TsConfigResult> Projects { get; }
+
+    public static ProjectGraph Load(IEnumerable<string> rootConfigPaths)
+    {
+        var comparer = OperatingSystem.IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+        var visited = new HashSet<string>(comparer);
+        var loaded = new Dictionary<string, TsConfigResult>(comparer);
+        var stack = new List<string>();
+        var projects = new List<TsConfigResult>();
+
+        void Visit(string configPath, bool isReference)
+        {
+            string full = Path.GetFullPath(configPath);
+            if (visited.Contains(full))
+            {
+                if (isReference && loaded[full].Composite != true)
+                {
+                    throw new Exception(
+                        $"Error: referenced project '{full}' must set compilerOptions.composite to true.");
+                }
+                return;
+            }
+
+            int cycleStart = stack.FindIndex(path => comparer.Equals(path, full));
+            if (cycleStart >= 0)
+            {
+                string cycle = string.Join(
+                    " -> ",
+                    stack.Skip(cycleStart).Append(full));
+                throw new Exception($"Error: circular project reference: {cycle}");
+            }
+
+            stack.Add(full);
+            var project = TsConfigLoader.Load(full);
+            loaded[full] = project;
+            if (isReference && project.Composite != true)
+            {
+                throw new Exception(
+                    $"Error: referenced project '{project.ConfigPath}' must set compilerOptions.composite to true.");
+            }
+            foreach (string reference in project.ProjectReferences)
+                Visit(reference, isReference: true);
+            stack.RemoveAt(stack.Count - 1);
+
+            visited.Add(full);
+            projects.Add(project);
+        }
+
+        foreach (string root in rootConfigPaths)
+            Visit(root, isReference: false);
+
+        return new ProjectGraph(projects);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -177,16 +177,47 @@ chains included. Command-line flags win over it.
 
 ```bash
 sharpts -p ./configs/tsconfig.json script.ts  # explicit config (file or directory)
+sharpts -p .                                  # check every selected project root
+sharpts -p . --watch                          # recheck after source/config changes
+sharpts --build                               # check references in dependency order
+sharpts --build packages/app --force          # rebuild a reference graph
 sharpts --no-tsconfig script.ts               # skip discovery entirely
 sharpts --showConfig script.ts                # print the resolved config as JSON, then exit
 ```
 
-SharpTS reads the strictness options, `checkJs`, the decorator options, `preserveConstEnums`,
-`outDir`, and `files[0]`. Emit options such as `target`, `module`, `jsx` and `sourceMap` do not
-apply — SharpTS compiles to .NET IL, not JavaScript — and are ignored silently; set
-`SHARPTS_TSCONFIG_VERBOSE=1` to list them. An unrecognized key is reported with a suggestion.
-`include`/`exclude` do not select inputs: SharpTS compiles the entry file and everything it
-imports.
+Project commands implement TypeScript's root-selection rules: `files` and `include` are unioned,
+`exclude` filters only files found through `include`, and imports can still pull excluded files
+into the semantic program. An explicit `files: []` remains empty. JavaScript roots are selected
+when `allowJs` or `checkJs` is enabled.
+
+The project model also supports:
+
+- `references` plus `--build`/`-b`, with referenced projects checked first and required to set
+  `composite`;
+- `incremental`, `composite`, `tsBuildInfoFile`, `--incremental`, `--force`, and `--watch`;
+- `baseUrl` and `paths`, including exact mappings, longest-prefix wildcard matching, and target
+  fallbacks;
+- `moduleResolution` values `classic`, `node`/`node10`, `node16`, `nodenext`, and `bundler`;
+- `lib`, `types`, and `typeRoots`, loaded as type-only declaration inputs. Named `lib` entries
+  come from an installed `typescript` package under `node_modules/typescript/lib`.
+
+Reference ordering and the `composite` requirement follow the
+[TypeScript project-reference model](https://www.typescriptlang.org/docs/handbook/project-references).
+
+SharpTS build state uses its own `.sharptsbuildinfo` format. If `tsBuildInfoFile` is set, SharpTS
+adds a `.sharpts` suffix rather than overwriting tsc's incompatible file. Watch mode currently
+re-evaluates the graph after a relevant change and uses that state to skip unchanged projects;
+parsed module and package caches are reused within each affected project check.
+
+`-p` without a script and `--build` are type-check-only. Script and `--compile` commands retain
+an explicit runtime entry point, but use the loaded project's module-resolution and declaration
+settings. Project-reference edges currently orchestrate semantic checks and build ordering; they
+do not yet emit or consume cross-project `.d.ts`/CLR artifacts, so imports between projects must
+still resolve through normal `paths` or package mappings.
+
+Emit options such as `target`, `module`, `jsx` and `sourceMap` do not apply — SharpTS compiles to
+.NET IL, not JavaScript — and are ignored silently; set `SHARPTS_TSCONFIG_VERBOSE=1` to list
+them. An unrecognized key is reported with a suggestion.
 
 ## Examples
 

--- a/SharpTS.Sdk/Sdk/Sdk.targets
+++ b/SharpTS.Sdk/Sdk/Sdk.targets
@@ -62,14 +62,10 @@
       <_SharpTSArgs>$(_SharpTSArgs) -o "$(SharpTSOutputPath)$(SharpTSOutputFileName)"</_SharpTSArgs>
       <_SharpTSArgs>$(_SharpTSArgs) --msbuild-errors</_SharpTSArgs>
       <_SharpTSArgs>$(_SharpTSArgs) --quiet</_SharpTSArgs>
-      <!--
-        The CLI discovers tsconfig.json on its own (walking up from the entry script). This
-        target has already read $(SharpTSTsConfigPath) and translated it into explicit flags
-        above, so let MSBuild remain the single source of truth: suppress the CLI's own
-        discovery. Without this, an SDK build would read tsconfig.json twice and could pick up
-        options MSBuild deliberately does not forward.
-      -->
-      <_SharpTSArgs>$(_SharpTSArgs) --no-tsconfig</_SharpTSArgs>
+      <!-- The CLI owns project-system semantics (paths, moduleResolution, declaration
+           packages, and the extends chain). Explicit MSBuild-derived flags below still win. -->
+      <_SharpTSArgs Condition="Exists('$(SharpTSTsConfigPath)')">$(_SharpTSArgs) --project "$(SharpTSTsConfigPath)"</_SharpTSArgs>
+      <_SharpTSArgs Condition="!Exists('$(SharpTSTsConfigPath)')">$(_SharpTSArgs) --no-tsconfig</_SharpTSArgs>
       <_SharpTSArgs Condition="'$(SharpTSPreserveConstEnums)' == 'true'">$(_SharpTSArgs) --preserveConstEnums</_SharpTSArgs>
       <_SharpTSArgs Condition="'$(SharpTSExperimentalDecorators)' == 'true'">$(_SharpTSArgs) --experimentalDecorators</_SharpTSArgs>
       <_SharpTSArgs Condition="'$(SharpTSDecorators)' == 'true'">$(_SharpTSArgs) --decorators</_SharpTSArgs>

--- a/SharpTS.Sdk/readme.md
+++ b/SharpTS.Sdk/readme.md
@@ -46,7 +46,7 @@ dotnet build
 
 ## tsconfig.json Integration
 
-The SDK automatically reads `tsconfig.json` if present. Supported options:
+The SDK automatically reads `tsconfig.json` if present. The MSBuild task extracts:
 
 | tsconfig.json | Maps to |
 |---------------|---------|
@@ -57,6 +57,11 @@ The SDK automatically reads `tsconfig.json` if present. Supported options:
 | `files[0]` | `SharpTSEntryPoint` (if not set) |
 
 MSBuild properties take precedence over tsconfig.json values.
+
+The compiler also receives the config through `--project`, so `extends`, strictness,
+`baseUrl`/`paths`, selectable `moduleResolution`, and `lib`/`types`/`typeRoots` use the same
+project model as the CLI. `files[0]` remains the default runtime entry point for SDK IL output;
+use `sharpts -p` or `sharpts --build` to type-check every `files`/`include` root.
 
 ## Example Projects
 

--- a/SharpTS.Tests/CliTests/CommandLineParserTests.cs
+++ b/SharpTS.Tests/CliTests/CommandLineParserTests.cs
@@ -417,6 +417,35 @@ public class CommandLineParserTests
     }
 
     [Fact]
+    public void Parse_ProjectWithoutScript_ReturnsProjectCommand()
+    {
+        var result = _parser.Parse(["-p", "tsconfig.json", "--incremental"]);
+
+        var project = Assert.IsType<ParsedCommand.Project>(result);
+        Assert.Equal("tsconfig.json", project.Options.ProjectPath);
+        Assert.True(project.Options.Incremental);
+    }
+
+    [Fact]
+    public void Parse_BuildCollectsProjectsAndFlags()
+    {
+        var result = _parser.Parse(["--build", "packages/a", "packages/b", "--force"]);
+
+        var build = Assert.IsType<ParsedCommand.Build>(result);
+        Assert.Equal(["packages/a", "packages/b"], build.ProjectPaths);
+        Assert.True(build.Options.Force);
+    }
+
+    [Fact]
+    public void Parse_BuildDefaultsToCurrentDirectory()
+    {
+        var result = _parser.Parse(["-b"]);
+
+        var build = Assert.IsType<ParsedCommand.Build>(result);
+        Assert.Equal(["."], build.ProjectPaths);
+    }
+
+    [Fact]
     public void Parse_OutputTarget_CaseInsensitive()
     {
         var result = _parser.Parse(["-c", "file.ts", "-t", "DLL"]);

--- a/SharpTS.Tests/ConfigurationTests/TsConfigLoaderTests.cs
+++ b/SharpTS.Tests/ConfigurationTests/TsConfigLoaderTests.cs
@@ -236,6 +236,129 @@ public class TsConfigLoaderTests
         Assert.Equal(DecoratorMode.Legacy, TsConfigLoader.Load(path).DecoratorMode);
     }
 
+    [Fact]
+    public void IncludeAndExclude_SelectRootFiles()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("src/main.ts", "export {};");
+        dir.CreateFile("src/main.spec.ts", "export {};");
+        dir.CreateFile("other.ts", "export {};");
+        var path = dir.CreateFile("tsconfig.json", """
+            { "include": ["src/**/*.ts"], "exclude": ["**/*.spec.ts"] }
+            """);
+
+        var result = TsConfigLoader.Load(path);
+
+        Assert.Equal([Path.GetFullPath(dir.GetPath("src/main.ts"))], result.RootFiles);
+    }
+
+    [Fact]
+    public void FilesAreUnionedWithIncludeAndNotFilteredByExclude()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("forced.ts", "export {};");
+        dir.CreateFile("src/included.ts", "export {};");
+        var path = dir.CreateFile("tsconfig.json", """
+            {
+              "files": ["forced.ts"],
+              "include": ["src"],
+              "exclude": ["forced.ts"]
+            }
+            """);
+
+        var result = TsConfigLoader.Load(path);
+
+        Assert.Equal(2, result.RootFiles.Count);
+        Assert.Contains(Path.GetFullPath(dir.GetPath("forced.ts")), result.RootFiles);
+        Assert.Contains(Path.GetFullPath(dir.GetPath("src/included.ts")), result.RootFiles);
+    }
+
+    [Fact]
+    public void IncludeSupportsWildcardsInDirectorySegments()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("src-a/one.ts", "export {};");
+        dir.CreateFile("src-b/two.ts", "export {};");
+        var path = dir.CreateFile(
+            "tsconfig.json",
+            """{ "include": ["src-*/*.ts"] }""");
+
+        Assert.Equal(2, TsConfigLoader.Load(path).RootFiles.Count);
+    }
+
+    [Fact]
+    public void EmptyFilesArrayIsPreserved()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("ignored.ts", "export {};");
+        var path = dir.CreateFile("tsconfig.json", """{ "files": [] }""");
+
+        Assert.Empty(TsConfigLoader.Load(path).RootFiles);
+    }
+
+    [Fact]
+    public void PathsAndBaseUrlResolveAgainstDeclaringConfig()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("configs/base.json", """
+            {
+              "compilerOptions": {
+                "baseUrl": "../src",
+                "paths": { "@app/*": ["app/*"] },
+                "moduleResolution": "bundler"
+              }
+            }
+            """);
+        var path = dir.CreateFile("tsconfig.json", """
+            { "extends": "./configs/base.json", "files": [] }
+            """);
+
+        var result = TsConfigLoader.Load(path);
+
+        Assert.Equal(ModuleResolutionMode.Bundler, result.ModuleResolution.Mode);
+        Assert.Equal(Path.GetFullPath(dir.GetPath("src")), result.ModuleResolution.BaseUrl);
+        Assert.Equal(
+            Path.GetFullPath(dir.GetPath("src/app/*")),
+            Assert.Single(result.ModuleResolution.Paths["@app/*"]));
+    }
+
+    [Fact]
+    public void TypesAndTypeRootsResolveDeclarationEntries()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        string declaration = dir.CreateFile(
+            "typings/custom/index.d.ts",
+            "declare const customGlobal: string;");
+        var path = dir.CreateFile("tsconfig.json", """
+            {
+              "files": [],
+              "compilerOptions": {
+                "typeRoots": ["./typings"],
+                "types": ["custom"]
+              }
+            }
+            """);
+
+        var result = TsConfigLoader.Load(path);
+
+        Assert.Equal(Path.GetFullPath(declaration), Assert.Single(result.DeclarationFiles));
+        Assert.Equal(Path.GetFullPath(dir.GetPath("typings")), Assert.Single(result.TypeRoots!));
+    }
+
+    [Fact]
+    public void ProjectReferencesResolveToConfigPaths()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        string referenced = dir.CreateFile("packages/core/tsconfig.json", """{ "files": [] }""");
+        var path = dir.CreateFile("tsconfig.json", """
+            { "files": [], "references": [{ "path": "./packages/core" }] }
+            """);
+
+        var result = TsConfigLoader.Load(path);
+
+        Assert.Equal(Path.GetFullPath(referenced), Assert.Single(result.ProjectReferences));
+    }
+
     #endregion
 
     #region Unknown-key diagnosis

--- a/SharpTS.Tests/IntegrationTests/CliProjectTests.cs
+++ b/SharpTS.Tests/IntegrationTests/CliProjectTests.cs
@@ -1,0 +1,243 @@
+using Xunit;
+
+namespace SharpTS.Tests.IntegrationTests;
+
+public class CliProjectTests
+{
+    [Fact]
+    public void ProjectCommandChecksEveryIncludedRoot()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("src/ok.ts", "export const ok: number = 1;");
+        dir.CreateFile("src/bad.ts", """export const bad: number = "wrong";""");
+        dir.CreateFile("ignored/bad.ts", """export const ignored: number = "wrong";""");
+        dir.CreateFile("tsconfig.json", """
+            { "include": ["src"], "exclude": ["ignored"] }
+            """);
+
+        var result = CliTestHelper.RunCli("-p .", dir.Path);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("src", result.StandardOutput);
+        Assert.DoesNotContain("ignored", result.StandardOutput);
+    }
+
+    [Fact]
+    public void ExcludeDoesNotBlockImportedDependencies()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("src/main.ts", """import { bad } from "../generated/bad"; console.log(bad);""");
+        dir.CreateFile("generated/bad.ts", """export const bad: number = "wrong";""");
+        dir.CreateFile("tsconfig.json", """
+            { "include": ["src"], "exclude": ["generated"] }
+            """);
+
+        var result = CliTestHelper.RunCli("-p .", dir.Path);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("bad.ts", result.StandardOutput);
+    }
+
+    [Fact]
+    public void ProjectCommandUsesBaseUrlPaths()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("src/main.ts", """import { value } from "@app/value"; const n: number = value;""");
+        dir.CreateFile("src/lib/value.ts", "export const value: number = 42;");
+        dir.CreateFile("tsconfig.json", """
+            {
+              "files": ["src/main.ts"],
+              "compilerOptions": {
+                "baseUrl": ".",
+                "paths": { "@app/*": ["src/lib/*"] },
+                "moduleResolution": "bundler"
+              }
+            }
+            """);
+
+        var result = CliTestHelper.RunCli("-p .", dir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("checked 1 root file(s)", result.StandardOutput);
+    }
+
+    [Fact]
+    public void ScriptExecutionUsesProjectPaths()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile(
+            "main.ts",
+            """import { value } from "@app/value"; console.log(value);""");
+        dir.CreateFile("src/value.ts", "export const value: number = 42;");
+        dir.CreateFile("tsconfig.json", """
+            {
+              "files": ["main.ts"],
+              "compilerOptions": {
+                "baseUrl": ".",
+                "paths": { "@app/*": ["src/*"] },
+                "moduleResolution": "bundler"
+              }
+            }
+            """);
+
+        var result = CliTestHelper.RunCli("main.ts", dir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("42\n", result.StandardOutput);
+    }
+
+    [Fact]
+    public void TypesAddsGlobalDeclarationPackages()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("types/custom/index.d.ts", "declare const projectName: string;");
+        dir.CreateFile("main.ts", "const name: string = projectName;");
+        dir.CreateFile("tsconfig.json", """
+            {
+              "files": ["main.ts"],
+              "compilerOptions": {
+                "typeRoots": ["types"],
+                "types": ["custom"]
+              }
+            }
+            """);
+
+        var result = CliTestHelper.RunCli("-p .", dir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+    }
+
+    [Fact]
+    public void TypesCanDeclareAnAmbientModule()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("types/virtual-package/index.d.ts", """
+            declare module "virtual-package" {
+              export function greet(name: string): string;
+            }
+            """);
+        dir.CreateFile("main.ts", """
+            import { greet } from "virtual-package";
+            const message: string = greet("SharpTS");
+            """);
+        dir.CreateFile("tsconfig.json", """
+            {
+              "files": ["main.ts"],
+              "compilerOptions": {
+                "typeRoots": ["types"],
+                "types": ["virtual-package"]
+              }
+            }
+            """);
+
+        var result = CliTestHelper.RunCli("-p .", dir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+    }
+
+    [Fact]
+    public void LibLoadsDeclarationsFromInstalledTypeScript()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile(
+            "node_modules/typescript/lib/lib.custom.d.ts",
+            "declare const libGlobal: number;");
+        dir.CreateFile("main.ts", "const value: number = libGlobal;");
+        dir.CreateFile("tsconfig.json", """
+            {
+              "files": ["main.ts"],
+              "compilerOptions": { "lib": ["custom"] }
+            }
+            """);
+
+        var result = CliTestHelper.RunCli("-p .", dir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+    }
+
+    [Fact]
+    public void BuildChecksReferencesInDependencyOrderAndReusesState()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("packages/core/core.ts", "export const core: number = 1;");
+        string coreConfig = dir.CreateFile(
+            "packages/core/tsconfig.json",
+            """{ "files": ["core.ts"], "compilerOptions": { "composite": true } }""");
+        dir.CreateFile("app.ts", "export const app: number = 1;");
+        string appConfig = dir.CreateFile("tsconfig.json", """
+            {
+              "files": ["app.ts"],
+              "references": [{ "path": "packages/core" }]
+            }
+            """);
+
+        var first = CliTestHelper.RunCli("--build .", dir.Path);
+        var second = CliTestHelper.RunCli("--build .", dir.Path);
+
+        Assert.Equal(0, first.ExitCode);
+        Assert.True(
+            first.StandardOutput.IndexOf(coreConfig, StringComparison.OrdinalIgnoreCase) <
+            first.StandardOutput.IndexOf(appConfig, StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(0, second.ExitCode);
+        Assert.Equal(2, second.StandardOutput.Split("up to date").Length - 1);
+        Assert.True(File.Exists(dir.GetPath("packages/core/tsconfig.sharptsbuildinfo")));
+        Assert.True(File.Exists(dir.GetPath("tsconfig.sharptsbuildinfo")));
+    }
+
+    [Fact]
+    public void IncrementalProjectInvalidatesWhenAnInputChanges()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("main.ts", "export const value: number = 1;");
+        dir.CreateFile("tsconfig.json", """
+            { "files": ["main.ts"], "compilerOptions": { "incremental": true } }
+            """);
+
+        var first = CliTestHelper.RunCli("-p .", dir.Path);
+        var second = CliTestHelper.RunCli("-p .", dir.Path);
+        dir.CreateFile("main.ts", "export const value: number = 2;");
+        var third = CliTestHelper.RunCli("-p .", dir.Path);
+
+        Assert.Equal(0, first.ExitCode);
+        Assert.Contains("up to date", second.StandardOutput);
+        Assert.DoesNotContain("up to date", third.StandardOutput);
+        Assert.Contains("checked", third.StandardOutput);
+    }
+
+    [Fact]
+    public void IncrementalProjectInvalidatesWhenIncludeFindsANewRoot()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("src/main.ts", "export const value: number = 1;");
+        dir.CreateFile("tsconfig.json", """
+            { "include": ["src"], "compilerOptions": { "incremental": true } }
+            """);
+
+        Assert.Equal(0, CliTestHelper.RunCli("-p .", dir.Path).ExitCode);
+        Assert.Contains("up to date", CliTestHelper.RunCli("-p .", dir.Path).StandardOutput);
+        dir.CreateFile("src/new.ts", "export const added: number = 2;");
+        var afterNewRoot = CliTestHelper.RunCli("-p .", dir.Path);
+
+        Assert.Equal(0, afterNewRoot.ExitCode);
+        Assert.DoesNotContain("up to date", afterNewRoot.StandardOutput);
+        Assert.Contains("checked 2 root file(s)", afterNewRoot.StandardOutput);
+    }
+
+    [Fact]
+    public void IncrementalProjectInvalidatesWhenCliCheckingOptionsChange()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("main.ts", "const value: number = null;");
+        dir.CreateFile("tsconfig.json", """
+            { "files": ["main.ts"], "compilerOptions": { "incremental": true } }
+            """);
+
+        var loose = CliTestHelper.RunCli("--strictNullChecks=false -p .", dir.Path);
+        var strict = CliTestHelper.RunCli("--strictNullChecks=true -p .", dir.Path);
+
+        Assert.Equal(0, loose.ExitCode);
+        Assert.Equal(1, strict.ExitCode);
+        Assert.DoesNotContain("up to date", strict.StandardOutput);
+        Assert.Contains("not assignable", strict.StandardOutput);
+    }
+}

--- a/SharpTS.Tests/Modules/ModuleResolutionOptionsTests.cs
+++ b/SharpTS.Tests/Modules/ModuleResolutionOptionsTests.cs
@@ -1,0 +1,84 @@
+using SharpTS.Configuration;
+using SharpTS.Modules;
+using SharpTS.Tests.IntegrationTests;
+using Xunit;
+
+namespace SharpTS.Tests.Modules;
+
+public class ModuleResolutionOptionsTests
+{
+    [Fact]
+    public void PathsUseLongestPrefixAndTargetFallbacks()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        string expected = dir.CreateFile("src/special/value.ts", "export const value = 1;");
+        dir.CreateFile("src/general/value.ts", "export const value = 2;");
+        string entry = dir.CreateFile("src/main.ts", "export {};");
+        var options = new ModuleResolutionOptions(
+            ModuleResolutionMode.Bundler,
+            dir.GetPath("src"),
+            new Dictionary<string, IReadOnlyList<string>>
+            {
+                ["@app/*"] = [dir.GetPath("src/general/*")],
+                ["@app/special/*"] = [dir.GetPath("missing/*"), dir.GetPath("src/special/*")],
+            });
+
+        var resolver = new ModuleResolver(entry, options);
+
+        Assert.Equal(Path.GetFullPath(expected), resolver.ResolveModulePath("@app/special/value", entry));
+    }
+
+    [Fact]
+    public void BaseUrlResolvesBareSourceFiles()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        string expected = dir.CreateFile("src/models/user.ts", "export interface User {}");
+        string entry = dir.CreateFile("src/main.ts", "export {};");
+        var options = new ModuleResolutionOptions(
+            ModuleResolutionMode.Classic,
+            dir.GetPath("src"),
+            new Dictionary<string, IReadOnlyList<string>>());
+
+        var resolver = new ModuleResolver(entry, options);
+
+        Assert.Equal(Path.GetFullPath(expected), resolver.ResolveModulePath("models/user", entry));
+    }
+
+    [Fact]
+    public void Node10IgnoresExportsWhileNode16UsesThem()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        string legacy = dir.CreateFile("node_modules/pkg/legacy.ts", "export const value = 1;");
+        string modern = dir.CreateFile("node_modules/pkg/modern.ts", "export const value = 2;");
+        dir.CreateFile("node_modules/pkg/package.json", """
+            { "main": "./legacy.ts", "exports": { ".": "./modern.ts" } }
+            """);
+        string entry = dir.CreateFile("main.ts", "export {};");
+
+        var node10 = new ModuleResolver(
+            entry,
+            new ModuleResolutionOptions(
+                ModuleResolutionMode.Node10, null,
+                new Dictionary<string, IReadOnlyList<string>>()));
+        var node16 = new ModuleResolver(
+            entry,
+            new ModuleResolutionOptions(
+                ModuleResolutionMode.Node16, null,
+                new Dictionary<string, IReadOnlyList<string>>()));
+
+        Assert.Equal(Path.GetFullPath(legacy), node10.ResolveModulePath("pkg", entry));
+        Assert.Equal(Path.GetFullPath(modern), node16.ResolveModulePath("pkg", entry));
+    }
+
+    [Fact]
+    public void RelativeJsSpecifierMapsToTypeScriptSource()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        string expected = dir.CreateFile("dep.ts", "export const value = 1;");
+        string entry = dir.CreateFile("main.ts", "export {};");
+
+        var resolver = new ModuleResolver(entry);
+
+        Assert.Equal(Path.GetFullPath(expected), resolver.ResolveModulePath("./dep.js", entry));
+    }
+}

--- a/SharpTS.Tests/Projects/ProjectGraphTests.cs
+++ b/SharpTS.Tests/Projects/ProjectGraphTests.cs
@@ -1,0 +1,66 @@
+using SharpTS.Projects;
+using SharpTS.Tests.IntegrationTests;
+using Xunit;
+
+namespace SharpTS.Tests.Projects;
+
+public class ProjectGraphTests
+{
+    [Fact]
+    public void ReferencesAreOrderedBeforeConsumers()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        string dependency = dir.CreateFile(
+            "dependency/tsconfig.json",
+            """{ "files": [], "compilerOptions": { "composite": true } }""");
+        string consumer = dir.CreateFile(
+            "tsconfig.json",
+            """{ "files": [], "references": [{ "path": "dependency" }] }""");
+
+        var graph = ProjectGraph.Load([consumer]);
+
+        Assert.Equal(
+            [Path.GetFullPath(dependency), Path.GetFullPath(consumer)],
+            graph.Projects.Select(project => project.ConfigPath));
+    }
+
+    [Fact]
+    public void ReferencedProjectsMustBeComposite()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("dependency/tsconfig.json", """{ "files": [] }""");
+        string consumer = dir.CreateFile(
+            "tsconfig.json",
+            """{ "files": [], "references": [{ "path": "dependency" }] }""");
+
+        var error = Assert.Throws<Exception>(() => ProjectGraph.Load([consumer]));
+
+        Assert.Contains("composite", error.Message);
+        Assert.Contains("dependency", error.Message);
+    }
+
+    [Fact]
+    public void CircularReferencesReportTheCycle()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        string first = dir.CreateFile("a/tsconfig.json", """
+            {
+              "files": [],
+              "compilerOptions": { "composite": true },
+              "references": [{ "path": "../b" }]
+            }
+            """);
+        dir.CreateFile("b/tsconfig.json", """
+            {
+              "files": [],
+              "compilerOptions": { "composite": true },
+              "references": [{ "path": "../a" }]
+            }
+            """);
+
+        var error = Assert.Throws<Exception>(() => ProjectGraph.Load([first]));
+
+        Assert.Contains("circular project reference", error.Message);
+        Assert.Contains("tsconfig.json", error.Message);
+    }
+}

--- a/docs/msbuild-sdk.md
+++ b/docs/msbuild-sdk.md
@@ -141,22 +141,25 @@ The SDK automatically reads `tsconfig.json` if present in the project directory.
 |--------------------|---------|-------|
 | `compilerOptions.preserveConstEnums` | `SharpTSPreserveConstEnums` | |
 | `compilerOptions.experimentalDecorators` | `SharpTSExperimentalDecorators` | Use Legacy (Stage 2) decorators |
+| `compilerOptions.decorators` | `SharpTSDecorators` | Use TC39 Stage 3 decorators |
 | `compilerOptions.emitDecoratorMetadata` | `SharpTSEmitDecoratorMetadata` | |
+| `files[0]` | `SharpTSEntryPoint` | First file used as runtime entry point |
 
-> **MSBuild reads tsconfig.json; the CLI's own discovery is suppressed.** The `sharpts` CLI
-> normally discovers `tsconfig.json` by walking up from the entry script, but an SDK build
-> already reads `$(SharpTSTsConfigPath)` here and translates it into explicit flags — so
-> `Sdk.targets` passes `--no-tsconfig` to keep MSBuild the single source of truth and avoid
-> reading the file twice. A consequence: the **strictness** options (`strict`,
-> `strictNullChecks`, `strictFunctionTypes`, `noImplicitAny`), which the CLI honors from
-> `tsconfig.json`, are **not** currently forwarded by the SDK. Pass them via
-> `SharpTSExtraArgs`-style customization or set them on the command line until the SDK grows
-> matching properties.
+> **The CLI is the project-system authority.** `Sdk.targets` passes
+> `--project "$(SharpTSTsConfigPath)"`, so SDK compilation applies the same `extends` chain,
+> strictness, module resolution, and declaration inputs as direct CLI use. The MSBuild task
+> still extracts the entry point and options that have explicit MSBuild overrides; those
+> command-line flags take precedence over values in the config.
+
+The CLI-applied project settings include `baseUrl`, `paths`, `moduleResolution`, `lib`, `types`,
+and `typeRoots`. `files`/`include`/`exclude` select roots for `sharpts -p`; SDK IL compilation
+still requires one `SharpTSEntryPoint` because a .NET assembly has a single runtime entry graph.
+Use `sharpts -p` or `sharpts --build` as a separate check when every project root must be
+validated.
 
 The bool merge below is a one-way OR — a `tsconfig.json` value of `false` cannot turn off an
 MSBuild property that is `true`. The CLI's own merge is fully tri-state for the strictness
 options; this asymmetry is deliberate, to avoid changing behavior for shipped SDK consumers.
-| `files[0]` | `SharpTSEntryPoint` | First file used as entry point |
 
 ### Priority Order
 


### PR DESCRIPTION
## Summary

- introduce a first-class resolved TypeScript project model shared by project checks, script execution, compilation, and the MSBuild SDK
- implement `files`/`include`/`exclude` root selection with TypeScript's union/filter semantics, including preserved `files: []` and imported files bypassing `exclude`
- add project-reference graph validation and dependency-first `--build`/`-b` checks, with `composite` enforcement and cycle diagnostics
- add SharpTS-owned incremental state, `--incremental`, `--force`, and debounced `--watch`/`-w` graph rechecks
- implement `baseUrl`/`paths`, target fallbacks, longest-prefix wildcard matching, JavaScript-to-TypeScript substitution, and selectable `classic`, `node10`, `node16`, `nodenext`, and `bundler` resolution
- load `lib`, `types`, and `typeRoots` declaration inputs, including ambient modules and triple-slash `types`/`lib` references
- pass the project through SDK compilation so CLI and MSBuild use the same resolver and declaration settings
- expand `--showConfig`, help, README, SDK docs, and focused unit/integration coverage

## Semantics

`sharpts -p <project>` with no script now checks every configured root and does not execute or emit. Script and `--compile` commands retain their explicit runtime entry point while inheriting the project's resolver and declaration inputs.

`sharpts --build [projects...]` checks referenced projects first. Build state uses `.sharptsbuildinfo`; when `tsBuildInfoFile` is configured, SharpTS adds a `.sharpts` suffix so it never overwrites tsc's incompatible state.

Project references currently provide graph validation, ordering, and project-level incrementality. They do not yet emit or consume cross-project `.d.ts` or CLR artifacts, so cross-project imports still resolve through `paths` or package mappings. This boundary is documented rather than hidden.

## Validation

- `dotnet test SharpTS.Tests/SharpTS.Tests.csproj --no-restore` — 15,766 passed
- `dotnet build SharpTS.sln` — succeeded, 0 warnings
- `dotnet publish SharpTS.csproj -c Release` — succeeded
- `dotnet pack SharpTS.Sdk/SharpTS.Sdk.csproj --no-build` — succeeded
