### PR TITLE
Emit TypeScript declaration files

### DIFF
--- a/Cli/CommandLineParser.cs
+++ b/Cli/CommandLineParser.cs
@@ -57,6 +57,9 @@ namespace SharpTS.Cli;
 /// <param name="Watch">Recheck a project when its inputs change.</param>
 /// <param name="Incremental">Reuse SharpTS project build state when inputs are unchanged.</param>
 /// <param name="Force">Ignore build state and check every project.</param>
+/// <param name="Declaration">Emit TypeScript declaration files for project-owned sources.</param>
+/// <param name="EmitDeclarationOnly">Emit declarations without running or producing a .NET assembly.</param>
+/// <param name="DeclarationDir">Optional root directory for generated declaration files.</param>
 public record GlobalOptions(
     DecoratorMode DecoratorMode = DecoratorMode.Stage3,
     bool EmitDecoratorMetadata = false,
@@ -69,7 +72,10 @@ public record GlobalOptions(
     bool ShowConfig = false,
     bool Watch = false,
     bool Incremental = false,
-    bool Force = false
+    bool Force = false,
+    bool Declaration = false,
+    bool EmitDeclarationOnly = false,
+    string? DeclarationDir = null
 )
 {
     public IReadOnlyList<string> References { get; init; } = References ?? [];
@@ -222,11 +228,24 @@ public class CommandLineParser
                 "Error: --project cannot be combined with --no-tsconfig.",
                 64);
         }
+        if (globalOptions.NoEmit && globalOptions.EmitDeclarationOnly)
+        {
+            return new ParsedCommand.Error(
+                "Error: --noEmit cannot be combined with --emitDeclarationOnly.",
+                64);
+        }
 
         if (remainingArgs.Length == 0)
         {
             if (globalOptions.ProjectPath is not null)
                 return new ParsedCommand.Project(globalOptions);
+            if (globalOptions.Declaration || globalOptions.EmitDeclarationOnly ||
+                globalOptions.DeclarationDir is not null)
+            {
+                return new ParsedCommand.Error(
+                    "Error: declaration options require --compile or -p/--project.",
+                    64);
+            }
             if (globalOptions.Watch || globalOptions.Incremental || globalOptions.Force)
             {
                 return new ParsedCommand.Error(
@@ -266,6 +285,13 @@ public class CommandLineParser
             return ParseGenDeclCommand(remainingArgs, globalOptions);
         }
 
+        if (globalOptions.Declaration || globalOptions.EmitDeclarationOnly ||
+            globalOptions.DeclarationDir is not null)
+        {
+            return new ParsedCommand.Error(
+                "Error: declaration options require --compile or -p/--project.",
+                64);
+        }
 
         // Handle script execution
         if (remainingArgs.Length >= 1)
@@ -341,6 +367,9 @@ public class CommandLineParser
         var watch = false;
         var incremental = false;
         var force = false;
+        var declaration = false;
+        var emitDeclarationOnly = false;
+        string? declarationDir = null;
         string? projectPath = null;
         var strictness = new StrictnessOptions();
         List<string> references = [];
@@ -396,6 +425,25 @@ public class CommandLineParser
                     if (!TryParseFlagBool(value, out flag)) return (default!, [], [], BadBool(name, value));
                     noEmit = flag;
                     break;
+                case "--declaration":
+                    if (!TryParseFlagBool(value, out flag)) return (default!, [], [], BadBool(name, value));
+                    declaration = flag;
+                    break;
+                case "--emitDeclarationOnly":
+                    if (!TryParseFlagBool(value, out flag)) return (default!, [], [], BadBool(name, value));
+                    emitDeclarationOnly = flag;
+                    if (flag) declaration = true;
+                    break;
+                case "--declarationDir" when value is not null:
+                    declarationDir = value;
+                    break;
+                case "--declarationDir" when i + 1 < args.Length:
+                    declarationDir = args[++i];
+                    break;
+                case "--declarationDir":
+                    return (default!, [], [], new ParsedCommand.Error(
+                        "Error: --declarationDir requires a path.",
+                        64));
                 case "--strict":
                     if (!TryParseFlagBool(value, out flag)) return (default!, [], [], BadBool(name, value));
                     strictness = strictness with { Strict = flag };
@@ -457,7 +505,8 @@ public class CommandLineParser
 
         var options = new GlobalOptions(
             decoratorMode, emitDecoratorMetadata, checkJs, references, strictness, noEmit,
-            projectPath, noTsConfig, showConfig, watch, incremental, force);
+            projectPath, noTsConfig, showConfig, watch, incremental, force,
+            declaration, emitDeclarationOnly, declarationDir);
         return (options, remaining.ToArray(), scriptArgs.ToArray(), null);
     }
 
@@ -616,10 +665,12 @@ public class CommandLineParser
             }
         }
 
-        if (globalOptions.NoEmit && pack)
+        if ((globalOptions.NoEmit || globalOptions.EmitDeclarationOnly) && pack)
         {
             return new ParsedCommand.Error(
-                "Error: --noEmit cannot be combined with --pack/--push (there is no assembly to package).",
+                globalOptions.NoEmit
+                    ? "Error: --noEmit cannot be combined with --pack/--push (there is no assembly to package)."
+                    : "Error: --emitDeclarationOnly cannot be combined with --pack/--push (there is no assembly to package).",
                 64,
                 ShowCompileUsage: true);
         }

--- a/Compilation/ILCompiler.Modules.cs
+++ b/Compilation/ILCompiler.Modules.cs
@@ -85,6 +85,9 @@ public partial class ILCompiler
         {
             if (stmt is Stmt.Export export)
             {
+                if (export.IsTypeOnly)
+                    continue;
+
                 if (export.IsDefaultExport)
                 {
                     // Default export field
@@ -114,6 +117,8 @@ public partial class ILCompiler
                     // Named exports like export { x, y as z }
                     foreach (var spec in export.NamedExports)
                     {
+                        if (spec.IsTypeOnly)
+                            continue;
                         string exportedName = spec.ExportedName?.Lexeme ?? spec.LocalName.Lexeme;
                         if (!exportFields.ContainsKey(exportedName))
                         {
@@ -136,6 +141,8 @@ public partial class ILCompiler
                         // export { x, y as z } from './module'
                         foreach (var spec in export.NamedExports)
                         {
+                            if (spec.IsTypeOnly)
+                                continue;
                             string exportedName = spec.ExportedName?.Lexeme ?? spec.LocalName.Lexeme;
                             if (!exportFields.ContainsKey(exportedName))
                             {
@@ -828,6 +835,8 @@ public partial class ILCompiler
         {
             if (stmt is not Stmt.Export export)
                 continue;
+            if (export.IsTypeOnly)
+                continue;
 
             // Default export of a class declaration
             if (export.IsDefaultExport && export.Declaration is Stmt.Class defaultClass)
@@ -849,6 +858,8 @@ public partial class ILCompiler
             {
                 foreach (var spec in export.NamedExports)
                 {
+                    if (spec.IsTypeOnly)
+                        continue;
                     string localName = spec.LocalName.Lexeme;
                     string exportedName = spec.ExportedName?.Lexeme ?? localName;
 
@@ -873,6 +884,8 @@ public partial class ILCompiler
                         // Re-export specific names
                         foreach (var spec in export.NamedExports)
                         {
+                            if (spec.IsTypeOnly)
+                                continue;
                             string importedName = spec.LocalName.Lexeme;
                             string exportedName = spec.ExportedName?.Lexeme ?? importedName;
 

--- a/Compilation/ILEmitter.Modules.cs
+++ b/Compilation/ILEmitter.Modules.cs
@@ -376,6 +376,9 @@ public partial class ILEmitter
     /// </summary>
     private void EmitExport(Stmt.Export export)
     {
+        if (export.IsTypeOnly)
+            return;
+
         if (_ctx.CurrentModulePath == null || _ctx.ModuleExportFields == null)
         {
             // Single-file (script) mode: there is no module to export into, so the
@@ -509,6 +512,8 @@ public partial class ILEmitter
             // export { x, y as z }
             foreach (var spec in export.NamedExports)
             {
+                if (spec.IsTypeOnly)
+                    continue;
                 string localName = spec.LocalName.Lexeme;
                 string exportedName = spec.ExportedName?.Lexeme ?? localName;
 
@@ -563,6 +568,8 @@ public partial class ILEmitter
                     // Re-export specific names
                     foreach (var spec in export.NamedExports)
                     {
+                        if (spec.IsTypeOnly)
+                            continue;
                         string importedName = spec.LocalName.Lexeme;
                         string exportedName = spec.ExportedName?.Lexeme ?? importedName;
 

--- a/Compilation/NonEscapingArrowLocalAnalyzer.cs
+++ b/Compilation/NonEscapingArrowLocalAnalyzer.cs
@@ -131,10 +131,12 @@ public static class NonEscapingArrowLocalAnalyzer
             // callable is expected ("object is not a function", #1229). Disqualify the exported
             // name(s), then fall through to the base walk so uses INSIDE the declaration's
             // initializer still count toward other candidates.
-            DisqualifyExportedNames(stmt.Declaration);
+            if (!stmt.IsTypeOnly)
+                DisqualifyExportedNames(stmt.Declaration);
             if (stmt.NamedExports != null)
                 foreach (var spec in stmt.NamedExports)
-                    Disqualified.Add(spec.LocalName.Lexeme);
+                    if (!stmt.IsTypeOnly && !spec.IsTypeOnly)
+                        Disqualified.Add(spec.LocalName.Lexeme);
 
             base.VisitExport(stmt);
         }

--- a/Configuration/TsConfigJson.Cli.cs
+++ b/Configuration/TsConfigJson.Cli.cs
@@ -5,7 +5,7 @@ namespace SharpTS.Configuration;
 
 // =============================================================================
 // CLI-only continuations of the tsconfig.json model. Deliberately NOT source-linked
-// into SharpTS.Sdk.Tasks: the MSBuild task reads a frozen six-key subset and has no
+// into SharpTS.Sdk.Tasks: the MSBuild task reads a frozen shared subset and has no
 // use for extends chains, strictness, or unknown-key capture — and keeping
 // [JsonExtensionData] out of its source-generated serializer avoids a known
 // System.Text.Json source-generator friction point.

--- a/Configuration/TsConfigJson.cs
+++ b/Configuration/TsConfigJson.cs
@@ -61,4 +61,13 @@ internal sealed partial class TsConfigCompilerOptions
 
     [JsonPropertyName("outDir")]
     public string? OutDir { get; set; }
+
+    [JsonPropertyName("declaration")]
+    public bool? Declaration { get; set; }
+
+    [JsonPropertyName("emitDeclarationOnly")]
+    public bool? EmitDeclarationOnly { get; set; }
+
+    [JsonPropertyName("declarationDir")]
+    public string? DeclarationDir { get; set; }
 }

--- a/Configuration/TsConfigKeyCatalog.cs
+++ b/Configuration/TsConfigKeyCatalog.cs
@@ -32,6 +32,7 @@ internal static class TsConfigKeyCatalog
         "preserveConstEnums", "experimentalDecorators", "decorators", "emitDecoratorMetadata",
         "rootDir", "outDir", "allowJs", "moduleResolution", "lib", "baseUrl", "paths",
         "typeRoots", "types", "incremental", "composite", "tsBuildInfoFile",
+        "declaration", "emitDeclarationOnly", "declarationDir",
     ];
 
     /// <summary>
@@ -41,7 +42,7 @@ internal static class TsConfigKeyCatalog
     private static readonly HashSet<string> EmitOptions = new(StringComparer.OrdinalIgnoreCase)
     {
         "target", "module", "moduleDetection", "jsx", "jsxFactory",
-        "jsxFragmentFactory", "jsxImportSource", "declaration", "declarationMap", "declarationDir",
+        "jsxFragmentFactory", "jsxImportSource", "declarationMap",
         "sourceMap", "inlineSourceMap", "inlineSources", "sourceRoot", "mapRoot", "outFile", "out",
         "removeComments", "importHelpers", "downlevelIteration", "isolatedModules",
         "verbatimModuleSyntax", "esModuleInterop", "allowSyntheticDefaultImports",

--- a/Configuration/TsConfigLoader.cs
+++ b/Configuration/TsConfigLoader.cs
@@ -191,9 +191,9 @@ public static class TsConfigLoader
     {
         var strictness = new StrictnessOptions();
         bool? checkJs = null, allowJs = null, preserveConstEnums = null, emitDecoratorMetadata = null;
-        bool? incremental = null, composite = null;
+        bool? incremental = null, composite = null, declaration = null, emitDeclarationOnly = null;
         DecoratorMode? decoratorMode = null;
-        string? rootDir = null, outDir = null, baseUrl = null, buildInfoFile = null;
+        string? rootDir = null, outDir = null, declarationDir = null, baseUrl = null, buildInfoFile = null;
         IReadOnlyList<string>? files = null, includes = null, excludes = null;
         IReadOnlyList<string>? libs = null, types = null, typeRoots = null;
         IReadOnlyDictionary<string, IReadOnlyList<string>> paths =
@@ -225,6 +225,8 @@ public static class TsConfigLoader
                 emitDecoratorMetadata = opts.EmitDecoratorMetadata ?? emitDecoratorMetadata;
                 incremental = opts.Incremental ?? incremental;
                 composite = opts.Composite ?? composite;
+                declaration = opts.Declaration ?? declaration;
+                emitDeclarationOnly = opts.EmitDeclarationOnly ?? emitDeclarationOnly;
 
                 // `decorators` (Stage 3) wins over `experimentalDecorators` (Legacy) when both
                 // are set — the same precedence the CLI's last-wins switch gives the arguments
@@ -236,6 +238,8 @@ public static class TsConfigLoader
                     rootDir = Path.GetFullPath(Path.Combine(dir, opts.RootDir!));
                 if (!string.IsNullOrWhiteSpace(opts.OutDir))
                     outDir = Path.GetFullPath(Path.Combine(dir, opts.OutDir!));
+                if (!string.IsNullOrWhiteSpace(opts.DeclarationDir))
+                    declarationDir = Path.GetFullPath(Path.Combine(dir, opts.DeclarationDir!));
                 if (!string.IsNullOrWhiteSpace(opts.BaseUrl))
                     baseUrl = Path.GetFullPath(Path.Combine(dir, opts.BaseUrl!));
                 if (!string.IsNullOrWhiteSpace(opts.TsBuildInfoFile))
@@ -293,6 +297,9 @@ public static class TsConfigLoader
             EmitDecoratorMetadata: emitDecoratorMetadata,
             RootDir: rootDir,
             OutDir: outDir,
+            Declaration: declaration,
+            EmitDeclarationOnly: emitDeclarationOnly,
+            DeclarationDir: declarationDir,
             EntryFile: files?.FirstOrDefault(),
             RootFiles: rootFiles,
             DeclarationFiles: declarationFiles,
@@ -374,6 +381,9 @@ public sealed record TsConfigResult(
     bool? EmitDecoratorMetadata,
     string? RootDir,
     string? OutDir,
+    bool? Declaration,
+    bool? EmitDeclarationOnly,
+    string? DeclarationDir,
     string? EntryFile,
     IReadOnlyList<string> RootFiles,
     IReadOnlyList<string> DeclarationFiles,

--- a/Declaration/SourceDeclarationEmitter.cs
+++ b/Declaration/SourceDeclarationEmitter.cs
@@ -1,0 +1,922 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using SharpTS.Modules;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Declaration;
+
+/// <summary>A generated TypeScript declaration file and its source/output paths.</summary>
+public sealed record DeclarationOutput(string SourcePath, string OutputPath, string Content);
+
+/// <summary>
+/// Emits declaration files from the checked source AST. This is intentionally separate from
+/// <see cref="DeclarationGenerator"/>, which describes CLR reflection metadata for interop.
+/// </summary>
+public static class SourceDeclarationEmitter
+{
+    public static IReadOnlyList<DeclarationOutput> EmitModules(
+        IEnumerable<ParsedModule> modules,
+        TypeMap typeMap,
+        IEnumerable<string> sourcePaths,
+        string? rootDir = null,
+        string? declarationDir = null,
+        string? outDir = null)
+    {
+        var comparer = OperatingSystem.IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+        var moduleByPath = modules
+            .Where(module => IsPhysicalSource(module.Path))
+            .ToDictionary(module => Path.GetFullPath(module.Path), comparer);
+        var requestedPaths = sourcePaths
+            .Where(IsPhysicalSource)
+            .Select(Path.GetFullPath)
+            .Distinct(comparer)
+            .ToArray();
+        string? commonRoot = rootDir is not null
+            ? Path.GetFullPath(rootDir)
+            : declarationDir is not null || outDir is not null
+                ? FindCommonDirectory(requestedPaths)
+                : null;
+        string? outputRoot = declarationDir ?? outDir;
+        if (outputRoot is not null)
+            outputRoot = Path.GetFullPath(outputRoot);
+
+        var outputs = new List<DeclarationOutput>();
+        var outputPaths = new HashSet<string>(comparer);
+        foreach (string sourcePath in requestedPaths)
+        {
+            if (!moduleByPath.TryGetValue(sourcePath, out var module))
+                continue;
+
+            string outputPath = GetOutputPath(sourcePath, commonRoot, outputRoot);
+            if (!outputPaths.Add(outputPath))
+                throw new DeclarationEmitException(
+                    $"Multiple source files map to declaration output '{outputPath}'.");
+
+            outputs.Add(new DeclarationOutput(
+                sourcePath,
+                outputPath,
+                EmitFile(module.Statements, module, typeMap)));
+        }
+        return outputs;
+    }
+
+    public static DeclarationOutput EmitSingleFile(
+        string sourcePath,
+        IReadOnlyList<Stmt> statements,
+        TypeMap typeMap,
+        string? rootDir = null,
+        string? declarationDir = null,
+        string? outDir = null)
+    {
+        sourcePath = Path.GetFullPath(sourcePath);
+        string? outputRoot = declarationDir ?? outDir;
+        if (outputRoot is not null)
+            outputRoot = Path.GetFullPath(outputRoot);
+        string outputPath = GetOutputPath(
+            sourcePath,
+            rootDir is null ? Path.GetDirectoryName(sourcePath) : Path.GetFullPath(rootDir),
+            outputRoot);
+        return new DeclarationOutput(
+            sourcePath,
+            outputPath,
+            EmitFile(statements, module: null, typeMap));
+    }
+
+    /// <summary>Writes a fully planned output set using replace-on-success temporary files.</summary>
+    public static void WriteAll(IEnumerable<DeclarationOutput> outputs)
+    {
+        foreach (DeclarationOutput output in outputs)
+        {
+            if (File.Exists(output.OutputPath) &&
+                string.Equals(File.ReadAllText(output.OutputPath), output.Content, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            string? directory = Path.GetDirectoryName(output.OutputPath);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+
+            string temporaryPath = output.OutputPath + $".{Guid.NewGuid():N}.tmp";
+            try
+            {
+                File.WriteAllText(temporaryPath, output.Content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                File.Move(temporaryPath, output.OutputPath, overwrite: true);
+            }
+            finally
+            {
+                if (File.Exists(temporaryPath))
+                    File.Delete(temporaryPath);
+            }
+        }
+    }
+
+    private static string EmitFile(
+        IReadOnlyList<Stmt> statements,
+        ParsedModule? module,
+        TypeMap typeMap)
+    {
+        var emitter = new FileEmitter(module, typeMap);
+        return emitter.Emit(statements);
+    }
+
+    private static string GetOutputPath(string sourcePath, string? rootDir, string? outputRoot)
+    {
+        string fileName = GetDeclarationFileName(sourcePath);
+        if (outputRoot is null)
+            return Path.Combine(Path.GetDirectoryName(sourcePath)!, fileName);
+
+        string relativeDirectory = "";
+        if (rootDir is not null)
+        {
+            string relative = Path.GetRelativePath(rootDir, sourcePath);
+            if (relative == ".." ||
+                relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal) ||
+                Path.IsPathRooted(relative))
+            {
+                throw new DeclarationEmitException(
+                    $"Source file '{sourcePath}' is outside declaration rootDir '{rootDir}'.");
+            }
+            relativeDirectory = Path.GetDirectoryName(relative) ?? "";
+        }
+        return Path.GetFullPath(Path.Combine(outputRoot, relativeDirectory, fileName));
+    }
+
+    private static string GetDeclarationFileName(string sourcePath)
+    {
+        string fileName = Path.GetFileName(sourcePath);
+        if (fileName.EndsWith(".mts", StringComparison.OrdinalIgnoreCase))
+            return fileName[..^4] + ".d.mts";
+        if (fileName.EndsWith(".cts", StringComparison.OrdinalIgnoreCase))
+            return fileName[..^4] + ".d.cts";
+        string extension = Path.GetExtension(fileName);
+        return fileName[..^extension.Length] + ".d.ts";
+    }
+
+    private static bool IsPhysicalSource(string path) =>
+        !path.StartsWith("stdlib:", StringComparison.Ordinal) &&
+        !path.StartsWith("dotnet:", StringComparison.Ordinal) &&
+        !path.EndsWith(".d.ts", StringComparison.OrdinalIgnoreCase) &&
+        !path.EndsWith(".d.mts", StringComparison.OrdinalIgnoreCase) &&
+        !path.EndsWith(".d.cts", StringComparison.OrdinalIgnoreCase) &&
+        (path.EndsWith(".ts", StringComparison.OrdinalIgnoreCase) ||
+         path.EndsWith(".tsx", StringComparison.OrdinalIgnoreCase) ||
+         path.EndsWith(".mts", StringComparison.OrdinalIgnoreCase) ||
+         path.EndsWith(".cts", StringComparison.OrdinalIgnoreCase));
+
+    private static string? FindCommonDirectory(IReadOnlyList<string> paths)
+    {
+        if (paths.Count == 0)
+            return null;
+        string common = Path.GetDirectoryName(paths[0])!;
+        foreach (string path in paths.Skip(1))
+        {
+            string directory = Path.GetDirectoryName(path)!;
+            while (!IsUnder(directory, common))
+            {
+                string? parent = Path.GetDirectoryName(common);
+                if (parent is null || parent == common)
+                    return Path.GetPathRoot(common);
+                common = parent;
+            }
+        }
+        return common;
+    }
+
+    private static bool IsUnder(string candidate, string parent)
+    {
+        string relative = Path.GetRelativePath(parent, candidate);
+        return relative == "." ||
+               (!Path.IsPathRooted(relative) &&
+                relative != ".." &&
+                !relative.StartsWith(".." + Path.DirectorySeparatorChar, StringComparison.Ordinal));
+    }
+
+    private sealed class FileEmitter(ParsedModule? module, TypeMap typeMap)
+    {
+        private readonly StringBuilder _builder = new();
+        private readonly IReadOnlyDictionary<string, string> _dotNetImports =
+            CollectDotNetImports(module?.Statements ?? []);
+        private int _indent;
+
+        public string Emit(IReadOnlyList<Stmt> statements)
+        {
+            foreach (Stmt statement in statements)
+                EmitTopLevel(statement);
+            return _builder.ToString().TrimEnd() + Environment.NewLine;
+        }
+
+        private void EmitTopLevel(Stmt statement)
+        {
+            switch (statement)
+            {
+                case Stmt.Import import when !import.ModulePath.StartsWith("dotnet:", StringComparison.Ordinal):
+                    WriteLine(RenderImport(import));
+                    break;
+                case Stmt.ImportAlias alias:
+                    WriteLine($"{(alias.IsExported ? "export " : "")}import {alias.AliasName.Lexeme} = {string.Join(".", alias.QualifiedPath.Select(token => token.Lexeme))};");
+                    break;
+                case Stmt.ImportRequire require when !require.ModulePath.StartsWith("dotnet:", StringComparison.Ordinal):
+                    WriteLine($"{(require.IsExported ? "export " : "")}import {require.AliasName.Lexeme} = require({Quote(require.ModulePath)});");
+                    break;
+                case Stmt.Export export:
+                    EmitExport(export);
+                    break;
+                default:
+                    EmitDeclaration(statement, ExportKind.None, ResolveLocalType(statement));
+                    break;
+            }
+        }
+
+        private void EmitExport(Stmt.Export export)
+        {
+            if (export.ExportAssignment is not null)
+            {
+                TypeInfo type = module?.ExportAssignmentType ?? typeMap.Get(export.ExportAssignment)
+                    ?? TypeInfo.Any.Shared;
+                WriteLine($"declare const _export: {TypeInfoDeclarationRenderer.Render(type)};");
+                WriteLine("export = _export;");
+                return;
+            }
+
+            if (export.Declaration is not null)
+            {
+                TypeInfo? type = export.IsDefaultExport
+                    ? module?.DefaultExportType
+                    : GetExportedType(export.Declaration);
+                EmitDeclaration(
+                    export.Declaration,
+                    export.IsDefaultExport ? ExportKind.Default : ExportKind.Named,
+                    type);
+                return;
+            }
+
+            if (export.DefaultExpr is not null)
+            {
+                TypeInfo type = module?.DefaultExportType ?? typeMap.Get(export.DefaultExpr)
+                    ?? TypeInfo.Any.Shared;
+                WriteLine($"declare const _default: {TypeInfoDeclarationRenderer.Render(type)};");
+                WriteLine("export default _default;");
+                return;
+            }
+
+            if (export.FromModulePath is not null)
+            {
+                if (export.NamespaceExportName is not null)
+                {
+                    WriteLine($"export {(export.IsTypeOnly ? "type " : "")}* as {export.NamespaceExportName.Lexeme} from {Quote(export.FromModulePath)};");
+                }
+                else if (export.NamedExports is not null)
+                {
+                    WriteLine($"export {(export.IsTypeOnly ? "type " : "")}{{ {RenderExportSpecifiers(export.NamedExports)} }} from {Quote(export.FromModulePath)};");
+                }
+                else
+                {
+                    WriteLine($"export {(export.IsTypeOnly ? "type " : "")}* from {Quote(export.FromModulePath)};");
+                }
+                return;
+            }
+
+            if (export.NamedExports is not null)
+                WriteLine($"export {(export.IsTypeOnly ? "type " : "")}{{ {RenderExportSpecifiers(export.NamedExports)} }};");
+        }
+
+        private TypeInfo? GetExportedType(Stmt declaration)
+        {
+            string? name = DeclarationName(declaration);
+            return name is not null && module?.ExportedTypes.TryGetValue(name, out TypeInfo? type) == true
+                ? type
+                : ResolveLocalType(declaration);
+        }
+
+        private TypeInfo? ResolveLocalType(Stmt declaration) => declaration switch
+        {
+            Stmt.Function function => typeMap.GetFunctionType(function.Name.Lexeme),
+            Stmt.Class @class => typeMap.GetClassType(@class.Name.Lexeme),
+            Stmt.Var variable when variable.Initializer is not null => typeMap.Get(variable.Initializer),
+            Stmt.Var variable when variable.HoistTypeInferenceInitializer is not null =>
+                typeMap.Get(variable.HoistTypeInferenceInitializer),
+            Stmt.Const constant => typeMap.Get(constant.Initializer),
+            _ => null,
+        };
+
+        private void EmitDeclaration(Stmt statement, ExportKind exportKind, TypeInfo? resolvedType)
+        {
+            switch (statement)
+            {
+                case Stmt.Function function when !function.Name.Lexeme.StartsWith("__genArrow_", StringComparison.Ordinal):
+                    EmitFunction(function, exportKind, resolvedType);
+                    break;
+                case Stmt.Class @class:
+                    EmitClass(@class, exportKind, resolvedType);
+                    break;
+                case Stmt.Interface @interface:
+                    EmitInterface(@interface, exportKind, resolvedType);
+                    break;
+                case Stmt.TypeAlias alias:
+                    WriteLine($"{ExportPrefix(exportKind, ambient: false)}type {alias.Name.Lexeme}{RenderTypeParameters(alias.TypeParameters)} = {alias.TypeDefinition};");
+                    break;
+                case Stmt.Enum @enum:
+                    EmitEnum(@enum, exportKind, resolvedType as TypeInfo.Enum);
+                    break;
+                case Stmt.Namespace @namespace:
+                    EmitNamespace(@namespace, exportKind);
+                    break;
+                case Stmt.Var variable when !variable.Name.Lexeme.StartsWith("_dest", StringComparison.Ordinal):
+                    EmitVariable(variable.Name.Lexeme, variable.TypeAnnotation,
+                        variable.Initializer ?? variable.HoistTypeInferenceInitializer,
+                        exportKind, isConst: false, isVar: variable.IsVar, resolvedType);
+                    break;
+                case Stmt.Const constant:
+                    EmitVariable(constant.Name.Lexeme, constant.TypeAnnotation, constant.Initializer,
+                        exportKind, isConst: true, isVar: false, resolvedType);
+                    break;
+                case Stmt.DeclareModule declareModule:
+                    WriteLine($"declare module {Quote(declareModule.ModulePath)} {{");
+                    WithIndent(() =>
+                    {
+                        foreach (Stmt member in declareModule.Members)
+                            EmitDeclaration(member, ExportKind.None, ResolveLocalType(member));
+                    });
+                    WriteLine("}");
+                    break;
+                case Stmt.DeclareGlobal declareGlobal:
+                    WriteLine("declare global {");
+                    WithIndent(() =>
+                    {
+                        foreach (Stmt member in declareGlobal.Members)
+                            EmitDeclaration(member, ExportKind.None, ResolveLocalType(member));
+                    });
+                    WriteLine("}");
+                    break;
+                case Stmt.Export nestedExport:
+                    EmitExport(nestedExport);
+                    break;
+                case Stmt.ImportAlias alias:
+                    WriteLine($"{(alias.IsExported ? "export " : "")}import {alias.AliasName.Lexeme} = {string.Join(".", alias.QualifiedPath.Select(token => token.Lexeme))};");
+                    break;
+                case Stmt.ImportRequire require:
+                    WriteLine($"{(require.IsExported ? "export " : "")}import {require.AliasName.Lexeme} = require({Quote(require.ModulePath)});");
+                    break;
+            }
+        }
+
+        private void EmitVariable(
+            string name,
+            string? annotation,
+            Expr? initializer,
+            ExportKind exportKind,
+            bool isConst,
+            bool isVar,
+            TypeInfo? resolvedType)
+        {
+            TypeInfo type = resolvedType ?? (initializer is null ? null : typeMap.Get(initializer))
+                ?? TypeInfo.Any.Shared;
+            string typeText = RenderAnnotation(annotation, type);
+            string kind = isConst ? "const" : isVar ? "var" : "let";
+            WriteLine($"{ExportPrefix(exportKind, ambient: true)}{kind} {name}: {typeText};");
+        }
+
+        private void EmitFunction(Stmt.Function function, ExportKind exportKind, TypeInfo? resolvedType)
+        {
+            switch (resolvedType)
+            {
+                case TypeInfo.OverloadedFunction overloaded:
+                    foreach (TypeInfo.Function signature in overloaded.Signatures)
+                        EmitFunctionSignature(function, exportKind, signature.ParamTypes, signature.ReturnType, null);
+                    return;
+                case TypeInfo.GenericOverloadedFunction overloaded:
+                    foreach (TypeInfo.Function signature in overloaded.Signatures)
+                        EmitFunctionSignature(function, exportKind, signature.ParamTypes, signature.ReturnType, overloaded.TypeParams);
+                    return;
+                case TypeInfo.GenericFunction generic:
+                    EmitFunctionSignature(function, exportKind, generic.ParamTypes, generic.ReturnType, generic.TypeParams);
+                    return;
+                case TypeInfo.Function simple:
+                    EmitFunctionSignature(function, exportKind, simple.ParamTypes, simple.ReturnType, null);
+                    return;
+                default:
+                    EmitFunctionSignature(function, exportKind, null, null, null);
+                    return;
+            }
+        }
+
+        private void EmitFunctionSignature(
+            Stmt.Function function,
+            ExportKind exportKind,
+            IReadOnlyList<TypeInfo>? resolvedParameters,
+            TypeInfo? resolvedReturnType,
+            IReadOnlyList<TypeInfo.TypeParameter>? resolvedTypeParameters)
+        {
+            string typeParameters = function.TypeParams is { Count: > 0 }
+                ? RenderTypeParameters(function.TypeParams)
+                : resolvedTypeParameters is { Count: > 0 }
+                    ? $"<{string.Join(", ", resolvedTypeParameters.Select(TypeInfoDeclarationRenderer.RenderTypeParameterDeclaration))}>"
+                    : "";
+            string parameters = RenderParameters(function.Parameters, resolvedParameters);
+            string returnType = RenderAnnotation(function.ReturnType, resolvedReturnType);
+            WriteLine($"{ExportPrefix(exportKind, ambient: true, defaultAmbient: false)}function {function.Name.Lexeme}{typeParameters}({parameters}): {returnType};");
+        }
+
+        private void EmitClass(Stmt.Class @class, ExportKind exportKind, TypeInfo? resolvedType)
+        {
+            string modifiers = @class.IsAbstract ? "abstract " : "";
+            string heritage = RenderHeritage(@class);
+            WriteLine($"{ExportPrefix(exportKind, ambient: true, defaultAmbient: false)}{modifiers}class {@class.Name.Lexeme}{RenderTypeParameters(@class.TypeParams)}{heritage} {{");
+            WithIndent(() =>
+            {
+                var methods = @class.Methods
+                    .GroupBy(method => (method.Name.Lexeme, method.IsStatic, method.ComputedKey is not null))
+                    .SelectMany(group => group.Any(method => method.Body is null)
+                        ? group.Where(method => method.Body is null)
+                        : group.Take(1));
+                foreach (Stmt.Function method in methods)
+                    EmitClassMethod(method, resolvedType);
+                foreach (Stmt.Field field in @class.Fields)
+                    EmitClassField(field, resolvedType);
+                foreach (Stmt.Accessor accessor in @class.Accessors ?? [])
+                    EmitAccessor(accessor, resolvedType);
+                foreach (Stmt.AutoAccessor accessor in @class.AutoAccessors ?? [])
+                    EmitAutoAccessor(accessor, resolvedType);
+                foreach (Stmt.IndexSignature index in @class.IndexSignatures ?? [])
+                    WriteLine($"[{index.KeyName.Lexeme}: {RenderIndexKeyType(index.KeyType)}]: {index.ValueType};");
+            });
+            WriteLine("}");
+        }
+
+        private void EmitClassMethod(Stmt.Function method, TypeInfo? classType)
+        {
+            TypeInfo? resolved = GetClassMemberType(classType, method.Name.Lexeme, method.IsStatic, method.IsPrivate);
+            static (IReadOnlyList<TypeInfo>? Params, TypeInfo? Return, IReadOnlyList<TypeInfo.TypeParameter>? TypeParams)
+                Signature(
+                    IReadOnlyList<TypeInfo>? parameters,
+                    TypeInfo? returnType,
+                    IReadOnlyList<TypeInfo.TypeParameter>? typeParameters) =>
+                (parameters, returnType, typeParameters);
+            IEnumerable<(IReadOnlyList<TypeInfo>? Params, TypeInfo? Return, IReadOnlyList<TypeInfo.TypeParameter>? TypeParams)> signatures =
+                resolved switch
+                {
+                    TypeInfo.OverloadedFunction overloaded => overloaded.Signatures.Select(signature =>
+                        Signature(signature.ParamTypes, signature.ReturnType, null)),
+                    TypeInfo.GenericOverloadedFunction overloaded => overloaded.Signatures.Select(signature =>
+                        Signature(signature.ParamTypes, signature.ReturnType, overloaded.TypeParams)),
+                    TypeInfo.GenericFunction generic =>
+                        [Signature(generic.ParamTypes, generic.ReturnType, generic.TypeParams)],
+                    TypeInfo.Function function =>
+                        [Signature(function.ParamTypes, function.ReturnType, null)],
+                    _ => [Signature(null, null, null)],
+                };
+
+            foreach (var signature in signatures)
+            {
+                string access = method.IsPrivate ? "" : RenderAccess(method.Access);
+                string name = RenderMemberName(method.Name, method.ComputedKey, method.IsPrivate);
+                string typeParameters = method.TypeParams is { Count: > 0 }
+                    ? RenderTypeParameters(method.TypeParams)
+                    : signature.TypeParams is { Count: > 0 }
+                        ? $"<{string.Join(", ", signature.TypeParams.Select(TypeInfoDeclarationRenderer.RenderTypeParameterDeclaration))}>"
+                        : "";
+                string parameters = RenderParameters(method.Parameters, signature.Params);
+                string staticModifier = method.IsStatic ? "static " : "";
+                string abstractModifier = method.IsAbstract ? "abstract " : "";
+                string returnType = RenderAnnotation(method.ReturnType, signature.Return);
+                if (method.Name.Lexeme == "constructor")
+                    WriteLine($"{access}constructor({parameters});");
+                else
+                    WriteLine($"{access}{staticModifier}{abstractModifier}{name}{typeParameters}({parameters}): {returnType};");
+            }
+        }
+
+        private void EmitClassField(Stmt.Field field, TypeInfo? classType)
+        {
+            string access = field.IsPrivate ? "" : RenderAccess(field.Access);
+            string staticModifier = field.IsStatic ? "static " : "";
+            string readonlyModifier = field.IsReadonly ? "readonly " : "";
+            string optional = field.IsOptional ? "?" : "";
+            string name = RenderMemberName(field.Name, field.ComputedKey, field.IsPrivate);
+            TypeInfo? resolved = GetClassFieldType(classType, field.Name.Lexeme, field.IsStatic, field.IsPrivate)
+                ?? (field.Initializer is null ? null : typeMap.Get(field.Initializer));
+            string type = RenderAnnotation(field.TypeAnnotation, resolved);
+            WriteLine($"{access}{staticModifier}{readonlyModifier}{name}{optional}: {type};");
+        }
+
+        private void EmitAccessor(Stmt.Accessor accessor, TypeInfo? classType)
+        {
+            string access = RenderAccess(accessor.Access);
+            string staticModifier = accessor.IsStatic ? "static " : "";
+            string name = RenderMemberName(accessor.Name, accessor.ComputedKey, isPrivate: false);
+            if (accessor.Kind.Lexeme == "get")
+            {
+                TypeInfo? type = GetClassGetterType(classType, accessor.Name.Lexeme);
+                WriteLine($"{access}{staticModifier}get {name}(): {RenderAnnotation(accessor.ReturnType, type)};");
+            }
+            else
+            {
+                Stmt.Parameter parameter = accessor.SetterParam!;
+                string type = RenderAnnotation(
+                    parameter.Type,
+                    GetClassSetterType(classType, accessor.Name.Lexeme));
+                WriteLine($"{access}{staticModifier}set {name}({parameter.Name.Lexeme}: {type});");
+            }
+        }
+
+        private void EmitAutoAccessor(Stmt.AutoAccessor accessor, TypeInfo? classType)
+        {
+            TypeInfo? resolved = GetClassFieldType(classType, accessor.Name.Lexeme, accessor.IsStatic, isPrivate: false)
+                ?? (accessor.Initializer is null ? null : typeMap.Get(accessor.Initializer));
+            WriteLine($"{RenderAccess(accessor.Access)}{(accessor.IsStatic ? "static " : "")}accessor {accessor.Name.Lexeme}: " +
+                      $"{RenderAnnotation(accessor.TypeAnnotation, resolved)};");
+        }
+
+        private void EmitInterface(Stmt.Interface @interface, ExportKind exportKind, TypeInfo? resolvedType)
+        {
+            string extends = @interface.Extends is { Count: > 0 }
+                ? $" extends {string.Join(", ", @interface.Extends)}"
+                : "";
+            WriteLine($"{ExportPrefix(exportKind, ambient: false)}interface {@interface.Name.Lexeme}{RenderTypeParameters(@interface.TypeParams)}{extends} {{");
+            WithIndent(() =>
+            {
+                foreach (Stmt.CallSignature call in @interface.CallSignatures ?? [])
+                    WriteLine($"{RenderTypeParameters(call.TypeParams)}({RenderParameters(call.Parameters, null)}): {call.ReturnType};");
+                foreach (Stmt.ConstructorSignature constructor in @interface.ConstructorSignatures ?? [])
+                    WriteLine($"new {RenderTypeParameters(constructor.TypeParams)}({RenderParameters(constructor.Parameters, null)}): {constructor.ReturnType};");
+                foreach (Stmt.InterfaceMember member in @interface.Members)
+                {
+                    string readOnly = member.IsReadonly ? "readonly " : "";
+                    string optional = member.IsOptional ? "?" : "";
+                    TypeInfo? resolvedMember = GetInterfaceMemberType(resolvedType, member.Name.Lexeme);
+                    string functionType = resolvedMember is null
+                        ? member.Type
+                        : TypeInfoDeclarationRenderer.Render(resolvedMember);
+                    if (member.IsMethod && TrySplitFunctionType(functionType, out string? parameters, out string? result))
+                        WriteLine($"{member.Name.Lexeme}{optional}{parameters}: {result};");
+                    else
+                        WriteLine($"{readOnly}{member.Name.Lexeme}{optional}: " +
+                                  $"{RenderAnnotation(member.Type, resolvedMember)};");
+                }
+                foreach (Stmt.IndexSignature index in @interface.IndexSignatures ?? [])
+                    WriteLine($"[{index.KeyName.Lexeme}: {RenderIndexKeyType(index.KeyType)}]: {index.ValueType};");
+            });
+            WriteLine("}");
+        }
+
+        private void EmitEnum(Stmt.Enum @enum, ExportKind exportKind, TypeInfo.Enum? resolved)
+        {
+            WriteLine($"{ExportPrefix(exportKind, ambient: true)}{(@enum.IsConst ? "const " : "")}enum {@enum.Name.Lexeme} {{");
+            WithIndent(() =>
+            {
+                foreach (Stmt.EnumMember member in @enum.Members)
+                {
+                    string? value = RenderConstantExpression(member.Value);
+                    if (value is null && resolved?.Members.TryGetValue(member.Name.Lexeme, out object? checkedValue) == true)
+                        value = RenderConstant(checkedValue);
+                    WriteLine($"{member.Name.Lexeme}{(value is null ? "" : $" = {value}")},");
+                }
+            });
+            WriteLine("}");
+        }
+
+        private void EmitNamespace(Stmt.Namespace @namespace, ExportKind exportKind)
+        {
+            WriteLine($"{ExportPrefix(exportKind, ambient: true)}namespace {@namespace.Name.Lexeme} {{");
+            WithIndent(() =>
+            {
+                foreach (Stmt member in @namespace.Members)
+                    EmitDeclaration(member, ExportKind.None, ResolveLocalType(member));
+            });
+            WriteLine("}");
+        }
+
+        private static string RenderImport(Stmt.Import import)
+        {
+            string typePrefix = import.IsTypeOnly ? "type " : "";
+            var bindings = new List<string>();
+            if (import.DefaultImport is not null)
+                bindings.Add(import.DefaultImport.Lexeme);
+            if (import.NamespaceImport is not null)
+                bindings.Add($"* as {import.NamespaceImport.Lexeme}");
+            if (import.NamedImports is { Count: > 0 })
+            {
+                string named = string.Join(", ", import.NamedImports.Select(specifier =>
+                    $"{(specifier.IsTypeOnly ? "type " : "")}{specifier.Imported.Lexeme}" +
+                    $"{(specifier.LocalName is null ? "" : $" as {specifier.LocalName.Lexeme}")}"));
+                bindings.Add($"{{ {named} }}");
+            }
+            return bindings.Count == 0
+                ? $"import {Quote(import.ModulePath)};"
+                : $"import {typePrefix}{string.Join(", ", bindings)} from {Quote(import.ModulePath)};";
+        }
+
+        private static string RenderExportSpecifiers(IEnumerable<Stmt.ExportSpecifier> specifiers) =>
+            string.Join(", ", specifiers.Select(specifier =>
+                $"{(specifier.IsTypeOnly ? "type " : "")}" +
+                (specifier.ExportedName is null
+                    ? specifier.LocalName.Lexeme
+                    : $"{specifier.LocalName.Lexeme} as {specifier.ExportedName.Lexeme}")));
+
+        private string RenderParameters(
+            IReadOnlyList<Stmt.Parameter> parameters,
+            IReadOnlyList<TypeInfo>? resolvedTypes)
+        {
+            return string.Join(", ", parameters.Select((parameter, index) =>
+            {
+                string access = parameter.IsParameterProperty && parameter.Access is not null
+                    ? RenderAccess(parameter.Access.Value)
+                    : "";
+                string readOnly = parameter.IsParameterProperty && parameter.IsReadonly ? "readonly " : "";
+                string rest = parameter.IsRest ? "..." : "";
+                string optional = parameter.IsOptional || parameter.DefaultValue is not null ? "?" : "";
+                TypeInfo? resolved = resolvedTypes is not null && index < resolvedTypes.Count
+                    ? resolvedTypes[index]
+                    : null;
+                string type = RenderAnnotation(parameter.Type, resolved);
+                return $"{access}{readOnly}{rest}{parameter.Name.Lexeme}{optional}: {type}";
+            }));
+        }
+
+        private static string RenderTypeParameters(IReadOnlyList<TypeParam>? parameters)
+        {
+            if (parameters is not { Count: > 0 })
+                return "";
+            return $"<{string.Join(", ", parameters.Select(parameter =>
+            {
+                string variance = parameter.Variance switch
+                {
+                    TypeParameterVariance.In => "in ",
+                    TypeParameterVariance.Out => "out ",
+                    TypeParameterVariance.InOut => "in out ",
+                    _ => "",
+                };
+                return $"{variance}{(parameter.IsConst ? "const " : "")}{parameter.Name.Lexeme}" +
+                       $"{(parameter.Constraint is null ? "" : $" extends {parameter.Constraint}")}" +
+                       $"{(parameter.Default is null ? "" : $" = {parameter.Default}")}";
+            }))}>";
+        }
+
+        private static string RenderHeritage(Stmt.Class @class)
+        {
+            var parts = new List<string>();
+            string? superclass = Expr.GetSuperclassName(@class.SuperclassExpr);
+            if (superclass is not null)
+            {
+                string typeArguments = @class.SuperclassTypeArgs is { Count: > 0 }
+                    ? $"<{string.Join(", ", @class.SuperclassTypeArgs)}>"
+                    : "";
+                parts.Add($"extends {superclass}{typeArguments}");
+            }
+            if (@class.Interfaces is { Count: > 0 })
+            {
+                var interfaces = @class.Interfaces.Select((token, index) =>
+                {
+                    string typeArguments = @class.InterfaceTypeArgs is not null &&
+                                           index < @class.InterfaceTypeArgs.Count &&
+                                           @class.InterfaceTypeArgs[index].Count > 0
+                        ? $"<{string.Join(", ", @class.InterfaceTypeArgs[index])}>"
+                        : "";
+                    return token.Lexeme + typeArguments;
+                });
+                parts.Add($"implements {string.Join(", ", interfaces)}");
+            }
+            return parts.Count == 0 ? "" : " " + string.Join(" ", parts);
+        }
+
+        private static string RenderMemberName(Token name, Expr? computedKey, bool isPrivate)
+        {
+            if (computedKey is not null)
+                return $"[{RenderNameExpression(computedKey)}]";
+            return isPrivate ? $"#{name.Lexeme.TrimStart('#')}" : name.Lexeme;
+        }
+
+        private static string RenderNameExpression(Expr expression) => expression switch
+        {
+            Expr.Variable variable => variable.Name.Lexeme,
+            Expr.Get get => $"{RenderNameExpression(get.Object)}.{get.Name.Lexeme}",
+            Expr.GetIndex get => $"{RenderNameExpression(get.Object)}[{RenderNameExpression(get.Index)}]",
+            Expr.Literal literal => RenderConstant(literal.Value) ?? "undefined",
+            _ => throw new DeclarationEmitException(
+                $"Computed declaration name using '{expression.GetType().Name}' cannot currently be emitted."),
+        };
+
+        private static string? RenderConstantExpression(Expr? expression) => expression switch
+        {
+            null => null,
+            Expr.Literal literal => RenderConstant(literal.Value),
+            Expr.Variable variable => variable.Name.Lexeme,
+            Expr.Get get => $"{RenderNameExpression(get.Object)}.{get.Name.Lexeme}",
+            Expr.Grouping grouping => $"({RenderConstantExpression(grouping.Expression)})",
+            Expr.Unary unary => $"{unary.Operator.Lexeme}{RenderConstantExpression(unary.Right)}",
+            Expr.Binary binary =>
+                $"{RenderConstantExpression(binary.Left)} {binary.Operator.Lexeme} {RenderConstantExpression(binary.Right)}",
+            _ => null,
+        };
+
+        private static string? RenderConstant(object? value) => value switch
+        {
+            null => "null",
+            string text => Quote(text),
+            bool boolean => boolean ? "true" : "false",
+            double number => number.ToString("R", CultureInfo.InvariantCulture),
+            float number => number.ToString("R", CultureInfo.InvariantCulture),
+            int number => number.ToString(CultureInfo.InvariantCulture),
+            long number => number.ToString(CultureInfo.InvariantCulture),
+            System.Numerics.BigInteger number => $"{number.ToString(CultureInfo.InvariantCulture)}n",
+            _ => null,
+        };
+
+        private static bool TrySplitFunctionType(string type, out string? parameters, out string? result)
+        {
+            int arrow = type.LastIndexOf("=>", StringComparison.Ordinal);
+            if (arrow < 0)
+            {
+                parameters = null;
+                result = null;
+                return false;
+            }
+            parameters = type[..arrow].Trim();
+            result = type[(arrow + 2)..].Trim();
+            return true;
+        }
+
+        private string RenderAnnotation(string? annotation, TypeInfo? resolved)
+        {
+            foreach (var (name, modulePath) in _dotNetImports)
+            {
+                if ((annotation is not null && ContainsIdentifier(annotation, name)) ||
+                    (annotation is null && HasNamedType(resolved, name)))
+                {
+                    throw new DeclarationEmitException(
+                        $"Public declaration type '{name}' comes from CLR import '{modulePath}' " +
+                        "and is not portable to TypeScript consumers.");
+                }
+            }
+            string rendered = TypeInfoDeclarationRenderer.Render(resolved ?? TypeInfo.Any.Shared);
+            return annotation ?? rendered;
+        }
+
+        private static IReadOnlyDictionary<string, string> CollectDotNetImports(
+            IReadOnlyList<Stmt> statements)
+        {
+            var imports = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (Stmt.Import import in statements.OfType<Stmt.Import>())
+            {
+                if (!import.ModulePath.StartsWith("dotnet:", StringComparison.Ordinal))
+                    continue;
+                foreach (Stmt.ImportSpecifier specifier in import.NamedImports ?? [])
+                {
+                    string localName = specifier.LocalName?.Lexeme ?? specifier.Imported.Lexeme;
+                    imports[localName] = import.ModulePath;
+                }
+            }
+            return imports;
+        }
+
+        private static bool ContainsIdentifier(string text, string identifier)
+        {
+            int start = 0;
+            while ((start = text.IndexOf(identifier, start, StringComparison.Ordinal)) >= 0)
+            {
+                int end = start + identifier.Length;
+                bool leftBoundary = start == 0 || !IsIdentifierPart(text[start - 1]);
+                bool rightBoundary = end == text.Length || !IsIdentifierPart(text[end]);
+                if (leftBoundary && rightBoundary)
+                    return true;
+                start = end;
+            }
+            return false;
+        }
+
+        private static bool IsIdentifierPart(char character) =>
+            char.IsLetterOrDigit(character) || character is '_' or '$';
+
+        private static bool HasNamedType(TypeInfo? type, string name) => type switch
+        {
+            TypeInfo.Class @class => @class.Name == name,
+            TypeInfo.MutableClass @class => @class.Name == name,
+            TypeInfo.GenericClass @class => @class.Name == name,
+            TypeInfo.Instance instance => HasNamedType(instance.ResolvedClassType, name),
+            TypeInfo.InstantiatedGeneric generic => HasNamedType(generic.GenericDefinition, name),
+            _ => false,
+        };
+
+        private static TypeInfo? GetClassMemberType(TypeInfo? type, string name, bool isStatic, bool isPrivate) =>
+            type switch
+            {
+                TypeInfo.Class @class when isPrivate && isStatic =>
+                    @class.StaticPrivateMethodTypes.GetValueOrDefault(name),
+                TypeInfo.Class @class when isPrivate =>
+                    @class.PrivateMethodTypes.GetValueOrDefault(name),
+                TypeInfo.Class @class when isStatic => @class.StaticMethods.GetValueOrDefault(name),
+                TypeInfo.Class @class => @class.Methods.GetValueOrDefault(name),
+                TypeInfo.GenericClass @class when isPrivate && isStatic =>
+                    @class.StaticPrivateMethodTypes.GetValueOrDefault(name),
+                TypeInfo.GenericClass @class when isPrivate =>
+                    @class.PrivateMethodTypes.GetValueOrDefault(name),
+                TypeInfo.GenericClass @class when isStatic => @class.StaticMethods.GetValueOrDefault(name),
+                TypeInfo.GenericClass @class => @class.Methods.GetValueOrDefault(name),
+                _ => null,
+            };
+
+        private static TypeInfo? GetInterfaceMemberType(TypeInfo? type, string name) => type switch
+        {
+            TypeInfo.Interface @interface => @interface.Members.GetValueOrDefault(name),
+            TypeInfo.GenericInterface @interface => @interface.Members.GetValueOrDefault(name),
+            _ => null,
+        };
+
+        private static TypeInfo? GetClassFieldType(TypeInfo? type, string name, bool isStatic, bool isPrivate) =>
+            type switch
+            {
+                TypeInfo.Class @class when isPrivate && isStatic =>
+                    @class.StaticPrivateFieldTypes.GetValueOrDefault(name),
+                TypeInfo.Class @class when isPrivate =>
+                    @class.PrivateFieldTypes.GetValueOrDefault(name),
+                TypeInfo.Class @class when isStatic => @class.StaticProperties.GetValueOrDefault(name),
+                TypeInfo.Class @class => @class.FieldTypes.GetValueOrDefault(name),
+                TypeInfo.GenericClass @class when isPrivate && isStatic =>
+                    @class.StaticPrivateFieldTypes.GetValueOrDefault(name),
+                TypeInfo.GenericClass @class when isPrivate =>
+                    @class.PrivateFieldTypes.GetValueOrDefault(name),
+                TypeInfo.GenericClass @class when isStatic => @class.StaticProperties.GetValueOrDefault(name),
+                TypeInfo.GenericClass @class => @class.FieldTypes.GetValueOrDefault(name),
+                _ => null,
+            };
+
+        private static TypeInfo? GetClassGetterType(TypeInfo? type, string name) => type switch
+        {
+            TypeInfo.Class @class => @class.Getters.GetValueOrDefault(name),
+            TypeInfo.GenericClass @class => @class.Getters.GetValueOrDefault(name),
+            _ => null,
+        };
+
+        private static TypeInfo? GetClassSetterType(TypeInfo? type, string name) => type switch
+        {
+            TypeInfo.Class @class => @class.Setters.GetValueOrDefault(name),
+            TypeInfo.GenericClass @class => @class.Setters.GetValueOrDefault(name),
+            _ => null,
+        };
+
+        private static string? DeclarationName(Stmt declaration) => declaration switch
+        {
+            Stmt.Function function => function.Name.Lexeme,
+            Stmt.Class @class => @class.Name.Lexeme,
+            Stmt.Interface @interface => @interface.Name.Lexeme,
+            Stmt.TypeAlias alias => alias.Name.Lexeme,
+            Stmt.Enum @enum => @enum.Name.Lexeme,
+            Stmt.Namespace @namespace => @namespace.Name.Lexeme,
+            Stmt.Var variable => variable.Name.Lexeme,
+            Stmt.Const constant => constant.Name.Lexeme,
+            _ => null,
+        };
+
+        private static string ExportPrefix(
+            ExportKind kind,
+            bool ambient,
+            bool defaultAmbient = true) => kind switch
+        {
+            ExportKind.Default => ambient && defaultAmbient ? "export default declare " : "export default ",
+            ExportKind.Named => ambient ? "export declare " : "export ",
+            _ => ambient ? "declare " : "",
+        };
+
+        private static string RenderAccess(AccessModifier access) => access switch
+        {
+            AccessModifier.Private => "private ",
+            AccessModifier.Protected => "protected ",
+            _ => "public ",
+        };
+
+        private static string RenderIndexKeyType(TokenType keyType) => keyType switch
+        {
+            TokenType.TYPE_NUMBER => "number",
+            TokenType.TYPE_SYMBOL => "symbol",
+            _ => "string",
+        };
+
+        private static string Quote(string text) => JsonSerializer.Serialize(text);
+
+        private void WriteLine(string line)
+        {
+            if (_builder.Length > 0 && _builder[^1] != '\n')
+                _builder.AppendLine();
+            _builder.Append(' ', _indent * 4).AppendLine(line);
+        }
+
+        private void WithIndent(Action action)
+        {
+            _indent++;
+            try { action(); }
+            finally { _indent--; }
+        }
+    }
+
+    private enum ExportKind
+    {
+        None,
+        Named,
+        Default,
+    }
+}

--- a/Declaration/TypeInfoDeclarationRenderer.cs
+++ b/Declaration/TypeInfoDeclarationRenderer.cs
@@ -1,0 +1,316 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Declaration;
+
+/// <summary>Renders checked SharpTS types as valid TypeScript type syntax.</summary>
+internal static class TypeInfoDeclarationRenderer
+{
+    public static string Render(TypeInfo type) => Render(type, 0);
+
+    private static string Render(TypeInfo type, int parentPrecedence)
+    {
+        const int conditionalPrecedence = 1;
+        const int unionPrecedence = 2;
+        const int intersectionPrecedence = 3;
+        const int prefixPrecedence = 4;
+        const int primaryPrecedence = 5;
+
+        (string Text, int Precedence) rendered = type switch
+        {
+            TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } => ("number", primaryPrecedence),
+            TypeInfo.Primitive { Type: TokenType.TYPE_BOOLEAN } => ("boolean", primaryPrecedence),
+            TypeInfo.String => ("string", primaryPrecedence),
+            TypeInfo.Void => ("void", primaryPrecedence),
+            TypeInfo.Any or TypeInfo.Inferred => ("any", primaryPrecedence),
+            TypeInfo.Null => ("null", primaryPrecedence),
+            TypeInfo.Undefined => ("undefined", primaryPrecedence),
+            TypeInfo.Unknown => ("unknown", primaryPrecedence),
+            TypeInfo.Never => ("never", primaryPrecedence),
+            TypeInfo.Symbol => ("symbol", primaryPrecedence),
+            TypeInfo.UniqueSymbol => ("unique symbol", primaryPrecedence),
+            TypeInfo.BigInt => ("bigint", primaryPrecedence),
+            TypeInfo.Object => ("object", primaryPrecedence),
+            TypeInfo.StringLiteral s => (JsonSerializer.Serialize(s.Value), primaryPrecedence),
+            TypeInfo.NumberLiteral n => (n.Value.ToString("R", CultureInfo.InvariantCulture), primaryPrecedence),
+            TypeInfo.BooleanLiteral b => (b.Value ? "true" : "false", primaryPrecedence),
+            TypeInfo.BigIntLiteral b => ($"{b.Value.ToString(CultureInfo.InvariantCulture)}n", primaryPrecedence),
+
+            TypeInfo.Class c => (c.Name, primaryPrecedence),
+            TypeInfo.MutableClass c => (c.Name, primaryPrecedence),
+            TypeInfo.GenericClass c => (c.Name, primaryPrecedence),
+            TypeInfo.Interface i => (i.Name, primaryPrecedence),
+            TypeInfo.GenericInterface i => (i.Name, primaryPrecedence),
+            TypeInfo.Enum e => (e.Name, primaryPrecedence),
+            TypeInfo.Instance i => (Render(i.ResolvedClassType, primaryPrecedence), primaryPrecedence),
+            TypeInfo.RecursiveTypeAlias a => (
+                a.TypeArguments is { Count: > 0 }
+                    ? $"{a.AliasName}<{string.Join(", ", a.TypeArguments.Select(type => Render(type)))}>"
+                    : a.AliasName,
+                primaryPrecedence),
+            TypeInfo.TypeParameter p => (p.Name, primaryPrecedence),
+            TypeInfo.InferredTypeParameter p => (
+                p.Constraint is null ? $"infer {p.Name}" : $"infer {p.Name} extends {Render(p.Constraint)}",
+                primaryPrecedence),
+
+            TypeInfo.Array a => (
+                a.IsReadonly
+                    ? $"ReadonlyArray<{Render(a.ElementType)}>"
+                    : $"Array<{Render(a.ElementType)}>",
+                primaryPrecedence),
+            TypeInfo.Tuple t => (RenderTuple(t), primaryPrecedence),
+            TypeInfo.Map m => ($"Map<{Render(m.KeyType)}, {Render(m.ValueType)}>", primaryPrecedence),
+            TypeInfo.Set s => ($"Set<{Render(s.ElementType)}>", primaryPrecedence),
+            TypeInfo.Iterator i => ($"IterableIterator<{Render(i.ElementType)}>", primaryPrecedence),
+            TypeInfo.Iterable i => ($"Iterable<{Render(i.ElementType)}>", primaryPrecedence),
+            TypeInfo.AsyncIterable i => ($"AsyncIterable<{Render(i.ElementType)}>", primaryPrecedence),
+            TypeInfo.AsyncIterator i => ($"AsyncIterableIterator<{Render(i.ElementType)}>", primaryPrecedence),
+            TypeInfo.WeakMap m => ($"WeakMap<{Render(m.KeyType)}, {Render(m.ValueType)}>", primaryPrecedence),
+            TypeInfo.WeakSet s => ($"WeakSet<{Render(s.ElementType)}>", primaryPrecedence),
+            TypeInfo.WeakRef w => ($"WeakRef<{Render(w.TargetType)}>", primaryPrecedence),
+            TypeInfo.FinalizationRegistry f => ($"FinalizationRegistry<{Render(f.TargetType)}>", primaryPrecedence),
+            TypeInfo.Promise p => ($"Promise<{Render(p.ValueType)}>", primaryPrecedence),
+            TypeInfo.Generator g => ($"Generator<{Render(g.YieldType)}>", primaryPrecedence),
+            TypeInfo.AsyncGenerator g => ($"AsyncGenerator<{Render(g.YieldType)}>", primaryPrecedence),
+
+            TypeInfo.Function f => (RenderFunction(f.ParamTypes, f.ReturnType, f.MinArity,
+                f.HasRestParam, f.ParamNames, null, f.ThisType), conditionalPrecedence),
+            TypeInfo.GenericFunction f => (RenderFunction(f.ParamTypes, f.ReturnType, f.MinArity,
+                f.HasRestParam, f.ParamNames, f.TypeParams, f.ThisType), conditionalPrecedence),
+            TypeInfo.OverloadedFunction f => (
+                RenderFunction(f.Implementation.ParamTypes, f.Implementation.ReturnType,
+                    f.Implementation.MinArity, f.Implementation.HasRestParam,
+                    f.Implementation.ParamNames, null, f.Implementation.ThisType),
+                conditionalPrecedence),
+            TypeInfo.GenericOverloadedFunction f => (
+                RenderFunction(f.Implementation.ParamTypes, f.Implementation.ReturnType,
+                    f.Implementation.MinArity, f.Implementation.HasRestParam,
+                    f.Implementation.ParamNames, f.TypeParams, f.Implementation.ThisType),
+                conditionalPrecedence),
+
+            TypeInfo.Record r => (RenderRecord(r), primaryPrecedence),
+            TypeInfo.Union u => (
+                string.Join(" | ", u.FlattenedTypes.Select(t => Render(t, unionPrecedence))),
+                unionPrecedence),
+            TypeInfo.Intersection i => (
+                string.Join(" & ", i.FlattenedTypes.Select(t => Render(t, intersectionPrecedence))),
+                intersectionPrecedence),
+            TypeInfo.SpreadType s => ($"...{Render(s.Inner, prefixPrecedence)}", prefixPrecedence),
+            TypeInfo.KeyOf k => ($"keyof {Render(k.SourceType, prefixPrecedence)}", prefixPrecedence),
+            TypeInfo.TypeOf t => ($"typeof {t.Path}", prefixPrecedence),
+            TypeInfo.IndexedAccess i => (
+                $"{Render(i.ObjectType, primaryPrecedence)}[{Render(i.IndexType)}]",
+                primaryPrecedence),
+            TypeInfo.ConditionalType c => (
+                $"{Render(c.CheckType, conditionalPrecedence)} extends {Render(c.ExtendsType, conditionalPrecedence)} ? " +
+                $"{Render(c.TrueType, conditionalPrecedence)} : {Render(c.FalseType, conditionalPrecedence)}",
+                conditionalPrecedence),
+            TypeInfo.MappedType m => (RenderMapped(m), primaryPrecedence),
+            TypeInfo.InstantiatedGeneric i => (
+                $"{GenericName(i.GenericDefinition)}<{string.Join(", ", i.TypeArguments.Select(type => Render(type)))}>",
+                primaryPrecedence),
+            TypeInfo.TemplateLiteralType t => (RenderTemplateLiteral(t), primaryPrecedence),
+            TypeInfo.IntrinsicStringType i => (
+                $"{i.Operation}<{Render(i.Inner)}>",
+                primaryPrecedence),
+            TypeInfo.TypePredicate p => (
+                p.IsAssertion
+                    ? $"asserts {p.ParameterName} is {Render(p.PredicateType)}"
+                    : $"{p.ParameterName} is {Render(p.PredicateType)}",
+                conditionalPrecedence),
+            TypeInfo.AssertsNonNull a => ($"asserts {a.ParameterName}", conditionalPrecedence),
+
+            TypeInfo.Date => ("Date", primaryPrecedence),
+            TypeInfo.RegExp => ("RegExp", primaryPrecedence),
+            TypeInfo.Error e => (e.Name, primaryPrecedence),
+            TypeInfo.Timeout => ("NodeJS.Timeout", primaryPrecedence),
+            TypeInfo.Buffer => ("Buffer", primaryPrecedence),
+            TypeInfo.EventEmitter => ("EventEmitter", primaryPrecedence),
+            TypeInfo.AbortController => ("AbortController", primaryPrecedence),
+            TypeInfo.AbortSignal => ("AbortSignal", primaryPrecedence),
+            TypeInfo.Worker => ("Worker", primaryPrecedence),
+            TypeInfo.MessagePort => ("MessagePort", primaryPrecedence),
+            TypeInfo.MessageChannel => ("MessageChannel", primaryPrecedence),
+            TypeInfo.SharedArrayBuffer => ("SharedArrayBuffer", primaryPrecedence),
+            TypeInfo.ArrayBuffer => ("ArrayBuffer", primaryPrecedence),
+            TypeInfo.DataView => ("DataView", primaryPrecedence),
+            TypeInfo.TypedArray t => ($"{t.ElementType}Array", primaryPrecedence),
+            TypeInfo.AtomicsNamespace => ("typeof Atomics", prefixPrecedence),
+
+            TypeInfo.ExternalDotNetType d => throw new DeclarationEmitException(
+                $"Public declaration type '{d.TypeScriptName}' maps to CLR type '{d.ClrTypeName}' and is not portable to TypeScript consumers."),
+            TypeInfo.Module m => throw new DeclarationEmitException(
+                $"Module namespace type from '{m.ModulePath}' cannot currently be named in a portable declaration."),
+            TypeInfo.Namespace n => ($"typeof {n.Name}", prefixPrecedence),
+            TypeInfo.CallSignature s => (
+                RenderFunction(s.ParamTypes, s.ReturnType, s.MinArity, s.HasRestParam,
+                    s.ParamNames, s.TypeParams, null).Replace(" => ", ": ", StringComparison.Ordinal),
+                conditionalPrecedence),
+            TypeInfo.ConstructorSignature s => (
+                $"new {RenderFunction(s.ParamTypes, s.ReturnType, s.MinArity, s.HasRestParam, s.ParamNames, s.TypeParams, null)}",
+                conditionalPrecedence),
+            _ => throw new DeclarationEmitException(
+                $"Type '{type.GetType().Name}' cannot currently be represented in a TypeScript declaration."),
+        };
+
+        return rendered.Precedence < parentPrecedence ? $"({rendered.Text})" : rendered.Text;
+    }
+
+    private static string RenderFunction(
+        IReadOnlyList<TypeInfo> parameterTypes,
+        TypeInfo returnType,
+        int minimumArity,
+        bool hasRest,
+        IReadOnlyList<string>? names,
+        IReadOnlyList<TypeInfo.TypeParameter>? typeParameters,
+        TypeInfo? thisType)
+    {
+        var parameters = new List<string>();
+        if (thisType is not null)
+            parameters.Add($"this: {Render(thisType)}");
+
+        for (int index = 0; index < parameterTypes.Count; index++)
+        {
+            bool rest = hasRest && index == parameterTypes.Count - 1;
+            bool optional = !rest && index >= minimumArity;
+            string name = names is not null && index < names.Count && !string.IsNullOrWhiteSpace(names[index])
+                ? names[index]
+                : $"arg{index}";
+            parameters.Add($"{(rest ? "..." : "")}{name}{(optional ? "?" : "")}: {Render(parameterTypes[index])}");
+        }
+
+        string typeParametersText = typeParameters is { Count: > 0 }
+            ? $"<{string.Join(", ", typeParameters.Select(RenderTypeParameter))}>"
+            : "";
+        return $"{typeParametersText}({string.Join(", ", parameters)}) => {Render(returnType)}";
+    }
+
+    private static string RenderTuple(TypeInfo.Tuple tuple)
+    {
+        var elements = tuple.Elements.Select(element =>
+        {
+            string name = element.Name is null ? "" : $"{element.Name}{(element.IsOptional ? "?" : "")}: ";
+            string marker = element.IsSpread ? "..." : "";
+            string optional = element.Name is null && element.IsOptional ? "?" : "";
+            return $"{marker}{name}{Render(element.Type)}{optional}";
+        }).ToList();
+        if (tuple.RestElementType is not null)
+            elements.Add($"...{Render(tuple.RestElementType)}[]");
+        return $"{(tuple.IsReadonly ? "readonly " : "")}[{string.Join(", ", elements)}]";
+    }
+
+    private static string RenderRecord(TypeInfo.Record record)
+    {
+        var members = new List<string>();
+        if (record.CallSignatures is not null)
+            members.AddRange(record.CallSignatures.Select(RenderCallSignature));
+        if (record.ConstructorSignatures is not null)
+            members.AddRange(record.ConstructorSignatures.Select(RenderConstructorSignature));
+
+        foreach (var field in record.Fields.OrderBy(pair => pair.Key, StringComparer.Ordinal))
+        {
+            string readOnly = record.IsReadonly || record.IsGetterOnly(field.Key) ? "readonly " : "";
+            string optional = record.IsFieldOptional(field.Key) ? "?" : "";
+            members.Add($"{readOnly}{QuoteProperty(field.Key)}{optional}: {Render(field.Value)};");
+        }
+        if (record.StringIndexType is not null)
+            members.Add($"[key: string]: {Render(record.StringIndexType)};");
+        if (record.NumberIndexType is not null)
+            members.Add($"[key: number]: {Render(record.NumberIndexType)};");
+        if (record.SymbolIndexType is not null)
+            members.Add($"[key: symbol]: {Render(record.SymbolIndexType)};");
+        return $"{{ {string.Join(" ", members)} }}";
+    }
+
+    private static string RenderCallSignature(TypeInfo.CallSignature signature) =>
+        $"{RenderTypeParameters(signature.TypeParams)}{RenderParameters(signature.ParamTypes, signature.MinArity, signature.HasRestParam, signature.ParamNames)}: {Render(signature.ReturnType)};";
+
+    private static string RenderConstructorSignature(TypeInfo.ConstructorSignature signature) =>
+        $"new {RenderTypeParameters(signature.TypeParams)}{RenderParameters(signature.ParamTypes, signature.MinArity, signature.HasRestParam, signature.ParamNames)}: {Render(signature.ReturnType)};";
+
+    private static string RenderParameters(
+        IReadOnlyList<TypeInfo> types,
+        int minimumArity,
+        bool hasRest,
+        IReadOnlyList<string>? names)
+    {
+        var parameters = types.Select((type, index) =>
+        {
+            bool rest = hasRest && index == types.Count - 1;
+            bool optional = !rest && index >= minimumArity;
+            string name = names is not null && index < names.Count ? names[index] : $"arg{index}";
+            return $"{(rest ? "..." : "")}{name}{(optional ? "?" : "")}: {Render(type)}";
+        });
+        return $"({string.Join(", ", parameters)})";
+    }
+
+    private static string RenderMapped(TypeInfo.MappedType mapped)
+    {
+        string readOnly = mapped.Modifiers.HasFlag(MappedTypeModifiers.AddReadonly) ? "+readonly "
+            : mapped.Modifiers.HasFlag(MappedTypeModifiers.RemoveReadonly) ? "-readonly "
+            : "";
+        string optional = mapped.Modifiers.HasFlag(MappedTypeModifiers.AddOptional) ? "+?"
+            : mapped.Modifiers.HasFlag(MappedTypeModifiers.RemoveOptional) ? "-?"
+            : "";
+        string remap = mapped.AsClause is null ? "" : $" as {Render(mapped.AsClause)}";
+        return $"{{ {readOnly}[{mapped.ParameterName} in {Render(mapped.Constraint)}{remap}]{optional}: {Render(mapped.ValueType)} }}";
+    }
+
+    private static string RenderTemplateLiteral(TypeInfo.TemplateLiteralType template)
+    {
+        var builder = new StringBuilder("`");
+        for (int index = 0; index < template.InterpolatedTypes.Count; index++)
+        {
+            builder.Append(template.Strings[index].Replace("`", "\\`", StringComparison.Ordinal));
+            builder.Append("${").Append(Render(template.InterpolatedTypes[index])).Append('}');
+        }
+        builder.Append(template.Strings[^1].Replace("`", "\\`", StringComparison.Ordinal)).Append('`');
+        return builder.ToString();
+    }
+
+    private static string RenderTypeParameters(IReadOnlyList<TypeInfo.TypeParameter>? typeParameters) =>
+        typeParameters is { Count: > 0 }
+            ? $"<{string.Join(", ", typeParameters.Select(RenderTypeParameter))}>"
+            : "";
+
+    private static string RenderTypeParameter(TypeInfo.TypeParameter parameter)
+    {
+        string variance = parameter.Variance switch
+        {
+            TypeParameterVariance.In => "in ",
+            TypeParameterVariance.Out => "out ",
+            TypeParameterVariance.InOut => "in out ",
+            _ => "",
+        };
+        string text = $"{variance}{(parameter.IsConst ? "const " : "")}{parameter.Name}";
+        if (parameter.Constraint is not null)
+            text += $" extends {Render(parameter.Constraint)}";
+        if (parameter.Default is not null)
+            text += $" = {Render(parameter.Default)}";
+        return text;
+    }
+
+    internal static string RenderTypeParameterDeclaration(TypeInfo.TypeParameter parameter) =>
+        RenderTypeParameter(parameter);
+
+    private static string GenericName(TypeInfo type) => type switch
+    {
+        TypeInfo.GenericClass c => c.Name,
+        TypeInfo.GenericInterface i => i.Name,
+        TypeInfo.RecursiveTypeAlias a => a.AliasName,
+        _ => Render(type),
+    };
+
+    private static string QuoteProperty(string name) =>
+        IsIdentifier(name) ? name : JsonSerializer.Serialize(name);
+
+    private static bool IsIdentifier(string name) =>
+        name.Length > 0 &&
+        (char.IsLetter(name[0]) || name[0] is '_' or '$') &&
+        name.Skip(1).All(character => char.IsLetterOrDigit(character) || character is '_' or '$');
+}
+
+public sealed class DeclarationEmitException(string message) : Exception(message);

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -1729,6 +1729,9 @@ public partial class Interpreter : IDisposable
     /// </summary>
     private ExecutionResult ExecuteExport(Stmt.Export export)
     {
+        if (export.IsTypeOnly)
+            return ExecutionResult.Success();
+
         // Handle export = assignment (CommonJS-style)
         if (export.ExportAssignment != null)
         {
@@ -1779,6 +1782,8 @@ public partial class Interpreter : IDisposable
             // export { x, y }
             foreach (var spec in export.NamedExports)
             {
+                if (spec.IsTypeOnly)
+                    continue;
                 string localName = spec.LocalName.Lexeme;
                 string exportedName = spec.ExportedName?.Lexeme ?? localName;
                 var value = _environment.Get(spec.LocalName).ToObject();
@@ -1820,6 +1825,8 @@ public partial class Interpreter : IDisposable
                     // Re-export specific names
                     foreach (var spec in export.NamedExports)
                     {
+                        if (spec.IsTypeOnly)
+                            continue;
                         string importedName = spec.LocalName.Lexeme;
                         string exportedName = spec.ExportedName?.Lexeme ?? importedName;
                         object? value = cjsExports != null

--- a/Parsing/AST.cs
+++ b/Parsing/AST.cs
@@ -530,6 +530,7 @@ public abstract record Stmt
     /// <param name="IsDefaultExport">True for 'export default'</param>
     /// <param name="ExportAssignment">CommonJS export assignment: export = expr</param>
     /// <param name="NamespaceExportName">Namespace re-export alias: export * as ns from './file'</param>
+    /// <param name="IsTypeOnly">True for a statement-level <c>export type</c>.</param>
     public record Export(
         Token Keyword,
         Stmt? Declaration,
@@ -538,7 +539,8 @@ public abstract record Stmt
         string? FromModulePath,
         bool IsDefaultExport,
         Expr? ExportAssignment = null,
-        Token? NamespaceExportName = null
+        Token? NamespaceExportName = null,
+        bool IsTypeOnly = false
     ) : Stmt;
 
     /// <summary>
@@ -546,7 +548,8 @@ public abstract record Stmt
     /// </summary>
     /// <param name="LocalName">Name in current module</param>
     /// <param name="ExportedName">Exported as (null = same as local)</param>
-    public record ExportSpecifier(Token LocalName, Token? ExportedName);
+    /// <param name="IsTypeOnly">True for an inline <c>type</c> modifier.</param>
+    public record ExportSpecifier(Token LocalName, Token? ExportedName, bool IsTypeOnly = false);
 
     /// <summary>
     /// File-level directive decorators (e.g., @Namespace("MyCompany.Libraries"))

--- a/Parsing/Parser.Modules.cs
+++ b/Parsing/Parser.Modules.cs
@@ -214,6 +214,13 @@ public partial class Parser
     private Stmt ExportDeclaration(List<Decorator>? classDecorators = null)
     {
         Token keyword = Previous();
+        bool isTypeOnlyExport = false;
+        if (Check(TokenType.TYPE) &&
+            PeekNext().Type is TokenType.LEFT_BRACE or TokenType.STAR)
+        {
+            Advance();
+            isTypeOnlyExport = true;
+        }
 
         // Decorators are only valid on the class-producing export forms below. Every other
         // branch calls this first so `@dec export function/const/{…}/…` reports the same
@@ -290,7 +297,8 @@ public partial class Parser
             }
 
             ConsumeSemicolon("Expect ';' after export.");
-            return new Stmt.Export(keyword, null, namedExports, null, fromPath, IsDefaultExport: false);
+            return new Stmt.Export(keyword, null, namedExports, null, fromPath,
+                IsDefaultExport: false, IsTypeOnly: isTypeOnlyExport);
         }
 
         // export * from './module' (re-export all) or
@@ -309,7 +317,7 @@ public partial class Parser
 
             // Represent as export with null named exports and a fromPath (meaning all)
             return new Stmt.Export(keyword, null, null, null, fromPath, IsDefaultExport: false,
-                NamespaceExportName: namespaceExportName);
+                NamespaceExportName: namespaceExportName, IsTypeOnly: isTypeOnlyExport);
         }
 
         // export import X = Namespace.Member (re-export alias)
@@ -441,6 +449,19 @@ public partial class Parser
         {
             do
             {
+                bool isTypeOnly = false;
+                if (Check(TokenType.TYPE))
+                {
+                    TokenType nextType = PeekNext().Type;
+                    if (nextType != TokenType.AS &&
+                        nextType != TokenType.COMMA &&
+                        nextType != TokenType.RIGHT_BRACE)
+                    {
+                        Advance();
+                        isTypeOnly = true;
+                    }
+                }
+
                 Token localName = ConsumeSpecifierName("Expect export name.");
                 Token? exportedName = null;
 
@@ -449,7 +470,7 @@ public partial class Parser
                     exportedName = ConsumeIdentifierName("Expect exported name after 'as'.");
                 }
 
-                specifiers.Add(new Stmt.ExportSpecifier(localName, exportedName));
+                specifiers.Add(new Stmt.ExportSpecifier(localName, exportedName, isTypeOnly));
                 if (!Match(TokenType.COMMA)) break;
             } while (!Check(TokenType.RIGHT_BRACE));
         }

--- a/Program.cs
+++ b/Program.cs
@@ -232,6 +232,12 @@ static (GlobalOptions Options, TsConfigResult? Config) ApplyTsConfig(GlobalOptio
             },
             CheckJs = cli.CheckJs || (config.CheckJs ?? false),
             EmitDecoratorMetadata = cli.EmitDecoratorMetadata || (config.EmitDecoratorMetadata ?? false),
+            Declaration = cli.Declaration || config.Declaration == true ||
+                config.EmitDeclarationOnly == true || config.Composite == true,
+            EmitDeclarationOnly = cli.EmitDeclarationOnly || config.EmitDeclarationOnly == true,
+            DeclarationDir = cli.DeclarationDir is not null
+                ? Path.GetFullPath(cli.DeclarationDir)
+                : config.DeclarationDir,
             DecoratorMode = cli.DecoratorMode == DecoratorMode.Stage3 && config.DecoratorMode is { } m
                 ? m
                 : cli.DecoratorMode,
@@ -285,6 +291,9 @@ static void PrintResolvedConfig(GlobalOptions options, StrictnessOptions cliStri
             ["noImplicitAny"] = effective.NoImplicitAny,
             ["checkJs"] = options.CheckJs,
             ["emitDecoratorMetadata"] = options.EmitDecoratorMetadata,
+            ["declaration"] = options.Declaration,
+            ["emitDeclarationOnly"] = options.EmitDeclarationOnly,
+            ["declarationDir"] = options.DeclarationDir,
         },
         ["sharpts"] = new Dictionary<string, object?>
         {
@@ -664,11 +673,11 @@ static void CompileFile(string inputPath, string outputPath, bool preserveConstE
         }
         else
         {
-            CompileSingleFile(statements, outputPath, preserveConstEnums, useReferenceAssemblies, sdkPath, verifyIL, decoratorMode, outputOptions, metadata, references, target, bundlerMode, absolutePath, lexer.Pragmas, externalRefs, globalOptions);
+            CompileSingleFile(statements, outputPath, preserveConstEnums, useReferenceAssemblies, sdkPath, verifyIL, decoratorMode, outputOptions, metadata, references, target, bundlerMode, absolutePath, lexer.Pragmas, externalRefs, globalOptions, project);
         }
 
-        // --noEmit stopped before any assembly was written, so there is nothing to pack.
-        if (globalOptions.NoEmit) return;
+        // These modes stopped before any assembly was written, so there is nothing to pack.
+        if (globalOptions.NoEmit || globalOptions.EmitDeclarationOnly) return;
 
         // Package if requested
         if (packOptions.Pack)
@@ -747,6 +756,36 @@ static void CompileModuleFile(string absolutePath, string outputPath, bool prese
             Environment.Exit(1);
         return;
     }
+
+    if (globalOptions.Declaration)
+    {
+        var reporter = new DiagnosticReporter { MsBuildFormat = outputOptions.MsBuildErrors, QuietMode = outputOptions.QuietMode };
+        var diagnostics = checker.GetDiagnostics();
+        reporter.ReportAll(diagnostics);
+        if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
+            Environment.Exit(1);
+
+        IReadOnlyList<string> sources = project is null
+            ? allModules
+                .Select(module => module.Path)
+                .Where(path => IsDeclarationSource(path) && !IsNodeModulesPath(path))
+                .ToArray()
+            : project.RootFiles;
+        var declarations = SourceDeclarationEmitter.EmitModules(
+            typeModules,
+            typeMap,
+            sources,
+            project?.RootDir,
+            globalOptions.DeclarationDir,
+            project?.OutDir);
+        SourceDeclarationEmitter.WriteAll(declarations);
+        if (!outputOptions.QuietMode)
+            foreach (var declaration in declarations)
+                Console.WriteLine($"Declaration emitted to {declaration.OutputPath}");
+    }
+
+    if (globalOptions.EmitDeclarationOnly)
+        return;
 
     // Dead Code Analysis
     DeadCodeAnalyzer deadCodeAnalyzer = new(typeMap);
@@ -844,7 +883,7 @@ static void EmitCompiledAssembly(string outputPath, bool preserveConstEnums, boo
     }
 }
 
-static void CompileSingleFile(List<Stmt> statements, string outputPath, bool preserveConstEnums, bool useReferenceAssemblies, string? sdkPath, bool verifyIL, DecoratorMode decoratorMode, OutputOptions outputOptions, AssemblyMetadata? metadata, IReadOnlyList<string> references, OutputTarget target, BundlerMode bundlerMode, string? sourcePath = null, TypeScriptPragmas? pragmas = null, ReferenceSet? externalRefs = null, GlobalOptions? globalOptions = null)
+static void CompileSingleFile(List<Stmt> statements, string outputPath, bool preserveConstEnums, bool useReferenceAssemblies, string? sdkPath, bool verifyIL, DecoratorMode decoratorMode, OutputOptions outputOptions, AssemblyMetadata? metadata, IReadOnlyList<string> references, OutputTarget target, BundlerMode bundlerMode, string? sourcePath = null, TypeScriptPragmas? pragmas = null, ReferenceSet? externalRefs = null, GlobalOptions? globalOptions = null, TsConfigResult? project = null)
 {
     externalRefs ??= ReferenceSet.Empty;
     globalOptions ??= new GlobalOptions();
@@ -878,6 +917,23 @@ static void CompileSingleFile(List<Stmt> statements, string outputPath, bool pre
     // --noEmit: type-check only, never produce an assembly.
     if (globalOptions.NoEmit) return;
 
+    if (globalOptions.Declaration && sourcePath is not null && IsDeclarationSource(sourcePath))
+    {
+        var declaration = SourceDeclarationEmitter.EmitSingleFile(
+            sourcePath,
+            statements,
+            typeMap,
+            project?.RootDir,
+            globalOptions.DeclarationDir,
+            project?.OutDir);
+        SourceDeclarationEmitter.WriteAll([declaration]);
+        if (!outputOptions.QuietMode)
+            Console.WriteLine($"Declaration emitted to {declaration.OutputPath}");
+    }
+
+    if (globalOptions.EmitDeclarationOnly)
+        return;
+
     // Dead Code Analysis Phase
     DeadCodeAnalyzer deadCodeAnalyzer = new(typeMap);
     DeadCodeInfo deadCodeInfo = deadCodeAnalyzer.Analyze(statements);
@@ -886,6 +942,19 @@ static void CompileSingleFile(List<Stmt> statements, string outputPath, bool pre
     EmitCompiledAssembly(outputPath, preserveConstEnums, useReferenceAssemblies, sdkPath, verifyIL, decoratorMode, outputOptions, metadata, references, target, bundlerMode, externalRefs,
         compiler => compiler.Compile(statements, typeMap, deadCodeInfo));
 }
+
+static bool IsDeclarationSource(string path) =>
+    !path.EndsWith(".d.ts", StringComparison.OrdinalIgnoreCase) &&
+    !path.EndsWith(".d.mts", StringComparison.OrdinalIgnoreCase) &&
+    !path.EndsWith(".d.cts", StringComparison.OrdinalIgnoreCase) &&
+    (path.EndsWith(".ts", StringComparison.OrdinalIgnoreCase) ||
+     path.EndsWith(".tsx", StringComparison.OrdinalIgnoreCase) ||
+     path.EndsWith(".mts", StringComparison.OrdinalIgnoreCase) ||
+     path.EndsWith(".cts", StringComparison.OrdinalIgnoreCase));
+
+static bool IsNodeModulesPath(string path) =>
+    Path.GetFullPath(path).Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+        .Any(part => part.Equals("node_modules", StringComparison.OrdinalIgnoreCase));
 
 /// <summary>
 /// Prints the compiler's collected non-fatal warnings to stderr. They are collected on the
@@ -1292,6 +1361,9 @@ static void PrintHelp()
     Console.WriteLine("  -r, --reference <asm.dll>     Add a .NET assembly reference (repeatable; all modes)");
     Console.WriteLine("  --checkJs                     Type-check .js/.cjs/.mjs/.jsx files too");
     Console.WriteLine("  --noEmit                      Type-check only; don't run or emit an assembly");
+    Console.WriteLine("  --declaration                 Emit .d.ts declarations for TypeScript sources");
+    Console.WriteLine("  --emitDeclarationOnly         Emit declarations without a .NET assembly");
+    Console.WriteLine("  --declarationDir <path>       Directory for generated declarations");
     Console.WriteLine();
     Console.WriteLine("Type Checking (tsc-compatible; all accept =false, e.g. --strict=false):");
     Console.WriteLine("  --strict                      Umbrella for the three flags below");
@@ -1318,9 +1390,11 @@ static void PrintHelp()
     Console.WriteLine("  exclude. Project references, incremental/watch builds, lib/types/typeRoots,");
     Console.WriteLine("  baseUrl/paths, and classic/node10/node16/nodenext/bundler resolution are");
     Console.WriteLine("  supported. target/module/jsx do not apply to .NET IL output.");
+    Console.WriteLine("  declaration, emitDeclarationOnly, declarationDir, rootDir, and outDir");
+    Console.WriteLine("  control .d.ts output for --compile and project commands.");
     Console.WriteLine("  Set SHARPTS_TSCONFIG_VERBOSE=1 to list every option that was ignored.");
     Console.WriteLine("  Script and --compile commands still use their named file as the runtime");
-    Console.WriteLine("  entry point; project commands are type-check-only.");
+    Console.WriteLine("  entry point; project commands emit no runtime assembly but may emit declarations.");
     Console.WriteLine();
     Console.WriteLine(".NET References:");
     Console.WriteLine("  A sharpts.json next to (or above) the entry script supplies project-level");
@@ -1340,6 +1414,9 @@ static void PrintHelp()
     Console.WriteLine("  -t, --target <type>           Output type: dll (default) or exe");
     Console.WriteLine("  --bundler <mode>              Bundler selection: auto (default), sdk, or builtin");
     Console.WriteLine("  --preserveConstEnums          Preserve const enum declarations");
+    Console.WriteLine("  --declaration                 Emit .d.ts declarations alongside the assembly");
+    Console.WriteLine("  --emitDeclarationOnly         Emit declarations without a .NET assembly");
+    Console.WriteLine("  --declarationDir <path>       Directory for generated declarations");
     Console.WriteLine("  --ref-asm                     Emit reference-assembly-compatible output");
     Console.WriteLine("  --sdk-path <path>             Path to .NET SDK reference assemblies");
     Console.WriteLine("  --verify                      Verify emitted IL");
@@ -1359,6 +1436,7 @@ static void PrintHelp()
     Console.WriteLine("  sharpts script.ts arg1 arg2       Run script with arguments");
     Console.WriteLine("  sharpts script.ts -- --flag val   Pass flags to script (use -- separator)");
     Console.WriteLine("  sharpts --compile app.ts          Compile to app.dll");
+    Console.WriteLine("  sharpts --compile lib.ts --emitDeclarationOnly --declarationDir types");
     Console.WriteLine("  sharpts -p .                      Check every tsconfig project root");
     Console.WriteLine("  sharpts --build                   Check referenced projects incrementally");
     Console.WriteLine("  sharpts --build --watch           Keep the project graph up to date");
@@ -1379,6 +1457,9 @@ static void PrintCompileUsage()
     Console.WriteLine("  --bundler <mode>       Bundler selection: auto (default), sdk, or builtin");
     Console.WriteLine("  -r, --reference <dll>  Add assembly reference (repeatable)");
     Console.WriteLine("  --preserveConstEnums   Preserve const enum declarations");
+    Console.WriteLine("  --declaration          Emit .d.ts declarations alongside the assembly");
+    Console.WriteLine("  --emitDeclarationOnly  Emit declarations without a .NET assembly");
+    Console.WriteLine("  --declarationDir <dir> Declaration output directory");
     Console.WriteLine("  --ref-asm              Emit reference-assembly-compatible output");
     Console.WriteLine("  --sdk-path <path>      Path to .NET SDK reference assemblies");
     Console.WriteLine("  --verify               Verify emitted IL");

--- a/Projects/ProjectBuildState.cs
+++ b/Projects/ProjectBuildState.cs
@@ -7,7 +7,7 @@ namespace SharpTS.Projects;
 /// <summary>SharpTS-owned incremental project state. The format is intentionally not tsc's.</summary>
 internal static class ProjectBuildState
 {
-    private const int FormatVersion = 1;
+    private const int FormatVersion = 2;
 
     private static readonly string ToolVersion =
         typeof(ProjectBuildState).Assembly.GetName().Version?.ToString() ?? "unknown";
@@ -17,7 +17,8 @@ internal static class ProjectBuildState
         string ToolVersion,
         string ConfigPath,
         string OptionsKey,
-        Dictionary<string, string> Inputs);
+        Dictionary<string, string> Inputs,
+        Dictionary<string, string> Outputs);
 
     public static bool IsUpToDate(TsConfigResult project, string optionsKey)
     {
@@ -47,6 +48,11 @@ internal static class ProjectBuildState
                 if (!File.Exists(path) || !string.Equals(Hash(path), expectedHash, StringComparison.Ordinal))
                     return false;
             }
+            foreach (var (path, expectedHash) in state.Outputs)
+            {
+                if (!File.Exists(path) || !string.Equals(Hash(path), expectedHash, StringComparison.Ordinal))
+                    return false;
+            }
             return true;
         }
         catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
@@ -58,7 +64,8 @@ internal static class ProjectBuildState
     public static void Write(
         TsConfigResult project,
         string optionsKey,
-        IEnumerable<string> inputPaths)
+        IEnumerable<string> inputPaths,
+        IEnumerable<string>? outputPaths = null)
     {
         var comparer = OperatingSystem.IsWindows()
             ? StringComparer.OrdinalIgnoreCase
@@ -69,12 +76,16 @@ internal static class ProjectBuildState
             .Concat(project.ExtendsChain)
             .Distinct(comparer)
             .ToDictionary(path => Path.GetFullPath(path), Hash, comparer);
+        var outputs = (outputPaths ?? [])
+            .Where(File.Exists)
+            .Distinct(comparer)
+            .ToDictionary(path => Path.GetFullPath(path), Hash, comparer);
 
         string? directory = Path.GetDirectoryName(project.BuildInfoFile);
         if (!string.IsNullOrEmpty(directory))
             Directory.CreateDirectory(directory);
 
-        var state = new State(FormatVersion, ToolVersion, project.ConfigPath, optionsKey, inputs);
+        var state = new State(FormatVersion, ToolVersion, project.ConfigPath, optionsKey, inputs, outputs);
         File.WriteAllText(
             project.BuildInfoFile,
             JsonSerializer.Serialize(state, new JsonSerializerOptions { WriteIndented = true }));

--- a/Projects/ProjectCommandRunner.cs
+++ b/Projects/ProjectCommandRunner.cs
@@ -1,5 +1,6 @@
 using SharpTS.Cli;
 using SharpTS.Configuration;
+using SharpTS.Declaration;
 using SharpTS.Diagnostics;
 using SharpTS.Modules;
 using SharpTS.Parsing;
@@ -31,14 +32,17 @@ public static class ProjectCommandRunner
                     continue;
                 }
 
-                if (!CheckProject(project, cliOptions, out var inputs))
+                if (!CheckProject(project, cliOptions, out var inputs, out var outputs))
                 {
                     return 1;
                 }
 
                 if (useIncremental)
-                    ProjectBuildState.Write(project, optionsKey, inputs);
-                Console.WriteLine($"{project.ConfigPath}: checked {project.RootFiles.Count} root file(s)");
+                    ProjectBuildState.Write(project, optionsKey, inputs, outputs);
+                string emitted = outputs.Count == 0
+                    ? ""
+                    : $"; emitted {outputs.Count} declaration file(s)";
+                Console.WriteLine($"{project.ConfigPath}: checked {project.RootFiles.Count} root file(s){emitted}");
             }
             return 0;
         }
@@ -124,9 +128,11 @@ public static class ProjectCommandRunner
     private static bool CheckProject(
         TsConfigResult project,
         GlobalOptions cliOptions,
-        out IReadOnlyList<string> inputs)
+        out IReadOnlyList<string> inputs,
+        out IReadOnlyList<string> outputs)
     {
         inputs = [];
+        outputs = [];
         foreach (string warning in project.Warnings)
             Console.WriteLine(warning);
 
@@ -156,7 +162,7 @@ public static class ProjectCommandRunner
 
         var checker = new TypeChecker(options.TypeCheckerOptions);
         checker.SetDecoratorMode(options.DecoratorMode);
-        checker.CheckModules(modules, resolver);
+        TypeMap typeMap = checker.CheckModules(modules, resolver);
 
         var errors = checker.GetDiagnostics()
             .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
@@ -165,7 +171,25 @@ public static class ProjectCommandRunner
             Console.WriteLine($"Error: {diagnostic}");
 
         inputs = resolver.LoadedFilePaths;
-        return errors.Length == 0;
+        if (errors.Length > 0)
+            return false;
+
+        if (options.Declaration && !options.NoEmit)
+        {
+            var declarations = SourceDeclarationEmitter.EmitModules(
+                modules,
+                typeMap,
+                modules
+                    .Select(module => module.Path)
+                    .Where(IsProjectDeclarationSource)
+                    .Where(path => !IsNodeModulesPath(path)),
+                project.RootDir,
+                options.DeclarationDir,
+                project.OutDir);
+            SourceDeclarationEmitter.WriteAll(declarations);
+            outputs = declarations.Select(output => output.OutputPath).ToArray();
+        }
+        return true;
     }
 
     private static GlobalOptions MergeOptions(GlobalOptions cli, TsConfigResult project) =>
@@ -180,6 +204,12 @@ public static class ProjectCommandRunner
             },
             CheckJs = cli.CheckJs || project.CheckJs == true,
             EmitDecoratorMetadata = cli.EmitDecoratorMetadata || project.EmitDecoratorMetadata == true,
+            Declaration = cli.Declaration || project.Declaration == true ||
+                project.EmitDeclarationOnly == true || project.Composite == true,
+            EmitDeclarationOnly = cli.EmitDeclarationOnly || project.EmitDeclarationOnly == true,
+            DeclarationDir = cli.DeclarationDir is not null
+                ? Path.GetFullPath(cli.DeclarationDir)
+                : project.DeclarationDir,
             DecoratorMode = cli.DecoratorMode == DecoratorMode.Stage3 && project.DecoratorMode is { } configured
                 ? configured
                 : cli.DecoratorMode,
@@ -216,6 +246,19 @@ public static class ProjectCommandRunner
                fileName.EndsWith(".cjs", StringComparison.OrdinalIgnoreCase);
     }
 
+    private static bool IsProjectDeclarationSource(string path) =>
+        !path.EndsWith(".d.ts", StringComparison.OrdinalIgnoreCase) &&
+        !path.EndsWith(".d.mts", StringComparison.OrdinalIgnoreCase) &&
+        !path.EndsWith(".d.cts", StringComparison.OrdinalIgnoreCase) &&
+        (path.EndsWith(".ts", StringComparison.OrdinalIgnoreCase) ||
+         path.EndsWith(".tsx", StringComparison.OrdinalIgnoreCase) ||
+         path.EndsWith(".mts", StringComparison.OrdinalIgnoreCase) ||
+         path.EndsWith(".cts", StringComparison.OrdinalIgnoreCase));
+
+    private static bool IsNodeModulesPath(string path) =>
+        Path.GetFullPath(path).Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Any(part => part.Equals("node_modules", StringComparison.OrdinalIgnoreCase));
+
     private static IEnumerable<string> WatchDirectories(TsConfigResult project)
     {
         yield return Path.GetDirectoryName(project.ConfigPath)!;
@@ -250,6 +293,9 @@ public static class ProjectCommandRunner
             options.CheckJs.ToString(),
             options.DecoratorMode.ToString(),
             options.EmitDecoratorMetadata.ToString(),
+            options.Declaration.ToString(),
+            options.EmitDeclarationOnly.ToString(),
+            options.DeclarationDir is null ? "" : Path.GetFullPath(options.DeclarationDir),
             .. options.References
                 .Select(Path.GetFullPath)
                 .OrderBy(path => path, PathComparer),

--- a/README.md
+++ b/README.md
@@ -201,6 +201,27 @@ The project model also supports:
 - `lib`, `types`, and `typeRoots`, loaded as type-only declaration inputs. Named `lib` entries
   come from an installed `typescript` package under `node_modules/typescript/lib`.
 
+**TypeScript declaration output:**
+
+SharpTS can emit checked `.d.ts` files for TypeScript consumers while continuing to compile
+runtime code directly to .NET IL:
+
+```bash
+sharpts --compile src/library.ts --declaration
+sharpts --compile src/library.ts --emitDeclarationOnly --declarationDir types
+sharpts -p .                                  # emits when tsconfig enables declaration
+```
+
+The matching `tsconfig.json` options are `declaration`, `emitDeclarationOnly`, and
+`declarationDir`. `rootDir` controls the preserved source hierarchy; when `declarationDir` is
+absent, `outDir` is used, then the source directory. `.mts` and `.cts` inputs produce `.d.mts`
+and `.d.cts`. Project, build, incremental, watch, and MSBuild SDK paths all use the same emitter.
+Type-only imports and exports are preserved, implementation bodies are removed, and inferred
+public types come from SharpTS's checker. Declaration output is not written when checking fails.
+
+JavaScript output remains an intentional non-goal: SharpTS does not emit JavaScript, bundle or
+minify it, or generate JavaScript source maps. Declaration maps are not currently supported.
+
 Reference ordering and the `composite` requirement follow the
 [TypeScript project-reference model](https://www.typescriptlang.org/docs/handbook/project-references).
 
@@ -209,15 +230,17 @@ adds a `.sharpts` suffix rather than overwriting tsc's incompatible file. Watch 
 re-evaluates the graph after a relevant change and uses that state to skip unchanged projects;
 parsed module and package caches are reused within each affected project check.
 
-`-p` without a script and `--build` are type-check-only. Script and `--compile` commands retain
-an explicit runtime entry point, but use the loaded project's module-resolution and declaration
-settings. Project-reference edges currently orchestrate semantic checks and build ordering; they
-do not yet emit or consume cross-project `.d.ts`/CLR artifacts, so imports between projects must
-still resolve through normal `paths` or package mappings.
+`-p` without a script and `--build` do not produce runtime assemblies, but emit declarations
+when configured. Script and `--compile` commands retain an explicit runtime entry point and use
+the loaded project's module-resolution and declaration settings. Project-reference edges
+orchestrate semantic checks and build ordering and can emit
+each project's `.d.ts` files. They do not yet automatically consume cross-project `.d.ts`/CLR
+artifacts, so imports between projects must still resolve through normal `paths` or package
+mappings.
 
-Emit options such as `target`, `module`, `jsx` and `sourceMap` do not apply — SharpTS compiles to
-.NET IL, not JavaScript — and are ignored silently; set `SHARPTS_TSCONFIG_VERBOSE=1` to list
-them. An unrecognized key is reported with a suggestion.
+JavaScript emit options such as `target`, `module`, `jsx` and `sourceMap` do not apply — SharpTS
+compiles to .NET IL, not JavaScript — and are ignored silently; set
+`SHARPTS_TSCONFIG_VERBOSE=1` to list them. An unrecognized key is reported with a suggestion.
 
 ## Examples
 

--- a/Runtime/Types/VmModule.cs
+++ b/Runtime/Types/VmModule.cs
@@ -350,6 +350,9 @@ public sealed class VmSourceTextModule : VmModuleBase
 
     private static void CollectExport(Stmt.Export exp, List<Stmt> toRun, List<(string, string)> exported)
     {
+        if (exp.IsTypeOnly)
+            return;
+
         if (exp.Declaration != null)
         {
             toRun.Add(exp.Declaration);
@@ -359,7 +362,11 @@ public sealed class VmSourceTextModule : VmModuleBase
         else if (exp.NamedExports != null)
         {
             foreach (var spec in exp.NamedExports)
+            {
+                if (spec.IsTypeOnly)
+                    continue;
                 exported.Add((spec.LocalName.Lexeme, (spec.ExportedName ?? spec.LocalName).Lexeme));
+            }
         }
         else if (exp.IsDefaultExport && exp.DefaultExpr != null)
         {

--- a/SharpTS.Sdk.Tasks/ReadTsConfigTask.cs
+++ b/SharpTS.Sdk.Tasks/ReadTsConfigTask.cs
@@ -61,6 +61,18 @@ public sealed class ReadTsConfigTask : Task
     [Output]
     public string OutDir { get; set; } = string.Empty;
 
+    /// <summary>Output: Whether TypeScript declarations should be generated.</summary>
+    [Output]
+    public bool Declaration { get; set; }
+
+    /// <summary>Output: Whether declarations are the only requested output.</summary>
+    [Output]
+    public bool EmitDeclarationOnly { get; set; }
+
+    /// <summary>Output: The declarationDir from compilerOptions, if present.</summary>
+    [Output]
+    public string DeclarationDir { get; set; } = string.Empty;
+
     public override bool Execute()
     {
         // Validate input path
@@ -104,6 +116,9 @@ public sealed class ReadTsConfigTask : Task
                 EmitDecoratorMetadata = opts.EmitDecoratorMetadata ?? false;
                 RootDir = opts.RootDir ?? string.Empty;
                 OutDir = opts.OutDir ?? string.Empty;
+                Declaration = opts.Declaration ?? false;
+                EmitDeclarationOnly = opts.EmitDeclarationOnly ?? false;
+                DeclarationDir = opts.DeclarationDir ?? string.Empty;
             }
 
             // Extract entry file using collection expressions and pattern matching
@@ -117,7 +132,9 @@ public sealed class ReadTsConfigTask : Task
                 $"Successfully loaded tsconfig.json from '{TsConfigPath}': " +
                 $"preserveConstEnums={PreserveConstEnums}, " +
                 $"experimentalDecorators={ExperimentalDecorators}, decorators={Decorators}, " +
-                $"emitDecoratorMetadata={EmitDecoratorMetadata}, entryFile={EntryFile}");
+                $"emitDecoratorMetadata={EmitDecoratorMetadata}, declaration={Declaration}, " +
+                $"emitDeclarationOnly={EmitDeclarationOnly}, declarationDir={DeclarationDir}, " +
+                $"entryFile={EntryFile}");
 
             return true;
         }

--- a/SharpTS.Sdk.Tasks/SharpTS.Sdk.Tasks.csproj
+++ b/SharpTS.Sdk.Tasks/SharpTS.Sdk.Tasks.csproj
@@ -32,7 +32,7 @@
       would also have to be packed there. Linking a single .cs keeps the contract shared with
       zero packaging impact and keeps Microsoft.Build.* out of the SharpTS CLI.
 
-      Only the shared six-key subset is linked. The CLI-only members (extends, strictness,
+      Only the shared compiler-option subset is linked. The CLI-only members (extends, strictness,
       include/exclude, [JsonExtensionData]) live in the sibling TsConfigJson.Cli.cs partial,
       which is intentionally NOT linked.
     -->

--- a/SharpTS.Sdk.Tasks/TsConfigSourceGenerationContext.cs
+++ b/SharpTS.Sdk.Tasks/TsConfigSourceGenerationContext.cs
@@ -11,7 +11,7 @@ using SharpTS.Configuration;
 /// <remarks>
 /// The model itself lives in <c>Configuration/TsConfigJson.cs</c> in the main SharpTS
 /// project and is source-linked into this assembly (see SharpTS.Sdk.Tasks.csproj) so the
-/// CLI and MSBuild agree on the tsconfig.json contract. Only the shared six-key subset is
+/// CLI and MSBuild agree on the tsconfig.json contract. Only the shared compiler-option subset is
 /// linked; the CLI's extends/strictness/unknown-key members are not, so this generated
 /// serializer never sees them.
 /// </remarks>

--- a/SharpTS.Sdk/Sdk/Sdk.props
+++ b/SharpTS.Sdk/Sdk/Sdk.props
@@ -15,6 +15,9 @@
     <SharpTSExperimentalDecorators Condition="'$(SharpTSExperimentalDecorators)' == ''">false</SharpTSExperimentalDecorators>
     <SharpTSDecorators Condition="'$(SharpTSDecorators)' == ''">false</SharpTSDecorators>
     <SharpTSEmitDecoratorMetadata Condition="'$(SharpTSEmitDecoratorMetadata)' == ''">false</SharpTSEmitDecoratorMetadata>
+    <SharpTSGenerateDeclarations Condition="'$(SharpTSGenerateDeclarations)' == ''">false</SharpTSGenerateDeclarations>
+    <SharpTSEmitDeclarationOnly Condition="'$(SharpTSEmitDeclarationOnly)' == ''">false</SharpTSEmitDeclarationOnly>
+    <SharpTSDeclarationDir Condition="'$(SharpTSDeclarationDir)' == ''"></SharpTSDeclarationDir>
     <SharpTSVerifyIL Condition="'$(SharpTSVerifyIL)' == ''">false</SharpTSVerifyIL>
     <SharpTSUseReferenceAssemblies Condition="'$(SharpTSUseReferenceAssemblies)' == ''">false</SharpTSUseReferenceAssemblies>
 

--- a/SharpTS.Sdk/Sdk/Sdk.targets
+++ b/SharpTS.Sdk/Sdk/Sdk.targets
@@ -13,6 +13,9 @@
       <Output TaskParameter="ExperimentalDecorators" PropertyName="_TsConfigExperimentalDecorators" />
       <Output TaskParameter="Decorators" PropertyName="_TsConfigDecorators" />
       <Output TaskParameter="EmitDecoratorMetadata" PropertyName="_TsConfigEmitDecoratorMetadata" />
+      <Output TaskParameter="Declaration" PropertyName="_TsConfigDeclaration" />
+      <Output TaskParameter="EmitDeclarationOnly" PropertyName="_TsConfigEmitDeclarationOnly" />
+      <Output TaskParameter="DeclarationDir" PropertyName="_TsConfigDeclarationDir" />
       <Output TaskParameter="EntryFile" PropertyName="_TsConfigEntryFile" />
     </ReadTsConfigTask>
 
@@ -22,6 +25,10 @@
       <SharpTSExperimentalDecorators Condition="'$(SharpTSExperimentalDecorators)' == 'false' and '$(_TsConfigExperimentalDecorators)' == 'true'">true</SharpTSExperimentalDecorators>
       <SharpTSDecorators Condition="'$(SharpTSDecorators)' == 'false' and '$(_TsConfigDecorators)' == 'true'">true</SharpTSDecorators>
       <SharpTSEmitDecoratorMetadata Condition="'$(SharpTSEmitDecoratorMetadata)' == 'false' and '$(_TsConfigEmitDecoratorMetadata)' == 'true'">true</SharpTSEmitDecoratorMetadata>
+      <SharpTSGenerateDeclarations Condition="'$(SharpTSGenerateDeclarations)' == 'false' and '$(_TsConfigDeclaration)' == 'true'">true</SharpTSGenerateDeclarations>
+      <SharpTSEmitDeclarationOnly Condition="'$(SharpTSEmitDeclarationOnly)' == 'false' and '$(_TsConfigEmitDeclarationOnly)' == 'true'">true</SharpTSEmitDeclarationOnly>
+      <SharpTSGenerateDeclarations Condition="'$(SharpTSEmitDeclarationOnly)' == 'true'">true</SharpTSGenerateDeclarations>
+      <SharpTSDeclarationDir Condition="'$(SharpTSDeclarationDir)' == ''">$(_TsConfigDeclarationDir)</SharpTSDeclarationDir>
       <SharpTSEntryPoint Condition="'$(SharpTSEntryPoint)' == ''">$(_TsConfigEntryFile)</SharpTSEntryPoint>
     </PropertyGroup>
 
@@ -70,6 +77,9 @@
       <_SharpTSArgs Condition="'$(SharpTSExperimentalDecorators)' == 'true'">$(_SharpTSArgs) --experimentalDecorators</_SharpTSArgs>
       <_SharpTSArgs Condition="'$(SharpTSDecorators)' == 'true'">$(_SharpTSArgs) --decorators</_SharpTSArgs>
       <_SharpTSArgs Condition="'$(SharpTSEmitDecoratorMetadata)' == 'true'">$(_SharpTSArgs) --emitDecoratorMetadata</_SharpTSArgs>
+      <_SharpTSArgs Condition="'$(SharpTSGenerateDeclarations)' == 'true'">$(_SharpTSArgs) --declaration</_SharpTSArgs>
+      <_SharpTSArgs Condition="'$(SharpTSEmitDeclarationOnly)' == 'true'">$(_SharpTSArgs) --emitDeclarationOnly</_SharpTSArgs>
+      <_SharpTSArgs Condition="'$(SharpTSDeclarationDir)' != ''">$(_SharpTSArgs) --declarationDir "$(SharpTSDeclarationDir)"</_SharpTSArgs>
       <_SharpTSArgs Condition="'$(SharpTSVerifyIL)' == 'true'">$(_SharpTSArgs) --verify</_SharpTSArgs>
       <_SharpTSArgs Condition="'$(SharpTSUseReferenceAssemblies)' == 'true'">$(_SharpTSArgs) --ref-asm</_SharpTSArgs>
       <!-- Pass assembly references from ReferencePath (populated by ResolveAssemblyReferences) -->

--- a/SharpTS.Sdk/readme.md
+++ b/SharpTS.Sdk/readme.md
@@ -26,6 +26,7 @@ dotnet build
 - Compiles TypeScript directly to .NET IL (no JavaScript intermediate)
 - Automatic import discovery via ModuleResolver
 - tsconfig.json integration
+- Optional TypeScript `.d.ts` declaration output
 - Standard MSBuild commands (`dotnet build`, `dotnet clean`)
 - MSBuild-compatible error output for IDE integration
 
@@ -41,6 +42,9 @@ dotnet build
 | `SharpTSExperimentalDecorators` | Enable legacy (Stage 2) decorators | `false` |
 | `SharpTSDecorators` | Enable TC39 Stage 3 decorators | `false` |
 | `SharpTSEmitDecoratorMetadata` | Emit decorator metadata | `false` |
+| `SharpTSGenerateDeclarations` | Emit TypeScript declarations | `false` |
+| `SharpTSEmitDeclarationOnly` | Emit declarations without a .NET assembly | `false` |
+| `SharpTSDeclarationDir` | Declaration output directory | _(source/outDir default)_ |
 | `SharpTSVerifyIL` | Verify generated IL | `false` |
 | `SharpTSUseReferenceAssemblies` | Use reference assembly mode | `false` |
 
@@ -54,6 +58,9 @@ The SDK automatically reads `tsconfig.json` if present. The MSBuild task extract
 | `compilerOptions.experimentalDecorators` | `SharpTSExperimentalDecorators` |
 | `compilerOptions.decorators` | `SharpTSDecorators` |
 | `compilerOptions.emitDecoratorMetadata` | `SharpTSEmitDecoratorMetadata` |
+| `compilerOptions.declaration` | `SharpTSGenerateDeclarations` |
+| `compilerOptions.emitDeclarationOnly` | `SharpTSEmitDeclarationOnly` |
+| `compilerOptions.declarationDir` | `SharpTSDeclarationDir` |
 | `files[0]` | `SharpTSEntryPoint` (if not set) |
 
 MSBuild properties take precedence over tsconfig.json values.

--- a/SharpTS.Tests/CliTests/DeclarationCommandLineTests.cs
+++ b/SharpTS.Tests/CliTests/DeclarationCommandLineTests.cs
@@ -1,0 +1,58 @@
+using SharpTS.Cli;
+using Xunit;
+
+namespace SharpTS.Tests.CliTests;
+
+public class DeclarationCommandLineTests
+{
+    private readonly CommandLineParser _parser = new();
+
+    [Fact]
+    public void ParseCompileDeclarationOptions()
+    {
+        var result = _parser.Parse([
+            "--declaration",
+            "--declarationDir=types",
+            "--compile",
+            "library.ts",
+        ]);
+
+        var compile = Assert.IsType<ParsedCommand.Compile>(result);
+        Assert.True(compile.GlobalOptions.Declaration);
+        Assert.False(compile.GlobalOptions.EmitDeclarationOnly);
+        Assert.Equal("types", compile.GlobalOptions.DeclarationDir);
+    }
+
+    [Fact]
+    public void EmitDeclarationOnlyImpliesDeclaration()
+    {
+        var result = _parser.Parse(["--emitDeclarationOnly", "--compile", "library.ts"]);
+
+        var compile = Assert.IsType<ParsedCommand.Compile>(result);
+        Assert.True(compile.GlobalOptions.Declaration);
+        Assert.True(compile.GlobalOptions.EmitDeclarationOnly);
+    }
+
+    [Fact]
+    public void NoEmitConflictsWithEmitDeclarationOnly()
+    {
+        var result = _parser.Parse([
+            "--noEmit",
+            "--emitDeclarationOnly",
+            "--compile",
+            "library.ts",
+        ]);
+
+        var error = Assert.IsType<ParsedCommand.Error>(result);
+        Assert.Contains("cannot be combined", error.Message);
+    }
+
+    [Fact]
+    public void DeclarationOptionsAreRejectedForScriptExecution()
+    {
+        var result = _parser.Parse(["--declaration", "library.ts"]);
+
+        var error = Assert.IsType<ParsedCommand.Error>(result);
+        Assert.Contains("require --compile or -p/--project", error.Message);
+    }
+}

--- a/SharpTS.Tests/IntegrationTests/CliDeclarationEmitTests.cs
+++ b/SharpTS.Tests/IntegrationTests/CliDeclarationEmitTests.cs
@@ -1,0 +1,222 @@
+using Xunit;
+
+namespace SharpTS.Tests.IntegrationTests;
+
+public class CliDeclarationEmitTests
+{
+    [Fact]
+    public void CompileEmitDeclarationOnlyWritesDtsWithoutAssembly()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("src/library.ts", """
+            export interface Box<T> {
+              value: T;
+              map<U>(fn: (value: T) => U): Box<U>;
+            }
+
+            export class Service {
+              private secret: number = 1;
+              run(value: string) {
+                return value.length;
+              }
+            }
+
+            export const answer = 42;
+            export function identity<T>(value: T) {
+              return value;
+            }
+            """);
+
+        var result = CliTestHelper.RunCli(
+            "--no-tsconfig --compile src/library.ts --emitDeclarationOnly " +
+            "--declarationDir types -o library.dll",
+            dir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.False(File.Exists(dir.GetPath("library.dll")));
+        string declaration = File.ReadAllText(dir.GetPath("types/library.d.ts"));
+        Assert.Contains("export interface Box<T>", declaration);
+        Assert.Contains("map<U>(arg0: (arg0: T) => U): Box<U>;", declaration);
+        Assert.Contains("export declare class Service", declaration);
+        Assert.Contains("public run(value: string): number;", declaration);
+        Assert.Contains("private secret: number;", declaration);
+        Assert.Contains("export declare const answer: 42;", declaration);
+        Assert.Contains("export declare function identity<T>(value: T): T;", declaration);
+    }
+
+    [Fact]
+    public void ProjectDeclarationEmitUsesRootDirAndDeclarationDir()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("src/models/user.ts", "export interface User { name: string; }");
+        dir.CreateFile("src/index.ts", """
+            export { User } from "./models/user";
+            export const version: string = "1.0";
+            """);
+        dir.CreateFile("tsconfig.json", """
+            {
+              "include": ["src"],
+              "compilerOptions": {
+                "declaration": true,
+                "emitDeclarationOnly": true,
+                "rootDir": "src",
+                "declarationDir": "types"
+              }
+            }
+            """);
+
+        var result = CliTestHelper.RunCli("-p .", dir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("emitted 2 declaration file(s)", result.StandardOutput);
+        Assert.True(File.Exists(dir.GetPath("types/index.d.ts")));
+        Assert.True(File.Exists(dir.GetPath("types/models/user.d.ts")));
+    }
+
+    [Fact]
+    public void DeclarationEmitPreservesTypeOnlyImportsAndExports()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("src/types.ts", """
+            export interface Box<T> { value: T; }
+            export const runtime = 1;
+            """);
+        dir.CreateFile("src/index.ts", """
+            import type { Box } from "./types";
+            export type { Box } from "./types";
+            export { type Box as RenamedBox } from "./types";
+            export function wrap<T>(value: T): Box<T> {
+              return { value };
+            }
+            """);
+        dir.CreateFile("tsconfig.json", """
+            {
+              "files": ["src/index.ts", "src/types.ts"],
+              "compilerOptions": {
+                "declaration": true,
+                "rootDir": "src",
+                "declarationDir": "types"
+              }
+            }
+            """);
+
+        var result = CliTestHelper.RunCli("-p .", dir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+        string declaration = File.ReadAllText(dir.GetPath("types/index.d.ts"));
+        Assert.Contains("""import type { Box } from "./types";""", declaration);
+        Assert.Contains("""export type { Box } from "./types";""", declaration);
+        Assert.Contains("""export { type Box as RenamedBox } from "./types";""", declaration);
+    }
+
+    [Fact]
+    public void TypeOnlyExportsHaveNoRuntimeBinding()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("types.ts", """
+            export interface Box<T> { value: T; }
+            export const value = 42;
+            """);
+        dir.CreateFile("main.ts", """
+            import { value } from "./types";
+            interface LocalOnly { name: string; }
+            export { type LocalOnly };
+            export type { Box } from "./types";
+            console.log(value);
+            """);
+
+        var result = CliTestHelper.RunCli("main.ts", dir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("42\n", result.StandardOutput);
+    }
+
+    [Fact]
+    public void ProjectEmitUsesModuleSpecificDeclarationExtensions()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("src/esm.mts", "export const esm = true;");
+        dir.CreateFile("src/common.cts", "export const common = true;");
+        dir.CreateFile("tsconfig.json", """
+            {
+              "include": ["src"],
+              "compilerOptions": {
+                "declaration": true,
+                "rootDir": "src",
+                "declarationDir": "types"
+              }
+            }
+            """);
+
+        var result = CliTestHelper.RunCli("-p .", dir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(File.Exists(dir.GetPath("types/esm.d.mts")));
+        Assert.True(File.Exists(dir.GetPath("types/common.d.cts")));
+    }
+
+    [Fact]
+    public void IncrementalProjectInvalidatesWhenDeclarationOutputIsDeleted()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("main.ts", "export const value = 1;");
+        dir.CreateFile("tsconfig.json", """
+            {
+              "files": ["main.ts"],
+              "compilerOptions": {
+                "declaration": true,
+                "incremental": true
+              }
+            }
+            """);
+
+        var first = CliTestHelper.RunCli("-p .", dir.Path);
+        var second = CliTestHelper.RunCli("-p .", dir.Path);
+        File.Delete(dir.GetPath("main.d.ts"));
+        var third = CliTestHelper.RunCli("-p .", dir.Path);
+
+        Assert.Equal(0, first.ExitCode);
+        Assert.Contains("up to date", second.StandardOutput);
+        Assert.Equal(0, third.ExitCode);
+        Assert.DoesNotContain("up to date", third.StandardOutput);
+        Assert.True(File.Exists(dir.GetPath("main.d.ts")));
+    }
+
+    [Fact]
+    public void DeclarationEmitDoesNotWritePartialOutputWhenCheckingFails()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("main.ts", """export const value: number = "wrong";""");
+        dir.CreateFile("tsconfig.json", """
+            {
+              "files": ["main.ts"],
+              "compilerOptions": { "declaration": true }
+            }
+            """);
+
+        var result = CliTestHelper.RunCli("-p .", dir.Path);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.False(File.Exists(dir.GetPath("main.d.ts")));
+    }
+
+    [Fact]
+    public void DeclarationEmitRejectsClrTypesInPublicSurface()
+    {
+        using var dir = CliTestHelper.CreateTempDirectory();
+        dir.CreateFile("main.ts", """
+            import { StringBuilder } from "dotnet:System.Text";
+            export function makeBuilder(): StringBuilder {
+              return new StringBuilder();
+            }
+            """);
+
+        var result = CliTestHelper.RunCli(
+            "--no-tsconfig --compile main.ts --emitDeclarationOnly",
+            dir.Path);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("is not portable to TypeScript consumers", result.StandardOutput);
+        Assert.False(File.Exists(dir.GetPath("main.d.ts")));
+    }
+}

--- a/SharpTS.Tests/SdkTests/ReadTsConfigTaskTests.cs
+++ b/SharpTS.Tests/SdkTests/ReadTsConfigTaskTests.cs
@@ -189,6 +189,33 @@ public class ReadTsConfigTaskTests : IDisposable
     }
 
     [Fact]
+    public void Execute_DeclarationOptions_SetProperties()
+    {
+        var path = CreateTsConfig("""
+            {
+                "compilerOptions": {
+                    "declaration": true,
+                    "emitDeclarationOnly": true,
+                    "declarationDir": "./types"
+                }
+            }
+            """);
+
+        var task = new ReadTsConfigTask
+        {
+            BuildEngine = _buildEngine,
+            TsConfigPath = path
+        };
+
+        var result = task.Execute();
+
+        Assert.True(result);
+        Assert.True(task.Declaration);
+        Assert.True(task.EmitDeclarationOnly);
+        Assert.Equal("./types", task.DeclarationDir);
+    }
+
+    [Fact]
     public void Execute_AllCompilerOptions_SetsAllProperties()
     {
         var path = CreateTsConfig("""

--- a/docs/msbuild-sdk.md
+++ b/docs/msbuild-sdk.md
@@ -120,6 +120,9 @@ Then use the SDK without a version number:
 | `SharpTSExperimentalDecorators` | `false` | `--experimentalDecorators` | Use Legacy (Stage 2) decorators instead of default Stage 3 |
 | `SharpTSNoDecorators` | `false` | `--noDecorators` | Disable decorator support |
 | `SharpTSEmitDecoratorMetadata` | `false` | `--emitDecoratorMetadata` | Emit design-time type metadata |
+| `SharpTSGenerateDeclarations` | `false` | `--declaration` | Emit TypeScript `.d.ts` declarations |
+| `SharpTSEmitDeclarationOnly` | `false` | `--emitDeclarationOnly` | Emit declarations without a .NET assembly |
+| `SharpTSDeclarationDir` | _(empty)_ | `--declarationDir` | Declaration output directory |
 | `SharpTSVerifyIL` | `false` | `--verify` | Verify generated IL after compilation |
 | `SharpTSUseReferenceAssemblies` | `false` | `--ref-asm` | Emit reference-assembly-compatible output |
 
@@ -143,6 +146,9 @@ The SDK automatically reads `tsconfig.json` if present in the project directory.
 | `compilerOptions.experimentalDecorators` | `SharpTSExperimentalDecorators` | Use Legacy (Stage 2) decorators |
 | `compilerOptions.decorators` | `SharpTSDecorators` | Use TC39 Stage 3 decorators |
 | `compilerOptions.emitDecoratorMetadata` | `SharpTSEmitDecoratorMetadata` | |
+| `compilerOptions.declaration` | `SharpTSGenerateDeclarations` | |
+| `compilerOptions.emitDeclarationOnly` | `SharpTSEmitDeclarationOnly` | Implies declaration output |
+| `compilerOptions.declarationDir` | `SharpTSDeclarationDir` | |
 | `files[0]` | `SharpTSEntryPoint` | First file used as runtime entry point |
 
 > **The CLI is the project-system authority.** `Sdk.targets` passes


### PR DESCRIPTION
## Summary

- add checker-backed TypeScript declaration emit for functions, classes, interfaces, aliases, enums, namespaces, variables, imports, and re-exports
- support `--declaration`, `--emitDeclarationOnly`, and `--declarationDir` plus the matching tsconfig and MSBuild SDK options
- integrate declaration outputs with project/build/watch and incremental output validation
- preserve type-only import/export syntax while erasing it from runtime paths
- keep JavaScript output, bundling, minification, source maps, and declaration maps out of scope

Public APIs that expose CLR-only imports fail declaration emit with a portability error instead of producing declarations TypeScript consumers cannot resolve.

## Validation

- `dotnet build SharpTS.sln --no-restore`
- `dotnet test SharpTS.Tests/SharpTS.Tests.csproj --no-restore` — 15,788 passed
- generated `.d.ts` files validated with installed `tsc --noEmit`
