### PR TITLE
Complete CLR interop support

### DIFF
--- a/Compilation/ExternalMethodResolver.cs
+++ b/Compilation/ExternalMethodResolver.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using SharpTS.Declaration;
 using SharpTS.Diagnostics.Exceptions;
 using SharpTS.Parsing;
 using SharpTS.Runtime.DotNet;
@@ -63,7 +64,7 @@ public class ExternalMethodResolver(TypeMap? typeMap, TypeProvider types)
     /// <exception cref="Exception">When no compatible overload is found.</exception>
     public MethodCandidate ResolveMethod(MethodInfo[] methods, List<Expr> arguments, string? overloadHint = null)
     {
-        return Resolve(methods.Cast<MethodBase>().ToArray(), arguments, overloadHint);
+        return Resolve(methods.Cast<MethodBase>().ToArray(), arguments, overloadHint, allowByRef: true);
     }
 
     /// <summary>
@@ -77,10 +78,11 @@ public class ExternalMethodResolver(TypeMap? typeMap, TypeProvider types)
     /// <exception cref="Exception">When no compatible overload is found.</exception>
     public MethodCandidate ResolveConstructor(ConstructorInfo[] constructors, List<Expr> arguments, string? overloadHint = null)
     {
-        return Resolve(constructors.Cast<MethodBase>().ToArray(), arguments, overloadHint);
+        return Resolve(constructors.Cast<MethodBase>().ToArray(), arguments, overloadHint, allowByRef: false);
     }
 
-    private MethodCandidate Resolve(MethodBase[] candidates, List<Expr> arguments, string? overloadHint = null)
+    private MethodCandidate Resolve(
+        MethodBase[] candidates, List<Expr> arguments, string? overloadHint, bool allowByRef)
     {
         // Apply @DotNetOverload hint filter — narrow to matching signatures before scoring.
         if (!string.IsNullOrWhiteSpace(overloadHint))
@@ -99,29 +101,42 @@ public class ExternalMethodResolver(TypeMap? typeMap, TypeProvider types)
 
         foreach (var method in candidates)
         {
+            if (method is MethodInfo methodInfo &&
+                DotNetInteropClassifier.UnsupportedMethodReason(methodInfo) != null)
+            {
+                continue;
+            }
+            if (method is ConstructorInfo constructor &&
+                DotNetInteropClassifier.UnsupportedConstructorReason(constructor) != null)
+            {
+                continue;
+            }
             var parameters = method.GetParameters();
+            if (!allowByRef && parameters.Any(p => p.ParameterType.IsByRef))
+                continue;
+            var inputParameters = DotNetMethodResolver.GetInputParameters(parameters);
             bool hasParams = parameters.Length > 0 &&
                              parameters[^1].IsDefined(typeof(ParamArrayAttribute), false);
 
             if (hasParams)
             {
-                var candidate = ScoreWithParams(method, parameters, arguments);
+                var candidate = ScoreWithParams(method, inputParameters, arguments);
                 if (candidate.TotalCost < (int)ConversionCost.Incompatible)
                     scored.Add(candidate);
             }
             else
             {
                 // Non-params: argument count must match exactly (or handle optional params)
-                if (arguments.Count > parameters.Length)
+                if (arguments.Count > inputParameters.Length)
                     continue;
 
                 // Check if missing arguments have default values
-                if (arguments.Count < parameters.Length)
+                if (arguments.Count < inputParameters.Length)
                 {
                     bool allOptional = true;
-                    for (int i = arguments.Count; i < parameters.Length; i++)
+                    for (int i = arguments.Count; i < inputParameters.Length; i++)
                     {
-                        if (!parameters[i].HasDefaultValue)
+                        if (!inputParameters[i].HasDefaultValue)
                         {
                             allOptional = false;
                             break;
@@ -131,7 +146,7 @@ public class ExternalMethodResolver(TypeMap? typeMap, TypeProvider types)
                         continue;
                 }
 
-                var candidate = ScoreRegular(method, parameters, arguments);
+                var candidate = ScoreRegular(method, inputParameters, arguments);
                 if (candidate.TotalCost < (int)ConversionCost.Incompatible)
                     scored.Add(candidate);
             }
@@ -166,7 +181,7 @@ public class ExternalMethodResolver(TypeMap? typeMap, TypeProvider types)
         for (int i = 0; i < arguments.Count; i++)
         {
             var tsType = _typeMap?.TryGet(arguments[i], out var t) == true ? t : null;
-            var cost = ScoreTypeConversion(tsType, parameters[i].ParameterType);
+            var cost = ScoreTypeConversion(tsType, DotNetMethodResolver.GetInputType(parameters[i]));
 
             if (cost == ConversionCost.Incompatible)
                 return new MethodCandidate(method, (int)ConversionCost.Incompatible, -1, false);
@@ -192,7 +207,7 @@ public class ExternalMethodResolver(TypeMap? typeMap, TypeProvider types)
         for (int i = 0; i < regularParamCount; i++)
         {
             var tsType = _typeMap?.TryGet(arguments[i], out var t) == true ? t : null;
-            var cost = ScoreTypeConversion(tsType, parameters[i].ParameterType);
+            var cost = ScoreTypeConversion(tsType, DotNetMethodResolver.GetInputType(parameters[i]));
 
             if (cost == ConversionCost.Incompatible)
                 return new MethodCandidate(method, (int)ConversionCost.Incompatible, -1, false);
@@ -235,33 +250,37 @@ public class ExternalMethodResolver(TypeMap? typeMap, TypeProvider types)
         if (targetType == _types.Object || targetType == typeof(object))
             return ConversionCost.ObjectFallback;
 
+        // Non-null values convert against Nullable<T>'s underlying type. Keep the original
+        // target around for the dedicated null branch below.
+        Type effectiveTarget = Nullable.GetUnderlyingType(targetType) ?? targetType;
+
         // TypeScript number -> .NET numeric types
         if (IsNumberType(tsType))
         {
-            if (targetType == _types.Double || targetType == typeof(double))
+            if (effectiveTarget == _types.Double || effectiveTarget == typeof(double))
                 return ConversionCost.Exact;
 
-            if (targetType == typeof(float) || targetType.FullName == "System.Single")
+            if (effectiveTarget == typeof(float) || effectiveTarget.FullName == "System.Single")
                 return ConversionCost.Lossless;
 
             // Integer types are narrowing conversions
-            if (targetType == _types.Int32 || targetType == typeof(int) ||
-                targetType == _types.Int64 || targetType == typeof(long) ||
-                targetType == _types.Byte || targetType == typeof(byte) ||
-                targetType == _types.Char || targetType == typeof(char) ||
-                targetType.FullName == "System.Int16" ||
-                targetType.FullName == "System.SByte" ||
-                targetType.FullName == "System.UInt16" ||
-                targetType.FullName == "System.UInt32" ||
-                targetType.FullName == "System.UInt64" ||
-                targetType.FullName == "System.Decimal")
+            if (effectiveTarget == _types.Int32 || effectiveTarget == typeof(int) ||
+                effectiveTarget == _types.Int64 || effectiveTarget == typeof(long) ||
+                effectiveTarget == _types.Byte || effectiveTarget == typeof(byte) ||
+                effectiveTarget == _types.Char || effectiveTarget == typeof(char) ||
+                effectiveTarget.FullName == "System.Int16" ||
+                effectiveTarget.FullName == "System.SByte" ||
+                effectiveTarget.FullName == "System.UInt16" ||
+                effectiveTarget.FullName == "System.UInt32" ||
+                effectiveTarget.FullName == "System.UInt64" ||
+                effectiveTarget.FullName == "System.Decimal")
             {
                 return ConversionCost.Narrowing;
             }
 
             // Number to boolean/string is incompatible
-            if (targetType == _types.Boolean || targetType == typeof(bool) ||
-                targetType == _types.String || targetType == typeof(string))
+            if (effectiveTarget == _types.Boolean || effectiveTarget == typeof(bool) ||
+                effectiveTarget == _types.String || effectiveTarget == typeof(string))
             {
                 return ConversionCost.Incompatible;
             }
@@ -270,12 +289,12 @@ public class ExternalMethodResolver(TypeMap? typeMap, TypeProvider types)
         // TypeScript boolean -> .NET bool
         if (IsBooleanType(tsType))
         {
-            if (targetType == _types.Boolean || targetType == typeof(bool))
+            if (effectiveTarget == _types.Boolean || effectiveTarget == typeof(bool))
                 return ConversionCost.Exact;
 
             // Boolean to number/string is incompatible
-            if (IsNumericTarget(targetType) ||
-                targetType == _types.String || targetType == typeof(string))
+            if (IsNumericTarget(effectiveTarget) ||
+                effectiveTarget == _types.String || effectiveTarget == typeof(string))
             {
                 return ConversionCost.Incompatible;
             }
@@ -284,18 +303,18 @@ public class ExternalMethodResolver(TypeMap? typeMap, TypeProvider types)
         // TypeScript string -> .NET string
         if (IsStringType(tsType))
         {
-            if (targetType == _types.String || targetType == typeof(string))
+            if (effectiveTarget == _types.String || effectiveTarget == typeof(string))
                 return ConversionCost.Exact;
 
             // String to number/bool is incompatible
-            if (IsNumericTarget(targetType) ||
-                targetType == _types.Boolean || targetType == typeof(bool))
+            if (IsNumericTarget(effectiveTarget) ||
+                effectiveTarget == _types.Boolean || effectiveTarget == typeof(bool))
             {
                 return ConversionCost.Incompatible;
             }
 
             // String to char - allowed as narrowing (first char)
-            if (targetType == _types.Char || targetType == typeof(char))
+            if (effectiveTarget == _types.Char || effectiveTarget == typeof(char))
                 return ConversionCost.Narrowing;
         }
 
@@ -303,6 +322,11 @@ public class ExternalMethodResolver(TypeMap? typeMap, TypeProvider types)
         // DotNetDelegateShim.CreateForTSFunction. Lossless so delegate-typed overloads
         // beat `object` overloads for the same call.
         if (tsType is TSTypeInfo.Function && typeof(Delegate).IsAssignableFrom(targetType))
+            return ConversionCost.Lossless;
+
+        // Guest arrays are materialized element-by-element when crossing into a CLR
+        // array parameter. Rank that path above object fallback.
+        if (tsType is TSTypeInfo.Array or TSTypeInfo.Tuple && targetType.IsArray)
             return ConversionCost.Lossless;
 
         // TypeScript any/unknown -> object fallback

--- a/Compilation/ILCompiler.Classes.cs
+++ b/Compilation/ILCompiler.Classes.cs
@@ -37,11 +37,10 @@ public partial class ILCompiler
         string? dotNetTypeName = GetDotNetTypeMapping(classStmt);
         if (dotNetTypeName != null)
         {
-            // Convert friendly syntax to CLR name (e.g., "List<>" -> "List`1")
-            string clrTypeName = ToClrTypeName(dotNetTypeName);
-
-            // Try to resolve the external type
-            Type? externalType = TryResolveExternalType(clrTypeName);
+            // Resolve ordinary and constructed-generic friendly names through the same parser
+            // interpreter mode and dotnet: imports use.
+            Type? externalType = Runtime.DotNet.DotNetTypeRegistry.ResolveFriendly(
+                dotNetTypeName, TryResolveExternalType);
 
             if (externalType != null)
             {
@@ -63,7 +62,7 @@ public partial class ILCompiler
             else
             {
                 // Warning: type not found but continue compilation
-                AddWarning($"External .NET type '{clrTypeName}' not found in loaded assemblies.");
+                AddWarning($"External .NET type '{dotNetTypeName}' not found in loaded assemblies.");
             }
 
             // Skip DefineType - don't emit TypeBuilder for external types
@@ -553,25 +552,6 @@ public partial class ILCompiler
             }
         }
         return result;
-    }
-
-    /// <summary>
-    /// Converts friendly generic syntax to CLR syntax.
-    /// Examples: "List&lt;&gt;" -> "System.Collections.Generic.List`1"
-    ///           "Dictionary&lt;,&gt;" -> "System.Collections.Generic.Dictionary`2"
-    /// </summary>
-    private static string ToClrTypeName(string friendlyName)
-    {
-        int genericStart = friendlyName.IndexOf('<');
-        if (genericStart < 0) return friendlyName;
-
-        string baseName = friendlyName[..genericStart];
-        string genericPart = friendlyName[genericStart..];
-
-        // Count commas + 1 = number of type parameters
-        int paramCount = genericPart.Count(c => c == ',') + 1;
-
-        return $"{baseName}`{paramCount}";
     }
 
     /// <summary>

--- a/Compilation/ILCompiler.Modules.cs
+++ b/Compilation/ILCompiler.Modules.cs
@@ -29,7 +29,7 @@ public partial class ILCompiler
         // direct external-interop IL (RegisterDotNetImports), never to export-field reads.
         // (Also avoids duplicate $Module_ names: distinct specifiers in one namespace share
         // a filename-derived ModuleName.)
-        if (module.IsDotNetModule)
+        if (module.IsDotNetModule || module.IsDotNetExtensionModule)
         {
             return;
         }
@@ -340,7 +340,8 @@ public partial class ILCompiler
 
                 // dotnet: imports need no import fields — every use site compiles to direct
                 // external-interop IL keyed off the ExternalTypes registry (RegisterDotNetImports).
-                if (DotNetImports.IsDotNetSpecifier(import.ModulePath))
+                if (DotNetImports.IsDotNetSpecifier(import.ModulePath) ||
+                    DotNetExtensionImports.IsSpecifier(import.ModulePath))
                     continue;
 
                 // Default import: import x from './module'
@@ -510,7 +511,7 @@ public partial class ILCompiler
         }
 
         // dotnet: interop modules have no module type and nothing to initialize.
-        if (module.IsDotNetModule)
+        if (module.IsDotNetModule || module.IsDotNetExtensionModule)
         {
             return;
         }

--- a/Compilation/ILEmitter.Calls.ExternalInterop.cs
+++ b/Compilation/ILEmitter.Calls.ExternalInterop.cs
@@ -1,7 +1,10 @@
 using System.Reflection;
 using System.Reflection.Emit;
+using SharpTS.Declaration;
 using SharpTS.Diagnostics.Exceptions;
 using SharpTS.Parsing;
+using SharpTS.Runtime.DotNet;
+using SharpTS.TypeSystem;
 
 namespace SharpTS.Compilation;
 
@@ -11,9 +14,130 @@ namespace SharpTS.Compilation;
 public partial class ILEmitter
 {
     /// <summary>
+    /// Resolves the CLR type behind a statically known <c>dotnet:</c> or
+    /// <c>@DotNetType</c> instance expression.
+    /// </summary>
+    private bool TryResolveExternalReceiverType(Expr receiver, out Type externalType)
+    {
+        return TryResolveExternalTypeInfo(
+            _ctx.TypeMap?.Get(receiver), out externalType);
+    }
+
+    private bool TryResolveExternalTypeInfo(
+        TypeSystem.TypeInfo? typeInfo,
+        out Type externalType)
+    {
+        externalType = null!;
+        if (typeInfo is not TypeSystem.TypeInfo.Instance instance)
+            return false;
+
+        string? simpleName = instance.ResolvedClassType switch
+        {
+            TypeSystem.TypeInfo.Class c => c.Name,
+            TypeSystem.TypeInfo.MutableClass mc => mc.Name,
+            _ => null
+        };
+        if (simpleName == null) return false;
+
+        if (_ctx.TypeMapper.ExternalTypes.TryGetValue(simpleName, out var bySimpleName))
+        {
+            externalType = bySimpleName;
+            return true;
+        }
+
+        if (_ctx.TypeMapper.ExternalTypes.TryGetValue(
+                _ctx.ResolveClassName(simpleName), out var byQualifiedName))
+        {
+            externalType = byQualifiedName;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Emits a direct call to a public single-parameter CLR indexer getter.</summary>
+    private bool TryEmitExternalIndexerGet(Expr receiver, Type externalType, Expr index)
+    {
+        var getters = externalType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead &&
+                        p.GetIndexParameters().Length == 1 &&
+                        DotNetInteropClassifier.UnsupportedSlotReason(
+                            p.PropertyType) == null &&
+                        DotNetInteropClassifier.UnsupportedSlotReason(
+                            p.GetIndexParameters()[0].ParameterType) == null)
+            .Select(p => p.GetGetMethod())
+            .OfType<MethodInfo>()
+            .ToArray();
+        if (getters.Length == 0) return false;
+
+        var arguments = new List<Expr> { index };
+        var resolver = new ExternalMethodResolver(_ctx.TypeMap, _ctx.Types);
+        var candidate = resolver.ResolveMethod(getters, arguments);
+        var getter = (MethodInfo)candidate.Method;
+
+        EmitExpression(receiver);
+        EmitBoxIfNeeded(receiver);
+        bool isValueType = PrepareReceiverForMemberAccess(externalType);
+        EmitExternalCallArguments(arguments, getter, candidate);
+        IL.Emit(isValueType ? OpCodes.Call : OpCodes.Callvirt, getter);
+        BoxResultIfValueType(getter.ReturnType);
+        SetStackUnknown();
+        return true;
+    }
+
+    /// <summary>Emits a direct call to a public single-parameter CLR indexer setter.</summary>
+    private bool TryEmitExternalIndexerSet(Expr receiver, Type externalType, Expr index, Expr value)
+    {
+        var setters = externalType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanWrite &&
+                        p.GetIndexParameters().Length == 1 &&
+                        DotNetInteropClassifier.UnsupportedSlotReason(
+                            p.PropertyType) == null &&
+                        DotNetInteropClassifier.UnsupportedSlotReason(
+                            p.GetIndexParameters()[0].ParameterType) == null)
+            .Select(p => p.GetSetMethod())
+            .OfType<MethodInfo>()
+            .ToArray();
+        if (setters.Length == 0) return false;
+
+        var arguments = new List<Expr> { index, value };
+        var resolver = new ExternalMethodResolver(_ctx.TypeMap, _ctx.Types);
+        var candidate = resolver.ResolveMethod(setters, arguments);
+        var setter = (MethodInfo)candidate.Method;
+        var parameters = setter.GetParameters();
+
+        EmitExpression(receiver);
+        EmitBoxIfNeeded(receiver);
+        bool isValueType = PrepareReceiverForMemberAccess(externalType);
+
+        EmitExpression(index);
+        EmitExternalTypeConversion(parameters[0].ParameterType);
+
+        // Preserve the original TypeScript RHS as the assignment-expression result. The CLR
+        // setter may narrow it (for example number -> int), but JS assignment returns the RHS.
+        EmitExpression(value);
+        EnsureBoxed();
+        var result = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, result);
+        IL.Emit(OpCodes.Ldloc, result);
+        EmitExternalTypeConversion(parameters[1].ParameterType);
+
+        IL.Emit(isValueType ? OpCodes.Call : OpCodes.Callvirt, setter);
+        IL.Emit(OpCodes.Ldloc, result);
+        SetStackUnknown();
+        return true;
+    }
+
+    /// <summary>
     /// Emits an instance method call on an external .NET type (via @DotNetType).
     /// </summary>
-    private void EmitExternalInstanceMethodCall(Expr receiver, Type externalType, string methodName, List<Expr> arguments)
+    private void EmitExternalInstanceMethodCall(
+        Expr receiver,
+        Type externalType,
+        string methodName,
+        List<Expr> arguments,
+        List<string>? genericTypeArguments,
+        TypeSystem.TypeInfo? contextualResultType)
     {
         // Special-case event subscription: these names are reserved on @DotNetType
         // instances and route to DotNetEventBinder.Compiled(Add|Remove)EventListener.
@@ -31,8 +155,17 @@ public partial class ILEmitter
 
         if (methods.Length == 0)
         {
+            if (TryEmitExternalExtensionMethodCall(
+                    receiver, externalType, methodName, arguments))
+            {
+                return;
+            }
             throw new CompileException($"Instance method '{methodName}' (or '{pascalMethodName}') not found on external type {externalType.FullName}");
         }
+
+        methods = CloseExternalGenericMethods(
+            methods, arguments,
+            genericTypeArguments, contextualResultType);
 
         // Use type-aware overload resolution, honoring @DotNetOverload if declared.
         var resolver = new ExternalMethodResolver(_ctx.TypeMap, _ctx.Types);
@@ -59,22 +192,63 @@ public partial class ILEmitter
         }
 
         // Emit arguments with type conversion (handles params arrays)
-        EmitExternalCallArguments(arguments, method, candidate);
+        var byRefOutputs = EmitExternalCallArguments(arguments, method, candidate);
 
         // Emit the call - use Call for value types (with address), Callvirt for reference types
         IL.Emit(isValueType ? OpCodes.Call : OpCodes.Callvirt, method);
 
-        // Handle return value
-        if (method.ReturnType == typeof(void))
-        {
-            IL.Emit(OpCodes.Ldnull); // void returns undefined
-        }
-        else
-        {
-            BoxResultIfValueType(method.ReturnType);
-        }
+        EmitExternalCallResult(method, byRefOutputs);
         SetStackUnknown();
     }
+
+    private bool TryEmitExternalExtensionMethodCall(
+        Expr receiver,
+        Type receiverType,
+        string methodName,
+        List<Expr> arguments)
+    {
+        if (_ctx.ModuleResolver == null || _ctx.CurrentModulePath == null)
+            return false;
+        var module = _ctx.ModuleResolver.GetCachedModule(_ctx.CurrentModulePath);
+        if (module == null || module.DotNetExtensionTypes.Count == 0)
+            return false;
+
+        var allArguments = new List<Expr>(arguments.Count + 1) { receiver };
+        allArguments.AddRange(arguments);
+        var argumentTypes = new Type?[allArguments.Count];
+        argumentTypes[0] = receiverType;
+        for (int i = 0; i < arguments.Count; i++)
+            argumentTypes[i + 1] = TryGetExternalArgumentClrType(arguments[i]);
+
+        var methods = DotNetExtensionMethodResolver.GetClosedCandidates(
+            module.DotNetExtensionTypes, methodName, argumentTypes);
+        if (methods.Length == 0)
+            return false;
+
+        var resolver = new ExternalMethodResolver(_ctx.TypeMap, _ctx.Types);
+        var candidate = resolver.ResolveMethod(methods, allArguments);
+        var method = (MethodInfo)candidate.Method;
+        var byRefOutputs = EmitExternalCallArguments(
+            allArguments, method, candidate);
+        IL.Emit(OpCodes.Call, method);
+        EmitExternalCallResult(method, byRefOutputs);
+        SetStackUnknown();
+        return true;
+    }
+
+    private Type? TryGetExternalArgumentClrType(Expr argument)
+    {
+        if (TryResolveExternalReceiverType(argument, out var external))
+            return external;
+
+        return TryGetExternalClrType(_ctx.TypeMap?.Get(argument));
+    }
+
+    private Type? TryGetExternalClrType(TypeSystem.TypeInfo? type) =>
+        type != null &&
+        DotNetTypeSynthesizer.TryGetClrArgumentType(type, out var clr)
+            ? clr
+            : null;
 
     /// <summary>
     /// Emits construction of an external .NET type (via @DotNetType).
@@ -107,7 +281,12 @@ public partial class ILEmitter
     /// <summary>
     /// Emits a static method call on an external .NET type (via @DotNetType).
     /// </summary>
-    private void EmitExternalStaticMethodCall(Type externalType, string methodName, List<Expr> arguments)
+    private void EmitExternalStaticMethodCall(
+        Type externalType,
+        string methodName,
+        List<Expr> arguments,
+        List<string>? genericTypeArguments,
+        TypeSystem.TypeInfo? contextualResultType)
     {
         // Special-case static event subscription.
         if (methodName == "addEventListener" || methodName == "removeEventListener")
@@ -127,6 +306,10 @@ public partial class ILEmitter
             throw new CompileException($"Static method '{methodName}' (or '{pascalMethodName}') not found on external type {externalType.FullName}");
         }
 
+        methods = CloseExternalGenericMethods(
+            methods, arguments,
+            genericTypeArguments, contextualResultType);
+
         // Use type-aware overload resolution, honoring @DotNetOverload if declared.
         var resolver = new ExternalMethodResolver(_ctx.TypeMap, _ctx.Types);
         string? hint = _ctx.TypeMapper.GetOverloadHint(externalType, methodName);
@@ -134,52 +317,125 @@ public partial class ILEmitter
         var method = (MethodInfo)candidate.Method;
 
         // Emit arguments with type conversion (handles params arrays)
-        EmitExternalCallArguments(arguments, method, candidate);
+        var byRefOutputs = EmitExternalCallArguments(arguments, method, candidate);
 
         // Emit the static call
         IL.Emit(OpCodes.Call, method);
 
-        // Handle return value
-        if (method.ReturnType == typeof(void))
-        {
-            IL.Emit(OpCodes.Ldnull); // void returns undefined
-        }
-        else if (method.ReturnType.IsValueType)
-        {
-            IL.Emit(OpCodes.Box, method.ReturnType);
-        }
+        EmitExternalCallResult(method, byRefOutputs);
         SetStackUnknown();
+    }
+
+    private MethodInfo[] CloseExternalGenericMethods(
+        MethodInfo[] methods,
+        List<Expr> arguments,
+        List<string>? explicitTypeArguments,
+        TypeSystem.TypeInfo? contextualResultType)
+    {
+        var argumentTypes = arguments
+            .Select(TryGetExternalArgumentClrType)
+            .ToArray();
+        Type[]? explicitTypes = explicitTypeArguments is { Count: > 0 }
+            ? explicitTypeArguments.Select(ResolveTypeArg).ToArray()
+            : null;
+        Type? expectedReturnType = TryGetExternalClrType(contextualResultType);
+        var closed = DotNetGenericMethodInference.CloseCandidates(
+            methods, argumentTypes,
+            explicitTypes, expectedReturnType);
+        if (closed.Length == 0)
+        {
+            string methodName = methods.Length > 0 ? methods[0].Name : "<unknown>";
+            throw new CompileException(
+                $"No generic instantiation of '{methodName}' matches argument CLR types " +
+                $"({string.Join(", ", argumentTypes.Select(type => type?.FullName ?? "unknown"))}) " +
+                $"derived from TypeScript types ({string.Join(", ", arguments.Select(argument => _ctx.TypeMap?.Get(argument)?.ToString() ?? "unknown"))}) " +
+                "and the supplied explicit type arguments.");
+        }
+        return closed;
     }
 
     /// <summary>
     /// Emits arguments for an external method call, handling params arrays if present.
     /// </summary>
-    private void EmitExternalCallArguments(List<Expr> arguments, MethodBase method, MethodCandidate candidate)
+    private List<(ParameterInfo Parameter, LocalBuilder Local)> EmitExternalCallArguments(
+        List<Expr> arguments, MethodBase method, MethodCandidate candidate)
     {
         var parameters = method.GetParameters();
+        var byRefOutputs = new List<(ParameterInfo, LocalBuilder)>();
 
         if (candidate.ParamsStartIndex < 0)
         {
-            // No params array - emit arguments normally
-            for (int i = 0; i < arguments.Count; i++)
+            int argumentIndex = 0;
+            foreach (var parameter in parameters)
             {
-                EmitExpression(arguments[i]);
-                EmitExternalTypeConversion(parameters[i].ParameterType);
+                if (parameter.ParameterType.IsByRef)
+                {
+                    var elementType = parameter.ParameterType.GetElementType()!;
+                    var local = IL.DeclareLocal(elementType);
+                    if (parameter.IsOut)
+                    {
+                        IL.Emit(OpCodes.Ldloca, local);
+                        IL.Emit(OpCodes.Initobj, elementType);
+                    }
+                    else
+                    {
+                        EmitExpression(arguments[argumentIndex++]);
+                        EmitExternalTypeConversion(elementType);
+                        IL.Emit(OpCodes.Stloc, local);
+                    }
+                    IL.Emit(OpCodes.Ldloca, local);
+                    if (!parameter.IsIn)
+                        byRefOutputs.Add((parameter, local));
+                    continue;
+                }
+
+                if (argumentIndex < arguments.Count)
+                {
+                    EmitExpression(arguments[argumentIndex++]);
+                    EmitExternalTypeConversion(parameter.ParameterType);
+                }
+                else
+                {
+                    EmitExternalDefaultValue(parameter);
+                }
             }
         }
         else
         {
-            // Emit regular (non-params) arguments first
-            for (int i = 0; i < candidate.ParamsStartIndex; i++)
+            int argumentIndex = 0;
+            for (int i = 0; i < parameters.Length - 1; i++)
             {
-                EmitExpression(arguments[i]);
-                EmitExternalTypeConversion(parameters[i].ParameterType);
+                var parameter = parameters[i];
+                if (parameter.ParameterType.IsByRef)
+                {
+                    var byRefElementType = parameter.ParameterType.GetElementType()!;
+                    var local = IL.DeclareLocal(byRefElementType);
+                    if (parameter.IsOut)
+                    {
+                        IL.Emit(OpCodes.Ldloca, local);
+                        IL.Emit(OpCodes.Initobj, byRefElementType);
+                    }
+                    else
+                    {
+                        EmitExpression(arguments[argumentIndex++]);
+                        EmitExternalTypeConversion(byRefElementType);
+                        IL.Emit(OpCodes.Stloc, local);
+                    }
+                    IL.Emit(OpCodes.Ldloca, local);
+                    if (!parameter.IsIn)
+                        byRefOutputs.Add((parameter, local));
+                }
+                else
+                {
+                    EmitExpression(arguments[argumentIndex++]);
+                    EmitExternalTypeConversion(parameter.ParameterType);
+                }
             }
 
             // Create and fill the params array
             var paramsParam = parameters[candidate.ParamsStartIndex];
             var elementType = paramsParam.ParameterType.GetElementType()!;
-            int paramsCount = arguments.Count - candidate.ParamsStartIndex;
+            int paramsCount = arguments.Count - argumentIndex;
 
             // Emit array creation: new T[paramsCount]
             IL.Emit(OpCodes.Ldc_I4, paramsCount);
@@ -191,7 +447,7 @@ public partial class ILEmitter
             {
                 IL.Emit(OpCodes.Dup);                    // Duplicate array reference
                 IL.Emit(OpCodes.Ldc_I4, i);              // Push index
-                EmitExpression(arguments[candidate.ParamsStartIndex + i]);
+                EmitExpression(arguments[argumentIndex + i]);
 
                 // For object[], box value types but leave reference types as-is
                 if (isObjectArray)
@@ -218,6 +474,107 @@ public partial class ILEmitter
             }
             SetStackUnknown();
         }
+
+        return byRefOutputs;
+    }
+
+    /// <summary>
+    /// Materializes the TypeScript-visible result. Calls with writable by-ref parameters
+    /// return <c>[result?, ...updatedValues]</c>; ordinary calls retain their prior result.
+    /// </summary>
+    private void EmitExternalCallResult(
+        MethodInfo method,
+        List<(ParameterInfo Parameter, LocalBuilder Local)> byRefOutputs)
+    {
+        if (byRefOutputs.Count == 0)
+        {
+            if (method.ReturnType == typeof(void))
+                IL.Emit(OpCodes.Ldnull);
+            else if (method.ReturnType.IsArray)
+                EmitExternalArrayReturn(method.ReturnType);
+            else
+                BoxResultIfValueType(method.ReturnType);
+            return;
+        }
+
+        LocalBuilder? returnLocal = null;
+        if (method.ReturnType != typeof(void))
+        {
+            returnLocal = IL.DeclareLocal(method.ReturnType);
+            IL.Emit(OpCodes.Stloc, returnLocal);
+        }
+
+        int count = byRefOutputs.Count + (returnLocal == null ? 0 : 1);
+        IL.Emit(OpCodes.Ldc_I4, count);
+        IL.Emit(OpCodes.Newarr, _ctx.Types.Object);
+        int tupleIndex = 0;
+
+        if (returnLocal != null)
+        {
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Ldc_I4, tupleIndex++);
+            IL.Emit(OpCodes.Ldloc, returnLocal);
+            if (method.ReturnType.IsArray)
+                EmitExternalArrayReturn(method.ReturnType);
+            else if (method.ReturnType.IsValueType)
+                IL.Emit(OpCodes.Box, method.ReturnType);
+            IL.Emit(OpCodes.Stelem_Ref);
+        }
+
+        foreach (var (parameter, local) in byRefOutputs)
+        {
+            Type elementType = parameter.ParameterType.GetElementType()!;
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Ldc_I4, tupleIndex++);
+            IL.Emit(OpCodes.Ldloc, local);
+            if (elementType.IsArray)
+                EmitExternalArrayReturn(elementType);
+            else if (elementType.IsValueType)
+                IL.Emit(OpCodes.Box, elementType);
+            IL.Emit(OpCodes.Stelem_Ref);
+        }
+
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.CreateArray);
+    }
+
+    private void EmitExternalDefaultValue(ParameterInfo parameter)
+    {
+        object? value = parameter.HasDefaultValue ? parameter.DefaultValue : null;
+        Type targetType = parameter.ParameterType;
+        if (value == null || value == DBNull.Value || value == Missing.Value)
+        {
+            EmitDefaultForType(targetType);
+            return;
+        }
+
+        if (targetType.IsEnum)
+        {
+            EmitExternalIntegralConstant(Convert.ToInt64(value));
+            return;
+        }
+
+        switch (value)
+        {
+            case string text: IL.Emit(OpCodes.Ldstr, text); break;
+            case bool boolean: IL.Emit(boolean ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0); break;
+            case char character: IL.Emit(OpCodes.Ldc_I4, (int)character); break;
+            case float single: IL.Emit(OpCodes.Ldc_R4, single); break;
+            case double number: IL.Emit(OpCodes.Ldc_R8, number); break;
+            case decimal:
+                EmitDefaultForType(targetType);
+                break;
+            default:
+                EmitExternalIntegralConstant(Convert.ToInt64(value));
+                break;
+        }
+    }
+
+    private void EmitExternalIntegralConstant(long value)
+    {
+        if (value is >= int.MinValue and <= int.MaxValue)
+            IL.Emit(OpCodes.Ldc_I4, (int)value);
+        else
+            IL.Emit(OpCodes.Ldc_I8, value);
     }
 
     /// <summary>
@@ -225,7 +582,45 @@ public partial class ILEmitter
     /// </summary>
     private void EmitExternalTypeConversion(Type targetType)
     {
-        if (targetType == _ctx.Types.Double || targetType == typeof(double))
+        var nullableUnderlying = Nullable.GetUnderlyingType(targetType);
+        if (nullableUnderlying != null)
+        {
+            // Native primitive values can be converted directly and wrapped. Boxed/unknown
+            // values need a null branch because CLR boxing represents an empty Nullable<T>
+            // as null, while a present value is boxed as T.
+            if (_stackType is StackType.Double or StackType.Boolean)
+            {
+                EmitExternalTypeConversion(nullableUnderlying);
+                IL.Emit(OpCodes.Newobj, targetType.GetConstructor([nullableUnderlying])!);
+                SetStackUnknown();
+                return;
+            }
+
+            var nullValue = IL.DefineLabel();
+            var converted = IL.DefineLabel();
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Brfalse, nullValue);
+            EmitExternalTypeConversion(nullableUnderlying);
+            IL.Emit(OpCodes.Newobj, targetType.GetConstructor([nullableUnderlying])!);
+            IL.Emit(OpCodes.Br, converted);
+
+            IL.MarkLabel(nullValue);
+            IL.Emit(OpCodes.Pop);
+            var empty = IL.DeclareLocal(targetType);
+            IL.Emit(OpCodes.Ldloca, empty);
+            IL.Emit(OpCodes.Initobj, targetType);
+            IL.Emit(OpCodes.Ldloc, empty);
+
+            IL.MarkLabel(converted);
+            SetStackUnknown();
+            return;
+        }
+
+        if (targetType.IsArray)
+        {
+            EmitExternalArrayConversion(targetType);
+        }
+        else if (targetType == _ctx.Types.Double || targetType == typeof(double))
         {
             // If we already have a native double on the stack, no conversion needed
             if (_stackType == StackType.Double)
@@ -405,6 +800,144 @@ public partial class ILEmitter
             }
             // Reference types are already objects, no conversion needed
         }
+    }
+
+    /// <summary>
+    /// Converts a guest <c>$Array</c>/<see cref="System.Collections.IList"/> on the stack
+    /// to a concrete CLR array. The loop is emitted into the standalone output, so generic
+    /// array calls do not acquire a runtime dependency on SharpTS.dll.
+    /// </summary>
+    private void EmitExternalArrayConversion(Type targetType)
+    {
+        Type elementType = targetType.GetElementType()!;
+        var source = IL.DeclareLocal(_ctx.Types.Object);
+        var list = IL.DeclareLocal(typeof(System.Collections.IList));
+        var result = IL.DeclareLocal(targetType);
+        var index = IL.DeclareLocal(_ctx.Types.Int32);
+
+        EnsureBoxed();
+        IL.Emit(OpCodes.Stloc, source);
+
+        var nonNull = IL.DefineLabel();
+        var finished = IL.DefineLabel();
+        IL.Emit(OpCodes.Ldloc, source);
+        IL.Emit(OpCodes.Brtrue, nonNull);
+        IL.Emit(OpCodes.Ldnull);
+        IL.Emit(OpCodes.Br, finished);
+        IL.MarkLabel(nonNull);
+
+        var ordinaryList = IL.DefineLabel();
+        var listReady = IL.DefineLabel();
+        IL.Emit(OpCodes.Ldloc, source);
+        IL.Emit(OpCodes.Isinst, _ctx.Runtime!.TSArrayType);
+        IL.Emit(OpCodes.Brfalse, ordinaryList);
+        IL.Emit(OpCodes.Ldloc, source);
+        IL.Emit(OpCodes.Castclass, _ctx.Runtime.TSArrayType);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime.TSArrayElementsGetter);
+        IL.Emit(OpCodes.Castclass, typeof(System.Collections.IList));
+        IL.Emit(OpCodes.Stloc, list);
+        IL.Emit(OpCodes.Br, listReady);
+
+        IL.MarkLabel(ordinaryList);
+        IL.Emit(OpCodes.Ldloc, source);
+        IL.Emit(OpCodes.Castclass, typeof(System.Collections.IList));
+        IL.Emit(OpCodes.Stloc, list);
+        IL.MarkLabel(listReady);
+
+        IL.Emit(OpCodes.Ldloc, list);
+        IL.Emit(OpCodes.Callvirt,
+            typeof(System.Collections.ICollection).GetProperty("Count")!.GetGetMethod()!);
+        IL.Emit(OpCodes.Newarr, elementType);
+        IL.Emit(OpCodes.Stloc, result);
+        IL.Emit(OpCodes.Ldc_I4_0);
+        IL.Emit(OpCodes.Stloc, index);
+
+        var loop = IL.DefineLabel();
+        var done = IL.DefineLabel();
+        IL.MarkLabel(loop);
+        IL.Emit(OpCodes.Ldloc, index);
+        IL.Emit(OpCodes.Ldloc, list);
+        IL.Emit(OpCodes.Callvirt,
+            typeof(System.Collections.ICollection).GetProperty("Count")!.GetGetMethod()!);
+        IL.Emit(OpCodes.Bge, done);
+
+        IL.Emit(OpCodes.Ldloc, result);
+        IL.Emit(OpCodes.Ldloc, index);
+        IL.Emit(OpCodes.Ldloc, list);
+        IL.Emit(OpCodes.Ldloc, index);
+        IL.Emit(OpCodes.Callvirt,
+            typeof(System.Collections.IList).GetMethod("get_Item", [typeof(int)])!);
+        SetStackUnknown();
+        EmitExternalTypeConversion(elementType);
+        IL.Emit(OpCodes.Stelem, elementType);
+
+        IL.Emit(OpCodes.Ldloc, index);
+        IL.Emit(OpCodes.Ldc_I4_1);
+        IL.Emit(OpCodes.Add);
+        IL.Emit(OpCodes.Stloc, index);
+        IL.Emit(OpCodes.Br, loop);
+        IL.MarkLabel(done);
+        IL.Emit(OpCodes.Ldloc, result);
+        IL.MarkLabel(finished);
+        SetStackUnknown();
+    }
+
+    /// <summary>Materializes a CLR array on the stack as an emitted guest <c>$Array</c>.</summary>
+    private void EmitExternalArrayReturn(Type arrayType)
+    {
+        Type elementType = arrayType.GetElementType()!;
+        var source = IL.DeclareLocal(arrayType);
+        var elements = IL.DeclareLocal(_ctx.Types.ObjectArray);
+        var index = IL.DeclareLocal(_ctx.Types.Int32);
+        IL.Emit(OpCodes.Stloc, source);
+
+        var nonNull = IL.DefineLabel();
+        var finished = IL.DefineLabel();
+        IL.Emit(OpCodes.Ldloc, source);
+        IL.Emit(OpCodes.Brtrue, nonNull);
+        IL.Emit(OpCodes.Ldnull);
+        IL.Emit(OpCodes.Br, finished);
+        IL.MarkLabel(nonNull);
+
+        IL.Emit(OpCodes.Ldloc, source);
+        IL.Emit(OpCodes.Ldlen);
+        IL.Emit(OpCodes.Conv_I4);
+        IL.Emit(OpCodes.Newarr, _ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, elements);
+        IL.Emit(OpCodes.Ldc_I4_0);
+        IL.Emit(OpCodes.Stloc, index);
+
+        var loop = IL.DefineLabel();
+        var done = IL.DefineLabel();
+        IL.MarkLabel(loop);
+        IL.Emit(OpCodes.Ldloc, index);
+        IL.Emit(OpCodes.Ldloc, source);
+        IL.Emit(OpCodes.Ldlen);
+        IL.Emit(OpCodes.Conv_I4);
+        IL.Emit(OpCodes.Bge, done);
+
+        IL.Emit(OpCodes.Ldloc, elements);
+        IL.Emit(OpCodes.Ldloc, index);
+        IL.Emit(OpCodes.Ldloc, source);
+        IL.Emit(OpCodes.Ldloc, index);
+        IL.Emit(OpCodes.Ldelem, elementType);
+        if (elementType.IsArray)
+            EmitExternalArrayReturn(elementType);
+        else
+            BoxResultIfValueType(elementType);
+        IL.Emit(OpCodes.Stelem_Ref);
+
+        IL.Emit(OpCodes.Ldloc, index);
+        IL.Emit(OpCodes.Ldc_I4_1);
+        IL.Emit(OpCodes.Add);
+        IL.Emit(OpCodes.Stloc, index);
+        IL.Emit(OpCodes.Br, loop);
+        IL.MarkLabel(done);
+
+        IL.Emit(OpCodes.Ldloc, elements);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.CreateArray);
+        IL.MarkLabel(finished);
+        SetStackUnknown();
     }
 
     /// <summary>

--- a/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -10,7 +10,11 @@ namespace SharpTS.Compilation;
 /// </summary>
 public partial class ILEmitter
 {
-    private void EmitMethodCall(Expr.Get methodGet, List<Expr> arguments)
+    private void EmitMethodCall(
+        Expr.Get methodGet,
+        List<Expr> arguments,
+        List<string>? genericTypeArguments = null,
+        TypeSystem.TypeInfo? contextualResultType = null)
     {
         string methodName = methodGet.Name.Lexeme;
 
@@ -102,7 +106,9 @@ public partial class ILEmitter
 
         // Try direct dispatch for known class instance methods
         TypeSystem.TypeInfo? objType = _ctx.TypeMap?.Get(methodGet.Object);
-        if (TryEmitDirectMethodCall(methodGet.Object, objType, methodName, arguments))
+        if (TryEmitDirectMethodCall(
+                methodGet.Object, objType, methodName, arguments,
+                genericTypeArguments, contextualResultType))
             return;
 
         // Timeout instance methods: ref(), unref()
@@ -339,7 +345,8 @@ public partial class ILEmitter
     /// Returns true if direct dispatch was emitted, false to fall back to runtime dispatch.
     /// </summary>
     private bool TryEmitDirectMethodCall(Expr receiver, TypeSystem.TypeInfo? receiverType,
-        string methodName, List<Expr> arguments)
+        string methodName, List<Expr> arguments, List<string>? genericTypeArguments,
+        TypeSystem.TypeInfo? contextualResultType)
     {
         // Only handle Instance types (e.g., let p: Person = ...)
         if (receiverType is not TypeSystem.TypeInfo.Instance instance)
@@ -361,7 +368,9 @@ public partial class ILEmitter
         // Check if this is an external .NET type (@DotNetType)
         if (_ctx.TypeMapper.ExternalTypes.TryGetValue(simpleClassName, out var externalType))
         {
-            EmitExternalInstanceMethodCall(receiver, externalType, methodName, arguments);
+            EmitExternalInstanceMethodCall(
+                receiver, externalType, methodName, arguments,
+                genericTypeArguments, contextualResultType);
             return true;
         }
 
@@ -371,7 +380,9 @@ public partial class ILEmitter
         // Also check if the qualified name is an external type
         if (_ctx.TypeMapper.ExternalTypes.TryGetValue(className, out externalType))
         {
-            EmitExternalInstanceMethodCall(receiver, externalType, methodName, arguments);
+            EmitExternalInstanceMethodCall(
+                receiver, externalType, methodName, arguments,
+                genericTypeArguments, contextualResultType);
             return true;
         }
 

--- a/Compilation/ILEmitter.Calls.cs
+++ b/Compilation/ILEmitter.Calls.cs
@@ -201,9 +201,16 @@ public partial class ILEmitter
             _ when _ctx.TypeMapper.ExternalTypes.TryGetValue(typeArg, out var external) => external,
             _ when _ctx.TypeMapper.ExternalTypes.TryGetValue(
                 _ctx.ResolveClassName(typeArg), out var qualifiedExternal) => qualifiedExternal,
-            _ when DotNetTypeRegistry.ResolveFriendly(typeArg) is { } resolved => resolved,
             _ when _ctx.GenericTypeParameters.TryGetValue(typeArg, out var gp) => gp,
             _ when _ctx.Classes.TryGetValue(_ctx.ResolveClassName(typeArg), out var tb) => tb,
+            // Ambient scan of every loaded assembly — must stay below the program's own
+            // generic parameters and classes. Compiled classes are public types in the
+            // global namespace under their bare TypeScript name, so a bare-name scan run
+            // any earlier binds `Foo<Bar>` to an unrelated loaded assembly's `Bar`, and
+            // the emitted AssemblyRef is unresolvable at runtime. Names reachable here
+            // are neither primitives, `@DotNetType`/`dotnet:` imports (both registered in
+            // ExternalTypes), nor user classes — in practice fully-qualified CLR names.
+            _ when DotNetTypeRegistry.ResolveFriendly(typeArg) is { } resolved => resolved,
             _ => _ctx.Types.Object
         };
     }

--- a/Compilation/ILEmitter.Calls.cs
+++ b/Compilation/ILEmitter.Calls.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using SharpTS.Diagnostics.Exceptions;
 using SharpTS.Parsing;
+using SharpTS.Runtime.DotNet;
 using SharpTS.TypeSystem;
 
 namespace SharpTS.Compilation;
@@ -142,7 +143,9 @@ public partial class ILEmitter
             externalStaticGet.Object is Expr.Variable externalClassVar &&
             _ctx.TypeMapper?.ExternalTypes.TryGetValue(externalClassVar.Name.Lexeme, out var externalType) == true)
         {
-            EmitExternalStaticMethodCall(externalType, externalStaticGet.Name.Lexeme, c.Arguments);
+            EmitExternalStaticMethodCall(
+                externalType, externalStaticGet.Name.Lexeme,
+                c.Arguments, c.TypeArgs, _ctx.TypeMap?.Get(c));
             return;
         }
 
@@ -175,7 +178,9 @@ public partial class ILEmitter
                 return;
 
             // Instance method dispatch (Array/String/Map/Promise/etc.)
-            EmitMethodCall(methodGet, c.Arguments);
+            EmitMethodCall(
+                methodGet, c.Arguments, c.TypeArgs,
+                _ctx.TypeMap?.Get(c));
             return;
         }
 
@@ -193,6 +198,10 @@ public partial class ILEmitter
             "number" => _ctx.Types.Double,
             "string" => _ctx.Types.String,
             "boolean" => _ctx.Types.Boolean,
+            _ when _ctx.TypeMapper.ExternalTypes.TryGetValue(typeArg, out var external) => external,
+            _ when _ctx.TypeMapper.ExternalTypes.TryGetValue(
+                _ctx.ResolveClassName(typeArg), out var qualifiedExternal) => qualifiedExternal,
+            _ when DotNetTypeRegistry.ResolveFriendly(typeArg) is { } resolved => resolved,
             _ when _ctx.GenericTypeParameters.TryGetValue(typeArg, out var gp) => gp,
             _ when _ctx.Classes.TryGetValue(_ctx.ResolveClassName(typeArg), out var tb) => tb,
             _ => _ctx.Types.Object

--- a/Compilation/ILEmitter.Modules.cs
+++ b/Compilation/ILEmitter.Modules.cs
@@ -24,7 +24,8 @@ public partial class ILEmitter
 
         // dotnet: interop imports emit no binding code — use sites compile to direct
         // external-interop IL via the ExternalTypes registry (see RegisterDotNetImports).
-        if (SharpTS.Modules.DotNetImports.IsDotNetSpecifier(import.ModulePath))
+        if (SharpTS.Modules.DotNetImports.IsDotNetSpecifier(import.ModulePath) ||
+            SharpTS.Modules.DotNetExtensionImports.IsSpecifier(import.ModulePath))
             return;
 
         // Check for built-in module imports (fs, path, etc.) and stdlib-internal

--- a/Compilation/ILEmitter.Operators.cs
+++ b/Compilation/ILEmitter.Operators.cs
@@ -1,8 +1,15 @@
 using System.Reflection.Emit;
+using SharpTS.Declaration;
 using SharpTS.Diagnostics.Exceptions;
 using SharpTS.Parsing;
+using SharpTS.Runtime.DotNet;
 using SharpTS.TypeSystem;
 using static SharpTS.TypeSystem.OperatorDescriptor;
+using BindingFlags = System.Reflection.BindingFlags;
+using FieldInfo = System.Reflection.FieldInfo;
+using MemberInfo = System.Reflection.MemberInfo;
+using MethodInfo = System.Reflection.MethodInfo;
+using PropertyInfo = System.Reflection.PropertyInfo;
 
 namespace SharpTS.Compilation;
 
@@ -15,6 +22,9 @@ public partial class ILEmitter
     {
         // Try constant folding first
         if (TryEmitConstantFolded(b))
+            return;
+
+        if (TryEmitExternalBinaryOperator(b))
             return;
 
         // instanceof/in are valid with any operand type — bypass bigint-arithmetic path
@@ -195,6 +205,34 @@ public partial class ILEmitter
         }
     }
 
+    private bool TryEmitExternalBinaryOperator(Expr.Binary binary)
+    {
+        Type? leftType = TryResolveExternalReceiverType(binary.Left, out var resolvedLeft)
+            ? resolvedLeft
+            : null;
+        Type? rightType = TryResolveExternalReceiverType(binary.Right, out var resolvedRight)
+            ? resolvedRight
+            : null;
+        if (leftType == null && rightType == null)
+            return false;
+
+        var methods = DotNetOperatorResolver.GetBinaryCandidates(
+            binary.Operator.Type, leftType, rightType);
+        if (methods.Length == 0)
+            return false;
+
+        var arguments = new List<Expr> { binary.Left, binary.Right };
+        var resolver = new ExternalMethodResolver(_ctx.TypeMap, _ctx.Types);
+        var candidate = resolver.ResolveMethod(methods, arguments);
+        var method = (System.Reflection.MethodInfo)candidate.Method;
+        var byRefOutputs = EmitExternalCallArguments(arguments, method, candidate);
+        IL.Emit(OpCodes.Call, method);
+        EmitExternalCallResult(method, byRefOutputs);
+
+        SetStackUnknown();
+        return true;
+    }
+
     /// <summary>
     /// Emits power operator (**) using Math.Pow.
     /// </summary>
@@ -366,6 +404,9 @@ public partial class ILEmitter
             return;
         }
 
+        if (TryEmitExternalUnaryOperator(u))
+            return;
+
         switch (u.Operator.Type)
         {
             case TokenType.MINUS:
@@ -484,8 +525,31 @@ public partial class ILEmitter
         }
     }
 
+    private bool TryEmitExternalUnaryOperator(Expr.Unary unary)
+    {
+        if (!TryResolveExternalReceiverType(unary.Right, out var operandType))
+            return false;
+        var methods = DotNetOperatorResolver.GetUnaryCandidates(
+            unary.Operator.Type, operandType);
+        if (methods.Length == 0)
+            return false;
+
+        var arguments = new List<Expr> { unary.Right };
+        var resolver = new ExternalMethodResolver(_ctx.TypeMap, _ctx.Types);
+        var candidate = resolver.ResolveMethod(methods, arguments);
+        var method = (System.Reflection.MethodInfo)candidate.Method;
+        var byRefOutputs = EmitExternalCallArguments(arguments, method, candidate);
+        IL.Emit(OpCodes.Call, method);
+        EmitExternalCallResult(method, byRefOutputs);
+        SetStackUnknown();
+        return true;
+    }
+
     protected override void EmitCompoundAssign(Expr.CompoundAssign ca)
     {
+        if (TryEmitExternalCompoundAssign(ca))
+            return;
+
         // Promoted string-accumulator append (#857): `s += E` where `s` is a StringBuilder slot →
         // `sb.Append(E)`. Promotion guarantees statement position, so the Append-returned builder on the
         // stack is the value Stmt.Expression pops. See EmitAssign and StringAccumulatorPromotionAnalyzer.
@@ -661,6 +725,74 @@ public partial class ILEmitter
             }
             SetStackUnknown();
         }
+    }
+
+    private bool TryEmitExternalCompoundAssign(Expr.CompoundAssign compound)
+    {
+        if (!TryResolveExternalTypeInfo(
+                _ctx.TypeMap?.Get(compound), out var leftType) ||
+            DotNetOperatorResolver.GetBinaryTokenForCompound(
+                compound.Operator.Type) is not { } binaryToken)
+        {
+            return false;
+        }
+
+        Type? rightType = TryResolveExternalReceiverType(
+            compound.Value, out var resolvedRight)
+            ? resolvedRight
+            : null;
+        var methods = DotNetOperatorResolver.GetBinaryCandidates(
+            binaryToken, leftType, rightType);
+        if (methods.Length == 0)
+            return false;
+
+        var variable = new Expr.Variable(compound.Name);
+        var arguments = new List<Expr> { variable, compound.Value };
+        var resolver = new ExternalMethodResolver(_ctx.TypeMap, _ctx.Types);
+        var candidate = resolver.ResolveMethod(methods, arguments);
+        var method = (System.Reflection.MethodInfo)candidate.Method;
+        var byRefOutputs = EmitExternalCallArguments(arguments, method, candidate);
+        IL.Emit(OpCodes.Call, method);
+        EmitExternalCallResult(method, byRefOutputs);
+
+        var result = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, result);
+        StoreExternalOperatorVariable(compound.Name.Lexeme, result);
+        IL.Emit(OpCodes.Ldloc, result);
+        SetStackUnknown();
+        return true;
+    }
+
+    private void StoreExternalOperatorVariable(string name, LocalBuilder boxedValue)
+    {
+        var local = _ctx.Locals.GetLocal(name);
+        FieldBuilder? topLevelField = null;
+        _ctx.TopLevelStaticVars?.TryGetValue(name, out topLevelField);
+
+        IL.Emit(OpCodes.Ldloc, boxedValue);
+        if (local != null)
+        {
+            ConvertExternalOperatorStorage(local.LocalType);
+            IL.Emit(OpCodes.Stloc, local);
+        }
+        else if (topLevelField != null)
+        {
+            ConvertExternalOperatorStorage(topLevelField.FieldType);
+            IL.Emit(OpCodes.Stsfld, topLevelField);
+        }
+        else
+        {
+            _resolver.TryStoreVariable(name);
+        }
+    }
+
+    private void ConvertExternalOperatorStorage(Type storageType)
+    {
+        if (_ctx.Types.IsObject(storageType))
+            return;
+        IL.Emit(storageType.IsValueType
+            ? OpCodes.Unbox_Any
+            : OpCodes.Castclass, storageType);
     }
 
     protected override void EmitLogicalAssign(Expr.LogicalAssign la)
@@ -1218,6 +1350,10 @@ public partial class ILEmitter
 
     protected override void EmitPrefixIncrement(Expr.PrefixIncrement pi)
     {
+        if (TryEmitExternalIncrement(
+                pi.Operand, pi.Operator.Type, isPrefix: true))
+            return;
+
         if (pi.Operand is Expr.Variable v)
         {
             // Integer loop-counter prototype (#928): native int64 increment, no double/box round trip.
@@ -1410,6 +1546,10 @@ public partial class ILEmitter
 
     protected override void EmitPostfixIncrement(Expr.PostfixIncrement pi)
     {
+        if (TryEmitExternalIncrement(
+                pi.Operand, pi.Operator.Type, isPrefix: false))
+            return;
+
         if (pi.Operand is Expr.Variable v)
         {
             // Integer loop-counter prototype (#928): native int64 increment, no double/box round trip.
@@ -1495,6 +1635,403 @@ public partial class ILEmitter
         }
     }
 
+    private bool TryEmitExternalIncrement(
+        Expr operand,
+        TokenType token,
+        bool isPrefix)
+    {
+        if (!TryResolveExternalReceiverType(operand, out var operandType))
+        {
+            return false;
+        }
+
+        var methods = DotNetOperatorResolver.GetIncrementCandidates(token, operandType);
+        if (methods.Length == 0)
+            return false;
+        var arguments = new List<Expr> { operand };
+        var resolver = new ExternalMethodResolver(_ctx.TypeMap, _ctx.Types);
+        var candidate = resolver.ResolveMethod(methods, arguments);
+        var method = (System.Reflection.MethodInfo)candidate.Method;
+
+        if (operand is Expr.Get get)
+            return TryEmitExternalPropertyIncrement(
+                get, operandType, method, isPrefix);
+        if (operand is Expr.GetIndex getIndex)
+            return TryEmitExternalIndexerIncrement(
+                getIndex, operandType, method, isPrefix);
+        if (operand is not Expr.Variable variable)
+            return false;
+
+        // Preserve the original boxed value for postfix semantics, then invoke the CLR
+        // op_Increment/op_Decrement once and write the returned value back to the l-value.
+        EmitExpression(operand);
+        EnsureBoxed();
+        var oldValue = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, oldValue);
+
+        IL.Emit(OpCodes.Ldloc, oldValue);
+        EmitExternalTypeConversion(method.GetParameters()[0].ParameterType);
+        IL.Emit(OpCodes.Call, method);
+        BoxResultIfValueType(method.ReturnType);
+        var newValue = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, newValue);
+
+        StoreExternalOperatorVariable(variable.Name.Lexeme, newValue);
+        IL.Emit(OpCodes.Ldloc, isPrefix ? newValue : oldValue);
+        SetStackUnknown();
+        return true;
+    }
+
+    private bool TryEmitExternalPropertyCompound(Expr.CompoundSet compound)
+    {
+        if (!TryResolveExternalReceiverType(compound.Object, out var ownerType) ||
+            ownerType.IsValueType ||
+            !TryResolveExternalWritableMember(
+                ownerType, compound.Name.Lexeme, out var member, out var valueType) ||
+            DotNetOperatorResolver.GetBinaryTokenForCompound(
+                compound.Operator.Type) is not { } binaryToken ||
+            !TryResolveExternalBinaryOperator(
+                new Expr.Get(compound.Object, compound.Name),
+                valueType,
+                compound.Value,
+                binaryToken,
+                out var method))
+        {
+            return false;
+        }
+
+        var receiver = SpillExternalReceiver(compound.Object);
+        var oldValue = EmitExternalMemberRead(receiver, ownerType, member, valueType);
+        var newValue = EmitExternalOperatorCall(oldValue, compound.Value, method);
+        EmitExternalMemberWrite(receiver, ownerType, member, valueType, newValue);
+        IL.Emit(OpCodes.Ldloc, newValue);
+        SetStackUnknown();
+        return true;
+    }
+
+    private bool TryEmitExternalIndexerCompound(Expr.CompoundSetIndex compound)
+    {
+        if (!TryResolveExternalReceiverType(compound.Object, out var ownerType) ||
+            ownerType.IsValueType ||
+            DotNetOperatorResolver.GetBinaryTokenForCompound(
+                compound.Operator.Type) is not { } binaryToken ||
+            !TryResolveExternalWritableIndexer(
+                ownerType, compound.Index, out var property, out var getter, out var getterCandidate) ||
+            !TryResolveExternalBinaryOperator(
+                new Expr.GetIndex(compound.Object, compound.Index),
+                property.PropertyType,
+                compound.Value,
+                binaryToken,
+                out var method))
+        {
+            return false;
+        }
+
+        var receiver = SpillExternalReceiver(compound.Object);
+        var index = SpillExternalValue(compound.Index);
+        var oldValue = EmitExternalIndexerRead(
+            receiver, index, ownerType, getter, getterCandidate);
+        var newValue = EmitExternalOperatorCall(oldValue, compound.Value, method);
+        EmitExternalIndexerWrite(receiver, index, ownerType, property, newValue);
+        IL.Emit(OpCodes.Ldloc, newValue);
+        SetStackUnknown();
+        return true;
+    }
+
+    private bool TryEmitExternalPropertyIncrement(
+        Expr.Get get,
+        Type operandType,
+        MethodInfo method,
+        bool isPrefix)
+    {
+        if (!TryResolveExternalReceiverType(get.Object, out var ownerType) ||
+            ownerType.IsValueType ||
+            !TryResolveExternalWritableMember(
+                ownerType, get.Name.Lexeme, out var member, out var valueType) ||
+            valueType != operandType ||
+            !valueType.IsAssignableFrom(method.ReturnType))
+        {
+            return false;
+        }
+
+        var receiver = SpillExternalReceiver(get.Object);
+        var oldValue = EmitExternalMemberRead(receiver, ownerType, member, valueType);
+        var newValue = EmitExternalUnaryOperatorCall(oldValue, method);
+        EmitExternalMemberWrite(receiver, ownerType, member, valueType, newValue);
+        IL.Emit(OpCodes.Ldloc, isPrefix ? newValue : oldValue);
+        SetStackUnknown();
+        return true;
+    }
+
+    private bool TryEmitExternalIndexerIncrement(
+        Expr.GetIndex getIndex,
+        Type operandType,
+        MethodInfo method,
+        bool isPrefix)
+    {
+        if (!TryResolveExternalReceiverType(getIndex.Object, out var ownerType) ||
+            ownerType.IsValueType ||
+            !TryResolveExternalWritableIndexer(
+                ownerType, getIndex.Index, out var property, out var getter, out var getterCandidate) ||
+            property.PropertyType != operandType ||
+            !property.PropertyType.IsAssignableFrom(method.ReturnType))
+        {
+            return false;
+        }
+
+        var receiver = SpillExternalReceiver(getIndex.Object);
+        var index = SpillExternalValue(getIndex.Index);
+        var oldValue = EmitExternalIndexerRead(
+            receiver, index, ownerType, getter, getterCandidate);
+        var newValue = EmitExternalUnaryOperatorCall(oldValue, method);
+        EmitExternalIndexerWrite(receiver, index, ownerType, property, newValue);
+        IL.Emit(OpCodes.Ldloc, isPrefix ? newValue : oldValue);
+        SetStackUnknown();
+        return true;
+    }
+
+    private bool TryResolveExternalBinaryOperator(
+        Expr leftExpression,
+        Type leftType,
+        Expr rightExpression,
+        TokenType token,
+        out MethodInfo method)
+    {
+        Type? rightType = TryResolveExternalReceiverType(
+            rightExpression, out var resolvedRight)
+            ? resolvedRight
+            : null;
+        var methods = DotNetOperatorResolver.GetBinaryCandidates(
+                token, leftType, rightType)
+            .Where(candidate =>
+            {
+                var parameters = candidate.GetParameters();
+                return parameters[0].ParameterType.IsAssignableFrom(leftType) &&
+                       leftType.IsAssignableFrom(candidate.ReturnType);
+            })
+            .ToArray();
+        var exactLeft = methods
+            .Where(candidate =>
+                candidate.GetParameters()[0].ParameterType == leftType)
+            .ToArray();
+        if (exactLeft.Length > 0)
+            methods = exactLeft;
+        if (methods.Length == 0)
+        {
+            method = null!;
+            return false;
+        }
+
+        var resolver = new ExternalMethodResolver(_ctx.TypeMap, _ctx.Types);
+        var candidate = resolver.ResolveMethod(
+            methods, [leftExpression, rightExpression]);
+        method = (MethodInfo)candidate.Method;
+        return true;
+    }
+
+    private bool TryResolveExternalWritableMember(
+        Type ownerType,
+        string jsName,
+        out MemberInfo member,
+        out Type valueType)
+    {
+        string pascalName = NamingConventions.ToPascalCase(jsName);
+        var property = ownerType.GetProperty(
+                           pascalName, BindingFlags.Public | BindingFlags.Instance)
+                       ?? ownerType.GetProperty(
+                           jsName, BindingFlags.Public | BindingFlags.Instance);
+        if (property is { CanRead: true, CanWrite: true } &&
+            property.GetIndexParameters().Length == 0 &&
+            property.GetGetMethod() != null &&
+            property.GetSetMethod() != null &&
+            DotNetInteropClassifier.UnsupportedSlotReason(property.PropertyType) == null)
+        {
+            member = property;
+            valueType = property.PropertyType;
+            return true;
+        }
+
+        var field = ownerType.GetField(
+                        pascalName, BindingFlags.Public | BindingFlags.Instance)
+                    ?? ownerType.GetField(
+                        jsName, BindingFlags.Public | BindingFlags.Instance);
+        if (field is { IsInitOnly: false, IsLiteral: false } &&
+            DotNetInteropClassifier.UnsupportedSlotReason(field.FieldType) == null)
+        {
+            member = field;
+            valueType = field.FieldType;
+            return true;
+        }
+
+        member = null!;
+        valueType = null!;
+        return false;
+    }
+
+    private bool TryResolveExternalWritableIndexer(
+        Type ownerType,
+        Expr indexExpression,
+        out PropertyInfo property,
+        out MethodInfo getter,
+        out MethodCandidate getterCandidate)
+    {
+        var properties = ownerType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(candidate =>
+                candidate.CanRead &&
+                candidate.CanWrite &&
+                candidate.GetGetMethod() != null &&
+                candidate.GetSetMethod() != null &&
+                candidate.GetIndexParameters().Length == 1 &&
+                DotNetInteropClassifier.UnsupportedSlotReason(candidate.PropertyType) == null &&
+                DotNetInteropClassifier.UnsupportedSlotReason(
+                    candidate.GetIndexParameters()[0].ParameterType) == null)
+            .ToArray();
+        if (properties.Length == 0)
+        {
+            property = null!;
+            getter = null!;
+            getterCandidate = default;
+            return false;
+        }
+
+        var getters = properties.Select(candidate => candidate.GetGetMethod()!).ToArray();
+        var resolver = new ExternalMethodResolver(_ctx.TypeMap, _ctx.Types);
+        getterCandidate = resolver.ResolveMethod(getters, [indexExpression]);
+        var resolvedGetter = (MethodInfo)getterCandidate.Method;
+        getter = resolvedGetter;
+        property = properties.First(candidate => candidate.GetGetMethod() == resolvedGetter);
+        return true;
+    }
+
+    private LocalBuilder SpillExternalReceiver(Expr receiver)
+    {
+        EmitExpression(receiver);
+        EnsureBoxed();
+        var local = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, local);
+        return local;
+    }
+
+    private LocalBuilder SpillExternalValue(Expr value)
+    {
+        EmitExpression(value);
+        EnsureBoxed();
+        var local = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, local);
+        return local;
+    }
+
+    private LocalBuilder EmitExternalMemberRead(
+        LocalBuilder receiver,
+        Type ownerType,
+        MemberInfo member,
+        Type valueType)
+    {
+        IL.Emit(OpCodes.Ldloc, receiver);
+        IL.Emit(OpCodes.Castclass, ownerType);
+        switch (member)
+        {
+            case PropertyInfo property:
+                IL.Emit(OpCodes.Callvirt, property.GetGetMethod()!);
+                break;
+            case FieldInfo field:
+                IL.Emit(OpCodes.Ldfld, field);
+                break;
+        }
+        BoxResultIfValueType(valueType);
+        var oldValue = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, oldValue);
+        return oldValue;
+    }
+
+    private void EmitExternalMemberWrite(
+        LocalBuilder receiver,
+        Type ownerType,
+        MemberInfo member,
+        Type valueType,
+        LocalBuilder value)
+    {
+        IL.Emit(OpCodes.Ldloc, receiver);
+        IL.Emit(OpCodes.Castclass, ownerType);
+        IL.Emit(OpCodes.Ldloc, value);
+        EmitExternalTypeConversion(valueType);
+        switch (member)
+        {
+            case PropertyInfo property:
+                IL.Emit(OpCodes.Callvirt, property.GetSetMethod()!);
+                break;
+            case FieldInfo field:
+                IL.Emit(OpCodes.Stfld, field);
+                break;
+        }
+    }
+
+    private LocalBuilder EmitExternalIndexerRead(
+        LocalBuilder receiver,
+        LocalBuilder index,
+        Type ownerType,
+        MethodInfo getter,
+        MethodCandidate getterCandidate)
+    {
+        IL.Emit(OpCodes.Ldloc, receiver);
+        IL.Emit(OpCodes.Castclass, ownerType);
+        IL.Emit(OpCodes.Ldloc, index);
+        EmitExternalTypeConversion(getter.GetParameters()[0].ParameterType);
+        IL.Emit(OpCodes.Callvirt, getter);
+        BoxResultIfValueType(getter.ReturnType);
+        var oldValue = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, oldValue);
+        return oldValue;
+    }
+
+    private void EmitExternalIndexerWrite(
+        LocalBuilder receiver,
+        LocalBuilder index,
+        Type ownerType,
+        PropertyInfo property,
+        LocalBuilder value)
+    {
+        var setter = property.GetSetMethod()!;
+        var parameters = setter.GetParameters();
+        IL.Emit(OpCodes.Ldloc, receiver);
+        IL.Emit(OpCodes.Castclass, ownerType);
+        IL.Emit(OpCodes.Ldloc, index);
+        EmitExternalTypeConversion(parameters[0].ParameterType);
+        IL.Emit(OpCodes.Ldloc, value);
+        EmitExternalTypeConversion(parameters[1].ParameterType);
+        IL.Emit(OpCodes.Callvirt, setter);
+    }
+
+    private LocalBuilder EmitExternalOperatorCall(
+        LocalBuilder oldValue,
+        Expr rightExpression,
+        MethodInfo method)
+    {
+        var parameters = method.GetParameters();
+        IL.Emit(OpCodes.Ldloc, oldValue);
+        EmitExternalTypeConversion(parameters[0].ParameterType);
+        EmitExpression(rightExpression);
+        EmitExternalTypeConversion(parameters[1].ParameterType);
+        IL.Emit(OpCodes.Call, method);
+        BoxResultIfValueType(method.ReturnType);
+        var newValue = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, newValue);
+        return newValue;
+    }
+
+    private LocalBuilder EmitExternalUnaryOperatorCall(
+        LocalBuilder oldValue,
+        MethodInfo method)
+    {
+        IL.Emit(OpCodes.Ldloc, oldValue);
+        EmitExternalTypeConversion(method.GetParameters()[0].ParameterType);
+        IL.Emit(OpCodes.Call, method);
+        BoxResultIfValueType(method.ReturnType);
+        var newValue = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, newValue);
+        return newValue;
+    }
+
     /// <summary>
     /// Emits <c>++</c>/<c>--</c> on a class's static data field accessed as <c>Class.field</c>
     /// (member access). Returns false (emitting nothing) when <paramref name="get"/> is not a known
@@ -1570,6 +2107,9 @@ public partial class ILEmitter
 
     protected override void EmitCompoundSet(Expr.CompoundSet cs)
     {
+        if (TryEmitExternalPropertyCompound(cs))
+            return;
+
         // Static field fast path: this.staticField op= value inside a static method/block
         if (cs.Object is Expr.This &&
             TryResolveStaticThisField(new Expr.Get(cs.Object, cs.Name), out _, out var staticFieldCS))
@@ -1661,6 +2201,9 @@ public partial class ILEmitter
 
     protected override void EmitCompoundSetIndex(Expr.CompoundSetIndex csi)
     {
+        if (TryEmitExternalIndexerCompound(csi))
+            return;
+
         // Compound assignment on array element: arr[i] += x
         // 1. Get current value
         // 2. Apply operation

--- a/Compilation/ILEmitter.Properties.External.cs
+++ b/Compilation/ILEmitter.Properties.External.cs
@@ -1,4 +1,5 @@
 using System.Reflection.Emit;
+using SharpTS.Declaration;
 using SharpTS.Diagnostics.Exceptions;
 using SharpTS.Parsing;
 using SharpTS.TypeSystem;
@@ -19,6 +20,11 @@ public partial class ILEmitter
         // Try to find a static property (first PascalCase, then original name)
         var property = externalType.GetProperty(pascalPropertyName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
                     ?? externalType.GetProperty(propertyName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+        if (property != null &&
+            DotNetInteropClassifier.UnsupportedSlotReason(property.PropertyType) != null)
+        {
+            property = null;
+        }
 
         if (property != null)
         {
@@ -39,6 +45,11 @@ public partial class ILEmitter
         // Try to find a static field
         var field = externalType.GetField(pascalPropertyName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
                  ?? externalType.GetField(propertyName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+        if (field != null &&
+            DotNetInteropClassifier.UnsupportedSlotReason(field.FieldType) != null)
+        {
+            field = null;
+        }
 
         if (field != null)
         {
@@ -273,12 +284,22 @@ public partial class ILEmitter
         // Try to find the property (first PascalCase, then original name)
         var property = externalType.GetProperty(pascalPropertyName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
                     ?? externalType.GetProperty(propertyName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        if (property != null &&
+            DotNetInteropClassifier.UnsupportedSlotReason(property.PropertyType) != null)
+        {
+            property = null;
+        }
 
         if (property == null)
         {
             // Try to find a field instead
             var field = externalType.GetField(pascalPropertyName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
                      ?? externalType.GetField(propertyName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+            if (field != null &&
+                DotNetInteropClassifier.UnsupportedSlotReason(field.FieldType) != null)
+            {
+                field = null;
+            }
 
             if (field != null)
             {
@@ -321,12 +342,22 @@ public partial class ILEmitter
         // Try to find the property (first PascalCase, then original name)
         var property = externalType.GetProperty(pascalPropertyName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
                     ?? externalType.GetProperty(propertyName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        if (property != null &&
+            DotNetInteropClassifier.UnsupportedSlotReason(property.PropertyType) != null)
+        {
+            property = null;
+        }
 
         if (property == null)
         {
             // Try to find a field instead
             var field = externalType.GetField(pascalPropertyName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
                      ?? externalType.GetField(propertyName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+            if (field != null &&
+                DotNetInteropClassifier.UnsupportedSlotReason(field.FieldType) != null)
+            {
+                field = null;
+            }
 
             if (field != null)
             {

--- a/Compilation/ILEmitter.Properties.cs
+++ b/Compilation/ILEmitter.Properties.cs
@@ -772,6 +772,15 @@ public partial class ILEmitter
 
     protected override void EmitGetIndex(Expr.GetIndex gi)
     {
+        // A statically known external CLR instance can expose a real indexer. Emit its getter
+        // directly so compiled output remains standalone and matches interpreter reflection.
+        if (!gi.Optional &&
+            TryResolveExternalReceiverType(gi.Object, out var externalIndexerType) &&
+            TryEmitExternalIndexerGet(gi.Object, externalIndexerType, gi.Index))
+        {
+            return;
+        }
+
         // Optional bracket access: emit nullish check around the entire index operation
         if (gi.Optional)
         {
@@ -1083,6 +1092,12 @@ public partial class ILEmitter
 
     protected override void EmitSetIndex(Expr.SetIndex si)
     {
+        if (TryResolveExternalReceiverType(si.Object, out var externalIndexerType) &&
+            TryEmitExternalIndexerSet(si.Object, externalIndexerType, si.Index, si.Value))
+        {
+            return;
+        }
+
         // globalThis[key] = value → GlobalThisSetProperty(key, value)
         if (si.Object is Expr.Variable gtSetIdx && gtSetIdx.Name.Lexeme == "globalThis")
         {

--- a/Declaration/DiscoveryGenerator.cs
+++ b/Declaration/DiscoveryGenerator.cs
@@ -139,7 +139,8 @@ public class DiscoveryGenerator
 
         string? typeReason = DotNetInteropClassifier.UnsupportedTypeReason(type);
         string? importLine = typeReason == null
-            ? $"import {{ {metadata.SimpleName} }} from \"dotnet:{metadata.FullName}\";"
+            ? $"import {{ {Runtime.DotNet.DotNetTypeRegistry.GetFriendlySimpleName(type)} }} from " +
+              $"\"dotnet:{Runtime.DotNet.DotNetTypeRegistry.GetFriendlyFullName(type)}\";"
             : null;
 
         var members = new List<MemberReport>();
@@ -152,7 +153,9 @@ public class DiscoveryGenerator
         else
         {
             foreach (var ctor in metadata.Constructors)
-                members.Add(BuildCallableReport("Constructors", "constructor", ctor.Parameters, returnType: null));
+                members.Add(BuildCallableReport(
+                    "Constructors", "constructor", ctor.Parameters,
+                    returnType: null, isConstructor: true));
 
             foreach (var prop in metadata.StaticProperties)
                 members.Add(BuildPropertyReport("Static properties", prop, isStatic: true));
@@ -161,10 +164,16 @@ public class DiscoveryGenerator
                 members.Add(BuildPropertyReport("Instance properties", prop, isStatic: false));
 
             foreach (var method in metadata.StaticMethods)
-                members.Add(BuildCallableReport("Static methods", method.TypeScriptName, method.Parameters, method.ReturnType, isStatic: true));
+                members.Add(BuildCallableReport(
+                    "Static methods", method.TypeScriptName, method.Parameters,
+                    method.ReturnType, isStatic: true,
+                    genericParameters: method.GenericParameters));
 
             foreach (var method in metadata.Methods)
-                members.Add(BuildCallableReport("Instance methods", method.TypeScriptName, method.Parameters, method.ReturnType));
+                members.Add(BuildCallableReport(
+                    "Instance methods", method.TypeScriptName, method.Parameters,
+                    method.ReturnType,
+                    genericParameters: method.GenericParameters));
         }
 
         return new TypeReport(metadata.FullName, metadata.SimpleName, kind, importLine, typeReason, members);
@@ -172,22 +181,53 @@ public class DiscoveryGenerator
 
     /// <summary>Builds a report line for a constructor or method (a callable with parameters).</summary>
     private static MemberReport BuildCallableReport(
-        string category, string name, List<ParameterMetadata> parameters, Type? returnType, bool isStatic = false)
+        string category,
+        string name,
+        List<ParameterMetadata> parameters,
+        Type? returnType,
+        bool isStatic = false,
+        bool isConstructor = false,
+        List<Type>? genericParameters = null)
     {
         string prefix = isStatic ? "static " : "";
-        string paramText = string.Join(", ", parameters.Select(DotNetTypeMapper.DescribeParameter));
-        string returnText = returnType == null ? "" : $": {DotNetTypeMapper.Describe(returnType)}";
-        string signature = $"{prefix}{name}({paramText}){returnText}";
+        string typeParameters = genericParameters is { Count: > 0 }
+            ? $"<{string.Join(", ", genericParameters.Select(p => p.Name))}>"
+            : "";
+        bool lowerByRef = returnType != null;
+        string paramText = string.Join(", ", parameters
+            .Where(p => !lowerByRef || !(p.IsByRef && p.IsOut))
+            .Select(DescribeInteropInput));
+        string returnText = returnType == null ? "" : $": {DescribeInteropReturn(returnType, parameters)}";
+        string signature = $"{prefix}{name}{typeParameters}({paramText}){returnText}";
 
         // A member is usable only if every parameter slot and the return slot are marshalable.
         string? reason = null;
         foreach (var p in parameters)
         {
-            reason = DotNetInteropClassifier.UnsupportedSlotReason(p.ParameterType);
+            if (isConstructor && p.ParameterType.IsByRef)
+            {
+                reason = DotNetInteropClassifier.ReasonByRefConstructor;
+            }
+            else if (genericParameters is { Count: > 0 })
+            {
+                reason = DotNetInteropClassifier.UnsupportedGenericMethodSlotReason(
+                    p.ParameterType, genericParameters, isParameter: true);
+            }
+            else
+            {
+                reason = lowerByRef
+                    ? DotNetInteropClassifier.UnsupportedParameterReason(p.ParameterType)
+                    : DotNetInteropClassifier.UnsupportedSlotReason(p.ParameterType);
+            }
             if (reason != null) break;
         }
         if (reason == null && returnType != null)
-            reason = DotNetInteropClassifier.UnsupportedSlotReason(returnType);
+        {
+            reason = genericParameters is { Count: > 0 }
+                ? DotNetInteropClassifier.UnsupportedGenericMethodSlotReason(
+                    returnType, genericParameters, isParameter: false)
+                : DotNetInteropClassifier.UnsupportedSlotReason(returnType);
+        }
 
         return new MemberReport(category, signature, reason == null, reason);
     }
@@ -196,9 +236,45 @@ public class DiscoveryGenerator
     {
         string prefix = isStatic ? "static " : "";
         string accessors = prop.CanWrite ? "{ get; set; }" : "{ get; }";
-        string signature = $"{prefix}{prop.TypeScriptName}: {DotNetTypeMapper.Describe(prop.PropertyType)}   {accessors}";
-        string? reason = DotNetInteropClassifier.UnsupportedSlotReason(prop.PropertyType);
+        string member = prop.IsIndexer
+            ? $"[{string.Join(", ", prop.IndexParameters.Select(DotNetTypeMapper.DescribeParameter))}]"
+            : prop.TypeScriptName;
+        string signature = $"{prefix}{member}: {DotNetTypeMapper.Describe(prop.PropertyType)}   {accessors}";
+        string? reason = prop.IsIndexer && prop.IndexParameters.Count != 1
+            ? DotNetInteropClassifier.ReasonMultiParameterIndexer
+            : DotNetInteropClassifier.UnsupportedSlotReason(prop.PropertyType);
+        if (reason == null)
+        {
+            foreach (var parameter in prop.IndexParameters)
+            {
+                reason = DotNetInteropClassifier.UnsupportedSlotReason(parameter.ParameterType);
+                if (reason != null) break;
+            }
+        }
         return new MemberReport(category, signature, reason == null, reason);
+    }
+
+    private static string DescribeInteropInput(ParameterMetadata parameter)
+    {
+        Type type = parameter.ParameterType.IsByRef
+            ? parameter.ParameterType.GetElementType()!
+            : parameter.ParameterType;
+        string name = DotNetTypeMapper.ToTypeScriptPropertyName(parameter.Name);
+        string optional = parameter.IsOptional ? "?" : "";
+        return $"{name}{optional}: {DotNetTypeMapper.Describe(type)}";
+    }
+
+    private static string DescribeInteropReturn(Type returnType, List<ParameterMetadata> parameters)
+    {
+        var outputs = parameters
+            .Where(p => p.IsByRef && !p.IsIn)
+            .Select(p => DotNetTypeMapper.Describe(p.ParameterType.GetElementType()!))
+            .ToList();
+        if (outputs.Count == 0)
+            return DotNetTypeMapper.Describe(returnType);
+        if (returnType != typeof(void))
+            outputs.Insert(0, DotNetTypeMapper.Describe(returnType));
+        return $"[{string.Join(", ", outputs)}]";
     }
 
     private static string KindOf(Type type)
@@ -219,7 +295,7 @@ public class DiscoveryGenerator
     /// </summary>
     private static Type? ResolveType(string typeName)
     {
-        Type? type = Runtime.DotNet.DotNetTypeRegistry.Resolve(typeName);
+        Type? type = Runtime.DotNet.DotNetTypeRegistry.ResolveFriendly(typeName);
         if (type != null)
             return type;
 

--- a/Declaration/DotNetInteropClassifier.cs
+++ b/Declaration/DotNetInteropClassifier.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace SharpTS.Declaration;
 
 /// <summary>
@@ -8,16 +10,19 @@ namespace SharpTS.Declaration;
 /// <remarks>
 /// The <c>--gen-decl</c> discovery tool (<see cref="DiscoveryEmitter"/>) and the runtime
 /// interop marshaller (<c>Runtime/DotNet/DotNetMarshaller.cs</c>) must never disagree about
-/// what is callable, so both classify against these rules. The marshaller has no code path
-/// for by-ref (<c>ref</c>/<c>out</c>/<c>in</c>) slots, pointers, or ref structs
-/// (<c>Span&lt;T&gt;</c>/<c>ReadOnlySpan&lt;T&gt;</c>), and open generic parameters have no
-/// concrete runtime type — those are the four unsupported categories. When the <c>dotnet:</c>
-/// import resolver lands (#1195) it should call these same helpers.
+/// what is callable, so both classify against these rules. Method parameters passed by
+/// reference are projected to ordinary TypeScript inputs/tuple outputs; by-ref returns,
+/// pointers, ref structs (<c>Span&lt;T&gt;</c>/<c>ReadOnlySpan&lt;T&gt;</c>), and open generic
+/// parameters remain unsupported.
 /// </remarks>
 public static class DotNetInteropClassifier
 {
-    /// <summary>Human-readable reason a slot is unsupported: a by-ref parameter/return.</summary>
-    public const string ReasonByRef = "by-ref (ref/out/in) is not marshalable";
+    /// <summary>Human-readable reason a slot is unsupported: a by-ref return.</summary>
+    public const string ReasonByRef = "by-ref returns cannot cross the interop boundary";
+
+    /// <summary>Human-readable reason a by-ref constructor parameter is unsupported.</summary>
+    public const string ReasonByRefConstructor =
+        "by-ref constructor parameters cannot be tuple-lowered because new must return the constructed instance";
 
     /// <summary>Human-readable reason a slot is unsupported: a pointer type.</summary>
     public const string ReasonPointer = "pointer types are not marshalable";
@@ -28,13 +33,18 @@ public static class DotNetInteropClassifier
     /// <summary>Human-readable reason a slot is unsupported: an unbound generic parameter.</summary>
     public const string ReasonOpenGeneric = "open generic has no concrete runtime type";
 
+    /// <summary>Human-readable reason a CLR indexer cannot use TypeScript bracket syntax.</summary>
+    public const string ReasonMultiParameterIndexer =
+        "indexers with multiple parameters cannot use TypeScript bracket syntax";
+
     /// <summary>
     /// Returns null if a single type slot (a parameter or a method/property return type) can
     /// be marshaled across the interop boundary today, or a human-readable reason if it can't.
     /// </summary>
     public static string? UnsupportedSlotReason(Type type)
     {
-        // by-ref (ref/out/in) — the marshaller has no path to write back to the caller's slot.
+        // By-ref return/property slots cannot be materialized as a TypeScript value. Method
+        // parameters are classified through UnsupportedParameterReason instead.
         if (type.IsByRef)
             return ReasonByRef;
 
@@ -56,6 +66,78 @@ public static class DotNetInteropClassifier
     }
 
     /// <summary>
+    /// Returns null when a method parameter is supported. A by-ref parameter is usable when
+    /// its element type is usable: the bridge supplies it as an input when appropriate and
+    /// returns its updated value in a tuple.
+    /// </summary>
+    public static string? UnsupportedParameterReason(Type type)
+    {
+        if (type.IsByRef)
+            type = type.GetElementType()!;
+        return UnsupportedSlotReason(type);
+    }
+
+    /// <summary>
+    /// Classifies a slot on a generic method definition. Open shapes are supported when every
+    /// unbound parameter belongs to that method; invocation closes them before marshalling.
+    /// </summary>
+    public static string? UnsupportedGenericMethodSlotReason(
+        Type type,
+        IReadOnlyCollection<Type> methodGenericParameters,
+        bool isParameter)
+    {
+        if (isParameter && type.IsByRef)
+            type = type.GetElementType()!;
+
+        string? reason = UnsupportedSlotReason(type);
+        if (reason != ReasonOpenGeneric)
+            return reason;
+        return EnumerateGenericParameters(type).All(methodGenericParameters.Contains)
+            ? null
+            : reason;
+    }
+
+    /// <summary>Returns the first unsupported boundary slot on a reflected method.</summary>
+    public static string? UnsupportedMethodReason(MethodInfo method)
+    {
+        var genericParameters = method.IsGenericMethodDefinition
+            ? method.GetGenericArguments()
+            : Type.EmptyTypes;
+
+        string? reason = genericParameters.Length > 0
+            ? UnsupportedGenericMethodSlotReason(
+                method.ReturnType, genericParameters, isParameter: false)
+            : UnsupportedSlotReason(method.ReturnType);
+        if (reason != null)
+            return reason;
+
+        foreach (var parameter in method.GetParameters())
+        {
+            reason = genericParameters.Length > 0
+                ? UnsupportedGenericMethodSlotReason(
+                    parameter.ParameterType, genericParameters, isParameter: true)
+                : UnsupportedParameterReason(parameter.ParameterType);
+            if (reason != null)
+                return reason;
+        }
+        return null;
+    }
+
+    /// <summary>Returns the first unsupported boundary slot on a CLR constructor.</summary>
+    public static string? UnsupportedConstructorReason(ConstructorInfo constructor)
+    {
+        foreach (var parameter in constructor.GetParameters())
+        {
+            if (parameter.ParameterType.IsByRef)
+                return ReasonByRefConstructor;
+            string? reason = UnsupportedSlotReason(parameter.ParameterType);
+            if (reason != null)
+                return reason;
+        }
+        return null;
+    }
+
+    /// <summary>
     /// Returns null if the type itself can be imported/used as a whole, or a reason if it
     /// can't (an open generic type definition, a pointer, or a ref struct).
     /// </summary>
@@ -68,5 +150,24 @@ public static class DotNetInteropClassifier
         if (type.IsByRefLike)
             return ReasonRefStruct;
         return null;
+    }
+
+    private static IEnumerable<Type> EnumerateGenericParameters(Type type)
+    {
+        if (type.IsGenericParameter)
+        {
+            yield return type;
+            yield break;
+        }
+        if (type.HasElementType)
+        {
+            foreach (var parameter in EnumerateGenericParameters(type.GetElementType()!))
+                yield return parameter;
+        }
+        foreach (var argument in type.GetGenericArguments())
+        {
+            foreach (var parameter in EnumerateGenericParameters(argument))
+                yield return parameter;
+        }
     }
 }

--- a/Declaration/DotNetTypeMapper.cs
+++ b/Declaration/DotNetTypeMapper.cs
@@ -35,6 +35,9 @@ public static class DotNetTypeMapper
         if (type == typeof(void))
             return "void";
 
+        if (type.IsGenericParameter)
+            return type.Name;
+
         // Primitives
         if (type == typeof(string))
             return "string";
@@ -158,6 +161,12 @@ public static class DotNetTypeMapper
             return "any";
 
         // Regular types - use the type name
+        if (type.IsGenericType)
+        {
+            string baseName = StripArity(type.Name);
+            return $"{baseName}<{string.Join(", ", type.GetGenericArguments().Select(MapToTypeScript))}>";
+        }
+
         if (type.IsClass || type.IsInterface || type.IsValueType)
         {
             // For known .NET types that map to TypeScript primitives, we've already handled them

--- a/Declaration/TypeInspector.cs
+++ b/Declaration/TypeInspector.cs
@@ -40,7 +40,8 @@ public record MethodMetadata(
     string TypeScriptName,
     Type ReturnType,
     List<ParameterMetadata> Parameters,
-    ObsoleteMetadata? Obsolete = null
+    ObsoleteMetadata? Obsolete = null,
+    List<Type>? GenericParameters = null
 );
 
 public record PropertyMetadata(
@@ -50,8 +51,12 @@ public record PropertyMetadata(
     bool CanRead,
     bool CanWrite,
     ObsoleteMetadata? Obsolete = null,
-    bool IsIndexer = false
-);
+    bool IsIndexer = false,
+    List<ParameterMetadata>? IndexParameters = null
+)
+{
+    public List<ParameterMetadata> IndexParameters { get; init; } = IndexParameters ?? [];
+}
 
 public record FieldMetadata(
     string Name,
@@ -235,10 +240,6 @@ public class TypeInspector
         if (!includeInherited && method.DeclaringType == typeof(object))
             return false;
 
-        // Exclude generic method definitions for MVP (no generic support)
-        if (method.IsGenericMethodDefinition)
-            return false;
-
         return true;
     }
 
@@ -269,7 +270,10 @@ public class TypeInspector
             DotNetTypeMapper.ToTypeScriptMethodName(method.Name),
             method.ReturnType,
             parameters,
-            ExtractObsoleteInfo(method)
+            ExtractObsoleteInfo(method),
+            method.IsGenericMethodDefinition
+                ? method.GetGenericArguments().ToList()
+                : null
         );
     }
 
@@ -282,7 +286,8 @@ public class TypeInspector
             property.CanRead,
             property.CanWrite,
             ExtractObsoleteInfo(property),
-            IsIndexer: property.GetIndexParameters().Length > 0
+            IsIndexer: property.GetIndexParameters().Length > 0,
+            IndexParameters: property.GetIndexParameters().Select(ToParameterMetadata).ToList()
         );
     }
 

--- a/Declaration/TypeScriptEmitter.cs
+++ b/Declaration/TypeScriptEmitter.cs
@@ -237,21 +237,24 @@ public class TypeScriptEmitter
     {
         EmitDeprecatedJsDoc(method.Obsolete);
         string staticModifier = isStatic ? "static " : "";
-        var parameters = FormatParameters(method.Parameters);
-        string returnType = DotNetTypeMapper.MapToTypeScript(method.ReturnType);
+        string typeParameters = method.GenericParameters is { Count: > 0 }
+            ? $"<{string.Join(", ", method.GenericParameters.Select(p => p.Name))}>"
+            : "";
+        var parameters = FormatParameters(method.Parameters, lowerByRef: true);
+        string returnType = FormatInteropReturn(method);
 
         if (isInterface)
         {
             // Interface methods don't have static modifier
-            AppendLine($"{method.TypeScriptName}({parameters}): {returnType};");
+            AppendLine($"{method.TypeScriptName}{typeParameters}({parameters}): {returnType};");
         }
         else
         {
-            AppendLine($"{staticModifier}{method.TypeScriptName}({parameters}): {returnType};");
+            AppendLine($"{staticModifier}{method.TypeScriptName}{typeParameters}({parameters}): {returnType};");
         }
     }
 
-    private string FormatParameters(List<ParameterMetadata> parameters)
+    private string FormatParameters(List<ParameterMetadata> parameters, bool lowerByRef = false)
     {
         if (parameters.Count == 0)
             return "";
@@ -259,7 +262,12 @@ public class TypeScriptEmitter
         var parts = new List<string>();
         foreach (var param in parameters)
         {
-            string tsType = DotNetTypeMapper.MapToTypeScript(param.ParameterType);
+            if (lowerByRef && param.IsByRef && param.IsOut)
+                continue;
+            Type parameterType = lowerByRef && param.ParameterType.IsByRef
+                ? param.ParameterType.GetElementType()!
+                : param.ParameterType;
+            string tsType = DotNetTypeMapper.MapToTypeScript(parameterType);
             string optionalMark = param.IsOptional ? "?" : "";
 
             // Use camelCase for parameter names
@@ -269,6 +277,19 @@ public class TypeScriptEmitter
         }
 
         return string.Join(", ", parts);
+    }
+
+    private static string FormatInteropReturn(MethodMetadata method)
+    {
+        var outputs = method.Parameters
+            .Where(p => p.IsByRef && !p.IsIn)
+            .Select(p => DotNetTypeMapper.MapToTypeScript(p.ParameterType.GetElementType()!))
+            .ToList();
+        if (outputs.Count == 0)
+            return DotNetTypeMapper.MapToTypeScript(method.ReturnType);
+        if (method.ReturnType != typeof(void))
+            outputs.Insert(0, DotNetTypeMapper.MapToTypeScript(method.ReturnType));
+        return $"[{string.Join(", ", outputs)}]";
     }
 
     private void EmitDeprecatedJsDoc(ObsoleteMetadata? obsolete)

--- a/Execution/Interpreter.Calls.cs
+++ b/Execution/Interpreter.Calls.cs
@@ -3,6 +3,7 @@ using SharpTS.Parsing;
 using SharpTS.Runtime;
 using SharpTS.Runtime.BuiltIns;
 using SharpTS.Runtime.Exceptions;
+using SharpTS.Runtime.DotNet;
 using SharpTS.Runtime.Types;
 using SharpTS.TypeSystem;
 using System.Buffers;
@@ -184,7 +185,19 @@ public partial class Interpreter
             }
         }
 
-        object? callee = (await ctx.EvaluateExprAsync(call.Callee)).ToObject();
+        object? callee;
+        if (call.Callee is Expr.Get extensionGet &&
+            _currentModule is { DotNetExtensionTypes.Count: > 0 })
+        {
+            object? receiver = (await ctx.EvaluateExprAsync(extensionGet.Object)).ToObject();
+            callee = TryBindDotNetExtension(receiver, extensionGet.Name.Lexeme, out var extension)
+                ? extension
+                : EvaluateGetOnObject(extensionGet, receiver).ToObject();
+        }
+        else
+        {
+            callee = (await ctx.EvaluateExprAsync(call.Callee)).ToObject();
+        }
 
         // Optional call: return undefined if callee is nullish.
         // Per ECMA-262 §13.3.9, the short-circuit extends to the entire chain.
@@ -227,6 +240,18 @@ public partial class Interpreter
             // Per ECMA-262 §10.2.1: missing arguments become undefined; do not
             // reject calls for user-defined functions. Built-in methods enforce
             // their own min-arity in BuiltInMethod.Call.
+            if (function is DotNetMethod dotNetMethod)
+            {
+                IReadOnlyList<Type>? explicitTypes = call.TypeArgs is { Count: > 0 }
+                    ? ResolveDotNetGenericTypeArguments(call.TypeArgs)
+                    : null;
+                return dotNetMethod.CallWithTypeHints(
+                    this,
+                    argumentsList,
+                    ResolveDotNetArgumentTypeHints(call.Arguments),
+                    explicitTypes,
+                    ResolveDotNetResultTypeHint(call));
+            }
             return function.Call(this, argumentsList);
         }
         finally
@@ -428,7 +453,19 @@ public partial class Interpreter
             }
         }
 
-        object? callee = Evaluate(call.Callee);
+        object? callee;
+        if (call.Callee is Expr.Get extensionGet &&
+            _currentModule is { DotNetExtensionTypes.Count: > 0 })
+        {
+            object? receiver = Evaluate(extensionGet.Object);
+            callee = TryBindDotNetExtension(receiver, extensionGet.Name.Lexeme, out var extension)
+                ? extension
+                : EvaluateGetOnObject(extensionGet, receiver).ToObject();
+        }
+        else
+        {
+            callee = Evaluate(call.Callee);
+        }
 
         // Optional call: return undefined if callee is nullish.
         // Per ECMA-262 §13.3.9, the short-circuit extends to the entire chain:
@@ -442,7 +479,9 @@ public partial class Interpreter
 
         // V2 fast path: no spread args — zero boxing (CallV2 is on the interface;
         // unmigrated implementors run through the boxing DIM bridge)
-        if (callee is ISharpTSCallable v2Callee && !HasSpreadArgs(call.Arguments))
+        if (callee is ISharpTSCallable v2Callee &&
+            callee is not DotNetMethod &&
+            !HasSpreadArgs(call.Arguments))
         {
             int argCount = call.Arguments.Count;
             var rented = ArrayPool<RuntimeValue>.Shared.Rent(Math.Max(argCount, 1));
@@ -493,13 +532,91 @@ public partial class Interpreter
 
             // Per ECMA-262 §10.2.1: missing arguments become undefined; do not
             // reject calls for user-defined functions.
-            return RuntimeValue.FromBoxed(function.Call(this, argumentsList));
+            object? result;
+            if (function is DotNetMethod dotNetMethod)
+            {
+                IReadOnlyList<Type>? explicitTypes = call.TypeArgs is { Count: > 0 }
+                    ? ResolveDotNetGenericTypeArguments(call.TypeArgs)
+                    : null;
+                result = dotNetMethod.CallWithTypeHints(
+                    this,
+                    argumentsList,
+                    ResolveDotNetArgumentTypeHints(call.Arguments),
+                    explicitTypes,
+                    ResolveDotNetResultTypeHint(call));
+            }
+            else
+            {
+                result = function.Call(this, argumentsList);
+            }
+            return RuntimeValue.FromBoxed(result);
         }
         finally
         {
             ArgumentListPool.Return(argumentsList);
         }
     }
+
+    private bool TryBindDotNetExtension(
+        object? receiver,
+        string memberName,
+        out DotNetExtensionMethod extension)
+    {
+        if (receiver is DotNetInstance instance &&
+            _currentModule is { DotNetExtensionTypes.Count: > 0 } module &&
+            DotNetTypeRegistry.GetMethods(
+                instance.Type, memberName, isStatic: false).Length == 0 &&
+            DotNetExtensionMethodResolver.GetReceiverClosedCandidates(
+                module.DotNetExtensionTypes, memberName, instance.Type).Length > 0)
+        {
+            extension = new DotNetExtensionMethod(
+                instance, module.DotNetExtensionTypes, memberName);
+            return true;
+        }
+
+        extension = null!;
+        return false;
+    }
+
+    private Type[] ResolveDotNetGenericTypeArguments(IReadOnlyList<string> typeArguments)
+    {
+        var resolved = new Type[typeArguments.Count];
+        for (int i = 0; i < typeArguments.Count; i++)
+        {
+            string typeArgument = typeArguments[i];
+            Type? importedType = _environment.TryGet(typeArgument, out var value) &&
+                                 value.ToObject() is DotNetClass dotNetClass
+                ? dotNetClass.Type
+                : null;
+            resolved[i] = importedType ?? DotNetTypeRegistry.ResolveFriendly(typeArgument)
+                ?? throw new InvalidOperationException(
+                    $"Could not resolve CLR generic type argument '{typeArgument}'.");
+        }
+        return resolved;
+    }
+
+    private Type?[]? ResolveDotNetArgumentTypeHints(IReadOnlyList<Expr> arguments)
+    {
+        if (_typeMap == null || HasSpreadArgs(arguments))
+            return null;
+
+        var result = new Type?[arguments.Count];
+        for (int i = 0; i < arguments.Count; i++)
+        {
+            if (_typeMap.Get(arguments[i]) is { } type &&
+                DotNetTypeSynthesizer.TryGetClrArgumentType(type, out var clr))
+            {
+                result[i] = clr;
+            }
+        }
+        return result;
+    }
+
+    private Type? ResolveDotNetResultTypeHint(Expr.Call call) =>
+        _typeMap?.Get(call) is { } type &&
+        DotNetTypeSynthesizer.TryGetClrArgumentType(type, out var clr)
+            ? clr
+            : null;
 
     /// <summary>
     /// Checks if any arguments are spread expressions.
@@ -584,6 +701,9 @@ public partial class Interpreter
         object? left = leftRV.ToObject();
         object? right = rightRV.ToObject();
 
+        if (TryEvaluateDotNetBinary(op.Type, left, right, out var clrResult))
+            return clrResult;
+
         var desc = SemanticOperatorResolver.Resolve(op.Type);
 
         return desc switch
@@ -608,6 +728,31 @@ public partial class Interpreter
             OperatorDescriptor.InstanceOf => RuntimeValue.FromBoxed(EvaluateInstanceof(left, right)),
             _ => RuntimeValue.Undefined
         };
+    }
+
+    private bool TryEvaluateDotNetBinary(
+        TokenType token,
+        object? left,
+        object? right,
+        out RuntimeValue result)
+    {
+        Type? leftType = left is DotNetInstance leftInstance ? leftInstance.Type : null;
+        Type? rightType = right is DotNetInstance rightInstance ? rightInstance.Type : null;
+        var methods = DotNetOperatorResolver.GetBinaryCandidates(token, leftType, rightType);
+        if (methods.Length == 0)
+        {
+            result = default;
+            return false;
+        }
+
+        var arguments = new List<object?> { left, right };
+        var candidate = DotNetMethodResolver.ResolveMethod(methods, arguments);
+        var method = (System.Reflection.MethodInfo)candidate.Method;
+        var invokeArgs = DotNetMethod.BuildInvokeArgs(
+            method.GetParameters(), arguments, candidate, this);
+        object? value = DotNetInstance.InvokeWithMapping(() => method.Invoke(null, invokeArgs));
+        result = RuntimeValue.FromBoxed(DotNetMarshaller.WrapReturn(value, method.ReturnType));
+        return true;
     }
 
     /// <summary>
@@ -1089,6 +1234,13 @@ public partial class Interpreter
     /// </summary>
     private RuntimeValue ApplyCompoundOperatorRV(TokenType op, RuntimeValue left, RuntimeValue right)
     {
+        if (DotNetOperatorResolver.GetBinaryTokenForCompound(op) is { } binaryToken &&
+            TryEvaluateDotNetBinary(
+                binaryToken, left.ToObject(), right.ToObject(), out var clrResult))
+        {
+            return clrResult;
+        }
+
         // Fast path: both numeric (most common for compound assignment)
         if (left.IsNumber && right.IsNumber)
         {

--- a/Execution/Interpreter.DotNet.cs
+++ b/Execution/Interpreter.DotNet.cs
@@ -24,12 +24,11 @@ public partial class Interpreter
         string? mapping = ExtractDotNetTypeMapping(classStmt);
         if (mapping == null) return false;
 
-        string clrName = DotNetTypeRegistry.ToClrTypeName(mapping);
-        Type? type = DotNetTypeRegistry.Resolve(clrName);
+        Type? type = DotNetTypeRegistry.ResolveFriendly(mapping);
         if (type == null)
         {
             throw new InterpreterException(
-                $"@DotNetType: .NET type '{clrName}' not found in any loaded assembly.");
+                $"@DotNetType: .NET type '{mapping}' not found in any loaded assembly.");
         }
 
         var overloadHints = ExtractOverloadHints(classStmt);

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -6,6 +6,7 @@ using SharpTS.Parsing;
 using SharpTS.Parsing.Visitors;
 using SharpTS.Runtime;
 using SharpTS.Runtime.BuiltIns;
+using SharpTS.Runtime.DotNet;
 using SharpTS.Runtime.Exceptions;
 using SharpTS.Runtime.Types;
 
@@ -975,6 +976,13 @@ public partial class Interpreter
             return RuntimeValue.Undefined;
         }
 
+        // CLR indexers are real properties with parameters. Route them before the string-key
+        // synthetic dot-property fallback, which would otherwise look for a member named "0".
+        if (obj is DotNetInstance { HasReadableIndexer: true } dotNetInstance)
+        {
+            return RuntimeValue.FromBoxed(dotNetInstance.GetIndex(index, this));
+        }
+
         // Built-in namespace singletons and prototype objects resolve dot-notation access via
         // BuiltInRegistry.GetInstanceMember or hand-written fallbacks in EvaluateGetOnFallback
         // (SharpTSArrayGlobal, SharpTSArrayPrototype, SharpTSBuiltInConstructor, etc.).
@@ -1172,6 +1180,12 @@ public partial class Interpreter
                 return RuntimeValue.FromBoxed(value);
             }
             afn.SetProperty(index?.ToString() ?? "", value);
+            return RuntimeValue.FromBoxed(value);
+        }
+
+        if (obj is DotNetInstance { HasWritableIndexer: true } dotNetInstance)
+        {
+            dotNetInstance.SetIndex(index, value, this);
             return RuntimeValue.FromBoxed(value);
         }
 

--- a/Execution/Interpreter.Helpers.cs
+++ b/Execution/Interpreter.Helpers.cs
@@ -1,6 +1,7 @@
 using SharpTS.Modules;
 using SharpTS.Parsing;
 using SharpTS.Runtime;
+using SharpTS.Runtime.DotNet;
 using SharpTS.Runtime.Types;
 
 namespace SharpTS.Execution;
@@ -34,6 +35,9 @@ public partial class Interpreter
             case SharpTSObject simpleObj:
                 value = simpleObj.GetProperty(name.Lexeme);
                 return true;
+            case DotNetInstance external:
+                value = external.GetMember(name.Lexeme);
+                return true;
             default:
                 value = null;
                 return false;
@@ -59,6 +63,9 @@ public partial class Interpreter
                 return true;
             case SharpTSObject simpleObj:
                 value = simpleObj.GetPropertyRV(name.Lexeme);
+                return true;
+            case DotNetInstance external:
+                value = RuntimeValue.FromBoxed(external.GetMember(name.Lexeme));
                 return true;
             default:
                 value = RuntimeValue.Undefined;
@@ -91,6 +98,9 @@ public partial class Interpreter
             case SharpTSObject simpleObj:
                 simpleObj.SetProperty(name.Lexeme, value);
                 return true;
+            case DotNetInstance external:
+                external.SetMember(name.Lexeme, value, this);
+                return true;
             default:
                 return false;
         }
@@ -103,11 +113,16 @@ public partial class Interpreter
     /// <param name="index">The index value (expected to be a double).</param>
     /// <param name="value">The retrieved value if successful.</param>
     /// <returns><c>true</c> if the element was found; otherwise <c>false</c>.</returns>
-    private static bool TryGetIndex(object? obj, object? index, out object? value)
+    private bool TryGetIndex(object? obj, object? index, out object? value)
     {
         if (obj is SharpTSArray array && index is double idx)
         {
             value = array.Get((int)idx);
+            return true;
+        }
+        if (obj is DotNetInstance external && external.HasReadableIndexer)
+        {
+            value = external.GetIndex(index, this);
             return true;
         }
         value = null;
@@ -121,11 +136,16 @@ public partial class Interpreter
     /// <param name="index">The index value (expected to be a double).</param>
     /// <param name="value">The value to set.</param>
     /// <returns><c>true</c> if the element was set; otherwise <c>false</c>.</returns>
-    private static bool TrySetIndex(object? obj, object? index, object? value)
+    private bool TrySetIndex(object? obj, object? index, object? value)
     {
         if (obj is SharpTSArray array && index is double idx)
         {
             array.Set((int)idx, value);
+            return true;
+        }
+        if (obj is DotNetInstance external && external.HasWritableIndexer)
+        {
+            external.SetIndex(index, value, this);
             return true;
         }
         return false;
@@ -197,13 +217,55 @@ public partial class Interpreter
     /// <summary>Increments a variable l-value, returning the old or new value.</summary>
     private RuntimeValue IncrementVariable(Expr.Variable variable, double delta, bool returnOld)
     {
+        RuntimeValue oldValue = _environment.Get(variable.Name);
+        if (TryEvaluateDotNetIncrement(
+                oldValue,
+                delta > 0 ? TokenType.PLUS_PLUS : TokenType.MINUS_MINUS,
+                out var clrValue))
+        {
+            _environment.Assign(variable.Name, clrValue);
+            return returnOld ? oldValue : clrValue;
+        }
+
         // ECMA-262 13.4 (postfix)/13.5.7 (prefix): apply ToNumber to the operand's current
         // value before adding ±1. A widened (`any`) variable can hold a non-number — a numeric
         // string ("5"→5), undefined (→NaN), etc. — so coerce rather than asserting a boxed double.
-        double current = CoerceToNumber(_environment.Get(variable.Name));
+        double current = CoerceToNumber(oldValue);
         double newValue = current + delta;
         _environment.Assign(variable.Name, RuntimeValue.FromNumber(newValue));
         return RuntimeValue.FromNumber(returnOld ? current : newValue);
+    }
+
+    private bool TryEvaluateDotNetIncrement(
+        RuntimeValue current,
+        TokenType token,
+        out RuntimeValue result)
+    {
+        if (current.ToObject() is not SharpTS.Runtime.DotNet.DotNetInstance instance)
+        {
+            result = default;
+            return false;
+        }
+
+        var methods = SharpTS.Runtime.DotNet.DotNetOperatorResolver.GetIncrementCandidates(
+            token, instance.Type);
+        if (methods.Length == 0)
+        {
+            result = default;
+            return false;
+        }
+
+        var arguments = new List<object?> { instance };
+        var candidate = SharpTS.Runtime.DotNet.DotNetMethodResolver.ResolveMethod(
+            methods, arguments);
+        var method = (System.Reflection.MethodInfo)candidate.Method;
+        var invokeArgs = SharpTS.Runtime.DotNet.DotNetMethod.BuildInvokeArgs(
+            method.GetParameters(), arguments, candidate, this);
+        object? value = SharpTS.Runtime.DotNet.DotNetInstance.InvokeWithMapping(
+            () => method.Invoke(null, invokeArgs));
+        result = RuntimeValue.FromBoxed(
+            SharpTS.Runtime.DotNet.DotNetMarshaller.WrapReturn(value, method.ReturnType));
+        return true;
     }
 
     /// <summary>
@@ -214,6 +276,16 @@ public partial class Interpreter
     {
         if (TryGetProperty(obj, name, out object? currentObj))
         {
+            RuntimeValue oldValue = RuntimeValue.FromBoxed(currentObj);
+            if (TryEvaluateDotNetIncrement(
+                    oldValue,
+                    delta > 0 ? TokenType.PLUS_PLUS : TokenType.MINUS_MINUS,
+                    out RuntimeValue externalValue) &&
+                TrySetProperty(obj, name, externalValue.ToObject()))
+            {
+                return returnOld ? oldValue : externalValue;
+            }
+
             // ECMA-262 ToNumber on the member's current value (matches the variable path and
             // compiled mode's ConvertToNumber): a non-numeric `any` member ("5"→5, undefined→NaN)
             // follows JS semantics instead of throwing on a failed hard cast (#471).
@@ -236,6 +308,16 @@ public partial class Interpreter
     {
         if (TryGetIndex(obj, index, out object? currentObj))
         {
+            RuntimeValue oldValue = RuntimeValue.FromBoxed(currentObj);
+            if (TryEvaluateDotNetIncrement(
+                    oldValue,
+                    delta > 0 ? TokenType.PLUS_PLUS : TokenType.MINUS_MINUS,
+                    out RuntimeValue externalValue) &&
+                TrySetIndex(obj, index, externalValue.ToObject()))
+            {
+                return returnOld ? oldValue : externalValue;
+            }
+
             // ECMA-262 ToNumber on the element's current value (see IncrementProperty): a
             // non-numeric element in an `any[]` ("7"→7, undefined→NaN) follows JS semantics
             // instead of throwing on a failed hard cast (#471).

--- a/Execution/Interpreter.Operators.cs
+++ b/Execution/Interpreter.Operators.cs
@@ -4,6 +4,7 @@ using SharpTS.Runtime;
 using SharpTS.Runtime.BuiltIns;
 using SharpTS.Runtime.Exceptions;
 using SharpTS.Runtime.Types;
+using DotNet = SharpTS.Runtime.DotNet;
 
 namespace SharpTS.Execution;
 
@@ -122,6 +123,16 @@ public partial class Interpreter
             RuntimeValue newValue = ApplyCompoundOperatorRV(
                 compound.Operator.Type, RuntimeValue.FromBoxed(typedArray[ti]), addValue);
             typedArray[ti] = newValue.ToObject();
+            return newValue;
+        }
+
+        if (obj is DotNet.DotNetInstance external && external.HasReadableIndexer)
+        {
+            RuntimeValue current = RuntimeValue.FromBoxed(external.GetIndex(index, this));
+            RuntimeValue addValue = await ctx.EvaluateExprAsync(compound.Value);
+            RuntimeValue newValue = ApplyCompoundOperatorRV(
+                compound.Operator.Type, current, addValue);
+            external.SetIndex(index, newValue.ToObject(), this);
             return newValue;
         }
 
@@ -412,6 +423,25 @@ public partial class Interpreter
     /// </summary>
     private RuntimeValue EvaluateUnaryOperationRV(Token op, RuntimeValue rv)
     {
+        if (rv.ToObject() is DotNet.DotNetInstance instance)
+        {
+            var methods = DotNet.DotNetOperatorResolver.GetUnaryCandidates(
+                op.Type, instance.Type);
+            if (methods.Length > 0)
+            {
+                var arguments = new List<object?> { instance };
+                var candidate = DotNet.DotNetMethodResolver.ResolveMethod(
+                    methods, arguments);
+                var method = (System.Reflection.MethodInfo)candidate.Method;
+                var invokeArgs = DotNet.DotNetMethod.BuildInvokeArgs(
+                    method.GetParameters(), arguments, candidate, this);
+                object? value = DotNet.DotNetInstance.InvokeWithMapping(
+                    () => method.Invoke(null, invokeArgs));
+                return RuntimeValue.FromBoxed(
+                    DotNet.DotNetMarshaller.WrapReturn(value, method.ReturnType));
+            }
+        }
+
         switch (op.Type)
         {
             case TokenType.BANG:

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -658,7 +658,7 @@ public partial class Interpreter
         {
             // @DotNetType external types
             TypeCategory.External when obj is DotNetInstance dotNetInstance =>
-                RuntimeValue.FromBoxed(dotNetInstance.GetMember(memberName)),
+                EvaluateGetOnDotNetInstance(dotNetInstance, memberName),
             TypeCategory.External when obj is DotNetClass dotNetClass =>
                 RuntimeValue.FromBoxed(dotNetClass.GetStaticMember(memberName)),
 
@@ -686,6 +686,22 @@ public partial class Interpreter
             // Fallback for remaining types (IDictionary, ISharpTSPropertyAccessor, unknown types)
             _ => RuntimeValue.FromBoxed(EvaluateGetOnFallback(obj, memberName))
         };
+    }
+
+    private RuntimeValue EvaluateGetOnDotNetInstance(
+        DotNetInstance instance,
+        string memberName)
+    {
+        object? value = instance.GetMember(memberName);
+        if (value is SharpTSUndefined &&
+            _currentModule is { DotNetExtensionTypes.Count: > 0 } module &&
+            DotNetExtensionMethodResolver.GetReceiverClosedCandidates(
+                module.DotNetExtensionTypes, memberName, instance.Type).Length > 0)
+        {
+            value = new DotNetExtensionMethod(
+                instance, module.DotNetExtensionTypes, memberName);
+        }
+        return RuntimeValue.FromBoxed(value);
     }
 
     /// <summary>

--- a/Execution/Interpreter.cs
+++ b/Execution/Interpreter.cs
@@ -1534,6 +1534,14 @@ public partial class Interpreter : IDisposable
             return;
         }
 
+        // Extension imports only modify member lookup in the importing module. Their virtual
+        // modules have no runtime exports or initialization side effects of their own.
+        if (module.IsDotNetExtensionModule)
+        {
+            moduleInstance.IsExecuted = true;
+            return;
+        }
+
         // Handle built-in modules specially - populate exports from interpreter implementations
         if (module.IsBuiltIn)
         {

--- a/Modules/DotNetExtensionImports.cs
+++ b/Modules/DotNetExtensionImports.cs
@@ -1,0 +1,60 @@
+using System.Runtime.CompilerServices;
+using SharpTS.Parsing;
+using SharpTS.Runtime.DotNet;
+
+namespace SharpTS.Modules;
+
+/// <summary>Resolution and validation for module-scoped CLR extension-method imports.</summary>
+public static class DotNetExtensionImports
+{
+    public const string Prefix = "dotnet-extensions:";
+
+    public static bool IsSpecifier(string specifier) =>
+        specifier.StartsWith(Prefix, StringComparison.Ordinal);
+
+    public static ParsedModule CreateModule(string virtualPath)
+    {
+        string typeName = virtualPath[Prefix.Length..];
+        Type? container = DotNetTypeRegistry.ResolveFriendly(typeName);
+        if (container == null || !(container.IsPublic || container.IsNestedPublic))
+            throw new Exception(
+                $"Module Error: cannot resolve public extension container '{typeName}'.");
+        if (!(container.IsAbstract && container.IsSealed))
+            throw new Exception(
+                $"Module Error: extension container '{typeName}' must be a static class.");
+        if (!container.GetMethods(System.Reflection.BindingFlags.Public |
+                                  System.Reflection.BindingFlags.Static)
+                .Any(m => m.IsDefined(typeof(ExtensionAttribute), inherit: false)))
+        {
+            throw new Exception(
+                $"Module Error: '{typeName}' contains no public extension methods.");
+        }
+
+        return new ParsedModule(virtualPath, [])
+        {
+            IsScript = false,
+            IsTypeChecked = true,
+            DotNetExtensionContainer = container
+        };
+    }
+
+    public static void EnsureSideEffectImport(
+        ParsedModule importingModule,
+        ParsedModule extensionModule,
+        Stmt.Import import)
+    {
+        if (import.DefaultImport != null ||
+            import.NamespaceImport != null ||
+            import.NamedImports != null ||
+            import.IsTypeOnly)
+        {
+            throw new Exception(
+                $"Module Error: '{import.ModulePath}' must be imported for side effects: " +
+                $"import \"{import.ModulePath}\";");
+        }
+
+        Type container = extensionModule.DotNetExtensionContainer!;
+        if (!importingModule.DotNetExtensionTypes.Contains(container))
+            importingModule.DotNetExtensionTypes.Add(container);
+    }
+}

--- a/Modules/DotNetImports.cs
+++ b/Modules/DotNetImports.cs
@@ -122,14 +122,22 @@ public static class DotNetImports
                 "type by name: import { Widget } from \"dotnet:MyLib.Widget\".");
         }
 
-        if (specifier.Contains('<') || specifier.Contains('`'))
+        if (specifier.Contains('`'))
         {
             throw new Exception(
                 $"Module Error: cannot import 'dotnet:{specifier}': {DotNetInteropClassifier.ReasonOpenGeneric}. " +
-                "Generic .NET types are not importable via dotnet: specifiers; use an @DotNetType declaration for a closed generic.");
+                "Use a constructed friendly name such as List<number>, not CLR backtick syntax.");
         }
 
-        var type = ResolveExportCandidate(specifier, name, resolve);
+        Type type;
+        try
+        {
+            type = ResolveExportCandidate(specifier, name, resolve);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new Exception($"Module Error: cannot import 'dotnet:{specifier}': {ex.Message}", ex);
+        }
 
         string? unsupported = DotNetInteropClassifier.UnsupportedTypeReason(type);
         if (unsupported != null)
@@ -147,7 +155,7 @@ public static class DotNetImports
         var specType = ResolvePublic(specifier, resolve);
         if (specType != null)
         {
-            if (name == specType.Name) return specType;
+            if (name == DotNetTypeRegistry.GetFriendlySimpleName(specType)) return specType;
 
             // A different name against a type specifier can only mean a nested type.
             var nested = ResolvePublic($"{specifier}+{name}", resolve);
@@ -174,7 +182,7 @@ public static class DotNetImports
     /// </summary>
     private static Type? ResolvePublic(string clrName, Func<string, Type?> resolve)
     {
-        var type = resolve(clrName);
+        var type = DotNetTypeRegistry.ResolveFriendly(clrName, resolve);
         return type != null && (type.IsPublic || type.IsNestedPublic) ? type : null;
     }
 

--- a/Modules/ModuleResolver.cs
+++ b/Modules/ModuleResolver.cs
@@ -200,7 +200,8 @@ public class ModuleResolver
 
         // dotnet: scheme — .NET interop imports resolve via reflection, not the file system.
         // The specifier itself is the virtual module path (and cache key).
-        if (DotNetImports.IsDotNetSpecifier(specifier))
+        if (DotNetImports.IsDotNetSpecifier(specifier) ||
+            DotNetExtensionImports.IsSpecifier(specifier))
         {
             if (kind == ResolutionKind.Cjs)
             {
@@ -765,6 +766,16 @@ public class ModuleResolver
             return dotnetModule;
         }
 
+        if (DotNetExtensionImports.IsSpecifier(absolutePath))
+        {
+            if (!_moduleCache.TryGetValue(absolutePath, out var extensionModule))
+            {
+                extensionModule = DotNetExtensionImports.CreateModule(absolutePath);
+                _moduleCache[absolutePath] = extensionModule;
+            }
+            return extensionModule;
+        }
+
         // Primitive C# module — materialize a placeholder ParsedModule with types.
         // Origin-gating in ResolveModulePath has already ensured only stdlib-origin
         // modules resolve here, so no per-caller check is needed.
@@ -986,6 +997,11 @@ public class ModuleResolver
                     if (importedModule.IsDotNetModule)
                     {
                         DotNetImports.EnsureImports(importedModule, import);
+                    }
+                    else if (importedModule.IsDotNetExtensionModule)
+                    {
+                        DotNetExtensionImports.EnsureSideEffectImport(
+                            module, importedModule, import);
                     }
                     // Files loaded via import are always modules, even if they have no exports
                     // (e.g., side-effect imports like `import './polyfill'`)
@@ -1450,6 +1466,7 @@ public class ModuleResolver
             && !absolutePath.StartsWith(AmbientModulePrefix, StringComparison.Ordinal)
             && !DotNetImports.IsDotNetSpecifier(absolutePath)
             && !absolutePath.StartsWith(TypeScriptLibProvider.VirtualPathPrefix, StringComparison.Ordinal)
+            && !DotNetExtensionImports.IsSpecifier(absolutePath)
             && !absolutePath.StartsWith(PrimitiveRegistry.Prefix, StringComparison.Ordinal))
         {
             absolutePath = Path.GetFullPath(absolutePath);

--- a/Modules/ParsedModule.cs
+++ b/Modules/ParsedModule.cs
@@ -134,6 +134,17 @@ public class ParsedModule
     public bool IsDotNetModule => DotNetExports != null;
 
     /// <summary>
+    /// For a <c>dotnet-extensions:</c> virtual module, the public static container whose
+    /// extension methods the importing source module activates.
+    /// </summary>
+    public Type? DotNetExtensionContainer { get; set; }
+
+    /// <summary>Extension containers activated only within this source module.</summary>
+    public List<Type> DotNetExtensionTypes { get; } = [];
+
+    public bool IsDotNetExtensionModule => DotNetExtensionContainer != null;
+
+    /// <summary>
     /// True if file has no import/export statements (is a "script" file).
     /// Scripts share global scope; modules have isolated scope.
     /// </summary>

--- a/Runtime/DotNet/DotNetExtensionMethod.cs
+++ b/Runtime/DotNet/DotNetExtensionMethod.cs
@@ -1,0 +1,63 @@
+using System.Reflection;
+using SharpTS.Execution;
+using SharpTS.Runtime.Types;
+
+namespace SharpTS.Runtime.DotNet;
+
+/// <summary>Callable bound to a CLR receiver and the current module's extension containers.</summary>
+internal sealed class DotNetExtensionMethod(
+    DotNetInstance receiver,
+    IReadOnlyList<Type> containers,
+    string memberName) : ISharpTSCallable
+{
+    public int Arity()
+    {
+        var methods = DotNetExtensionMethodResolver.GetReceiverClosedCandidates(
+            containers, memberName, receiver.Type);
+        int minimum = int.MaxValue;
+        foreach (var method in methods)
+        {
+            int required = method.GetParameters()
+                .Skip(1)
+                .Count(p => !p.IsOptional &&
+                            !p.IsOut &&
+                            !p.IsDefined(typeof(ParamArrayAttribute), false));
+            minimum = Math.Min(minimum, required);
+        }
+        return minimum == int.MaxValue ? 0 : minimum;
+    }
+
+    public object? Call(Interpreter interpreter, List<object?> arguments)
+    {
+        var allArguments = new List<object?>(arguments.Count + 1) { receiver };
+        allArguments.AddRange(arguments);
+        var argumentTypes = allArguments.Select(RuntimeArgumentType).ToArray();
+        MethodInfo[] methods = DotNetExtensionMethodResolver.GetClosedCandidates(
+            containers, memberName, argumentTypes);
+        if (methods.Length == 0)
+        {
+            throw new InvalidOperationException(
+                $"No compatible extension method '{memberName}' could infer its generic arguments.");
+        }
+
+        var candidate = DotNetMethodResolver.ResolveMethod(methods, allArguments);
+        var method = (MethodInfo)candidate.Method;
+        var invokeArgs = DotNetMethod.BuildInvokeArgs(
+            method.GetParameters(), allArguments, candidate, interpreter);
+        return DotNetInstance.InvokeWithMapping(() =>
+        {
+            object? value = method.Invoke(null, invokeArgs);
+            return DotNetMethod.WrapInvocationResult(method, invokeArgs, value);
+        });
+    }
+
+    private static Type? RuntimeArgumentType(object? value) => value switch
+    {
+        DotNetInstance instance => instance.Type,
+        SharpTSUndefined or null => null,
+        double => typeof(double),
+        bool => typeof(bool),
+        string => typeof(string),
+        _ => value.GetType()
+    };
+}

--- a/Runtime/DotNet/DotNetExtensionMethodResolver.cs
+++ b/Runtime/DotNet/DotNetExtensionMethodResolver.cs
@@ -1,0 +1,69 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using SharpTS.Declaration;
+
+namespace SharpTS.Runtime.DotNet;
+
+/// <summary>Discovers and closes imported CLR extension methods.</summary>
+internal static class DotNetExtensionMethodResolver
+{
+    internal static MethodInfo[] GetClosedCandidates(
+        IEnumerable<Type> containers,
+        string memberName,
+        IReadOnlyList<Type?> argumentTypes)
+    {
+        var methods = new List<MethodInfo>();
+        foreach (var container in containers)
+        {
+            foreach (var method in container.GetMethods(
+                         BindingFlags.Public | BindingFlags.Static))
+            {
+                if (!method.IsDefined(typeof(ExtensionAttribute), inherit: false) ||
+                    !string.Equals(
+                        DotNetTypeMapper.ToTypeScriptMethodName(method.Name),
+                        memberName,
+                        StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (method.GetParameters().Length != argumentTypes.Count)
+                    continue;
+                var closed = DotNetGenericMethodInference.TryClose(method, argumentTypes);
+                if (closed != null)
+                    methods.Add(closed);
+            }
+        }
+        return methods.ToArray();
+    }
+
+    internal static MethodInfo[] GetReceiverClosedCandidates(
+        IEnumerable<Type> containers,
+        string memberName,
+        Type receiverType)
+    {
+        var methods = new List<MethodInfo>();
+        foreach (var container in containers)
+        {
+            foreach (var method in container.GetMethods(
+                         BindingFlags.Public | BindingFlags.Static))
+            {
+                if (!method.IsDefined(typeof(ExtensionAttribute), inherit: false) ||
+                    !string.Equals(
+                        DotNetTypeMapper.ToTypeScriptMethodName(method.Name),
+                        memberName,
+                        StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var argumentTypes = new Type?[method.GetParameters().Length];
+                argumentTypes[0] = receiverType;
+                var closed = DotNetGenericMethodInference.TryClose(method, argumentTypes);
+                if (closed != null)
+                    methods.Add(closed);
+            }
+        }
+        return methods.ToArray();
+    }
+}

--- a/Runtime/DotNet/DotNetGenericMethodInference.cs
+++ b/Runtime/DotNet/DotNetGenericMethodInference.cs
@@ -1,0 +1,206 @@
+using System.Reflection;
+
+namespace SharpTS.Runtime.DotNet;
+
+/// <summary>Closes generic CLR methods by unifying parameter shapes with known argument types.</summary>
+internal static class DotNetGenericMethodInference
+{
+    internal static MethodInfo[] CloseCandidates(
+        IEnumerable<MethodInfo> methods,
+        IReadOnlyList<Type?> argumentTypes,
+        IReadOnlyList<Type>? explicitTypeArguments = null,
+        Type? expectedReturnType = null)
+    {
+        var closed = new List<MethodInfo>();
+        foreach (var method in methods)
+        {
+            var candidate = TryClose(
+                method, argumentTypes,
+                explicitTypeArguments, expectedReturnType);
+            if (candidate != null)
+                closed.Add(candidate);
+        }
+        return closed.ToArray();
+    }
+
+    internal static MethodInfo? TryClose(
+        MethodInfo method,
+        IReadOnlyList<Type?> argumentTypes,
+        IReadOnlyList<Type>? explicitTypeArguments = null,
+        Type? expectedReturnType = null)
+    {
+        if (!method.IsGenericMethodDefinition)
+        {
+            return explicitTypeArguments is { Count: > 0 } || method.ContainsGenericParameters
+                ? null
+                : method;
+        }
+
+        var genericArguments = method.GetGenericArguments();
+        if (explicitTypeArguments is { Count: > 0 })
+        {
+            if (explicitTypeArguments.Count != genericArguments.Length)
+                return null;
+            try
+            {
+                return method.MakeGenericMethod(explicitTypeArguments.ToArray());
+            }
+            catch (ArgumentException)
+            {
+                return null;
+            }
+        }
+
+        var parameters = DotNetMethodResolver.GetInputParameters(method.GetParameters());
+        bool hasParams = parameters.Length > 0 &&
+                         parameters[^1].IsDefined(typeof(ParamArrayAttribute), false);
+        int fixedCount = hasParams ? parameters.Length - 1 : parameters.Length;
+        if ((!hasParams && argumentTypes.Count > parameters.Length) ||
+            (hasParams && argumentTypes.Count < fixedCount))
+            return null;
+
+        var inferred = new Dictionary<Type, Type>();
+        int regularCount = Math.Min(argumentTypes.Count, fixedCount);
+        for (int i = 0; i < regularCount; i++)
+        {
+            Type? actual = argumentTypes[i];
+            if (actual == null)
+                continue;
+            if (!TryUnify(DotNetMethodResolver.GetInputType(parameters[i]), actual, inferred))
+                return null;
+        }
+
+        if (hasParams)
+        {
+            Type elementType = DotNetMethodResolver.GetInputType(parameters[^1]).GetElementType()!;
+            for (int i = fixedCount; i < argumentTypes.Count; i++)
+            {
+                Type? actual = argumentTypes[i];
+                if (actual != null && !TryUnify(elementType, actual, inferred))
+                    return null;
+            }
+        }
+
+        if (expectedReturnType != null &&
+            !TryUnify(method.ReturnType, expectedReturnType, inferred))
+        {
+            return null;
+        }
+
+        if (genericArguments.Any(parameter => !inferred.ContainsKey(parameter)))
+            return null;
+
+        try
+        {
+            return method.MakeGenericMethod(
+                genericArguments.Select(parameter => inferred[parameter]).ToArray());
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+    }
+
+    private static bool TryUnify(Type pattern, Type actual, Dictionary<Type, Type> inferred)
+    {
+        if (pattern.IsByRef)
+            pattern = pattern.GetElementType()!;
+        if (actual.IsByRef)
+            actual = actual.GetElementType()!;
+
+        if (pattern.IsGenericParameter)
+        {
+            if (!inferred.TryGetValue(pattern, out var existing))
+            {
+                inferred[pattern] = actual;
+                return true;
+            }
+            return existing == actual ||
+                   existing.IsAssignableFrom(actual) ||
+                   actual.IsAssignableFrom(existing);
+        }
+
+        if (pattern.IsArray)
+        {
+            return actual.IsArray &&
+                   TryUnify(pattern.GetElementType()!, actual.GetElementType()!, inferred);
+        }
+
+        if (typeof(Delegate).IsAssignableFrom(pattern) &&
+            typeof(Delegate).IsAssignableFrom(actual) &&
+            pattern.GetMethod("Invoke") is { } patternInvoke &&
+            actual.GetMethod("Invoke") is { } actualInvoke)
+        {
+            var patternParameters = patternInvoke.GetParameters();
+            var actualParameters = actualInvoke.GetParameters();
+            if (patternParameters.Length != actualParameters.Length)
+                return false;
+            for (int i = 0; i < patternParameters.Length; i++)
+            {
+                if (!TryUnify(
+                        patternParameters[i].ParameterType,
+                        actualParameters[i].ParameterType,
+                        inferred))
+                    return false;
+            }
+            return TryUnify(
+                patternInvoke.ReturnType, actualInvoke.ReturnType, inferred);
+        }
+
+        if (pattern.IsGenericType)
+        {
+            Type definition = pattern.GetGenericTypeDefinition();
+            Type? matchingActual = FindConstructedType(actual, definition);
+            if (matchingActual == null)
+                return false;
+
+            var patternArguments = pattern.GetGenericArguments();
+            var actualArguments = matchingActual.GetGenericArguments();
+            for (int i = 0; i < patternArguments.Length; i++)
+            {
+                if (!TryUnify(patternArguments[i], actualArguments[i], inferred))
+                    return false;
+            }
+            return true;
+        }
+
+        return pattern.IsAssignableFrom(actual) || NumericTypesAreBridgeCompatible(pattern, actual);
+    }
+
+    private static Type? FindConstructedType(Type actual, Type genericDefinition)
+    {
+        if (actual.IsGenericType && actual.GetGenericTypeDefinition() == genericDefinition)
+            return actual;
+
+        foreach (var interfaceType in actual.GetInterfaces())
+        {
+            if (interfaceType.IsGenericType &&
+                interfaceType.GetGenericTypeDefinition() == genericDefinition)
+            {
+                return interfaceType;
+            }
+        }
+
+        for (Type? current = actual.BaseType; current != null; current = current.BaseType)
+        {
+            if (current.IsGenericType &&
+                current.GetGenericTypeDefinition() == genericDefinition)
+            {
+                return current;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool NumericTypesAreBridgeCompatible(Type left, Type right) =>
+        IsNumeric(left) && IsNumeric(right);
+
+    private static bool IsNumeric(Type type) =>
+        type == typeof(double) || type == typeof(float) ||
+        type == typeof(int) || type == typeof(uint) ||
+        type == typeof(long) || type == typeof(ulong) ||
+        type == typeof(short) || type == typeof(ushort) ||
+        type == typeof(byte) || type == typeof(sbyte) ||
+        type == typeof(decimal);
+}

--- a/Runtime/DotNet/DotNetInstance.cs
+++ b/Runtime/DotNet/DotNetInstance.cs
@@ -90,6 +90,53 @@ public sealed class DotNetInstance : ITypeCategorized
         }
     }
 
+    internal bool HasReadableIndexer => DotNetTypeRegistry.GetIndexers(Type, writable: false).Length > 0;
+
+    internal bool HasWritableIndexer => DotNetTypeRegistry.GetIndexers(Type, writable: true).Length > 0;
+
+    /// <summary>Reads a public single-parameter CLR indexer.</summary>
+    public object? GetIndex(object? index, Interpreter interpreter)
+    {
+        var accessors = DotNetTypeRegistry.GetIndexers(Type, writable: false)
+            .Select(p => p.GetGetMethod())
+            .OfType<MethodInfo>()
+            .ToArray();
+        if (accessors.Length == 0)
+        {
+            throw new Runtime.Exceptions.ThrowException(DotNetExceptionMapper.Map(
+                new MissingMemberException($"No readable single-parameter indexer found on '{Type.FullName}'.")));
+        }
+
+        var arguments = new List<object?> { index };
+        var candidate = DotNetMethodResolver.ResolveMethod(accessors, arguments);
+        var accessor = (MethodInfo)candidate.Method;
+        var invokeArgs = DotNetMethod.BuildInvokeArgs(
+            accessor.GetParameters(), arguments, candidate, interpreter);
+        return InvokeWithMapping(() =>
+            DotNetMarshaller.WrapReturn(accessor.Invoke(Underlying, invokeArgs), accessor.ReturnType));
+    }
+
+    /// <summary>Writes a public single-parameter CLR indexer.</summary>
+    public void SetIndex(object? index, object? value, Interpreter interpreter)
+    {
+        var accessors = DotNetTypeRegistry.GetIndexers(Type, writable: true)
+            .Select(p => p.GetSetMethod())
+            .OfType<MethodInfo>()
+            .ToArray();
+        if (accessors.Length == 0)
+        {
+            throw new Runtime.Exceptions.ThrowException(DotNetExceptionMapper.Map(
+                new MissingMemberException($"No writable single-parameter indexer found on '{Type.FullName}'.")));
+        }
+
+        var arguments = new List<object?> { index, value };
+        var candidate = DotNetMethodResolver.ResolveMethod(accessors, arguments);
+        var accessor = (MethodInfo)candidate.Method;
+        var invokeArgs = DotNetMethod.BuildInvokeArgs(
+            accessor.GetParameters(), arguments, candidate, interpreter);
+        InvokeWithMapping(() => accessor.Invoke(Underlying, invokeArgs));
+    }
+
     private Dictionary<(string, ISharpTSCallable), Delegate> GetOrCreateSubscriptions()
     {
         return _eventSubscriptions ??= new Dictionary<(string, ISharpTSCallable), Delegate>();

--- a/Runtime/DotNet/DotNetMarshaller.cs
+++ b/Runtime/DotNet/DotNetMarshaller.cs
@@ -154,6 +154,20 @@ internal static class DotNetMarshaller
         if (value == null) return null;
         if (declaredReturnType == typeof(void)) return SharpTSUndefined.Instance;
 
+        // CLR arrays cross back as ordinary guest arrays, recursively preserving jagged
+        // array shape and wrapping external element values through the same return seam.
+        if (value is Array array)
+        {
+            Type elementType = declaredReturnType.IsArray
+                ? declaredReturnType.GetElementType()!
+                : value.GetType().GetElementType() ?? typeof(object);
+            var elements = new object?[array.Length];
+            int index = 0;
+            foreach (object? element in array)
+                elements[index++] = WrapReturn(element, elementType);
+            return new SharpTSArray(elements);
+        }
+
         // Primitives pass through unchanged — the interpreter treats double/string/bool natively.
         var actualType = value.GetType();
         if (actualType == typeof(double) || actualType == typeof(int) || actualType == typeof(long) ||

--- a/Runtime/DotNet/DotNetMethod.cs
+++ b/Runtime/DotNet/DotNetMethod.cs
@@ -28,7 +28,7 @@ internal sealed class DotNetMethod : ISharpTSCallable
         int min = int.MaxValue;
         foreach (var m in _overloads)
         {
-            var ps = m.GetParameters();
+            var ps = DotNetMethodResolver.GetInputParameters(m.GetParameters());
             int required = ps.Count(p => !p.HasDefaultValue &&
                 !p.IsDefined(typeof(ParamArrayAttribute), false));
             if (required < min) min = required;
@@ -37,8 +37,45 @@ internal sealed class DotNetMethod : ISharpTSCallable
     }
 
     public object? Call(Interpreter interpreter, List<object?> arguments)
+        => CallCore(
+            interpreter, arguments,
+            genericTypeArguments: null,
+            argumentTypeHints: null,
+            expectedReturnType: null);
+
+    internal object? CallWithGenericTypeArguments(
+        Interpreter interpreter,
+        List<object?> arguments,
+        IReadOnlyList<Type> genericTypeArguments)
+        => CallCore(
+            interpreter, arguments,
+            genericTypeArguments,
+            argumentTypeHints: null,
+            expectedReturnType: null);
+
+    internal object? CallWithTypeHints(
+        Interpreter interpreter,
+        List<object?> arguments,
+        IReadOnlyList<Type?>? argumentTypeHints,
+        IReadOnlyList<Type>? genericTypeArguments,
+        Type? expectedReturnType)
+        => CallCore(
+            interpreter, arguments,
+            genericTypeArguments,
+            argumentTypeHints,
+            expectedReturnType);
+
+    private object? CallCore(
+        Interpreter interpreter,
+        List<object?> arguments,
+        IReadOnlyList<Type>? genericTypeArguments,
+        IReadOnlyList<Type?>? argumentTypeHints,
+        Type? expectedReturnType)
     {
-        var candidate = DotNetMethodResolver.ResolveMethod(_overloads, arguments, _overloadHint);
+        var candidate = DotNetMethodResolver.ResolveMethod(
+            _overloads, arguments, _overloadHint,
+            genericTypeArguments, argumentTypeHints,
+            expectedReturnType);
         var method = (MethodInfo)candidate.Method;
         var parameters = method.GetParameters();
 
@@ -47,7 +84,7 @@ internal sealed class DotNetMethod : ISharpTSCallable
         return DotNetInstance.InvokeWithMapping(() =>
         {
             var result = method.Invoke(_receiver, invokeArgs);
-            return DotNetMarshaller.WrapReturn(result, method.ReturnType);
+            return WrapInvocationResult(method, invokeArgs, result);
         });
     }
 
@@ -65,13 +102,20 @@ internal sealed class DotNetMethod : ISharpTSCallable
         if (candidate.ParamsStartIndex < 0)
         {
             var result = new object?[parameters.Length];
-            for (int i = 0; i < arguments.Count; i++)
+            int argumentIndex = 0;
+            for (int i = 0; i < parameters.Length; i++)
             {
-                result[i] = DotNetMarshaller.Convert(arguments[i], parameters[i].ParameterType, interpreter);
-            }
-            for (int i = arguments.Count; i < parameters.Length; i++)
-            {
-                result[i] = parameters[i].HasDefaultValue ? parameters[i].DefaultValue : null;
+                var parameter = parameters[i];
+                if (parameter.ParameterType.IsByRef && parameter.IsOut)
+                {
+                    result[i] = null;
+                    continue;
+                }
+
+                Type target = DotNetMethodResolver.GetInputType(parameter);
+                result[i] = argumentIndex < arguments.Count
+                    ? DotNetMarshaller.Convert(arguments[argumentIndex++], target, interpreter)
+                    : parameter.HasDefaultValue ? parameter.DefaultValue : null;
             }
             return result;
         }
@@ -83,9 +127,19 @@ internal sealed class DotNetMethod : ISharpTSCallable
         int variadicCount = arguments.Count - fixedCount;
 
         var result2 = new object?[parameters.Length];
-        for (int i = 0; i < fixedCount; i++)
+        int fixedArgumentIndex = 0;
+        for (int i = 0; i < parameters.Length - 1; i++)
         {
-            result2[i] = DotNetMarshaller.Convert(arguments[i], parameters[i].ParameterType, interpreter);
+            var parameter = parameters[i];
+            if (parameter.ParameterType.IsByRef && parameter.IsOut)
+            {
+                result2[i] = null;
+                continue;
+            }
+            result2[i] = DotNetMarshaller.Convert(
+                arguments[fixedArgumentIndex++],
+                DotNetMethodResolver.GetInputType(parameter),
+                interpreter);
         }
 
         var variadic = Array.CreateInstance(elementType, Math.Max(0, variadicCount));
@@ -95,5 +149,32 @@ internal sealed class DotNetMethod : ISharpTSCallable
         }
         result2[^1] = variadic;
         return result2;
+    }
+
+    private static bool IsTupleOutput(ParameterInfo parameter) =>
+        parameter.ParameterType.IsByRef && !parameter.IsIn;
+
+    internal static object? WrapInvocationResult(
+        MethodInfo method,
+        object?[] invokeArgs,
+        object? result)
+    {
+        var parameters = method.GetParameters();
+        if (parameters.Any(IsTupleOutput))
+        {
+            var values = new List<object?>();
+            if (method.ReturnType != typeof(void))
+                values.Add(DotNetMarshaller.WrapReturn(result, method.ReturnType));
+            for (int i = 0; i < parameters.Length; i++)
+            {
+                if (IsTupleOutput(parameters[i]))
+                {
+                    values.Add(DotNetMarshaller.WrapReturn(
+                        invokeArgs[i], parameters[i].ParameterType.GetElementType()!));
+                }
+            }
+            return new SharpTSArray(values);
+        }
+        return DotNetMarshaller.WrapReturn(result, method.ReturnType);
     }
 }

--- a/Runtime/DotNet/DotNetMethodResolver.cs
+++ b/Runtime/DotNet/DotNetMethodResolver.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using System.Reflection;
+using SharpTS.Declaration;
 using SharpTS.Runtime.Types;
 
 namespace SharpTS.Runtime.DotNet;
@@ -39,9 +40,24 @@ internal static class DotNetMethodResolver
     public static RuntimeMethodCandidate ResolveMethod(
         MethodInfo[] candidates,
         IReadOnlyList<object?> arguments,
-        string? overloadHint = null)
+        string? overloadHint = null,
+        IReadOnlyList<Type>? genericTypeArguments = null,
+        IReadOnlyList<Type?>? argumentTypeHints = null,
+        Type? expectedReturnType = null)
     {
-        return Resolve(candidates.Cast<MethodBase>().ToArray(), arguments, overloadHint);
+        var argumentTypes = arguments.Select(GetRuntimeArgumentType).ToArray();
+        if (argumentTypeHints != null)
+        {
+            for (int i = 0; i < argumentTypes.Length &&
+                            i < argumentTypeHints.Count; i++)
+            {
+                argumentTypes[i] = argumentTypeHints[i] ?? argumentTypes[i];
+            }
+        }
+        candidates = DotNetGenericMethodInference.CloseCandidates(
+            candidates, argumentTypes,
+            genericTypeArguments, expectedReturnType);
+        return Resolve(candidates.Cast<MethodBase>().ToArray(), arguments, overloadHint, allowByRef: true);
     }
 
     public static RuntimeMethodCandidate ResolveConstructor(
@@ -49,13 +65,14 @@ internal static class DotNetMethodResolver
         IReadOnlyList<object?> arguments,
         string? overloadHint = null)
     {
-        return Resolve(candidates.Cast<MethodBase>().ToArray(), arguments, overloadHint);
+        return Resolve(candidates.Cast<MethodBase>().ToArray(), arguments, overloadHint, allowByRef: false);
     }
 
     private static RuntimeMethodCandidate Resolve(
         MethodBase[] candidates,
         IReadOnlyList<object?> arguments,
-        string? overloadHint)
+        string? overloadHint,
+        bool allowByRef)
     {
         if (candidates.Length == 0)
         {
@@ -72,26 +89,39 @@ internal static class DotNetMethodResolver
         var scored = new List<RuntimeMethodCandidate>();
         foreach (var method in pool)
         {
+            if (method is MethodInfo methodInfo &&
+                DotNetInteropClassifier.UnsupportedMethodReason(methodInfo) != null)
+            {
+                continue;
+            }
+            if (method is ConstructorInfo constructor &&
+                DotNetInteropClassifier.UnsupportedConstructorReason(constructor) != null)
+            {
+                continue;
+            }
             var parameters = method.GetParameters();
+            if (!allowByRef && parameters.Any(p => p.ParameterType.IsByRef))
+                continue;
+            var inputParameters = GetInputParameters(parameters);
             bool hasParams = parameters.Length > 0 &&
                              parameters[^1].IsDefined(typeof(ParamArrayAttribute), false);
 
             if (hasParams)
             {
-                var candidate = ScoreWithParams(method, parameters, arguments);
+                var candidate = ScoreWithParams(method, inputParameters, arguments);
                 if (candidate.TotalCost < (int)RuntimeConversionCost.Incompatible)
                     scored.Add(candidate);
             }
             else
             {
-                if (arguments.Count > parameters.Length) continue;
+                if (arguments.Count > inputParameters.Length) continue;
 
-                if (arguments.Count < parameters.Length)
+                if (arguments.Count < inputParameters.Length)
                 {
                     bool allOptional = true;
-                    for (int i = arguments.Count; i < parameters.Length; i++)
+                    for (int i = arguments.Count; i < inputParameters.Length; i++)
                     {
-                        if (!parameters[i].HasDefaultValue)
+                        if (!inputParameters[i].HasDefaultValue)
                         {
                             allOptional = false;
                             break;
@@ -100,7 +130,7 @@ internal static class DotNetMethodResolver
                     if (!allOptional) continue;
                 }
 
-                var candidate = ScoreRegular(method, parameters, arguments);
+                var candidate = ScoreRegular(method, inputParameters, arguments);
                 if (candidate.TotalCost < (int)RuntimeConversionCost.Incompatible)
                     scored.Add(candidate);
             }
@@ -133,7 +163,7 @@ internal static class DotNetMethodResolver
         int totalCost = 0;
         for (int i = 0; i < arguments.Count; i++)
         {
-            var cost = ScoreConversion(arguments[i], parameters[i].ParameterType);
+            var cost = ScoreConversion(arguments[i], GetInputType(parameters[i]));
             if (cost == RuntimeConversionCost.Incompatible)
                 return new RuntimeMethodCandidate(method, (int)RuntimeConversionCost.Incompatible, -1, false);
             totalCost += (int)cost;
@@ -153,7 +183,7 @@ internal static class DotNetMethodResolver
         int totalCost = 0;
         for (int i = 0; i < regularParamCount; i++)
         {
-            var cost = ScoreConversion(arguments[i], parameters[i].ParameterType);
+            var cost = ScoreConversion(arguments[i], GetInputType(parameters[i]));
             if (cost == RuntimeConversionCost.Incompatible)
                 return new RuntimeMethodCandidate(method, (int)RuntimeConversionCost.Incompatible, -1, false);
             totalCost += (int)cost;
@@ -168,6 +198,46 @@ internal static class DotNetMethodResolver
             totalCost += (int)cost;
         }
         return new RuntimeMethodCandidate(method, totalCost, regularParamCount, true);
+    }
+
+    /// <summary>
+    /// TypeScript-visible inputs for a CLR parameter list. Pure <c>out</c> slots are supplied
+    /// by the bridge; <c>ref</c> and <c>in</c> slots consume ordinary input arguments.
+    /// </summary>
+    internal static ParameterInfo[] GetInputParameters(ParameterInfo[] parameters) =>
+        parameters.Where(static p => !(p.ParameterType.IsByRef && p.IsOut)).ToArray();
+
+    internal static Type GetInputType(ParameterInfo parameter) =>
+        parameter.ParameterType.IsByRef
+            ? parameter.ParameterType.GetElementType()!
+            : parameter.ParameterType;
+
+    private static Type? GetRuntimeArgumentType(object? argument)
+    {
+        if (argument is null or SharpTSUndefined)
+            return null;
+        if (argument is SharpTSArray array)
+        {
+            Type? elementType = null;
+            foreach (var element in array)
+            {
+                Type? current = GetRuntimeArgumentType(element);
+                if (current == null)
+                    continue;
+                if (elementType == null)
+                {
+                    elementType = current;
+                }
+                else if (elementType != current)
+                {
+                    return typeof(object[]);
+                }
+            }
+            return (elementType ?? typeof(object)).MakeArrayType();
+        }
+        return argument is DotNetInstance instance
+            ? instance.Type
+            : argument.GetType();
     }
 
     private static RuntimeConversionCost ScoreConversion(object? arg, Type target)
@@ -229,6 +299,9 @@ internal static class DotNetMethodResolver
             if (target.IsInstanceOfType(dni.Underlying)) return RuntimeConversionCost.Exact;
             return RuntimeConversionCost.Incompatible;
         }
+
+        if (arg is SharpTSArray && target.IsArray)
+            return RuntimeConversionCost.Lossless;
 
         // TS callable → .NET delegate: lossless (shim built at invoke time).
         // Ranks above `object` so an `Action` overload wins over an `object` overload.

--- a/Runtime/DotNet/DotNetOperatorResolver.cs
+++ b/Runtime/DotNet/DotNetOperatorResolver.cs
@@ -1,0 +1,120 @@
+using System.Reflection;
+using SharpTS.Parsing;
+
+namespace SharpTS.Runtime.DotNet;
+
+/// <summary>
+/// Discovers CLR operator methods for TypeScript operator tokens. The bridge only consults
+/// this resolver when at least one operand is a known CLR interop value/type, preserving
+/// JavaScript coercion for ordinary TypeScript values.
+/// </summary>
+internal static class DotNetOperatorResolver
+{
+    internal static MethodInfo[] GetBinaryCandidates(TokenType token, Type? leftType, Type? rightType)
+    {
+        string? name = GetBinaryMethodName(token);
+        if (name == null)
+            return [];
+
+        return EnumerateDeclaringTypes(leftType, rightType)
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy))
+            .Where(method =>
+                method.IsSpecialName &&
+                method.Name == name &&
+                method.GetParameters().Length == 2 &&
+                !method.ContainsGenericParameters)
+            .Distinct()
+            .ToArray();
+    }
+
+    internal static MethodInfo[] GetUnaryCandidates(TokenType token, Type operandType)
+    {
+        string? name = token switch
+        {
+            TokenType.PLUS => "op_UnaryPlus",
+            TokenType.MINUS => "op_UnaryNegation",
+            TokenType.BANG => "op_LogicalNot",
+            TokenType.TILDE => "op_OnesComplement",
+            _ => null
+        };
+        if (name == null)
+            return [];
+
+        return operandType.GetMethods(
+                BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(method =>
+                method.IsSpecialName &&
+                method.Name == name &&
+                method.GetParameters().Length == 1 &&
+                !method.ContainsGenericParameters)
+            .ToArray();
+    }
+
+    internal static MethodInfo[] GetIncrementCandidates(TokenType token, Type operandType)
+    {
+        string? name = token switch
+        {
+            TokenType.PLUS_PLUS => "op_Increment",
+            TokenType.MINUS_MINUS => "op_Decrement",
+            _ => null
+        };
+        if (name == null)
+            return [];
+
+        return operandType.GetMethods(
+                BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(method =>
+                method.IsSpecialName &&
+                method.Name == name &&
+                method.GetParameters().Length == 1 &&
+                !method.ContainsGenericParameters)
+            .ToArray();
+    }
+
+    internal static TokenType? GetBinaryTokenForCompound(TokenType token) => token switch
+    {
+        TokenType.PLUS_EQUAL => TokenType.PLUS,
+        TokenType.MINUS_EQUAL => TokenType.MINUS,
+        TokenType.STAR_EQUAL => TokenType.STAR,
+        TokenType.SLASH_EQUAL => TokenType.SLASH,
+        TokenType.PERCENT_EQUAL => TokenType.PERCENT,
+        TokenType.AMPERSAND_EQUAL => TokenType.AMPERSAND,
+        TokenType.PIPE_EQUAL => TokenType.PIPE,
+        TokenType.CARET_EQUAL => TokenType.CARET,
+        TokenType.LESS_LESS_EQUAL => TokenType.LESS_LESS,
+        TokenType.GREATER_GREATER_EQUAL => TokenType.GREATER_GREATER,
+        TokenType.GREATER_GREATER_GREATER_EQUAL => TokenType.GREATER_GREATER_GREATER,
+        _ => null
+    };
+
+    private static IEnumerable<Type> EnumerateDeclaringTypes(Type? leftType, Type? rightType)
+    {
+        if (leftType != null)
+            yield return leftType;
+        if (rightType != null && rightType != leftType)
+            yield return rightType;
+    }
+
+    private static string? GetBinaryMethodName(TokenType token) => token switch
+    {
+        TokenType.PLUS => "op_Addition",
+        TokenType.MINUS => "op_Subtraction",
+        TokenType.STAR => "op_Multiply",
+        TokenType.SLASH => "op_Division",
+        TokenType.PERCENT => "op_Modulus",
+        TokenType.AMPERSAND => "op_BitwiseAnd",
+        TokenType.PIPE => "op_BitwiseOr",
+        TokenType.CARET => "op_ExclusiveOr",
+        TokenType.LESS_LESS => "op_LeftShift",
+        TokenType.GREATER_GREATER => "op_RightShift",
+        TokenType.GREATER_GREATER_GREATER => "op_UnsignedRightShift",
+        TokenType.EQUAL_EQUAL or TokenType.EQUAL_EQUAL_EQUAL => "op_Equality",
+        TokenType.BANG_EQUAL or TokenType.BANG_EQUAL_EQUAL => "op_Inequality",
+        TokenType.LESS => "op_LessThan",
+        TokenType.LESS_EQUAL => "op_LessThanOrEqual",
+        TokenType.GREATER => "op_GreaterThan",
+        TokenType.GREATER_EQUAL => "op_GreaterThanOrEqual",
+        _ => null
+    };
+}

--- a/Runtime/DotNet/DotNetTypeRegistry.cs
+++ b/Runtime/DotNet/DotNetTypeRegistry.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reflection;
+using SharpTS.Declaration;
 
 namespace SharpTS.Runtime.DotNet;
 
@@ -17,6 +18,7 @@ public static class DotNetTypeRegistry
     private static readonly ConcurrentDictionary<(Type, string, bool), MethodInfo[]> _methodCache = new();
     private static readonly ConcurrentDictionary<(Type, string, bool), MemberInfo?> _propertyOrFieldCache = new();
     private static readonly ConcurrentDictionary<(Type, string, bool), EventInfo?> _eventCache = new();
+    private static readonly ConcurrentDictionary<(Type, bool), PropertyInfo[]> _indexerCache = new();
 
     /// <summary>
     /// Resolves a fully-qualified .NET type name, searching all currently loaded assemblies.
@@ -52,6 +54,114 @@ public static class DotNetTypeRegistry
     }
 
     /// <summary>
+    /// Resolves a friendly CLR type spelling, including constructed generics such as
+    /// <c>System.Collections.Generic.Dictionary&lt;string, System.Int32&gt;</c>.
+    /// TypeScript primitive spellings are accepted as convenient aliases
+    /// (<c>number</c> is <see cref="double"/>).
+    /// </summary>
+    /// <param name="friendlyName">The friendly or ordinary CLR type name.</param>
+    /// <param name="resolve">
+    /// Optional resolver for non-generic type names. The compiler and language server pass
+    /// reference-aware resolvers here; interpreter callers use the loaded-assembly default.
+    /// </param>
+    public static Type? ResolveFriendly(string friendlyName, Func<string, Type?>? resolve = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(friendlyName);
+        resolve ??= Resolve;
+
+        string name = friendlyName.Trim();
+        if (TryResolveAlias(name, out var alias))
+            return resolve(alias.FullName!) ?? alias;
+
+        if (name.EndsWith("[]", StringComparison.Ordinal))
+        {
+            var element = ResolveFriendly(name[..^2], resolve);
+            return element?.MakeArrayType();
+        }
+
+        if (name.EndsWith('?'))
+        {
+            var underlying = ResolveFriendly(name[..^1], resolve);
+            if (underlying is not { IsValueType: true }) return null;
+            var nullableDefinition = resolve("System.Nullable`1") ?? typeof(Nullable<>);
+            return nullableDefinition.MakeGenericType(underlying);
+        }
+
+        int genericStart = name.IndexOf('<');
+        if (genericStart < 0) return resolve(name);
+        if (!name.EndsWith('>'))
+            throw new ArgumentException($"Malformed generic .NET type name '{friendlyName}'.");
+
+        string baseName = name[..genericStart].Trim();
+        string argumentsText = name[(genericStart + 1)..^1];
+        var argumentNames = SplitGenericArguments(argumentsText);
+        if (argumentNames.Count == 0)
+            throw new ArgumentException($"Generic .NET type '{friendlyName}' has no type arguments.");
+
+        string definitionName = $"{baseName}`{argumentNames.Count}";
+        var definition = resolve(definitionName);
+        if (definition == null || !definition.IsGenericTypeDefinition) return null;
+
+        // Preserve the legacy open-generic spellings List<> / Dictionary<,>. They remain
+        // discoverable, but the interop classifier will reject them as runtime values.
+        if (argumentNames.All(string.IsNullOrWhiteSpace)) return definition;
+        if (argumentNames.Any(string.IsNullOrWhiteSpace))
+            throw new ArgumentException($"Generic .NET type '{friendlyName}' has a missing type argument.");
+
+        var arguments = new Type[argumentNames.Count];
+        for (int i = 0; i < argumentNames.Count; i++)
+        {
+            arguments[i] = ResolveFriendly(argumentNames[i], resolve)
+                ?? throw new ArgumentException(
+                    $"Could not resolve generic type argument '{argumentNames[i]}' in '{friendlyName}'.");
+        }
+
+        try
+        {
+            return definition.MakeGenericType(arguments);
+        }
+        catch (ArgumentException ex)
+        {
+            throw new ArgumentException(
+                $"The generic arguments for '{friendlyName}' do not satisfy the CLR type constraints.", ex);
+        }
+    }
+
+    /// <summary>Returns a CLR type's source-facing simple name without generic arity.</summary>
+    public static string GetFriendlySimpleName(Type type)
+    {
+        string name = type.Name;
+        int tick = name.IndexOf('`');
+        return tick >= 0 ? name[..tick] : name;
+    }
+
+    /// <summary>
+    /// Formats a resolved CLR type as a round-trippable friendly name suitable for a
+    /// <c>dotnet:</c> specifier.
+    /// </summary>
+    public static string GetFriendlyFullName(Type type)
+    {
+        if (type.IsArray)
+            return GetFriendlyFullName(type.GetElementType()!) + "[]";
+
+        var nullable = Nullable.GetUnderlyingType(type);
+        if (nullable != null)
+            return GetFriendlyFullName(nullable) + "?";
+
+        if (TryGetAlias(type, out var alias))
+            return alias;
+
+        if (!type.IsGenericType)
+            return type.FullName ?? type.Name;
+
+        var definition = type.GetGenericTypeDefinition();
+        string baseName = definition.FullName ?? definition.Name;
+        int tick = baseName.IndexOf('`');
+        if (tick >= 0) baseName = baseName[..tick];
+        return $"{baseName}<{string.Join(", ", type.GetGenericArguments().Select(GetFriendlyFullName))}>";
+    }
+
+    /// <summary>
     /// Clears the type and member caches. Used by tests to ensure isolation.
     /// </summary>
     public static void ClearCache()
@@ -60,22 +170,86 @@ public static class DotNetTypeRegistry
         _methodCache.Clear();
         _propertyOrFieldCache.Clear();
         _eventCache.Clear();
+        _indexerCache.Clear();
     }
 
-    /// <summary>
-    /// Converts a friendly generic type name to CLR syntax.
-    /// Example: <c>List&lt;&gt;</c> -> <c>System.Collections.Generic.List`1</c>.
-    /// Mirrors <c>ILCompiler.ToClrTypeName</c> so both modes accept the same syntax.
-    /// </summary>
-    public static string ToClrTypeName(string friendlyName)
+    private static List<string> SplitGenericArguments(string arguments)
     {
-        int genericStart = friendlyName.IndexOf('<');
-        if (genericStart < 0) return friendlyName;
+        var result = new List<string>();
+        int depth = 0;
+        int start = 0;
 
-        string baseName = friendlyName[..genericStart];
-        string genericPart = friendlyName[genericStart..];
-        int paramCount = genericPart.Count(c => c == ',') + 1;
-        return $"{baseName}`{paramCount}";
+        for (int i = 0; i < arguments.Length; i++)
+        {
+            switch (arguments[i])
+            {
+                case '<':
+                    depth++;
+                    break;
+                case '>':
+                    depth--;
+                    if (depth < 0)
+                        throw new ArgumentException($"Malformed generic argument list '<{arguments}>'.");
+                    break;
+                case ',' when depth == 0:
+                    result.Add(arguments[start..i].Trim());
+                    start = i + 1;
+                    break;
+            }
+        }
+
+        if (depth != 0)
+            throw new ArgumentException($"Malformed generic argument list '<{arguments}>'.");
+
+        result.Add(arguments[start..].Trim());
+        return result;
+    }
+
+    private static bool TryResolveAlias(string name, out Type type)
+    {
+        type = name switch
+        {
+            "bool" or "boolean" or "System.Boolean" => typeof(bool),
+            "byte" or "System.Byte" => typeof(byte),
+            "sbyte" or "System.SByte" => typeof(sbyte),
+            "char" or "System.Char" => typeof(char),
+            "short" or "System.Int16" => typeof(short),
+            "ushort" or "System.UInt16" => typeof(ushort),
+            "int" or "System.Int32" => typeof(int),
+            "uint" or "System.UInt32" => typeof(uint),
+            "long" or "System.Int64" => typeof(long),
+            "ulong" or "System.UInt64" => typeof(ulong),
+            "float" or "System.Single" => typeof(float),
+            "number" or "double" or "System.Double" => typeof(double),
+            "decimal" or "System.Decimal" => typeof(decimal),
+            "string" or "System.String" => typeof(string),
+            "object" or "unknown" or "any" or "System.Object" => typeof(object),
+            "void" or "System.Void" => typeof(void),
+            _ => null!
+        };
+        return type != null;
+    }
+
+    private static bool TryGetAlias(Type type, out string alias)
+    {
+        alias = type == typeof(bool) ? "boolean"
+            : type == typeof(byte) ? "byte"
+            : type == typeof(sbyte) ? "sbyte"
+            : type == typeof(char) ? "char"
+            : type == typeof(short) ? "short"
+            : type == typeof(ushort) ? "ushort"
+            : type == typeof(int) ? "int"
+            : type == typeof(uint) ? "uint"
+            : type == typeof(long) ? "long"
+            : type == typeof(ulong) ? "ulong"
+            : type == typeof(float) ? "float"
+            : type == typeof(double) ? "number"
+            : type == typeof(decimal) ? "decimal"
+            : type == typeof(string) ? "string"
+            : type == typeof(object) ? "object"
+            : type == typeof(void) ? "void"
+            : null!;
+        return alias != null;
     }
 
     /// <summary>
@@ -89,7 +263,9 @@ public static class DotNetTypeRegistry
             string pascal = ToPascalCase(name);
             var flags = BindingFlags.Public | (stat ? BindingFlags.Static : BindingFlags.Instance);
             return t.GetMethods(flags)
-                .Where(m => m.Name == name || m.Name == pascal)
+                .Where(m =>
+                    (m.Name == name || m.Name == pascal) &&
+                    DotNetInteropClassifier.UnsupportedMethodReason(m) == null)
                 .ToArray();
         });
     }
@@ -106,9 +282,17 @@ public static class DotNetTypeRegistry
             var flags = BindingFlags.Public | (stat ? BindingFlags.Static : BindingFlags.Instance);
 
             var property = t.GetProperty(pascal, flags) ?? t.GetProperty(name, flags);
-            if (property != null) return property;
+            if (property != null &&
+                DotNetInteropClassifier.UnsupportedSlotReason(property.PropertyType) == null)
+            {
+                return property;
+            }
 
-            return (MemberInfo?)t.GetField(pascal, flags) ?? t.GetField(name, flags);
+            var field = t.GetField(pascal, flags) ?? t.GetField(name, flags);
+            return field != null &&
+                   DotNetInteropClassifier.UnsupportedSlotReason(field.FieldType) == null
+                ? field
+                : null;
         });
     }
 
@@ -124,6 +308,25 @@ public static class DotNetTypeRegistry
             string pascal = ToPascalCase(name);
             var flags = BindingFlags.Public | (stat ? BindingFlags.Static : BindingFlags.Instance);
             return t.GetEvent(pascal, flags) ?? t.GetEvent(name, flags);
+        });
+    }
+
+    /// <summary>
+    /// Returns public single-parameter instance indexers, filtered for readable or writable use.
+    /// </summary>
+    internal static PropertyInfo[] GetIndexers(Type type, bool writable)
+    {
+        return _indexerCache.GetOrAdd((type, writable), static key =>
+        {
+            var (target, write) = key;
+            return target.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.GetIndexParameters().Length == 1 &&
+                            (write ? p.CanWrite : p.CanRead) &&
+                            DotNetInteropClassifier.UnsupportedSlotReason(
+                                p.PropertyType) == null &&
+                            DotNetInteropClassifier.UnsupportedSlotReason(
+                                p.GetIndexParameters()[0].ParameterType) == null)
+                .ToArray();
         });
     }
 

--- a/SharpTS.LanguageServer/Services/DecoratorService.cs
+++ b/SharpTS.LanguageServer/Services/DecoratorService.cs
@@ -66,7 +66,9 @@ public sealed class DecoratorService
             // @DotNetType("X") → show the resolved CLR type + its XML doc.
             if (name == "DotNetType" && arg is not null)
             {
-                var type = _resolve(DotNetTypeRegistry.ToClrTypeName(arg));
+                Type? type;
+                try { type = DotNetTypeRegistry.ResolveFriendly(arg, _resolve); }
+                catch (ArgumentException) { type = null; }
                 if (type is not null)
                     return Markdown(TypeMarkdown(type));
             }

--- a/SharpTS.LanguageServer/Services/InteropAnalyzer.cs
+++ b/SharpTS.LanguageServer/Services/InteropAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using SharpTS.Diagnostics;
 using SharpTS.Modules;
 using SharpTS.Parsing;
@@ -30,7 +31,7 @@ namespace SharpTS.LanguageServer.Services;
 /// When a <see cref="PositionMap"/> is supplied to <see cref="Analyze"/>, diagnostics carry
 /// token-precise ranges (Phase 4a); otherwise they fall back to line-only locations.
 ///
-/// RESOLUTION SEAM: <see cref="DotNetTypeRegistry.Resolve"/> by default (in-process,
+/// RESOLUTION SEAM: <see cref="DotNetTypeRegistry.ResolveFriendly"/> by default (in-process,
 /// mirrors the interpreter); the production server injects
 /// <c>AssemblyReferenceLoader.TryResolve</c> to validate against the project's referenced
 /// assemblies. Member/overload/event lookups reuse the runtime's own resolvers
@@ -70,6 +71,9 @@ public sealed class InteropAnalyzer
                 AnalyzeClass(cls, diags, bindings, positions);
             else if (stmt is Stmt.Import import && DotNetImports.IsDotNetSpecifier(import.ModulePath))
                 AnalyzeDotNetImport(import, diags, bindings, positions);
+            else if (stmt is Stmt.Import extensionImport &&
+                     DotNetExtensionImports.IsSpecifier(extensionImport.ModulePath))
+                AnalyzeDotNetExtensionImport(extensionImport, diags, positions);
         }
 
         // Pass 2 — Tier 3d: validate event-subscription call sites against the bindings.
@@ -78,6 +82,52 @@ public sealed class InteropAnalyzer
             visitor.Visit(stmt);
 
         return diags;
+    }
+
+    private void AnalyzeDotNetExtensionImport(
+        Stmt.Import import,
+        List<Diagnostic> diags,
+        PositionMap? pos)
+    {
+        if (import.DefaultImport != null ||
+            import.NamespaceImport != null ||
+            import.NamedImports != null ||
+            import.IsTypeOnly)
+        {
+            diags.Add(Diagnostic.TypeError(
+                $"'{import.ModulePath}' must be imported for side effects.",
+                Loc(import.Keyword, pos)));
+            return;
+        }
+
+        string typeName = import.ModulePath[DotNetExtensionImports.Prefix.Length..];
+        Type? container;
+        try
+        {
+            container = DotNetTypeRegistry.ResolveFriendly(typeName, _resolve);
+        }
+        catch (ArgumentException ex)
+        {
+            diags.Add(Diagnostic.TypeError(ex.Message, Loc(import.Keyword, pos)));
+            return;
+        }
+
+        if (container == null || !(container.IsPublic || container.IsNestedPublic))
+        {
+            diags.Add(Diagnostic.TypeError(
+                $"Cannot resolve public extension container '{typeName}'.",
+                Loc(import.Keyword, pos)));
+            return;
+        }
+        if (!(container.IsAbstract && container.IsSealed) ||
+            !container.GetMethods(BindingFlags.Public | BindingFlags.Static)
+                .Any(method => method.IsDefined(
+                    typeof(ExtensionAttribute), inherit: false)))
+        {
+            diags.Add(Diagnostic.TypeError(
+                $"'{typeName}' is not a public static extension-method container.",
+                Loc(import.Keyword, pos)));
+        }
     }
 
     /// <summary>
@@ -128,13 +178,23 @@ public sealed class InteropAnalyzer
         var (mapping, at, nameTok) = FindDotNetType(cls);
         if (mapping is null) return;
 
-        string clrName = DotNetTypeRegistry.ToClrTypeName(mapping);
-        Type? type = _resolve(clrName);
+        Type? type;
+        try
+        {
+            type = DotNetTypeRegistry.ResolveFriendly(mapping, _resolve);
+        }
+        catch (ArgumentException ex)
+        {
+            diags.Add(Diagnostic.TypeError(
+                $"@DotNetType: invalid .NET type '{mapping}': {ex.Message}",
+                Loc(at!, nameTok!, pos)));
+            return;
+        }
         if (type == null)
         {
             // Tier 1 — mirrors Interpreter.DotNet.cs:31, surfaced statically at edit time.
             diags.Add(Diagnostic.TypeError(
-                $"@DotNetType: .NET type '{clrName}' not found in any loaded assembly.",
+                $"@DotNetType: .NET type '{mapping}' not found in any loaded assembly.",
                 Loc(at!, nameTok!, pos)));
             return;
         }

--- a/SharpTS.LanguageServer/Services/MemberHoverService.cs
+++ b/SharpTS.LanguageServer/Services/MemberHoverService.cs
@@ -126,7 +126,10 @@ public sealed class MemberHoverService
         if (cls.Decorators is null) return null;
         foreach (var d in cls.Decorators)
             if (d.Expression is Expr.Call { Callee: Expr.Variable { Name.Lexeme: "DotNetType" }, Arguments: [Expr.Literal { Value: string clr }] })
-                return _resolve(DotNetTypeRegistry.ToClrTypeName(clr));
+            {
+                try { return DotNetTypeRegistry.ResolveFriendly(clr, _resolve); }
+                catch (ArgumentException) { return null; }
+            }
         return null;
     }
 
@@ -135,7 +138,10 @@ public sealed class MemberHoverService
     private Type? ResolveExternal(TypeInfo? ti, IReadOnlyDictionary<string, Type> bindings)
     {
         if (ti is TypeInfo.ExternalDotNetType ext)
-            return _resolve(ext.ClrTypeName) ?? ext.ResolvedType;
+        {
+            try { return DotNetTypeRegistry.ResolveFriendly(ext.ClrTypeName, _resolve) ?? ext.ResolvedType; }
+            catch (ArgumentException) { return ext.ResolvedType; }
+        }
         var name = ClassName(ti);
         return name is not null && bindings.TryGetValue(name, out var t) ? t : null;
     }

--- a/SharpTS.Tests/CompilerTests/AmbientTypeArgumentPrecedenceTests.cs
+++ b/SharpTS.Tests/CompilerTests/AmbientTypeArgumentPrecedenceTests.cs
@@ -1,0 +1,104 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>
+/// Pins the resolution precedence in <c>ILEmitter.ResolveTypeArg</c>: a generic type argument
+/// naming one of the program's own TypeScript classes must resolve to that class, never to a
+/// same-named .NET type discovered by scanning loaded assemblies.
+///
+/// The scan is a legitimate last resort for fully-qualified CLR names in interop code, but
+/// compiled TypeScript classes are public types in the global namespace under their bare name,
+/// so running it any earlier lets an unrelated loaded assembly capture the type argument. The
+/// resulting assembly reference is unresolvable when the compiled program is loaded from bytes
+/// (as the in-process test harness does), surfacing as
+/// <c>FileNotFoundException: Could not load file or assembly 'test_&lt;guid&gt;'</c> thrown from
+/// <c>$Program.Main</c> — and, being dependent on which sibling assemblies happen to be loaded,
+/// it presents as an intermittent failure rather than a deterministic one.
+///
+/// <see cref="SharpTsAmbientProbe"/> is the collision bait: a global-namespace type in this
+/// already-loaded test assembly whose name the program below also declares.
+/// </summary>
+public class AmbientTypeArgumentPrecedenceTests
+{
+    private const string Source = """
+        class SharpTsAmbientProbe {
+            value: number;
+            constructor(v: number) {
+                this.value = v;
+            }
+            get(): number {
+                return this.value;
+            }
+        }
+        class Box<T extends SharpTsAmbientProbe> {
+            item: T;
+            constructor(item: T) {
+                this.item = item;
+            }
+            unwrap(): number {
+                return this.item.get();
+            }
+        }
+        const box: Box<SharpTsAmbientProbe> = new Box<SharpTsAmbientProbe>(new SharpTsAmbientProbe(7));
+        console.log(box.unwrap());
+        """;
+
+    /// <summary>
+    /// The emitted metadata must not reference this test assembly. Asserting on the assembly
+    /// reference table catches the mis-resolution directly, independently of whether the stray
+    /// reference happens to be loadable at runtime.
+    /// </summary>
+    [Fact]
+    public void TypeArgumentNamingUserClass_DoesNotReferenceAmbientAssembly()
+    {
+        var tempDir = Path.Combine(
+            Path.GetTempPath(), $"sharpts_ambient_typearg_{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempDir);
+        var dllPath = Path.Combine(tempDir, "ambient_typearg_test.dll");
+
+        try
+        {
+            var statements = new Parser(new Lexer(Source).ScanTokens()).ParseOrThrow();
+            var typeMap = new TypeChecker().Check(statements);
+            var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+
+            var compiler = new ILCompiler("ambient_typearg_test");
+            compiler.Compile(statements, typeMap, deadCodeInfo);
+            compiler.Save(dllPath);
+
+            using var stream = File.OpenRead(dllPath);
+            using var peReader = new PEReader(stream);
+            var metadata = peReader.GetMetadataReader();
+            var references = metadata.AssemblyReferences
+                .Select(handle => metadata.GetString(metadata.GetAssemblyReference(handle).Name))
+                .ToList();
+
+            var ambientAssembly = typeof(SharpTsAmbientProbe).Assembly.GetName().Name!;
+            Assert.False(
+                references.Contains(ambientAssembly),
+                "Generic type argument 'SharpTsAmbientProbe' resolved to the ambient .NET type "
+                    + "instead of the program's own class. Emitted references: "
+                    + string.Join(", ", references));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    /// <summary>
+    /// The user-visible half: the program must still run and see its own class.
+    /// </summary>
+    [Theory, ModeData]
+    public void TypeArgumentNamingUserClass_RunsAgainstUserClass(ExecutionMode mode)
+    {
+        Assert.Equal("7\n", TestHarness.Run(Source, mode));
+    }
+}

--- a/SharpTS.Tests/CompilerTests/DotNetTypeTests.cs
+++ b/SharpTS.Tests/CompilerTests/DotNetTypeTests.cs
@@ -1245,4 +1245,24 @@ public class DotNetTypeTests
     }
 
     #endregion
+
+    [Fact]
+    public void ConstructedGenericDecorator_Works()
+    {
+        var source = """
+            @DotNetType("System.Collections.Generic.List<number>")
+            declare class NumberList {
+                constructor();
+                add(value: number): void;
+                readonly count: number;
+            }
+            const values = new NumberList();
+            values.add(1.25);
+            values.add(2.5);
+            console.log(values.count);
+            """;
+
+        var output = TestHarness.RunCompiled(source, DecoratorMode.Legacy);
+        Assert.Equal("2\n", output);
+    }
 }

--- a/SharpTS.Tests/DeclarationTests/DiscoveryGeneratorTests.cs
+++ b/SharpTS.Tests/DeclarationTests/DiscoveryGeneratorTests.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using SharpTS.Declaration;
+using SharpTS.Runtime.DotNet;
+using SharpTS.Tests.Infrastructure;
 using Xunit;
 
 namespace SharpTS.Tests.DeclarationTests;
@@ -48,11 +50,13 @@ public class DiscoveryGeneratorTests
     }
 
     [Fact]
-    public void Classifier_MarksByRefUnsupported()
+    public void Classifier_AllowsByRefParametersButNotByRefReturns()
     {
+        Type byRef = typeof(int).MakeByRefType();
         Assert.Equal(
             DotNetInteropClassifier.ReasonByRef,
-            DotNetInteropClassifier.UnsupportedSlotReason(typeof(int).MakeByRefType()));
+            DotNetInteropClassifier.UnsupportedSlotReason(byRef));
+        Assert.Null(DotNetInteropClassifier.UnsupportedParameterReason(byRef));
     }
 
     [Fact]
@@ -70,6 +74,13 @@ public class DiscoveryGeneratorTests
         Assert.Equal(
             DotNetInteropClassifier.ReasonOpenGeneric,
             DotNetInteropClassifier.UnsupportedSlotReason(openArg));
+    }
+
+    [Fact]
+    public void RuntimeRegistry_DoesNotExposeByRefReturnMethods()
+    {
+        Assert.Empty(DotNetTypeRegistry.GetMethods(
+            typeof(ByRefBoundaryFixture), "valueRef", isStatic: false));
     }
 
     // ── Type-detail report ───────────────────────────────────────────
@@ -112,16 +123,16 @@ public class DiscoveryGeneratorTests
     }
 
     [Fact]
-    public void GenerateForType_Guid_RendersOutParamFaithfullyAndFlagsIt()
+    public void GenerateForType_Guid_RendersTupleLoweredOutParam()
     {
         var report = _generator.Generate("System.Guid");
 
-        // tryParse(input: string, result: out Guid): bool — faithful `out`, by-ref unsupported.
+        // `out Guid` is omitted from inputs and returned after the ordinary boolean result.
         var tryParse = report.Type!.Members.FirstOrDefault(m =>
-            m.Signature == "static tryParse(input: string, result: out Guid): bool");
+            m.Signature == "static tryParse(input: string): [bool, Guid]");
         Assert.NotNull(tryParse);
-        Assert.False(tryParse!.Usable);
-        Assert.Equal(DotNetInteropClassifier.ReasonByRef, tryParse.UnsupportedReason);
+        Assert.True(tryParse!.Usable);
+        Assert.Null(tryParse.UnsupportedReason);
     }
 
     [Fact]
@@ -129,6 +140,44 @@ public class DiscoveryGeneratorTests
     {
         var report = _generator.Generate("System.Guid");
         Assert.Equal("struct", report.Type!.Kind);
+    }
+
+    [Fact]
+    public void Generate_ConstructedGeneric_HasRoundTrippableImportAndIndexer()
+    {
+        var report = _generator.Generate("System.Collections.Generic.List<number>");
+
+        Assert.Equal(
+            "import { List } from \"dotnet:System.Collections.Generic.List<number>\";",
+            report.Type!.ImportLine);
+        Assert.Contains(report.Type.Members, m =>
+            m.Signature == "[index: int]: double   { get; set; }" && m.Usable);
+    }
+
+    [Fact]
+    public void Generate_GenericMethod_IsUsableAndRendersTypeParameters()
+    {
+        var report = _generator.Generate(
+            "SharpTS.Tests.Infrastructure.GenericMethodFixture");
+
+        Assert.Contains(report.Type!.Members, m =>
+            m.Signature == "echo<T>(value: T): T" &&
+            m.Usable &&
+            m.UnsupportedReason == null);
+    }
+
+    [Fact]
+    public void Generate_ByRefConstructorAndReturn_AreExplicitlyUnsupported()
+    {
+        var report = _generator.Generate(
+            "SharpTS.Tests.Infrastructure.ByRefBoundaryFixture");
+
+        Assert.Contains(report.Type!.Members, m =>
+            m.Category == "Constructors" &&
+            m.UnsupportedReason == DotNetInteropClassifier.ReasonByRefConstructor);
+        Assert.Contains(report.Type.Members, m =>
+            m.Signature == "valueRef(): int" &&
+            m.UnsupportedReason == DotNetInteropClassifier.ReasonByRef);
     }
 
     // ── Namespace table of contents ──────────────────────────────────

--- a/SharpTS.Tests/Infrastructure/AmbientGlobalNamespaceProbe.cs
+++ b/SharpTS.Tests/Infrastructure/AmbientGlobalNamespaceProbe.cs
@@ -1,0 +1,22 @@
+// This type is deliberately declared in the GLOBAL namespace and must stay there.
+//
+// Compiled TypeScript classes are emitted as public types in the global namespace under
+// their bare TypeScript name, so `Assembly.GetType("Foo")` over the loaded assemblies can
+// match one. Any compiler-side resolution that scans AppDomain.CurrentDomain.GetAssemblies()
+// for a bare name is therefore capable of binding a TypeScript type reference to a type in
+// an unrelated assembly, which emits an assembly reference the compiled program cannot
+// resolve at runtime.
+//
+// AmbientTypeArgumentPrecedenceTests declares a TypeScript class of this exact name and
+// asserts the compiler prefers it over this one. Renaming or namespacing this type silently
+// disarms that test.
+
+/// <summary>
+/// Collision bait for <c>AmbientTypeArgumentPrecedenceTests</c>. Never referenced by
+/// production code; exists only so a loaded assembly contains a global-namespace type whose
+/// name a test TypeScript program can also declare.
+/// </summary>
+public sealed class SharpTsAmbientProbe
+{
+    public int Marker => 1;
+}

--- a/SharpTS.Tests/Infrastructure/DotNetTypeFixtures.cs
+++ b/SharpTS.Tests/Infrastructure/DotNetTypeFixtures.cs
@@ -50,6 +50,138 @@ public class CallbackFixture
     public event EventHandler? Ping;
 }
 
+/// <summary>Controlled nullable-value surface for dual-mode CLR interop tests.</summary>
+public class NullableFixture
+{
+    public int? Echo(int? value) => value;
+
+    public int OrDefault(int? value, int fallback) => value ?? fallback;
+}
+
+/// <summary>Controlled ref/out/in surface for tuple-lowered CLR interop tests.</summary>
+public class ByRefFixture
+{
+    public bool TryDouble(string text, out int value) =>
+        int.TryParse(text, out value);
+
+    public void Increment(ref int value) => value++;
+
+    public string Mix(int addend, ref int current, out bool changed)
+    {
+        current += addend;
+        changed = addend != 0;
+        return $"value={current}";
+    }
+
+    public int ReadOnlyAdd(in int value, int addend) => value + addend;
+}
+
+public delegate T GenericTransformer<T>(T value);
+
+/// <summary>Controlled ordinary generic-method surface for inference and explicit-type tests.</summary>
+public class GenericMethodFixture
+{
+    public T Echo<T>(T value) => value;
+
+    public T[] Copy<T>(T[] values) => values.ToArray();
+
+    public T Transform<T>(T value, GenericTransformer<T> transform) =>
+        transform(value);
+
+    public T FromFactory<T>(Func<T> factory) => factory();
+
+    public void Tap<T>(T value, Action<T> callback) => callback(value);
+
+    public T DefaultValue<T>() => default!;
+
+    public T[] EmptyArray<T>() => [];
+
+    public static T StaticEcho<T>(T value) => value;
+
+    public string TypeName<T>() => typeof(T).Name;
+
+    public T Constrained<T>(T value) where T : struct => value;
+}
+
+/// <summary>Unsupported managed-reference boundaries used to pin discovery diagnostics.</summary>
+public class ByRefBoundaryFixture
+{
+    private int _value;
+
+    public ByRefBoundaryFixture(ref int value)
+    {
+        _value = value;
+    }
+
+    public ref int ValueRef() => ref _value;
+}
+
+/// <summary>Controlled user-defined operator surface for dual-mode CLR interop tests.</summary>
+public sealed class OperatorFixture(int value)
+{
+    private OperatorFixture? _slot;
+
+    public int Value { get; } = value;
+
+    public OperatorFixture Current
+    {
+        get => _slot ?? this;
+        set => _slot = value;
+    }
+
+    public OperatorFixture this[int index]
+    {
+        get => _slot ?? this;
+        set => _slot = value;
+    }
+
+    public static OperatorFixture operator +(OperatorFixture left, OperatorFixture right) =>
+        new(left.Value + right.Value);
+
+    public static OperatorFixture operator *(OperatorFixture left, int factor) =>
+        new(left.Value * factor);
+
+    public static OperatorFixture operator -(OperatorFixture value) =>
+        new(-value.Value);
+
+    public static OperatorFixture operator ++(OperatorFixture value) =>
+        new(value.Value + 1);
+
+    public static OperatorFixture operator --(OperatorFixture value) =>
+        new(value.Value - 1);
+
+    public static bool operator !(OperatorFixture value) =>
+        value.Value == 0;
+
+    public static bool operator >(OperatorFixture left, OperatorFixture right) =>
+        left.Value > right.Value;
+
+    public static bool operator <(OperatorFixture left, OperatorFixture right) =>
+        left.Value < right.Value;
+
+    public static bool operator ==(OperatorFixture? left, OperatorFixture? right) =>
+        ReferenceEquals(left, right) ||
+        (left is not null && right is not null && left.Value == right.Value);
+
+    public static bool operator !=(OperatorFixture? left, OperatorFixture? right) =>
+        !(left == right);
+
+    public override bool Equals(object? obj) =>
+        obj is OperatorFixture other && this == other;
+
+    public override int GetHashCode() => Value;
+}
+
+/// <summary>Controlled generic extension-method surface for module-scoping tests.</summary>
+public static class EnumerableExtensionFixture
+{
+    public static int CountItems<T>(this IEnumerable<T> values) =>
+        values.Count();
+
+    public static T FirstItem<T>(this IEnumerable<T> values) =>
+        values.First();
+}
+
 /// <summary>
 /// Fixture for testing static event subscription via <see cref="DotNetTypeFixtures"/>-style
 /// declarations. Lives here so the static event state can be reset between tests.

--- a/SharpTS.Tests/InterpreterTests/DotNetTypeInterpreterTests.cs
+++ b/SharpTS.Tests/InterpreterTests/DotNetTypeInterpreterTests.cs
@@ -588,4 +588,24 @@ public class DotNetTypeInterpreterTests
     }
 
     #endregion
+
+    [Fact]
+    public void ConstructedGenericDecorator_Works()
+    {
+        var source = """
+            @DotNetType("System.Collections.Generic.List<number>")
+            declare class NumberList {
+                constructor();
+                add(value: number): void;
+                readonly count: number;
+            }
+            const values = new NumberList();
+            values.add(1.25);
+            values.add(2.5);
+            console.log(values.count);
+            """;
+
+        var output = TestHarness.RunInterpreted(source, DecoratorMode.Legacy);
+        Assert.Equal("2\n", output);
+    }
 }

--- a/SharpTS.Tests/LanguageServer/InteropAnalyzerTests.cs
+++ b/SharpTS.Tests/LanguageServer/InteropAnalyzerTests.cs
@@ -136,6 +136,21 @@ public class InteropAnalyzerTests
             "const sb = new StringBuilder();"));
 
     [Fact]
+    public void ConstructedGenericBindings_AreValidWithBothResolvers()
+    {
+        const string imports =
+            "import { List } from \"dotnet:System.Collections.Generic.List<number>\";\n";
+        const string declaration =
+            "@DotNetType(\"System.Collections.Generic.List<number>\")\n" +
+            "declare class NumberList { constructor(); add(value: number): void; }\n";
+
+        Assert.Empty(Analyze(imports + declaration));
+
+        using var loader = new AssemblyReferenceLoader(Array.Empty<string>());
+        Assert.Empty(Analyze(imports + declaration, loader.TryResolve));
+    }
+
+    [Fact]
     public void DotNetImport_UnresolvableName_Diagnostic()
     {
         var d = Analyze("import { Nope } from \"dotnet:System.NoSuchNs\";");
@@ -164,5 +179,19 @@ public class InteropAnalyzerTests
             "AppDomain.currentDomain.addEventListener(\"Typo\", (s: any, a: any) => {});");
         Assert.Single(d);
         Assert.Contains("Event 'Typo' not found", d[0].Message);
+    }
+
+    [Fact]
+    public void DotNetExtensionImport_ValidSideEffectForm_NoDiagnostics()
+        => Assert.Empty(Analyze(
+            "import \"dotnet-extensions:System.Linq.Enumerable\";"));
+
+    [Fact]
+    public void DotNetExtensionImport_NamedForm_Diagnostic()
+    {
+        var d = Analyze(
+            "import { Enumerable } from \"dotnet-extensions:System.Linq.Enumerable\";");
+        Assert.Single(d);
+        Assert.Contains("side effects", d[0].Message);
     }
 }

--- a/SharpTS.Tests/SharedTests/DotNetImportTests.cs
+++ b/SharpTS.Tests/SharedTests/DotNetImportTests.cs
@@ -89,6 +89,426 @@ public class DotNetImportTests
         Assert.Contains(errors, d => d.Message.Contains("not assignable"));
     }
 
+    [Theory, ModeData]
+    public void ConstructedGenericList_ConstructionMethodsAndIndexer(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { List } from "dotnet:System.Collections.Generic.List<number>";
+                const values = new List();
+                values.add(1.5);
+                values.add(2.5);
+                values[1] = 9.25;
+                console.log(values[0]);
+                console.log(values[1]);
+                console.log(values.count);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("1.5\n9.25\n2\n", output);
+    }
+
+    [Theory, ModeData]
+    public void ConstructedGenericDictionary_StringIndexer(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { Dictionary } from "dotnet:System.Collections.Generic.Dictionary<string, number>";
+                const values = new Dictionary();
+                values["answer"] = 42;
+                console.log(values["answer"]);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("42\n", output);
+    }
+
+    [Fact]
+    public void ConstructedGenericIndexer_IsStaticallyTyped()
+    {
+        var errors = CheckErrors(new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { List } from "dotnet:System.Collections.Generic.List<number>";
+                const values = new List();
+                values[0] = "not a number";
+                """
+        }, "./main.ts");
+
+        Assert.Contains(errors, d => d.Message.Contains("index signature", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ConstructedGenericResolver_HandlesNestedArguments()
+    {
+        var type = Runtime.DotNet.DotNetTypeRegistry.ResolveFriendly(
+            "System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<number>>");
+
+        Assert.Equal(typeof(Dictionary<string, List<double>>), type);
+    }
+
+    [Theory, ModeData]
+    public void NullableValueTypes_RoundTripValuesAndNull(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { NullableFixture } from "dotnet:SharpTS.Tests.Infrastructure.NullableFixture";
+                const fixture = new NullableFixture();
+                const present: number | null = fixture.echo(7);
+                const missing: number | null = fixture.echo(null);
+                console.log(present);
+                console.log(missing);
+                console.log(fixture.orDefault(missing, 11));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("7\nnull\n11\n", output);
+    }
+
+    [Fact]
+    public void NullableValueReturn_IsStaticallyNullable()
+    {
+        var errors = CheckErrors(new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { NullableFixture } from "dotnet:SharpTS.Tests.Infrastructure.NullableFixture";
+                const fixture = new NullableFixture();
+                const value: number = fixture.echo(null);
+                """
+        }, "./main.ts");
+
+        Assert.Contains(errors, d => d.Message.Contains("not assignable", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory, ModeData]
+    public void ByRefParameters_AreTupleLowered(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { ByRefFixture } from "dotnet:SharpTS.Tests.Infrastructure.ByRefFixture";
+                const fixture = new ByRefFixture();
+                const [ok, parsed] = fixture.tryDouble("41");
+                const [incremented] = fixture.increment(parsed);
+                const [message, mixed, changed] = fixture.mix(1, incremented);
+                console.log(ok);
+                console.log(parsed);
+                console.log(incremented);
+                console.log(message);
+                console.log(mixed);
+                console.log(changed);
+                console.log(fixture.readOnlyAdd(mixed, 2));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("true\n41\n42\nvalue=43\n43\ntrue\n45\n", output);
+    }
+
+    [Fact]
+    public void ByRefTuple_IsStaticallyTypedAndOutIsNotAnInput()
+    {
+        var errors = CheckErrors(new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { ByRefFixture } from "dotnet:SharpTS.Tests.Infrastructure.ByRefFixture";
+                const fixture = new ByRefFixture();
+                const result: [boolean, number] = fixture.tryDouble("12");
+                const wrong: string = result[1];
+                fixture.tryDouble("12", 0);
+                """
+        }, "./main.ts");
+
+        Assert.Contains(errors, d => d.Message.Contains("not assignable", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(errors, d => d.Message.Contains("Expected 1 arguments", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory, ModeData]
+    public void BclTryParse_UsesTupleLowering(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { Guid } from "dotnet:System.Guid";
+                const [ok, value] = Guid.tryParse("d85b1407-351d-4694-9392-03acc5870eb1");
+                const typed: Guid = value;
+                console.log(ok);
+                console.log(typed.toString());
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("true\nd85b1407-351d-4694-9392-03acc5870eb1\n", output);
+    }
+
+    [Theory, ModeData]
+    public void UserDefinedClrOperators_DispatchForImportedOperands(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { OperatorFixture } from "dotnet:SharpTS.Tests.Infrastructure.OperatorFixture";
+                const a = new OperatorFixture(4);
+                const b = new OperatorFixture(6);
+                const sum: OperatorFixture = a + b;
+                const scaled: OperatorFixture = sum * 3;
+                console.log(sum.value);
+                console.log(scaled.value);
+                console.log(b > a);
+                console.log(a < b);
+                console.log(a === new OperatorFixture(4));
+                console.log(a !== b);
+                console.log((-a).value);
+                console.log(!new OperatorFixture(0));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("10\n30\ntrue\ntrue\ntrue\ntrue\n-4\ntrue\n", output);
+    }
+
+    [Theory, ModeData]
+    public void UserDefinedClrOperators_SupportCompoundAndIncrementVariables(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { OperatorFixture } from "dotnet:SharpTS.Tests.Infrastructure.OperatorFixture";
+                let value = new OperatorFixture(2);
+                const added: OperatorFixture = value += new OperatorFixture(3);
+                console.log(added.value);
+                console.log(value.value);
+                const scaled: OperatorFixture = value *= 2;
+                console.log(scaled.value);
+                const old: OperatorFixture = value++;
+                console.log(old.value);
+                console.log(value.value);
+                const decremented: OperatorFixture = --value;
+                console.log(decremented.value);
+                console.log(value.value);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("5\n5\n10\n10\n11\n10\n10\n", output);
+    }
+
+    [Theory, ModeData]
+    public void UserDefinedClrOperators_WriteBackPropertiesAndIndexersOnce(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { OperatorFixture } from "dotnet:SharpTS.Tests.Infrastructure.OperatorFixture";
+                const holder = new OperatorFixture(4);
+                let receiverCalls = 0;
+                let indexCalls = 0;
+                function receiver(): OperatorFixture {
+                    receiverCalls++;
+                    return holder;
+                }
+                function index(): number {
+                    indexCalls++;
+                    return 0;
+                }
+
+                const propertyResult: OperatorFixture =
+                    receiver().current += new OperatorFixture(2);
+                console.log(propertyResult.value);
+
+                const oldIndex: OperatorFixture = receiver()[index()]++;
+                console.log(oldIndex.value);
+                console.log(holder[0].value);
+
+                const prefixIndex: OperatorFixture = ++receiver()[index()];
+                console.log(prefixIndex.value);
+                console.log(holder[0].value);
+                console.log(receiverCalls);
+                console.log(indexCalls);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("6\n6\n7\n8\n8\n3\n2\n", output);
+    }
+
+    [Theory, ModeData]
+    public void GenericClrMethods_InferAndAcceptExplicitTypeArguments(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { GenericMethodFixture } from "dotnet:SharpTS.Tests.Infrastructure.GenericMethodFixture";
+                const fixture = new GenericMethodFixture();
+                const inferredNumber: number = fixture.echo(42);
+                const inferredString: string = GenericMethodFixture.staticEcho("hello");
+                const explicitString: string = fixture.echo<string>("world");
+                const explicitImported: GenericMethodFixture =
+                    fixture.echo<GenericMethodFixture>(fixture);
+                const constrained: number = fixture.constrained(7);
+                console.log(inferredNumber);
+                console.log(inferredString);
+                console.log(explicitString);
+                console.log(explicitImported.echo("imported"));
+                console.log(constrained);
+                console.log(fixture.typeName<number>());
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("42\nhello\nworld\nimported\n7\nDouble\n", output);
+    }
+
+    [Theory, ModeData]
+    public void GenericClrMethods_InferAndMarshalGuestArrays(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { GenericMethodFixture } from "dotnet:SharpTS.Tests.Infrastructure.GenericMethodFixture";
+                const fixture = new GenericMethodFixture();
+                const numbers: number[] = [1, 2, 3];
+                const copied: number[] = fixture.copy(numbers);
+                copied[0] = 9;
+                console.log(copied.join(","));
+                console.log(numbers.join(","));
+
+                const words: string[] = fixture.copy(["alpha", "beta"]);
+                console.log(words.map(word => word.toUpperCase()).join("|"));
+
+                const nested: number[][] = fixture.copy([[1, 2], [3]]);
+                console.log(nested.map(values => values.join("-")).join("|"));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("9,2,3\n1,2,3\nALPHA|BETA\n1-2|3\n", output);
+    }
+
+    [Theory, ModeData]
+    public void GenericClrMethods_InferThroughCallbackSignatures(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { GenericMethodFixture } from "dotnet:SharpTS.Tests.Infrastructure.GenericMethodFixture";
+                const fixture = new GenericMethodFixture();
+
+                const transformed: number =
+                    fixture.transform(5, value => value * 3);
+                const generated: string =
+                    fixture.fromFactory(() => "made");
+                let observed = 0;
+                fixture.tap(7, value => observed = value);
+
+                console.log(transformed);
+                console.log(generated);
+                console.log(observed);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("15\nmade\n7\n", output);
+    }
+
+    [Theory, ModeData]
+    public void GenericClrMethods_InferResultOnlyParametersFromContext(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { GenericMethodFixture } from "dotnet:SharpTS.Tests.Infrastructure.GenericMethodFixture";
+                const fixture = new GenericMethodFixture();
+
+                const value: number = fixture.defaultValue();
+                const values: number[] = fixture.emptyArray();
+                function obtain(): number {
+                    return fixture.defaultValue();
+                }
+
+                console.log(value);
+                console.log(values.length);
+                console.log(obtain());
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("0\n0\n0\n", output);
+    }
+
+    [Theory, ModeData]
+    public void GenericExtensionMethods_AreInferredAndModuleScoped(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { List } from "dotnet:System.Collections.Generic.List<number>";
+                import "dotnet-extensions:System.Linq.Enumerable";
+                const values = new List();
+                values.add(2.5);
+                values.add(7.5);
+                const first: number = values.first();
+                console.log(values.count());
+                console.log(first);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+        Assert.Equal("2\n2.5\n", output);
+    }
+
+    [Fact]
+    public void ExtensionMethods_DoNotLeakIntoOtherModules()
+    {
+        var errors = CheckErrors(new Dictionary<string, string>
+        {
+            ["./enabled.ts"] = """
+                import { List } from "dotnet:System.Collections.Generic.List<number>";
+                import "dotnet-extensions:SharpTS.Tests.Infrastructure.EnumerableExtensionFixture";
+                export function enabled(values: List): string {
+                    const result: string = values.countItems();
+                    return result;
+                }
+                """,
+            ["./disabled.ts"] = """
+                import { List } from "dotnet:System.Collections.Generic.List<number>";
+                export function disabled(values: List): string {
+                    const result: string = values.countItems();
+                    return result;
+                }
+                """,
+            ["./main.ts"] = """
+                import "./enabled";
+                import "./disabled";
+                """
+        }, "./main.ts");
+
+        Assert.Single(errors, d =>
+            d.Message.Contains("not assignable", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ExtensionContainer_RequiresSideEffectImport()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { Enumerable } from "dotnet-extensions:System.Linq.Enumerable";
+                console.log(Enumerable);
+                """
+        };
+
+        var ex = Assert.ThrowsAny<Exception>(() =>
+            TestHarness.RunModules(files, "./main.ts", ExecutionMode.Interpreted));
+        Assert.Contains("side effects", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     #endregion
 
     #region Namespace form, aliases, nested types
@@ -352,19 +772,19 @@ public class DotNetImportTests
     }
 
     [Fact]
-    public void GenericSpecifier_ThrowsModuleError()
+    public void OpenGenericSpecifier_ThrowsModuleError()
     {
         var files = new Dictionary<string, string>
         {
             ["./main.ts"] = """
-                import { List } from "dotnet:System.Collections.Generic.List<number>";
+                import { List } from "dotnet:System.Collections.Generic.List`1";
                 console.log(1);
                 """
         };
 
         var ex = Assert.ThrowsAny<Exception>(() =>
             TestHarness.RunModules(files, "./main.ts", ExecutionMode.Interpreted));
-        Assert.Contains("Generic .NET types", ex.Message);
+        Assert.Contains(DotNetInteropClassifier.ReasonOpenGeneric, ex.Message);
     }
 
     [Fact]

--- a/TypeSystem/DotNetTypeSynthesizer.cs
+++ b/TypeSystem/DotNetTypeSynthesizer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using SharpTS.Declaration;
 using SharpTS.Parsing;
+using SharpTS.Runtime.DotNet;
 
 namespace SharpTS.TypeSystem;
 
@@ -34,15 +35,343 @@ namespace SharpTS.TypeSystem;
 public static class DotNetTypeSynthesizer
 {
     private static readonly ConcurrentDictionary<Type, TypeInfo.Class> _cache = new();
+    private static readonly ConcurrentDictionary<TypeInfo.Class, Type> _clrTypes =
+        new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
     /// Returns the synthesized class type for a .NET type. Cached per <see cref="Type"/> so all
     /// import sites across all modules share one <see cref="TypeInfo.Class"/> identity.
     /// </summary>
-    public static TypeInfo.Class Synthesize(Type type) => _cache.GetOrAdd(type, Build);
+    public static TypeInfo.Class Synthesize(Type type)
+    {
+        var synthesized = _cache.GetOrAdd(type, Build);
+        _clrTypes.TryAdd(synthesized, type);
+        return synthesized;
+    }
 
     /// <summary>Clears the synthesis cache. Used by tests to ensure isolation.</summary>
-    public static void ClearCache() => _cache.Clear();
+    public static void ClearCache()
+    {
+        _cache.Clear();
+        _clrTypes.Clear();
+    }
+
+    /// <summary>Resolves a synthesized imported instance type back to its CLR type.</summary>
+    public static bool TryGetClrType(TypeInfo type, out Type clrType)
+    {
+        if (type is TypeInfo.Instance instance &&
+            instance.ResolvedClassType is TypeInfo.Class classType &&
+            _clrTypes.TryGetValue(classType, out clrType!))
+        {
+            return true;
+        }
+
+        clrType = null!;
+        return false;
+    }
+
+    /// <summary>
+    /// Maps a statically known TypeScript call-argument shape to the CLR type used for
+    /// generic-method inference. Unlike <see cref="TryGetClrType"/>, this includes guest
+    /// primitives, arrays/tuples, and callable signatures.
+    /// </summary>
+    public static bool TryGetClrArgumentType(TypeInfo type, out Type clrType)
+    {
+        Type? resolved = type switch
+        {
+            TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or
+                TypeInfo.NumberLiteral => typeof(double),
+            TypeInfo.Primitive { Type: TokenType.TYPE_BOOLEAN } or
+                TypeInfo.BooleanLiteral => typeof(bool),
+            TypeInfo.String or TypeInfo.StringLiteral => typeof(string),
+            TypeInfo.Array array when TryGetClrArgumentType(
+                array.ElementType, out var element) => element.MakeArrayType(),
+            TypeInfo.Tuple tuple => HomogeneousClrType(
+                tuple.ElementTypes.Concat(
+                    tuple.RestElementType != null
+                        ? [tuple.RestElementType]
+                        : Enumerable.Empty<TypeInfo>()),
+                asArray: true),
+            TypeInfo.Union union => HomogeneousClrType(
+                union.FlattenedTypes, asArray: false),
+            TypeInfo.Function function => GetDelegateType(function),
+            TypeInfo.Instance when TryGetClrType(type, out var external) => external,
+            _ => null
+        };
+        clrType = resolved!;
+        return resolved != null;
+    }
+
+    private static Type? HomogeneousClrType(
+        IEnumerable<TypeInfo> types,
+        bool asArray)
+    {
+        var resolved = new List<Type>();
+        foreach (var type in types)
+        {
+            if (!TryGetClrArgumentType(type, out var clr))
+                return null;
+            resolved.Add(clr);
+        }
+        if (resolved.Count == 0)
+            return asArray ? typeof(object[]) : null;
+        Type first = resolved[0];
+        if (resolved.Any(type => type != first))
+            return null;
+        return asArray ? first.MakeArrayType() : first;
+    }
+
+    private static Type? GetDelegateType(TypeInfo.Function function)
+    {
+        var parameterTypes = new List<Type>(function.ParamTypes.Count);
+        foreach (var parameter in function.ParamTypes)
+        {
+            if (!TryGetClrArgumentType(parameter, out var parameterType))
+                return null;
+            parameterTypes.Add(parameterType);
+        }
+
+        try
+        {
+            if (function.ReturnType is TypeInfo.Void)
+                return System.Linq.Expressions.Expression.GetActionType(
+                    parameterTypes.ToArray());
+            if (!TryGetClrArgumentType(function.ReturnType, out var returnType))
+                return null;
+            parameterTypes.Add(returnType);
+            return System.Linq.Expressions.Expression.GetFuncType(
+                parameterTypes.ToArray());
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Resolves a user-defined CLR binary operator when at least one operand is a synthesized
+    /// interop instance. This is intentionally absent for ordinary TS values.
+    /// </summary>
+    internal static bool TryResolveBinaryOperator(
+        TypeInfo left,
+        TypeInfo right,
+        TokenType token,
+        out TypeInfo result)
+    {
+        Type? leftClr = TryGetClrType(left, out var resolvedLeft) ? resolvedLeft : null;
+        Type? rightClr = TryGetClrType(right, out var resolvedRight) ? resolvedRight : null;
+        if (leftClr == null && rightClr == null)
+        {
+            result = null!;
+            return false;
+        }
+
+        foreach (var method in DotNetOperatorResolver.GetBinaryCandidates(token, leftClr, rightClr))
+        {
+            var parameters = method.GetParameters();
+            if (!OperatorParameterAccepts(parameters[0].ParameterType, left, leftClr) ||
+                !OperatorParameterAccepts(parameters[1].ParameterType, right, rightClr))
+            {
+                continue;
+            }
+
+            result = MapOperatorResult(method.ReturnType, left, leftClr, right, rightClr);
+            return true;
+        }
+
+        result = null!;
+        return false;
+    }
+
+    internal static bool TryResolveUnaryOperator(
+        TypeInfo operand,
+        TokenType token,
+        out TypeInfo result)
+    {
+        if (!TryGetClrType(operand, out var operandClr))
+        {
+            result = null!;
+            return false;
+        }
+
+        foreach (var method in DotNetOperatorResolver.GetUnaryCandidates(token, operandClr))
+        {
+            if (!OperatorParameterAccepts(
+                    method.GetParameters()[0].ParameterType, operand, operandClr))
+            {
+                continue;
+            }
+            result = MapOperatorResult(
+                method.ReturnType, operand, operandClr, operand, operandClr);
+            return true;
+        }
+
+        result = null!;
+        return false;
+    }
+
+    internal static bool TryResolveCompoundOperator(
+        TypeInfo left,
+        TypeInfo right,
+        TokenType token,
+        out TypeInfo result)
+    {
+        TokenType? binary = DotNetOperatorResolver.GetBinaryTokenForCompound(token);
+        if (binary != null)
+            return TryResolveBinaryOperator(left, right, binary.Value, out result);
+        result = null!;
+        return false;
+    }
+
+    internal static bool TryResolveIncrementOperator(
+        TypeInfo operand,
+        TokenType token,
+        out TypeInfo result)
+    {
+        if (!TryGetClrType(operand, out var operandClr))
+        {
+            result = null!;
+            return false;
+        }
+
+        foreach (var method in DotNetOperatorResolver.GetIncrementCandidates(
+                     token, operandClr))
+        {
+            if (!OperatorParameterAccepts(
+                    method.GetParameters()[0].ParameterType, operand, operandClr))
+            {
+                continue;
+            }
+            result = MapOperatorResult(
+                method.ReturnType, operand, operandClr, operand, operandClr);
+            return true;
+        }
+
+        result = null!;
+        return false;
+    }
+
+    /// <summary>Builds the module-scoped TypeScript member exposed by imported extension methods.</summary>
+    internal static bool TryBuildExtensionMember(
+        TypeInfo receiver,
+        string memberName,
+        IEnumerable<Type> containers,
+        out TypeInfo member)
+    {
+        if (!TryGetClrType(receiver, out var receiverClr))
+        {
+            member = null!;
+            return false;
+        }
+
+        var signatures = new List<TypeInfo.Function>();
+        foreach (var method in DotNetExtensionMethodResolver.GetReceiverClosedCandidates(
+                     containers, memberName, receiverClr))
+        {
+            var parameters = method.GetParameters();
+            if (parameters.Length == 0 ||
+                !parameters[0].ParameterType.IsAssignableFrom(receiverClr) ||
+                DotNetInteropClassifier.UnsupportedSlotReason(method.ReturnType) != null ||
+                parameters.Skip(1).Any(p =>
+                    DotNetInteropClassifier.UnsupportedParameterReason(p.ParameterType) != null))
+            {
+                continue;
+            }
+
+            var visibleTypes = new List<TypeInfo>();
+            int required = 0;
+            bool hasRest = false;
+            for (int i = 1; i < parameters.Length; i++)
+            {
+                var parameter = parameters[i];
+                if (parameter.ParameterType.IsByRef && parameter.IsOut)
+                    continue;
+                if (parameter.IsDefined(
+                        typeof(ParamArrayAttribute), inherit: false) &&
+                    i == parameters.Length - 1)
+                {
+                    visibleTypes.Add(new TypeInfo.Array(TypeInfo.Any.Shared));
+                    hasRest = true;
+                    break;
+                }
+                Type parameterType = parameter.ParameterType.IsByRef
+                    ? parameter.ParameterType.GetElementType()!
+                    : parameter.ParameterType;
+                visibleTypes.Add(MapExternalSlot(parameterType, receiver, receiverClr));
+                if (!parameter.IsOptional)
+                    required = visibleTypes.Count;
+            }
+
+            TypeInfo returnType = MapExternalSlot(method.ReturnType, receiver, receiverClr);
+            var outputs = parameters.Skip(1)
+                .Where(p => p.ParameterType.IsByRef && !p.IsIn)
+                .Select(p => MapExternalSlot(
+                    p.ParameterType.GetElementType()!, receiver, receiverClr))
+                .ToList();
+            if (outputs.Count > 0)
+            {
+                if (method.ReturnType != typeof(void))
+                    outputs.Insert(0, returnType);
+                returnType = TypeInfo.Tuple.FromTypes(outputs, outputs.Count);
+            }
+
+            signatures.Add(new TypeInfo.Function(
+                visibleTypes, returnType, required, hasRest));
+        }
+
+        member = signatures.Count switch
+        {
+            0 => null!,
+            1 => signatures[0],
+            _ => new TypeInfo.OverloadedFunction(
+                signatures, MostPermissiveSignature(signatures))
+        };
+        return signatures.Count > 0;
+    }
+
+    private static bool OperatorParameterAccepts(Type target, TypeInfo source, Type? sourceClr)
+    {
+        if (sourceClr != null)
+            return target.IsAssignableFrom(sourceClr);
+        if (source is TypeInfo.Any or TypeInfo.Inferred or TypeInfo.Unknown)
+            return true;
+        if (source is TypeInfo.Null)
+            return !target.IsValueType || Nullable.GetUnderlyingType(target) != null;
+        if (source is TypeInfo.String or TypeInfo.StringLiteral)
+            return target == typeof(string) || target == typeof(char);
+        if (source is TypeInfo.Primitive { Type: TokenType.TYPE_BOOLEAN } or TypeInfo.BooleanLiteral)
+            return target == typeof(bool);
+        if (source is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral)
+            return IsNumeric(target) || target.IsEnum;
+        return target == typeof(object);
+    }
+
+    private static TypeInfo MapOperatorResult(
+        Type returnType,
+        TypeInfo left,
+        Type? leftClr,
+        TypeInfo right,
+        Type? rightClr)
+    {
+        if (returnType == leftClr) return left;
+        if (returnType == rightClr) return right;
+        var nullable = Nullable.GetUnderlyingType(returnType);
+        if (nullable != null)
+        {
+            return new TypeInfo.Union(
+                [MapOperatorResult(nullable, left, leftClr, right, rightClr), TypeInfo.Null.Shared]);
+        }
+        if (returnType == typeof(bool)) return TypeInfo.Primitive.Boolean;
+        if (returnType == typeof(string) || returnType == typeof(char)) return TypeInfo.String.Shared;
+        if (IsNumeric(returnType)) return TypeInfo.Primitive.Number;
+        return TypeInfo.Any.Shared;
+    }
+
+    private static TypeInfo MapExternalSlot(
+        Type type,
+        TypeInfo receiver,
+        Type receiverClr) =>
+        MapOperatorResult(type, receiver, receiverClr, receiver, receiverClr);
 
     private static TypeInfo.Class Build(Type type)
     {
@@ -61,12 +390,39 @@ public static class DotNetTypeSynthesizer
             if (member != null) mc.StaticMethods.TryAdd(group.Key, member);
         }
 
+        // TypeInspector deliberately keeps generic method definitions out of ordinary
+        // declaration metadata. Synthesize their callable surface directly so TypeScript
+        // calls can infer method type arguments (or accept explicit ones) while the runtime
+        // closes the same MethodInfo immediately before overload resolution.
+        AddGenericMethodGroups(type, mc, isStatic: false);
+        AddGenericMethodGroups(type, mc, isStatic: true);
+
         foreach (var prop in meta.Properties)
         {
             if (prop.IsIndexer || !prop.CanRead) continue;
             if (DotNetInteropClassifier.UnsupportedSlotReason(prop.PropertyType) != null) continue;
             if (mc.FieldTypes.TryAdd(prop.TypeScriptName, MapSlot(prop.PropertyType, type, mc)) && !prop.CanWrite)
                 mc.ReadonlyFields.Add(prop.TypeScriptName);
+        }
+
+        // A CLR indexer maps directly to the corresponding TypeScript class index signature.
+        // TypeScript bracket syntax carries one key, so multi-parameter CLR indexers remain
+        // unavailable (call their get_Item/set_Item accessor explicitly if needed).
+        foreach (var indexer in type.GetProperties(
+                     System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
+        {
+            var indexParameters = indexer.GetIndexParameters();
+            if (indexParameters.Length != 1 || !indexer.CanRead) continue;
+            if (DotNetInteropClassifier.UnsupportedSlotReason(indexer.PropertyType) != null) continue;
+            if (DotNetInteropClassifier.UnsupportedSlotReason(indexParameters[0].ParameterType) != null) continue;
+
+            var valueType = MapSlot(indexer.PropertyType, type, mc);
+            var keyType = Nullable.GetUnderlyingType(indexParameters[0].ParameterType)
+                          ?? indexParameters[0].ParameterType;
+            if (keyType == typeof(string) || keyType == typeof(char))
+                mc.StringIndexType ??= valueType;
+            else if (IsNumeric(keyType) || keyType.IsEnum)
+                mc.NumberIndexType ??= valueType;
         }
 
         foreach (var field in meta.Fields)
@@ -114,6 +470,181 @@ public static class DotNetTypeSynthesizer
         return mc.Freeze();
     }
 
+    private static void AddGenericMethodGroups(
+        Type self,
+        TypeInfo.MutableClass mc,
+        bool isStatic)
+    {
+        var flags = System.Reflection.BindingFlags.Public |
+                    (isStatic
+                        ? System.Reflection.BindingFlags.Static
+                        : System.Reflection.BindingFlags.Instance);
+        var target = isStatic ? mc.StaticMethods : mc.Methods;
+        foreach (var group in self.GetMethods(flags)
+                     .Where(m => m.IsGenericMethodDefinition && !m.IsSpecialName)
+                     .GroupBy(
+                         m => DotNetTypeMapper.ToTypeScriptMethodName(m.Name),
+                         StringComparer.Ordinal))
+        {
+            var genericSignatures = group
+                .Select(m => BuildGenericMethodSignature(m, self, mc))
+                .Where(s => s != null)
+                .Cast<TypeInfo.GenericFunction>()
+                .ToList();
+            if (genericSignatures.Count == 0)
+                continue;
+
+            TypeInfo member;
+            if (genericSignatures.Count == 1)
+            {
+                member = genericSignatures[0];
+            }
+            else if (GenericSignaturesShareParameters(genericSignatures))
+            {
+                var first = genericSignatures[0];
+                var functions = genericSignatures.Select(g => new TypeInfo.Function(
+                    g.ParamTypes, g.ReturnType, g.RequiredParams, g.HasRestParam)).ToList();
+                member = new TypeInfo.GenericOverloadedFunction(
+                    first.TypeParams, functions, MostPermissiveSignature(functions));
+            }
+            else
+            {
+                // The current TypeInfo model has no overload set whose individual signatures
+                // own different generic parameter lists. Runtime dispatch still supports it.
+                member = TypeInfo.Any.Shared;
+            }
+
+            // Mixed generic/non-generic CLR overload sets also cannot be represented faithfully
+            // by the existing TypeInfo union. Keep the call available and let CLR overload
+            // resolution enforce it rather than publishing an incorrect static signature.
+            target[group.Key] = target.ContainsKey(group.Key)
+                ? TypeInfo.Any.Shared
+                : member;
+        }
+    }
+
+    private static TypeInfo.GenericFunction? BuildGenericMethodSignature(
+        System.Reflection.MethodInfo method,
+        Type self,
+        TypeInfo.MutableClass mc)
+    {
+        var genericParameters = method.GetGenericArguments();
+        if (!IsSupportedGenericMethodSlot(
+                method.ReturnType, genericParameters, isParameter: false))
+        {
+            return null;
+        }
+
+        var parameters = method.GetParameters();
+        if (parameters.Any(p => !IsSupportedGenericMethodSlot(
+                p.ParameterType, genericParameters, isParameter: true)))
+        {
+            return null;
+        }
+
+        var typeParameters = genericParameters
+            .Select(p => new TypeInfo.TypeParameter(p.Name))
+            .ToList();
+        var substitutions = genericParameters
+            .Select((parameter, index) => (parameter, typeParameters[index]))
+            .ToDictionary(pair => pair.parameter, pair => pair.Item2);
+
+        var parameterTypes = new List<TypeInfo>();
+        int required = 0;
+        bool hasRest = false;
+        foreach (var parameter in parameters)
+        {
+            if (parameter.ParameterType.IsByRef && parameter.IsOut)
+                continue;
+
+            Type parameterType = parameter.ParameterType.IsByRef
+                ? parameter.ParameterType.GetElementType()!
+                : parameter.ParameterType;
+            if (parameter.IsDefined(typeof(ParamArrayAttribute), inherit: false))
+            {
+                parameterTypes.Add(new TypeInfo.Array(
+                    MapGenericSlot(
+                        parameterType.GetElementType()!, self, mc, substitutions)));
+                hasRest = true;
+                break;
+            }
+
+            parameterTypes.Add(MapGenericSlot(parameterType, self, mc, substitutions));
+            if (!parameter.IsOptional)
+                required = parameterTypes.Count;
+        }
+
+        TypeInfo returnType = MapGenericSlot(
+            method.ReturnType, self, mc, substitutions);
+        var outputs = parameters
+            .Where(p => p.ParameterType.IsByRef && !p.IsIn)
+            .Select(p => MapGenericSlot(
+                p.ParameterType.GetElementType()!, self, mc, substitutions))
+            .ToList();
+        if (outputs.Count > 0)
+        {
+            if (method.ReturnType != typeof(void))
+                outputs.Insert(0, returnType);
+            returnType = TypeInfo.Tuple.FromTypes(outputs, outputs.Count);
+        }
+
+        return new TypeInfo.GenericFunction(
+            typeParameters, parameterTypes, returnType, required, hasRest);
+    }
+
+    private static bool GenericSignaturesShareParameters(
+        IReadOnlyList<TypeInfo.GenericFunction> signatures)
+    {
+        var first = signatures[0].TypeParams;
+        return signatures.Skip(1).All(signature =>
+            signature.TypeParams.Count == first.Count &&
+            signature.TypeParams.Select(p => p.Name)
+                .SequenceEqual(first.Select(p => p.Name), StringComparer.Ordinal));
+    }
+
+    private static bool IsSupportedGenericMethodSlot(
+        Type slot,
+        IReadOnlyCollection<Type> methodParameters,
+        bool isParameter) =>
+        DotNetInteropClassifier.UnsupportedGenericMethodSlotReason(
+            slot, methodParameters, isParameter) == null;
+
+    private static TypeInfo MapGenericSlot(
+        Type clrType,
+        Type self,
+        TypeInfo.MutableClass mc,
+        IReadOnlyDictionary<Type, TypeInfo.TypeParameter> substitutions)
+    {
+        if (substitutions.TryGetValue(clrType, out var parameter))
+            return parameter;
+        if (clrType.IsArray)
+        {
+            return new TypeInfo.Array(
+                MapGenericSlot(clrType.GetElementType()!, self, mc, substitutions));
+        }
+        if (typeof(Delegate).IsAssignableFrom(clrType) &&
+            clrType.GetMethod("Invoke") is { } genericInvoke)
+        {
+            return new TypeInfo.Function(
+                genericInvoke.GetParameters()
+                    .Select(parameter => MapGenericSlot(
+                        parameter.ParameterType, self, mc, substitutions))
+                    .ToList(),
+                MapGenericSlot(genericInvoke.ReturnType, self, mc, substitutions),
+                genericInvoke.GetParameters().Length);
+        }
+
+        var nullableUnderlying = Nullable.GetUnderlyingType(clrType);
+        if (nullableUnderlying != null)
+        {
+            return new TypeInfo.Union(
+                [MapGenericSlot(nullableUnderlying, self, mc, substitutions),
+                    TypeInfo.Null.Shared]);
+        }
+
+        return MapSlot(clrType, self, mc);
+    }
+
     /// <summary>
     /// Builds the callable type for one JS-facing method name: a single <see cref="TypeInfo.Function"/>,
     /// an <see cref="TypeInfo.OverloadedFunction"/> for overload sets, or null when every overload
@@ -126,9 +657,20 @@ public static class DotNetTypeSynthesizer
         {
             if (DotNetInteropClassifier.UnsupportedSlotReason(m.ReturnType) != null)
                 continue;
-            if (m.Parameters.Any(p => DotNetInteropClassifier.UnsupportedSlotReason(p.ParameterType) != null))
+            if (m.Parameters.Any(p => DotNetInteropClassifier.UnsupportedParameterReason(p.ParameterType) != null))
                 continue;
-            signatures.Add(BuildSignature(m.Parameters, MapSlot(m.ReturnType, self, mc), self, mc));
+            var returnType = MapSlot(m.ReturnType, self, mc);
+            var tupleOutputs = m.Parameters
+                .Where(p => p.IsByRef && !p.IsIn)
+                .Select(p => MapSlot(p.ParameterType.GetElementType()!, self, mc))
+                .ToList();
+            if (tupleOutputs.Count > 0)
+            {
+                if (m.ReturnType != typeof(void))
+                    tupleOutputs.Insert(0, returnType);
+                returnType = TypeInfo.Tuple.FromTypes(tupleOutputs, tupleOutputs.Count);
+            }
+            signatures.Add(BuildSignature(m.Parameters, returnType, self, mc));
         }
 
         return signatures.Count switch
@@ -185,6 +727,8 @@ public static class DotNetTypeSynthesizer
         for (int i = 0; i < parameters.Count; i++)
         {
             var p = parameters[i];
+            if (p.IsByRef && p.IsOut)
+                continue;
             if (p.IsParams && i == parameters.Count - 1)
             {
                 // params-array: the checker models rest params as an array-typed final slot.
@@ -192,8 +736,11 @@ public static class DotNetTypeSynthesizer
                 hasRest = true;
                 break;
             }
-            paramTypes.Add(MapSlot(p.ParameterType, self, mc));
-            if (!p.IsOptional) requiredParams = i + 1;
+            var parameterType = p.ParameterType.IsByRef
+                ? p.ParameterType.GetElementType()!
+                : p.ParameterType;
+            paramTypes.Add(MapSlot(parameterType, self, mc));
+            if (!p.IsOptional) requiredParams = paramTypes.Count;
         }
 
         return new TypeInfo.Function(paramTypes, returnType, requiredParams, hasRest);
@@ -227,23 +774,42 @@ public static class DotNetTypeSynthesizer
     private static TypeInfo MapSlot(Type clrType, Type self, TypeInfo.MutableClass mc)
     {
         if (clrType == typeof(void)) return TypeInfo.Void.Shared;
+
+        var nullableUnderlying = Nullable.GetUnderlyingType(clrType);
+        if (nullableUnderlying != null)
+        {
+            return new TypeInfo.Union(
+                [MapSlot(nullableUnderlying, self, mc), TypeInfo.Null.Shared]);
+        }
+
         if (clrType == typeof(string) || clrType == typeof(char)) return TypeInfo.String.Shared;
         if (clrType == typeof(bool)) return TypeInfo.Primitive.Boolean;
 
-        if (clrType == typeof(double) || clrType == typeof(float) ||
-            clrType == typeof(int) || clrType == typeof(uint) ||
-            clrType == typeof(long) || clrType == typeof(ulong) ||
-            clrType == typeof(short) || clrType == typeof(ushort) ||
-            clrType == typeof(byte) || clrType == typeof(sbyte) ||
-            clrType == typeof(decimal))
-        {
-            return TypeInfo.Primitive.Number;
-        }
+        if (IsNumeric(clrType)) return TypeInfo.Primitive.Number;
 
         // The containing type itself: keeps fluent chains statically typed. Instance wraps the
         // MutableClass; Instance.ResolvedClassType resolves to the frozen Class after Freeze().
         if (clrType == self) return new TypeInfo.Instance(mc);
 
+        if (typeof(Delegate).IsAssignableFrom(clrType) &&
+            clrType.GetMethod("Invoke") is { } invoke)
+        {
+            return new TypeInfo.Function(
+                invoke.GetParameters()
+                    .Select(parameter => MapSlot(parameter.ParameterType, self, mc))
+                    .ToList(),
+                MapSlot(invoke.ReturnType, self, mc),
+                invoke.GetParameters().Length);
+        }
+
         return TypeInfo.Any.Shared;
     }
+
+    private static bool IsNumeric(Type type) =>
+        type == typeof(double) || type == typeof(float) ||
+        type == typeof(int) || type == typeof(uint) ||
+        type == typeof(long) || type == typeof(ulong) ||
+        type == typeof(short) || type == typeof(ushort) ||
+        type == typeof(byte) || type == typeof(sbyte) ||
+        type == typeof(decimal);
 }

--- a/TypeSystem/TypeChecker.Calls.cs
+++ b/TypeSystem/TypeChecker.Calls.cs
@@ -13,7 +13,9 @@ namespace SharpTS.TypeSystem;
 /// </remarks>
 public partial class TypeChecker
 {
-    private TypeInfo CheckCall(Expr.Call call)
+    private TypeInfo CheckCall(
+        Expr.Call call,
+        TypeInfo? contextualResultType = null)
     {
         // JSX-origin calls (parser-lowered elements) bypass ordinary call checking entirely:
         // the JSX pipeline owns their semantics and diagnostics (see TypeChecker.Jsx.cs), so
@@ -36,6 +38,20 @@ public partial class TypeChecker
         }
 
         TypeInfo calleeType = CheckExpr(call.Callee);
+        if (call.Callee is Expr.Get extensionGet &&
+            calleeType is not (TypeInfo.Function or TypeInfo.OverloadedFunction or
+                TypeInfo.GenericFunction) &&
+            _typeMap.Get(extensionGet.Object) is { } extensionReceiver &&
+            _currentModule != null &&
+            DotNetTypeSynthesizer.TryBuildExtensionMember(
+                extensionReceiver,
+                extensionGet.Name.Lexeme,
+                _currentModule.DotNetExtensionTypes,
+                out var extensionMember))
+        {
+            calleeType = extensionMember;
+            _typeMap.Set(call.Callee, extensionMember);
+        }
 
         // Optional call: if callee could be nullish, strip null/undefined and check the rest.
         // The result type will be unioned with undefined at the end.
@@ -95,13 +111,34 @@ public partial class TypeChecker
             else
             {
                 // Infer type arguments from call arguments
-                typeArgs = InferTypeArguments(genericFunc, argTypes);
+                typeArgs = InferTypeArguments(
+                    genericFunc, argTypes, contextualResultType);
             }
 
             // Instantiate the function with the type arguments
             var instantiatedFunc = InstantiateGenericFunction(genericFunc, typeArgs);
             if (instantiatedFunc is TypeInfo.Function instFunc)
             {
+                // Re-contextualize callback arguments after inference. The first pass may
+                // infer T from an ordinary value (or from an explicitly annotated callback);
+                // this pass gives unannotated arrow parameters the now-concrete delegate
+                // signature and records that precise callable type for CLR generic inference.
+                for (int i = 0; i < call.Arguments.Count &&
+                                i < instFunc.ParamTypes.Count; i++)
+                {
+                    if (call.Arguments[i] is Expr.ArrowFunction arrow &&
+                        instFunc.ParamTypes[i] is TypeInfo.Function expectedCallback)
+                    {
+                        TypeInfo callbackType = CheckArrowFunction(
+                            arrow, expectedCallback);
+                        // The argument is converted to the declared CLR delegate shape. Keep
+                        // that contextual signature in the call-site map (not merely the
+                        // arrow's value-returning implementation type): a value-returning
+                        // expression arrow is valid for an Action/void sink, but must still
+                        // infer as Action<T>, not Func<T,T>.
+                        _typeMap.Set(arrow, expectedCallback);
+                    }
+                }
                 return instFunc.ReturnType;
             }
             return TypeInfo.Any.Shared;

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -69,6 +69,12 @@ public partial class TypeChecker
                 _typeMap.Set(expr, sourceType);
                 return sourceType;
             }
+            case Expr.Call call:
+            {
+                TypeInfo result = CheckCall(call, contextualType);
+                _typeMap.Set(expr, result);
+                return result;
+            }
             default:
                 return CheckExpr(expr);
         }

--- a/TypeSystem/TypeChecker.Generics.Inference.cs
+++ b/TypeSystem/TypeChecker.Generics.Inference.cs
@@ -14,7 +14,10 @@ public partial class TypeChecker
     /// <summary>
     /// Infers type arguments from call arguments for a generic function.
     /// </summary>
-    private List<TypeInfo> InferTypeArguments(TypeInfo.GenericFunction gf, List<TypeInfo> argTypes)
+    private List<TypeInfo> InferTypeArguments(
+        TypeInfo.GenericFunction gf,
+        List<TypeInfo> argTypes,
+        TypeInfo? contextualResultType = null)
     {
         Dictionary<string, TypeInfo> inferred = [];
 
@@ -43,6 +46,12 @@ public partial class TypeChecker
                 InferFromType(restDeclared, TypeInfo.Tuple.FromTypes(restArgs, restArgs.Count), inferred);
             }
         }
+
+        // A concrete assignment/return context is valid evidence for type parameters
+        // that appear only in the result (`const n: number = host.create<T>()`).
+        // Calls checked without a context retain the existing constraint/any fallback.
+        if (contextualResultType is not null and not TypeInfo.Any)
+            InferFromType(gf.ReturnType, contextualResultType, inferred);
 
         // Build result list in order of type parameters
         List<TypeInfo> result = [];
@@ -153,6 +162,16 @@ public partial class TypeChecker
         {
             // Recurse into array element types
             InferFromType(paramArr.ElementType, argArr.ElementType, inferred);
+        }
+        else if (paramType is TypeInfo.Array tupleParamArr && argType is TypeInfo.Tuple argTuple)
+        {
+            // Array literals commonly retain tuple precision. A CLR `T[]` parameter still
+            // infers T from every fixed/rest tuple element rather than losing inference at
+            // the tuple-vs-array representation boundary.
+            foreach (var element in argTuple.ElementTypes)
+                InferFromType(tupleParamArr.ElementType, element, inferred);
+            if (argTuple.RestElementType != null)
+                InferFromType(tupleParamArr.ElementType, argTuple.RestElementType, inferred);
         }
         else if (paramType is TypeInfo.Function paramFunc && argType is TypeInfo.Function argFunc)
         {

--- a/TypeSystem/TypeChecker.Operators.cs
+++ b/TypeSystem/TypeChecker.Operators.cs
@@ -18,6 +18,11 @@ public partial class TypeChecker
     {
         TypeInfo left = CheckExpr(binary.Left);
         TypeInfo right = CheckExpr(binary.Right);
+        if (DotNetTypeSynthesizer.TryResolveBinaryOperator(
+                left, right, binary.Operator.Type, out var clrResult))
+        {
+            return clrResult;
+        }
         var desc = SemanticOperatorResolver.Resolve(binary.Operator.Type);
         int line = binary.Operator.Line;
 
@@ -442,6 +447,19 @@ public partial class TypeChecker
 
         int line = compound.Operator.Line;
 
+        if (DotNetTypeSynthesizer.TryResolveCompoundOperator(
+                varType, valueType, compound.Operator.Type, out var clrResult))
+        {
+            if (!IsCompatible(varType, clrResult))
+            {
+                throw new TypeCheckException(
+                    $"Operator result type '{clrResult}' is not assignable to '{varType}'.",
+                    line: line > 0 ? line : null,
+                    tsCode: "TS2322");
+            }
+            return clrResult;
+        }
+
         // For += with strings, allow string concatenation
         if (compound.Operator.Type == TokenType.PLUS_EQUAL)
         {
@@ -478,8 +496,8 @@ public partial class TypeChecker
 
     private TypeInfo CheckCompoundSet(Expr.CompoundSet compound)
     {
-        CheckExpr(compound.Object);
-        CheckExpr(compound.Value);
+        TypeInfo objType = CheckExpr(compound.Object);
+        TypeInfo valueType = CheckExpr(compound.Value);
 
         // Invalidate any narrowings affected by this property assignment
         var basePath = Narrowing.NarrowingPathExtractor.TryExtract(compound.Object);
@@ -487,6 +505,23 @@ public partial class TypeChecker
         {
             var assignedPath = new Narrowing.NarrowingPath.PropertyAccess(basePath, compound.Name.Lexeme);
             InvalidateNarrowingsFor(assignedPath);
+        }
+
+        if (DotNetTypeSynthesizer.TryGetClrType(objType, out _))
+        {
+            TypeInfo memberType = CheckGetOnType(objType, compound.Name);
+            if (DotNetTypeSynthesizer.TryResolveCompoundOperator(
+                    memberType, valueType, compound.Operator.Type, out var clrResult))
+            {
+                if (!IsCompatible(memberType, clrResult))
+                {
+                    throw new TypeCheckException(
+                        $"Operator result type '{clrResult}' is not assignable to '{memberType}'.",
+                        line: compound.Operator.Line > 0 ? compound.Operator.Line : null,
+                        tsCode: "TS2322");
+                }
+                return clrResult;
+            }
         }
 
         return TypeInfo.Any.Shared;
@@ -516,6 +551,31 @@ public partial class TypeChecker
             }
 
             InvalidateNarrowingsFor(assignedPath);
+        }
+
+        if (DotNetTypeSynthesizer.TryGetClrType(objType, out _))
+        {
+            TokenType keyType = indexType switch
+            {
+                TypeInfo.String or TypeInfo.StringLiteral => TokenType.TYPE_STRING,
+                TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral =>
+                    TokenType.TYPE_NUMBER,
+                _ => TokenType.EOF
+            };
+            TypeInfo? elementType = GetClassIndexType(objType, keyType);
+            if (elementType != null &&
+                DotNetTypeSynthesizer.TryResolveCompoundOperator(
+                    elementType, valueType, compound.Operator.Type, out var clrResult))
+            {
+                if (!IsCompatible(elementType, clrResult))
+                {
+                    throw new TypeCheckException(
+                        $"Operator result type '{clrResult}' is not assignable to '{elementType}'.",
+                        line: compound.Operator.Line > 0 ? compound.Operator.Line : null,
+                        tsCode: "TS2322");
+                }
+                return clrResult;
+            }
         }
 
         if (!IsNumber(indexType))
@@ -699,6 +759,9 @@ public partial class TypeChecker
     private TypeInfo CheckPrefixIncrement(Expr.PrefixIncrement prefix)
     {
         TypeInfo operandType = CheckExpr(prefix.Operand);
+        if (DotNetTypeSynthesizer.TryResolveIncrementOperator(
+                operandType, prefix.Operator.Type, out var clrResult))
+            return clrResult;
         if (!IsNumber(operandType) && !IsBigInt(operandType))
         {
             throw new TypeCheckException("An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.", line: prefix.Operator.Line, tsCode: "TS2356");
@@ -709,6 +772,9 @@ public partial class TypeChecker
     private TypeInfo CheckPostfixIncrement(Expr.PostfixIncrement postfix)
     {
         TypeInfo operandType = CheckExpr(postfix.Operand);
+        if (DotNetTypeSynthesizer.TryResolveIncrementOperator(
+                operandType, postfix.Operator.Type, out _))
+            return operandType;
         if (!IsNumber(operandType) && !IsBigInt(operandType))
         {
             throw new TypeCheckException("An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.", line: postfix.Operator.Line, tsCode: "TS2356");
@@ -776,6 +842,11 @@ public partial class TypeChecker
             return TypeInfo.String.Shared;
         }
         TypeInfo right = CheckExpr(unary.Right);
+        if (DotNetTypeSynthesizer.TryResolveUnaryOperator(
+                right, unary.Operator.Type, out var clrResult))
+        {
+            return clrResult;
+        }
         if (unary.Operator.Type == TokenType.VOID)
             return TypeInfo.Undefined.Shared;
         if (unary.Operator.Type == TokenType.MINUS)

--- a/TypeSystem/TypeChecker.Properties.Helpers.cs
+++ b/TypeSystem/TypeChecker.Properties.Helpers.cs
@@ -284,7 +284,21 @@ public partial class TypeChecker
         // the class was frozen (e.g., method return types on @DotNetType shims).
         if (instance.ResolvedClassType is TypeInfo.Class instanceClassType)
         {
-            return CheckGetOnRegularInstance(instanceClassType, memberName);
+            var regularMember = CheckGetOnRegularInstance(instanceClassType, memberName);
+            if (regularMember is TypeInfo.Any &&
+                _currentModule != null &&
+                DotNetTypeSynthesizer.TryGetClrType(instance, out var receiverClr) &&
+                Runtime.DotNet.DotNetTypeRegistry.GetMethods(
+                    receiverClr, memberNameStr, isStatic: false).Length == 0 &&
+                DotNetTypeSynthesizer.TryBuildExtensionMember(
+                    instance,
+                    memberNameStr,
+                    _currentModule.DotNetExtensionTypes,
+                    out var extensionMember))
+            {
+                return extensionMember;
+            }
+            return regularMember;
         }
 
         return TypeInfo.Any.Shared;

--- a/TypeSystem/TypeChecker.Properties.Index.cs
+++ b/TypeSystem/TypeChecker.Properties.Index.cs
@@ -505,6 +505,14 @@ public partial class TypeChecker
                     throw new TypeCheckException($" Cannot assign '{valueType}' to index signature type '{rec.StringIndexType}'.", tsCode: "TS2322");
                 return valueType;
             }
+            if (GetClassIndexType(objType, TokenType.TYPE_STRING) is { } classStringIndex)
+            {
+                if (!IsCompatible(classStringIndex, valueType))
+                    throw new TypeCheckException(
+                        $" Cannot assign '{valueType}' to index signature type '{classStringIndex}'.",
+                        tsCode: "TS2322");
+                return valueType;
+            }
 
             // Allow bracket assignment on any object/interface
             if (objType is TypeInfo.Record or TypeInfo.Interface or TypeInfo.Instance)
@@ -626,6 +634,16 @@ public partial class TypeChecker
             {
                 if (!IsCompatible(rec2.NumberIndexType, valueType))
                     throw new TypeCheckException($" Cannot assign '{valueType}' to number index signature type '{rec2.NumberIndexType}'.", tsCode: "TS2322");
+                return valueType;
+            }
+            var classNumberIndex = GetClassIndexType(objType, TokenType.TYPE_NUMBER)
+                                   ?? GetClassIndexType(objType, TokenType.TYPE_STRING);
+            if (classNumberIndex != null)
+            {
+                if (!IsCompatible(classNumberIndex, valueType))
+                    throw new TypeCheckException(
+                        $" Cannot assign '{valueType}' to number index signature type '{classNumberIndex}'.",
+                        tsCode: "TS2322");
                 return valueType;
             }
 

--- a/docs/dotnet-types.md
+++ b/docs/dotnet-types.md
@@ -59,8 +59,8 @@ dotnet example.dll
 
 A `dotnet:` import specifier binds .NET types as first-class module imports. The static type
 surface is synthesized directly from reflection metadata, so it always matches the real CLR
-type, and members the interop layer cannot marshal (the same four categories `--gen-decl`
-marks `[unsupported]`) are simply absent from the surface.
+type, and members the interop layer cannot marshal (as reported by `--gen-decl`) are simply
+absent from the surface.
 
 ### Two specifier forms
 
@@ -76,6 +76,10 @@ import { Math as SysMath } from "dotnet:System";
 
 // Nested types resolve through their declaring type's specifier
 import { SpecialFolder } from "dotnet:System.Environment";
+
+// Closed generic types use a friendly constructed name
+import { List } from "dotnet:System.Collections.Generic.List<number>";
+import { Dictionary } from "dotnet:System.Collections.Generic.Dictionary<string, number>";
 ```
 
 ### What you get
@@ -92,14 +96,62 @@ import { SpecialFolder } from "dotnet:System.Environment";
 - **Overload resolution** — cost-based, same as `@DotNetType`. If you need to force a
   specific overload with `@DotNetOverload`, use a `@DotNetType` declaration for that type
   instead; the two binding styles compose freely in one program.
+- **CLR indexers** — public single-parameter indexers use ordinary bracket syntax:
+  `list[0]`, `list[0] = value`, and `dictionary["key"]`.
+- **Nullable value types** — `Nullable<T>` is typed as `T | null` and values/null round-trip
+  consistently in both execution modes.
+- **Generic methods** — ordinary instance/static methods infer CLR method type arguments from
+  direct and nested inputs, guest arrays, and typed callback/delegate signatures. A concrete
+  assignment or return context can infer parameters that occur only in the result. Explicit
+  TypeScript arguments remain available when the call has no inference evidence:
+
+  ```typescript
+  const same = fixture.echo(42);              // Echo<double>(double)
+  const copy = fixture.copy([1, 2, 3]);        // Copy<double>(double[])
+  const made = fixture.fromFactory(() => 42);  // FromFactory<double>(Func<double>)
+  const zero: number = fixture.defaultValue(); // DefaultValue<double>()
+  const name = fixture.typeName<number>();    // TypeName<double>()
+  ```
+
+  CLR constraints are enforced when the reflected method is closed. A result-only call
+  without a concrete context still needs explicit `<T>`.
+- **`ref` / `out` / `in` methods** — `out` parameters are omitted from the call; `ref` and
+  `in` parameters are ordinary inputs. Writable `ref`/`out` values are returned in a tuple:
+  a non-void method returns `[result, ...updated]`, while a void method returns
+  `[...updated]`.
+- **CLR operators** — unary and binary operator methods dispatch when an operand is a
+  statically known imported CLR instance. Compound assignment and `++`/`--` also dispatch
+  for imported CLR variables and writable property/indexer l-values, write the operator
+  result back, and evaluate each receiver/index exactly once. Ordinary TypeScript values
+  retain JavaScript coercion semantics.
+- **Extension methods** — activate a public static extension container for one source module
+  with a side-effect import:
+
+  ```typescript
+  import { List } from "dotnet:System.Collections.Generic.List<number>";
+  import "dotnet-extensions:System.Linq.Enumerable";
+
+  const values = new List();
+  values.add(1);
+  console.log(values.count());
+  ```
+
+  Generic arguments infer from the constructed receiver (for example,
+  `List<number>` → `IEnumerable<double>` → `TSource = double`).
 
 ### Scope and restrictions
 
 - **Named imports only.** Default imports, `import * as ns`, `export … from "dotnet:…"`,
   `import x = require("dotnet:…")`, and dynamic `import("dotnet:…")` are rejected with a
   clear error — a .NET namespace is not an enumerable module object.
-- **No generic types.** `dotnet:System.Collections.Generic.List<number>` is rejected; use an
-  `@DotNetType` declaration with a closed-generic CLR name for those.
+- **Closed generics only.** Constructed names such as
+  `dotnet:System.Collections.Generic.List<number>` are supported, including nested generics.
+  Open definitions (`List\`1`, `List<>`) cannot be runtime values. In friendly names,
+  `number` means CLR `double`; C# aliases (`int`, `string`, `bool`, etc.) and fully-qualified
+  CLR names are also accepted.
+- **Extension imports are side-effect-only and module-scoped.** Default, named, namespace,
+  type-only, re-export, and CommonJS forms are rejected. Instance members take precedence
+  over extension methods.
 - **No paths in specifiers.** `dotnet:./libs/MyLib.dll#MyLib.Widget` is rejected — specifiers
   name types or namespaces. Point SharpTS at the assembly via `sharpts.json` or `-r`
   (below), then import the type by name.
@@ -176,7 +228,9 @@ declare class TypeScriptName {
 }
 ```
 
-- **First argument**: The fully-qualified .NET type name (e.g., `System.Text.StringBuilder`)
+- **First argument**: The fully-qualified .NET type name (e.g., `System.Text.StringBuilder`),
+  optionally constructed with friendly generic arguments (e.g.,
+  `System.Collections.Generic.List<number>`)
 - **`declare class`**: Indicates this is an external type with no implementation in TypeScript
 
 ### Declaring External Types
@@ -561,10 +615,11 @@ System.Text.StringBuilder — class
 ```
 
 Each member is marked `[usable]` or `[unsupported]` using the **same rules the runtime interop
-marshaller enforces**, so the tool and your program can never disagree about what's callable. The
-four unsupported categories are by-ref (`ref`/`out`/`in`) parameters, pointer types, ref structs
-(`Span<T>`/`ReadOnlySpan<T>`), and open generics. Signatures are shown with faithful .NET types
-(`int`, `char[]`, `ReadOnlySpan<char>`, `out Guid`), not coerced into TypeScript.
+marshaller enforces**, so the tool and your program can never disagree about what's callable.
+By-ref method parameters are shown using the tuple-lowered TypeScript call shape. Generic
+method definitions are shown with their `<T>` parameters. By-ref constructors/returns,
+pointer types, ref structs (`Span<T>`/`ReadOnlySpan<T>`), and open generic type definitions
+remain unsupported.
 
 > The `import { … } from "dotnet:…";` line is ready to copy into your program — see
 > [Importing .NET Types](#importing-net-types-dotnet-imports). It resolves with the exact same
@@ -615,18 +670,19 @@ The following .NET features are not currently supported:
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| Generic types | Not supported | Cannot declare `List<T>` directly |
-| `ref` / `out` parameters | Not supported | Methods with ref/out params cannot be called |
+| Generic types | Closed types supported | Use a constructed name such as `List<number>`; open `List<T>` definitions are not runtime values |
+| Generic methods | Supported (both modes) | Ordinary methods infer through nested inputs, guest arrays, delegate signatures, and concrete result contexts, or accept explicit `<T>`; extension methods infer from their receiver |
+| `ref` / `out` / `in` parameters | Supported on methods (both modes) | Tuple lowering preserves results and updated values. By-ref constructors are intentionally rejected because `new` must return the instance; managed-reference returns are rejected rather than exposed as misleading snapshots |
 | Events | Supported (both modes) | Use `addEventListener`/`removeEventListener` — see [Events](#events) |
 | Delegates | Supported (both modes) | TS functions auto-convert to delegate params — see [Delegates](#delegates-and-callbacks) |
-| Indexers | Not supported | Cannot use `obj[index]` syntax |
-| Operators | Not supported | Operator overloads not accessible |
-| Extension methods | Not supported | Must call as static methods |
-| Nullable value types | Partial | Generated as `T \| null` but runtime behavior varies |
+| Indexers | Supported (both modes) | Public single-parameter indexers use `obj[index]` syntax |
+| Operators | Supported (both modes) | Unary/binary operators plus compound and `++`/`--` write-back on variables and writable property/indexer l-values; compiled write-back receivers must be reference types |
+| Extension methods | Supported (both modes) | Side-effect-only `dotnet-extensions:` imports are module-scoped; instance members win |
+| Nullable value types | Supported (both modes) | Generated as `T \| null`; values and null marshal consistently |
 
 ### Workarounds
 
-For unsupported features, consider:
+For remaining unsupported signatures, consider:
 1. Creating a C# wrapper class that exposes a simpler API
 2. Using reflection-based interop via compiled TypeScript (see [.NET Integration Guide](dotnet-integration.md))
 
@@ -640,12 +696,12 @@ The interpreter builds a shim on demand so the delegate's Invoke signature
 round-trips through the TS callable:
 
 ```typescript
-@DotNetType("System.Collections.Generic.List`1")
+@DotNetType("System.Collections.Generic.List<number>")
 declare class IntList {
     constructor();
     add(item: number): void;
-    forEach(action: (item: number) => void): void;  // Action<int>
-    findAll(predicate: (item: number) => boolean): IntList;  // Predicate<int>
+    forEach(action: (item: number) => void): void;  // Action<double>
+    findAll(predicate: (item: number) => boolean): IntList;  // Predicate<double>
 }
 
 let items = new IntList();


### PR DESCRIPTION
## Summary

- add closed generic CLR types and generic method inference across ordinary arguments, guest arrays, delegate callbacks, and contextual result types
- support ref/out/in calls, CLR indexers, nullable value behavior, user-defined operators, compound/write-back operators, and extension-method imports
- align interpreter, IL compiler, declaration generation, type checking, and language-server interop behavior
- expand dual-mode CLR fixtures and documentation for the supported surface and remaining limitations

## Validation

- dotnet build SharpTS.sln --no-restore
- focused CLR integration suite: 191/191 passed
- shared generics/array/callback regression suite: 170/170 passed
- git diff --check: clean

The full test suite was attempted during development but did not finish within the local execution window; it produced no failure output before timeout.