### PR TITLE
Hermetic ambient walks, node:* declaration imports, and a warning-free build

### DIFF
--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -288,9 +288,9 @@ public partial class ILCompiler
         {
             if (CreateDebugScope(module.Document) is not { } scope) continue;
 
-            // Phases are not consistent about whether CurrentPath is normalized, so index both
-            // spellings rather than depending on which one a given phase happens to use.
-            _debugScopesByModule[NormalizeToEmissionPath(module.Path)] = scope;
+            // Keyed by raw path only. NormalizeToEmissionPath never respells a path — it folds
+            // script-module paths to null — and null-path emission (scripts, the entry point) is
+            // served by the _entryPointDebugScope fallback, not a dictionary entry.
             _debugScopesByModule[module.Path] = scope;
             entryScope = scope;
         }

--- a/Configuration/FileDiscovery.cs
+++ b/Configuration/FileDiscovery.cs
@@ -5,7 +5,9 @@ namespace SharpTS.Configuration;
 /// <summary>
 /// Shared upward config/manifest-file discovery used by <see cref="TsConfigLoader"/>,
 /// <see cref="Packaging.PackageJsonLoader"/>, and <see cref="References.SharpTsManifestLoader"/>,
-/// so all three loaders apply one walk policy.
+/// so all three loaders apply one walk policy. Ambient walks elsewhere (module resolution's
+/// node_modules/@types/package.json probes) share the same ceilings via
+/// <see cref="AmbientParent"/>.
 /// </summary>
 internal static class FileDiscovery
 {
@@ -39,14 +41,7 @@ internal static class FileDiscovery
             ? NormalizeDir(new DirectoryInfo(stopDirectory).FullName)
             : null;
 
-        var ceilings = new[]
-            {
-                Path.GetTempPath(),
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
-            }
-            .Where(p => !string.IsNullOrEmpty(p))
-            .Select(p => NormalizeDir(Path.GetFullPath(p)))
-            .ToArray();
+        var ceilings = WalkCeilings();
 
         bool isStartDirectory = true;
         while (dir != null)
@@ -75,6 +70,35 @@ internal static class FileDiscovery
 
         return null;
     }
+
+    /// <summary>
+    /// The parent of <paramref name="directory"/> for ambient upward walks, or null when
+    /// ascending would enter a ceiling (system temp root or user profile root). The caller's
+    /// start directory is always probed — even when it is itself a ceiling — matching the
+    /// <see cref="FindNearestFile"/> policy: files directly under a ceiling are ambient noise
+    /// from unrelated tooling, not part of the program being resolved.
+    /// </summary>
+    internal static string? AmbientParent(string directory)
+    {
+        string? parent = Path.GetDirectoryName(NormalizeDir(directory));
+        if (string.IsNullOrEmpty(parent))
+            return null;
+        string normalized = NormalizeDir(Path.GetFullPath(parent));
+        return WalkCeilings().Any(c => string.Equals(normalized, c, StringComparison.OrdinalIgnoreCase))
+            ? null
+            : parent;
+    }
+
+    // Recomputed per call: tests and embedders may redirect TMP/TEMP at runtime.
+    private static string[] WalkCeilings() =>
+        new[]
+            {
+                Path.GetTempPath(),
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+            }
+            .Where(p => !string.IsNullOrEmpty(p))
+            .Select(p => NormalizeDir(Path.GetFullPath(p)))
+            .ToArray();
 
     private static string NormalizeDir(string path) =>
         path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);

--- a/Configuration/TsConfigLoader.cs
+++ b/Configuration/TsConfigLoader.cs
@@ -167,15 +167,15 @@ public static class TsConfigLoader
         }
 
         // Bare specifier: an honest subset of node resolution — walk up looking in node_modules.
-        var dir = new DirectoryInfo(declaringDir);
+        string? dir = declaringDir;
         while (dir != null)
         {
-            string baseDir = Path.Combine(dir.FullName, "node_modules", spec);
+            string baseDir = Path.Combine(dir, "node_modules", spec);
             foreach (var candidate in new[] { baseDir, baseDir + ".json", Path.Combine(baseDir, FileName) })
             {
                 if (File.Exists(candidate)) return Path.GetFullPath(candidate);
             }
-            dir = dir.Parent;
+            dir = FileDiscovery.AmbientParent(dir);
         }
 
         throw new Exception(

--- a/Modules/CommonJsDetector.cs
+++ b/Modules/CommonJsDetector.cs
@@ -1,3 +1,5 @@
+using SharpTS.Configuration;
+
 namespace SharpTS.Modules;
 
 /// <summary>
@@ -7,7 +9,8 @@ namespace SharpTS.Modules;
 /// Resolution rules (in order):
 /// <list type="number">
 /// <item>Extension: <c>.cjs</c>/<c>.cts</c> → CJS; <c>.mjs</c>/<c>.mts</c>/<c>.ts</c>/<c>.tsx</c> → ESM.</item>
-/// <item><c>.js</c>/<c>.jsx</c>: walk up to nearest <c>package.json</c>.
+/// <item><c>.js</c>/<c>.jsx</c>: walk up to nearest <c>package.json</c> (stopping at
+/// <see cref="Configuration.FileDiscovery"/>'s ambient ceilings — temp root, user profile).
 /// <c>"type":"module"</c> → ESM; <c>"type":"commonjs"</c> or no field → CJS (Node default).</item>
 /// <item>Fallback heuristic for <c>.js</c> with no reachable <c>package.json</c>:
 /// content scan for <c>require(</c>/<c>module.exports</c>/<c>exports.</c>
@@ -88,7 +91,7 @@ public static class CommonJsDetector
                     return pkg.Type ?? "";
                 }
             }
-            dir = Path.GetDirectoryName(dir);
+            dir = FileDiscovery.AmbientParent(dir);
         }
         return null;
     }

--- a/Modules/ModuleResolver.cs
+++ b/Modules/ModuleResolver.cs
@@ -1120,10 +1120,13 @@ public class ModuleResolver
 
     private bool IsRuntimeFacadeSpecifier(string specifier)
     {
-        string bareSpecifier = specifier.StartsWith("node:", StringComparison.Ordinal)
-            ? specifier[5..]
-            : specifier;
-        return _stdlibChain.TryResolve(bareSpecifier, out var resolved)
+        // A node:* specifier in a declaration file always refers to an ambient module
+        // declaration or the stdlib facade — never to a loadable source file. @types/node
+        // imports modules SharpTS's stdlib doesn't provide (e.g. node:console); those must
+        // bind ambiently rather than fall through to bare-specifier file resolution.
+        if (specifier.StartsWith("node:", StringComparison.Ordinal))
+            return true;
+        return _stdlibChain.TryResolve(specifier, out var resolved)
             && resolved is not null;
     }
 

--- a/Modules/ModuleResolver.cs
+++ b/Modules/ModuleResolver.cs
@@ -406,8 +406,8 @@ public class ModuleResolver
                 }
             }
 
-            // Move up one directory
-            currentDir = Path.GetDirectoryName(currentDir);
+            // Move up one directory, stopping at ambient-walk ceilings (temp root, user profile)
+            currentDir = FileDiscovery.AmbientParent(currentDir);
         }
 
         return null;
@@ -583,7 +583,7 @@ public class ModuleResolver
                 // Found a package.json but no matching import — stop walking
                 return null;
             }
-            dir = Path.GetDirectoryName(dir);
+            dir = FileDiscovery.AmbientParent(dir);
         }
         return null;
     }
@@ -612,7 +612,7 @@ public class ModuleResolver
                     return ResolveExportsPath(resolved, dir);
                 return null;
             }
-            dir = Path.GetDirectoryName(dir);
+            dir = FileDiscovery.AmbientParent(dir);
         }
         return null;
     }
@@ -1756,7 +1756,7 @@ public class ModuleResolver
         while (directory is not null)
         {
             roots.Add(Path.Combine(directory, "node_modules", "@types"));
-            directory = Path.GetDirectoryName(directory);
+            directory = FileDiscovery.AmbientParent(directory);
         }
         return roots;
     }

--- a/Parsing/Parser.Spans.cs
+++ b/Parsing/Parser.Spans.cs
@@ -80,37 +80,4 @@ public partial class Parser
             if (part is Stmt.Sequence nested) RecordLoweredParts(nested, span);
         }
     }
-
-    /// <summary>Records a node's extent as covering exactly one token.</summary>
-    private void RecordSpan(object? node, Token token)
-    {
-        if (node is null || token.Start < 0) return;
-        _spans.Record(node, token.Span);
-    }
-
-    /// <summary>Records a node's extent as running from one token through another.</summary>
-    private void RecordSpan(object? node, Token first, Token last)
-    {
-        if (node is null || first.Start < 0) return;
-        int end = last.End >= 0 ? last.End : first.End;
-        _spans.Record(node, new SourceSpan(first.Start, Math.Max(first.Start, end)));
-    }
-
-    /// <summary>
-    /// Gives a node the parser synthesized the position of the source construct it stands for, so
-    /// that lowered code still points back at what the user wrote.
-    /// </summary>
-    private void CopySpan(object original, object replacement) => _spans.CopySpan(original, replacement);
-
-    /// <summary>
-    /// Gives every node in <paramref name="replacements"/> the position of the construct it was
-    /// lowered from. Destructuring and similar rewrites expand one statement into several.
-    /// </summary>
-    private void CopySpan(object original, IEnumerable<object> replacements) => _spans.CopySpan(original, replacements);
-
-    /// <summary>
-    /// Marks a node as pure scaffolding with no source of its own, so stepping passes through it
-    /// instead of attributing it to whatever statement happens to be nearby.
-    /// </summary>
-    private void MarkHidden(object node) => _spans.MarkHidden(node);
 }

--- a/SharpTS.Tests/Compilation/DebugSymbolsTests.cs
+++ b/SharpTS.Tests/Compilation/DebugSymbolsTests.cs
@@ -389,11 +389,11 @@ public class DebugSymbolsTests
             // ---- sequence points, attributed to the file each method came from
             var byMethod = SequencePointsByMethod(artifacts);
 
-            var helperMethod = Assert.Single(byMethod.Where(m => m.Key.Contains("twice", StringComparison.Ordinal)));
+            var helperMethod = Assert.Single(byMethod, m => m.Key.Contains("twice", StringComparison.Ordinal));
             Assert.Equal("helper.ts", helperMethod.Value.Document);
             Assert.Equal([2, 3], helperMethod.Value.Lines);
 
-            var entryMethod = Assert.Single(byMethod.Where(m => m.Key.Contains("total", StringComparison.Ordinal)));
+            var entryMethod = Assert.Single(byMethod, m => m.Key.Contains("total", StringComparison.Ordinal));
             Assert.Equal("main.ts", entryMethod.Value.Document);
             Assert.Equal([3, 4, 5, 7], entryMethod.Value.Lines);
 

--- a/SharpTS.Tests/Infrastructure/MockHttpServer.cs
+++ b/SharpTS.Tests/Infrastructure/MockHttpServer.cs
@@ -410,6 +410,17 @@ public class MockHttpServer : IDisposable
             // Ignore stop errors
         }
 
+        // Let the accept loop observe the cancellation/stop and exit before the listener and
+        // token source are torn down under it. Bounded so a wedged request can't hang teardown.
+        try
+        {
+            _listenerTask?.Wait(TimeSpan.FromSeconds(2));
+        }
+        catch
+        {
+            // Cancellation surfaces here as AggregateException; the loop is done either way
+        }
+
         try
         {
             _listener.Close();

--- a/SharpTS.Tests/Modules/TypeScriptProgramTests.cs
+++ b/SharpTS.Tests/Modules/TypeScriptProgramTests.cs
@@ -198,6 +198,54 @@ public class TypeScriptProgramTests
     }
 
     [Fact]
+    public void AutomaticTypes_DeclarationPackageNodeImportsDoNotResolveAsFiles()
+    {
+        string entryPath = VirtualPath("node-facade-imports", "src", "main.ts");
+        string packageRoot = VirtualPath(
+            "node-facade-imports", "node_modules", "@types", "node");
+        var files = new Dictionary<string, string>
+        {
+            [entryPath] = "export const answer: number = 42;",
+            [Path.Combine(packageRoot, "index.d.ts")] = """
+                /// <reference path="./console.d.ts" />
+                /// <reference path="./web-globals/console.d.ts" />
+                """,
+            [Path.Combine(packageRoot, "console.d.ts")] = """
+                declare module "node:console" {
+                    interface ConsoleShape {
+                        log(message: string): void;
+                    }
+                    const console: ConsoleShape;
+                    export = console;
+                }
+                """,
+            // Mirrors @types/node's web-globals/console.d.ts: an ESM namespace import of
+            // the package's own ambient "node:console" declaration — a module SharpTS's
+            // stdlib does not provide, so it must not fall through to bare-specifier
+            // file resolution.
+            [Path.Combine(packageRoot, "web-globals", "console.d.ts")] = """
+                export {};
+
+                import * as console from "node:console";
+
+                declare global {
+                    var webConsole: typeof console;
+                }
+                """,
+        };
+        // The legacy/embedding options path (Disabled) resolves imports eagerly rather
+        // than deferring failures to the checker, so it is the path that crashes when
+        // the facade guard misses.
+        var resolver = new ModuleResolver(entryPath, files);
+
+        var entry = resolver.LoadProgram(entryPath);
+        var modules = resolver.GetModulesInOrder(entry);
+
+        Assert.Contains(modules, module =>
+            module.Path.EndsWith("console.d.ts", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void AutomaticTypes_AppliesPackageTypesVersions()
     {
         string entryPath = VirtualPath("types-versions", "src", "main.ts");

--- a/SharpTS.Tests/ReplTests/ReplCompletionProviderTests.cs
+++ b/SharpTS.Tests/ReplTests/ReplCompletionProviderTests.cs
@@ -26,9 +26,6 @@ public class ReplCompletionProviderTests
     private static List<string> Names(ReplEngine engine, string text) =>
         engine.Completions.GetCandidates(text, text.Length).Select(c => c.Name).ToList();
 
-    private static List<string> Names(ReplEngine engine, string text, int caret) =>
-        engine.Completions.GetCandidates(text, caret).Select(c => c.Name).ToList();
-
     // ===================== Context classification =====================
 
     [Theory]

--- a/SharpTS.Tests/TypeCheckerTests/InterfaceImplementationCompatibilityTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/InterfaceImplementationCompatibilityTests.cs
@@ -26,9 +26,6 @@ public class InterfaceImplementationCompatibilityTests
         return new TypeChecker(maxErrors: 50).CheckWithRecovery(parseResult.Statements).Diagnostics;
     }
 
-    private static void AssertHasCode(IReadOnlyList<Diagnostic> diags, string tsCode) =>
-        Assert.Contains(diags, d => d.TsCode == tsCode);
-
     private static void AssertNoCode(IReadOnlyList<Diagnostic> diags, string tsCode) =>
         Assert.DoesNotContain(diags, d => d.TsCode == tsCode);
 


### PR DESCRIPTION
Three independent fixes that shipped on this branch together.

## Stop ambient upward walks at the temp and user-profile ceilings

FileDiscovery already refused to let a stray `tsconfig.json` in `%TEMP%` reconfigure whatever compiles below it, but six other upward walks never got that policy: ModuleResolver''s `node_modules` probe, subpath-import and self-reference `package.json` walks, and `@types` roots; CommonJsDetector''s `package.json` type walk; and TsConfigLoader''s bare `extends` walk. Any of them could pick up debris that unrelated tooling left in the global temp folder or the user profile.

The ceiling policy is now shared through `FileDiscovery.AmbientParent`: the start directory is still probed even when it is itself a ceiling, but no walk ascends into one. Validated by running the full suite with a hostile `%TEMP%` (a commonjs `package.json`, a strict `tsconfig.json`, a `sharpts.json`, and `node_modules/@types/node` all present).

## Bind declaration-file node:* imports ambiently, not as files

The declaration-file facade guard skipped a `node:*` import only when the stdlib chain could serve the bare name, so @types/node''s own `web-globals/console.d.ts` — `import * as console from "node:console"`, a module SharpTS''s stdlib does not provide — fell through to bare-specifier file resolution and threw. The CLI path hid this by deferring resolution failures to the checker; embedding callers using `TypeScriptProgramOptions.Disabled` crashed outright.

A `node:*` specifier in a declaration file can only mean an ambient module declaration or the stdlib facade, never a loadable source file, so the guard now skips every `node:*` import unconditionally. Regression test mirrors the real @types/node shape (verified against @types/node 25.9.1 on disk).

## Clear all build warnings (11 → 0)

Two were substantive:

- **CS8604 in `ILCompiler.RegisterModuleDocuments`** — the debug-scope table indexed a "normalized spelling" that `NormalizeToEmissionPath` can never produce: it either returns the path unchanged or folds a script path to `null`, so the insert was a duplicate key write today and a null-key `ArgumentNullException` if the phases ever reorder. Registration now keys by raw path only and documents that null-path emission is served by the entry-point fallback.
- **IDE0052 in `MockHttpServer`** — the accept-loop task was assigned but never observed, so `Dispose` could tear down the listener and token source while the loop was still touching them during parallel test cleanup. `Dispose` now joins the loop (2s bound) before closing either.

The rest: removed never-called members (the Parser span-recording wrappers left over from the span-table work, an unused REPL-completion test helper overload, an unused diagnostic assertion helper) and switched `DebugSymbolsTests` to the `Assert.Single` predicate overload (xUnit2031).

## Testing

- Full suite: 16,093 passed, 0 failed
- Build: 0 warnings, 0 errors
- Hermeticity commit additionally validated against a hostile `%TEMP%` as described above