### PR TITLE
LSP: add checker-backed local go-to-definition

### DIFF
--- a/SharpTS.LanguageServer/Handlers/DefinitionHandler.cs
+++ b/SharpTS.LanguageServer/Handlers/DefinitionHandler.cs
@@ -1,0 +1,53 @@
+using MediatR;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpTS.LanguageServer.Services;
+
+namespace SharpTS.LanguageServer.Handlers;
+
+/// <summary>
+/// Serves <c>textDocument/definition</c> for checker-resolved local value bindings.
+/// </summary>
+/// <remarks>
+/// Registered only in <see cref="LanguageFeatureMode.Full"/> so the VS Code extension continues
+/// leaving ordinary TypeScript navigation exclusively to <c>tsserver</c>.
+/// </remarks>
+public sealed class DefinitionHandler : DefinitionHandlerBase
+{
+    private readonly DocumentStore _store;
+    private readonly DefinitionService _definitions;
+
+    public DefinitionHandler(DocumentStore store, DefinitionService definitions)
+    {
+        _store = store;
+        _definitions = definitions;
+    }
+
+    public override Task<LocationOrLocationLinks?> Handle(
+        DefinitionParams request,
+        CancellationToken ct)
+    {
+        string uri = request.TextDocument.Uri.ToString();
+        if (!_store.TryGet(uri, out var text))
+            return Task.FromResult<LocationOrLocationLinks?>(null);
+
+        ct.ThrowIfCancellationRequested();
+
+        var locations = _definitions.FindDefinitions(
+                request.TextDocument.Uri.GetFileSystemPath(),
+                text,
+                request.Position)
+            .Select(location => new LocationOrLocationLink(location));
+        return Task.FromResult<LocationOrLocationLinks?>(
+            new LocationOrLocationLinks(locations));
+    }
+
+    protected override DefinitionRegistrationOptions CreateRegistrationOptions(
+        DefinitionCapability capability,
+        ClientCapabilities clientCapabilities)
+        => new()
+        {
+            DocumentSelector = TextDocumentSelector.ForLanguage("typescript", "typescriptreact"),
+        };
+}

--- a/SharpTS.LanguageServer/Services/DefinitionService.cs
+++ b/SharpTS.LanguageServer/Services/DefinitionService.cs
@@ -1,0 +1,88 @@
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpTS.Diagnostics;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace SharpTS.LanguageServer.Services;
+
+/// <summary>
+/// Resolves source positions to checker-bound local value declarations.
+/// </summary>
+/// <remarks>
+/// The service intentionally returns no result for names the checker did not bind. In particular,
+/// property/member navigation and cross-module import targets need their own complete semantic
+/// domains; guessing from matching text would produce incorrect navigation under shadowing.
+/// </remarks>
+public sealed class DefinitionService
+{
+    /// <summary>
+    /// Finds the local value declaration selected by an LSP position.
+    /// </summary>
+    public IReadOnlyList<Location> FindDefinitions(
+        string path,
+        string text,
+        Position position)
+    {
+        var document = new SourceDocument(path, text);
+
+        ParseDiagnosticResult parsed;
+        try
+        {
+            var parser = new Parser(
+                    new Lexer(text) { JsxTolerant = IsJsx(path) }.ScanTokens(),
+                    DecoratorMode.Stage3)
+                .WithSourceDocument(document);
+            if (IsJsx(path))
+                parser.WithJsx(text, JsxParseOptions.Default);
+            parsed = parser.Parse();
+        }
+        catch
+        {
+            return [];
+        }
+
+        if (!parsed.IsSuccess)
+            return [];
+
+        var checker = new TypeChecker().WithFilePath(path);
+        try
+        {
+            // Recovery keeps useful bindings from the rest of a file when an unrelated statement
+            // has a type error. A failure in checker setup still degrades safely to no definition.
+            checker.CheckWithRecovery(parsed.Statements, document);
+        }
+        catch
+        {
+            return [];
+        }
+
+        int offset = document.Lines.ToOffset(
+            (int)position.Line + 1,
+            (int)position.Character + 1);
+        return checker.Bindings.FindDefinitions(document, offset)
+            .Select(ToLocation)
+            .ToArray();
+    }
+
+    private static Location ToLocation(BindingDeclaration declaration)
+    {
+        var document = declaration.Document;
+        var (startLine, startColumn) = document.Lines.ToPosition(declaration.Name.Start);
+        var (endLine, endColumn) = document.Lines.ToPosition(declaration.Name.End);
+        return new Location
+        {
+            Uri = DocumentUri.FromFileSystemPath(document.Path),
+            Range = new Range(
+                startLine - 1,
+                startColumn - 1,
+                endLine - 1,
+                endColumn - 1),
+        };
+    }
+
+    private static bool IsJsx(string path) =>
+        path.EndsWith(".tsx", StringComparison.OrdinalIgnoreCase) ||
+        path.EndsWith(".jsx", StringComparison.OrdinalIgnoreCase);
+}

--- a/SharpTS.LanguageServer/SharpTS.LanguageServer.csproj
+++ b/SharpTS.LanguageServer/SharpTS.LanguageServer.csproj
@@ -10,7 +10,7 @@
     <ToolCommandName>sharpts-lsp</ToolCommandName>
     <PackageId>SharpTS.LanguageServer</PackageId>
     <IsPackable>true</IsPackable>
-    <Description>LSP language server for SharpTS (.NET interop diagnostics, hover, completion).</Description>
+    <Description>LSP language server for SharpTS (.NET interop diagnostics, completion, and standalone navigation).</Description>
   </PropertyGroup>
 
   <!-- Directory.Build.props sets PackageLicenseFile=LICENSE for all packages; include the

--- a/SharpTS.LanguageServer/SharpTSLanguageServer.cs
+++ b/SharpTS.LanguageServer/SharpTSLanguageServer.cs
@@ -36,7 +36,8 @@ public static class SharpTSLanguageServer
                     .AddSingleton(new DiagnosticsService(resolve))
                     .AddSingleton(new DecoratorService(resolve, typeNames))
                     .AddSingleton(new MemberHoverService(resolve))
-                    .AddSingleton<DocumentSymbolService>())
+                    .AddSingleton<DocumentSymbolService>()
+                    .AddSingleton<DefinitionService>())
                 // Served in both modes: this is the interop knowledge no other server has.
                 .WithHandler<TextDocumentSyncHandler>()
                 .WithHandler<HoverHandler>()
@@ -46,7 +47,11 @@ public static class SharpTSLanguageServer
             // Registering a handler is what advertises its capability, so the mode has to be
             // decided here rather than consulted later.
             if (mode == LanguageFeatureMode.Full)
-                options.WithHandler<DocumentSymbolHandler>();
+            {
+                options
+                    .WithHandler<DocumentSymbolHandler>()
+                    .WithHandler<DefinitionHandler>();
+            }
         });
 
         await server.WaitForExit;

--- a/SharpTS.Tests/LanguageServer/DefinitionServiceTests.cs
+++ b/SharpTS.Tests/LanguageServer/DefinitionServiceTests.cs
@@ -1,0 +1,231 @@
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpTS.LanguageServer;
+using SharpTS.LanguageServer.Handlers;
+using SharpTS.LanguageServer.Services;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+using Xunit;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace SharpTS.Tests.LanguageServer;
+
+/// <summary>
+/// Covers local value navigation through the checker's semantic binding index. These cases are
+/// deliberately scope-sensitive: a text search could pass the simple name checks but not the
+/// shadowing, hoisting, or parameter-default cases.
+/// </summary>
+public class DefinitionServiceTests
+{
+    private readonly DefinitionService _definitions = new();
+
+    [Fact]
+    public void ForwardFunctionReferenceResolvesThroughHoisting()
+    {
+        const string source = """
+            greet();
+            function greet(): void {}
+            """;
+
+        var definition = Assert.Single(Definitions(source, "greet", occurrence: 0));
+
+        Assert.Equal(new Range(1, 9, 1, 14), definition.Range);
+    }
+
+    [Fact]
+    public void ShadowedLocalResolvesToTheNarrowestCheckerScope()
+    {
+        const string source = """
+            const value = 1;
+            function read(): number {
+              const value = 2;
+              return value;
+            }
+            """;
+
+        var definition = Assert.Single(Definitions(source, "value", occurrence: 2));
+
+        Assert.Equal(new Range(2, 8, 2, 13), definition.Range);
+    }
+
+    [Fact]
+    public void ParameterDefaultBindsToThePrecedingParameter()
+    {
+        const string source =
+            "function scale(input: number, factor: number = input): number { return factor; }\n";
+
+        var definition = Assert.Single(Definitions(source, "input", occurrence: 1));
+
+        Assert.Equal(new Range(0, 15, 0, 20), definition.Range);
+    }
+
+    [Fact]
+    public void AssignmentTargetResolvesToItsDeclaration()
+    {
+        const string source = """
+            let count = 0;
+            count = 1;
+            """;
+
+        var definition = Assert.Single(Definitions(source, "count", occurrence: 1));
+
+        Assert.Equal(new Range(0, 4, 0, 9), definition.Range);
+    }
+
+    [Fact]
+    public void ArrowBodyResolvesToItsParameter()
+    {
+        const string source = "const select = (item: number): number => item;\n";
+
+        var definition = Assert.Single(Definitions(source, "item", occurrence: 1));
+
+        Assert.Equal(new Range(0, 16, 0, 20), definition.Range);
+    }
+
+    [Fact]
+    public void CatchAndLoopBindingsUseTheirLexicalDeclarations()
+    {
+        const string source = """
+            try {} catch (error) { console.log(error); }
+            for (const item of [1]) { console.log(item); }
+            """;
+
+        var catchDefinition = Assert.Single(Definitions(source, "error", occurrence: 1));
+        var loopDefinition = Assert.Single(Definitions(source, "item", occurrence: 1));
+
+        Assert.Equal(new Range(0, 14, 0, 19), catchDefinition.Range);
+        Assert.Equal(new Range(1, 11, 1, 15), loopDefinition.Range);
+    }
+
+    [Fact]
+    public void ClassValueReferenceResolvesToTheClassDeclaration()
+    {
+        const string source = "class Box { create() { return new Box(); } }\n";
+
+        var definition = Assert.Single(Definitions(source, "Box", occurrence: 1));
+
+        Assert.Equal(new Range(0, 6, 0, 9), definition.Range);
+    }
+
+    [Fact]
+    public void TypeErrorsElsewhereDoNotEraseValidBindings()
+    {
+        const string source = """
+            const target = 1;
+            const bad: number = "wrong";
+            console.log(target);
+            """;
+
+        var definition = Assert.Single(Definitions(source, "target", occurrence: 1));
+
+        Assert.Equal(new Range(0, 6, 0, 12), definition.Range);
+    }
+
+    [Fact]
+    public void PropertyNamesAreNotGuessedFromMatchingText()
+    {
+        const string source = """
+            const value = 1;
+            const object = { value: 2 };
+            console.log(object.value);
+            """;
+
+        Assert.Empty(Definitions(source, "value", occurrence: 2));
+    }
+
+    [Fact]
+    public void FunctionOverloadsShareOneIdentityWithAllDeclarations()
+    {
+        const string source = """
+            function convert(value: string): string;
+            function convert(value: number): number;
+            function convert(value: string | number): string | number { return value; }
+            convert("x");
+            """;
+
+        var definitions = Definitions(source, "convert", occurrence: 3);
+
+        Assert.Equal(3, definitions.Count);
+        Assert.Equal(
+            [0, 1, 2],
+            definitions.Select(location => (int)location.Range.Start.Line).ToArray());
+    }
+
+    [Fact]
+    public void ReusedCheckerDoesNotReturnStaleDeclarationsFromAPriorCheck()
+    {
+        var checker = new TypeChecker();
+        var first = Parse("first.ts", "const current = 1; console.log(current);\n");
+        checker.CheckWithRecovery(first.Statements, first.Document);
+
+        var second = Parse("second.ts", "const current = 2; console.log(current);\n");
+        checker.CheckWithRecovery(second.Statements, second.Document);
+
+        var definition = Assert.Single(checker.Bindings.FindDefinitions(
+            second.Document,
+            second.Document.Text.LastIndexOf("current", StringComparison.Ordinal)));
+        Assert.Same(second.Document, definition.Document);
+        Assert.Equal(6, definition.Name.Start);
+    }
+
+    [Fact]
+    public async Task HandlerReturnsTheDefinitionFromTheOpenDocumentSnapshot()
+    {
+        string path = Path.GetFullPath("handler-definition-test.ts");
+        DocumentUri uri = DocumentUri.FromFileSystemPath(path);
+        const string source = "const answer = 42;\nconsole.log(answer);\n";
+        var store = new DocumentStore();
+        store.Set(uri.ToString(), source);
+        var handler = new DefinitionHandler(store, new DefinitionService());
+
+        var result = await handler.Handle(
+            new DefinitionParams
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Position = new Position(1, 12),
+            },
+            CancellationToken.None);
+
+        var target = Assert.Single(Assert.IsAssignableFrom<LocationOrLocationLinks>(result));
+        Assert.True(target.IsLocation);
+        var location = Assert.IsType<Location>(target.Location);
+        Assert.Equal(new Range(0, 6, 0, 12), location.Range);
+    }
+
+    private IReadOnlyList<Location> Definitions(
+        string source,
+        string name,
+        int occurrence)
+    {
+        int offset = NthIndexOf(source, name, occurrence);
+        var lines = new SharpTS.Parsing.LineIndex(source);
+        var (line, column) = lines.ToPosition(offset);
+        return _definitions.FindDefinitions(
+            Path.GetFullPath("definition-test.ts"),
+            source,
+            new Position(line - 1, column - 1));
+    }
+
+    private static int NthIndexOf(string source, string value, int occurrence)
+    {
+        int offset = -1;
+        for (int i = 0; i <= occurrence; i++)
+        {
+            offset = source.IndexOf(value, offset + 1, StringComparison.Ordinal);
+            Assert.True(offset >= 0, $"Occurrence {occurrence} of '{value}' was not found.");
+        }
+        return offset;
+    }
+
+    private static (List<Stmt> Statements, SourceDocument Document) Parse(
+        string path,
+        string source)
+    {
+        var document = new SourceDocument(path, source);
+        var parsed = new Parser(new Lexer(source).ScanTokens())
+            .WithSourceDocument(document)
+            .Parse();
+        Assert.True(parsed.IsSuccess);
+        return (parsed.Statements, document);
+    }
+}

--- a/TypeSystem/BindingIndex.cs
+++ b/TypeSystem/BindingIndex.cs
@@ -1,0 +1,151 @@
+using SharpTS.Parsing;
+
+namespace SharpTS.TypeSystem;
+
+/// <summary>
+/// The namespace in which a TypeScript binding is resolved.
+/// </summary>
+public enum BindingNamespace
+{
+    Value,
+    Type,
+    Label,
+}
+
+/// <summary>
+/// One source declaration participating in a semantic binding.
+/// </summary>
+public sealed record BindingDeclaration(SourceDocument Document, Token Name);
+
+/// <summary>
+/// Stable identity for one checker-resolved symbol.
+/// </summary>
+/// <remarks>
+/// A symbol may have more than one declaration (for example, function overloads or legal
+/// <c>var</c> redeclarations). Uses point at the identity rather than directly at a span so later
+/// references and rename support can share the same resolution result.
+/// </remarks>
+public sealed class BindingSymbol
+{
+    private readonly List<BindingDeclaration> _declarations = [];
+
+    internal BindingSymbol(
+        int id,
+        int generation,
+        string name,
+        BindingNamespace bindingNamespace)
+    {
+        Id = id;
+        Generation = generation;
+        Name = name;
+        Namespace = bindingNamespace;
+    }
+
+    public int Id { get; }
+    internal int Generation { get; }
+    public string Name { get; }
+    public BindingNamespace Namespace { get; }
+    public IReadOnlyList<BindingDeclaration> Declarations => _declarations;
+
+    internal void AddDeclaration(SourceDocument? document, Token name)
+    {
+        if (document is null || name.Start < 0)
+            return;
+
+        if (_declarations.Any(d =>
+                ReferenceEquals(d.Document, document) && ReferenceEquals(d.Name, name)))
+            return;
+
+        _declarations.Add(new BindingDeclaration(document, name));
+    }
+}
+
+/// <summary>
+/// Checker-produced map from source tokens to semantic binding identities.
+/// </summary>
+/// <remarks>
+/// This is deliberately populated at the same points where <see cref="TypeEnvironment"/> defines
+/// and resolves names. It therefore follows the checker's real hoisting and shadowing behavior
+/// instead of maintaining a second, editor-only implementation of TypeScript scopes.
+/// </remarks>
+public sealed class BindingIndex
+{
+    private readonly Dictionary<Token, BindingSymbol> _tokens =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<Token, SourceDocument> _documents =
+        new(ReferenceEqualityComparer.Instance);
+    private int _nextId = 1;
+    private int _generation;
+
+    internal void Clear()
+    {
+        _tokens.Clear();
+        _documents.Clear();
+        _generation++;
+    }
+
+    internal BindingSymbol Declare(
+        Token declaration,
+        SourceDocument? document,
+        BindingNamespace bindingNamespace,
+        BindingSymbol? existing = null)
+    {
+        if (_tokens.TryGetValue(declaration, out var alreadyDeclared))
+            return alreadyDeclared;
+
+        var symbol = existing is { Generation: var generation } && generation == _generation
+            ? existing
+            : new BindingSymbol(
+                _nextId++,
+                _generation,
+                declaration.Lexeme,
+                bindingNamespace);
+
+        symbol.AddDeclaration(document, declaration);
+        _tokens[declaration] = symbol;
+        if (document is not null && declaration.Start >= 0)
+            _documents[declaration] = document;
+        return symbol;
+    }
+
+    internal void Bind(Token use, SourceDocument? document, BindingSymbol symbol)
+    {
+        if (use.Start < 0 || symbol.Generation != _generation)
+            return;
+
+        _tokens[use] = symbol;
+        if (document is not null)
+            _documents[use] = document;
+    }
+
+    /// <summary>
+    /// Returns the declarations for the binding at a UTF-16 source offset.
+    /// </summary>
+    public IReadOnlyList<BindingDeclaration> FindDefinitions(
+        SourceDocument document,
+        int offset,
+        BindingNamespace bindingNamespace = BindingNamespace.Value)
+    {
+        BindingSymbol? best = null;
+        int bestLength = int.MaxValue;
+
+        foreach (var (token, symbol) in _tokens)
+        {
+            if (symbol.Namespace != bindingNamespace ||
+                !_documents.TryGetValue(token, out var tokenDocument) ||
+                !ReferenceEquals(tokenDocument, document) ||
+                !token.Span.Contains(offset))
+            {
+                continue;
+            }
+
+            if (token.Span.Length < bestLength)
+            {
+                best = symbol;
+                bestLength = token.Span.Length;
+            }
+        }
+
+        return best?.Declarations ?? [];
+    }
+}

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1445,7 +1445,7 @@ public partial class TypeChecker
                 // Rest parameters are not counted toward required params
                 if (param.IsRest)
                 {
-                    paramScope.Define(param.Name.Lexeme, paramType);
+                    DeclareValue(paramScope, param.Name, paramType);
                     continue;
                 }
 
@@ -1475,7 +1475,7 @@ public partial class TypeChecker
                     requiredParams++;
                 }
 
-                paramScope.Define(param.Name.Lexeme, paramType);
+                DeclareValue(paramScope, param.Name, paramType);
             }
 
             // Determine return type (use expected type if available and no explicit annotation)
@@ -1508,7 +1508,7 @@ public partial class TypeChecker
         // Note: Parameters can shadow the function name, so define name first
         if (arrow.Name != null)
         {
-            arrowEnv.Define(arrow.Name.Lexeme, funcType);
+            DeclareValue(arrowEnv, arrow.Name, funcType);
             arrowEnv.MarkAsConst(arrow.Name.Lexeme);  // Function name is read-only in strict mode
         }
 
@@ -1519,7 +1519,10 @@ public partial class TypeChecker
         var bodyParamTypes = WidenOptionalParamsForBody(paramTypes, arrow.Parameters);
         for (int i = 0; i < arrow.Parameters.Count; i++)
         {
-            arrowEnv.Define(arrow.Parameters[i].Name.Lexeme, bodyParamTypes[i]);
+            DeclareValue(
+                arrowEnv,
+                arrow.Parameters[i].Name,
+                bodyParamTypes[i]);
         }
 
         // Save and set context - function bodies are isolated from outer loop/switch/label context
@@ -1666,6 +1669,8 @@ public partial class TypeChecker
 
     private TypeInfo CheckAssign(Expr.Assign assign)
     {
+        BindValueUse(assign.Name);
+
         // For assignment, check against the DECLARED type, not the narrowed type
         // This allows reassigning within narrowed scopes (e.g., x = "found" when x was narrowed to null)
         // Use GetDeclaredType to get the original declared type, not the potentially narrowed type
@@ -1792,6 +1797,7 @@ public partial class TypeChecker
         // structural signatures.
         if (_environment.Get(name.Lexeme) is { } declared)
         {
+            BindValueUse(name);
             var declaredPath = new Narrowing.NarrowingPath.Variable(name.Lexeme);
             return GetNarrowing(declaredPath) ?? declared;
         }
@@ -1989,7 +1995,7 @@ public partial class TypeChecker
         // If named, define the name in class body scope for self-reference
         if (classExpr.Name != null)
         {
-            classTypeEnv.Define(classExpr.Name.Lexeme, mutableClass);
+            DeclareValue(classTypeEnv, classExpr.Name, mutableClass);
         }
 
         using (new EnvironmentScope(this, classTypeEnv))
@@ -2267,7 +2273,10 @@ public partial class TypeChecker
 
                 var bodyParamTypes = WidenOptionalParamsForBody(methodType.ParamTypes, method.Parameters);
                 for (int i = 0; i < method.Parameters.Count; i++)
-                    methodEnv.Define(method.Parameters[i].Name.Lexeme, bodyParamTypes[i]);
+                    DeclareValue(
+                        methodEnv,
+                        method.Parameters[i].Name,
+                        bodyParamTypes[i]);
 
                 TypeEnvironment previousEnvFunc = _environment;
                 TypeInfo? previousReturnFunc = _currentFunctionReturnType;
@@ -2397,7 +2406,10 @@ public partial class TypeChecker
                         if (accessor.SetterParam != null)
                         {
                             TypeInfo setterParamType = classTypeForBody.Setters[accessor.Name.Lexeme];
-                            accessorEnv.Define(accessor.SetterParam.Name.Lexeme, setterParamType);
+                            DeclareValue(
+                                accessorEnv,
+                                accessor.SetterParam.Name,
+                                setterParamType);
                         }
                     }
 

--- a/TypeSystem/TypeChecker.Namespaces.cs
+++ b/TypeSystem/TypeChecker.Namespaces.cs
@@ -16,6 +16,7 @@ public partial class TypeChecker
     private void CheckNamespace(Stmt.Namespace ns)
     {
         string name = ns.Name.Lexeme;
+        RegisterValueDeclaration(ns.Name, mergeWithLocal: true);
 
         // Get or create namespace - use mutable dictionaries for construction
         TypeInfo.Namespace? existingNs = _environment.GetNamespace(name);
@@ -353,6 +354,8 @@ public partial class TypeChecker
         };
 
         // Register the alias
+        if (isValue)
+            RegisterValueDeclaration(importAlias.AliasName);
         _environment.DefineImportAlias(aliasName, resolvedType, isValue);
     }
 }

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -39,6 +39,8 @@ public partial class TypeChecker
 
     private void CheckClassDeclaration(Stmt.Class classStmt)
     {
+        RegisterValueDeclaration(classStmt.Name);
+
         // Check class decorators
         CheckDecorators(classStmt.Decorators, DecoratorTarget.Class);
 
@@ -881,7 +883,10 @@ public partial class TypeChecker
                 var bodyParamTypes = WidenOptionalParamsForBody(methodType.ParamTypes, method.Parameters);
                 for (int i = 0; i < method.Parameters.Count; i++)
                 {
-                    methodEnv.Define(method.Parameters[i].Name.Lexeme, bodyParamTypes[i]);
+                    DeclareValue(
+                        methodEnv,
+                        method.Parameters[i].Name,
+                        bodyParamTypes[i]);
                 }
 
                 // Save and set context - method bodies are isolated from outer loop/switch/label context
@@ -1029,7 +1034,10 @@ public partial class TypeChecker
                             TypeInfo setterParamType = accessor.ComputedKey != null
                                 ? (accessor.SetterParam.Type != null ? ResolveAnnotation(accessor.SetterParam.Type, accessor.SetterParam.TypeAnnotationNode)! : TypeInfo.Any.Shared)
                                 : classTypeForBody.Setters[accessor.Name.Lexeme];
-                            accessorEnv.Define(accessor.SetterParam.Name.Lexeme, setterParamType);
+                            DeclareValue(
+                                accessorEnv,
+                                accessor.SetterParam.Name,
+                                setterParamType);
                         }
                     }
 

--- a/TypeSystem/TypeChecker.Statements.ControlFlow.cs
+++ b/TypeSystem/TypeChecker.Statements.ControlFlow.cs
@@ -76,7 +76,9 @@ public partial class TypeChecker
         if (tryCatch.CatchBlock != null && tryCatch.CatchParam != null)
         {
             TypeEnvironment catchEnv = new(_environment);
-            catchEnv.Define(tryCatch.CatchParam.Lexeme,
+            DeclareValue(
+                catchEnv,
+                tryCatch.CatchParam,
                 tryCatch.CatchParamType == "unknown"
                     ? TypeInfo.Unknown.Shared
                     : TypeInfo.Any.Shared);

--- a/TypeSystem/TypeChecker.Statements.Enums.cs
+++ b/TypeSystem/TypeChecker.Statements.Enums.cs
@@ -11,6 +11,8 @@ public partial class TypeChecker
 {
     private void CheckEnumDeclaration(Stmt.Enum enumStmt)
     {
+        RegisterValueDeclaration(enumStmt.Name, mergeWithLocal: true);
+
         Dictionary<string, object> members = [];
         double? currentNumericValue = null;
         bool hasNumeric = false;
@@ -98,7 +100,7 @@ public partial class TypeChecker
         };
 
         var enumType = new TypeInfo.Enum(enumStmt.Name.Lexeme, members.ToFrozenDictionary(), kind, enumStmt.IsConst);
-        _environment.Define(enumStmt.Name.Lexeme, enumType);
+        DeclareValue(enumStmt.Name, enumType, mergeWithLocal: true);
         _environment.DefineType(enumStmt.Name.Lexeme, enumType);
     }
 

--- a/TypeSystem/TypeChecker.Statements.Functions.cs
+++ b/TypeSystem/TypeChecker.Statements.Functions.cs
@@ -165,10 +165,12 @@ public partial class TypeChecker
             switch (stmt)
             {
                 case Stmt.Var v when v.IsVar:
+                    RegisterValueDeclaration(v.Name, mergeWithLocal: true);
                     if (!_environment.IsDefinedLocally(v.Name.Lexeme))
                         _environment.Define(v.Name.Lexeme, TypeInfo.Any.Shared);
                     break;
                 case Stmt.Export { Declaration: Stmt.Var v } when v.IsVar:
+                    RegisterValueDeclaration(v.Name, mergeWithLocal: true);
                     if (!_environment.IsDefinedLocally(v.Name.Lexeme))
                         _environment.Define(v.Name.Lexeme, TypeInfo.Any.Shared);
                     break;
@@ -201,18 +203,22 @@ public partial class TypeChecker
             {
                 // `let` is Stmt.Var with IsVar == false; `var` is handled by HoistVarDeclarations.
                 case Stmt.Var v when !v.IsVar:
+                    RegisterValueDeclaration(v.Name);
                     if (!_environment.IsDefinedLocally(v.Name.Lexeme))
                         _environment.Define(v.Name.Lexeme, TypeInfo.Any.Shared);
                     break;
                 case Stmt.Const c:
+                    RegisterValueDeclaration(c.Name);
                     if (!_environment.IsDefinedLocally(c.Name.Lexeme))
                         _environment.Define(c.Name.Lexeme, TypeInfo.Any.Shared);
                     break;
                 case Stmt.Export { Declaration: Stmt.Var v } when !v.IsVar:
+                    RegisterValueDeclaration(v.Name);
                     if (!_environment.IsDefinedLocally(v.Name.Lexeme))
                         _environment.Define(v.Name.Lexeme, TypeInfo.Any.Shared);
                     break;
                 case Stmt.Export { Declaration: Stmt.Const c }:
+                    RegisterValueDeclaration(c.Name);
                     if (!_environment.IsDefinedLocally(c.Name.Lexeme))
                         _environment.Define(c.Name.Lexeme, TypeInfo.Any.Shared);
                     break;
@@ -241,11 +247,13 @@ public partial class TypeChecker
             switch (stmt)
             {
                 case Stmt.Class cls:
+                    RegisterValueDeclaration(cls.Name);
                     _classDeclarationLines[cls.Name.Lexeme] = cls.Name.Line;
                     if (!_environment.IsDefinedLocally(cls.Name.Lexeme))
                         _environment.Define(cls.Name.Lexeme, TypeInfo.Any.Shared);
                     break;
                 case Stmt.Export { Declaration: Stmt.Class exportCls }:
+                    RegisterValueDeclaration(exportCls.Name);
                     _classDeclarationLines[exportCls.Name.Lexeme] = exportCls.Name.Line;
                     if (!_environment.IsDefinedLocally(exportCls.Name.Lexeme))
                         _environment.Define(exportCls.Name.Lexeme, TypeInfo.Any.Shared);
@@ -286,6 +294,8 @@ public partial class TypeChecker
     /// </summary>
     private void HoistConstFunctionExpression(Token name, string? typeAnnotation, Expr.ArrowFunction arrow, TypeNode? typeAnnotationNode = null)
     {
+        RegisterValueDeclaration(name);
+
         // Skip if already defined
         if (_environment.IsDefinedLocally(name.Lexeme)) return;
 
@@ -385,6 +395,7 @@ public partial class TypeChecker
     private void HoistSingleFunction(Stmt.Function funcStmt)
     {
         string funcName = funcStmt.Name.Lexeme;
+        RegisterValueDeclaration(funcStmt.Name, mergeWithLocal: true);
 
         // Skip if already defined (e.g., from overload processing)
         // But allow overwriting built-in Any types (like process, console) with user definitions
@@ -474,6 +485,8 @@ public partial class TypeChecker
     /// </summary>
     private void CheckFunctionDeclaration(Stmt.Function funcStmt)
     {
+        RegisterValueDeclaration(funcStmt.Name, mergeWithLocal: true);
+
         string funcName = funcStmt.Name.Lexeme;
 
         // Build the function type for this declaration
@@ -675,7 +688,10 @@ public partial class TypeChecker
         var bodyParamTypes = WidenOptionalParamsForBody(paramTypes, funcStmt.Parameters);
         for (int i = 0; i < funcStmt.Parameters.Count; i++)
         {
-            funcEnv.Define(funcStmt.Parameters[i].Name.Lexeme, bodyParamTypes[i]);
+            DeclareValue(
+                funcEnv,
+                funcStmt.Parameters[i].Name,
+                bodyParamTypes[i]);
         }
 
         // Save and set context - function bodies are isolated from outer loop/switch/label context

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -134,6 +134,8 @@ public partial class TypeChecker
 
     internal VoidResult VisitVar(Stmt.Var stmt)
     {
+        RegisterValueDeclaration(stmt.Name, mergeWithLocal: stmt.IsVar);
+
         // Captured before any provisional Define overwrites it — used for the TS2403
         // redeclaration check once this declaration's type settles. Locally only: a same-named
         // var in an OUTER scope is shadowing, not redeclaration.
@@ -371,6 +373,8 @@ public partial class TypeChecker
 
     internal VoidResult VisitConst(Stmt.Const stmt)
     {
+        RegisterValueDeclaration(stmt.Name);
+
         TypeInfo constDeclaredType;
 
         // Track variable-to-variable aliases for narrowing invalidation
@@ -956,7 +960,7 @@ public partial class TypeChecker
         };
 
         TypeEnvironment forOfEnv = new(_environment);
-        forOfEnv.Define(stmt.Variable.Lexeme, elementType);
+        DeclareValue(forOfEnv, stmt.Variable, elementType);
 
         CheckLoopBody(stmt.Body, conditionNarrowings: null, loopEnvironment: forOfEnv);
         return VoidResult.Instance;
@@ -990,7 +994,13 @@ public partial class TypeChecker
         }
 
         TypeEnvironment forInEnv = new(_environment);
-        forInEnv.Define(stmt.Variable.Lexeme, TypeInfo.String.Shared);
+        if (stmt.IsDeclaration)
+            DeclareValue(forInEnv, stmt.Variable, TypeInfo.String.Shared);
+        else
+        {
+            BindValueUse(stmt.Variable);
+            forInEnv.Define(stmt.Variable.Lexeme, TypeInfo.String.Shared);
+        }
 
         CheckLoopBody(stmt.Body, conditionNarrowings: null, loopEnvironment: forInEnv);
         return VoidResult.Instance;
@@ -1316,7 +1326,7 @@ public partial class TypeChecker
             // Define variable (const-like - cannot reassign)
             if (binding.Name != null)
             {
-                _environment.Define(binding.Name.Lexeme, resourceType);
+                DeclareValue(binding.Name, resourceType);
             }
         }
     }

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -60,6 +60,61 @@ public partial class TypeChecker
 
     private TypeEnvironment _environment = new();
     private TypeMap _typeMap = new();
+    private SourceDocument? _standaloneSourceDocument;
+
+    /// <summary>
+    /// Semantic declaration identities and use-to-declaration bindings produced by the most recent
+    /// check.
+    /// </summary>
+    public BindingIndex Bindings { get; } = new();
+
+    private SourceDocument? CurrentSourceDocument =>
+        _currentModule?.Document ?? _standaloneSourceDocument;
+
+    private void DeclareValue(
+        TypeEnvironment environment,
+        Token declaration,
+        TypeInfo type,
+        bool mergeWithLocal = false)
+    {
+        BindingSymbol symbol = RegisterValueDeclaration(
+            environment,
+            declaration,
+            mergeWithLocal);
+        environment.Define(declaration.Lexeme, type);
+        environment.DefineValueBinding(declaration.Lexeme, symbol);
+    }
+
+    private BindingSymbol RegisterValueDeclaration(
+        TypeEnvironment environment,
+        Token declaration,
+        bool mergeWithLocal = false)
+    {
+        BindingSymbol? existing = mergeWithLocal
+            ? environment.GetLocalValueBinding(declaration.Lexeme)
+            : null;
+        BindingSymbol symbol = Bindings.Declare(
+            declaration,
+            CurrentSourceDocument,
+            BindingNamespace.Value,
+            existing);
+        environment.DefineValueBinding(declaration.Lexeme, symbol);
+        return symbol;
+    }
+
+    private void DeclareValue(Token declaration, TypeInfo type, bool mergeWithLocal = false) =>
+        DeclareValue(_environment, declaration, type, mergeWithLocal);
+
+    private BindingSymbol RegisterValueDeclaration(
+        Token declaration,
+        bool mergeWithLocal = false) =>
+        RegisterValueDeclaration(_environment, declaration, mergeWithLocal);
+
+    private void BindValueUse(Token use)
+    {
+        if (_environment.GetValueBinding(use.Lexeme) is { } symbol)
+            Bindings.Bind(use, CurrentSourceDocument, symbol);
+    }
 
     /// <summary>
     /// When false (TypeScript's <c>strictNullChecks: off</c>), <c>null</c> and <c>undefined</c>
@@ -796,7 +851,7 @@ public partial class TypeChecker
 
             if (param.IsRest)
             {
-                paramScope.Define(param.Name.Lexeme, paramType);
+                DeclareValue(paramScope, param.Name, paramType);
                 continue;
             }
 
@@ -831,8 +886,12 @@ public partial class TypeChecker
                 requiredParams++;
             }
 
-            paramScope.Define(param.Name.Lexeme,
-                param.IsOptional && param.DefaultValue == null ? CreateUnion(paramType, TypeInfo.Undefined.Shared) : paramType);
+            DeclareValue(
+                paramScope,
+                param.Name,
+                param.IsOptional && param.DefaultValue == null
+                    ? CreateUnion(paramType, TypeInfo.Undefined.Shared)
+                    : paramType);
         }
 
         bool hasRest = parameters.Any(p => p.IsRest);
@@ -913,8 +972,16 @@ public partial class TypeChecker
     /// </summary>
     /// <param name="statements">The AST statements to check.</param>
     /// <returns>A TypeMap containing the resolved type for each expression.</returns>
-    public TypeMap Check(List<Stmt> statements)
+    public TypeMap Check(List<Stmt> statements) => Check(statements, sourceDocument: null);
+
+    /// <summary>
+    /// Type-checks statements while retaining their source document in the semantic binding index.
+    /// </summary>
+    public TypeMap Check(List<Stmt> statements, SourceDocument? sourceDocument)
     {
+        Bindings.Clear();
+        _standaloneSourceDocument = sourceDocument;
+
         // Clear caches for fresh check
         _compatibilityCache = null;
         _expandedTypeAliasCache = null;
@@ -963,8 +1030,20 @@ public partial class TypeChecker
     /// </summary>
     /// <param name="statements">The AST statements to check.</param>
     /// <returns>A TypeCheckDiagnosticResult containing the type map and any errors encountered.</returns>
-    public TypeCheckDiagnosticResult CheckWithRecovery(List<Stmt> statements)
+    public TypeCheckDiagnosticResult CheckWithRecovery(List<Stmt> statements) =>
+        CheckWithRecovery(statements, sourceDocument: null);
+
+    /// <summary>
+    /// Type-checks statements with recovery while retaining their source document in the semantic
+    /// binding index.
+    /// </summary>
+    public TypeCheckDiagnosticResult CheckWithRecovery(
+        List<Stmt> statements,
+        SourceDocument? sourceDocument)
     {
+        Bindings.Clear();
+        _standaloneSourceDocument = sourceDocument;
+
         _diagnostics.Clear();
         _recoveryMode = true;
         // Clear caches for fresh check
@@ -1196,7 +1275,7 @@ public partial class TypeChecker
             EnumKind.Numeric,
             enumStmt.IsConst
         );
-        _environment.Define(enumStmt.Name.Lexeme, enumType);
+        DeclareValue(enumStmt.Name, enumType);
         _environment.DefineType(enumStmt.Name.Lexeme, enumType);
     }
 
@@ -1208,6 +1287,9 @@ public partial class TypeChecker
     /// <returns>A TypeMap containing resolved types for all expressions across all modules</returns>
     public TypeMap CheckModules(List<ParsedModule> modules, ModuleResolver resolver)
     {
+        Bindings.Clear();
+        _standaloneSourceDocument = null;
+
         // Clear compatibility cache for fresh check
         _compatibilityCache = null;
 

--- a/TypeSystem/TypeEnvironment.cs
+++ b/TypeSystem/TypeEnvironment.cs
@@ -18,6 +18,9 @@ namespace SharpTS.TypeSystem;
 /// <seealso cref="TypeInfo"/>
 public class TypeEnvironment : ScopeChain<TypeInfo, TypeEnvironment>
 {
+    private readonly Dictionary<string, BindingSymbol> _valueBindings =
+        new(StringComparer.Ordinal);
+
     // TypeScript symbols have independent type and value facets.  Keeping these
     // bindings separate is essential for declarations such as
     // `interface Error { ... }` + `declare var Error: ErrorConstructor`.
@@ -31,6 +34,34 @@ public class TypeEnvironment : ScopeChain<TypeInfo, TypeEnvironment>
     public TypeEnvironment(TypeEnvironment? enclosing = null, bool? strictMode = null)
         : base(enclosing, strictMode)
     {
+    }
+
+    /// <summary>
+    /// Defines a value while preserving the semantic identity of an enclosing binding when this is
+    /// a checker-created narrowing scope. Source declarations replace that inherited identity via
+    /// <see cref="DefineValueBinding"/>.
+    /// </summary>
+    public new void Define(string name, TypeInfo value)
+    {
+        base.Define(name, value);
+        if (!_valueBindings.ContainsKey(name) &&
+            Enclosing?.GetValueBinding(name) is { } enclosingBinding)
+        {
+            _valueBindings[name] = enclosingBinding;
+        }
+    }
+
+    internal void DefineValueBinding(string name, BindingSymbol symbol) =>
+        _valueBindings[name] = symbol;
+
+    internal BindingSymbol? GetLocalValueBinding(string name) =>
+        _valueBindings.GetValueOrDefault(name);
+
+    internal BindingSymbol? GetValueBinding(string name)
+    {
+        if (_valueBindings.TryGetValue(name, out var symbol))
+            return symbol;
+        return Enclosing?.GetValueBinding(name);
     }
 
     /// <summary>

--- a/docs/plans/lsp-server.md
+++ b/docs/plans/lsp-server.md
@@ -1,13 +1,12 @@
 # Plan: Replace the LspBridge with a real Language Server (Direction B)
 
-**Status:** In progress on branch `wrk/lsp-server`. Landed: Phase 0, Phase 1
-(interop analyzer + project refs), LspBridge teardown, Phase 2 (decorator hover,
-completion, CLR-type-name completion, signatureHelp), Phase 3 (extension rewrite),
-Phase 4a (token-based: precise diagnostic columns + .NET member hover for declarations
-& usages), and the OmniSharp split (the server now lives in a separate `SharpTS.LanguageServer`
-executable / `sharpts-lsp` tool — OmniSharp is fully out of the core `SharpTS.dll`/tool/package).
-Remaining: Phase 4b (general TS hover/go-to-def — deferred, competes with tsserver),
-Phase 5 (polish/multi-editor packaging).
+**Status:** In progress. Landed: Phase 0, Phase 1 (interop analyzer + project refs),
+LspBridge teardown, Phase 2 (decorator hover, completion, CLR-type-name completion,
+signatureHelp), Phase 3 (extension rewrite), Phase 4a (token-based interop navigation),
+source spans and document symbols, plus the first Phase 4b slice: checker-resolved local-value
+go-to-definition. The server lives in the separate `SharpTS.LanguageServer` executable /
+`sharpts-lsp` tool, keeping OmniSharp out of the core package. Remaining: type-namespace and
+cross-module definition, references, safe rename, and Phase 5 lifecycle/polish.
 **Author:** investigation + design pass, 2026-06-22
 **Decision:** Throw away the bespoke `LspBridge` JSON protocol and the hand-rolled
 VS Code providers. Stand up a genuine LSP server over SharpTS's own
@@ -258,25 +257,20 @@ Also surface the half-built **named-arg properties** (`GetAttributeInfoHandler`
 returns settable properties that the old client never used) as additional completion
 items inside the decorator parens — small, real UX improvement.
 
-### 5.4 Hover-for-types & go-to-definition  (Phase 4 — needs new infra)
-The explore pass found the blocker: **AST nodes carry no source spans** (only
-`Token` has line + char-offset, no end), and `TypeMap` keys expressions by *object
-identity*, not position. There is no `position → AST node` index. So general hover
-("what's the type here?") and go-to-definition require new infrastructure:
+### 5.4 General navigation (Phase 4)
 
-- **Preferred (the right thing):** add a `SourceSpan` (start+end line/col) to the
-  `Expr`/`Stmt` base records in `Parsing/AST.cs` and populate it in the parser from
-  the consumed tokens. This is invasive (touches many parser productions) but it is
-  also **the single biggest lever for IDE quality** because it simultaneously fixes
-  the "diagnostic column defaults to 1 / no end span" problem across the *entire*
-  checker — every squiggle gets a precise range, not just the line. Scope it as its
-  own phase with the parser owner.
-- With spans in place: build `PositionIndex` (interval tree over nodes), map
-  position → narrowest `Expr`, look it up in the `TypeMap` from the check pass for
-  hover, and trace named types to their declaration token for definition.
+The reference-keyed `SpanTable` and per-file `SourceDocument` have now landed. Document symbols
+use statement spans, while local-value definition uses a checker-produced `BindingIndex`: semantic
+identities are attached when `TypeEnvironment` defines declarations and uses are captured at the
+same lookup seam. This makes hoisting, shadowing, parameters, and overload merging follow the real
+checker instead of a second editor-only scope walker.
 
-This phase is explicitly **deferred** — Phases 1–3 deliver the headline value
-(live SharpTS diagnostics + decorator IntelliSense in every editor) without it.
+The server advertises these features only in `--language-features full`; the VS Code extension
+continues to launch `interop-only`, leaving ordinary TypeScript navigation to `tsserver`.
+
+Still required for the complete navigation milestone: type-namespace bindings, import/re-export
+provenance across the module graph, the inverse reference index, and safe rename. Property/member
+definition remains deliberately absent until it can resolve a complete semantic domain.
 
 ---
 
@@ -382,9 +376,10 @@ single-file binary so non-VS-Code editors don't need the full SDK.
   member hover for `@DotNetType` members (declarations token-based; usages via the type
   checker's `TypeMap`, mapping the receiver's class name back to the binding). No parser
   surgery, no record-equality risk. ~7 tests + e2e (precise columns, declaration + usage hover).
-- ⬜ **Phase 4b — general TS hover + go-to-definition (deferred).** Only if worth competing
-  with `tsserver`: parser-wide AST spans (reference-keyed side table, NOT base-record fields —
-  value equality) + position→`TypeMap` index + symbol table. **NOT DONE / may not be worth it.**
+- 🟨 **Phase 4b — standalone general navigation.** Reference-keyed source spans, document
+  symbols, semantic binding identities, and local-value go-to-definition have landed. Type
+  bindings, module-aware definition, references, and safe rename remain. VS Code stays in
+  `interop-only`; these capabilities are for standalone clients.
 - ⬜ **Phase 5 — Polish & reach.** Multi-editor docs; `dotnet tool`/self-contained
   packaging; debounce/cancellation; config→server wiring (`sharpts.diagnostics`);
   loader reload on `.csproj`/`bin` change; STATUS.md/README updates. **NOT YET DONE.**


### PR DESCRIPTION
## Summary

- add stable semantic binding identities populated at the TypeEnvironment declaration and lookup seams
- serve textDocument/definition for local value bindings in full language-feature mode only
- handle hoisting, shadowing, parameters, assignments, catch/loop bindings, classes, and overload declarations
- refuse unsafe property/member guesses until their complete semantic domain is indexed
- preserve the existing TypeChecker APIs and document the remaining navigation work

## Scope

This is the next M3 slice of #1306: local value definition. Type-namespace bindings, import/re-export provenance, cross-module definition, references, safe rename, and Track D remain for follow-up work, so the epic stays open.

## Verification

- dotnet build SharpTS.LanguageServer/SharpTS.LanguageServer.csproj --no-restore
- dotnet test SharpTS.Tests/SharpTS.Tests.csproj --no-restore --filter FullyQualifiedName~DefinitionServiceTests (12 passed)
- dotnet test SharpTS.Tests/SharpTS.Tests.csproj --no-restore --filter FullyQualifiedName~LanguageServer (63 passed before the final handler-only test addition)
- dotnet test SharpTS.Tests/SharpTS.Tests.csproj --no-restore --filter FullyQualifiedName~TypeChecker (1,412 passed)
- full suite: 16,216 passed

Refs #1306