### PR TITLE
Add module-aware go-to-definition

### DIFF
--- a/Modules/ModuleResolver.cs
+++ b/Modules/ModuleResolver.cs
@@ -53,6 +53,7 @@ public class ModuleResolver
     /// <see cref="NormalizePath"/> (full path + OS-appropriate casing).
     /// </summary>
     private readonly Dictionary<string, string>? _virtualFiles;
+    private readonly bool _virtualFilesFallBackToDisk;
 
     /// <summary>
     /// Creates a new module resolver rooted at the given path.
@@ -77,6 +78,21 @@ public class ModuleResolver
     public ModuleResolver(string basePath, IReadOnlyDictionary<string, string>? virtualFiles)
         : this(basePath, ModuleResolutionOptions.Default, virtualFiles, TypeScriptProgramOptions.Disabled) { }
 
+    /// <summary>
+    /// Creates a resolver whose in-memory files overlay the real file system. Overlay content wins
+    /// for open/dirty documents while unopened dependencies continue resolving from disk.
+    /// </summary>
+    public ModuleResolver(
+        string basePath,
+        IReadOnlyDictionary<string, string> overlayFiles,
+        bool fallBackToFileSystem)
+        : this(
+            basePath,
+            ModuleResolutionOptions.Default,
+            overlayFiles,
+            TypeScriptProgramOptions.Disabled,
+            fallBackToFileSystem) { }
+
     public ModuleResolver(
         string basePath,
         IReadOnlyDictionary<string, string>? virtualFiles,
@@ -97,11 +113,13 @@ public class ModuleResolver
         string basePath,
         ModuleResolutionOptions resolutionOptions,
         IReadOnlyDictionary<string, string>? virtualFiles,
-        TypeScriptProgramOptions programOptions)
+        TypeScriptProgramOptions programOptions,
+        bool virtualFilesFallBackToDisk = false)
     {
         _basePath = Path.GetDirectoryName(Path.GetFullPath(basePath)) ?? ".";
         _resolutionOptions = resolutionOptions;
         _programOptions = programOptions;
+        _virtualFilesFallBackToDisk = virtualFilesFallBackToDisk;
         _stdlibChain = new StdlibProviderChain(
         [
             new PrimitiveProvider(),
@@ -122,7 +140,8 @@ public class ModuleResolver
     private bool ResolverFileExists(string path)
     {
         if (_virtualFiles is null) return File.Exists(path);
-        return _virtualFiles.ContainsKey(NormalizePath(path));
+        return _virtualFiles.ContainsKey(NormalizePath(path)) ||
+               (_virtualFilesFallBackToDisk && File.Exists(path));
     }
 
     private bool ResolverDirectoryExists(string path)
@@ -132,7 +151,7 @@ public class ModuleResolver
         var prefix = canonical + Path.DirectorySeparatorChar;
         foreach (var k in _virtualFiles.Keys)
             if (k.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) return true;
-        return false;
+        return _virtualFilesFallBackToDisk && Directory.Exists(path);
     }
 
     private string ResolverReadAllText(string path)

--- a/Modules/ParsedModule.cs
+++ b/Modules/ParsedModule.cs
@@ -58,6 +58,19 @@ public class ParsedModule
     public Dictionary<string, TypeInfo> ExportedTypes { get; } = [];
 
     /// <summary>
+    /// Checker binding identities for named value exports. These preserve declaration provenance
+    /// through imports and re-exports for editor features; runtime export behavior remains in
+    /// <see cref="ExportedValues"/>.
+    /// </summary>
+    public Dictionary<string, BindingSymbol> ExportedValueBindings { get; } = [];
+
+    /// <summary>
+    /// Checker binding identities for named type exports. TypeScript's type and value facets are
+    /// tracked independently because declarations such as classes and enums participate in both.
+    /// </summary>
+    public Dictionary<string, BindingSymbol> ExportedTypeBindings { get; } = [];
+
+    /// <summary>
     /// Named exports from this module (name -> runtime value).
     /// Populated during interpretation.
     /// </summary>
@@ -68,6 +81,12 @@ public class ParsedModule
     /// Populated during type checking.
     /// </summary>
     public TypeInfo? DefaultExportType { get; set; }
+
+    /// <summary>Binding provenance for the default export's value facet, when source-backed.</summary>
+    public BindingSymbol? DefaultValueBinding { get; set; }
+
+    /// <summary>Binding provenance for the default export's type facet, when source-backed.</summary>
+    public BindingSymbol? DefaultTypeBinding { get; set; }
 
     /// <summary>
     /// Default export value, if any.

--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -785,8 +785,9 @@ public partial class Parser
                  Check(TokenType.VOID) ||  // void type
                  Check(TokenType.NULL) || Check(TokenType.UNDEFINED) || Check(TokenType.UNKNOWN) || Check(TokenType.NEVER))
         {
-            typeName = Advance().Lexeme;
-            typeNode = new NamedTypeNode(typeName, null, Previous().Line);
+            Token nameToken = Advance();
+            typeName = nameToken.Lexeme;
+            typeNode = new NamedTypeNode(typeName, null, nameToken.Line, nameToken);
 
             // Qualified type name (namespace member): `Intl.CollatorOptions`, `NodeJS.Timer`.
             // The dotted name carries on the NamedTypeNode; resolution hands the whole "Foo.Bar"
@@ -797,7 +798,9 @@ public partial class Parser
             {
                 Advance(); // consume '.'
                 typeName += "." + Advance().Lexeme;
-                typeNode = new NamedTypeNode(typeName, null, Previous().Line);
+                typeNode = typeNode is NamedTypeNode named
+                    ? named with { Name = typeName }
+                    : new NamedTypeNode(typeName, null, nameToken.Line, nameToken);
             }
         }
         else

--- a/Parsing/TypeNodes.cs
+++ b/Parsing/TypeNodes.cs
@@ -16,7 +16,11 @@ public abstract record TypeNode(int Line);
 /// <summary>A type reference by name: <c>Foo</c>, <c>Box&lt;string&gt;</c>. Type arguments are
 /// null for a bare reference. Also covers primitive/keyword names (<c>string</c>, <c>void</c>,
 /// …) — resolution treats them uniformly, exactly like the string path.</summary>
-public sealed record NamedTypeNode(string Name, List<TypeNode>? TypeArguments, int Line) : TypeNode(Line);
+public sealed record NamedTypeNode(
+    string Name,
+    List<TypeNode>? TypeArguments,
+    int Line,
+    Token? NameToken = null) : TypeNode(Line);
 
 /// <summary>A literal type: <c>"ok"</c>, <c>42</c>, <c>true</c>, <c>1n</c> (bigint literals carry
 /// their <c>System.Numerics.BigInteger</c> value).</summary>

--- a/SharpTS.LanguageServer/DocumentStore.cs
+++ b/SharpTS.LanguageServer/DocumentStore.cs
@@ -13,4 +13,8 @@ public sealed class DocumentStore
     public void Set(string uri, string text) => _docs[uri] = text;
     public bool TryGet(string uri, out string text) => _docs.TryGetValue(uri, out text!);
     public void Remove(string uri) => _docs.TryRemove(uri, out _);
+
+    /// <summary>Returns a stable snapshot of all open documents for module-resolution overlays.</summary>
+    public IReadOnlyDictionary<string, string> Snapshot() =>
+        new Dictionary<string, string>(_docs);
 }

--- a/SharpTS.LanguageServer/Handlers/DefinitionHandler.cs
+++ b/SharpTS.LanguageServer/Handlers/DefinitionHandler.cs
@@ -7,7 +7,7 @@ using SharpTS.LanguageServer.Services;
 namespace SharpTS.LanguageServer.Handlers;
 
 /// <summary>
-/// Serves <c>textDocument/definition</c> for checker-resolved local value bindings.
+/// Serves <c>textDocument/definition</c> for checker-resolved value and type bindings.
 /// </summary>
 /// <remarks>
 /// Registered only in <see cref="LanguageFeatureMode.Full"/> so the VS Code extension continues
@@ -34,10 +34,21 @@ public sealed class DefinitionHandler : DefinitionHandlerBase
 
         ct.ThrowIfCancellationRequested();
 
+        var overlay = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (openUri, openText) in _store.Snapshot())
+        {
+            if (Uri.TryCreate(openUri, UriKind.Absolute, out var parsedUri) &&
+                parsedUri.IsFile)
+            {
+                overlay[Path.GetFullPath(parsedUri.LocalPath)] = openText;
+            }
+        }
+
         var locations = _definitions.FindDefinitions(
                 request.TextDocument.Uri.GetFileSystemPath(),
                 text,
-                request.Position)
+                request.Position,
+                overlay)
             .Select(location => new LocationOrLocationLink(location));
         return Task.FromResult<LocationOrLocationLinks?>(
             new LocationOrLocationLinks(locations));

--- a/SharpTS.LanguageServer/Services/DefinitionService.cs
+++ b/SharpTS.LanguageServer/Services/DefinitionService.cs
@@ -1,6 +1,7 @@
 using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using SharpTS.Diagnostics;
+using SharpTS.Configuration;
+using SharpTS.Modules;
 using SharpTS.Parsing;
 using SharpTS.TypeSystem;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
@@ -8,50 +9,57 @@ using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 namespace SharpTS.LanguageServer.Services;
 
 /// <summary>
-/// Resolves source positions to checker-bound local value declarations.
+/// Resolves source positions to checker-bound declarations across a module graph.
 /// </summary>
 /// <remarks>
 /// The service intentionally returns no result for names the checker did not bind. In particular,
-/// property/member navigation and cross-module import targets need their own complete semantic
-/// domains; guessing from matching text would produce incorrect navigation under shadowing.
+/// property/member navigation still needs its own complete semantic domain; guessing from matching
+/// text would produce incorrect navigation under shadowing.
 /// </remarks>
 public sealed class DefinitionService
 {
     /// <summary>
-    /// Finds the local value declaration selected by an LSP position.
+    /// Finds the value or type declaration selected by an LSP position.
     /// </summary>
     public IReadOnlyList<Location> FindDefinitions(
         string path,
         string text,
-        Position position)
+        Position position,
+        IReadOnlyDictionary<string, string>? openDocuments = null)
     {
-        var document = new SourceDocument(path, text);
+        string absolutePath = Path.GetFullPath(path);
+        var overlay = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (openDocuments is not null)
+        {
+            foreach (var (documentPath, documentText) in openDocuments)
+                overlay[Path.GetFullPath(documentPath)] = documentText;
+        }
+        overlay[absolutePath] = text;
 
-        ParseDiagnosticResult parsed;
+        ParsedModule entry;
+        ModuleResolver resolver;
         try
         {
-            var parser = new Parser(
-                    new Lexer(text) { JsxTolerant = IsJsx(path) }.ScanTokens(),
-                    DecoratorMode.Stage3)
-                .WithSourceDocument(document);
-            if (IsJsx(path))
-                parser.WithJsx(text, JsxParseOptions.Default);
-            parsed = parser.Parse();
+            resolver = new ModuleResolver(
+                absolutePath,
+                ModuleResolutionOptions.Default,
+                overlay,
+                new TypeScriptProgramOptions { PreferDeclarationFiles = true },
+                virtualFilesFallBackToDisk: true);
+            entry = resolver.LoadModule(absolutePath, DecoratorMode.Stage3);
         }
         catch
         {
             return [];
         }
 
-        if (!parsed.IsSuccess)
+        if (entry.Document is not { } document)
             return [];
 
-        var checker = new TypeChecker().WithFilePath(path);
+        var checker = new TypeChecker().WithFilePath(absolutePath);
         try
         {
-            // Recovery keeps useful bindings from the rest of a file when an unrelated statement
-            // has a type error. A failure in checker setup still degrades safely to no definition.
-            checker.CheckWithRecovery(parsed.Statements, document);
+            checker.CheckModules(resolver.GetModulesInOrder(entry), resolver);
         }
         catch
         {
@@ -61,7 +69,14 @@ public sealed class DefinitionService
         int offset = document.Lines.ToOffset(
             (int)position.Line + 1,
             (int)position.Character + 1);
-        return checker.Bindings.FindDefinitions(document, offset)
+        IReadOnlyList<BindingDeclaration> declarations =
+            checker.Bindings.FindDefinitions(document, offset, BindingNamespace.Value);
+        if (declarations.Count == 0)
+        {
+            declarations =
+                checker.Bindings.FindDefinitions(document, offset, BindingNamespace.Type);
+        }
+        return declarations
             .Select(ToLocation)
             .ToArray();
     }
@@ -81,8 +96,4 @@ public sealed class DefinitionService
                 endColumn - 1),
         };
     }
-
-    private static bool IsJsx(string path) =>
-        path.EndsWith(".tsx", StringComparison.OrdinalIgnoreCase) ||
-        path.EndsWith(".jsx", StringComparison.OrdinalIgnoreCase);
 }

--- a/SharpTS.Tests/LanguageServer/DefinitionServiceTests.cs
+++ b/SharpTS.Tests/LanguageServer/DefinitionServiceTests.cs
@@ -122,6 +122,20 @@ public class DefinitionServiceTests
     }
 
     [Fact]
+    public void UnresolvedImportDoesNotEraseValidLocalBindings()
+    {
+        const string source = """
+            import { absent } from "./not-present";
+            const target = 1;
+            console.log(target);
+            """;
+
+        var definition = Assert.Single(Definitions(source, "target", occurrence: 1));
+
+        Assert.Equal(new Range(1, 6, 1, 12), definition.Range);
+    }
+
+    [Fact]
     public void PropertyNamesAreNotGuessedFromMatchingText()
     {
         const string source = """
@@ -192,6 +206,113 @@ public class DefinitionServiceTests
         Assert.Equal(new Range(0, 6, 0, 12), location.Range);
     }
 
+    [Fact]
+    public async Task HandlerResolvesAnAliasedImportToADirtyOpenDependency()
+    {
+        string root = Path.GetFullPath("open-module-definition-test");
+        string dependencyPath = Path.Combine(root, "dependency.ts");
+        string entryPath = Path.Combine(root, "entry.ts");
+        DocumentUri dependencyUri = DocumentUri.FromFileSystemPath(dependencyPath);
+        DocumentUri entryUri = DocumentUri.FromFileSystemPath(entryPath);
+        const string dependency = "export const original = 1;\n";
+        const string entry = """
+            import { original as local } from "./dependency";
+            console.log(local);
+            """;
+        var store = new DocumentStore();
+        store.Set(dependencyUri.ToString(), dependency);
+        store.Set(entryUri.ToString(), entry);
+        var handler = new DefinitionHandler(store, new DefinitionService());
+
+        var result = await handler.Handle(
+            new DefinitionParams
+            {
+                TextDocument = new TextDocumentIdentifier(entryUri),
+                Position = new Position(1, 12),
+            },
+            CancellationToken.None);
+
+        var target = Assert.Single(Assert.IsAssignableFrom<LocationOrLocationLinks>(result));
+        var location = Assert.IsType<Location>(target.Location);
+        Assert.Equal(dependencyUri, location.Uri);
+        Assert.Equal(new Range(0, 13, 0, 21), location.Range);
+    }
+
+    [Fact]
+    public void DefaultImportResolvesToTheNamedDefaultDeclaration()
+    {
+        string root = Path.GetFullPath("default-module-definition-test");
+        string dependencyPath = Path.Combine(root, "dependency.ts");
+        string entryPath = Path.Combine(root, "entry.ts");
+        const string dependency = "export default function launch(): void {}\n";
+        const string entry = """
+            import start from "./dependency";
+            start();
+            """;
+        var overlay = new Dictionary<string, string>
+        {
+            [dependencyPath] = dependency,
+            [entryPath] = entry,
+        };
+
+        var definition = Assert.Single(
+            Definitions(entryPath, entry, "start", occurrence: 1, overlay));
+
+        Assert.Equal(DocumentUri.FromFileSystemPath(dependencyPath), definition.Uri);
+        Assert.Equal(new Range(0, 24, 0, 30), definition.Range);
+    }
+
+    [Fact]
+    public void ReExportChainPreservesTheOriginalValueDeclaration()
+    {
+        string root = Path.GetFullPath("reexport-module-definition-test");
+        string dependencyPath = Path.Combine(root, "dependency.ts");
+        string barrelPath = Path.Combine(root, "barrel.ts");
+        string entryPath = Path.Combine(root, "entry.ts");
+        const string dependency = "export function run(): void {}\n";
+        const string barrel = "export { run as execute } from \"./dependency\";\n";
+        const string entry = """
+            import { execute as start } from "./barrel";
+            start();
+            """;
+        var overlay = new Dictionary<string, string>
+        {
+            [dependencyPath] = dependency,
+            [barrelPath] = barrel,
+            [entryPath] = entry,
+        };
+
+        var definition = Assert.Single(
+            Definitions(entryPath, entry, "start", occurrence: 1, overlay));
+
+        Assert.Equal(DocumentUri.FromFileSystemPath(dependencyPath), definition.Uri);
+        Assert.Equal(new Range(0, 16, 0, 19), definition.Range);
+    }
+
+    [Fact]
+    public void TypeOnlyImportInAnAnnotationResolvesToItsInterface()
+    {
+        string root = Path.GetFullPath("type-module-definition-test");
+        string dependencyPath = Path.Combine(root, "dependency.ts");
+        string entryPath = Path.Combine(root, "entry.ts");
+        const string dependency = "export interface Shape { size: number; }\n";
+        const string entry = """
+            import type { Shape as LocalShape } from "./dependency";
+            const value: LocalShape = { size: 1 };
+            """;
+        var overlay = new Dictionary<string, string>
+        {
+            [dependencyPath] = dependency,
+            [entryPath] = entry,
+        };
+
+        var definition = Assert.Single(
+            Definitions(entryPath, entry, "LocalShape", occurrence: 1, overlay));
+
+        Assert.Equal(DocumentUri.FromFileSystemPath(dependencyPath), definition.Uri);
+        Assert.Equal(new Range(0, 17, 0, 22), definition.Range);
+    }
+
     private IReadOnlyList<Location> Definitions(
         string source,
         string name,
@@ -204,6 +325,23 @@ public class DefinitionServiceTests
             Path.GetFullPath("definition-test.ts"),
             source,
             new Position(line - 1, column - 1));
+    }
+
+    private IReadOnlyList<Location> Definitions(
+        string path,
+        string source,
+        string name,
+        int occurrence,
+        IReadOnlyDictionary<string, string> openDocuments)
+    {
+        int offset = NthIndexOf(source, name, occurrence);
+        var lines = new SharpTS.Parsing.LineIndex(source);
+        var (line, column) = lines.ToPosition(offset);
+        return _definitions.FindDefinitions(
+            path,
+            source,
+            new Position(line - 1, column - 1),
+            openDocuments);
     }
 
     private static int NthIndexOf(string source, string value, int occurrence)

--- a/TypeSystem/BindingIndex.cs
+++ b/TypeSystem/BindingIndex.cs
@@ -70,7 +70,7 @@ public sealed class BindingSymbol
 /// </remarks>
 public sealed class BindingIndex
 {
-    private readonly Dictionary<Token, BindingSymbol> _tokens =
+    private readonly Dictionary<Token, Dictionary<BindingNamespace, BindingSymbol>> _tokens =
         new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<Token, SourceDocument> _documents =
         new(ReferenceEqualityComparer.Instance);
@@ -90,7 +90,8 @@ public sealed class BindingIndex
         BindingNamespace bindingNamespace,
         BindingSymbol? existing = null)
     {
-        if (_tokens.TryGetValue(declaration, out var alreadyDeclared))
+        if (_tokens.TryGetValue(declaration, out var facets) &&
+            facets.TryGetValue(bindingNamespace, out var alreadyDeclared))
             return alreadyDeclared;
 
         var symbol = existing is { Generation: var generation } && generation == _generation
@@ -102,7 +103,12 @@ public sealed class BindingIndex
                 bindingNamespace);
 
         symbol.AddDeclaration(document, declaration);
-        _tokens[declaration] = symbol;
+        if (facets is null)
+        {
+            facets = [];
+            _tokens[declaration] = facets;
+        }
+        facets[bindingNamespace] = symbol;
         if (document is not null && declaration.Start >= 0)
             _documents[declaration] = document;
         return symbol;
@@ -113,7 +119,12 @@ public sealed class BindingIndex
         if (use.Start < 0 || symbol.Generation != _generation)
             return;
 
-        _tokens[use] = symbol;
+        if (!_tokens.TryGetValue(use, out var facets))
+        {
+            facets = [];
+            _tokens[use] = facets;
+        }
+        facets[symbol.Namespace] = symbol;
         if (document is not null)
             _documents[use] = document;
     }
@@ -129,9 +140,9 @@ public sealed class BindingIndex
         BindingSymbol? best = null;
         int bestLength = int.MaxValue;
 
-        foreach (var (token, symbol) in _tokens)
+        foreach (var (token, facets) in _tokens)
         {
-            if (symbol.Namespace != bindingNamespace ||
+            if (!facets.TryGetValue(bindingNamespace, out var symbol) ||
                 !_documents.TryGetValue(token, out var tokenDocument) ||
                 !ReferenceEquals(tokenDocument, document) ||
                 !token.Span.Contains(offset))

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -29,6 +29,7 @@ public partial class TypeChecker
             // identical semantics by construction, with none of the scanning hazards strings
             // have for COMPOSITE types. Never routes back through ToTypeInfo(string).
             case NamedTypeNode { TypeArguments: null } named:
+                BindTypeUse(named.NameToken, named.Name);
                 return ResolveTypeName(named.Name);
 
             // Generic references resolve their argument nodes and hand off to the shared
@@ -37,6 +38,7 @@ public partial class TypeChecker
             // errors). ResolveGenericType owns the built-ins-before-aliases shadowing precedence.
             case NamedTypeNode { TypeArguments: { } argNodes } named:
             {
+                BindTypeUse(named.NameToken, named.Name);
                 List<TypeInfo> typeArgs = new(argNodes.Count);
                 foreach (var argNode in argNodes)
                 {

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -116,6 +116,38 @@ public partial class TypeChecker
             Bindings.Bind(use, CurrentSourceDocument, symbol);
     }
 
+    private BindingSymbol RegisterTypeDeclaration(
+        TypeEnvironment environment,
+        Token declaration,
+        bool mergeWithLocal = false)
+    {
+        BindingSymbol? existing = mergeWithLocal
+            ? environment.GetLocalTypeSymbol(declaration.Lexeme)
+            : null;
+        BindingSymbol symbol = Bindings.Declare(
+            declaration,
+            CurrentSourceDocument,
+            BindingNamespace.Type,
+            existing);
+        environment.DefineTypeBinding(declaration.Lexeme, symbol);
+        return symbol;
+    }
+
+    private BindingSymbol RegisterTypeDeclaration(
+        Token declaration,
+        bool mergeWithLocal = false) =>
+        RegisterTypeDeclaration(_environment, declaration, mergeWithLocal);
+
+    private void BindTypeUse(Token? use, string name)
+    {
+        if (use is null)
+            return;
+
+        string rootName = name.Split('.', 2)[0];
+        if (_environment.GetTypeSymbol(rootName) is { } symbol)
+            Bindings.Bind(use, CurrentSourceDocument, symbol);
+    }
+
     /// <summary>
     /// When false (TypeScript's <c>strictNullChecks: off</c>), <c>null</c> and <c>undefined</c>
     /// are assignable to every type (except <c>never</c>). Defaults to true to preserve SharpTS's
@@ -1202,13 +1234,24 @@ public partial class TypeChecker
             switch (stmt)
             {
                 case Stmt.Interface itf:
+                    RegisterTypeDeclaration(itf.Name, mergeWithLocal: true);
                     PreRegisterInterface(itf);
                     break;
                 case Stmt.TypeAlias alias:
+                    RegisterTypeDeclaration(alias.Name);
                     PreRegisterTypeAlias(alias);
                     break;
                 case Stmt.Enum enumStmt:
+                    RegisterTypeDeclaration(enumStmt.Name, mergeWithLocal: true);
                     PreRegisterEnum(enumStmt);
+                    break;
+                case Stmt.Class cls:
+                    // Register only the source identity here. The semantic class type is still
+                    // created by CheckClassDeclaration, preserving the existing inheritance order.
+                    RegisterTypeDeclaration(cls.Name);
+                    break;
+                case Stmt.Namespace ns:
+                    RegisterTypeDeclaration(ns.Name, mergeWithLocal: true);
                     break;
                 // Note: Classes are not pre-registered here because doing so creates MutableClass
                 // objects that break inheritance checking. Classes are properly registered during
@@ -1617,6 +1660,11 @@ public partial class TypeChecker
     /// </summary>
     private void CollectModuleExports(ParsedModule module)
     {
+        module.ExportedValueBindings.Clear();
+        module.ExportedTypeBindings.Clear();
+        module.DefaultValueBinding = null;
+        module.DefaultTypeBinding = null;
+
         var moduleEnv = new TypeEnvironment(_environment);
 
         // CJS modules have module, exports, and global in scope
@@ -1688,6 +1736,11 @@ public partial class TypeChecker
                             {
                                 var type = CheckExpr(export.DefaultExpr);
                                 module.DefaultExportType = type;
+                                if (export.DefaultExpr is Expr.Variable variable)
+                                {
+                                    module.DefaultValueBinding =
+                                        _environment.GetValueBinding(variable.Name.Lexeme);
+                                }
                             }
                             else if (export.NamedExports != null && export.FromModulePath == null)
                             {
@@ -1722,6 +1775,11 @@ public partial class TypeChecker
                     if (export.Declaration != null)
                     {
                         module.DefaultExportType = GetDeclaredType(export.Declaration);
+                        RecordExportedDeclarationBindings(
+                            module,
+                            export.Declaration,
+                            exportedName: "default",
+                            isDefault: true);
                     }
                     // DefaultExpr already handled above
                 }
@@ -1730,17 +1788,38 @@ public partial class TypeChecker
                     string name = GetDeclarationName(export.Declaration);
                     var type = GetDeclaredType(export.Declaration);
                     module.ExportedTypes[name] = type;
+                    RecordExportedDeclarationBindings(
+                        module,
+                        export.Declaration,
+                        exportedName: name,
+                        isDefault: false);
                 }
                 else if (export.NamedExports != null && export.FromModulePath == null)
                 {
                     foreach (var spec in export.NamedExports)
                     {
+                        bool isTypeOnly = export.IsTypeOnly || spec.IsTypeOnly;
                         var type = _environment.Get(spec.LocalName.Lexeme)
                             ?? _environment.GetTypeBinding(spec.LocalName.Lexeme);
                         if (type != null)
                         {
                             string exportedName = spec.ExportedName?.Lexeme ?? spec.LocalName.Lexeme;
                             module.ExportedTypes[exportedName] = type;
+                        }
+
+                        string bindingName = spec.LocalName.Lexeme;
+                        string exportedBindingName =
+                            spec.ExportedName?.Lexeme ?? bindingName;
+                        if (!isTypeOnly &&
+                            _environment.GetValueBinding(bindingName) is { } valueBinding)
+                        {
+                            module.ExportedValueBindings[exportedBindingName] = valueBinding;
+                            BindExportSpecifier(spec, valueBinding);
+                        }
+                        if (_environment.GetTypeSymbol(bindingName) is { } typeBinding)
+                        {
+                            module.ExportedTypeBindings[exportedBindingName] = typeBinding;
+                            BindExportSpecifier(spec, typeBinding);
                         }
                     }
                 }
@@ -1766,14 +1845,28 @@ public partial class TypeChecker
                         {
                             var namespaceType = CreateModuleNamespaceType(
                                 export.NamespaceExportName.Lexeme, sourceModule);
+                            var namespaceValueBinding = Bindings.Declare(
+                                export.NamespaceExportName,
+                                CurrentSourceDocument,
+                                BindingNamespace.Value);
+                            var namespaceTypeBinding = Bindings.Declare(
+                                export.NamespaceExportName,
+                                CurrentSourceDocument,
+                                BindingNamespace.Type);
                             if (export.NamespaceExportName.Type == TokenType.DEFAULT
                                 || export.NamespaceExportName.Lexeme == "default")
                             {
                                 module.DefaultExportType = namespaceType;
+                                module.DefaultValueBinding = namespaceValueBinding;
+                                module.DefaultTypeBinding = namespaceTypeBinding;
                             }
                             else
                             {
                                 module.ExportedTypes[export.NamespaceExportName.Lexeme] = namespaceType;
+                                module.ExportedValueBindings[export.NamespaceExportName.Lexeme] =
+                                    namespaceValueBinding;
+                                module.ExportedTypeBindings[export.NamespaceExportName.Lexeme] =
+                                    namespaceTypeBinding;
                             }
                         }
                         else if (export.NamedExports != null)
@@ -1786,6 +1879,7 @@ public partial class TypeChecker
                             foreach (var spec in export.NamedExports)
                             {
                                 string exportedName = spec.ExportedName?.Lexeme ?? spec.LocalName.Lexeme;
+                                bool isTypeOnly = export.IsTypeOnly || spec.IsTypeOnly;
                                 if (sourceModule.ExportedTypes.TryGetValue(spec.LocalName.Lexeme, out var type))
                                 {
                                     module.ExportedTypes[exportedName] = type;
@@ -1793,6 +1887,22 @@ public partial class TypeChecker
                                 else if (sourceModule.IsCommonJs)
                                 {
                                     module.ExportedTypes[exportedName] = TypeInfo.Any.Shared;
+                                }
+
+                                if (!isTypeOnly &&
+                                    sourceModule.ExportedValueBindings.TryGetValue(
+                                        spec.LocalName.Lexeme,
+                                        out var valueBinding))
+                                {
+                                    module.ExportedValueBindings[exportedName] = valueBinding;
+                                    BindExportSpecifier(spec, valueBinding);
+                                }
+                                if (sourceModule.ExportedTypeBindings.TryGetValue(
+                                        spec.LocalName.Lexeme,
+                                        out var typeBinding))
+                                {
+                                    module.ExportedTypeBindings[exportedName] = typeBinding;
+                                    BindExportSpecifier(spec, typeBinding);
                                 }
                             }
                         }
@@ -1802,6 +1912,14 @@ public partial class TypeChecker
                             foreach (var (name, type) in sourceModule.ExportedTypes)
                             {
                                 module.ExportedTypes[name] = type;
+                            }
+                            foreach (var (name, binding) in sourceModule.ExportedValueBindings)
+                            {
+                                module.ExportedValueBindings[name] = binding;
+                            }
+                            foreach (var (name, binding) in sourceModule.ExportedTypeBindings)
+                            {
+                                module.ExportedTypeBindings[name] = binding;
                             }
                         }
                     }
@@ -1825,6 +1943,36 @@ public partial class TypeChecker
                 moduleEnv.Enclosing?.DefineImportAlias(globalName, globalType, isValue: true);
         }
         }
+    }
+
+    private void RecordExportedDeclarationBindings(
+        ParsedModule module,
+        Stmt declaration,
+        string exportedName,
+        bool isDefault)
+    {
+        string localName = GetDeclarationName(declaration);
+        if (_environment.GetValueBinding(localName) is { } valueBinding)
+        {
+            if (isDefault)
+                module.DefaultValueBinding = valueBinding;
+            else
+                module.ExportedValueBindings[exportedName] = valueBinding;
+        }
+        if (_environment.GetTypeSymbol(localName) is { } typeBinding)
+        {
+            if (isDefault)
+                module.DefaultTypeBinding = typeBinding;
+            else
+                module.ExportedTypeBindings[exportedName] = typeBinding;
+        }
+    }
+
+    private void BindExportSpecifier(Stmt.ExportSpecifier specifier, BindingSymbol binding)
+    {
+        Bindings.Bind(specifier.LocalName, CurrentSourceDocument, binding);
+        if (specifier.ExportedName is { } exportedName)
+            Bindings.Bind(exportedName, CurrentSourceDocument, binding);
     }
 
     private static TypeInfo.Namespace CreateModuleNamespaceType(
@@ -1864,6 +2012,10 @@ public partial class TypeChecker
                         if (isCjsImport)
                         {
                             env.Define(import.DefaultImport.Lexeme, TypeInfo.Any.Shared);
+                            BindImportedDeclaration(
+                                env,
+                                import.DefaultImport,
+                                BindingNamespace.Value);
                         }
                         else
                         {
@@ -1884,6 +2036,20 @@ public partial class TypeChecker
                                     importedModule.DefaultExportType,
                                     isValue: !import.IsTypeOnly);
                             }
+
+                            if (!import.IsTypeOnly)
+                            {
+                                BindImportedDeclaration(
+                                    env,
+                                    import.DefaultImport,
+                                    BindingNamespace.Value,
+                                    importedModule.DefaultValueBinding);
+                            }
+                            BindImportedDeclaration(
+                                env,
+                                import.DefaultImport,
+                                BindingNamespace.Type,
+                                importedModule.DefaultTypeBinding);
                         }
                     }
 
@@ -1893,12 +2059,27 @@ public partial class TypeChecker
                         if (isCjsImport)
                         {
                             env.Define(import.NamespaceImport.Lexeme, TypeInfo.Any.Shared);
+                            BindImportedDeclaration(
+                                env,
+                                import.NamespaceImport,
+                                BindingNamespace.Value);
                         }
                         else
                         {
                             var namespaceType = CreateModuleNamespaceType(
                                 import.NamespaceImport.Lexeme, importedModule);
                             env.DefineNamespace(import.NamespaceImport.Lexeme, namespaceType);
+                            if (!import.IsTypeOnly)
+                            {
+                                BindImportedDeclaration(
+                                    env,
+                                    import.NamespaceImport,
+                                    BindingNamespace.Value);
+                            }
+                            BindImportedDeclaration(
+                                env,
+                                import.NamespaceImport,
+                                BindingNamespace.Type);
                         }
                     }
 
@@ -1913,6 +2094,11 @@ public partial class TypeChecker
                             if (isCjsImport)
                             {
                                 env.Define(localName, TypeInfo.Any.Shared);
+                                BindImportedDeclaration(
+                                    env,
+                                    spec.LocalName ?? spec.Imported,
+                                    BindingNamespace.Value,
+                                    importedToken: spec.Imported);
                                 continue;
                             }
 
@@ -1924,6 +2110,32 @@ public partial class TypeChecker
                             env.DefineImportAlias(
                                 localName, type,
                                 isValue: !import.IsTypeOnly && !spec.IsTypeOnly);
+
+                            bool isTypeOnly = import.IsTypeOnly || spec.IsTypeOnly;
+                            Token localToken = spec.LocalName ?? spec.Imported;
+                            if (!isTypeOnly &&
+                                importedModule.ExportedValueBindings.TryGetValue(
+                                    importedName,
+                                    out var valueBinding))
+                            {
+                                BindImportedDeclaration(
+                                    env,
+                                    localToken,
+                                    BindingNamespace.Value,
+                                    valueBinding,
+                                    spec.Imported);
+                            }
+                            if (importedModule.ExportedTypeBindings.TryGetValue(
+                                    importedName,
+                                    out var typeBinding))
+                            {
+                                BindImportedDeclaration(
+                                    env,
+                                    localToken,
+                                    BindingNamespace.Type,
+                                    typeBinding,
+                                    spec.Imported);
+                            }
                         }
                     }
                 }
@@ -1942,6 +2154,29 @@ public partial class TypeChecker
                 }
             }
         }
+    }
+
+    private BindingSymbol BindImportedDeclaration(
+        TypeEnvironment environment,
+        Token localName,
+        BindingNamespace bindingNamespace,
+        BindingSymbol? sourceBinding = null,
+        Token? importedToken = null)
+    {
+        BindingSymbol binding = sourceBinding ?? Bindings.Declare(
+            localName,
+            CurrentSourceDocument,
+            bindingNamespace);
+
+        if (bindingNamespace == BindingNamespace.Value)
+            environment.DefineValueBinding(localName.Lexeme, binding);
+        else if (bindingNamespace == BindingNamespace.Type)
+            environment.DefineTypeBinding(localName.Lexeme, binding);
+
+        Bindings.Bind(localName, CurrentSourceDocument, binding);
+        if (importedToken is not null && !ReferenceEquals(importedToken, localName))
+            Bindings.Bind(importedToken, CurrentSourceDocument, binding);
+        return binding;
     }
 
     /// <summary>

--- a/TypeSystem/TypeEnvironment.cs
+++ b/TypeSystem/TypeEnvironment.cs
@@ -20,6 +20,8 @@ public class TypeEnvironment : ScopeChain<TypeInfo, TypeEnvironment>
 {
     private readonly Dictionary<string, BindingSymbol> _valueBindings =
         new(StringComparer.Ordinal);
+    private readonly Dictionary<string, BindingSymbol> _typeBindings =
+        new(StringComparer.Ordinal);
 
     // TypeScript symbols have independent type and value facets.  Keeping these
     // bindings separate is essential for declarations such as
@@ -62,6 +64,19 @@ public class TypeEnvironment : ScopeChain<TypeInfo, TypeEnvironment>
         if (_valueBindings.TryGetValue(name, out var symbol))
             return symbol;
         return Enclosing?.GetValueBinding(name);
+    }
+
+    internal void DefineTypeBinding(string name, BindingSymbol symbol) =>
+        _typeBindings[name] = symbol;
+
+    internal BindingSymbol? GetLocalTypeSymbol(string name) =>
+        _typeBindings.GetValueOrDefault(name);
+
+    internal BindingSymbol? GetTypeSymbol(string name)
+    {
+        if (_typeBindings.TryGetValue(name, out var symbol))
+            return symbol;
+        return Enclosing?.GetTypeSymbol(name);
     }
 
     /// <summary>

--- a/docs/plans/lsp-server.md
+++ b/docs/plans/lsp-server.md
@@ -260,17 +260,20 @@ items inside the decorator parens — small, real UX improvement.
 ### 5.4 General navigation (Phase 4)
 
 The reference-keyed `SpanTable` and per-file `SourceDocument` have now landed. Document symbols
-use statement spans, while local-value definition uses a checker-produced `BindingIndex`: semantic
-identities are attached when `TypeEnvironment` defines declarations and uses are captured at the
-same lookup seam. This makes hoisting, shadowing, parameters, and overload merging follow the real
-checker instead of a second editor-only scope walker.
+use statement spans, while definition uses a checker-produced `BindingIndex`: independent value
+and type identities are attached when `TypeEnvironment` defines declarations and uses are captured
+at the same lookup seam. The language server checks the resolver's real dependency graph, overlays
+dirty open documents on disk, and carries source identities through named/default imports and
+re-exports. This makes hoisting, shadowing, parameters, overload merging, aliases, and module
+provenance follow the real checker instead of a second editor-only scope walker.
 
 The server advertises these features only in `--language-features full`; the VS Code extension
 continues to launch `interop-only`, leaving ordinary TypeScript navigation to `tsserver`.
 
-Still required for the complete navigation milestone: type-namespace bindings, import/re-export
-provenance across the module graph, the inverse reference index, and safe rename. Property/member
-definition remains deliberately absent until it can resolve a complete semantic domain.
+Still required for the complete navigation milestone: the inverse reference index, safe rename,
+and the remaining type/member domains (notably type parameters and qualified namespace/property
+members). Property/member definition remains deliberately absent until it can resolve a complete
+semantic domain.
 
 ---
 
@@ -377,9 +380,10 @@ single-file binary so non-VS-Code editors don't need the full SDK.
   checker's `TypeMap`, mapping the receiver's class name back to the binding). No parser
   surgery, no record-equality risk. ~7 tests + e2e (precise columns, declaration + usage hover).
 - 🟨 **Phase 4b — standalone general navigation.** Reference-keyed source spans, document
-  symbols, semantic binding identities, and local-value go-to-definition have landed. Type
-  bindings, module-aware definition, references, and safe rename remain. VS Code stays in
-  `interop-only`; these capabilities are for standalone clients.
+  symbols, semantic value/type binding identities, and module-aware go-to-definition through
+  imports/re-exports have landed. References, safe rename, type-parameter navigation, and
+  qualified member navigation remain. VS Code stays in `interop-only`; these capabilities are
+  for standalone clients.
 - ⬜ **Phase 5 — Polish & reach.** Multi-editor docs; `dotnet tool`/self-contained
   packaging; debounce/cancellation; config→server wiring (`sharpts.diagnostics`);
   loader reload on `.csproj`/`bin` change; STATUS.md/README updates. **NOT YET DONE.**


### PR DESCRIPTION
Part of #1306.

Summary:
- preserve independent value and type binding identities through module exports, imports, aliases, and re-exports
- resolve definitions against the real module graph with dirty open-document overlays and disk fallback
- retain named type tokens for type-space navigation while leaving qualified property/member navigation unsupported
- keep valid local definitions available when unrelated imports fail to resolve
- update the LSP roadmap and add focused language-server coverage

Testing:
- dotnet build SharpTS.sln --no-restore
- dotnet test SharpTS.Tests/SharpTS.Tests.csproj --no-restore --filter FullyQualifiedName~DefinitionServiceTests (17 passed)
- dotnet test SharpTS.Tests/SharpTS.Tests.csproj --no-restore (16,222 passed)