### PR TITLE
Add semantic references support

### DIFF
--- a/SharpTS.LanguageServer/DocumentStore.cs
+++ b/SharpTS.LanguageServer/DocumentStore.cs
@@ -14,7 +14,15 @@ public sealed class DocumentStore
     public bool TryGet(string uri, out string text) => _docs.TryGetValue(uri, out text!);
     public void Remove(string uri) => _docs.TryRemove(uri, out _);
 
-    /// <summary>Returns a stable snapshot of all open documents for module-resolution overlays.</summary>
-    public IReadOnlyDictionary<string, string> Snapshot() =>
-        new Dictionary<string, string>(_docs);
+    /// <summary>Returns open file documents keyed by normalized file-system path.</summary>
+    public IReadOnlyDictionary<string, string> SnapshotFileSystemDocuments()
+    {
+        var documents = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (documentUri, text) in _docs)
+        {
+            if (Uri.TryCreate(documentUri, UriKind.Absolute, out var uri) && uri.IsFile)
+                documents[Path.GetFullPath(uri.LocalPath)] = text;
+        }
+        return documents;
+    }
 }

--- a/SharpTS.LanguageServer/Handlers/DefinitionHandler.cs
+++ b/SharpTS.LanguageServer/Handlers/DefinitionHandler.cs
@@ -34,21 +34,11 @@ public sealed class DefinitionHandler : DefinitionHandlerBase
 
         ct.ThrowIfCancellationRequested();
 
-        var overlay = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var (openUri, openText) in _store.Snapshot())
-        {
-            if (Uri.TryCreate(openUri, UriKind.Absolute, out var parsedUri) &&
-                parsedUri.IsFile)
-            {
-                overlay[Path.GetFullPath(parsedUri.LocalPath)] = openText;
-            }
-        }
-
         var locations = _definitions.FindDefinitions(
                 request.TextDocument.Uri.GetFileSystemPath(),
                 text,
                 request.Position,
-                overlay)
+                _store.SnapshotFileSystemDocuments())
             .Select(location => new LocationOrLocationLink(location));
         return Task.FromResult<LocationOrLocationLinks?>(
             new LocationOrLocationLinks(locations));

--- a/SharpTS.LanguageServer/Handlers/ReferencesHandler.cs
+++ b/SharpTS.LanguageServer/Handlers/ReferencesHandler.cs
@@ -1,0 +1,56 @@
+using MediatR;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpTS.LanguageServer.Services;
+
+namespace SharpTS.LanguageServer.Handlers;
+
+/// <summary>
+/// Serves semantic references for checker-bound value and type identities.
+/// </summary>
+/// <remarks>
+/// Registered only in <see cref="LanguageFeatureMode.Full"/> so the VS Code extension continues
+/// leaving ordinary TypeScript navigation exclusively to <c>tsserver</c>.
+/// </remarks>
+public sealed class ReferencesHandler : ReferencesHandlerBase
+{
+    private readonly DocumentStore _store;
+    private readonly ReferenceService _references;
+
+    public ReferencesHandler(DocumentStore store, ReferenceService references)
+    {
+        _store = store;
+        _references = references;
+    }
+
+    public override Task<LocationContainer?> Handle(
+        ReferenceParams request,
+        CancellationToken ct)
+    {
+        string uri = request.TextDocument.Uri.ToString();
+        if (!_store.TryGet(uri, out var text))
+            return Task.FromResult<LocationContainer?>(null);
+
+        ct.ThrowIfCancellationRequested();
+
+        var locations = _references.FindReferences(
+            request.TextDocument.Uri.GetFileSystemPath(),
+            text,
+            request.Position,
+            request.Context.IncludeDeclaration,
+            _store.SnapshotFileSystemDocuments());
+        return Task.FromResult<LocationContainer?>(
+            new LocationContainer(locations));
+    }
+
+    protected override ReferenceRegistrationOptions CreateRegistrationOptions(
+        ReferenceCapability capability,
+        ClientCapabilities clientCapabilities)
+        => new()
+        {
+            DocumentSelector = TextDocumentSelector.ForLanguage(
+                "typescript",
+                "typescriptreact"),
+        };
+}

--- a/SharpTS.LanguageServer/Services/DefinitionService.cs
+++ b/SharpTS.LanguageServer/Services/DefinitionService.cs
@@ -1,10 +1,5 @@
-using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
-using SharpTS.Configuration;
-using SharpTS.Modules;
-using SharpTS.Parsing;
 using SharpTS.TypeSystem;
-using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace SharpTS.LanguageServer.Services;
 
@@ -27,73 +22,28 @@ public sealed class DefinitionService
         Position position,
         IReadOnlyDictionary<string, string>? openDocuments = null)
     {
-        string absolutePath = Path.GetFullPath(path);
-        var overlay = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        if (openDocuments is not null)
-        {
-            foreach (var (documentPath, documentText) in openDocuments)
-                overlay[Path.GetFullPath(documentPath)] = documentText;
-        }
-        overlay[absolutePath] = text;
-
-        ParsedModule entry;
-        ModuleResolver resolver;
-        try
-        {
-            resolver = new ModuleResolver(
-                absolutePath,
-                ModuleResolutionOptions.Default,
-                overlay,
-                new TypeScriptProgramOptions { PreferDeclarationFiles = true },
-                virtualFilesFallBackToDisk: true);
-            entry = resolver.LoadModule(absolutePath, DecoratorMode.Stage3);
-        }
-        catch
-        {
-            return [];
-        }
-
-        if (entry.Document is not { } document)
+        if (NavigationModelBuilder.TryBuild(path, text, openDocuments) is not { } model)
             return [];
 
-        var checker = new TypeChecker().WithFilePath(absolutePath);
-        try
-        {
-            checker.CheckModules(resolver.GetModulesInOrder(entry), resolver);
-        }
-        catch
-        {
-            return [];
-        }
-
-        int offset = document.Lines.ToOffset(
+        int offset = model.Document.Lines.ToOffset(
             (int)position.Line + 1,
             (int)position.Character + 1);
         IReadOnlyList<BindingDeclaration> declarations =
-            checker.Bindings.FindDefinitions(document, offset, BindingNamespace.Value);
+            model.Checker.Bindings.FindDefinitions(
+                model.Document,
+                offset,
+                BindingNamespace.Value);
         if (declarations.Count == 0)
         {
             declarations =
-                checker.Bindings.FindDefinitions(document, offset, BindingNamespace.Type);
+                model.Checker.Bindings.FindDefinitions(
+                    model.Document,
+                    offset,
+                    BindingNamespace.Type);
         }
         return declarations
-            .Select(ToLocation)
+            .Select(declaration =>
+                NavigationLocations.From(declaration.Document, declaration.Name))
             .ToArray();
-    }
-
-    private static Location ToLocation(BindingDeclaration declaration)
-    {
-        var document = declaration.Document;
-        var (startLine, startColumn) = document.Lines.ToPosition(declaration.Name.Start);
-        var (endLine, endColumn) = document.Lines.ToPosition(declaration.Name.End);
-        return new Location
-        {
-            Uri = DocumentUri.FromFileSystemPath(document.Path),
-            Range = new Range(
-                startLine - 1,
-                startColumn - 1,
-                endLine - 1,
-                endColumn - 1),
-        };
     }
 }

--- a/SharpTS.LanguageServer/Services/NavigationModelBuilder.cs
+++ b/SharpTS.LanguageServer/Services/NavigationModelBuilder.cs
@@ -1,0 +1,133 @@
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpTS.Configuration;
+using SharpTS.Modules;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace SharpTS.LanguageServer.Services;
+
+internal sealed record CheckedNavigationModel(
+    TypeChecker Checker,
+    SourceDocument Document);
+
+/// <summary>
+/// Builds the semantic module graph shared by definition, references, and later rename support.
+/// </summary>
+internal static class NavigationModelBuilder
+{
+    public static CheckedNavigationModel? TryBuild(
+        string path,
+        string text,
+        IReadOnlyDictionary<string, string>? openDocuments)
+    {
+        try
+        {
+            string absolutePath = Path.GetFullPath(path);
+            var overlay = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (openDocuments is not null)
+            {
+                foreach (var (documentPath, documentText) in openDocuments)
+                    overlay[Path.GetFullPath(documentPath)] = documentText;
+            }
+            overlay[absolutePath] = text;
+
+            var resolver = new ModuleResolver(
+                absolutePath,
+                ModuleResolutionOptions.Default,
+                overlay,
+                new TypeScriptProgramOptions { PreferDeclarationFiles = true },
+                virtualFilesFallBackToDisk: true);
+            ParsedModule entry = resolver.LoadModule(absolutePath, DecoratorMode.Stage3);
+            if (entry.Document is not { } document)
+                return null;
+
+            // Load open roots to discover reverse importers, then check only the undirected module
+            // component containing the requested file. This includes open importers and forward
+            // dependencies without merging globals from unrelated open script files.
+            List<ParsedModule> loadedRoots = [entry];
+            foreach (string openPath in overlay.Keys.Order(StringComparer.OrdinalIgnoreCase))
+            {
+                if (string.Equals(openPath, absolutePath, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                try
+                {
+                    ParsedModule root = resolver.LoadModule(openPath, DecoratorMode.Stage3);
+                    if (!loadedRoots.Contains(root))
+                        loadedRoots.Add(root);
+                }
+                catch
+                {
+                    // The requested root remains authoritative and independently useful.
+                }
+            }
+
+            List<ParsedModule> loadedModules = resolver.GetModulesInOrder(loadedRoots);
+            HashSet<ParsedModule> component = FindConnectedComponent(
+                entry,
+                loadedModules);
+            List<ParsedModule> connectedRoots = loadedRoots
+                .Where(component.Contains)
+                .ToList();
+
+            var checker = new TypeChecker().WithFilePath(absolutePath);
+            checker.CheckModules(
+                resolver.GetModulesInOrder(connectedRoots),
+                resolver);
+            return new CheckedNavigationModel(checker, document);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static HashSet<ParsedModule> FindConnectedComponent(
+        ParsedModule entry,
+        IReadOnlyList<ParsedModule> modules)
+    {
+        HashSet<ParsedModule> component = [entry];
+        Queue<ParsedModule> pending = new([entry]);
+
+        while (pending.TryDequeue(out var current))
+        {
+            foreach (var adjacent in current.Dependencies.Concat(current.ReferencedScripts))
+            {
+                if (component.Add(adjacent))
+                    pending.Enqueue(adjacent);
+            }
+
+            foreach (var candidate in modules)
+            {
+                if ((candidate.Dependencies.Contains(current) ||
+                     candidate.ReferencedScripts.Contains(current)) &&
+                    component.Add(candidate))
+                {
+                    pending.Enqueue(candidate);
+                }
+            }
+        }
+
+        return component;
+    }
+}
+
+internal static class NavigationLocations
+{
+    public static Location From(SourceDocument document, Token token)
+    {
+        var (startLine, startColumn) = document.Lines.ToPosition(token.Start);
+        var (endLine, endColumn) = document.Lines.ToPosition(token.End);
+        return new Location
+        {
+            Uri = DocumentUri.FromFileSystemPath(document.Path),
+            Range = new Range(
+                startLine - 1,
+                startColumn - 1,
+                endLine - 1,
+                endColumn - 1),
+        };
+    }
+}

--- a/SharpTS.LanguageServer/Services/ReferenceService.cs
+++ b/SharpTS.LanguageServer/Services/ReferenceService.cs
@@ -1,0 +1,29 @@
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace SharpTS.LanguageServer.Services;
+
+/// <summary>
+/// Resolves a source position to every checker-bound occurrence of the same semantic symbol.
+/// </summary>
+public sealed class ReferenceService
+{
+    public IReadOnlyList<Location> FindReferences(
+        string path,
+        string text,
+        Position position,
+        bool includeDeclaration,
+        IReadOnlyDictionary<string, string>? openDocuments = null)
+    {
+        if (NavigationModelBuilder.TryBuild(path, text, openDocuments) is not { } model)
+            return [];
+
+        int offset = model.Document.Lines.ToOffset(
+            (int)position.Line + 1,
+            (int)position.Character + 1);
+        return model.Checker.Bindings
+            .FindReferences(model.Document, offset, includeDeclaration)
+            .Select(occurrence =>
+                NavigationLocations.From(occurrence.Document, occurrence.Name))
+            .ToArray();
+    }
+}

--- a/SharpTS.LanguageServer/SharpTSLanguageServer.cs
+++ b/SharpTS.LanguageServer/SharpTSLanguageServer.cs
@@ -37,7 +37,8 @@ public static class SharpTSLanguageServer
                     .AddSingleton(new DecoratorService(resolve, typeNames))
                     .AddSingleton(new MemberHoverService(resolve))
                     .AddSingleton<DocumentSymbolService>()
-                    .AddSingleton<DefinitionService>())
+                    .AddSingleton<DefinitionService>()
+                    .AddSingleton<ReferenceService>())
                 // Served in both modes: this is the interop knowledge no other server has.
                 .WithHandler<TextDocumentSyncHandler>()
                 .WithHandler<HoverHandler>()
@@ -50,7 +51,8 @@ public static class SharpTSLanguageServer
             {
                 options
                     .WithHandler<DocumentSymbolHandler>()
-                    .WithHandler<DefinitionHandler>();
+                    .WithHandler<DefinitionHandler>()
+                    .WithHandler<ReferencesHandler>();
             }
         });
 

--- a/SharpTS.Tests/LanguageServer/ReferenceServiceTests.cs
+++ b/SharpTS.Tests/LanguageServer/ReferenceServiceTests.cs
@@ -1,0 +1,436 @@
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpTS.LanguageServer;
+using SharpTS.LanguageServer.Handlers;
+using SharpTS.LanguageServer.Services;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+using Xunit;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace SharpTS.Tests.LanguageServer;
+
+/// <summary>
+/// Covers inverse semantic binding lookup. These cases intentionally require checker identity:
+/// text matching cannot distinguish shadowing, properties, overload groups, or type/value facets.
+/// </summary>
+public class ReferenceServiceTests
+{
+    private readonly ReferenceService _references = new();
+
+    [Fact]
+    public void DeclarationInclusionFollowsTheRequestContext()
+    {
+        const string source = """
+            const value = 1;
+            console.log(value);
+            value;
+            """;
+
+        var withoutDeclaration = References(
+            source, "value", occurrence: 1, includeDeclaration: false);
+        var withDeclaration = References(
+            source, "value", occurrence: 1, includeDeclaration: true);
+
+        Assert.Equal(
+            [
+                new Range(1, 12, 1, 17),
+                new Range(2, 0, 2, 5),
+            ],
+            withoutDeclaration.Select(location => location.Range).ToArray());
+        Assert.Equal(
+            [
+                new Range(0, 6, 0, 11),
+                new Range(1, 12, 1, 17),
+                new Range(2, 0, 2, 5),
+            ],
+            withDeclaration.Select(location => location.Range).ToArray());
+    }
+
+    [Fact]
+    public void ShadowedBindingDoesNotIncludeSameNamedOuterOccurrences()
+    {
+        const string source = """
+            const value = 1;
+            function read(): number {
+              const value = 2;
+              return value;
+            }
+            console.log(value);
+            """;
+
+        var references = References(
+            source, "value", occurrence: 2, includeDeclaration: true);
+
+        Assert.Equal(
+            [
+                new Range(2, 8, 2, 13),
+                new Range(3, 9, 3, 14),
+            ],
+            references.Select(location => location.Range).ToArray());
+    }
+
+    [Fact]
+    public void OverloadDeclarationsAndCallShareOneReferenceIdentity()
+    {
+        const string source = """
+            function convert(value: string): string;
+            function convert(value: number): number;
+            function convert(value: string | number): string | number { return value; }
+            convert("x");
+            """;
+
+        var withoutDeclarations = References(
+            source, "convert", occurrence: 3, includeDeclaration: false);
+        var withDeclarations = References(
+            source, "convert", occurrence: 3, includeDeclaration: true);
+
+        Assert.Single(withoutDeclarations);
+        Assert.Equal(new Range(3, 0, 3, 7), withoutDeclarations[0].Range);
+        Assert.Equal(
+            [0, 1, 2, 3],
+            withDeclarations.Select(location => (int)location.Range.Start.Line).ToArray());
+    }
+
+    [Fact]
+    public void ClassDeclarationUnionsItsTypeAndValueReferences()
+    {
+        const string source = """
+            class Box {}
+            const constructor = Box;
+            const item: Box = new Box();
+            """;
+
+        var references = References(
+            source, "Box", occurrence: 0, includeDeclaration: true);
+
+        Assert.Equal(
+            [
+                new Range(0, 6, 0, 9),
+                new Range(1, 20, 1, 23),
+                new Range(2, 12, 2, 15),
+                new Range(2, 22, 2, 25),
+            ],
+            references.Select(location => location.Range).ToArray());
+    }
+
+    [Fact]
+    public void PropertyNamesAreNotGuessedFromMatchingText()
+    {
+        const string source = """
+            const value = 1;
+            const object = { value: 2 };
+            console.log(value, object.value);
+            """;
+
+        var references = References(
+            source, "value", occurrence: 0, includeDeclaration: true);
+
+        Assert.Equal(
+            [
+                new Range(0, 6, 0, 11),
+                new Range(2, 12, 2, 17),
+            ],
+            references.Select(location => location.Range).ToArray());
+    }
+
+    [Fact]
+    public void OpenImporterReferencesResolveBackToTheSourceDeclaration()
+    {
+        string root = Path.GetFullPath("reference-module-test");
+        string dependencyPath = Path.Combine(root, "dependency.ts");
+        string entryPath = Path.Combine(root, "entry.ts");
+        const string dependency = "export const original = 1;\n";
+        const string entry = """
+            import { original as local } from "./dependency";
+            console.log(local);
+            local;
+            """;
+        var openDocuments = new Dictionary<string, string>
+        {
+            [dependencyPath] = dependency,
+            [entryPath] = entry,
+        };
+
+        var references = References(
+            dependencyPath,
+            dependency,
+            "original",
+            occurrence: 0,
+            includeDeclaration: false,
+            openDocuments);
+
+        Assert.Equal(4, references.Count);
+        Assert.All(
+            references,
+            location => Assert.Equal(
+                DocumentUri.FromFileSystemPath(entryPath),
+                location.Uri));
+        Assert.Equal(
+            [
+                new Range(0, 9, 0, 17),
+                new Range(0, 21, 0, 26),
+                new Range(1, 12, 1, 17),
+                new Range(2, 0, 2, 5),
+            ],
+            references.Select(location => location.Range).ToArray());
+    }
+
+    [Fact]
+    public void TypeOnlyImportReferencesIncludeAliasesAndAnnotations()
+    {
+        string root = Path.GetFullPath("type-reference-module-test");
+        string dependencyPath = Path.Combine(root, "dependency.ts");
+        string entryPath = Path.Combine(root, "entry.ts");
+        const string dependency = "export interface Shape { size: number; }\n";
+        const string entry = """
+            import type { Shape as LocalShape } from "./dependency";
+            const value: LocalShape = { size: 1 };
+            """;
+        var openDocuments = new Dictionary<string, string>
+        {
+            [dependencyPath] = dependency,
+            [entryPath] = entry,
+        };
+
+        var references = References(
+            entryPath,
+            entry,
+            "LocalShape",
+            occurrence: 1,
+            includeDeclaration: true,
+            openDocuments);
+
+        Assert.Equal(4, references.Count);
+        Assert.Equal(
+            DocumentUri.FromFileSystemPath(dependencyPath),
+            references[0].Uri);
+        Assert.Equal(new Range(0, 17, 0, 22), references[0].Range);
+        Assert.Equal(
+            [
+                new Range(0, 14, 0, 19),
+                new Range(0, 23, 0, 33),
+                new Range(1, 13, 1, 23),
+            ],
+            references.Skip(1).Select(location => location.Range).ToArray());
+    }
+
+    [Fact]
+    public void ReExportChainPreservesAllAliasOccurrences()
+    {
+        string root = Path.GetFullPath("reexport-reference-module-test");
+        string dependencyPath = Path.Combine(root, "dependency.ts");
+        string barrelPath = Path.Combine(root, "barrel.ts");
+        string entryPath = Path.Combine(root, "entry.ts");
+        const string dependency = "export function run(): void {}\n";
+        const string barrel = "export { run as execute } from \"./dependency\";\n";
+        const string entry = """
+            import { execute as start } from "./barrel";
+            start();
+            """;
+        var openDocuments = new Dictionary<string, string>
+        {
+            [dependencyPath] = dependency,
+            [barrelPath] = barrel,
+            [entryPath] = entry,
+        };
+
+        var references = References(
+            dependencyPath,
+            dependency,
+            "run",
+            occurrence: 0,
+            includeDeclaration: true,
+            openDocuments);
+
+        Assert.Equal(6, references.Count);
+        Assert.Equal(
+            new Range(0, 16, 0, 19),
+            Assert.Single(
+                references,
+                location =>
+                    location.Uri == DocumentUri.FromFileSystemPath(dependencyPath)).Range);
+        Assert.Equal(
+            [
+                new Range(0, 9, 0, 12),
+                new Range(0, 16, 0, 23),
+            ],
+            references
+                .Where(location =>
+                    location.Uri == DocumentUri.FromFileSystemPath(barrelPath))
+                .Select(location => location.Range)
+                .ToArray());
+        Assert.Equal(
+            [
+                new Range(0, 9, 0, 16),
+                new Range(0, 20, 0, 25),
+                new Range(1, 0, 1, 5),
+            ],
+            references
+                .Where(location =>
+                    location.Uri == DocumentUri.FromFileSystemPath(entryPath))
+                .Select(location => location.Range)
+                .ToArray());
+    }
+
+    [Fact]
+    public void MalformedUnrelatedOpenBufferDoesNotEraseReferences()
+    {
+        string root = Path.GetFullPath("isolated-reference-model-test");
+        string currentPath = Path.Combine(root, "current.ts");
+        string malformedPath = Path.Combine(root, "malformed.ts");
+        const string source = "const target = 1;\ntarget;\n";
+        var openDocuments = new Dictionary<string, string>
+        {
+            [currentPath] = source,
+            [malformedPath] = "const = ;",
+        };
+
+        var references = References(
+            currentPath,
+            source,
+            "target",
+            occurrence: 1,
+            includeDeclaration: true,
+            openDocuments);
+
+        Assert.Equal(2, references.Count);
+        Assert.All(
+            references,
+            location => Assert.Equal(
+                DocumentUri.FromFileSystemPath(currentPath),
+                location.Uri));
+    }
+
+    [Fact]
+    public void UnrelatedOpenScriptDoesNotMergeSameNamedGlobals()
+    {
+        string root = Path.GetFullPath("unrelated-reference-model-test");
+        string currentPath = Path.Combine(root, "current.ts");
+        string unrelatedPath = Path.Combine(root, "unrelated.ts");
+        const string source = "const target = 1;\ntarget;\n";
+        var openDocuments = new Dictionary<string, string>
+        {
+            [currentPath] = source,
+            [unrelatedPath] = "const target = 2;\ntarget;\n",
+        };
+
+        var references = References(
+            currentPath,
+            source,
+            "target",
+            occurrence: 1,
+            includeDeclaration: true,
+            openDocuments);
+
+        Assert.Equal(2, references.Count);
+        Assert.All(
+            references,
+            location => Assert.Equal(
+                DocumentUri.FromFileSystemPath(currentPath),
+                location.Uri));
+    }
+
+    [Fact]
+    public void ReusedCheckerDoesNotReturnStaleOccurrences()
+    {
+        var checker = new TypeChecker();
+        var first = Parse("first-reference.ts", "const current = 1; current;\n");
+        checker.CheckWithRecovery(first.Statements, first.Document);
+
+        var second = Parse("second-reference.ts", "const current = 2; current; current;\n");
+        checker.CheckWithRecovery(second.Statements, second.Document);
+
+        var references = checker.Bindings.FindReferences(
+            second.Document,
+            second.Document.Text.LastIndexOf("current", StringComparison.Ordinal),
+            includeDeclarations: true);
+
+        Assert.Equal(3, references.Count);
+        Assert.All(
+            references,
+            reference => Assert.Same(second.Document, reference.Document));
+    }
+
+    [Fact]
+    public async Task HandlerHonorsIncludeDeclaration()
+    {
+        string path = Path.GetFullPath("handler-reference-test.ts");
+        DocumentUri uri = DocumentUri.FromFileSystemPath(path);
+        const string source = "const answer = 42;\nconsole.log(answer);\n";
+        var store = new DocumentStore();
+        store.Set(uri.ToString(), source);
+        var handler = new ReferencesHandler(store, new ReferenceService());
+
+        var result = await handler.Handle(
+            new ReferenceParams
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Position = new Position(1, 12),
+                Context = new ReferenceContext { IncludeDeclaration = false },
+            },
+            CancellationToken.None);
+
+        var location = Assert.Single(
+            Assert.IsAssignableFrom<LocationContainer>(result));
+        Assert.Equal(new Range(1, 12, 1, 18), location.Range);
+    }
+
+    private IReadOnlyList<Location> References(
+        string source,
+        string name,
+        int occurrence,
+        bool includeDeclaration)
+    {
+        string path = Path.GetFullPath("reference-test.ts");
+        return References(
+            path,
+            source,
+            name,
+            occurrence,
+            includeDeclaration,
+            new Dictionary<string, string> { [path] = source });
+    }
+
+    private IReadOnlyList<Location> References(
+        string path,
+        string source,
+        string name,
+        int occurrence,
+        bool includeDeclaration,
+        IReadOnlyDictionary<string, string> openDocuments)
+    {
+        int offset = NthIndexOf(source, name, occurrence);
+        var lines = new LineIndex(source);
+        var (line, column) = lines.ToPosition(offset);
+        return _references.FindReferences(
+            path,
+            source,
+            new Position(line - 1, column - 1),
+            includeDeclaration,
+            openDocuments);
+    }
+
+    private static int NthIndexOf(string source, string value, int occurrence)
+    {
+        int offset = -1;
+        for (int i = 0; i <= occurrence; i++)
+        {
+            offset = source.IndexOf(value, offset + 1, StringComparison.Ordinal);
+            Assert.True(offset >= 0, $"Occurrence {occurrence} of '{value}' was not found.");
+        }
+        return offset;
+    }
+
+    private static (List<Stmt> Statements, SourceDocument Document) Parse(
+        string path,
+        string source)
+    {
+        var document = new SourceDocument(path, source);
+        var parsed = new Parser(new Lexer(source).ScanTokens())
+            .WithSourceDocument(document)
+            .Parse();
+        Assert.True(parsed.IsSuccess);
+        return (parsed.Statements, document);
+    }
+}

--- a/TypeSystem/BindingIndex.cs
+++ b/TypeSystem/BindingIndex.cs
@@ -18,6 +18,14 @@ public enum BindingNamespace
 public sealed record BindingDeclaration(SourceDocument Document, Token Name);
 
 /// <summary>
+/// One source occurrence of a semantic binding.
+/// </summary>
+public sealed record BindingOccurrence(
+    SourceDocument Document,
+    Token Name,
+    bool IsDeclaration);
+
+/// <summary>
 /// Stable identity for one checker-resolved symbol.
 /// </summary>
 /// <remarks>
@@ -74,6 +82,8 @@ public sealed class BindingIndex
         new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<Token, SourceDocument> _documents =
         new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<BindingSymbol, Dictionary<Token, SourceDocument>> _occurrences =
+        new(ReferenceEqualityComparer.Instance);
     private int _nextId = 1;
     private int _generation;
 
@@ -81,6 +91,7 @@ public sealed class BindingIndex
     {
         _tokens.Clear();
         _documents.Clear();
+        _occurrences.Clear();
         _generation++;
     }
 
@@ -110,7 +121,10 @@ public sealed class BindingIndex
         }
         facets[bindingNamespace] = symbol;
         if (document is not null && declaration.Start >= 0)
+        {
             _documents[declaration] = document;
+            RecordOccurrence(symbol, declaration, document);
+        }
         return symbol;
     }
 
@@ -124,9 +138,41 @@ public sealed class BindingIndex
             facets = [];
             _tokens[use] = facets;
         }
+        else if (facets.TryGetValue(symbol.Namespace, out var previous) &&
+                 !ReferenceEquals(previous, symbol))
+        {
+            RemoveOccurrence(previous, use);
+        }
         facets[symbol.Namespace] = symbol;
         if (document is not null)
+        {
             _documents[use] = document;
+            RecordOccurrence(symbol, use, document);
+        }
+    }
+
+    private void RecordOccurrence(
+        BindingSymbol symbol,
+        Token token,
+        SourceDocument document)
+    {
+        if (!_occurrences.TryGetValue(symbol, out var occurrences))
+        {
+            occurrences = new Dictionary<Token, SourceDocument>(
+                ReferenceEqualityComparer.Instance);
+            _occurrences[symbol] = occurrences;
+        }
+        occurrences[token] = document;
+    }
+
+    private void RemoveOccurrence(BindingSymbol symbol, Token token)
+    {
+        if (!_occurrences.TryGetValue(symbol, out var occurrences))
+            return;
+
+        occurrences.Remove(token);
+        if (occurrences.Count == 0)
+            _occurrences.Remove(symbol);
     }
 
     /// <summary>
@@ -158,5 +204,97 @@ public sealed class BindingIndex
         }
 
         return best?.Declarations ?? [];
+    }
+
+    /// <summary>
+    /// Returns all checker-bound occurrences for the semantic binding at a UTF-16 source offset.
+    /// When the selected token has both value and type facets (for example a class declaration),
+    /// occurrences from both identities are unioned.
+    /// </summary>
+    public IReadOnlyList<BindingOccurrence> FindReferences(
+        SourceDocument document,
+        int offset,
+        bool includeDeclarations)
+    {
+        IReadOnlyList<BindingSymbol> symbols = FindSymbols(document, offset);
+        if (symbols.Count == 0)
+            return [];
+
+        var occurrences = new Dictionary<Token, OccurrenceBuilder>(
+            ReferenceEqualityComparer.Instance);
+        foreach (var symbol in symbols)
+        {
+            if (!_occurrences.TryGetValue(symbol, out var symbolOccurrences))
+                continue;
+
+            foreach (var (token, occurrenceDocument) in symbolOccurrences)
+            {
+                bool isDeclaration = symbol.Declarations.Any(declaration =>
+                    ReferenceEquals(declaration.Document, occurrenceDocument) &&
+                    ReferenceEquals(declaration.Name, token));
+
+                if (occurrences.TryGetValue(token, out var existing))
+                {
+                    existing.IsDeclarationInEveryFacet &= isDeclaration;
+                }
+                else
+                {
+                    occurrences[token] = new OccurrenceBuilder(
+                        occurrenceDocument,
+                        isDeclaration);
+                }
+            }
+        }
+
+        return occurrences
+            .Where(pair =>
+                includeDeclarations || !pair.Value.IsDeclarationInEveryFacet)
+            .Select(pair => new BindingOccurrence(
+                pair.Value.Document,
+                pair.Key,
+                pair.Value.IsDeclarationInEveryFacet))
+            .OrderBy(occurrence => occurrence.Document.Path, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(occurrence => occurrence.Name.Start)
+            .ToArray();
+    }
+
+    private IReadOnlyList<BindingSymbol> FindSymbols(
+        SourceDocument document,
+        int offset)
+    {
+        var symbols = new HashSet<BindingSymbol>(ReferenceEqualityComparer.Instance);
+        int bestLength = int.MaxValue;
+
+        foreach (var (token, facets) in _tokens)
+        {
+            if (!_documents.TryGetValue(token, out var tokenDocument) ||
+                !ReferenceEquals(tokenDocument, document) ||
+                !token.Span.Contains(offset))
+            {
+                continue;
+            }
+
+            if (token.Span.Length < bestLength)
+            {
+                symbols.Clear();
+                bestLength = token.Span.Length;
+            }
+            if (token.Span.Length == bestLength)
+            {
+                foreach (var symbol in facets.Values)
+                    symbols.Add(symbol);
+            }
+        }
+
+        return symbols.ToArray();
+    }
+
+    private sealed class OccurrenceBuilder(
+        SourceDocument document,
+        bool isDeclarationInEveryFacet)
+    {
+        public SourceDocument Document { get; } = document;
+        public bool IsDeclarationInEveryFacet { get; set; } =
+            isDeclarationInEveryFacet;
     }
 }

--- a/docs/plans/lsp-server.md
+++ b/docs/plans/lsp-server.md
@@ -267,13 +267,19 @@ dirty open documents on disk, and carries source identities through named/defaul
 re-exports. This makes hoisting, shadowing, parameters, overload merging, aliases, and module
 provenance follow the real checker instead of a second editor-only scope walker.
 
+`textDocument/references` now uses the inverse side of that same index. It unions type/value facets
+only when the selected token has both, honors `includeDeclaration`, and discovers the connected
+component across open roots so references in open importers are included as well as forward
+dependencies without merging unrelated script globals. Unopened reverse importers are not yet a
+known-complete domain; safe rename must refuse that partial cross-module case until the lifecycle
+work maintains a workspace graph with reverse edges.
+
 The server advertises these features only in `--language-features full`; the VS Code extension
 continues to launch `interop-only`, leaving ordinary TypeScript navigation to `tsserver`.
 
-Still required for the complete navigation milestone: the inverse reference index, safe rename,
-and the remaining type/member domains (notably type parameters and qualified namespace/property
-members). Property/member definition remains deliberately absent until it can resolve a complete
-semantic domain.
+Still required for the complete navigation milestone: safe rename and the remaining type/member
+domains (notably type parameters and qualified namespace/property members). Property/member
+definition remains deliberately absent until it can resolve a complete semantic domain.
 
 ---
 
@@ -381,9 +387,10 @@ single-file binary so non-VS-Code editors don't need the full SDK.
   surgery, no record-equality risk. ~7 tests + e2e (precise columns, declaration + usage hover).
 - 🟨 **Phase 4b — standalone general navigation.** Reference-keyed source spans, document
   symbols, semantic value/type binding identities, and module-aware go-to-definition through
-  imports/re-exports have landed. References, safe rename, type-parameter navigation, and
-  qualified member navigation remain. VS Code stays in `interop-only`; these capabilities are
-  for standalone clients.
+  imports/re-exports have landed. The inverse binding index and references across open module roots
+  have also landed. Safe rename, type-parameter navigation, qualified member navigation, and a
+  complete reverse workspace graph remain. VS Code stays in `interop-only`; these capabilities
+  are for standalone clients.
 - ⬜ **Phase 5 — Polish & reach.** Multi-editor docs; `dotnet tool`/self-contained
   packaging; debounce/cancellation; config→server wiring (`sharpts.diagnostics`);
   loader reload on `.csproj`/`bin` change; STATUS.md/README updates. **NOT YET DONE.**


### PR DESCRIPTION
Part of #1306.

Summary:
- add an inverse checker binding index with declaration filtering and type/value facet unioning
- expose textDocument/references only in full language-feature mode
- share one checked navigation model between definition and references
- discover the connected component across open roots so reverse importers are included without merging unrelated script globals
- preserve aliases and re-export occurrences across module boundaries
- document why safe rename still waits for a complete reverse workspace graph

Testing:
- dotnet build SharpTS.sln --no-restore
- focused definition/reference tests: 29 passed
- dotnet test SharpTS.Tests/SharpTS.Tests.csproj --no-restore: 16,234 passed