### PR TITLE
LSP: discover closed reverse importers

### DIFF
--- a/SharpTS.LanguageServer/Services/NavigationModelBuilder.cs
+++ b/SharpTS.LanguageServer/Services/NavigationModelBuilder.cs
@@ -10,7 +10,16 @@ namespace SharpTS.LanguageServer.Services;
 
 internal sealed record CheckedNavigationModel(
     TypeChecker Checker,
-    SourceDocument Document);
+    SourceDocument Document,
+    NavigationGraphScope Scope);
+
+/// <summary>
+/// Describes the bounded root set used to discover reverse navigation edges.
+/// </summary>
+internal sealed record NavigationGraphScope(
+    string? ConfigPath,
+    IReadOnlyList<string> RootFiles,
+    bool IsComplete);
 
 /// <summary>
 /// Builds the semantic module graph shared by definition, references, and later rename support.
@@ -33,38 +42,73 @@ internal static class NavigationModelBuilder
             }
             overlay[absolutePath] = text;
 
+            NavigationWorkspace workspace = DiscoverWorkspace(absolutePath);
             var resolver = new ModuleResolver(
-                absolutePath,
-                ModuleResolutionOptions.Default,
+                workspace.BasePath,
+                workspace.ResolutionOptions,
                 overlay,
-                new TypeScriptProgramOptions { PreferDeclarationFiles = true },
-                virtualFilesFallBackToDisk: true);
-            ParsedModule entry = resolver.LoadModule(absolutePath, DecoratorMode.Stage3);
+                workspace.ProgramOptions,
+                virtualFilesFallBackToDisk: true)
+            {
+                JsxOptions = workspace.JsxOptions,
+            };
+
+            bool allRootsLoaded = true;
+            List<ParsedModule> declarationRoots = [];
+            foreach (string declarationPath in workspace.DeclarationFiles)
+            {
+                try
+                {
+                    declarationRoots.Add(
+                        resolver.LoadModule(declarationPath, workspace.DecoratorMode));
+                }
+                catch
+                {
+                    allRootsLoaded = false;
+                }
+            }
+            resolver.RegisterAmbientModuleDeclarations(declarationRoots);
+
+            ParsedModule entry = resolver.LoadProgram(
+                absolutePath,
+                workspace.DecoratorMode);
             if (entry.Document is not { } document)
                 return null;
 
-            // Load open roots to discover reverse importers, then check only the undirected module
-            // component containing the requested file. This includes open importers and forward
-            // dependencies without merging globals from unrelated open script files.
+            // Every configured root is a possible reverse importer. Open roots are retained as
+            // the fallback for files without a tsconfig and include dirty/new buffers that the
+            // disk-backed config matcher cannot yet enumerate.
             List<ParsedModule> loadedRoots = [entry];
-            foreach (string openPath in overlay.Keys.Order(StringComparer.OrdinalIgnoreCase))
+            var rootPaths = workspace.RootFiles
+                .Concat(overlay.Keys)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Order(StringComparer.OrdinalIgnoreCase);
+            foreach (string rootPath in rootPaths)
             {
-                if (string.Equals(openPath, absolutePath, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(rootPath, absolutePath, StringComparison.OrdinalIgnoreCase))
                     continue;
 
                 try
                 {
-                    ParsedModule root = resolver.LoadModule(openPath, DecoratorMode.Stage3);
+                    ParsedModule root = resolver.LoadProgram(
+                        rootPath,
+                        workspace.DecoratorMode);
                     if (!loadedRoots.Contains(root))
                         loadedRoots.Add(root);
                 }
                 catch
                 {
-                    // The requested root remains authoritative and independently useful.
+                    if (workspace.RootFiles.Contains(
+                            rootPath,
+                            StringComparer.OrdinalIgnoreCase))
+                    {
+                        allRootsLoaded = false;
+                    }
                 }
             }
 
-            List<ParsedModule> loadedModules = resolver.GetModulesInOrder(loadedRoots);
+            List<ParsedModule> loadedModules = resolver.GetModulesInOrder(
+                declarationRoots.Concat(loadedRoots));
             HashSet<ParsedModule> component = FindConnectedComponent(
                 entry,
                 loadedModules);
@@ -72,11 +116,19 @@ internal static class NavigationModelBuilder
                 .Where(component.Contains)
                 .ToList();
 
-            var checker = new TypeChecker().WithFilePath(absolutePath);
+            var checker = new TypeChecker(workspace.CheckerOptions)
+                .WithFilePath(absolutePath);
+            checker.SetDecoratorMode(workspace.DecoratorMode);
             checker.CheckModules(
                 resolver.GetModulesInOrder(connectedRoots),
                 resolver);
-            return new CheckedNavigationModel(checker, document);
+            return new CheckedNavigationModel(
+                checker,
+                document,
+                new NavigationGraphScope(
+                    workspace.ConfigPath,
+                    workspace.RootFiles,
+                    workspace.IsConfigured && allRootsLoaded));
         }
         catch
         {
@@ -88,6 +140,20 @@ internal static class NavigationModelBuilder
         ParsedModule entry,
         IReadOnlyList<ParsedModule> modules)
     {
+        var reverseEdges = new Dictionary<ParsedModule, List<ParsedModule>>();
+        foreach (var module in modules)
+        {
+            foreach (var dependency in module.Dependencies.Concat(module.ReferencedScripts))
+            {
+                if (!reverseEdges.TryGetValue(dependency, out var importers))
+                {
+                    importers = [];
+                    reverseEdges[dependency] = importers;
+                }
+                importers.Add(module);
+            }
+        }
+
         HashSet<ParsedModule> component = [entry];
         Queue<ParsedModule> pending = new([entry]);
 
@@ -99,18 +165,92 @@ internal static class NavigationModelBuilder
                     pending.Enqueue(adjacent);
             }
 
-            foreach (var candidate in modules)
+            if (!reverseEdges.TryGetValue(current, out var importers))
+                continue;
+
+            foreach (var importer in importers)
             {
-                if ((candidate.Dependencies.Contains(current) ||
-                     candidate.ReferencedScripts.Contains(current)) &&
-                    component.Add(candidate))
-                {
-                    pending.Enqueue(candidate);
-                }
+                if (component.Add(importer))
+                    pending.Enqueue(importer);
             }
         }
 
         return component;
+    }
+
+    private static NavigationWorkspace DiscoverWorkspace(string absolutePath)
+    {
+        string directory = Path.GetDirectoryName(absolutePath)
+            ?? Directory.GetCurrentDirectory();
+        string? configPath = TsConfigLoader.Discover(directory);
+        if (configPath is null)
+            return NavigationWorkspace.Unconfigured(absolutePath);
+
+        try
+        {
+            TsConfigResult project = TsConfigLoader.Load(configPath);
+            DecoratorMode decoratorMode = project.DecoratorMode ?? DecoratorMode.Stage3;
+            return new NavigationWorkspace(
+                BasePath: project.ConfigPath,
+                ResolutionOptions: project.ModuleResolution,
+                ProgramOptions: new TypeScriptProgramOptions
+                {
+                    LoadDefaultLib = true,
+                    NoLib = project.NoLib == true,
+                    Lib = project.Lib,
+                    Types = project.Types,
+                    TypeRoots = project.TypeRoots,
+                    PreferDeclarationFiles = true,
+                },
+                CheckerOptions: StrictnessOptions.Resolve(null, project.Strictness),
+                DecoratorMode: decoratorMode,
+                JsxOptions: new JsxParseOptions(
+                    project.Jsx ?? JsxMode.ReactJsx,
+                    project.JsxFactory ?? "React.createElement",
+                    project.JsxFragmentFactory ?? "React.Fragment",
+                    project.JsxImportSource ?? "react"),
+                RootFiles: project.RootFiles,
+                DeclarationFiles: project.DeclarationFiles,
+                ConfigPath: project.ConfigPath,
+                IsConfigured: true);
+        }
+        catch
+        {
+            // A broken config must not erase navigation in the requested/open files. The
+            // resulting scope is explicitly incomplete, so safe rename cannot use it.
+            return NavigationWorkspace.Unconfigured(absolutePath, configPath);
+        }
+    }
+
+    private sealed record NavigationWorkspace(
+        string BasePath,
+        ModuleResolutionOptions ResolutionOptions,
+        TypeScriptProgramOptions ProgramOptions,
+        TypeCheckerOptions CheckerOptions,
+        DecoratorMode DecoratorMode,
+        JsxParseOptions JsxOptions,
+        IReadOnlyList<string> RootFiles,
+        IReadOnlyList<string> DeclarationFiles,
+        string? ConfigPath,
+        bool IsConfigured)
+    {
+        public static NavigationWorkspace Unconfigured(
+            string absolutePath,
+            string? configPath = null) =>
+            new(
+                BasePath: absolutePath,
+                ResolutionOptions: ModuleResolutionOptions.Default,
+                ProgramOptions: new TypeScriptProgramOptions
+                {
+                    PreferDeclarationFiles = true,
+                },
+                CheckerOptions: TypeCheckerOptions.Default,
+                DecoratorMode: DecoratorMode.Stage3,
+                JsxOptions: JsxParseOptions.Default,
+                RootFiles: [],
+                DeclarationFiles: [],
+                ConfigPath: configPath,
+                IsConfigured: false);
     }
 }
 

--- a/SharpTS.LanguageServer/SharpTS.LanguageServer.csproj
+++ b/SharpTS.LanguageServer/SharpTS.LanguageServer.csproj
@@ -24,6 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="SharpTS.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" />
   </ItemGroup>
 

--- a/SharpTS.Tests/LanguageServer/ReferenceServiceTests.cs
+++ b/SharpTS.Tests/LanguageServer/ReferenceServiceTests.cs
@@ -3,6 +3,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 using SharpTS.LanguageServer;
 using SharpTS.LanguageServer.Handlers;
 using SharpTS.LanguageServer.Services;
+using SharpTS.Tests.IntegrationTests;
 using SharpTS.Parsing;
 using SharpTS.TypeSystem;
 using Xunit;
@@ -174,6 +175,159 @@ public class ReferenceServiceTests
                 new Range(2, 0, 2, 5),
             ],
             references.Select(location => location.Range).ToArray());
+    }
+
+    [Fact]
+    public void ClosedImportersAreDiscoveredFromTheConfiguredProject()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        directory.CreateFile(
+            "tsconfig.json",
+            """{ "include": ["src/**/*.ts"], "exclude": ["excluded"] }""");
+        string dependencyPath = directory.CreateFile(
+            "src/dependency.ts",
+            "export const original = 1;\n");
+        string importerPath = directory.CreateFile(
+            "src/importer.ts",
+            """
+            import { original as local } from "./dependency";
+            console.log(local);
+            local;
+            """);
+        string excludedPath = directory.CreateFile(
+            "excluded/importer.ts",
+            """
+            import { original } from "../src/dependency";
+            original;
+            """);
+        string dependency = File.ReadAllText(dependencyPath);
+
+        var references = References(
+            dependencyPath,
+            dependency,
+            "original",
+            occurrence: 0,
+            includeDeclaration: false,
+            new Dictionary<string, string> { [dependencyPath] = dependency });
+
+        Assert.Equal(4, references.Count);
+        Assert.All(
+            references,
+            location => Assert.Equal(
+                DocumentUri.FromFileSystemPath(importerPath),
+                location.Uri));
+        Assert.DoesNotContain(
+            references,
+            location => location.Uri == DocumentUri.FromFileSystemPath(excludedPath));
+    }
+
+    [Fact]
+    public void ConfiguredModuleResolutionIsUsedForClosedReverseImporters()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        directory.CreateFile(
+            "tsconfig.json",
+            """
+            {
+              "compilerOptions": {
+                "baseUrl": ".",
+                "paths": { "@lib/*": ["src/lib/*"] }
+              },
+              "include": ["src/**/*.ts"]
+            }
+            """);
+        string dependencyPath = directory.CreateFile(
+            "src/lib/dependency.ts",
+            "export interface Shape { size: number; }\n");
+        string importerPath = directory.CreateFile(
+            "src/importer.ts",
+            """
+            import type { Shape as LocalShape } from "@lib/dependency";
+            const value: LocalShape = { size: 1 };
+            """);
+        string dependency = File.ReadAllText(dependencyPath);
+
+        var references = References(
+            dependencyPath,
+            dependency,
+            "Shape",
+            occurrence: 0,
+            includeDeclaration: false,
+            new Dictionary<string, string> { [dependencyPath] = dependency });
+
+        Assert.Equal(3, references.Count);
+        Assert.All(
+            references,
+            location => Assert.Equal(
+                DocumentUri.FromFileSystemPath(importerPath),
+                location.Uri));
+    }
+
+    [Fact]
+    public void ConfiguredRootSetReportsWhetherReverseDiscoveryIsComplete()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        string configPath = directory.CreateFile(
+            "tsconfig.json",
+            """{ "include": ["src/**/*.ts"] }""");
+        string dependencyPath = directory.CreateFile(
+            "src/dependency.ts",
+            "export const value = 1;\n");
+        directory.CreateFile(
+            "src/importer.ts",
+            "import { value } from \"./dependency\";\nvalue;\n");
+        string dependency = File.ReadAllText(dependencyPath);
+
+        var model = Assert.IsType<CheckedNavigationModel>(
+            NavigationModelBuilder.TryBuild(
+                dependencyPath,
+                dependency,
+                new Dictionary<string, string> { [dependencyPath] = dependency }));
+
+        Assert.True(model.Scope.IsComplete);
+        Assert.Equal(Path.GetFullPath(configPath), model.Scope.ConfigPath);
+        Assert.Equal(2, model.Scope.RootFiles.Count);
+    }
+
+    [Fact]
+    public void FailedConfiguredRootMakesReverseDiscoveryExplicitlyIncomplete()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        directory.CreateFile(
+            "tsconfig.json",
+            """{ "include": ["src/**/*.ts"] }""");
+        string dependencyPath = directory.CreateFile(
+            "src/dependency.ts",
+            "export const value = 1;\n");
+        directory.CreateFile("src/broken.ts", "const = ;\n");
+        string dependency = File.ReadAllText(dependencyPath);
+
+        var model = Assert.IsType<CheckedNavigationModel>(
+            NavigationModelBuilder.TryBuild(
+                dependencyPath,
+                dependency,
+                new Dictionary<string, string> { [dependencyPath] = dependency }));
+
+        Assert.False(model.Scope.IsComplete);
+        Assert.NotNull(model.Scope.ConfigPath);
+    }
+
+    [Fact]
+    public void OpenDocumentFallbackIsExplicitlyIncompleteWithoutAConfig()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        string path = directory.GetPath("standalone.ts");
+        const string source = "const value = 1;\nvalue;\n";
+
+        var model = Assert.IsType<CheckedNavigationModel>(
+            NavigationModelBuilder.TryBuild(
+                path,
+                source,
+                new Dictionary<string, string> { [path] = source }));
+
+        Assert.False(model.Scope.IsComplete);
+        Assert.Null(model.Scope.ConfigPath);
+        Assert.Empty(model.Scope.RootFiles);
     }
 
     [Fact]

--- a/docs/plans/lsp-server.md
+++ b/docs/plans/lsp-server.md
@@ -268,11 +268,13 @@ re-exports. This makes hoisting, shadowing, parameters, overload merging, aliase
 provenance follow the real checker instead of a second editor-only scope walker.
 
 `textDocument/references` now uses the inverse side of that same index. It unions type/value facets
-only when the selected token has both, honors `includeDeclaration`, and discovers the connected
-component across open roots so references in open importers are included as well as forward
-dependencies without merging unrelated script globals. Unopened reverse importers are not yet a
-known-complete domain; safe rename must refuse that partial cross-module case until the lifecycle
-work maintains a workspace graph with reverse edges.
+only when the selected token has both and honors `includeDeclaration`. The navigation model now
+loads every root in the nearest `tsconfig.json` using that project's module-resolution, JSX,
+strictness, declaration-library, and ambient-type settings. An explicit reverse-edge map then
+selects the connected component, so references include closed importers in the configured project
+without merging unrelated script globals. The model records whether every configured root loaded;
+missing/broken configs and the open-document-only fallback are explicitly incomplete so safe rename
+can refuse them rather than silently emitting a partial edit.
 
 The server advertises these features only in `--language-features full`; the VS Code extension
 continues to launch `interop-only`, leaving ordinary TypeScript navigation to `tsserver`.
@@ -387,10 +389,11 @@ single-file binary so non-VS-Code editors don't need the full SDK.
   surgery, no record-equality risk. ~7 tests + e2e (precise columns, declaration + usage hover).
 - 🟨 **Phase 4b — standalone general navigation.** Reference-keyed source spans, document
   symbols, semantic value/type binding identities, and module-aware go-to-definition through
-  imports/re-exports have landed. The inverse binding index and references across open module roots
-  have also landed. Safe rename, type-parameter navigation, qualified member navigation, and a
-  complete reverse workspace graph remain. VS Code stays in `interop-only`; these capabilities
-  are for standalone clients.
+  imports/re-exports have landed. The inverse binding index, configured-project reverse graph,
+  closed-importer references, and explicit graph-completeness boundary have also landed. Safe
+  rename, type-parameter navigation, qualified member navigation, and multi-config/project-reference
+  workspace expansion remain. VS Code stays in `interop-only`; these capabilities are for
+  standalone clients.
 - ⬜ **Phase 5 — Polish & reach.** Multi-editor docs; `dotnet tool`/self-contained
   packaging; debounce/cancellation; config→server wiring (`sharpts.diagnostics`);
   loader reload on `.csproj`/`bin` change; STATUS.md/README updates. **NOT YET DONE.**


### PR DESCRIPTION
## Summary
- load every root from the nearest tsconfig with the configured module, JSX, strictness, library, and ambient-type settings
- build explicit reverse dependency edges so references include closed importers without merging unrelated script globals
- expose a completeness boundary that is false for broken roots/configs and open-document-only fallback
- cover closed importers, path aliases, excludes, and complete/incomplete scopes

## Verification
- dotnet test SharpTS.Tests/SharpTS.Tests.csproj --filter FullyQualifiedName~LanguageServer\|FullyQualifiedName~TsConfigLoaderTests --no-restore (131 passed)
- dotnet test SharpTS.Tests/SharpTS.Tests.csproj --no-restore (16,239 passed)
- git diff --check

Refs #1306