### PR TITLE
LSP: expand references across workspace projects

### DIFF
--- a/SharpTS.LanguageServer/Handlers/ReferencesHandler.cs
+++ b/SharpTS.LanguageServer/Handlers/ReferencesHandler.cs
@@ -17,11 +17,16 @@ public sealed class ReferencesHandler : ReferencesHandlerBase
 {
     private readonly DocumentStore _store;
     private readonly ReferenceService _references;
+    private readonly NavigationWorkspaceContext? _workspace;
 
-    public ReferencesHandler(DocumentStore store, ReferenceService references)
+    public ReferencesHandler(
+        DocumentStore store,
+        ReferenceService references,
+        NavigationWorkspaceContext? workspace = null)
     {
         _store = store;
         _references = references;
+        _workspace = workspace;
     }
 
     public override Task<LocationContainer?> Handle(
@@ -39,7 +44,8 @@ public sealed class ReferencesHandler : ReferencesHandlerBase
             text,
             request.Position,
             request.Context.IncludeDeclaration,
-            _store.SnapshotFileSystemDocuments());
+            _store.SnapshotFileSystemDocuments(),
+            _workspace?.SnapshotRoots());
         return Task.FromResult<LocationContainer?>(
             new LocationContainer(locations));
     }

--- a/SharpTS.LanguageServer/Services/NavigationModelBuilder.cs
+++ b/SharpTS.LanguageServer/Services/NavigationModelBuilder.cs
@@ -21,6 +21,11 @@ internal sealed record NavigationGraphScope(
     IReadOnlyList<string> RootFiles,
     bool IsComplete);
 
+internal sealed record CheckedNavigationWorkspace(
+    IReadOnlyList<CheckedNavigationModel> Models,
+    IReadOnlyList<string> ConfigPaths,
+    bool IsComplete);
+
 /// <summary>
 /// Builds the semantic module graph shared by definition, references, and later rename support.
 /// </summary>
@@ -31,18 +36,81 @@ internal static class NavigationModelBuilder
         string text,
         IReadOnlyDictionary<string, string>? openDocuments)
     {
+        string absolutePath = Path.GetFullPath(path);
+        Dictionary<string, string> overlay = CreateOverlay(
+            absolutePath,
+            text,
+            openDocuments);
+        string directory = Path.GetDirectoryName(absolutePath)
+            ?? Directory.GetCurrentDirectory();
+        string? configPath = TsConfigLoader.Discover(directory);
+        if (configPath is not null)
+        {
+            try
+            {
+                ProjectBuildResult configured = TryBuildProject(
+                    absolutePath,
+                    overlay,
+                    NavigationWorkspace.FromProject(TsConfigLoader.Load(configPath)),
+                    requireMembership: true);
+                if (configured.Model is not null)
+                    return configured.Model;
+            }
+            catch
+            {
+                // Fall through to an explicitly incomplete open-document model.
+            }
+        }
+
+        return TryBuildProject(
+            absolutePath,
+            overlay,
+            NavigationWorkspace.Unconfigured(absolutePath, configPath),
+            requireMembership: false).Model;
+    }
+
+    public static CheckedNavigationWorkspace BuildWorkspace(
+        string path,
+        string text,
+        IReadOnlyDictionary<string, string>? openDocuments,
+        IReadOnlyList<string> workspaceRoots)
+    {
+        string absolutePath = Path.GetFullPath(path);
+        Dictionary<string, string> overlay = CreateOverlay(
+            absolutePath,
+            text,
+            openDocuments);
+        NavigationProjectCatalog catalog =
+            NavigationProjectCatalog.Discover(workspaceRoots);
+        var models = new List<CheckedNavigationModel>();
+        bool isComplete = catalog.IsComplete;
+
+        foreach (TsConfigResult project in catalog.Projects)
+        {
+            ProjectBuildResult result = TryBuildProject(
+                absolutePath,
+                overlay,
+                NavigationWorkspace.FromProject(project),
+                requireMembership: true);
+            isComplete &= result.IsComplete;
+            if (result.Model is not null)
+                models.Add(result.Model);
+        }
+
+        return new CheckedNavigationWorkspace(
+            models,
+            catalog.ConfigPaths,
+            isComplete && models.Count > 0);
+    }
+
+    private static ProjectBuildResult TryBuildProject(
+        string absolutePath,
+        IReadOnlyDictionary<string, string> overlay,
+        NavigationWorkspace workspace,
+        bool requireMembership)
+    {
         try
         {
-            string absolutePath = Path.GetFullPath(path);
-            var overlay = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            if (openDocuments is not null)
-            {
-                foreach (var (documentPath, documentText) in openDocuments)
-                    overlay[Path.GetFullPath(documentPath)] = documentText;
-            }
-            overlay[absolutePath] = text;
-
-            NavigationWorkspace workspace = DiscoverWorkspace(absolutePath);
             var resolver = new ModuleResolver(
                 workspace.BasePath,
                 workspace.ResolutionOptions,
@@ -69,25 +137,11 @@ internal static class NavigationModelBuilder
             }
             resolver.RegisterAmbientModuleDeclarations(declarationRoots);
 
-            ParsedModule entry = resolver.LoadProgram(
-                absolutePath,
-                workspace.DecoratorMode);
-            if (entry.Document is not { } document)
-                return null;
-
-            // Every configured root is a possible reverse importer. Open roots are retained as
-            // the fallback for files without a tsconfig and include dirty/new buffers that the
-            // disk-backed config matcher cannot yet enumerate.
-            List<ParsedModule> loadedRoots = [entry];
-            var rootPaths = workspace.RootFiles
-                .Concat(overlay.Keys)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .Order(StringComparer.OrdinalIgnoreCase);
-            foreach (string rootPath in rootPaths)
+            List<ParsedModule> loadedRoots = [];
+            foreach (string rootPath in workspace.RootFiles
+                         .Distinct(StringComparer.OrdinalIgnoreCase)
+                         .Order(StringComparer.OrdinalIgnoreCase))
             {
-                if (string.Equals(rootPath, absolutePath, StringComparison.OrdinalIgnoreCase))
-                    continue;
-
                 try
                 {
                     ParsedModule root = resolver.LoadProgram(
@@ -98,12 +152,48 @@ internal static class NavigationModelBuilder
                 }
                 catch
                 {
-                    if (workspace.RootFiles.Contains(
-                            rootPath,
-                            StringComparer.OrdinalIgnoreCase))
-                    {
-                        allRootsLoaded = false;
-                    }
+                    allRootsLoaded = false;
+                }
+            }
+
+            ParsedModule? entry = resolver.GetCachedModule(absolutePath);
+            bool isMember = entry is not null;
+            if (entry is null && requireMembership)
+                return new ProjectBuildResult(null, allRootsLoaded);
+
+            entry ??= resolver.LoadProgram(absolutePath, workspace.DecoratorMode);
+            if (entry.Document is not { } document)
+                return new ProjectBuildResult(null, IsComplete: false);
+            if (!loadedRoots.Contains(entry))
+                loadedRoots.Add(entry);
+
+            // Dirty/new open buffers can be reverse importers even before the disk-backed
+            // tsconfig matcher sees them.
+            foreach (string openPath in overlay.Keys
+                         .Order(StringComparer.OrdinalIgnoreCase))
+            {
+                if (string.Equals(
+                        openPath,
+                        absolutePath,
+                        StringComparison.OrdinalIgnoreCase) ||
+                    workspace.RootFiles.Contains(
+                        openPath,
+                        StringComparer.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    ParsedModule root = resolver.LoadProgram(
+                        openPath,
+                        workspace.DecoratorMode);
+                    if (!loadedRoots.Contains(root))
+                        loadedRoots.Add(root);
+                }
+                catch
+                {
+                    // Configured roots, not unrelated dirty buffers, define completeness.
                 }
             }
 
@@ -122,17 +212,20 @@ internal static class NavigationModelBuilder
             checker.CheckModules(
                 resolver.GetModulesInOrder(connectedRoots),
                 resolver);
-            return new CheckedNavigationModel(
+            var model = new CheckedNavigationModel(
                 checker,
                 document,
                 new NavigationGraphScope(
                     workspace.ConfigPath,
                     workspace.RootFiles,
-                    workspace.IsConfigured && allRootsLoaded));
+                    workspace.IsConfigured && isMember && allRootsLoaded));
+            return new ProjectBuildResult(
+                model,
+                workspace.IsConfigured && allRootsLoaded);
         }
         catch
         {
-            return null;
+            return new ProjectBuildResult(null, IsComplete: false);
         }
     }
 
@@ -178,18 +271,38 @@ internal static class NavigationModelBuilder
         return component;
     }
 
-    private static NavigationWorkspace DiscoverWorkspace(string absolutePath)
+    private static Dictionary<string, string> CreateOverlay(
+        string absolutePath,
+        string text,
+        IReadOnlyDictionary<string, string>? openDocuments)
     {
-        string directory = Path.GetDirectoryName(absolutePath)
-            ?? Directory.GetCurrentDirectory();
-        string? configPath = TsConfigLoader.Discover(directory);
-        if (configPath is null)
-            return NavigationWorkspace.Unconfigured(absolutePath);
-
-        try
+        var overlay = new Dictionary<string, string>(
+            StringComparer.OrdinalIgnoreCase);
+        if (openDocuments is not null)
         {
-            TsConfigResult project = TsConfigLoader.Load(configPath);
-            DecoratorMode decoratorMode = project.DecoratorMode ?? DecoratorMode.Stage3;
+            foreach (var (documentPath, documentText) in openDocuments)
+                overlay[Path.GetFullPath(documentPath)] = documentText;
+        }
+        overlay[absolutePath] = text;
+        return overlay;
+    }
+
+    private sealed record NavigationWorkspace(
+        string BasePath,
+        ModuleResolutionOptions ResolutionOptions,
+        TypeScriptProgramOptions ProgramOptions,
+        TypeCheckerOptions CheckerOptions,
+        DecoratorMode DecoratorMode,
+        JsxParseOptions JsxOptions,
+        IReadOnlyList<string> RootFiles,
+        IReadOnlyList<string> DeclarationFiles,
+        string? ConfigPath,
+        bool IsConfigured)
+    {
+        public static NavigationWorkspace FromProject(TsConfigResult project)
+        {
+            DecoratorMode decoratorMode =
+                project.DecoratorMode ?? DecoratorMode.Stage3;
             return new NavigationWorkspace(
                 BasePath: project.ConfigPath,
                 ResolutionOptions: project.ModuleResolution,
@@ -214,26 +327,7 @@ internal static class NavigationModelBuilder
                 ConfigPath: project.ConfigPath,
                 IsConfigured: true);
         }
-        catch
-        {
-            // A broken config must not erase navigation in the requested/open files. The
-            // resulting scope is explicitly incomplete, so safe rename cannot use it.
-            return NavigationWorkspace.Unconfigured(absolutePath, configPath);
-        }
-    }
 
-    private sealed record NavigationWorkspace(
-        string BasePath,
-        ModuleResolutionOptions ResolutionOptions,
-        TypeScriptProgramOptions ProgramOptions,
-        TypeCheckerOptions CheckerOptions,
-        DecoratorMode DecoratorMode,
-        JsxParseOptions JsxOptions,
-        IReadOnlyList<string> RootFiles,
-        IReadOnlyList<string> DeclarationFiles,
-        string? ConfigPath,
-        bool IsConfigured)
-    {
         public static NavigationWorkspace Unconfigured(
             string absolutePath,
             string? configPath = null) =>
@@ -252,6 +346,10 @@ internal static class NavigationModelBuilder
                 ConfigPath: configPath,
                 IsConfigured: false);
     }
+
+    private sealed record ProjectBuildResult(
+        CheckedNavigationModel? Model,
+        bool IsComplete);
 }
 
 internal static class NavigationLocations

--- a/SharpTS.LanguageServer/Services/NavigationProjectCatalog.cs
+++ b/SharpTS.LanguageServer/Services/NavigationProjectCatalog.cs
@@ -1,0 +1,143 @@
+using SharpTS.Configuration;
+
+namespace SharpTS.LanguageServer.Services;
+
+/// <summary>
+/// Discovers configured TypeScript projects inside the initialized LSP workspace.
+/// </summary>
+internal sealed record NavigationProjectCatalog(
+    IReadOnlyList<TsConfigResult> Projects,
+    IReadOnlyList<string> ConfigPaths,
+    bool IsComplete)
+{
+    private static readonly HashSet<string> SkippedDirectoryNames =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ".git",
+            ".claude",
+            ".codex",
+            "bin",
+            "bower_components",
+            "jspm_packages",
+            "node_modules",
+            "obj",
+        };
+
+    public static NavigationProjectCatalog Discover(
+        IReadOnlyList<string> workspaceRoots)
+    {
+        var roots = workspaceRoots
+            .Select(Path.GetFullPath)
+            .Distinct(PathComparer)
+            .Order(PathComparer)
+            .ToArray();
+        if (roots.Length == 0)
+            return new NavigationProjectCatalog([], [], IsComplete: false);
+
+        var (discovered, scanComplete) = FindConfigPaths(roots);
+        var pending = new Queue<string>(discovered);
+        var visited = new HashSet<string>(PathComparer);
+        var configPaths = new List<string>();
+        var projects = new List<TsConfigResult>();
+        bool isComplete = scanComplete;
+
+        while (pending.TryDequeue(out string? configPath))
+        {
+            string full = Path.GetFullPath(configPath);
+            if (!visited.Add(full))
+                continue;
+
+            configPaths.Add(full);
+            TsConfigResult project;
+            try
+            {
+                project = TsConfigLoader.Load(full);
+                projects.Add(project);
+            }
+            catch
+            {
+                isComplete = false;
+                continue;
+            }
+
+            foreach (string reference in project.ProjectReferences)
+            {
+                if (roots.Any(root => IsWithin(reference, root)))
+                    pending.Enqueue(reference);
+                else
+                    isComplete = false;
+            }
+        }
+
+        return new NavigationProjectCatalog(
+            projects.OrderBy(project => project.ConfigPath, PathComparer).ToArray(),
+            configPaths.Order(PathComparer).ToArray(),
+            isComplete);
+    }
+
+    private static (IReadOnlyList<string> Paths, bool IsComplete) FindConfigPaths(
+        IReadOnlyList<string> roots)
+    {
+        var paths = new HashSet<string>(PathComparer);
+        var visitedDirectories = new HashSet<string>(PathComparer);
+        var pending = new Queue<string>(roots);
+        bool isComplete = true;
+
+        while (pending.TryDequeue(out string? directory))
+        {
+            string fullDirectory = Path.GetFullPath(directory);
+            if (!visitedDirectories.Add(fullDirectory))
+                continue;
+            if (!Directory.Exists(fullDirectory))
+            {
+                isComplete = false;
+                continue;
+            }
+
+            try
+            {
+                foreach (string config in Directory.EnumerateFiles(
+                             fullDirectory,
+                             TsConfigLoader.FileName,
+                             SearchOption.TopDirectoryOnly))
+                {
+                    paths.Add(Path.GetFullPath(config));
+                }
+
+                foreach (string child in Directory.EnumerateDirectories(
+                             fullDirectory,
+                             "*",
+                             SearchOption.TopDirectoryOnly))
+                {
+                    if (SkippedDirectoryNames.Contains(Path.GetFileName(child)))
+                        continue;
+                    if ((File.GetAttributes(child) & FileAttributes.ReparsePoint) != 0)
+                        continue;
+                    pending.Enqueue(child);
+                }
+            }
+            catch (Exception exception) when (
+                exception is IOException or UnauthorizedAccessException)
+            {
+                isComplete = false;
+            }
+        }
+
+        return (paths.Order(PathComparer).ToArray(), isComplete);
+    }
+
+    private static bool IsWithin(string path, string root)
+    {
+        string relative = Path.GetRelativePath(root, Path.GetFullPath(path));
+        return !Path.IsPathRooted(relative) &&
+            !relative.Equals("..", StringComparison.Ordinal) &&
+            !relative.StartsWith(
+                ".." + Path.DirectorySeparatorChar,
+                StringComparison.Ordinal);
+    }
+
+    private static StringComparer PathComparer =>
+        OperatingSystem.IsWindows()
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
+}

--- a/SharpTS.LanguageServer/Services/NavigationWorkspaceContext.cs
+++ b/SharpTS.LanguageServer/Services/NavigationWorkspaceContext.cs
@@ -1,0 +1,46 @@
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace SharpTS.LanguageServer.Services;
+
+/// <summary>
+/// Immutable snapshots of the workspace folders supplied during LSP initialization.
+/// </summary>
+public sealed class NavigationWorkspaceContext
+{
+    private string[] _roots = [];
+
+    public IReadOnlyList<string> SnapshotRoots() => [.. Volatile.Read(ref _roots)];
+
+    public void Initialize(InitializeParams request)
+    {
+        IEnumerable<string> roots = request.WorkspaceFolders?.Any() == true
+            ? request.WorkspaceFolders.Select(folder => folder.Uri.GetFileSystemPath())
+            : RootFallback(request);
+
+        Volatile.Write(
+            ref _roots,
+            roots
+                .Where(path => !string.IsNullOrWhiteSpace(path))
+                .Select(Path.GetFullPath)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Order(StringComparer.OrdinalIgnoreCase)
+                .ToArray());
+    }
+
+    private static IEnumerable<string> RootFallback(InitializeParams request)
+    {
+        if (request.RootUri is not null)
+        {
+            yield return request.RootUri.GetFileSystemPath();
+            yield break;
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.RootPath))
+        {
+            yield return request.RootPath;
+            yield break;
+        }
+
+        yield return Directory.GetCurrentDirectory();
+    }
+}

--- a/SharpTS.LanguageServer/Services/ReferenceService.cs
+++ b/SharpTS.LanguageServer/Services/ReferenceService.cs
@@ -1,6 +1,12 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpTS.TypeSystem;
 
 namespace SharpTS.LanguageServer.Services;
+
+internal sealed record NavigationReferenceResult(
+    IReadOnlyList<Location> Locations,
+    IReadOnlyList<string> ConfigPaths,
+    bool IsComplete);
 
 /// <summary>
 /// Resolves a source position to every checker-bound occurrence of the same semantic symbol.
@@ -12,18 +18,197 @@ public sealed class ReferenceService
         string text,
         Position position,
         bool includeDeclaration,
-        IReadOnlyDictionary<string, string>? openDocuments = null)
+        IReadOnlyDictionary<string, string>? openDocuments = null,
+        IReadOnlyList<string>? workspaceRoots = null)
+        => FindReferenceResult(
+            path,
+            text,
+            position,
+            includeDeclaration,
+            openDocuments,
+            workspaceRoots).Locations;
+
+    internal NavigationReferenceResult FindReferenceResult(
+        string path,
+        string text,
+        Position position,
+        bool includeDeclaration,
+        IReadOnlyDictionary<string, string>? openDocuments = null,
+        IReadOnlyList<string>? workspaceRoots = null)
     {
         if (NavigationModelBuilder.TryBuild(path, text, openDocuments) is not { } model)
-            return [];
+            return new NavigationReferenceResult([], [], IsComplete: false);
 
         int offset = model.Document.Lines.ToOffset(
             (int)position.Line + 1,
             (int)position.Character + 1);
-        return model.Checker.Bindings
-            .FindReferences(model.Document, offset, includeDeclaration)
-            .Select(occurrence =>
-                NavigationLocations.From(occurrence.Document, occurrence.Name))
+        IReadOnlyList<BindingSymbol> selectedSymbols =
+            model.Checker.Bindings.FindSymbols(model.Document, offset);
+        if (selectedSymbols.Count == 0)
+        {
+            return new NavigationReferenceResult(
+                [],
+                model.Scope.ConfigPath is null ? [] : [model.Scope.ConfigPath],
+                model.Scope.IsComplete);
+        }
+
+        var locations = new Dictionary<LocationKey, Location>();
+        AddOccurrences(
+            locations,
+            model.Checker.Bindings.FindReferences(
+                selectedSymbols,
+                includeDeclaration));
+
+        if (workspaceRoots is not { Count: > 0 })
+        {
+            return new NavigationReferenceResult(
+                Sort(locations.Values),
+                model.Scope.ConfigPath is null ? [] : [model.Scope.ConfigPath],
+                model.Scope.IsComplete);
+        }
+
+        BindingAnchor[] anchors = selectedSymbols
+            .SelectMany(symbol => symbol.Declarations.Select(declaration =>
+                new BindingAnchor(
+                    Path.GetFullPath(declaration.Document.Path),
+                    declaration.Name.Start,
+                    symbol.Namespace)))
+            .Distinct()
             .ToArray();
+        bool isComplete = anchors.Length > 0 &&
+            anchors.All(anchor => workspaceRoots.Any(
+                root => IsWithin(anchor.Path, root)));
+        var configPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var pathAnchors in anchors.GroupBy(
+                     anchor => anchor.Path,
+                     StringComparer.OrdinalIgnoreCase))
+        {
+            string anchorPath = pathAnchors.Key;
+            string? anchorText = ReadText(anchorPath, openDocuments);
+            if (anchorText is null)
+            {
+                isComplete = false;
+                continue;
+            }
+
+            CheckedNavigationWorkspace workspace =
+                NavigationModelBuilder.BuildWorkspace(
+                    anchorPath,
+                    anchorText,
+                    openDocuments,
+                    workspaceRoots);
+            isComplete &= workspace.IsComplete;
+            configPaths.UnionWith(workspace.ConfigPaths);
+
+            foreach (CheckedNavigationModel projectModel in workspace.Models)
+            {
+                var matchingSymbols = new HashSet<BindingSymbol>(
+                    ReferenceEqualityComparer.Instance);
+                foreach (BindingAnchor anchor in pathAnchors)
+                {
+                    foreach (BindingSymbol candidate in
+                             projectModel.Checker.Bindings.FindSymbols(
+                                 projectModel.Document,
+                                 anchor.Offset))
+                    {
+                        if (candidate.Namespace == anchor.Namespace &&
+                            candidate.Declarations.Any(declaration =>
+                                declaration.Name.Start == anchor.Offset &&
+                                string.Equals(
+                                    Path.GetFullPath(declaration.Document.Path),
+                                    anchor.Path,
+                                    StringComparison.OrdinalIgnoreCase)))
+                        {
+                            matchingSymbols.Add(candidate);
+                        }
+                    }
+                }
+
+                AddOccurrences(
+                    locations,
+                    projectModel.Checker.Bindings.FindReferences(
+                        matchingSymbols.ToArray(),
+                        includeDeclaration));
+            }
+        }
+
+        return new NavigationReferenceResult(
+            Sort(locations.Values),
+            configPaths.Order(StringComparer.OrdinalIgnoreCase).ToArray(),
+            isComplete);
+    }
+
+    private static void AddOccurrences(
+        Dictionary<LocationKey, Location> locations,
+        IReadOnlyList<BindingOccurrence> occurrences)
+    {
+        foreach (BindingOccurrence occurrence in occurrences)
+        {
+            Location location = NavigationLocations.From(
+                occurrence.Document,
+                occurrence.Name);
+            locations[LocationKey.From(location)] = location;
+        }
+    }
+
+    private static IReadOnlyList<Location> Sort(IEnumerable<Location> locations) =>
+        locations
+            .OrderBy(location => location.Uri.ToString(), StringComparer.OrdinalIgnoreCase)
+            .ThenBy(location => location.Range.Start.Line)
+            .ThenBy(location => location.Range.Start.Character)
+            .ToArray();
+
+    private static string? ReadText(
+        string path,
+        IReadOnlyDictionary<string, string>? openDocuments)
+    {
+        if (openDocuments is not null)
+        {
+            foreach (var (documentPath, documentText) in openDocuments)
+            {
+                if (string.Equals(
+                        Path.GetFullPath(documentPath),
+                        path,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return documentText;
+                }
+            }
+        }
+        return File.Exists(path) ? File.ReadAllText(path) : null;
+    }
+
+    private static bool IsWithin(string path, string root)
+    {
+        string relative = Path.GetRelativePath(
+            Path.GetFullPath(root),
+            Path.GetFullPath(path));
+        return !Path.IsPathRooted(relative) &&
+            !relative.Equals("..", StringComparison.Ordinal) &&
+            !relative.StartsWith(
+                ".." + Path.DirectorySeparatorChar,
+                StringComparison.Ordinal);
+    }
+
+    private sealed record BindingAnchor(
+        string Path,
+        int Offset,
+        BindingNamespace Namespace);
+
+    private readonly record struct LocationKey(
+        string Uri,
+        int StartLine,
+        int StartCharacter,
+        int EndLine,
+        int EndCharacter)
+    {
+        public static LocationKey From(Location location) =>
+            new(
+                location.Uri.ToString(),
+                (int)location.Range.Start.Line,
+                (int)location.Range.Start.Character,
+                (int)location.Range.End.Line,
+                (int)location.Range.End.Character);
     }
 }

--- a/SharpTS.LanguageServer/SharpTSLanguageServer.cs
+++ b/SharpTS.LanguageServer/SharpTSLanguageServer.cs
@@ -26,12 +26,19 @@ public static class SharpTSLanguageServer
         Func<IEnumerable<string>>? typeNames = null,
         LanguageFeatureMode mode = LanguageFeatureMode.Full)
     {
+        var workspaceContext = new NavigationWorkspaceContext();
         var server = await OmniSharp.Extensions.LanguageServer.Server.LanguageServer.From(options =>
         {
             options
+                .OnInitialize((_, request, _) =>
+                {
+                    workspaceContext.Initialize(request);
+                    return Task.CompletedTask;
+                })
                 .WithInput(Console.OpenStandardInput())
                 .WithOutput(Console.OpenStandardOutput())
                 .WithServices(services => services
+                    .AddSingleton(workspaceContext)
                     .AddSingleton<DocumentStore>()
                     .AddSingleton(new DiagnosticsService(resolve))
                     .AddSingleton(new DecoratorService(resolve, typeNames))

--- a/SharpTS.Tests/LanguageServer/NavigationWorkspaceTests.cs
+++ b/SharpTS.Tests/LanguageServer/NavigationWorkspaceTests.cs
@@ -1,0 +1,96 @@
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpTS.LanguageServer.Services;
+using SharpTS.Tests.IntegrationTests;
+using Xunit;
+
+namespace SharpTS.Tests.LanguageServer;
+
+public class NavigationWorkspaceTests
+{
+    [Fact]
+    public void InitializationCapturesEveryWorkspaceFolder()
+    {
+        using var first = CliTestHelper.CreateTempDirectory();
+        using var second = CliTestHelper.CreateTempDirectory();
+        var context = new NavigationWorkspaceContext();
+
+        context.Initialize(new InitializeParams
+        {
+            WorkspaceFolders = new Container<WorkspaceFolder>(
+                new WorkspaceFolder
+                {
+                    Name = "second",
+                    Uri = DocumentUri.FromFileSystemPath(second.Path),
+                },
+                new WorkspaceFolder
+                {
+                    Name = "first",
+                    Uri = DocumentUri.FromFileSystemPath(first.Path),
+                }),
+        });
+
+        string[] expected =
+        [
+            Path.GetFullPath(first.Path),
+            Path.GetFullPath(second.Path),
+        ];
+        Assert.True(
+            expected
+                .Order(StringComparer.OrdinalIgnoreCase)
+                .SequenceEqual(
+                    context.SnapshotRoots(),
+                    StringComparer.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void CatalogDoesNotTreatDependencyConfigsAsWorkspaceProjects()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        string configPath = directory.CreateFile(
+            "tsconfig.json",
+            """{ "files": [] }""");
+        directory.CreateFile("node_modules/pkg/tsconfig.json", "{ not json");
+
+        NavigationProjectCatalog catalog =
+            NavigationProjectCatalog.Discover([directory.Path]);
+
+        Assert.True(catalog.IsComplete);
+        Assert.Equal(
+            Path.GetFullPath(configPath),
+            Assert.Single(catalog.ConfigPaths));
+        Assert.Single(catalog.Projects);
+    }
+
+    [Fact]
+    public void ProjectReferenceOutsideTheWorkspaceMakesTheBoundaryIncomplete()
+    {
+        using var workspace = CliTestHelper.CreateTempDirectory();
+        using var external = CliTestHelper.CreateTempDirectory();
+        external.CreateFile(
+            "tsconfig.json",
+            """
+            {
+              "files": [],
+              "compilerOptions": { "composite": true }
+            }
+            """);
+        string relative = Path.GetRelativePath(workspace.Path, external.Path)
+            .Replace('\\', '/');
+        workspace.CreateFile(
+            "tsconfig.json",
+            $$"""
+            {
+              "files": [],
+              "references": [{ "path": "{{relative}}" }]
+            }
+            """);
+
+        NavigationProjectCatalog catalog =
+            NavigationProjectCatalog.Discover([workspace.Path]);
+
+        Assert.False(catalog.IsComplete);
+        Assert.Single(catalog.ConfigPaths);
+        Assert.Single(catalog.Projects);
+    }
+}

--- a/SharpTS.Tests/LanguageServer/ReferenceServiceTests.cs
+++ b/SharpTS.Tests/LanguageServer/ReferenceServiceTests.cs
@@ -260,6 +260,184 @@ public class ReferenceServiceTests
             references,
             location => Assert.Equal(
                 DocumentUri.FromFileSystemPath(importerPath),
+            location.Uri));
+    }
+
+    [Fact]
+    public void WorkspaceReferencesUnionConsumersWithDifferentProjectSettings()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        directory.CreateFile(
+            "tsconfig.json",
+            """
+            {
+              "files": [],
+              "references": [
+                { "path": "packages/lib" },
+                { "path": "apps/one" },
+                { "path": "apps/two/tsconfig.app.json" }
+              ]
+            }
+            """);
+        string dependencyPath = directory.CreateFile(
+            "packages/lib/src/dependency.ts",
+            "export const original = 1;\n");
+        directory.CreateFile(
+            "packages/lib/tsconfig.json",
+            """
+            {
+              "compilerOptions": { "composite": true },
+              "include": ["src/**/*.ts"]
+            }
+            """);
+        string firstPath = directory.CreateFile(
+            "apps/one/src/importer.ts",
+            """
+            import { original as first } from "@one/dependency";
+            first;
+            """);
+        directory.CreateFile(
+            "apps/one/tsconfig.json",
+            """
+            {
+              "compilerOptions": {
+                "composite": true,
+                "baseUrl": ".",
+                "paths": { "@one/*": ["../../packages/lib/src/*"] }
+              },
+              "include": ["src/**/*.ts"]
+            }
+            """);
+        string secondPath = directory.CreateFile(
+            "apps/two/src/importer.ts",
+            """
+            import { original as second } from "@two/dependency";
+            second;
+            """);
+        directory.CreateFile(
+            "apps/two/tsconfig.app.json",
+            """
+            {
+              "compilerOptions": {
+                "composite": true,
+                "baseUrl": ".",
+                "paths": { "@two/*": ["../../packages/lib/src/*"] }
+              },
+              "include": ["src/**/*.ts"]
+            }
+            """);
+        string first = File.ReadAllText(firstPath);
+        var openDocuments = new Dictionary<string, string>
+        {
+            [firstPath] = first,
+        };
+
+        NavigationReferenceResult result = ReferenceResult(
+            firstPath,
+            first,
+            "first",
+            occurrence: 1,
+            includeDeclaration: false,
+            openDocuments,
+            [directory.Path]);
+
+        Assert.True(result.IsComplete);
+        Assert.Equal(4, result.ConfigPaths.Count);
+        Assert.Equal(6, result.Locations.Count);
+        Assert.Equal(
+            3,
+            result.Locations.Count(location =>
+                location.Uri == DocumentUri.FromFileSystemPath(firstPath)));
+        Assert.Equal(
+            3,
+            result.Locations.Count(location =>
+                location.Uri == DocumentUri.FromFileSystemPath(secondPath)));
+        Assert.DoesNotContain(
+            result.Locations,
+            location =>
+                location.Uri == DocumentUri.FromFileSystemPath(dependencyPath));
+    }
+
+    [Fact]
+    public void BrokenWorkspaceConfigKeepsReferencesButMarksTheGraphIncomplete()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        string dependencyPath = directory.CreateFile(
+            "project/dependency.ts",
+            "export const value = 1;\n");
+        string importerPath = directory.CreateFile(
+            "project/importer.ts",
+            "import { value } from \"./dependency\";\nvalue;\n");
+        directory.CreateFile(
+            "project/tsconfig.json",
+            """{ "include": ["*.ts"] }""");
+        directory.CreateFile("broken/tsconfig.json", "{ not json");
+        string dependency = File.ReadAllText(dependencyPath);
+
+        NavigationReferenceResult result = ReferenceResult(
+            dependencyPath,
+            dependency,
+            "value",
+            occurrence: 0,
+            includeDeclaration: false,
+            new Dictionary<string, string> { [dependencyPath] = dependency },
+            [directory.Path]);
+
+        Assert.False(result.IsComplete);
+        Assert.Equal(2, result.Locations.Count);
+        Assert.All(
+            result.Locations,
+            location => Assert.Equal(
+                DocumentUri.FromFileSystemPath(importerPath),
+                location.Uri));
+    }
+
+    [Fact]
+    public void WorkspaceProjectCatalogIsRefreshedBetweenRequests()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        string dependencyPath = directory.CreateFile(
+            "lib/dependency.ts",
+            "export const value = 1;\n");
+        directory.CreateFile("lib/tsconfig.json", """{ "include": ["*.ts"] }""");
+        string dependency = File.ReadAllText(dependencyPath);
+        var openDocuments = new Dictionary<string, string>
+        {
+            [dependencyPath] = dependency,
+        };
+
+        NavigationReferenceResult before = ReferenceResult(
+            dependencyPath,
+            dependency,
+            "value",
+            occurrence: 0,
+            includeDeclaration: false,
+            openDocuments,
+            [directory.Path]);
+
+        string importerPath = directory.CreateFile(
+            "consumer/importer.ts",
+            "import { value } from \"../lib/dependency\";\nvalue;\n");
+        directory.CreateFile(
+            "consumer/tsconfig.json",
+            """{ "include": ["*.ts"] }""");
+        NavigationReferenceResult after = ReferenceResult(
+            dependencyPath,
+            dependency,
+            "value",
+            occurrence: 0,
+            includeDeclaration: false,
+            openDocuments,
+            [directory.Path]);
+
+        Assert.Empty(before.Locations);
+        Assert.True(before.IsComplete);
+        Assert.Equal(2, after.Locations.Count);
+        Assert.True(after.IsComplete);
+        Assert.All(
+            after.Locations,
+            location => Assert.Equal(
+                DocumentUri.FromFileSystemPath(importerPath),
                 location.Uri));
     }
 
@@ -530,6 +708,51 @@ public class ReferenceServiceTests
         Assert.Equal(new Range(1, 12, 1, 18), location.Range);
     }
 
+    [Fact]
+    public async Task HandlerUsesInitializedWorkspaceForClosedImporters()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        string dependencyPath = directory.CreateFile(
+            "dependency.ts",
+            "export const answer = 42;\n");
+        string importerPath = directory.CreateFile(
+            "importer.ts",
+            "import { answer } from \"./dependency\";\nanswer;\n");
+        directory.CreateFile(
+            "tsconfig.json",
+            """{ "include": ["*.ts"] }""");
+        string dependency = File.ReadAllText(dependencyPath);
+        DocumentUri uri = DocumentUri.FromFileSystemPath(dependencyPath);
+        var store = new DocumentStore();
+        store.Set(uri.ToString(), dependency);
+        var workspace = new NavigationWorkspaceContext();
+        workspace.Initialize(new InitializeParams
+        {
+            RootUri = DocumentUri.FromFileSystemPath(directory.Path),
+        });
+        var handler = new ReferencesHandler(
+            store,
+            new ReferenceService(),
+            workspace);
+
+        var result = Assert.IsAssignableFrom<LocationContainer>(
+            await handler.Handle(
+                new ReferenceParams
+                {
+                    TextDocument = new TextDocumentIdentifier(uri),
+                    Position = new Position(0, 13),
+                    Context = new ReferenceContext { IncludeDeclaration = false },
+                },
+                CancellationToken.None));
+
+        Assert.Equal(2, result.Count());
+        Assert.All(
+            result,
+            location => Assert.Equal(
+                DocumentUri.FromFileSystemPath(importerPath),
+                location.Uri));
+    }
+
     private IReadOnlyList<Location> References(
         string source,
         string name,
@@ -552,7 +775,8 @@ public class ReferenceServiceTests
         string name,
         int occurrence,
         bool includeDeclaration,
-        IReadOnlyDictionary<string, string> openDocuments)
+        IReadOnlyDictionary<string, string> openDocuments,
+        IReadOnlyList<string>? workspaceRoots = null)
     {
         int offset = NthIndexOf(source, name, occurrence);
         var lines = new LineIndex(source);
@@ -562,7 +786,29 @@ public class ReferenceServiceTests
             source,
             new Position(line - 1, column - 1),
             includeDeclaration,
-            openDocuments);
+            openDocuments,
+            workspaceRoots);
+    }
+
+    private NavigationReferenceResult ReferenceResult(
+        string path,
+        string source,
+        string name,
+        int occurrence,
+        bool includeDeclaration,
+        IReadOnlyDictionary<string, string> openDocuments,
+        IReadOnlyList<string> workspaceRoots)
+    {
+        int offset = NthIndexOf(source, name, occurrence);
+        var lines = new LineIndex(source);
+        var (line, column) = lines.ToPosition(offset);
+        return _references.FindReferenceResult(
+            path,
+            source,
+            new Position(line - 1, column - 1),
+            includeDeclaration,
+            openDocuments,
+            workspaceRoots);
     }
 
     private static int NthIndexOf(string source, string value, int occurrence)

--- a/TypeSystem/BindingIndex.cs
+++ b/TypeSystem/BindingIndex.cs
@@ -217,6 +217,16 @@ public sealed class BindingIndex
         bool includeDeclarations)
     {
         IReadOnlyList<BindingSymbol> symbols = FindSymbols(document, offset);
+        return FindReferences(symbols, includeDeclarations);
+    }
+
+    /// <summary>
+    /// Returns all checker-bound occurrences for explicit symbols from this index.
+    /// </summary>
+    public IReadOnlyList<BindingOccurrence> FindReferences(
+        IReadOnlyList<BindingSymbol> symbols,
+        bool includeDeclarations)
+    {
         if (symbols.Count == 0)
             return [];
 
@@ -258,7 +268,10 @@ public sealed class BindingIndex
             .ToArray();
     }
 
-    private IReadOnlyList<BindingSymbol> FindSymbols(
+    /// <summary>
+    /// Returns the narrowest checker-bound value/type facets at a UTF-16 source offset.
+    /// </summary>
+    public IReadOnlyList<BindingSymbol> FindSymbols(
         SourceDocument document,
         int offset)
     {

--- a/docs/plans/lsp-server.md
+++ b/docs/plans/lsp-server.md
@@ -276,6 +276,15 @@ without merging unrelated script globals. The model records whether every config
 missing/broken configs and the open-document-only fallback are explicitly incomplete so safe rename
 can refuse them rather than silently emitting a partial edit.
 
+For multi-project workspaces, the server captures the initialized workspace folders, discovers each
+`tsconfig.json` (skipping dependency/build/tool directories), and follows in-workspace project
+references including explicitly named config files. Each project keeps its own module-resolution
+and checker options. References are joined across those independent semantic models by canonical
+declaration document/offset/namespace identity, so consuming projects with different `paths`
+mappings are both covered. A malformed config, failed root, or project reference outside the
+workspace makes the aggregate graph explicitly incomplete while preserving valid navigation
+results.
+
 The server advertises these features only in `--language-features full`; the VS Code extension
 continues to launch `interop-only`, leaving ordinary TypeScript navigation to `tsserver`.
 
@@ -390,9 +399,9 @@ single-file binary so non-VS-Code editors don't need the full SDK.
 - 🟨 **Phase 4b — standalone general navigation.** Reference-keyed source spans, document
   symbols, semantic value/type binding identities, and module-aware go-to-definition through
   imports/re-exports have landed. The inverse binding index, configured-project reverse graph,
-  closed-importer references, and explicit graph-completeness boundary have also landed. Safe
-  rename, type-parameter navigation, qualified member navigation, and multi-config/project-reference
-  workspace expansion remain. VS Code stays in `interop-only`; these capabilities are for
+  closed-importer references, multi-config/project-reference workspace expansion, and explicit
+  graph-completeness boundaries have also landed. Safe rename, type-parameter navigation, and
+  qualified member navigation remain. VS Code stays in `interop-only`; these capabilities are for
   standalone clients.
 - ⬜ **Phase 5 — Polish & reach.** Multi-editor docs; `dotnet tool`/self-contained
   packaging; debounce/cancellation; config→server wiring (`sharpts.diagnostics`);


### PR DESCRIPTION
## Summary
- capture initialized LSP workspace folders and discover configured projects while excluding dependency/build/tool directories
- follow in-workspace project references, including explicitly named config files, and preserve each project's resolver/checker options
- union semantic references across project models through canonical declaration path, offset, and namespace identity
- keep valid results while marking malformed configs, failed roots, and out-of-workspace references incomplete
- cover differing path aliases, custom referenced configs, catalog refresh, workspace boundaries, and handler wiring

## Verification
- dotnet test SharpTS.Tests/SharpTS.Tests.csproj --filter FullyQualifiedName~LanguageServer --no-restore (97 passed)
- dotnet test SharpTS.Tests/SharpTS.Tests.csproj --no-restore (16,246 passed)
- dotnet build SharpTS.LanguageServer/SharpTS.LanguageServer.csproj --no-restore
- git diff --check

Refs #1306