### PR TITLE
Complete editor parity lifecycle and polish

### DIFF
--- a/Compilation/AsyncFunctionMoveNextEmitter.Await.cs
+++ b/Compilation/AsyncFunctionMoveNextEmitter.Await.cs
@@ -123,6 +123,7 @@ public abstract partial class AsyncFunctionMoveNextEmitter
         // would not reach the continuation's snapshot (#400). Suspending path only.
         _helpers.PersistLiveSpillsBeforeSuspend();
 
+        int yieldOffset = IL.ILOffset;
         IL.Emit(OpCodes.Ldarg_0);
         IL.Emit(OpCodes.Ldflda, AsyncBuilderField);
         IL.Emit(OpCodes.Ldarg_0);
@@ -134,6 +135,14 @@ public abstract partial class AsyncFunctionMoveNextEmitter
 
         // 7. Resume point (jumped to from the state switch)
         MarkAwaitResumeLabel(stateNumber);
+        if (Ctx.DebugScope is { } debugScope &&
+            Ctx.CurrentMethod is { } currentMethod)
+        {
+            debugScope.RecordAsyncStep(
+                currentMethod,
+                yieldOffset,
+                IL.ILOffset);
+        }
         IL.Emit(OpCodes.Ldarg_0);
         IL.Emit(OpCodes.Ldc_I4_M1);
         IL.Emit(OpCodes.Stfld, AsyncStateField);

--- a/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
+++ b/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
@@ -485,10 +485,19 @@ public partial class AsyncGeneratorMoveNextEmitter
         // For async generators, we need to return a ValueTask<bool> that will complete when the await completes
         // The simplest approach: wrap the continuing task
         // Create a continuation that resumes MoveNextAsync
+        int yieldOffset = _il.ILOffset;
         EmitAwaitSuspensionReturn();
 
         // 7. Resume point (jumped to from state switch)
         _il.MarkLabel(resumeLabel);
+        if (_ctx.DebugScope is { } debugScope &&
+            _ctx.CurrentMethod is { } currentMethod)
+        {
+            debugScope.RecordAsyncStep(
+                currentMethod,
+                yieldOffset,
+                _il.ILOffset);
+        }
 
         // Reset state to -1 (running)
         _il.Emit(OpCodes.Ldarg_0);

--- a/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/Compilation/ILCompiler.ArrowFunctions.cs
@@ -279,6 +279,7 @@ public partial class ILCompiler
                     TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
                     _types.Object
                 );
+                MarkCompilerGenerated(displayClass);
 
                 // Determine if any captured vars are top-level captured vars
                 bool needsEntryPointDC = _closures.EntryPointDisplayClass != null &&
@@ -1126,6 +1127,7 @@ public partial class ILCompiler
             $"<>c__{nameSuffix}{_closures.DisplayClassCounter++}",
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
             _types.Object);
+        MarkCompilerGenerated(displayClass);
 
         var fieldMap = new Dictionary<string, FieldBuilder>();
         foreach (var varName in capturedLocals)

--- a/Compilation/ILCompiler.Async.cs
+++ b/Compilation/ILCompiler.Async.cs
@@ -37,6 +37,12 @@ public partial class ILCompiler
             _types.TaskOfObject,
             paramTypes
         );
+        RegisterStateMachine(
+            stubMethod,
+            smBuilder.StateMachineType,
+            smBuilder.MoveNextMethod,
+            EmittedStateMachineKind.Async,
+            smBuilder.SetStateMachineMethod);
 
         // Store for later body emission
         _functions.Builders[qualifiedFunctionName] = stubMethod;
@@ -359,6 +365,12 @@ public partial class ILCompiler
                 // Define the stub method that will be called to invoke the async arrow
                 arrowBuilder.DefineStubMethod(_programType, _runtime);
                 MarkPadsUndefined(arrowBuilder.StubMethod); // #640
+                RegisterStateMachine(
+                    arrowBuilder.StubMethod,
+                    arrowBuilder.StateMachineType,
+                    arrowBuilder.MoveNextMethod,
+                    EmittedStateMachineKind.Async,
+                    arrowBuilder.SetStateMachineMethod);
 
                 _async.ArrowBuilders[arrowInfo.Arrow] = arrowBuilder;
                 continue; // Already handled the full setup
@@ -375,6 +387,12 @@ public partial class ILCompiler
             // Define the stub method that will be called to invoke the async arrow
             arrowBuilder.DefineStubMethod(_programType, _runtime);
             MarkPadsUndefined(arrowBuilder.StubMethod); // #640
+            RegisterStateMachine(
+                arrowBuilder.StubMethod,
+                arrowBuilder.StateMachineType,
+                arrowBuilder.MoveNextMethod,
+                EmittedStateMachineKind.Async,
+                arrowBuilder.SetStateMachineMethod);
 
             _async.ArrowBuilders[arrowInfo.Arrow] = arrowBuilder;
         }
@@ -999,6 +1017,12 @@ public partial class ILCompiler
             hasAsyncArrows: hasAsyncArrows,
             hasLock: hasLock
         );
+        RegisterStateMachine(
+            methodBuilder,
+            smBuilder.StateMachineType,
+            smBuilder.MoveNextMethod,
+            EmittedStateMachineKind.Async,
+            smBuilder.SetStateMachineMethod);
 
         // #682/#follow-up: attach the method's function display class (registered in Phase 4) to the
         // state machine so a direct-child async arrow's write AND a nested sync arrow's write/read share
@@ -1145,6 +1169,12 @@ public partial class ILCompiler
             // Define the stub method
             arrowBuilder.DefineStubMethod(_programType, _runtime);
             MarkPadsUndefined(arrowBuilder.StubMethod); // #640
+            RegisterStateMachine(
+                arrowBuilder.StubMethod,
+                arrowBuilder.StateMachineType,
+                arrowBuilder.MoveNextMethod,
+                EmittedStateMachineKind.Async,
+                arrowBuilder.SetStateMachineMethod);
 
             // Store the builder
             _async.ArrowBuilders[arrow] = arrowBuilder;

--- a/Compilation/ILCompiler.AsyncGenerators.cs
+++ b/Compilation/ILCompiler.AsyncGenerators.cs
@@ -55,6 +55,17 @@ public partial class ILCompiler
             _types.IAsyncEnumerableOfObject,  // Async generator returns IAsyncEnumerable<object>
             paramTypes
         );
+        RegisterStateMachine(
+            methodBuilder,
+            smBuilder.StateMachineType,
+            smBuilder.MoveNextAsyncMethod,
+            EmittedStateMachineKind.AsyncIterator,
+            smBuilder.CurrentGetMethod,
+            smBuilder.DisposeAsyncMethod,
+            smBuilder.GetAsyncEnumeratorMethod,
+            smBuilder.NextMethod,
+            smBuilder.ReturnMethod,
+            smBuilder.ThrowMethod);
 
         _functions.Builders[qualifiedName] = methodBuilder;
 
@@ -184,6 +195,17 @@ public partial class ILCompiler
             isInstanceMethod: isInstanceMethod,
             runtime: _runtime
         );
+        RegisterStateMachine(
+            methodBuilder,
+            smBuilder.StateMachineType,
+            smBuilder.MoveNextAsyncMethod,
+            EmittedStateMachineKind.AsyncIterator,
+            smBuilder.CurrentGetMethod,
+            smBuilder.DisposeAsyncMethod,
+            smBuilder.GetAsyncEnumeratorMethod,
+            smBuilder.NextMethod,
+            smBuilder.ReturnMethod,
+            smBuilder.ThrowMethod);
 
         // #725: wire the function display class registered for this async generator method in
         // DefineClass so a sync arrow that writes a captured method local shares storage with the

--- a/Compilation/ILCompiler.DebuggerMetadata.cs
+++ b/Compilation/ILCompiler.DebuggerMetadata.cs
@@ -1,0 +1,63 @@
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+namespace SharpTS.Compilation;
+
+public partial class ILCompiler
+{
+    private enum EmittedStateMachineKind
+    {
+        Async,
+        Iterator,
+        AsyncIterator,
+    }
+
+    private void RegisterStateMachine(
+        MethodBuilder kickoff,
+        TypeBuilder stateMachine,
+        MethodBuilder moveNext,
+        EmittedStateMachineKind kind,
+        params MethodBuilder?[] infrastructure)
+    {
+        MarkCompilerGenerated(stateMachine);
+
+        Type attributeType = kind switch
+        {
+            EmittedStateMachineKind.Async =>
+                typeof(AsyncStateMachineAttribute),
+            EmittedStateMachineKind.Iterator =>
+                typeof(IteratorStateMachineAttribute),
+            EmittedStateMachineKind.AsyncIterator =>
+                typeof(AsyncIteratorStateMachineAttribute),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+        kickoff.SetCustomAttribute(new CustomAttributeBuilder(
+            attributeType.GetConstructor([typeof(Type)])!,
+            [stateMachine]));
+
+        foreach (MethodBuilder? method in infrastructure)
+        {
+            if (method is null)
+                continue;
+            MarkCompilerGenerated(method);
+            method.SetCustomAttribute(new CustomAttributeBuilder(
+                typeof(System.Diagnostics.DebuggerNonUserCodeAttribute)
+                    .GetConstructor(Type.EmptyTypes)!,
+                []));
+        }
+
+        if (EmitDebugSymbols)
+            _debugInfo.RecordStateMachine(kickoff, moveNext);
+    }
+
+    private static void MarkCompilerGenerated(TypeBuilder type) =>
+        type.SetCustomAttribute(CompilerGeneratedAttribute());
+
+    private static void MarkCompilerGenerated(MethodBuilder method) =>
+        method.SetCustomAttribute(CompilerGeneratedAttribute());
+
+    private static CustomAttributeBuilder CompilerGeneratedAttribute() =>
+        new(
+            typeof(CompilerGeneratedAttribute).GetConstructor(Type.EmptyTypes)!,
+            []);
+}

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -287,6 +287,7 @@ public partial class ILCompiler
             $"<>c__FuncDisplayClass_{qualifiedFunctionName.Replace(".", "_").Replace(":", "_")}_{_closures.DisplayClassCounter++}",
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
             _types.Object);
+        MarkCompilerGenerated(displayClass);
 
         // Define fields for each captured variable
         var fieldMap = new Dictionary<string, FieldBuilder>();

--- a/Compilation/ILCompiler.Generators.cs
+++ b/Compilation/ILCompiler.Generators.cs
@@ -71,6 +71,20 @@ public partial class ILCompiler
             _types.IEnumerableOfObject,  // Generator returns IEnumerable<object>
             paramTypes
         );
+        RegisterStateMachine(
+            methodBuilder,
+            smBuilder.StateMachineType,
+            smBuilder.MoveNextMethod,
+            EmittedStateMachineKind.Iterator,
+            smBuilder.CurrentGetMethod,
+            smBuilder.NonGenericCurrentGetMethod,
+            smBuilder.ResetMethod,
+            smBuilder.DisposeMethod,
+            smBuilder.GetEnumeratorMethod,
+            smBuilder.NonGenericGetEnumeratorMethod,
+            smBuilder.NextMethod,
+            smBuilder.ReturnMethod,
+            smBuilder.ThrowMethod);
 
         _functions.Builders[qualifiedName] = methodBuilder;
 
@@ -431,6 +445,20 @@ public partial class ILCompiler
             isInstanceMethod: isInstanceMethod,
             runtime: _runtime
         );
+        RegisterStateMachine(
+            methodBuilder,
+            smBuilder.StateMachineType,
+            smBuilder.MoveNextMethod,
+            EmittedStateMachineKind.Iterator,
+            smBuilder.CurrentGetMethod,
+            smBuilder.NonGenericCurrentGetMethod,
+            smBuilder.ResetMethod,
+            smBuilder.DisposeMethod,
+            smBuilder.GetEnumeratorMethod,
+            smBuilder.NonGenericGetEnumeratorMethod,
+            smBuilder.NextMethod,
+            smBuilder.ReturnMethod,
+            smBuilder.ThrowMethod);
 
         // #724: wire the function display class registered for this method in DefineClass so an arrow
         // that WRITES a captured method local shares storage with the generator (mirrors the free-

--- a/Compilation/ILCompiler.InnerFunctions.cs
+++ b/Compilation/ILCompiler.InnerFunctions.cs
@@ -306,6 +306,7 @@ public partial class ILCompiler
                     TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
                     _types.Object
                 );
+                MarkCompilerGenerated(displayClass);
 
                 // Add fields for captured variables
                 Dictionary<string, FieldBuilder> fieldMap = [];

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -1555,17 +1555,24 @@ public partial class ILCompiler
     /// <see cref="EmitDebugSymbols"/> is set.
     /// </summary>
     /// <param name="pdbPath">
-    /// Where to write the PDB, and the path recorded in the assembly's CodeView entry. Defaults to
-    /// <paramref name="outputPath"/> with a <c>.pdb</c> extension. EXE builds pass the final
-    /// executable's location explicitly, because the assembly itself is emitted to a temporary
-    /// file before being bundled.
+    /// Where to write the PDB. Defaults to <paramref name="outputPath"/> with a <c>.pdb</c>
+    /// extension. The CodeView entry uses only the file name when the PDB is beside the output
+    /// assembly, which lets debuggers resolve relative output paths from the assembly directory;
+    /// otherwise it uses the PDB's full path. EXE builds pass the final executable's location
+    /// explicitly, because the assembly itself is emitted to a temporary file before being bundled.
     /// </param>
     public void Save(string outputPath, string? pdbPath)
     {
         if (EmitDebugSymbols)
             pdbPath ??= Path.ChangeExtension(outputPath, ".pdb");
 
-        var artifacts = SaveArtifacts(pdbPath);
+        string? codeViewPdbPath = pdbPath is null
+            ? null
+            : Path.GetDirectoryName(Path.GetFullPath(outputPath)) ==
+                Path.GetDirectoryName(Path.GetFullPath(pdbPath))
+                ? Path.GetFileName(pdbPath)
+                : Path.GetFullPath(pdbPath);
+        var artifacts = SaveArtifacts(codeViewPdbPath);
 
         File.WriteAllBytes(outputPath, artifacts.Assembly);
         if (artifacts.Pdb is not null)
@@ -1968,6 +1975,7 @@ public partial class ILCompiler
             "<>c__EntryPointDisplayClass",
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
             _types.Object);
+        MarkCompilerGenerated(displayClass);
 
         var ctor = displayClass.DefineConstructor(
             MethodAttributes.Public,

--- a/Compilation/ReloadingAssemblyReferenceLoader.cs
+++ b/Compilation/ReloadingAssemblyReferenceLoader.cs
@@ -1,0 +1,98 @@
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Atomically replaces metadata loaders when configured assembly files change. Retired metadata
+/// contexts remain alive until shutdown so a <see cref="Type"/> returned to an in-flight request
+/// can never be invalidated by a concurrent reload.
+/// </summary>
+public sealed class ReloadingAssemblyReferenceLoader : IDisposable
+{
+    private readonly object _gate = new();
+    private readonly string[] _assemblyPaths;
+    private readonly string? _sdkPath;
+    private readonly List<AssemblyReferenceLoader> _retired = [];
+    private AssemblyReferenceLoader _current;
+    private FileStamp[] _stamps;
+    private bool _disposed;
+
+    public ReloadingAssemblyReferenceLoader(
+        IEnumerable<string> assemblyPaths,
+        string? sdkPath = null)
+    {
+        _assemblyPaths = assemblyPaths
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        _sdkPath = sdkPath;
+        _stamps = CaptureStamps();
+        _current = new AssemblyReferenceLoader(_assemblyPaths, _sdkPath);
+    }
+
+    public int Generation { get; private set; }
+
+    public Type? TryResolve(string fullName)
+    {
+        lock (_gate)
+        {
+            ReloadIfChanged();
+            return _current.TryResolve(fullName);
+        }
+    }
+
+    public IReadOnlyList<Type> GetAllPublicTypes()
+    {
+        lock (_gate)
+        {
+            ReloadIfChanged();
+            return _current.GetAllPublicTypes().ToArray();
+        }
+    }
+
+    private void ReloadIfChanged()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        FileStamp[] currentStamps = CaptureStamps();
+        if (currentStamps.SequenceEqual(_stamps))
+            return;
+
+        var replacement = new AssemblyReferenceLoader(_assemblyPaths, _sdkPath);
+        _retired.Add(_current);
+        _current = replacement;
+        _stamps = currentStamps;
+        Generation++;
+    }
+
+    private FileStamp[] CaptureStamps() =>
+        _assemblyPaths.Select(FileStamp.Capture).ToArray();
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            _current.Dispose();
+            foreach (AssemblyReferenceLoader loader in _retired)
+                loader.Dispose();
+            _retired.Clear();
+        }
+    }
+
+    private readonly record struct FileStamp(
+        bool Exists,
+        long Length,
+        long LastWriteUtcTicks)
+    {
+        public static FileStamp Capture(string path)
+        {
+            var file = new FileInfo(path);
+            return file.Exists
+                ? new FileStamp(
+                    Exists: true,
+                    file.Length,
+                    file.LastWriteTimeUtc.Ticks)
+                : default;
+        }
+    }
+}

--- a/Compilation/Symbols/DebugEmitScope.cs
+++ b/Compilation/Symbols/DebugEmitScope.cs
@@ -57,6 +57,12 @@ internal sealed class DebugEmitScope(
         Collector.RecordSequencePoint(method, Document, ilOffset, startLine, startColumn, endLine, endColumn);
     }
 
+    internal void RecordAsyncStep(
+        MethodBase method,
+        int yieldOffset,
+        int resumeOffset) =>
+        Collector.RecordAsyncStep(method, yieldOffset, resumeOffset);
+
     /// <summary>
     /// Whether a statement is one a debugger should be able to stop on.
     /// </summary>

--- a/Compilation/Symbols/DebugInfoCollector.cs
+++ b/Compilation/Symbols/DebugInfoCollector.cs
@@ -29,12 +29,27 @@ internal sealed class DebugInfoCollector
     /// <summary>GUID identifying SHA-256 as a document hash algorithm, per the portable PDB spec.</summary>
     private static readonly Guid Sha256HashAlgorithm = new("8829d00f-11b8-4213-878b-770e8597ac16");
 
+    /// <summary>
+    /// GUID identifying C# source documents. SharpTS emits managed IL and uses the C# debugger
+    /// pipeline; a zero language GUID makes managed debuggers reject otherwise valid TypeScript
+    /// sequence points as having no associated target-code type.
+    /// </summary>
+    private static readonly Guid ManagedSourceLanguage =
+        new("3f5162f8-07c6-11d3-9053-00c04fa302a1");
+
     /// <summary>Line number marking a hidden sequence point in the debugger's own conventions.</summary>
     internal const int HiddenLine = 0xfeefee;
 
     private readonly Dictionary<string, SourceFile> _documents = new(StringComparer.OrdinalIgnoreCase);
     private readonly Dictionary<MethodBase, List<Point>> _methods = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<MethodBase, MethodLocalSymbols> _locals = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<MethodBase, MethodBase> _stateMachines =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<MethodBase, List<AsyncStep>> _asyncSteps =
+        new(ReferenceEqualityComparer.Instance);
+
+    private static readonly Guid AsyncMethodSteppingInformationKind =
+        new("54fd2ac5-e925-401a-9c2a-f94f171072f8");
 
     /// <summary>
     /// Starts collecting named locals and lexical scopes for a method body, returning the sink to
@@ -71,6 +86,31 @@ internal sealed class DebugInfoCollector
 
     /// <summary>A sequence point. <see cref="Document"/> is null for a hidden point.</summary>
     private readonly record struct Point(int IlOffset, SourceFile? Document, int StartLine, int StartColumn, int EndLine, int EndColumn);
+    private readonly record struct AsyncStep(int YieldOffset, int ResumeOffset);
+
+    /// <summary>
+    /// Associates a generated MoveNext body with the source-level kickoff method. Portable-PDB
+    /// readers use this table to present the original async/iterator frame instead of raw
+    /// state-machine plumbing.
+    /// </summary>
+    internal void RecordStateMachine(
+        MethodBase kickoffMethod,
+        MethodBase moveNextMethod)
+    {
+        _stateMachines[moveNextMethod] = kickoffMethod;
+    }
+
+    /// <summary>Records one await suspension/resume pair for async stepping.</summary>
+    internal void RecordAsyncStep(
+        MethodBase moveNextMethod,
+        int yieldOffset,
+        int resumeOffset)
+    {
+        if (!_asyncSteps.TryGetValue(moveNextMethod, out List<AsyncStep>? steps))
+            _asyncSteps[moveNextMethod] = steps = [];
+        if (steps.Count == 0 || steps[^1] != new AsyncStep(yieldOffset, resumeOffset))
+            steps.Add(new AsyncStep(yieldOffset, resumeOffset));
+    }
 
     /// <summary>
     /// Registers a source file, returning a stable key to pass to
@@ -164,7 +204,7 @@ internal sealed class DebugInfoCollector
                 name: pdb.GetOrAddDocumentName(document.Path),
                 hashAlgorithm: pdb.GetOrAddGuid(Sha256HashAlgorithm),
                 hash: pdb.GetOrAddBlob(document.Hash),
-                language: pdb.GetOrAddGuid(default));
+                language: pdb.GetOrAddGuid(ManagedSourceLanguage));
         }
 
         var byRid = new Dictionary<int, List<Point>>(_methods.Count);
@@ -187,9 +227,47 @@ internal sealed class DebugInfoCollector
             pdb.AddMethodDebugInformation(single?.Handle ?? default, pdb.GetOrAddBlob(blob));
         }
 
+        WriteStateMachineMetadata(pdb);
         WriteLocalScopes(pdb, methodIlSize);
         EmbedSources(pdb);
         return pdb;
+    }
+
+    private void WriteStateMachineMetadata(MetadataBuilder pdb)
+    {
+        foreach (var (moveNext, kickoff) in _stateMachines
+            .Select(pair => (
+                MoveNext: MethodHandle(pair.Key),
+                Kickoff: MethodHandle(pair.Value)))
+            .OrderBy(pair => MetadataTokens.GetRowNumber(pair.MoveNext)))
+        {
+            pdb.AddStateMachineMethod(moveNext, kickoff);
+        }
+
+        GuidHandle kind = pdb.GetOrAddGuid(AsyncMethodSteppingInformationKind);
+        foreach (var (method, steps) in _asyncSteps
+            .OrderBy(pair => MetadataTokens.GetRowNumber(MethodHandle(pair.Key))))
+        {
+            if (steps.Count == 0)
+                continue;
+
+            MethodDefinitionHandle moveNext = MethodHandle(method);
+            var blob = new BlobBuilder();
+            blob.WriteInt32(-1); // no catch-handler offset
+            foreach (AsyncStep step in steps.OrderBy(step => step.YieldOffset))
+            {
+                blob.WriteInt32(step.YieldOffset);
+                blob.WriteInt32(step.ResumeOffset);
+                blob.WriteCompressedInteger(MetadataTokens.GetRowNumber(moveNext));
+            }
+            pdb.AddCustomDebugInformation(
+                moveNext,
+                kind,
+                pdb.GetOrAddBlob(blob));
+        }
+
+        static MethodDefinitionHandle MethodHandle(MethodBase method) =>
+            MetadataTokens.MethodDefinitionHandle(method.MetadataToken);
     }
 
     /// <summary>

--- a/Parsing/Parser.Types.cs
+++ b/Parsing/Parser.Types.cs
@@ -472,12 +472,12 @@ public partial class Parser
                     // Node requires the constraint node; a constraint without node support drops
                     // the whole infer to the string path rather than losing the constraint.
                     _lastTypeNode = constraintNode is not null
-                        ? new InferTypeNode(paramName.Lexeme, paramName.Line, constraintNode)
+                        ? new InferTypeNode(paramName.Lexeme, paramName.Line, constraintNode, paramName)
                         : null;
                     return $"infer {paramName.Lexeme} extends {constraint}";
                 }
             }
-            _lastTypeNode = new InferTypeNode(paramName.Lexeme, paramName.Line);
+            _lastTypeNode = new InferTypeNode(paramName.Lexeme, paramName.Line, NameToken: paramName);
             return $"infer {paramName.Lexeme}";
         }
 
@@ -787,7 +787,8 @@ public partial class Parser
         {
             Token nameToken = Advance();
             typeName = nameToken.Lexeme;
-            typeNode = new NamedTypeNode(typeName, null, nameToken.Line, nameToken);
+            List<Token> nameTokens = [nameToken];
+            typeNode = new NamedTypeNode(typeName, null, nameToken.Line, nameToken, nameTokens);
 
             // Qualified type name (namespace member): `Intl.CollatorOptions`, `NodeJS.Timer`.
             // The dotted name carries on the NamedTypeNode; resolution hands the whole "Foo.Bar"
@@ -797,10 +798,12 @@ public partial class Parser
                    (PeekNext().Type == TokenType.IDENTIFIER || IsContextualKeyword(PeekNext().Type)))
             {
                 Advance(); // consume '.'
-                typeName += "." + Advance().Lexeme;
+                Token memberName = Advance();
+                nameTokens.Add(memberName);
+                typeName += "." + memberName.Lexeme;
                 typeNode = typeNode is NamedTypeNode named
-                    ? named with { Name = typeName }
-                    : new NamedTypeNode(typeName, null, nameToken.Line, nameToken);
+                    ? named with { Name = typeName, NameTokens = nameTokens }
+                    : new NamedTypeNode(typeName, null, nameToken.Line, nameToken, nameTokens);
             }
         }
         else
@@ -1352,7 +1355,7 @@ public partial class Parser
         // have node forms. Any missing component drops the whole mapped type to the string path.
         _lastTypeNode = constraintNode is not null && valueNode is not null && (!hasAs || asNode is not null)
             ? new MappedTypeNode(paramName.Lexeme, constraintNode, valueNode, asNode,
-                addReadonly, removeReadonly, addOptional, removeOptional, startLine)
+                addReadonly, removeReadonly, addOptional, removeOptional, startLine, paramName)
             : null;
         return $"{{ {readonlyMod}[{paramName.Lexeme} in {constraint}{asClause}]{optionalMod}: {valueType} }}";
     }

--- a/Parsing/TypeNodes.cs
+++ b/Parsing/TypeNodes.cs
@@ -20,7 +20,8 @@ public sealed record NamedTypeNode(
     string Name,
     List<TypeNode>? TypeArguments,
     int Line,
-    Token? NameToken = null) : TypeNode(Line);
+    Token? NameToken = null,
+    List<Token>? NameTokens = null) : TypeNode(Line);
 
 /// <summary>A literal type: <c>"ok"</c>, <c>42</c>, <c>true</c>, <c>1n</c> (bigint literals carry
 /// their <c>System.Numerics.BigInteger</c> value).</summary>
@@ -73,7 +74,11 @@ public sealed record ConditionalTypeNode(TypeNode CheckType, TypeNode ExtendsTyp
 /// constrained (<c>infer U extends C</c>). Resolves to <c>TypeInfo.InferredTypeParameter</c>;
 /// the constraint gates the match in <c>EvaluateConditionalType</c> (an inferred type that does
 /// not satisfy it sends the conditional to its false branch).</summary>
-public sealed record InferTypeNode(string Name, int Line, TypeNode? Constraint = null) : TypeNode(Line);
+public sealed record InferTypeNode(
+    string Name,
+    int Line,
+    TypeNode? Constraint = null,
+    Token? NameToken = null) : TypeNode(Line);
 
 /// <summary>A <c>typeof entity</c> query. The entity path is carried in its string-path spelling
 /// (<c>obj.prop</c>, <c>arr[0]</c>) and resolved by <c>EvaluateTypeOf</c> — the same evaluator the
@@ -137,7 +142,8 @@ public sealed record MappedTypeNode(
     bool RemoveReadonly,
     bool AddOptional,
     bool RemoveOptional,
-    int Line) : TypeNode(Line);
+    int Line,
+    Token? ParamToken = null) : TypeNode(Line);
 
 /// <summary>A member of an <see cref="ObjectTypeNode"/>. Not itself a type.</summary>
 public abstract record ObjectTypeMemberNode(int Line);

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ SharpTS supports two execution modes:
 - Compile to standalone executables or .NET assemblies
 - Reference assembly output for C# interop (`--ref-asm`)
 - IL verification (`--verify`)
+- Portable PDBs for debugging original TypeScript source (`--debug` / `-g`)
+
+### Editor Tooling
+
+- VS Code extension with interop IntelliSense and **Debug Current File**
+- Standalone `sharpts-lsp` tool for TypeScript/TSX diagnostics and safe interop quick fixes
+- Full standalone navigation: document symbols, definition, references, and completeness-gated rename
+- Neovim, Helix, and generic stdio-LSP setup documented in the [language server guide](docs/language-server.md)
 
 ### .NET Interop
 
@@ -113,6 +121,16 @@ sharpts script.ts
 ```bash
 sharpts --compile script.ts
 dotnet script.dll
+```
+
+Add `-g` to emit a portable PDB and debug the original `.ts` source. See
+[Debugging compiled TypeScript](docs/debugging-typescript.md).
+
+For editor support outside VS Code, install the separate language-server tool:
+
+```bash
+dotnet tool install --global SharpTS.LanguageServer
+sharpts-lsp --language-features full
 ```
 
 **Compile to self-contained executable:**

--- a/STATUS.md
+++ b/STATUS.md
@@ -464,7 +464,23 @@ SharpTS implements 35 Node.js built-in module specifiers, accessible via `import
 
 ---
 
-## 16. .NET INTEROP (`dotnet:` imports + `@DotNetType`)
+## 16. EDITOR TOOLING
+
+| Feature | Status | Notes |
+|---|---|---|
+| TypeScript-source portable PDBs | ✅ | `sharpts --compile app.ts -g`; source checksums, imported documents, sequence points, locals/scopes, state-machine mappings, and async stepping metadata |
+| VS Code debugging | ✅ | **SharpTS: Debug Current File** compiles the saved file and launches the installed `coreclr` adapter |
+| Interop language features | ✅ | Diagnostics, decorator/member hover, completion, signature help, and structured quick fixes in both LSP feature modes |
+| Standalone navigation | ✅ | Document symbols, definition, references, and safe rename across complete configured/project-reference workspaces |
+| Workspace lifecycle | ✅ | Incremental versioned sync, atomic snapshots, debounce/cancellation, cached analysis, reverse diagnostic invalidation, live diagnostics settings, and safe assembly reload |
+| General property/member rename | Deferred | Refused rather than producing a partial semantic edit |
+
+See [Language server setup](docs/language-server.md) and
+[Debugging compiled TypeScript](docs/debugging-typescript.md).
+
+---
+
+## 17. .NET INTEROP (`dotnet:` imports + `@DotNetType`)
 
 .NET types can be consumed two ways: **`dotnet:` import specifiers** (recommended — zero boilerplate, type surface synthesized from reflection; epic #1195) and **`@DotNetType` declare classes** (manual, curated surface, supports `@DotNetOverload` hints). **Both work in interpreter and compiled modes.**
 
@@ -492,7 +508,7 @@ Compiled mode uses late-bound reflection to the shim (`DotNetDelegateShim` / `Do
 
 ---
 
-## 17. CONFORMANCE TEST SUITES
+## 18. CONFORMANCE TEST SUITES
 
 Two external corpora pin SharpTS against canonical references. Both run as standalone projects (not in `SharpTS.sln`); see each project's README for full details. Pass rates here are subset-relative — neither suite runs the full corpus today.
 

--- a/SharpTS.LanguageServer/Conversions/LspConversions.cs
+++ b/SharpTS.LanguageServer/Conversions/LspConversions.cs
@@ -1,4 +1,5 @@
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Newtonsoft.Json.Linq;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 using SharpDiagnostic = SharpTS.Diagnostics.Diagnostic;
 using SharpSeverity = SharpTS.Diagnostics.DiagnosticSeverity;
@@ -34,7 +35,10 @@ public static class LspConversions
                 Range = ToRange(d, lines),
                 Severity = ToSeverity(d.Severity),
                 Message = d.Message,
-                Source = "sharpts"
+                Source = "sharpts",
+                Data = d.Properties is null
+                    ? null
+                    : JObject.FromObject(d.Properties),
             });
         }
         return result;

--- a/SharpTS.LanguageServer/DocumentStore.cs
+++ b/SharpTS.LanguageServer/DocumentStore.cs
@@ -1,28 +1,232 @@
-using System.Collections.Concurrent;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace SharpTS.LanguageServer;
 
 /// <summary>
-/// Tracks the current text of open documents (uri -> text). The overlay for in-memory
-/// type-checking of dirty buffers (fed to ModuleResolver's virtualFiles) builds on this.
+/// An immutable version of one open text document.
+/// </summary>
+public sealed record DocumentSnapshot(
+    string Uri,
+    string Text,
+    int Version,
+    string? FilePath);
+
+/// <summary>
+/// One atomically captured view of a request document and every open file overlay.
+/// </summary>
+public sealed record DocumentRequestSnapshot(
+    DocumentSnapshot Document,
+    long WorkspaceVersion,
+    IReadOnlyDictionary<string, DocumentSnapshot> FileSystemDocuments)
+{
+    public IReadOnlyDictionary<string, string> TextOverlay =>
+        FileSystemDocuments.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value.Text,
+            StringComparer.OrdinalIgnoreCase);
+}
+
+/// <summary>
+/// Tracks immutable, versioned open-document snapshots. All mutations and multi-document
+/// captures share one lock so a request never combines the requested version with an overlay
+/// from a different workspace instant.
 /// </summary>
 public sealed class DocumentStore
 {
-    private readonly ConcurrentDictionary<string, string> _docs = new();
+    private readonly object _gate = new();
+    private readonly Dictionary<string, DocumentSnapshot> _documents =
+        new(StringComparer.OrdinalIgnoreCase);
+    private long _workspaceVersion;
 
-    public void Set(string uri, string text) => _docs[uri] = text;
-    public bool TryGet(string uri, out string text) => _docs.TryGetValue(uri, out text!);
-    public void Remove(string uri) => _docs.TryRemove(uri, out _);
+    /// <summary>
+    /// Compatibility helper for service-level tests and non-LSP callers. Each call advances the
+    /// stored document version.
+    /// </summary>
+    public void Set(string uri, string text)
+    {
+        lock (_gate)
+        {
+            int version = _documents.TryGetValue(uri, out DocumentSnapshot? current)
+                ? current.Version + 1
+                : 0;
+            SetCore(uri, text, version);
+        }
+    }
+
+    public bool Open(string uri, string text, int version)
+    {
+        lock (_gate)
+        {
+            if (_documents.TryGetValue(uri, out DocumentSnapshot? current) &&
+                version < current.Version)
+            {
+                return false;
+            }
+
+            SetCore(uri, text, version);
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Applies an LSP incremental change batch in order. Stale or duplicate document versions
+    /// are ignored so delayed notifications cannot roll a buffer backwards.
+    /// </summary>
+    public bool ApplyChanges(
+        string uri,
+        int version,
+        IEnumerable<TextDocumentContentChangeEvent> changes)
+    {
+        lock (_gate)
+        {
+            if (!_documents.TryGetValue(uri, out DocumentSnapshot? current) ||
+                version <= current.Version)
+            {
+                return false;
+            }
+
+            string text = current.Text;
+            foreach (TextDocumentContentChangeEvent change in changes)
+            {
+                text = change.Range is null
+                    ? change.Text
+                    : ApplyIncrementalChange(text, change.Range, change.Text);
+            }
+
+            SetCore(uri, text, version);
+            return true;
+        }
+    }
+
+    public bool TryGet(string uri, out string text)
+    {
+        lock (_gate)
+        {
+            if (_documents.TryGetValue(uri, out DocumentSnapshot? snapshot))
+            {
+                text = snapshot.Text;
+                return true;
+            }
+        }
+
+        text = null!;
+        return false;
+    }
+
+    public bool TryGetSnapshot(string uri, out DocumentSnapshot snapshot)
+    {
+        lock (_gate)
+            return _documents.TryGetValue(uri, out snapshot!);
+    }
+
+    public bool TryCapture(
+        string uri,
+        out DocumentRequestSnapshot snapshot)
+    {
+        lock (_gate)
+        {
+            if (!_documents.TryGetValue(uri, out DocumentSnapshot? document))
+            {
+                snapshot = null!;
+                return false;
+            }
+
+            snapshot = new DocumentRequestSnapshot(
+                document,
+                _workspaceVersion,
+                CaptureFileSystemDocuments());
+            return true;
+        }
+    }
+
+    public bool IsCurrent(string uri, int version, long workspaceVersion)
+    {
+        lock (_gate)
+        {
+            return _workspaceVersion == workspaceVersion &&
+                _documents.TryGetValue(uri, out DocumentSnapshot? snapshot) &&
+                snapshot.Version == version;
+        }
+    }
+
+    public DocumentSnapshot? Remove(string uri)
+    {
+        lock (_gate)
+        {
+            if (!_documents.Remove(uri, out DocumentSnapshot? removed))
+                return null;
+
+            _workspaceVersion++;
+            return removed;
+        }
+    }
 
     /// <summary>Returns open file documents keyed by normalized file-system path.</summary>
     public IReadOnlyDictionary<string, string> SnapshotFileSystemDocuments()
     {
-        var documents = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var (documentUri, text) in _docs)
+        lock (_gate)
         {
-            if (Uri.TryCreate(documentUri, UriKind.Absolute, out var uri) && uri.IsFile)
-                documents[Path.GetFullPath(uri.LocalPath)] = text;
+            return CaptureFileSystemDocuments().ToDictionary(
+                pair => pair.Key,
+                pair => pair.Value.Text,
+                StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    public IReadOnlyList<DocumentSnapshot> SnapshotDocuments()
+    {
+        lock (_gate)
+            return [.. _documents.Values];
+    }
+
+    private void SetCore(string uri, string text, int version)
+    {
+        _documents[uri] = new DocumentSnapshot(
+            uri,
+            text,
+            version,
+            GetFilePath(uri));
+        _workspaceVersion++;
+    }
+
+    private Dictionary<string, DocumentSnapshot> CaptureFileSystemDocuments()
+    {
+        var documents = new Dictionary<string, DocumentSnapshot>(
+            StringComparer.OrdinalIgnoreCase);
+        foreach (DocumentSnapshot document in _documents.Values)
+        {
+            if (document.FilePath is not null)
+                documents[document.FilePath] = document;
         }
         return documents;
+    }
+
+    private static string? GetFilePath(string documentUri)
+    {
+        return Uri.TryCreate(documentUri, UriKind.Absolute, out Uri? uri) &&
+            uri.IsFile
+                ? Path.GetFullPath(uri.LocalPath)
+                : null;
+    }
+
+    private static string ApplyIncrementalChange(
+        string text,
+        OmniSharp.Extensions.LanguageServer.Protocol.Models.Range range,
+        string replacement)
+    {
+        var map = new PositionMap(text);
+        int start = map.ToOffset(
+            checked((int)range.Start.Line),
+            checked((int)range.Start.Character));
+        int end = map.ToOffset(
+            checked((int)range.End.Line),
+            checked((int)range.End.Character));
+        if (start > end)
+            throw new ArgumentException("The text change range ends before it starts.");
+
+        return string.Concat(
+            text.AsSpan(0, start),
+            replacement,
+            text.AsSpan(end));
     }
 }

--- a/SharpTS.LanguageServer/Handlers/CodeActionHandler.cs
+++ b/SharpTS.LanguageServer/Handlers/CodeActionHandler.cs
@@ -1,0 +1,48 @@
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpTS.LanguageServer.Services;
+
+namespace SharpTS.LanguageServer.Handlers;
+
+/// <summary>Serves structured quick fixes for SharpTS interop diagnostics.</summary>
+public sealed class CodeActionHandler : CodeActionHandlerBase
+{
+    private readonly InteropCodeActionService _actions;
+
+    public CodeActionHandler(InteropCodeActionService actions) =>
+        _actions = actions;
+
+    public override Task<CommandOrCodeActionContainer?> Handle(
+        CodeActionParams request,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult<CommandOrCodeActionContainer?>(
+            _actions.Create(request));
+    }
+
+    public override Task<CodeAction> Handle(
+        CodeAction request,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(request);
+    }
+
+    protected override CodeActionRegistrationOptions CreateRegistrationOptions(
+        CodeActionCapability capability,
+        ClientCapabilities clientCapabilities) =>
+        CreateRegistrationOptions();
+
+    internal static CodeActionRegistrationOptions CreateRegistrationOptions() =>
+        new()
+        {
+            DocumentSelector = TextDocumentSelector.ForLanguage(
+                "typescript",
+                "typescriptreact"),
+            CodeActionKinds = new Container<CodeActionKind>(
+                CodeActionKind.QuickFix),
+            ResolveProvider = false,
+        };
+}

--- a/SharpTS.LanguageServer/Handlers/CompletionHandler.cs
+++ b/SharpTS.LanguageServer/Handlers/CompletionHandler.cs
@@ -20,10 +20,15 @@ public sealed class CompletionHandler : CompletionHandlerBase
 
     public override Task<CompletionList> Handle(CompletionParams request, CancellationToken ct)
     {
-        if (!_store.TryGet(request.TextDocument.Uri.ToString(), out var text))
+        if (!_store.TryGetSnapshot(
+                request.TextDocument.Uri.ToString(),
+                out DocumentSnapshot? snapshot))
             return Task.FromResult(new CompletionList());
 
-        var list = _decorators.Completion(text, request.Position.Line, request.Position.Character);
+        var list = _decorators.Completion(
+            snapshot.Text,
+            request.Position.Line,
+            request.Position.Character);
         return Task.FromResult(list ?? new CompletionList());
     }
 

--- a/SharpTS.LanguageServer/Handlers/ConfigurationHandler.cs
+++ b/SharpTS.LanguageServer/Handlers/ConfigurationHandler.cs
@@ -1,0 +1,44 @@
+using MediatR;
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
+using SharpTS.LanguageServer.Conversions;
+using SharpTS.LanguageServer.Services;
+
+namespace SharpTS.LanguageServer.Handlers;
+
+/// <summary>Applies live <c>sharpts.diagnostics</c> changes and republishes open files.</summary>
+public sealed class ConfigurationHandler : DidChangeConfigurationHandlerBase
+{
+    private readonly DiagnosticsSettings _settings;
+    private readonly DiagnosticsCoordinator _diagnostics;
+
+    public ConfigurationHandler(
+        DiagnosticsSettings settings,
+        DiagnosticsCoordinator diagnostics)
+    {
+        _settings = settings;
+        _diagnostics = diagnostics;
+    }
+
+    public override Task<Unit> Handle(
+        DidChangeConfigurationParams request,
+        CancellationToken cancellationToken)
+    {
+        string? configured = FindDiagnosticsValue(request.Settings);
+        if (DiagnosticsSettings.TryParse(
+                configured,
+                out DiagnosticPublishMode mode) &&
+            mode != _settings.Mode)
+        {
+            _settings.Mode = mode;
+            _diagnostics.RepublishAll();
+        }
+
+        return Unit.Task;
+    }
+
+    internal static string? FindDiagnosticsValue(JToken? settings) =>
+        settings?.SelectToken("sharpts.diagnostics")?.Value<string>() ??
+        settings?["diagnostics"]?.Value<string>();
+}

--- a/SharpTS.LanguageServer/Handlers/DefinitionHandler.cs
+++ b/SharpTS.LanguageServer/Handlers/DefinitionHandler.cs
@@ -29,16 +29,16 @@ public sealed class DefinitionHandler : DefinitionHandlerBase
         CancellationToken ct)
     {
         string uri = request.TextDocument.Uri.ToString();
-        if (!_store.TryGet(uri, out var text))
+        if (!_store.TryCapture(uri, out DocumentRequestSnapshot? snapshot))
             return Task.FromResult<LocationOrLocationLinks?>(null);
 
         ct.ThrowIfCancellationRequested();
 
         var locations = _definitions.FindDefinitions(
                 request.TextDocument.Uri.GetFileSystemPath(),
-                text,
+                snapshot.Document.Text,
                 request.Position,
-                _store.SnapshotFileSystemDocuments())
+                snapshot.TextOverlay)
             .Select(location => new LocationOrLocationLink(location));
         return Task.FromResult<LocationOrLocationLinks?>(
             new LocationOrLocationLinks(locations));

--- a/SharpTS.LanguageServer/Handlers/DocumentSymbolHandler.cs
+++ b/SharpTS.LanguageServer/Handlers/DocumentSymbolHandler.cs
@@ -29,12 +29,14 @@ public sealed class DocumentSymbolHandler : DocumentSymbolHandlerBase
         DocumentSymbolParams request, CancellationToken ct)
     {
         string uri = request.TextDocument.Uri.ToString();
-        if (!_store.TryGet(uri, out var text))
+        if (!_store.TryGetSnapshot(uri, out DocumentSnapshot? snapshot))
             return Task.FromResult<SymbolInformationOrDocumentSymbolContainer?>(null);
 
         ct.ThrowIfCancellationRequested();
 
-        var symbols = _symbols.GetSymbols(request.TextDocument.Uri.GetFileSystemPath(), text)
+        var symbols = _symbols.GetSymbols(
+                request.TextDocument.Uri.GetFileSystemPath(),
+                snapshot.Text)
             .Select(symbol => new SymbolInformationOrDocumentSymbol(symbol))
             .ToArray();
 

--- a/SharpTS.LanguageServer/Handlers/HoverHandler.cs
+++ b/SharpTS.LanguageServer/Handlers/HoverHandler.cs
@@ -22,13 +22,16 @@ public sealed class HoverHandler : HoverHandlerBase
 
     public override Task<Hover?> Handle(HoverParams request, CancellationToken ct)
     {
-        if (!_store.TryGet(request.TextDocument.Uri.ToString(), out var text))
+        if (!_store.TryGetSnapshot(
+                request.TextDocument.Uri.ToString(),
+                out DocumentSnapshot? snapshot))
             return Task.FromResult<Hover?>(null);
 
         int line = request.Position.Line, ch = request.Position.Character;
         // Decorator hover first (cursor on @DotNetType / a builtin); then .NET member hover.
         return Task.FromResult(
-            _decorators.Hover(text, line, ch) ?? _members.Hover(text, line, ch));
+            _decorators.Hover(snapshot.Text, line, ch) ??
+            _members.Hover(snapshot.Text, line, ch));
     }
 
     protected override HoverRegistrationOptions CreateRegistrationOptions(

--- a/SharpTS.LanguageServer/Handlers/ReferencesHandler.cs
+++ b/SharpTS.LanguageServer/Handlers/ReferencesHandler.cs
@@ -34,17 +34,17 @@ public sealed class ReferencesHandler : ReferencesHandlerBase
         CancellationToken ct)
     {
         string uri = request.TextDocument.Uri.ToString();
-        if (!_store.TryGet(uri, out var text))
+        if (!_store.TryCapture(uri, out DocumentRequestSnapshot? snapshot))
             return Task.FromResult<LocationContainer?>(null);
 
         ct.ThrowIfCancellationRequested();
 
         var locations = _references.FindReferences(
             request.TextDocument.Uri.GetFileSystemPath(),
-            text,
+            snapshot.Document.Text,
             request.Position,
             request.Context.IncludeDeclaration,
-            _store.SnapshotFileSystemDocuments(),
+            snapshot.TextOverlay,
             _workspace?.SnapshotRoots());
         return Task.FromResult<LocationContainer?>(
             new LocationContainer(locations));

--- a/SharpTS.LanguageServer/Handlers/RenameHandler.cs
+++ b/SharpTS.LanguageServer/Handlers/RenameHandler.cs
@@ -1,0 +1,105 @@
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpTS.LanguageServer.Services;
+
+namespace SharpTS.LanguageServer.Handlers;
+
+/// <summary>
+/// Serves semantic rename only for complete configured-workspace symbol domains.
+/// </summary>
+public sealed class RenameHandler : RenameHandlerBase
+{
+    private readonly DocumentStore _store;
+    private readonly RenameService _rename;
+    private readonly NavigationWorkspaceContext _workspace;
+
+    public RenameHandler(
+        DocumentStore store,
+        RenameService rename,
+        NavigationWorkspaceContext workspace)
+    {
+        _store = store;
+        _rename = rename;
+        _workspace = workspace;
+    }
+
+    public override Task<WorkspaceEdit?> Handle(
+        RenameParams request,
+        CancellationToken ct)
+    {
+        string uri = request.TextDocument.Uri.ToString();
+        if (!_store.TryGet(uri, out var text))
+            return Task.FromResult<WorkspaceEdit?>(null);
+
+        ct.ThrowIfCancellationRequested();
+        return Task.FromResult(
+            _rename.Rename(
+                request.TextDocument.Uri.GetFileSystemPath(),
+                text,
+                request.Position,
+                request.NewName,
+                _store.SnapshotFileSystemDocuments(),
+                _workspace.SnapshotRoots()));
+    }
+
+    protected override RenameRegistrationOptions CreateRegistrationOptions(
+        RenameCapability capability,
+        ClientCapabilities clientCapabilities)
+        => CreateRenameRegistrationOptions();
+
+    internal static RenameRegistrationOptions CreateRenameRegistrationOptions() =>
+        new()
+        {
+            DocumentSelector = TextDocumentSelector.ForLanguage(
+                "typescript",
+                "typescriptreact"),
+            PrepareProvider = true,
+        };
+}
+
+/// <summary>
+/// Refuses rename before the client prompts when the semantic domain is incomplete.
+/// </summary>
+public sealed class PrepareRenameHandler : PrepareRenameHandlerBase
+{
+    private readonly DocumentStore _store;
+    private readonly RenameService _rename;
+    private readonly NavigationWorkspaceContext _workspace;
+
+    public PrepareRenameHandler(
+        DocumentStore store,
+        RenameService rename,
+        NavigationWorkspaceContext workspace)
+    {
+        _store = store;
+        _rename = rename;
+        _workspace = workspace;
+    }
+
+    public override Task<RangeOrPlaceholderRange?> Handle(
+        PrepareRenameParams request,
+        CancellationToken ct)
+    {
+        string uri = request.TextDocument.Uri.ToString();
+        if (!_store.TryGet(uri, out var text))
+            return Task.FromResult<RangeOrPlaceholderRange?>(null);
+
+        ct.ThrowIfCancellationRequested();
+        OmniSharp.Extensions.LanguageServer.Protocol.Models.Range? range = _rename.Prepare(
+            request.TextDocument.Uri.GetFileSystemPath(),
+            text,
+            request.Position,
+            _store.SnapshotFileSystemDocuments(),
+            _workspace.SnapshotRoots());
+        return Task.FromResult(
+            range is null
+                ? null
+                : new RangeOrPlaceholderRange(range));
+    }
+
+    protected override RenameRegistrationOptions CreateRegistrationOptions(
+        RenameCapability capability,
+        ClientCapabilities clientCapabilities)
+        => RenameHandler.CreateRenameRegistrationOptions();
+}

--- a/SharpTS.LanguageServer/Handlers/RenameHandler.cs
+++ b/SharpTS.LanguageServer/Handlers/RenameHandler.cs
@@ -29,17 +29,17 @@ public sealed class RenameHandler : RenameHandlerBase
         CancellationToken ct)
     {
         string uri = request.TextDocument.Uri.ToString();
-        if (!_store.TryGet(uri, out var text))
+        if (!_store.TryCapture(uri, out DocumentRequestSnapshot? snapshot))
             return Task.FromResult<WorkspaceEdit?>(null);
 
         ct.ThrowIfCancellationRequested();
         return Task.FromResult(
             _rename.Rename(
                 request.TextDocument.Uri.GetFileSystemPath(),
-                text,
+                snapshot.Document.Text,
                 request.Position,
                 request.NewName,
-                _store.SnapshotFileSystemDocuments(),
+                snapshot.TextOverlay,
                 _workspace.SnapshotRoots()));
     }
 
@@ -82,15 +82,15 @@ public sealed class PrepareRenameHandler : PrepareRenameHandlerBase
         CancellationToken ct)
     {
         string uri = request.TextDocument.Uri.ToString();
-        if (!_store.TryGet(uri, out var text))
+        if (!_store.TryCapture(uri, out DocumentRequestSnapshot? snapshot))
             return Task.FromResult<RangeOrPlaceholderRange?>(null);
 
         ct.ThrowIfCancellationRequested();
         OmniSharp.Extensions.LanguageServer.Protocol.Models.Range? range = _rename.Prepare(
             request.TextDocument.Uri.GetFileSystemPath(),
-            text,
+            snapshot.Document.Text,
             request.Position,
-            _store.SnapshotFileSystemDocuments(),
+            snapshot.TextOverlay,
             _workspace.SnapshotRoots());
         return Task.FromResult(
             range is null

--- a/SharpTS.LanguageServer/Handlers/SignatureHelpHandler.cs
+++ b/SharpTS.LanguageServer/Handlers/SignatureHelpHandler.cs
@@ -20,11 +20,16 @@ public sealed class SignatureHelpHandler : SignatureHelpHandlerBase
 
     public override Task<SignatureHelp?> Handle(SignatureHelpParams request, CancellationToken ct)
     {
-        if (!_store.TryGet(request.TextDocument.Uri.ToString(), out var text))
+        if (!_store.TryGetSnapshot(
+                request.TextDocument.Uri.ToString(),
+                out DocumentSnapshot? snapshot))
             return Task.FromResult<SignatureHelp?>(null);
 
         return Task.FromResult(
-            _decorators.SignatureHelp(text, request.Position.Line, request.Position.Character));
+            _decorators.SignatureHelp(
+                snapshot.Text,
+                request.Position.Line,
+                request.Position.Character));
     }
 
     protected override SignatureHelpRegistrationOptions CreateRegistrationOptions(

--- a/SharpTS.LanguageServer/Handlers/TextDocumentSyncHandler.cs
+++ b/SharpTS.LanguageServer/Handlers/TextDocumentSyncHandler.cs
@@ -10,19 +10,18 @@ using SharpTS.LanguageServer.Services;
 namespace SharpTS.LanguageServer.Handlers;
 
 /// <summary>
-/// Full-document text sync: on open/change, re-analyze and publish diagnostics; on close,
-/// clear them. Full sync is fine for Phase 1 (single-file analyzer); incremental sync +
-/// debounce + the module overlay come with the larger diagnostics work.
+/// Incremental text sync backed by immutable versions. Diagnostics are queued through the
+/// debounced workspace coordinator rather than computed on the protocol thread.
 /// </summary>
 public sealed class TextDocumentSyncHandler : TextDocumentSyncHandlerBase
 {
-    private readonly ILanguageServerFacade _facade;
     private readonly DocumentStore _store;
-    private readonly DiagnosticsService _diagnostics;
+    private readonly DiagnosticsCoordinator _diagnostics;
 
-    public TextDocumentSyncHandler(ILanguageServerFacade facade, DocumentStore store, DiagnosticsService diagnostics)
+    public TextDocumentSyncHandler(
+        DocumentStore store,
+        DiagnosticsCoordinator diagnostics)
     {
-        _facade = facade;
         _store = store;
         _diagnostics = diagnostics;
     }
@@ -31,13 +30,31 @@ public sealed class TextDocumentSyncHandler : TextDocumentSyncHandlerBase
 
     public override Task<Unit> Handle(DidOpenTextDocumentParams request, CancellationToken ct)
     {
-        Refresh(request.TextDocument.Uri, request.TextDocument.Text);
+        string uri = request.TextDocument.Uri.ToString();
+        if (_store.Open(
+                uri,
+                request.TextDocument.Text,
+                request.TextDocument.Version ?? 0))
+        {
+            _diagnostics.Queue(uri);
+        }
         return Unit.Task;
     }
 
     public override Task<Unit> Handle(DidChangeTextDocumentParams request, CancellationToken ct)
     {
-        Refresh(request.TextDocument.Uri, request.ContentChanges.LastOrDefault()?.Text ?? "");
+        string uri = request.TextDocument.Uri.ToString();
+        int version = request.TextDocument.Version ??
+            (_store.TryGetSnapshot(uri, out DocumentSnapshot? current)
+                ? current.Version + 1
+                : 0);
+        if (_store.ApplyChanges(
+                uri,
+                version,
+                request.ContentChanges))
+        {
+            _diagnostics.Queue(uri);
+        }
         return Unit.Task;
     }
 
@@ -45,12 +62,8 @@ public sealed class TextDocumentSyncHandler : TextDocumentSyncHandlerBase
 
     public override Task<Unit> Handle(DidCloseTextDocumentParams request, CancellationToken ct)
     {
-        _store.Remove(request.TextDocument.Uri.ToString());
-        _facade.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
-        {
-            Uri = request.TextDocument.Uri,
-            Diagnostics = new Container<Diagnostic>()
-        });
+        if (_store.Remove(request.TextDocument.Uri.ToString()) is { } closed)
+            _diagnostics.Close(closed);
         return Unit.Task;
     }
 
@@ -59,17 +72,7 @@ public sealed class TextDocumentSyncHandler : TextDocumentSyncHandlerBase
         => new()
         {
             DocumentSelector = TextDocumentSelector.ForLanguage("typescript", "typescriptreact"),
-            Change = TextDocumentSyncKind.Full
+            Change = TextDocumentSyncKind.Incremental,
+            Save = new SaveOptions { IncludeText = false },
         };
-
-    private void Refresh(DocumentUri uri, string text)
-    {
-        _store.Set(uri.ToString(), text);
-        _facade.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
-        {
-            Uri = uri,
-            Diagnostics = new Container<Diagnostic>(
-                _diagnostics.Analyze(text, fileName: uri.GetFileSystemPath()))
-        });
-    }
 }

--- a/SharpTS.LanguageServer/PositionMap.cs
+++ b/SharpTS.LanguageServer/PositionMap.cs
@@ -34,6 +34,17 @@ public sealed class PositionMap
         return (lo + 1, offset - _lineStarts[lo] + 1);
     }
 
+    /// <summary>Zero-based LSP position → global UTF-16 offset.</summary>
+    public int ToOffset(int line, int character)
+    {
+        if ((uint)line >= (uint)_lineStarts.Length)
+            throw new ArgumentOutOfRangeException(nameof(line));
+        if (character < 0)
+            throw new ArgumentOutOfRangeException(nameof(character));
+
+        return checked(_lineStarts[line] + character);
+    }
+
     /// <summary>Precise span for a single token (falls back to line-only if Start is unset).</summary>
     public SourceLocation Span(Token token)
     {

--- a/SharpTS.LanguageServer/Program.cs
+++ b/SharpTS.LanguageServer/Program.cs
@@ -1,5 +1,6 @@
 using SharpTS.Compilation;
 using SharpTS.LanguageServer;
+using SharpTS.LanguageServer.Conversions;
 using SharpTS.LanguageServer.Project;
 
 // Entry point for the `sharpts-lsp` tool: this executable *is* the language server
@@ -11,6 +12,7 @@ var references = new List<string>();
 // Standalone clients have no other TypeScript server, so navigation is on by default here. The
 // VS Code extension passes interop-only, where tsserver already provides it.
 var mode = LanguageFeatureMode.Full;
+var diagnosticMode = DiagnosticPublishMode.SharpTsOnly;
 
 for (int i = 0; i < args.Length; i++)
 {
@@ -30,6 +32,18 @@ for (int i = 0; i < args.Length; i++)
                         $"[LSP Fatal] Unknown --language-features value '{requested}'. Expected 'interop-only' or 'full'.");
                     Environment.Exit(64);
                     break;
+            }
+            break;
+        case "--diagnostics" when i + 1 < args.Length:
+            string requestedDiagnostics = args[++i];
+            if (!SharpTS.LanguageServer.Services.DiagnosticsSettings.TryParse(
+                    requestedDiagnostics,
+                    out diagnosticMode))
+            {
+                await Console.Error.WriteLineAsync(
+                    $"[LSP Fatal] Unknown --diagnostics value '{requestedDiagnostics}'. " +
+                    "Expected 'sharpts-only', 'all', or 'off'.");
+                Environment.Exit(64);
             }
             break;
     }
@@ -58,13 +72,17 @@ try
         await Console.Error.WriteLineAsync($"[LSP] sharpts.json ignored: {ex.Message}");
     }
 
-    using var loader = new AssemblyReferenceLoader(paths, sdkPath);
+    using var loader = new ReloadingAssemblyReferenceLoader(paths, sdkPath);
     Func<IEnumerable<string>> typeNames = () => loader.GetAllPublicTypes()
         .Select(t => t.FullName)
         .Where(n => !string.IsNullOrEmpty(n))
         .Cast<string>();
 
-    await SharpTSLanguageServer.RunAsync(loader.TryResolve, typeNames, mode);
+    await SharpTSLanguageServer.RunAsync(
+        loader.TryResolve,
+        typeNames,
+        mode,
+        diagnosticMode);
 }
 catch (Exception ex)
 {

--- a/SharpTS.LanguageServer/Services/DefinitionService.cs
+++ b/SharpTS.LanguageServer/Services/DefinitionService.cs
@@ -28,20 +28,13 @@ public sealed class DefinitionService
         int offset = model.Document.Lines.ToOffset(
             (int)position.Line + 1,
             (int)position.Character + 1);
-        IReadOnlyList<BindingDeclaration> declarations =
-            model.Checker.Bindings.FindDefinitions(
+        return model.Checker.Bindings.FindSymbols(
                 model.Document,
-                offset,
-                BindingNamespace.Value);
-        if (declarations.Count == 0)
-        {
-            declarations =
-                model.Checker.Bindings.FindDefinitions(
-                    model.Document,
-                    offset,
-                    BindingNamespace.Type);
-        }
-        return declarations
+                offset)
+            .SelectMany(symbol => symbol.Declarations)
+            .DistinctBy(declaration => (
+                declaration.Document.Path,
+                declaration.Name.Start))
             .Select(declaration =>
                 NavigationLocations.From(declaration.Document, declaration.Name))
             .ToArray();

--- a/SharpTS.LanguageServer/Services/DiagnosticsCoordinator.cs
+++ b/SharpTS.LanguageServer/Services/DiagnosticsCoordinator.cs
@@ -1,0 +1,314 @@
+using System.Diagnostics.CodeAnalysis;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
+
+namespace SharpTS.LanguageServer.Services;
+
+/// <summary>
+/// Debounces checks, cancels stale workspace work, updates dependency edges, and publishes only
+/// results produced from the still-current immutable snapshot.
+/// </summary>
+public sealed class DiagnosticsCoordinator : IDisposable
+{
+    private static readonly TimeSpan DefaultDebounce = TimeSpan.FromMilliseconds(150);
+
+    private readonly object _gate = new();
+    private readonly DocumentStore _store;
+    private readonly DiagnosticsService _diagnostics;
+    private readonly DocumentDependencyGraph _graph;
+    private readonly DiagnosticsSettings _settings;
+    private readonly Action<PublishDiagnosticsParams> _publish;
+    private readonly TimeSpan _debounce;
+    private readonly Dictionary<string, CancellationTokenSource> _documentCancellation =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<Task> _pending = [];
+    private CancellationTokenSource _workspaceCancellation = new();
+    private bool _disposed;
+
+    public DiagnosticsCoordinator(
+        ILanguageServerFacade facade,
+        DocumentStore store,
+        DiagnosticsService diagnostics,
+        DocumentDependencyGraph graph,
+        DiagnosticsSettings settings)
+        : this(
+            store,
+            diagnostics,
+            graph,
+            settings,
+            parameters => facade.TextDocument.PublishDiagnostics(parameters),
+            DefaultDebounce)
+    {
+    }
+
+    internal DiagnosticsCoordinator(
+        DocumentStore store,
+        DiagnosticsService diagnostics,
+        DocumentDependencyGraph graph,
+        DiagnosticsSettings settings,
+        Action<PublishDiagnosticsParams> publish,
+        TimeSpan debounce)
+    {
+        _store = store;
+        _diagnostics = diagnostics;
+        _graph = graph;
+        _settings = settings;
+        _publish = publish;
+        _debounce = debounce;
+    }
+
+    public void Queue(string uri)
+    {
+        CancellationToken token;
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            CancelWorkspace();
+
+            if (_documentCancellation.Remove(uri, out CancellationTokenSource? old))
+            {
+                old.Cancel();
+                old.Dispose();
+            }
+
+            var documentCancellation =
+                CancellationTokenSource.CreateLinkedTokenSource(
+                    _workspaceCancellation.Token);
+            _documentCancellation[uri] = documentCancellation;
+            token = documentCancellation.Token;
+        }
+
+        Track(RunChangedDocumentAsync(uri, token));
+    }
+
+    public void Close(DocumentSnapshot closed)
+    {
+        IReadOnlySet<string> affected =
+            closed.FilePath is null
+                ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                : _graph.Remove(closed.FilePath);
+        _diagnostics.Invalidate(closed.FilePath ?? closed.Uri);
+
+        CancellationToken token;
+        lock (_gate)
+        {
+            if (_documentCancellation.Remove(
+                    closed.Uri,
+                    out CancellationTokenSource? documentCancellation))
+            {
+                documentCancellation.Cancel();
+                documentCancellation.Dispose();
+            }
+            CancelWorkspace();
+            token = _workspaceCancellation.Token;
+        }
+
+        PublishEmpty(closed);
+        Track(RunAffectedDocumentsAsync(
+            affected.Where(path =>
+                closed.FilePath is null ||
+                !string.Equals(path, closed.FilePath, StringComparison.OrdinalIgnoreCase)),
+            token));
+    }
+
+    public void RepublishAll()
+    {
+        CancellationToken token;
+        lock (_gate)
+        {
+            ThrowIfDisposed();
+            CancelWorkspace();
+            token = _workspaceCancellation.Token;
+        }
+
+        Track(RunAffectedDocumentsAsync(
+            _store.SnapshotDocuments()
+                .Where(document => document.FilePath is not null)
+                .Select(document => document.FilePath!),
+            token));
+    }
+
+    internal async Task DrainAsync()
+    {
+        while (true)
+        {
+            Task[] pending;
+            lock (_gate)
+                pending = [.. _pending];
+            if (pending.Length == 0)
+                return;
+            await Task.WhenAll(pending);
+        }
+    }
+
+    private async Task RunChangedDocumentAsync(
+        string uri,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(_debounce, cancellationToken);
+            if (!_store.TryCapture(uri, out DocumentRequestSnapshot? snapshot))
+                return;
+
+            cancellationToken.ThrowIfCancellationRequested();
+            IReadOnlyList<Parsing.Stmt> statements = _diagnostics.GetStatements(
+                snapshot.Document,
+                cancellationToken);
+            IReadOnlySet<string> affected = _graph.Update(
+                snapshot.Document,
+                snapshot.TextOverlay,
+                statements,
+                cancellationToken);
+
+            await AnalyzeAndPublishAsync(snapshot, affected, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            // A newer document/workspace version owns publication now.
+        }
+    }
+
+    private async Task RunAffectedDocumentsAsync(
+        IEnumerable<string> affectedPaths,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await Task.Delay(_debounce, cancellationToken);
+            HashSet<string> pending = affectedPaths.ToHashSet(
+                StringComparer.OrdinalIgnoreCase);
+            foreach (DocumentSnapshot open in _store.SnapshotDocuments())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (open.FilePath is null || !pending.Contains(open.FilePath))
+                    continue;
+                if (!_store.TryCapture(open.Uri, out DocumentRequestSnapshot? snapshot))
+                    continue;
+
+                Publish(snapshot, snapshot.Document, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // A newer document/workspace version owns publication now.
+        }
+    }
+
+    private Task AnalyzeAndPublishAsync(
+        DocumentRequestSnapshot workspace,
+        IReadOnlySet<string> affectedPaths,
+        CancellationToken cancellationToken)
+    {
+        foreach (DocumentSnapshot document in workspace.FileSystemDocuments.Values)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (document.FilePath is null ||
+                !affectedPaths.Contains(document.FilePath))
+            {
+                continue;
+            }
+
+            Publish(workspace, document, cancellationToken);
+        }
+        return Task.CompletedTask;
+    }
+
+    private void Publish(
+        DocumentRequestSnapshot workspace,
+        DocumentSnapshot document,
+        CancellationToken cancellationToken)
+    {
+        var diagnostics = _diagnostics.Analyze(
+            workspace,
+            document,
+            _settings.Mode,
+            cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_store.IsCurrent(
+                document.Uri,
+                document.Version,
+                workspace.WorkspaceVersion))
+        {
+            return;
+        }
+
+        _publish(new PublishDiagnosticsParams
+        {
+            Uri = DocumentUri.Parse(document.Uri),
+            Version = document.Version,
+            Diagnostics = new Container<Diagnostic>(diagnostics),
+        });
+    }
+
+    private void PublishEmpty(DocumentSnapshot document)
+    {
+        _publish(new PublishDiagnosticsParams
+        {
+            Uri = DocumentUri.Parse(document.Uri),
+            Version = document.Version,
+            Diagnostics = new Container<Diagnostic>(),
+        });
+    }
+
+    private void Track(Task task)
+    {
+        lock (_gate)
+            _pending.Add(task);
+        _ = ObserveAsync(task);
+    }
+
+    [SuppressMessage(
+        "Usage",
+        "VSTHRD003",
+        Justification = "Background diagnostic tasks are isolated, caught, and never synchronously blocked.")]
+    private async Task ObserveAsync(Task task)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Diagnostics are advisory. A failed analysis must not terminate the LSP process;
+            // the next edit creates a fresh version and retries the pipeline.
+        }
+        finally
+        {
+            lock (_gate)
+                _pending.Remove(task);
+        }
+    }
+
+    private void CancelWorkspace()
+    {
+        _workspaceCancellation.Cancel();
+        _workspaceCancellation.Dispose();
+        _workspaceCancellation = new CancellationTokenSource();
+    }
+
+    private void ThrowIfDisposed() =>
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+    public void Dispose()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            _workspaceCancellation.Cancel();
+            _workspaceCancellation.Dispose();
+            foreach (CancellationTokenSource cancellation in
+                     _documentCancellation.Values)
+            {
+                cancellation.Cancel();
+                cancellation.Dispose();
+            }
+            _documentCancellation.Clear();
+        }
+    }
+}

--- a/SharpTS.LanguageServer/Services/DiagnosticsService.cs
+++ b/SharpTS.LanguageServer/Services/DiagnosticsService.cs
@@ -23,7 +23,10 @@ public sealed class DiagnosticsService
     /// <param name="resolve">CLR type resolver. Null = in-process registry (BCL only);
     /// the server injects an AssemblyReferenceLoader when a project/references are configured
     /// so the user's own @DotNetType targets resolve too.</param>
-    public DiagnosticsService(Func<string, Type?>? resolve = null) => _interop = new InteropAnalyzer(resolve);
+    public DiagnosticsService(
+        Func<string, Type?>? resolve = null,
+        Func<IEnumerable<string>>? typeNames = null) =>
+        _interop = new InteropAnalyzer(resolve, typeNames);
 
     public List<LspDiagnostic> Analyze(
         string text,

--- a/SharpTS.LanguageServer/Services/DiagnosticsService.cs
+++ b/SharpTS.LanguageServer/Services/DiagnosticsService.cs
@@ -1,6 +1,10 @@
+using System.Collections.Concurrent;
+using SharpTS.Diagnostics;
 using SharpTS.LanguageServer.Conversions;
 using SharpTS.Parsing;
+using SharpTS.TypeSystem;
 using LspDiagnostic = OmniSharp.Extensions.LanguageServer.Protocol.Models.Diagnostic;
+using SharpDiagnostic = SharpTS.Diagnostics.Diagnostic;
 
 namespace SharpTS.LanguageServer.Services;
 
@@ -11,29 +15,248 @@ namespace SharpTS.LanguageServer.Services;
 public sealed class DiagnosticsService
 {
     private readonly InteropAnalyzer _interop;
+    private readonly ConcurrentDictionary<string, CachedAnalysis> _cache =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, CachedWorkspaceCheck> _workspaceChecks =
+        new(StringComparer.OrdinalIgnoreCase);
 
     /// <param name="resolve">CLR type resolver. Null = in-process registry (BCL only);
     /// the server injects an AssemblyReferenceLoader when a project/references are configured
     /// so the user's own @DotNetType targets resolve too.</param>
     public DiagnosticsService(Func<string, Type?>? resolve = null) => _interop = new InteropAnalyzer(resolve);
 
-    public List<LspDiagnostic> Analyze(string text, DiagnosticPublishMode mode = DiagnosticPublishMode.SharpTsOnly, string? fileName = null)
+    public List<LspDiagnostic> Analyze(
+        string text,
+        DiagnosticPublishMode mode = DiagnosticPublishMode.SharpTsOnly,
+        string? fileName = null)
     {
+        var snapshot = new DocumentSnapshot(
+            fileName is null
+                ? "untitled:diagnostics"
+                : new Uri(Path.GetFullPath(fileName)).AbsoluteUri,
+            text,
+            Version: 0,
+            fileName is null ? null : Path.GetFullPath(fileName));
+        return Analyze(snapshot, mode, CancellationToken.None);
+    }
+
+    /// <summary>
+    /// Analyzes one immutable text version. Lexing, AST/source spans, interop diagnostics, and
+    /// the optional full type-check result are retained together and reused only for that exact
+    /// version and text.
+    /// </summary>
+    public List<LspDiagnostic> Analyze(
+        DocumentSnapshot snapshot,
+        DiagnosticPublishMode mode,
+        CancellationToken cancellationToken)
+    {
+        if (mode == DiagnosticPublishMode.Off)
+            return [];
+
+        CachedAnalysis analysis = GetOrBuild(snapshot, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var diagnostics = new List<SharpDiagnostic>(analysis.InteropDiagnostics);
+        if (mode == DiagnosticPublishMode.All)
+        {
+            diagnostics.AddRange(analysis.ParseResult.Diagnostics);
+            if (analysis.ParseResult.IsSuccess)
+            {
+                TypeCheckDiagnosticResult result =
+                    analysis.TypeCheckResult ??
+                    BuildTypeCheck(analysis, cancellationToken);
+                analysis.TypeCheckResult = result;
+                diagnostics.AddRange(result.Diagnostics);
+            }
+        }
+
+        return LspConversions.ToLsp(diagnostics, snapshot.Text, mode);
+    }
+
+    /// <summary>
+    /// Workspace-aware form used by diagnostic publication. In <c>all</c> mode it checks the
+    /// module graph from the same overlay snapshot and caches that result by workspace version.
+    /// </summary>
+    public List<LspDiagnostic> Analyze(
+        DocumentRequestSnapshot workspace,
+        DocumentSnapshot snapshot,
+        DiagnosticPublishMode mode,
+        CancellationToken cancellationToken)
+    {
+        if (mode != DiagnosticPublishMode.All ||
+            snapshot.FilePath is null)
+        {
+            return Analyze(snapshot, mode, cancellationToken);
+        }
+
+        CachedAnalysis analysis = GetOrBuild(snapshot, cancellationToken);
+        var diagnostics = new List<SharpDiagnostic>(
+            analysis.InteropDiagnostics);
+        diagnostics.AddRange(analysis.ParseResult.Diagnostics);
+        if (analysis.ParseResult.IsSuccess)
+        {
+            string path = snapshot.FilePath;
+            CachedWorkspaceCheck workspaceCheck = _workspaceChecks.AddOrUpdate(
+                path,
+                _ => BuildWorkspaceCheck(
+                    workspace,
+                    snapshot,
+                    analysis,
+                    cancellationToken),
+                (_, current) =>
+                    current.DocumentVersion == snapshot.Version &&
+                    current.WorkspaceVersion == workspace.WorkspaceVersion
+                        ? current
+                        : BuildWorkspaceCheck(
+                            workspace,
+                            snapshot,
+                            analysis,
+                            cancellationToken));
+            diagnostics.AddRange(workspaceCheck.Diagnostics);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return LspConversions.ToLsp(
+            diagnostics,
+            snapshot.Text,
+            DiagnosticPublishMode.All);
+    }
+
+    public void Invalidate(string uriOrPath)
+    {
+        _cache.TryRemove(uriOrPath, out _);
+        _workspaceChecks.TryRemove(uriOrPath, out _);
+    }
+
+    internal IReadOnlyList<Stmt> GetStatements(
+        DocumentSnapshot snapshot,
+        CancellationToken cancellationToken) =>
+        GetOrBuild(snapshot, cancellationToken).ParseResult.Statements;
+
+    private CachedAnalysis GetOrBuild(
+        DocumentSnapshot snapshot,
+        CancellationToken cancellationToken)
+    {
+        string key = snapshot.FilePath ?? snapshot.Uri;
+        return _cache.AddOrUpdate(
+            key,
+            _ => Build(snapshot, cancellationToken),
+            (_, current) =>
+                current.Version == snapshot.Version &&
+                string.Equals(current.Text, snapshot.Text, StringComparison.Ordinal)
+                    ? current
+                    : Build(snapshot, cancellationToken));
+    }
+
+    private CachedAnalysis Build(
+        DocumentSnapshot snapshot,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        string fileName = snapshot.FilePath ?? snapshot.Uri;
+
         // Stage3 decorators are the run-mode default and are required for @DotNetType to parse.
-        bool isTsx = fileName is not null &&
+        bool isTsx =
             (fileName.EndsWith(".tsx", StringComparison.OrdinalIgnoreCase) ||
              fileName.EndsWith(".jsx", StringComparison.OrdinalIgnoreCase));
-        var tokens = new Lexer(text) { JsxTolerant = isTsx }.ScanTokens();
-        var parser = new Parser(tokens, DecoratorMode.Stage3);
+        List<Token> tokens =
+            new Lexer(snapshot.Text) { JsxTolerant = isTsx }.ScanTokens();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var document = new SourceDocument(
+            fileName,
+            snapshot.Text,
+            isVirtual: snapshot.FilePath is null);
+        var parser = new Parser(tokens, DecoratorMode.Stage3)
+            .WithSourceDocument(document);
         if (isTsx)
         {
-            parser.WithJsx(text, JsxParseOptions.Default);
+            parser.WithJsx(snapshot.Text, JsxParseOptions.Default);
         }
-        var parsed = parser.Parse();
-        if (!parsed.IsSuccess)
-            return new List<LspDiagnostic>(); // syntax errors belong to tsserver
+        ParseDiagnosticResult parsed = parser.Parse();
+        cancellationToken.ThrowIfCancellationRequested();
 
-        var diags = _interop.Analyze(parsed.Statements, new PositionMap(text));
-        return LspConversions.ToLsp(diags, text, mode);
+        IReadOnlyList<SharpDiagnostic> interopDiagnostics = parsed.IsSuccess
+            ? _interop.Analyze(
+                parsed.Statements,
+                new PositionMap(snapshot.Text),
+                cancellationToken)
+            : [];
+
+        return new CachedAnalysis(
+            snapshot.Version,
+            snapshot.Text,
+            document,
+            tokens,
+            parsed,
+            interopDiagnostics);
     }
+
+    private static TypeCheckDiagnosticResult BuildTypeCheck(
+        CachedAnalysis analysis,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var checker = new TypeChecker(
+            TypeCheckerOptions.Default with { MaxErrors = int.MaxValue })
+            .WithFilePath(analysis.Document.Path)
+            .WithCancellation(cancellationToken);
+        return checker.CheckWithRecovery(
+            analysis.ParseResult.Statements,
+            analysis.Document);
+    }
+
+    private static CachedWorkspaceCheck BuildWorkspaceCheck(
+        DocumentRequestSnapshot workspace,
+        DocumentSnapshot snapshot,
+        CachedAnalysis analysis,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        CheckedNavigationModel? model = NavigationModelBuilder.TryBuild(
+            snapshot.FilePath!,
+            snapshot.Text,
+            workspace.TextOverlay,
+            cancellationToken);
+        IReadOnlyList<SharpDiagnostic> diagnostics;
+        if (model is null)
+        {
+            diagnostics = BuildTypeCheck(
+                    analysis,
+                    cancellationToken)
+                .Diagnostics;
+        }
+        else
+        {
+            diagnostics = model.Checker.GetDiagnostics()
+                .Where(diagnostic =>
+                    diagnostic.FilePath is null ||
+                    string.Equals(
+                        Path.GetFullPath(diagnostic.FilePath),
+                        snapshot.FilePath,
+                        StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+        }
+
+        return new CachedWorkspaceCheck(
+            snapshot.Version,
+            workspace.WorkspaceVersion,
+            diagnostics);
+    }
+
+    internal sealed record CachedAnalysis(
+        int Version,
+        string Text,
+        SourceDocument Document,
+        IReadOnlyList<Token> Tokens,
+        ParseDiagnosticResult ParseResult,
+        IReadOnlyList<SharpDiagnostic> InteropDiagnostics)
+    {
+        public TypeCheckDiagnosticResult? TypeCheckResult { get; set; }
+    }
+
+    private sealed record CachedWorkspaceCheck(
+        int DocumentVersion,
+        long WorkspaceVersion,
+        IReadOnlyList<SharpDiagnostic> Diagnostics);
 }

--- a/SharpTS.LanguageServer/Services/DiagnosticsSettings.cs
+++ b/SharpTS.LanguageServer/Services/DiagnosticsSettings.cs
@@ -1,0 +1,35 @@
+using SharpTS.LanguageServer.Conversions;
+
+namespace SharpTS.LanguageServer.Services;
+
+/// <summary>Thread-safe diagnostic publication mode for the lifetime of an LSP server.</summary>
+public sealed class DiagnosticsSettings
+{
+    private int _mode;
+
+    public DiagnosticsSettings(
+        DiagnosticPublishMode mode = DiagnosticPublishMode.SharpTsOnly)
+    {
+        _mode = (int)mode;
+    }
+
+    public DiagnosticPublishMode Mode
+    {
+        get => (DiagnosticPublishMode)Volatile.Read(ref _mode);
+        set => Volatile.Write(ref _mode, (int)value);
+    }
+
+    public static bool TryParse(
+        string? value,
+        out DiagnosticPublishMode mode)
+    {
+        mode = value switch
+        {
+            "sharpts-only" => DiagnosticPublishMode.SharpTsOnly,
+            "all" => DiagnosticPublishMode.All,
+            "off" => DiagnosticPublishMode.Off,
+            _ => default,
+        };
+        return value is "sharpts-only" or "all" or "off";
+    }
+}

--- a/SharpTS.LanguageServer/Services/DocumentDependencyGraph.cs
+++ b/SharpTS.LanguageServer/Services/DocumentDependencyGraph.cs
@@ -1,0 +1,164 @@
+using SharpTS.Modules;
+using SharpTS.Parsing;
+
+namespace SharpTS.LanguageServer.Services;
+
+/// <summary>
+/// Forward and reverse edges for open source documents. Updating a dependency returns the
+/// transitive open-importer set that must be checked and republished.
+/// </summary>
+public sealed class DocumentDependencyGraph
+{
+    private readonly object _gate = new();
+    private readonly Dictionary<string, HashSet<string>> _forward =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, HashSet<string>> _reverse =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public IReadOnlySet<string> Update(
+        DocumentSnapshot document,
+        IReadOnlyDictionary<string, string> overlay,
+        IReadOnlyList<Stmt> statements,
+        CancellationToken cancellationToken)
+    {
+        if (document.FilePath is null)
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        string path = document.FilePath;
+        HashSet<string> dependencies = ResolveDependencies(
+            path,
+            overlay,
+            statements,
+            cancellationToken);
+
+        lock (_gate)
+        {
+            HashSet<string> affected = CollectImporters(path);
+            RemoveForwardEdges(path);
+
+            _forward[path] = dependencies;
+            foreach (string dependency in dependencies)
+            {
+                if (!_reverse.TryGetValue(dependency, out HashSet<string>? importers))
+                {
+                    importers = new HashSet<string>(
+                        StringComparer.OrdinalIgnoreCase);
+                    _reverse[dependency] = importers;
+                }
+                importers.Add(path);
+            }
+
+            affected.UnionWith(CollectImporters(path));
+            affected.Add(path);
+            return affected;
+        }
+    }
+
+    public IReadOnlySet<string> Remove(string path)
+    {
+        path = Path.GetFullPath(path);
+        lock (_gate)
+        {
+            HashSet<string> affected = CollectImporters(path);
+            RemoveForwardEdges(path);
+            _forward.Remove(path);
+            affected.Add(path);
+            return affected;
+        }
+    }
+
+    internal IReadOnlySet<string> GetImporters(string path)
+    {
+        path = Path.GetFullPath(path);
+        lock (_gate)
+            return CollectImporters(path);
+    }
+
+    private HashSet<string> CollectImporters(string path)
+    {
+        var result = new HashSet<string>(
+            StringComparer.OrdinalIgnoreCase) { path };
+        Queue<string> pending = new([path]);
+        while (pending.TryDequeue(out string? current))
+        {
+            if (!_reverse.TryGetValue(current, out HashSet<string>? importers))
+                continue;
+
+            foreach (string importer in importers)
+            {
+                if (result.Add(importer))
+                    pending.Enqueue(importer);
+            }
+        }
+        return result;
+    }
+
+    private void RemoveForwardEdges(string path)
+    {
+        if (!_forward.TryGetValue(path, out HashSet<string>? oldDependencies))
+            return;
+
+        foreach (string dependency in oldDependencies)
+        {
+            if (!_reverse.TryGetValue(dependency, out HashSet<string>? importers))
+                continue;
+
+            importers.Remove(path);
+            if (importers.Count == 0)
+                _reverse.Remove(dependency);
+        }
+    }
+
+    private static HashSet<string> ResolveDependencies(
+        string path,
+        IReadOnlyDictionary<string, string> overlay,
+        IReadOnlyList<Stmt> statements,
+        CancellationToken cancellationToken)
+    {
+        var dependencies = new HashSet<string>(
+            StringComparer.OrdinalIgnoreCase);
+        var resolver = new ModuleResolver(path, overlay, fallBackToFileSystem: true);
+
+        foreach ((string Specifier, ResolutionKind Kind) dependency in
+                 EnumerateSpecifiers(statements))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                string resolved = resolver.ResolveModulePath(
+                    dependency.Specifier,
+                    path,
+                    dependency.Kind);
+                if (Path.IsPathRooted(resolved))
+                    dependencies.Add(Path.GetFullPath(resolved));
+            }
+            catch
+            {
+                // An unresolved edge cannot participate in invalidation yet. The importing
+                // document itself is still returned as affected and will be checked.
+            }
+        }
+
+        return dependencies;
+    }
+
+    private static IEnumerable<(string Specifier, ResolutionKind Kind)>
+        EnumerateSpecifiers(IEnumerable<Stmt> statements)
+    {
+        foreach (Stmt statement in statements)
+        {
+            switch (statement)
+            {
+                case Stmt.Import import:
+                    yield return (import.ModulePath, ResolutionKind.Esm);
+                    break;
+                case Stmt.Export { FromModulePath: { } from }:
+                    yield return (from, ResolutionKind.Esm);
+                    break;
+                case Stmt.ImportRequire import:
+                    yield return (import.ModulePath, ResolutionKind.Cjs);
+                    break;
+            }
+        }
+    }
+}

--- a/SharpTS.LanguageServer/Services/InteropAnalyzer.cs
+++ b/SharpTS.LanguageServer/Services/InteropAnalyzer.cs
@@ -56,7 +56,10 @@ public sealed class InteropAnalyzer
     private static SourceLocation Loc(Token start, Token end, PositionMap? pos)
         => pos is not null ? pos.Span(start, end) : SourceLocation.FromLine(start.Line);
 
-    public List<Diagnostic> Analyze(IEnumerable<Stmt> statements, PositionMap? positions = null)
+    public List<Diagnostic> Analyze(
+        IEnumerable<Stmt> statements,
+        PositionMap? positions = null,
+        CancellationToken cancellationToken = default)
     {
         var diags = new List<Diagnostic>();
         var bindings = new Dictionary<string, Type>(StringComparer.Ordinal);
@@ -67,6 +70,7 @@ public sealed class InteropAnalyzer
         // name -> CLR type bindings for the call-site pass.
         foreach (var stmt in stmtList)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (stmt is Stmt.Class cls)
                 AnalyzeClass(cls, diags, bindings, positions);
             else if (stmt is Stmt.Import import && DotNetImports.IsDotNetSpecifier(import.ModulePath))
@@ -79,7 +83,10 @@ public sealed class InteropAnalyzer
         // Pass 2 — Tier 3d: validate event-subscription call sites against the bindings.
         var visitor = new EventCallVisitor(bindings, diags, positions);
         foreach (var stmt in stmtList)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             visitor.Visit(stmt);
+        }
 
         return diags;
     }

--- a/SharpTS.LanguageServer/Services/InteropAnalyzer.cs
+++ b/SharpTS.LanguageServer/Services/InteropAnalyzer.cs
@@ -41,9 +41,15 @@ namespace SharpTS.LanguageServer.Services;
 public sealed class InteropAnalyzer
 {
     private readonly Func<string, Type?> _resolve;
+    private readonly Func<IEnumerable<string>>? _typeNames;
 
-    public InteropAnalyzer(Func<string, Type?>? resolve = null)
-        => _resolve = resolve ?? DotNetTypeRegistry.Resolve;
+    public InteropAnalyzer(
+        Func<string, Type?>? resolve = null,
+        Func<IEnumerable<string>>? typeNames = null)
+    {
+        _resolve = resolve ?? DotNetTypeRegistry.Resolve;
+        _typeNames = typeNames;
+    }
 
     // DOM-style addEventListener/removeEventListener are event-binder intrinsics
     // (Runtime/DotNet/DotNetEventBinder.cs), not real CLR methods — never flag them as
@@ -150,9 +156,25 @@ public sealed class InteropAnalyzer
 
         if (import.DefaultImport != null)
         {
-            diags.Add(Diagnostic.TypeError(
+            Diagnostic diagnostic = Diagnostic.TypeError(
                 $"'{import.ModulePath}' has no default export — dotnet: modules support named imports only.",
-                Loc(import.DefaultImport, pos)));
+                Loc(import.DefaultImport, pos));
+            string? exportName = ResolveDefaultImportExportName(specifier);
+            if (exportName is not null)
+            {
+                string localName = import.DefaultImport.Lexeme;
+                string replacement = string.Equals(
+                    exportName,
+                    localName,
+                    StringComparison.Ordinal)
+                    ? $"{{ {exportName} }}"
+                    : $"{{ {exportName} as {localName} }}";
+                diagnostic = WithReplacement(
+                    diagnostic,
+                    $"Convert to named import '{exportName}'",
+                    replacement);
+            }
+            diags.Add(diagnostic);
         }
 
         if (import.NamespaceImport != null)
@@ -182,7 +204,7 @@ public sealed class InteropAnalyzer
 
     private void AnalyzeClass(Stmt.Class cls, List<Diagnostic> diags, Dictionary<string, Type> bindings, PositionMap? pos)
     {
-        var (mapping, at, nameTok) = FindDotNetType(cls);
+        var (mapping, at, nameTok, endTok) = FindDotNetType(cls);
         if (mapping is null) return;
 
         Type? type;
@@ -200,9 +222,22 @@ public sealed class InteropAnalyzer
         if (type == null)
         {
             // Tier 1 — mirrors Interpreter.DotNet.cs:31, surfaced statically at edit time.
-            diags.Add(Diagnostic.TypeError(
+            string? suggestion = FindNearest(
+                mapping,
+                _typeNames?.Invoke() ?? []);
+            Diagnostic diagnostic = Diagnostic.TypeError(
                 $"@DotNetType: .NET type '{mapping}' not found in any loaded assembly.",
-                Loc(at!, nameTok!, pos)));
+                suggestion is null
+                    ? Loc(at!, nameTok!, pos)
+                    : Loc(at!, endTok!, pos));
+            if (suggestion is not null)
+            {
+                diagnostic = WithReplacement(
+                    diagnostic,
+                    $"Change .NET type to '{suggestion}'",
+                    $"@DotNetType(\"{suggestion}\")");
+            }
+            diags.Add(diagnostic);
             return;
         }
 
@@ -245,15 +280,34 @@ public sealed class InteropAnalyzer
         {
             string declared = isStatic ? "static" : "instance";
             string actual = isStatic ? "instance" : "static";
-            diags.Add(Diagnostic.TypeError(
+            Diagnostic diagnostic = Diagnostic.TypeError(
                 $"@DotNetType '{type.FullName}': member '{name}' exists but is {actual}, not {declared} as declared.",
-                Loc(token, pos)));
+                Loc(token, pos));
+            if (!isStatic)
+            {
+                diagnostic = WithReplacement(
+                    diagnostic,
+                    $"Make '{name}' static",
+                    $"static {name}");
+            }
+            diags.Add(diagnostic);
         }
         else
         {
-            diags.Add(Diagnostic.TypeError(
+            Diagnostic diagnostic = Diagnostic.TypeError(
                 $"@DotNetType '{type.FullName}': no {kind} '{name}' (nor PascalCase '{pascal}').",
-                Loc(token, pos)));
+                Loc(token, pos));
+            string? suggestion = FindNearest(
+                name,
+                MemberCandidates(type, isStatic, kind, name));
+            if (suggestion is not null)
+            {
+                diagnostic = WithReplacement(
+                    diagnostic,
+                    $"Change member to '{suggestion}'",
+                    suggestion);
+            }
+            diags.Add(diagnostic);
         }
     }
 
@@ -279,16 +333,43 @@ public sealed class InteropAnalyzer
     /// *matching* belongs to Tier 3e (by type name, not identity).</summary>
     private void CheckOverloadHint(Stmt.Function m, Type type, List<Diagnostic> diags, PositionMap? pos)
     {
-        string? hint = ExtractDecoratorArg(m.Decorators, "DotNetOverload");
-        if (hint is null) return;
+        var decorator = FindDecoratorStringArg(
+            m.Decorators,
+            "DotNetOverload");
+        if (decorator is null) return;
+        string hint = decorator.Value.Value;
         if (DotNetTypeRegistry.GetMethods(type, m.Name.Lexeme, m.IsStatic).Length == 0) return;
 
-        foreach (var part in hint.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+        string[] parts = hint.Split(
+            ',',
+            StringSplitOptions.TrimEntries |
+            StringSplitOptions.RemoveEmptyEntries);
+        for (int index = 0; index < parts.Length; index++)
         {
+            string part = parts[index];
             if (HintAliases.Contains(part) || _resolve(part) != null) continue;
-            diags.Add(Diagnostic.TypeError(
+            string? suggestion = FindNearest(
+                part,
+                HintAliases.Concat(_typeNames?.Invoke() ?? []));
+            Diagnostic diagnostic = Diagnostic.TypeError(
                 $"@DotNetOverload(\"{hint}\") on '{m.Name.Lexeme}': unknown type '{part}' in hint.",
-                Loc(m.Name, pos)));
+                suggestion is null
+                    ? Loc(m.Name, pos)
+                    : Loc(
+                        decorator.Value.At,
+                        decorator.Value.End,
+                        pos));
+            if (suggestion is not null)
+            {
+                string[] replacementParts = [.. parts];
+                replacementParts[index] = suggestion;
+                string replacementHint = string.Join(", ", replacementParts);
+                diagnostic = WithReplacement(
+                    diagnostic,
+                    $"Change overload type to '{suggestion}'",
+                    $"@DotNetOverload(\"{replacementHint}\")");
+            }
+            diags.Add(diagnostic);
         }
     }
 
@@ -304,25 +385,142 @@ public sealed class InteropAnalyzer
                 Loc(token, pos)));
     }
 
-    private static (string? mapping, Token? at, Token? name) FindDotNetType(Stmt.Class cls)
+    private static (string? mapping, Token? at, Token? name, Token? end) FindDotNetType(Stmt.Class cls)
     {
-        if (cls.Decorators == null) return (null, null, null);
+        if (cls.Decorators == null) return (null, null, null, null);
         foreach (var d in cls.Decorators)
-            if (d.Expression is Expr.Call { Callee: Expr.Variable v, Arguments: [Expr.Literal { Value: string typeName }] }
+            if (d.Expression is Expr.Call { Callee: Expr.Variable v, Arguments: [Expr.Literal { Value: string typeName }] } call
                 && v.Name.Lexeme == "DotNetType")
-                return (typeName, d.AtToken, v.Name);
-        return (null, null, null);
+                return (typeName, d.AtToken, v.Name, call.Paren);
+        return (null, null, null, null);
     }
 
-    private static string? ExtractDecoratorArg(List<Decorator>? decorators, string name)
+    private static (string Value, Token At, Token End)?
+        FindDecoratorStringArg(
+            List<Decorator>? decorators,
+            string name)
     {
         if (decorators == null) return null;
         foreach (var d in decorators)
-            if (d.Expression is Expr.Call { Callee: Expr.Variable v, Arguments: [Expr.Literal { Value: string arg }] }
+            if (d.Expression is Expr.Call { Callee: Expr.Variable v, Arguments: [Expr.Literal { Value: string arg }] } call
                 && v.Name.Lexeme == name)
-                return arg;
+                return (arg, d.AtToken, call.Paren);
         return null;
     }
+
+    private string? ResolveDefaultImportExportName(string specifier)
+    {
+        try
+        {
+            Type? type =
+                DotNetTypeRegistry.ResolveFriendly(specifier, _resolve);
+            if (type is null)
+                return null;
+            int genericMarker = type.Name.IndexOf('`');
+            return genericMarker < 0
+                ? type.Name
+                : type.Name[..genericMarker];
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+    }
+
+    private static IEnumerable<string> MemberCandidates(
+        Type type,
+        bool isStatic,
+        string kind,
+        string sourceName)
+    {
+        BindingFlags flags = BindingFlags.Public |
+            (isStatic
+                ? BindingFlags.Static | BindingFlags.FlattenHierarchy
+                : BindingFlags.Instance);
+        IEnumerable<string> names = string.Equals(
+            kind,
+            "method",
+            StringComparison.Ordinal)
+            ? type.GetMethods(flags)
+                .Where(method => !method.IsSpecialName)
+                .Select(method => method.Name)
+            : type.GetProperties(flags)
+                .Select(property => property.Name)
+                .Concat(type.GetFields(flags).Select(field => field.Name));
+
+        bool lowerCamel =
+            sourceName.Length > 0 && char.IsLower(sourceName[0]);
+        return names
+            .Select(name =>
+                lowerCamel && name.Length > 0
+                    ? char.ToLowerInvariant(name[0]) + name[1..]
+                    : name)
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string? FindNearest(
+        string source,
+        IEnumerable<string> candidates)
+    {
+        int bestDistance = int.MaxValue;
+        string? best = null;
+        bool tied = false;
+        foreach (string candidate in candidates
+            .Where(candidate => !string.IsNullOrWhiteSpace(candidate))
+            .Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            int distance = EditDistance(source, candidate);
+            if (distance < bestDistance)
+            {
+                bestDistance = distance;
+                best = candidate;
+                tied = false;
+            }
+            else if (distance == bestDistance &&
+                     !string.Equals(
+                         best,
+                         candidate,
+                         StringComparison.OrdinalIgnoreCase))
+            {
+                tied = true;
+            }
+        }
+
+        return bestDistance <= 2 && !tied ? best : null;
+    }
+
+    private static int EditDistance(string left, string right)
+    {
+        int[] previous = Enumerable.Range(0, right.Length + 1).ToArray();
+        int[] current = new int[right.Length + 1];
+        for (int i = 1; i <= left.Length; i++)
+        {
+            current[0] = i;
+            for (int j = 1; j <= right.Length; j++)
+            {
+                int substitution = char.ToUpperInvariant(left[i - 1]) ==
+                    char.ToUpperInvariant(right[j - 1])
+                    ? 0
+                    : 1;
+                current[j] = Math.Min(
+                    Math.Min(current[j - 1] + 1, previous[j] + 1),
+                    previous[j - 1] + substitution);
+            }
+            (previous, current) = (current, previous);
+        }
+        return previous[right.Length];
+    }
+
+    private static Diagnostic WithReplacement(
+        Diagnostic diagnostic,
+        string title,
+        string newText) =>
+        diagnostic with
+        {
+            Properties = InteropCodeActionMetadata.Replacement(
+                title,
+                newText),
+        };
 
     /// <summary>Tier 3d: finds addEventListener/removeEventListener calls whose receiver
     /// resolves (purely structurally) to a known @DotNetType, and checks arity + event name.

--- a/SharpTS.LanguageServer/Services/InteropCodeActionMetadata.cs
+++ b/SharpTS.LanguageServer/Services/InteropCodeActionMetadata.cs
@@ -1,0 +1,27 @@
+namespace SharpTS.LanguageServer.Services;
+
+/// <summary>
+/// Stable structured metadata attached to actionable interop diagnostics. Keeping the edit
+/// description separate from the human-readable message means clients never need to parse error
+/// prose to construct a quick fix.
+/// </summary>
+internal static class InteropCodeActionMetadata
+{
+    internal const string VersionKey = "sharpts.codeAction.version";
+    internal const string KindKey = "sharpts.codeAction.kind";
+    internal const string TitleKey = "sharpts.codeAction.title";
+    internal const string NewTextKey = "sharpts.codeAction.newText";
+    internal const int CurrentVersion = 1;
+    internal const string ReplaceDiagnosticRange = "replaceDiagnosticRange";
+
+    internal static IReadOnlyDictionary<string, object> Replacement(
+        string title,
+        string newText) =>
+        new Dictionary<string, object>(StringComparer.Ordinal)
+        {
+            [VersionKey] = CurrentVersion,
+            [KindKey] = ReplaceDiagnosticRange,
+            [TitleKey] = title,
+            [NewTextKey] = newText,
+        };
+}

--- a/SharpTS.LanguageServer/Services/InteropCodeActionService.cs
+++ b/SharpTS.LanguageServer/Services/InteropCodeActionService.cs
@@ -1,0 +1,82 @@
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+
+namespace SharpTS.LanguageServer.Services;
+
+/// <summary>Builds safe interop quick fixes from structured diagnostic data.</summary>
+public sealed class InteropCodeActionService
+{
+    public CommandOrCodeActionContainer Create(CodeActionParams request)
+    {
+        if (request.Context.Only is { } requestedKinds &&
+            !requestedKinds.Contains(CodeActionKind.QuickFix))
+        {
+            return new CommandOrCodeActionContainer();
+        }
+
+        var actions = new List<CommandOrCodeAction>();
+        foreach (Diagnostic diagnostic in request.Context.Diagnostics)
+        {
+            if (!string.Equals(
+                    diagnostic.Source,
+                    "sharpts",
+                    StringComparison.Ordinal) ||
+                !TryReadReplacement(
+                    diagnostic.Data,
+                    out string? title,
+                    out string? newText))
+            {
+                continue;
+            }
+
+            var edit = new TextEdit
+            {
+                Range = diagnostic.Range,
+                NewText = newText,
+            };
+            actions.Add(new CodeAction
+            {
+                Title = title,
+                Kind = CodeActionKind.QuickFix,
+                IsPreferred = true,
+                Diagnostics = new Container<Diagnostic>(diagnostic),
+                Edit = new WorkspaceEdit
+                {
+                    Changes =
+                        new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                        {
+                            [request.TextDocument.Uri] = [edit],
+                        },
+                },
+            });
+        }
+
+        return new CommandOrCodeActionContainer(actions);
+    }
+
+    private static bool TryReadReplacement(
+        JToken? data,
+        out string title,
+        out string newText)
+    {
+        title = "";
+        newText = "";
+        if (data is not JObject value ||
+            value.Value<int?>(InteropCodeActionMetadata.VersionKey) !=
+                InteropCodeActionMetadata.CurrentVersion ||
+            !string.Equals(
+                value.Value<string>(InteropCodeActionMetadata.KindKey),
+                InteropCodeActionMetadata.ReplaceDiagnosticRange,
+                StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        title =
+            value.Value<string>(InteropCodeActionMetadata.TitleKey) ?? "";
+        newText =
+            value.Value<string>(InteropCodeActionMetadata.NewTextKey) ?? "";
+        return title.Length > 0;
+    }
+}

--- a/SharpTS.LanguageServer/Services/NavigationModelBuilder.cs
+++ b/SharpTS.LanguageServer/Services/NavigationModelBuilder.cs
@@ -34,8 +34,10 @@ internal static class NavigationModelBuilder
     public static CheckedNavigationModel? TryBuild(
         string path,
         string text,
-        IReadOnlyDictionary<string, string>? openDocuments)
+        IReadOnlyDictionary<string, string>? openDocuments,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         string absolutePath = Path.GetFullPath(path);
         Dictionary<string, string> overlay = CreateOverlay(
             absolutePath,
@@ -52,9 +54,14 @@ internal static class NavigationModelBuilder
                     absolutePath,
                     overlay,
                     NavigationWorkspace.FromProject(TsConfigLoader.Load(configPath)),
-                    requireMembership: true);
+                    requireMembership: true,
+                    cancellationToken);
                 if (configured.Model is not null)
                     return configured.Model;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
             }
             catch
             {
@@ -66,15 +73,18 @@ internal static class NavigationModelBuilder
             absolutePath,
             overlay,
             NavigationWorkspace.Unconfigured(absolutePath, configPath),
-            requireMembership: false).Model;
+            requireMembership: false,
+            cancellationToken).Model;
     }
 
     public static CheckedNavigationWorkspace BuildWorkspace(
         string path,
         string text,
         IReadOnlyDictionary<string, string>? openDocuments,
-        IReadOnlyList<string> workspaceRoots)
+        IReadOnlyList<string> workspaceRoots,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         string absolutePath = Path.GetFullPath(path);
         Dictionary<string, string> overlay = CreateOverlay(
             absolutePath,
@@ -87,11 +97,13 @@ internal static class NavigationModelBuilder
 
         foreach (TsConfigResult project in catalog.Projects)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             ProjectBuildResult result = TryBuildProject(
                 absolutePath,
                 overlay,
                 NavigationWorkspace.FromProject(project),
-                requireMembership: true);
+                requireMembership: true,
+                cancellationToken);
             isComplete &= result.IsComplete;
             if (result.Model is not null)
                 models.Add(result.Model);
@@ -107,7 +119,8 @@ internal static class NavigationModelBuilder
         string absolutePath,
         IReadOnlyDictionary<string, string> overlay,
         NavigationWorkspace workspace,
-        bool requireMembership)
+        bool requireMembership,
+        CancellationToken cancellationToken)
     {
         try
         {
@@ -125,6 +138,7 @@ internal static class NavigationModelBuilder
             List<ParsedModule> declarationRoots = [];
             foreach (string declarationPath in workspace.DeclarationFiles)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 try
                 {
                     declarationRoots.Add(
@@ -142,6 +156,7 @@ internal static class NavigationModelBuilder
                          .Distinct(StringComparer.OrdinalIgnoreCase)
                          .Order(StringComparer.OrdinalIgnoreCase))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 try
                 {
                     ParsedModule root = resolver.LoadProgram(
@@ -172,6 +187,7 @@ internal static class NavigationModelBuilder
             foreach (string openPath in overlay.Keys
                          .Order(StringComparer.OrdinalIgnoreCase))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (string.Equals(
                         openPath,
                         absolutePath,
@@ -207,7 +223,8 @@ internal static class NavigationModelBuilder
                 .ToList();
 
             var checker = new TypeChecker(workspace.CheckerOptions)
-                .WithFilePath(absolutePath);
+                .WithFilePath(absolutePath)
+                .WithCancellation(cancellationToken);
             checker.SetDecoratorMode(workspace.DecoratorMode);
             checker.CheckModules(
                 resolver.GetModulesInOrder(connectedRoots),
@@ -222,6 +239,10 @@ internal static class NavigationModelBuilder
             return new ProjectBuildResult(
                 model,
                 workspace.IsConfigured && allRootsLoaded);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch
         {

--- a/SharpTS.LanguageServer/Services/ReferenceService.cs
+++ b/SharpTS.LanguageServer/Services/ReferenceService.cs
@@ -34,7 +34,8 @@ public sealed class ReferenceService
         Position position,
         bool includeDeclaration,
         IReadOnlyDictionary<string, string>? openDocuments = null,
-        IReadOnlyList<string>? workspaceRoots = null)
+        IReadOnlyList<string>? workspaceRoots = null,
+        bool includeDeclarationFacets = false)
     {
         if (NavigationModelBuilder.TryBuild(path, text, openDocuments) is not { } model)
             return new NavigationReferenceResult([], [], IsComplete: false);
@@ -44,6 +45,24 @@ public sealed class ReferenceService
             (int)position.Character + 1);
         IReadOnlyList<BindingSymbol> selectedSymbols =
             model.Checker.Bindings.FindSymbols(model.Document, offset);
+        if (includeDeclarationFacets)
+        {
+            var expandedSymbols = new HashSet<BindingSymbol>(
+                selectedSymbols,
+                ReferenceEqualityComparer.Instance);
+            foreach (BindingSymbol symbol in selectedSymbols)
+            {
+                foreach (BindingDeclaration declaration in symbol.Declarations)
+                {
+                    expandedSymbols.UnionWith(
+                        model.Checker.Bindings.FindSymbols(
+                            declaration.Document,
+                            declaration.Name.Start));
+                }
+            }
+
+            selectedSymbols = expandedSymbols.ToArray();
+        }
         if (selectedSymbols.Count == 0)
         {
             return new NavigationReferenceResult(

--- a/SharpTS.LanguageServer/Services/RenameService.cs
+++ b/SharpTS.LanguageServer/Services/RenameService.cs
@@ -1,0 +1,136 @@
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpTS.Parsing;
+using LspRange = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace SharpTS.LanguageServer.Services;
+
+/// <summary>
+/// Produces semantic workspace renames only when the complete affected project graph is known.
+/// </summary>
+public sealed class RenameService
+{
+    private readonly ReferenceService _references;
+
+    public RenameService(ReferenceService references)
+    {
+        _references = references;
+    }
+
+    public LspRange? Prepare(
+        string path,
+        string text,
+        Position position,
+        IReadOnlyDictionary<string, string>? openDocuments = null,
+        IReadOnlyList<string>? workspaceRoots = null)
+    {
+        NavigationReferenceResult result = FindCompleteDomain(
+            path,
+            text,
+            position,
+            openDocuments,
+            workspaceRoots);
+        if (!result.IsComplete || result.Locations.Count == 0)
+            return null;
+
+        DocumentUri currentUri = DocumentUri.FromFileSystemPath(
+            Path.GetFullPath(path));
+        return result.Locations
+            .Where(location => location.Uri == currentUri)
+            .Select(location => location.Range)
+            .FirstOrDefault(range => Contains(range, position));
+    }
+
+    public WorkspaceEdit? Rename(
+        string path,
+        string text,
+        Position position,
+        string newName,
+        IReadOnlyDictionary<string, string>? openDocuments = null,
+        IReadOnlyList<string>? workspaceRoots = null)
+    {
+        if (!IsBindingIdentifier(newName))
+            return null;
+
+        NavigationReferenceResult result = FindCompleteDomain(
+            path,
+            text,
+            position,
+            openDocuments,
+            workspaceRoots);
+        if (!result.IsComplete || result.Locations.Count == 0)
+            return null;
+
+        return new WorkspaceEdit
+        {
+            Changes = result.Locations
+                .GroupBy(location => location.Uri)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group
+                        .OrderByDescending(location => location.Range.Start.Line)
+                        .ThenByDescending(location => location.Range.Start.Character)
+                        .Select(location => new TextEdit
+                        {
+                            Range = location.Range,
+                            NewText = newName,
+                        })
+                        .AsEnumerable()),
+        };
+    }
+
+    private NavigationReferenceResult FindCompleteDomain(
+        string path,
+        string text,
+        Position position,
+        IReadOnlyDictionary<string, string>? openDocuments,
+        IReadOnlyList<string>? workspaceRoots)
+        => _references.FindReferenceResult(
+            path,
+            text,
+            position,
+            includeDeclaration: true,
+            openDocuments,
+            workspaceRoots);
+
+    private static bool Contains(LspRange range, Position position)
+    {
+        bool startsBefore =
+            position.Line > range.Start.Line ||
+            position.Line == range.Start.Line &&
+            position.Character >= range.Start.Character;
+        bool endsAfter =
+            position.Line < range.End.Line ||
+            position.Line == range.End.Line &&
+            position.Character < range.End.Character;
+        return startsBefore && endsAfter;
+    }
+
+    private static bool IsBindingIdentifier(string candidate)
+    {
+        if (string.IsNullOrEmpty(candidate))
+            return false;
+
+        try
+        {
+            List<Stmt> statements = new Parser(
+                    new Lexer($"let {candidate};").ScanTokens())
+                .ParseOrThrow();
+            return statements is
+            [
+                Stmt.Var
+                {
+                    Name.Lexeme: var parsedName,
+                    Initializer: null,
+                },
+            ] && string.Equals(
+                parsedName,
+                candidate,
+                StringComparison.Ordinal);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/SharpTS.LanguageServer/Services/RenameService.cs
+++ b/SharpTS.LanguageServer/Services/RenameService.cs
@@ -91,7 +91,8 @@ public sealed class RenameService
             position,
             includeDeclaration: true,
             openDocuments,
-            workspaceRoots);
+            workspaceRoots,
+            includeDeclarationFacets: true);
 
     private static bool Contains(LspRange range, Position position)
     {

--- a/SharpTS.LanguageServer/SharpTSLanguageServer.cs
+++ b/SharpTS.LanguageServer/SharpTSLanguageServer.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using OmniSharp.Extensions.LanguageServer.Server;
 using SharpTS.LanguageServer.Handlers;
+using SharpTS.LanguageServer.Conversions;
 using SharpTS.LanguageServer.Services;
 
 namespace SharpTS.LanguageServer;
@@ -24,9 +25,12 @@ public static class SharpTSLanguageServer
     public static async Task RunAsync(
         Func<string, Type?>? resolve = null,
         Func<IEnumerable<string>>? typeNames = null,
-        LanguageFeatureMode mode = LanguageFeatureMode.Full)
+        LanguageFeatureMode mode = LanguageFeatureMode.Full,
+        DiagnosticPublishMode diagnosticMode =
+            DiagnosticPublishMode.SharpTsOnly)
     {
         var workspaceContext = new NavigationWorkspaceContext();
+        var diagnosticsSettings = new DiagnosticsSettings(diagnosticMode);
         var server = await OmniSharp.Extensions.LanguageServer.Server.LanguageServer.From(options =>
         {
             options
@@ -39,8 +43,11 @@ public static class SharpTSLanguageServer
                 .WithOutput(Console.OpenStandardOutput())
                 .WithServices(services => services
                     .AddSingleton(workspaceContext)
+                    .AddSingleton(diagnosticsSettings)
                     .AddSingleton<DocumentStore>()
                     .AddSingleton(new DiagnosticsService(resolve))
+                    .AddSingleton<DocumentDependencyGraph>()
+                    .AddSingleton<DiagnosticsCoordinator>()
                     .AddSingleton(new DecoratorService(resolve, typeNames))
                     .AddSingleton(new MemberHoverService(resolve))
                     .AddSingleton<DocumentSymbolService>()
@@ -49,6 +56,7 @@ public static class SharpTSLanguageServer
                     .AddSingleton<RenameService>())
                 // Served in both modes: this is the interop knowledge no other server has.
                 .WithHandler<TextDocumentSyncHandler>()
+                .WithHandler<ConfigurationHandler>()
                 .WithHandler<HoverHandler>()
                 .WithHandler<CompletionHandler>()
                 .WithHandler<SignatureHelpHandler>();

--- a/SharpTS.LanguageServer/SharpTSLanguageServer.cs
+++ b/SharpTS.LanguageServer/SharpTSLanguageServer.cs
@@ -45,11 +45,12 @@ public static class SharpTSLanguageServer
                     .AddSingleton(workspaceContext)
                     .AddSingleton(diagnosticsSettings)
                     .AddSingleton<DocumentStore>()
-                    .AddSingleton(new DiagnosticsService(resolve))
+                    .AddSingleton(new DiagnosticsService(resolve, typeNames))
                     .AddSingleton<DocumentDependencyGraph>()
                     .AddSingleton<DiagnosticsCoordinator>()
                     .AddSingleton(new DecoratorService(resolve, typeNames))
                     .AddSingleton(new MemberHoverService(resolve))
+                    .AddSingleton<InteropCodeActionService>()
                     .AddSingleton<DocumentSymbolService>()
                     .AddSingleton<DefinitionService>()
                     .AddSingleton<ReferenceService>()
@@ -59,7 +60,8 @@ public static class SharpTSLanguageServer
                 .WithHandler<ConfigurationHandler>()
                 .WithHandler<HoverHandler>()
                 .WithHandler<CompletionHandler>()
-                .WithHandler<SignatureHelpHandler>();
+                .WithHandler<SignatureHelpHandler>()
+                .WithHandler<CodeActionHandler>();
 
             // Registering a handler is what advertises its capability, so the mode has to be
             // decided here rather than consulted later.

--- a/SharpTS.LanguageServer/SharpTSLanguageServer.cs
+++ b/SharpTS.LanguageServer/SharpTSLanguageServer.cs
@@ -45,7 +45,8 @@ public static class SharpTSLanguageServer
                     .AddSingleton(new MemberHoverService(resolve))
                     .AddSingleton<DocumentSymbolService>()
                     .AddSingleton<DefinitionService>()
-                    .AddSingleton<ReferenceService>())
+                    .AddSingleton<ReferenceService>()
+                    .AddSingleton<RenameService>())
                 // Served in both modes: this is the interop knowledge no other server has.
                 .WithHandler<TextDocumentSyncHandler>()
                 .WithHandler<HoverHandler>()
@@ -59,7 +60,9 @@ public static class SharpTSLanguageServer
                 options
                     .WithHandler<DocumentSymbolHandler>()
                     .WithHandler<DefinitionHandler>()
-                    .WithHandler<ReferencesHandler>();
+                    .WithHandler<ReferencesHandler>()
+                    .WithHandler<RenameHandler>()
+                    .WithHandler<PrepareRenameHandler>();
             }
         });
 

--- a/SharpTS.Tests/Compilation/DebugSymbolsTests.cs
+++ b/SharpTS.Tests/Compilation/DebugSymbolsTests.cs
@@ -68,6 +68,9 @@ public class DebugSymbolsTests
         var document = Assert.Single(reader.Documents.Select(reader.GetDocument));
         Assert.Equal(fixture.DocumentPath, reader.GetString(document.Name));
         Assert.Equal(SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(SourceText)), reader.GetBlobBytes(document.Hash));
+        Assert.Equal(
+            new Guid("3f5162f8-07c6-11d3-9053-00c04fa302a1"),
+            reader.GetGuid(document.Language));
 
         // MethodDebugInformation is parallel to MethodDef: row N describes method N.
         Assert.Equal(fixture.MethodDefRowCount, reader.MethodDebugInformation.Count);
@@ -412,6 +415,160 @@ public class DebugSymbolsTests
         }
     }
 
+    [Fact]
+    public void AsyncAndGeneratorBodiesCarryStateMachineDebugMetadata()
+    {
+        const string source = """
+            async function asyncWork(input: number): Promise<number> {
+              const before = input + 1;
+              const awaited = await Promise.resolve(before);
+              return awaited + 1;
+            }
+            function* numbers(limit: number): Generator<number> {
+              let current = 0;
+              while (current < limit) {
+                yield current;
+                current++;
+              }
+            }
+            async function* stream(): AsyncGenerator<number> {
+              const value = await Promise.resolve(1);
+              yield value;
+            }
+            asyncWork(1);
+            numbers(2);
+            stream();
+            """;
+
+        CompilationArtifacts artifacts = CompileTypeScript(
+            source,
+            emitDebugSymbols: true);
+        Dictionary<string, (string Document, int[] Lines)> byMethod =
+            SequencePointsByMethod(artifacts);
+
+        var asyncMoveNext = Assert.Single(
+            byMethod,
+            pair => pair.Key.Contains("<asyncWork>d__", StringComparison.Ordinal) &&
+                pair.Key.EndsWith("::MoveNext", StringComparison.Ordinal));
+        Assert.Equal([2, 3, 4], asyncMoveNext.Value.Lines);
+
+        var generatorMoveNext = Assert.Single(
+            byMethod,
+            pair => pair.Key.Contains("<numbers>d__", StringComparison.Ordinal) &&
+                pair.Key.EndsWith("::MoveNext", StringComparison.Ordinal));
+        Assert.Contains(8, generatorMoveNext.Value.Lines);
+        Assert.Contains(10, generatorMoveNext.Value.Lines);
+
+        var asyncGeneratorMoveNext = Assert.Single(
+            byMethod,
+            pair => pair.Key.Contains("<stream>d__", StringComparison.Ordinal) &&
+                pair.Key.EndsWith("::MoveNextAsync", StringComparison.Ordinal));
+        Assert.Equal([14, 15], asyncGeneratorMoveNext.Value.Lines);
+
+        MetadataReader pdb = ReadPdb(artifacts.Pdb!);
+        Assert.Equal(3, pdb.GetTableRowCount(TableIndex.StateMachineMethod));
+        Assert.Equal(
+            ["asyncWork", "numbers", "stream"],
+            StateMachineKickoffNames(artifacts));
+        Assert.True(
+            HasCustomDebugInformation(
+                pdb,
+                new Guid("54fd2ac5-e925-401a-9c2a-f94f171072f8")),
+            "async MoveNext methods should carry suspension/resume stepping information");
+        AssertAsyncStepRecordsAreValid(pdb);
+    }
+
+    [Fact]
+    public void StateMachineAndDisplayClassPresentationIsStable()
+    {
+        const string source = """
+            async function work(seed: number): Promise<number> {
+              let carried = seed;
+              const increment = () => ++carried;
+              await Promise.resolve(0);
+              return increment();
+            }
+            function* sequence(limit: number): Generator<number> {
+              let current = 0;
+              while (current < limit) {
+                yield current++;
+              }
+            }
+            work(1);
+            sequence(2);
+            """;
+
+        CompilationArtifacts first = CompileTypeScript(source, emitDebugSymbols: true);
+        CompilationArtifacts second = CompileTypeScript(source, emitDebugSymbols: true);
+        Assert.Equal(
+            GeneratedTypeNames(first.Assembly),
+            GeneratedTypeNames(second.Assembly));
+
+        using var reader = new PEReader(
+            new MemoryStream(first.Assembly, writable: false));
+        MetadataReader metadata = reader.GetMetadataReader();
+        TypeDefinitionHandle[] generatedTypes = metadata.TypeDefinitions
+            .Where(handle =>
+            {
+                string name = metadata.GetString(
+                    metadata.GetTypeDefinition(handle).Name);
+                return name.Contains("d__", StringComparison.Ordinal) ||
+                    name.Contains("DisplayClass", StringComparison.Ordinal);
+            })
+            .ToArray();
+        Assert.NotEmpty(generatedTypes);
+        Assert.All(generatedTypes, handle =>
+            Assert.True(HasAttribute(
+                metadata,
+                metadata.GetTypeDefinition(handle).GetCustomAttributes(),
+                "CompilerGeneratedAttribute")));
+
+        TypeDefinition asyncType = metadata.GetTypeDefinition(
+            Assert.Single(generatedTypes, handle =>
+                metadata.GetString(metadata.GetTypeDefinition(handle).Name)
+                    .Contains("<work>d__", StringComparison.Ordinal)));
+        string[] asyncFields = asyncType.GetFields()
+            .Select(handle => metadata.GetString(
+                metadata.GetFieldDefinition(handle).Name))
+            .ToArray();
+        Assert.Contains("seed", asyncFields);
+        Assert.Contains("increment", asyncFields);
+        Assert.Contains(generatedTypes, handle =>
+        {
+            TypeDefinition type = metadata.GetTypeDefinition(handle);
+            return metadata.GetString(type.Name)
+                    .Contains("FuncDisplayClass", StringComparison.Ordinal) &&
+                type.GetFields().Any(field =>
+                    metadata.GetString(metadata.GetFieldDefinition(field).Name) ==
+                    "carried");
+        });
+
+        MethodDefinitionHandle[] kickoffMethods = metadata.MethodDefinitions
+            .Where(handle =>
+            {
+                MethodDefinition method = metadata.GetMethodDefinition(handle);
+                return HasAttribute(
+                    metadata,
+                    method.GetCustomAttributes(),
+                    "AsyncStateMachineAttribute") ||
+                    HasAttribute(
+                        metadata,
+                        method.GetCustomAttributes(),
+                        "IteratorStateMachineAttribute");
+            })
+            .ToArray();
+        Assert.Equal(2, kickoffMethods.Length);
+
+        Assert.Contains(
+            metadata.MethodDefinitions.Select(metadata.GetMethodDefinition),
+            method =>
+                metadata.GetString(method.Name) == "SetStateMachine" &&
+                HasAttribute(
+                    metadata,
+                    method.GetCustomAttributes(),
+                    "DebuggerNonUserCodeAttribute"));
+    }
+
     // ---------------------------------------------------------------- just my code
 
     /// <summary>
@@ -476,6 +633,11 @@ public class DebugSymbolsTests
             string pdbPath = Path.Combine(directory, "program.pdb");
             Assert.True(File.Exists(pdbPath), "Save(path) should write symbols beside the assembly.");
             AssertCodeViewMatchesPdb(File.ReadAllBytes(dllPath), File.ReadAllBytes(pdbPath), "program.pdb");
+            using var reader = new PEReader(File.OpenRead(dllPath));
+            DebugDirectoryEntry codeView = Assert.Single(
+                reader.ReadDebugDirectory(),
+                entry => entry.Type == DebugDirectoryEntryType.CodeView);
+            Assert.Equal("program.pdb", reader.ReadCodeViewDebugDirectoryData(codeView).Path);
         }
         finally
         {
@@ -803,6 +965,103 @@ public class DebugSymbolsTests
             if (metadata.GetString(type.Name) == "DebuggableAttribute") return true;
         }
         return false;
+    }
+
+    private static string[] GeneratedTypeNames(byte[] image)
+    {
+        using var reader = new PEReader(
+            new MemoryStream(image, writable: false));
+        MetadataReader metadata = reader.GetMetadataReader();
+        return metadata.TypeDefinitions
+            .Select(metadata.GetTypeDefinition)
+            .Select(type => metadata.GetString(type.Name))
+            .Where(name =>
+                name.StartsWith("<>", StringComparison.Ordinal) ||
+                name.Contains("d__", StringComparison.Ordinal))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static bool HasAttribute(
+        MetadataReader metadata,
+        CustomAttributeHandleCollection attributes,
+        string name) =>
+        attributes
+            .Select(metadata.GetCustomAttribute)
+            .Any(attribute => AttributeTypeName(metadata, attribute) == name);
+
+    private static bool HasCustomDebugInformation(
+        MetadataReader metadata,
+        Guid kind)
+    {
+        foreach (CustomDebugInformationHandle handle in
+                 metadata.CustomDebugInformation)
+        {
+            CustomDebugInformation information =
+                metadata.GetCustomDebugInformation(handle);
+            if (metadata.GetGuid(information.Kind) == kind)
+                return true;
+        }
+        return false;
+    }
+
+    private static string[] StateMachineKickoffNames(
+        CompilationArtifacts artifacts)
+    {
+        using var reader = new PEReader(
+            new MemoryStream(artifacts.Assembly, writable: false));
+        MetadataReader metadata = reader.GetMetadataReader();
+        MetadataReader pdb = ReadPdb(artifacts.Pdb!);
+        var names = new List<string>();
+
+        for (int rid = 1; rid <= metadata.MethodDefinitions.Count; rid++)
+        {
+            MethodDebugInformation debugInformation =
+                pdb.GetMethodDebugInformation(
+                    MetadataTokens.MethodDebugInformationHandle(rid));
+            MethodDefinitionHandle kickoff =
+                debugInformation.GetStateMachineKickoffMethod();
+            if (!kickoff.IsNil)
+            {
+                names.Add(metadata.GetString(
+                    metadata.GetMethodDefinition(kickoff).Name));
+            }
+        }
+
+        return names.Order(StringComparer.Ordinal).ToArray();
+    }
+
+    private static void AssertAsyncStepRecordsAreValid(
+        MetadataReader metadata)
+    {
+        Guid asyncKind =
+            new("54fd2ac5-e925-401a-9c2a-f94f171072f8");
+        int records = 0;
+        foreach (CustomDebugInformationHandle handle in
+                 metadata.CustomDebugInformation)
+        {
+            CustomDebugInformation information =
+                metadata.GetCustomDebugInformation(handle);
+            if (metadata.GetGuid(information.Kind) != asyncKind)
+                continue;
+
+            Assert.Equal(HandleKind.MethodDefinition, information.Parent.Kind);
+            int moveNextRid = MetadataTokens.GetRowNumber(
+                (MethodDefinitionHandle)information.Parent);
+            BlobReader blob = metadata.GetBlobReader(information.Value);
+            Assert.Equal(-1, blob.ReadInt32());
+            while (blob.RemainingBytes > 0)
+            {
+                int yieldOffset = blob.ReadInt32();
+                int resumeOffset = blob.ReadInt32();
+                int resumeMethodRid = blob.ReadCompressedInteger();
+                Assert.True(yieldOffset < resumeOffset);
+                Assert.Equal(moveNextRid, resumeMethodRid);
+                records++;
+            }
+        }
+
+        Assert.True(records >= 2, "the async function and async generator should both record awaits");
     }
 
     private static List<SequencePoint> SequencePoints(MetadataReader pdb, int methodRid)

--- a/SharpTS.Tests/LanguageServer/InteropCodeActionTests.cs
+++ b/SharpTS.Tests/LanguageServer/InteropCodeActionTests.cs
@@ -1,0 +1,191 @@
+using Newtonsoft.Json.Linq;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpTS.LanguageServer.Conversions;
+using SharpTS.LanguageServer.Services;
+using Xunit;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace SharpTS.Tests.LanguageServer;
+
+public class InteropCodeActionTests
+{
+    [Fact]
+    public void MissingMemberCarriesStructuredReplacement()
+    {
+        Diagnostic diagnostic = Assert.Single(Analyze(
+            """
+            @DotNetType("System.Text.StringBuilder")
+            declare class SB { appendx(value: string): SB; }
+            """));
+
+        AssertReplacement(
+            diagnostic,
+            "Change member to 'append'",
+            "append");
+        Assert.Equal(new Range(1, 19, 1, 26), diagnostic.Range);
+    }
+
+    [Fact]
+    public void StaticMismatchCanMakeMemberStatic()
+    {
+        Diagnostic diagnostic = Assert.Single(Analyze(
+            """
+            @DotNetType("System.Math")
+            declare class MathBinding { abs(value: number): number; }
+            """));
+
+        AssertReplacement(
+            diagnostic,
+            "Make 'abs' static",
+            "static abs");
+    }
+
+    [Fact]
+    public void UnknownClrTypeCanReplaceWholeDecorator()
+    {
+        Diagnostic diagnostic = Assert.Single(Analyze(
+            """
+            @DotNetType("System.Text.StringBulder")
+            declare class SB {}
+            """,
+            () => ["System.Text.StringBuilder", "System.Text.Encoding"]));
+
+        AssertReplacement(
+            diagnostic,
+            "Change .NET type to 'System.Text.StringBuilder'",
+            "@DotNetType(\"System.Text.StringBuilder\")");
+        Assert.Equal(new Range(0, 0, 0, 39), diagnostic.Range);
+    }
+
+    [Fact]
+    public void BadOverloadHintCanReplaceWholeDecorator()
+    {
+        Diagnostic diagnostic = Assert.Single(Analyze(
+            """
+            @DotNetType("System.Convert")
+            declare class Conv {
+              @DotNetOverload("flot")
+              static toInt32(value: number): number;
+            }
+            """));
+
+        AssertReplacement(
+            diagnostic,
+            "Change overload type to 'float'",
+            "@DotNetOverload(\"float\")");
+        Assert.Equal(new Range(2, 2, 2, 25), diagnostic.Range);
+    }
+
+    [Fact]
+    public void DefaultDotNetImportCanConvertToNamedImport()
+    {
+        Diagnostic diagnostic = Assert.Single(Analyze(
+            """
+            import SB from "dotnet:System.Text.StringBuilder";
+            """));
+
+        AssertReplacement(
+            diagnostic,
+            "Convert to named import 'StringBuilder'",
+            "{ StringBuilder as SB }");
+        Assert.Equal(new Range(0, 7, 0, 9), diagnostic.Range);
+    }
+
+    [Fact]
+    public void ServiceBuildsPreferredQuickFixWithoutParsingMessage()
+    {
+        Diagnostic diagnostic = Assert.Single(Analyze(
+            """
+            @DotNetType("System.Text.StringBuilder")
+            declare class SB { appendx(value: string): SB; }
+            """));
+        diagnostic = diagnostic with
+        {
+            Message = "Localized or otherwise changed message text",
+        };
+        DocumentUri uri = DocumentUri.FromFileSystemPath(
+            Path.GetFullPath("interop-action.ts"));
+        var request = new CodeActionParams
+        {
+            TextDocument = new TextDocumentIdentifier(uri),
+            Range = diagnostic.Range,
+            Context = new CodeActionContext
+            {
+                Diagnostics = new Container<Diagnostic>(diagnostic),
+            },
+        };
+
+        CommandOrCodeAction action = Assert.Single(
+            new InteropCodeActionService().Create(request));
+        CodeAction codeAction = Assert.IsType<CodeAction>(
+            action.CodeAction);
+        Assert.Equal("Change member to 'append'", codeAction.Title);
+        Assert.Equal(CodeActionKind.QuickFix, codeAction.Kind);
+        Assert.True(codeAction.IsPreferred);
+        TextEdit edit = Assert.Single(
+            codeAction.Edit!.Changes![uri]);
+        Assert.Equal(diagnostic.Range, edit.Range);
+        Assert.Equal("append", edit.NewText);
+    }
+
+    [Fact]
+    public void NonSharpTsOrUnstructuredDiagnosticsProduceNoAction()
+    {
+        var range = new Range(0, 0, 0, 1);
+        DocumentUri uri = DocumentUri.FromFileSystemPath(
+            Path.GetFullPath("interop-action.ts"));
+        var request = new CodeActionParams
+        {
+            TextDocument = new TextDocumentIdentifier(uri),
+            Range = range,
+            Context = new CodeActionContext
+            {
+                Diagnostics = new Container<Diagnostic>(
+                    new Diagnostic
+                    {
+                        Range = range,
+                        Message = "no structured data",
+                        Source = "sharpts",
+                    },
+                    new Diagnostic
+                    {
+                        Range = range,
+                        Message = "foreign",
+                        Source = "typescript",
+                        Data = JObject.FromObject(new
+                        {
+                            sharpts = new { codeAction = new { } },
+                        }),
+                    }),
+            },
+        };
+
+        Assert.Empty(new InteropCodeActionService().Create(request));
+    }
+
+    private static List<Diagnostic> Analyze(
+        string source,
+        Func<IEnumerable<string>>? typeNames = null) =>
+        new DiagnosticsService(typeNames: typeNames).Analyze(
+            source,
+            DiagnosticPublishMode.SharpTsOnly);
+
+    private static void AssertReplacement(
+        Diagnostic diagnostic,
+        string title,
+        string newText)
+    {
+        JObject data = Assert.IsType<JObject>(diagnostic.Data);
+        Assert.Equal(1, data.Value<int>("sharpts.codeAction.version"));
+        Assert.Equal(
+            "replaceDiagnosticRange",
+            data.Value<string>("sharpts.codeAction.kind"));
+        Assert.Equal(
+            title,
+            data.Value<string>("sharpts.codeAction.title"));
+        Assert.Equal(
+            newText,
+            data.Value<string>("sharpts.codeAction.newText"));
+    }
+}

--- a/SharpTS.Tests/LanguageServer/NavigationDomainTests.cs
+++ b/SharpTS.Tests/LanguageServer/NavigationDomainTests.cs
@@ -1,0 +1,239 @@
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpTS.LanguageServer.Services;
+using Xunit;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace SharpTS.Tests.LanguageServer;
+
+public class NavigationDomainTests
+{
+    private readonly DefinitionService _definitions = new();
+    private readonly ReferenceService _references = new();
+
+    [Fact]
+    public void GenericTypeParameterUsesResolveToTheirDeclaration()
+    {
+        const string source =
+            "function identity<T>(value: T): T { return value; }\n";
+
+        Location parameterType = Assert.Single(
+            Definitions(source, "T", occurrence: 1));
+        Location returnType = Assert.Single(
+            Definitions(source, "T", occurrence: 2));
+        IReadOnlyList<Location> references = References(
+            source,
+            "T",
+            occurrence: 1);
+
+        Assert.Equal(new Range(0, 18, 0, 19), parameterType.Range);
+        Assert.Equal(parameterType, returnType);
+        Assert.Equal(
+            [
+                new Range(0, 18, 0, 19),
+                new Range(0, 28, 0, 29),
+                new Range(0, 32, 0, 33),
+            ],
+            references.Select(location => location.Range).ToArray());
+    }
+
+    [Fact]
+    public void MappedAndInferParametersHaveIndependentTypeIdentities()
+    {
+        const string source = """
+            type Keys<T> = { [K in keyof T]: K };
+            type Item<T> = T extends Array<infer U> ? U : never;
+            """;
+
+        Location mapped = Assert.Single(
+            Definitions(source, "K", occurrence: 1));
+        Location inferred = Assert.Single(
+            Definitions(source, "U", occurrence: 1));
+
+        Assert.Equal(new Range(0, 18, 0, 19), mapped.Range);
+        Assert.Equal(new Range(1, 37, 1, 38), inferred.Range);
+    }
+
+    [Fact]
+    public void BreakAndContinueLabelsResolveToTheLabeledStatement()
+    {
+        const string source = """
+            outer: for (let i = 0; i < 2; i++) {
+              if (i === 0) continue outer;
+              break outer;
+            }
+            """;
+
+        Location definition = Assert.Single(
+            Definitions(source, "outer", occurrence: 1));
+        IReadOnlyList<Location> references = References(
+            source,
+            "outer",
+            occurrence: 2);
+
+        Assert.Equal(new Range(0, 0, 0, 5), definition.Range);
+        Assert.Equal(
+            [
+                new Range(0, 0, 0, 5),
+                new Range(1, 24, 1, 29),
+                new Range(2, 8, 2, 13),
+            ],
+            references.Select(location => location.Range).ToArray());
+    }
+
+    [Fact]
+    public void QualifiedNamespaceTypeAndValueMembersResolvePrecisely()
+    {
+        const string source = """
+            namespace Tools {
+              export interface Shape { size: number; }
+              export const value = 1;
+              export namespace Nested {
+                export function run(): void {}
+              }
+            }
+            const shape: Tools.Shape = { size: 1 };
+            console.log(Tools.value);
+            Tools.Nested.run();
+            """;
+
+        Location shape = Assert.Single(
+            Definitions(source, "Shape", occurrence: 1));
+        Location value = Assert.Single(
+            Definitions(source, "value", occurrence: 1));
+        Location nested = Assert.Single(
+            Definitions(source, "Nested", occurrence: 1));
+        Location run = Assert.Single(
+            Definitions(source, "run", occurrence: 1));
+        IReadOnlyList<Location> runReferences = References(
+            source,
+            "run",
+            occurrence: 1);
+
+        Assert.Equal(new Range(1, 19, 1, 24), shape.Range);
+        Assert.Equal(new Range(2, 15, 2, 20), value.Range);
+        Assert.Equal(new Range(3, 19, 3, 25), nested.Range);
+        Assert.Equal(new Range(4, 20, 4, 23), run.Range);
+        Assert.Equal(
+            [
+                new Range(4, 20, 4, 23),
+                new Range(9, 13, 9, 16),
+            ],
+            runReferences.Select(location => location.Range).ToArray());
+    }
+
+    [Fact]
+    public void NamespaceImportMembersResolveAcrossModules()
+    {
+        string root = Path.GetFullPath("namespace-import-navigation");
+        string dependencyPath = Path.Combine(root, "dependency.ts");
+        string entryPath = Path.Combine(root, "entry.ts");
+        const string dependency = """
+            export interface Shape { size: number; }
+            export const value = 1;
+            """;
+        const string entry = """
+            import * as lib from "./dependency";
+            const shape: lib.Shape = { size: 1 };
+            console.log(lib.value);
+            """;
+        var openDocuments = new Dictionary<string, string>
+        {
+            [dependencyPath] = dependency,
+            [entryPath] = entry,
+        };
+
+        Location shape = Assert.Single(
+            Definitions(
+                entryPath,
+                entry,
+                "Shape",
+                occurrence: 0,
+                openDocuments));
+        Location value = Assert.Single(
+            Definitions(
+                entryPath,
+                entry,
+                "value",
+                occurrence: 0,
+                openDocuments));
+
+        Assert.Equal(DocumentUri.FromFileSystemPath(dependencyPath), shape.Uri);
+        Assert.Equal(new Range(0, 17, 0, 22), shape.Range);
+        Assert.Equal(DocumentUri.FromFileSystemPath(dependencyPath), value.Uri);
+        Assert.Equal(new Range(1, 13, 1, 18), value.Range);
+
+        IReadOnlyList<Location> valueReferences = _references.FindReferences(
+            entryPath,
+            entry,
+            PositionOf(entry, "value", occurrence: 0),
+            includeDeclaration: true,
+            openDocuments);
+        Assert.Equal(2, valueReferences.Count);
+        Assert.Contains(
+            valueReferences,
+            location =>
+                location.Uri == DocumentUri.FromFileSystemPath(dependencyPath) &&
+                location.Range == new Range(1, 13, 1, 18));
+    }
+
+    private IReadOnlyList<Location> Definitions(
+        string source,
+        string name,
+        int occurrence) =>
+        Definitions(
+            Path.GetFullPath("navigation-domain.ts"),
+            source,
+            name,
+            occurrence,
+            new Dictionary<string, string>());
+
+    private IReadOnlyList<Location> Definitions(
+        string path,
+        string source,
+        string name,
+        int occurrence,
+        IReadOnlyDictionary<string, string> openDocuments)
+    {
+        Position position = PositionOf(source, name, occurrence);
+        return _definitions.FindDefinitions(
+            path,
+            source,
+            position,
+            openDocuments);
+    }
+
+    private IReadOnlyList<Location> References(
+        string source,
+        string name,
+        int occurrence)
+    {
+        string path = Path.GetFullPath("navigation-domain.ts");
+        return _references.FindReferences(
+            path,
+            source,
+            PositionOf(source, name, occurrence),
+            includeDeclaration: true,
+            new Dictionary<string, string> { [path] = source });
+    }
+
+    private static Position PositionOf(
+        string source,
+        string name,
+        int occurrence)
+    {
+        int offset = -1;
+        for (int i = 0; i <= occurrence; i++)
+        {
+            offset = source.IndexOf(
+                name,
+                offset + 1,
+                StringComparison.Ordinal);
+            Assert.True(offset >= 0);
+        }
+
+        var lines = new SharpTS.Parsing.LineIndex(source);
+        var (line, column) = lines.ToPosition(offset);
+        return new Position(line - 1, column - 1);
+    }
+}

--- a/SharpTS.Tests/LanguageServer/RenameServiceTests.cs
+++ b/SharpTS.Tests/LanguageServer/RenameServiceTests.cs
@@ -1,0 +1,232 @@
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpTS.LanguageServer;
+using SharpTS.LanguageServer.Handlers;
+using SharpTS.LanguageServer.Services;
+using SharpTS.Tests.IntegrationTests;
+using Xunit;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace SharpTS.Tests.LanguageServer;
+
+public class RenameServiceTests
+{
+    [Fact]
+    public void CompleteWorkspaceRenameEditsDeclarationsAliasesAndClosedImporters()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        directory.CreateFile(
+            "tsconfig.json",
+            """{ "include": ["**/*.ts"] }""");
+        string dependencyPath = directory.CreateFile(
+            "dependency.ts",
+            "export const original = 1;\n");
+        string importerPath = directory.CreateFile(
+            "importer.ts",
+            """
+            import { original as local } from "./dependency";
+            console.log(local);
+            local;
+            """);
+        string dependency = File.ReadAllText(dependencyPath);
+
+        WorkspaceEdit? edit = Service().Rename(
+            dependencyPath,
+            dependency,
+            PositionOf(dependency, "original"),
+            "renamed",
+            new Dictionary<string, string> { [dependencyPath] = dependency },
+            [directory.Path]);
+
+        Assert.NotNull(edit);
+        Assert.NotNull(edit.Changes);
+        Assert.Equal(2, edit.Changes.Count);
+        Assert.Equal(
+            [new Range(0, 13, 0, 21)],
+            edit.Changes[DocumentUri.FromFileSystemPath(dependencyPath)]
+                .Select(textEdit => textEdit.Range)
+                .ToArray());
+        Assert.Equal(
+            [
+                new Range(2, 0, 2, 5),
+                new Range(1, 12, 1, 17),
+                new Range(0, 21, 0, 26),
+                new Range(0, 9, 0, 17),
+            ],
+            edit.Changes[DocumentUri.FromFileSystemPath(importerPath)]
+                .Select(textEdit => textEdit.Range)
+                .ToArray());
+        Assert.All(
+            edit.Changes.Values.SelectMany(edits => edits),
+            textEdit => Assert.Equal("renamed", textEdit.NewText));
+    }
+
+    [Fact]
+    public void RenameRefusesAnIncompleteWorkspace()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        string path = directory.CreateFile(
+            "project/value.ts",
+            "export const value = 1;\nvalue;\n");
+        directory.CreateFile(
+            "project/tsconfig.json",
+            """{ "include": ["*.ts"] }""");
+        directory.CreateFile("broken/tsconfig.json", "{ not json");
+        string source = File.ReadAllText(path);
+
+        WorkspaceEdit? edit = Service().Rename(
+            path,
+            source,
+            PositionOf(source, "value"),
+            "renamed",
+            new Dictionary<string, string> { [path] = source },
+            [directory.Path]);
+
+        Assert.Null(edit);
+    }
+
+    [Fact]
+    public void RenameRefusesOpenDocumentFallbackWithoutAConfig()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        string path = directory.GetPath("value.ts");
+        const string source = "const value = 1;\nvalue;\n";
+
+        WorkspaceEdit? edit = Service().Rename(
+            path,
+            source,
+            PositionOf(source, "value"),
+            "renamed",
+            new Dictionary<string, string> { [path] = source },
+            [directory.Path]);
+
+        Assert.Null(edit);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("two words")]
+    [InlineData("class")]
+    [InlineData("value; other")]
+    [InlineData("123name")]
+    public void RenameRefusesInvalidBindingIdentifiers(string newName)
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        directory.CreateFile("tsconfig.json", """{ "include": ["*.ts"] }""");
+        string path = directory.CreateFile(
+            "value.ts",
+            "const value = 1;\nvalue;\n");
+        string source = File.ReadAllText(path);
+
+        WorkspaceEdit? edit = Service().Rename(
+            path,
+            source,
+            PositionOf(source, "value"),
+            newName,
+            new Dictionary<string, string> { [path] = source },
+            [directory.Path]);
+
+        Assert.Null(edit);
+    }
+
+    [Fact]
+    public void PrepareRenameReturnsOnlyACompleteBoundToken()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        directory.CreateFile("tsconfig.json", """{ "include": ["*.ts"] }""");
+        string path = directory.CreateFile(
+            "value.ts",
+            "const value = 1;\nvalue;\n");
+        string source = File.ReadAllText(path);
+        var service = Service();
+
+        Range? range = service.Prepare(
+            path,
+            source,
+            PositionOf(source, "value", occurrence: 1),
+            new Dictionary<string, string> { [path] = source },
+            [directory.Path]);
+        Range? whitespace = service.Prepare(
+            path,
+            source,
+            new Position(0, 5),
+            new Dictionary<string, string> { [path] = source },
+            [directory.Path]);
+
+        Assert.Equal(new Range(1, 0, 1, 5), range);
+        Assert.Null(whitespace);
+    }
+
+    [Fact]
+    public async Task HandlersUseTheInitializedWorkspaceCompletenessBoundary()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        directory.CreateFile("tsconfig.json", """{ "include": ["*.ts"] }""");
+        string path = directory.CreateFile(
+            "value.ts",
+            "const value = 1;\nvalue;\n");
+        string source = File.ReadAllText(path);
+        DocumentUri uri = DocumentUri.FromFileSystemPath(path);
+        var store = new DocumentStore();
+        store.Set(uri.ToString(), source);
+        var workspace = new NavigationWorkspaceContext();
+        workspace.Initialize(new InitializeParams
+        {
+            RootUri = DocumentUri.FromFileSystemPath(directory.Path),
+        });
+        var references = new ReferenceService();
+        var rename = new RenameService(references);
+
+        var prepared = await new PrepareRenameHandler(
+            store,
+            rename,
+            workspace).Handle(
+            new PrepareRenameParams
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Position = PositionOf(source, "value", occurrence: 1),
+            },
+            CancellationToken.None);
+        WorkspaceEdit? edit = await new RenameHandler(
+            store,
+            rename,
+            workspace).Handle(
+            new RenameParams
+            {
+                TextDocument = new TextDocumentIdentifier(uri),
+                Position = PositionOf(source, "value", occurrence: 1),
+                NewName = "renamed",
+            },
+            CancellationToken.None);
+
+        Assert.NotNull(prepared);
+        Assert.NotNull(edit);
+        Assert.NotNull(edit.Changes);
+        Assert.Equal(
+            2,
+            Assert.Single(edit.Changes).Value.Count());
+    }
+
+    private static RenameService Service() =>
+        new(new ReferenceService());
+
+    private static Position PositionOf(
+        string source,
+        string text,
+        int occurrence = 0)
+    {
+        int offset = -1;
+        for (int i = 0; i <= occurrence; i++)
+        {
+            offset = source.IndexOf(
+                text,
+                offset + 1,
+                StringComparison.Ordinal);
+            Assert.True(offset >= 0);
+        }
+
+        string before = source[..offset];
+        string[] lines = before.Split('\n');
+        return new Position(lines.Length - 1, lines[^1].Length);
+    }
+}

--- a/SharpTS.Tests/LanguageServer/RenameServiceTests.cs
+++ b/SharpTS.Tests/LanguageServer/RenameServiceTests.cs
@@ -207,6 +207,65 @@ public class RenameServiceTests
             Assert.Single(edit.Changes).Value.Count());
     }
 
+    [Fact]
+    public void RenameFromAClassValueUseIncludesTheTypeFacet()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        directory.CreateFile("tsconfig.json", """{ "include": ["*.ts"] }""");
+        string path = directory.CreateFile(
+            "box.ts",
+            """
+            class Box {}
+            const constructor = Box;
+            const item: Box = new Box();
+            """);
+        string source = File.ReadAllText(path);
+
+        WorkspaceEdit? edit = Service().Rename(
+            path,
+            source,
+            PositionOf(source, "Box", occurrence: 1),
+            "Container",
+            new Dictionary<string, string> { [path] = source },
+            [directory.Path]);
+
+        Assert.NotNull(edit);
+        Assert.NotNull(edit.Changes);
+        Assert.Equal(
+            4,
+            Assert.Single(edit.Changes).Value.Count());
+    }
+
+    [Fact]
+    public void LabelRenameIncludesBreakAndContinueTargets()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        directory.CreateFile("tsconfig.json", """{ "include": ["*.ts"] }""");
+        string path = directory.CreateFile(
+            "labels.ts",
+            """
+            outer: for (let i = 0; i < 2; i++) {
+              if (i === 0) continue outer;
+              break outer;
+            }
+            """);
+        string source = File.ReadAllText(path);
+
+        WorkspaceEdit? edit = Service().Rename(
+            path,
+            source,
+            PositionOf(source, "outer", occurrence: 1),
+            "loop",
+            new Dictionary<string, string> { [path] = source },
+            [directory.Path]);
+
+        Assert.NotNull(edit);
+        Assert.NotNull(edit.Changes);
+        Assert.Equal(
+            3,
+            Assert.Single(edit.Changes).Value.Count());
+    }
+
     private static RenameService Service() =>
         new(new ReferenceService());
 

--- a/SharpTS.Tests/LanguageServer/WorkspaceLifecycleTests.cs
+++ b/SharpTS.Tests/LanguageServer/WorkspaceLifecycleTests.cs
@@ -1,0 +1,217 @@
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpTS.Compilation;
+using SharpTS.LanguageServer;
+using SharpTS.LanguageServer.Conversions;
+using SharpTS.LanguageServer.Handlers;
+using SharpTS.LanguageServer.Services;
+using SharpTS.Tests.IntegrationTests;
+using SharpTS.TypeSystem;
+using Xunit;
+using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
+
+namespace SharpTS.Tests.LanguageServer;
+
+public sealed class WorkspaceLifecycleTests
+{
+    [Fact]
+    public void DocumentStoreAppliesIncrementalChangesAndRejectsStaleVersions()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        string path = directory.CreateFile("input.ts", "const value = 1;\n");
+        string uri = new Uri(path).AbsoluteUri;
+        var store = new DocumentStore();
+
+        Assert.True(store.Open(uri, "const value = 1;\n", version: 3));
+        Assert.True(store.ApplyChanges(
+            uri,
+            version: 4,
+            [
+                new TextDocumentContentChangeEvent
+                {
+                    Range = new Range(
+                        new Position(0, 6),
+                        new Position(0, 11)),
+                    Text = "answer",
+                },
+                new TextDocumentContentChangeEvent
+                {
+                    Range = new Range(
+                        new Position(0, 15),
+                        new Position(0, 16)),
+                    Text = "2",
+                },
+            ]));
+        Assert.False(store.ApplyChanges(
+            uri,
+            version: 4,
+            [new TextDocumentContentChangeEvent { Text = "stale" }]));
+
+        Assert.True(store.TryCapture(uri, out DocumentRequestSnapshot? snapshot));
+        Assert.Equal(4, snapshot.Document.Version);
+        Assert.Equal("const answer = 2;\n", snapshot.Document.Text);
+        Assert.Same(
+            snapshot.Document,
+            Assert.Single(snapshot.FileSystemDocuments).Value);
+    }
+
+    [Fact]
+    public async Task DependencyChangeRepublishesOpenImporters()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        string dependencyPath = directory.CreateFile(
+            "dependency.ts",
+            "export const value = 1;\n");
+        string importerPath = directory.CreateFile(
+            "importer.ts",
+            "import { value } from \"./dependency\";\nconst text: string = value;\n");
+        string dependencyUri = new Uri(dependencyPath).AbsoluteUri;
+        string importerUri = new Uri(importerPath).AbsoluteUri;
+        var store = new DocumentStore();
+        store.Open(
+            dependencyUri,
+            File.ReadAllText(dependencyPath),
+            version: 1);
+        store.Open(
+            importerUri,
+            File.ReadAllText(importerPath),
+            version: 1);
+
+        List<PublishDiagnosticsParams> published = [];
+        using var coordinator = new DiagnosticsCoordinator(
+            store,
+            new DiagnosticsService(),
+            new DocumentDependencyGraph(),
+            new DiagnosticsSettings(DiagnosticPublishMode.All),
+            published.Add,
+            TimeSpan.Zero);
+
+        coordinator.Queue(importerUri);
+        await coordinator.DrainAsync();
+        Assert.NotEmpty(Assert.Single(published).Diagnostics);
+        published.Clear();
+
+        store.Open(
+            dependencyUri,
+            "export const value = \"ready\";\n",
+            version: 2);
+        coordinator.Queue(dependencyUri);
+        await coordinator.DrainAsync();
+
+        Assert.True(
+            new HashSet<string>(
+                published.Select(item => item.Uri.ToString()),
+                StringComparer.OrdinalIgnoreCase)
+                .SetEquals([dependencyUri, importerUri]));
+        Assert.Contains(published, item =>
+            string.Equals(
+                item.Uri.ToString(),
+                dependencyUri,
+                StringComparison.OrdinalIgnoreCase) &&
+            item.Version == 2);
+        Assert.Contains(published, item =>
+            string.Equals(
+                item.Uri.ToString(),
+                importerUri,
+                StringComparison.OrdinalIgnoreCase) &&
+            item.Version == 1);
+        Assert.Empty(Assert.Single(published, item =>
+            string.Equals(
+                item.Uri.ToString(),
+                importerUri,
+                StringComparison.OrdinalIgnoreCase)).Diagnostics);
+    }
+
+    [Fact]
+    public async Task NewVersionCancelsStaleDebouncedPublication()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        string path = directory.CreateFile("input.ts", "const first = 1;\n");
+        string uri = new Uri(path).AbsoluteUri;
+        var store = new DocumentStore();
+        store.Open(uri, "const first = 1;\n", version: 1);
+        List<PublishDiagnosticsParams> published = [];
+        using var coordinator = new DiagnosticsCoordinator(
+            store,
+            new DiagnosticsService(),
+            new DocumentDependencyGraph(),
+            new DiagnosticsSettings(),
+            published.Add,
+            TimeSpan.FromMilliseconds(25));
+
+        coordinator.Queue(uri);
+        store.Open(uri, "const second = 2;\n", version: 2);
+        coordinator.Queue(uri);
+        await coordinator.DrainAsync();
+
+        PublishDiagnosticsParams result = Assert.Single(published);
+        Assert.Equal(2, result.Version);
+    }
+
+    [Fact]
+    public void AllDiagnosticsUsesTheCachedFullCheckerResult()
+    {
+        const string source = "const value: string = 1;";
+        var snapshot = new DocumentSnapshot(
+            "untitled:check",
+            source,
+            Version: 1,
+            FilePath: null);
+        var service = new DiagnosticsService();
+
+        Assert.Empty(service.Analyze(
+            snapshot,
+            DiagnosticPublishMode.SharpTsOnly,
+            CancellationToken.None));
+        Assert.Contains(
+            service.Analyze(
+                snapshot,
+                DiagnosticPublishMode.All,
+                CancellationToken.None),
+            diagnostic => diagnostic.Message.Contains(
+                "not assignable",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ConfigurationAcceptsBothClientShapes()
+    {
+        Assert.Equal(
+            "off",
+            ConfigurationHandler.FindDiagnosticsValue(
+                Newtonsoft.Json.Linq.JObject.Parse(
+                    """{ "sharpts": { "diagnostics": "off" } }""")));
+        Assert.Equal(
+            "all",
+            ConfigurationHandler.FindDiagnosticsValue(
+                Newtonsoft.Json.Linq.JObject.Parse(
+                    """{ "diagnostics": "all" }""")));
+    }
+
+    [Fact]
+    public void CheckerObservesEditorCancellation()
+    {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var checker = new TypeChecker()
+            .WithCancellation(cancellation.Token);
+
+        Assert.Throws<OperationCanceledException>(() =>
+            checker.CheckWithRecovery([]));
+    }
+
+    [Fact]
+    public void ReferenceLoaderReloadKeepsTypesFromRetiredContextUsable()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        string assemblyPath = directory.CreateFile("changing.dll", "not an assembly");
+        using var loader = new ReloadingAssemblyReferenceLoader([assemblyPath]);
+        Type? original = loader.TryResolve("System.String");
+        Assert.NotNull(original);
+
+        File.WriteAllText(assemblyPath, "changed assembly placeholder");
+        Assert.NotNull(loader.TryResolve("System.String"));
+
+        Assert.Equal(1, loader.Generation);
+        Assert.Equal("System.String", original!.FullName);
+    }
+}

--- a/TypeSystem/TypeChecker.Expressions.cs
+++ b/TypeSystem/TypeChecker.Expressions.cs
@@ -1368,27 +1368,10 @@ public partial class TypeChecker
         if (arrow.TypeParams != null && arrow.TypeParams.Count > 0)
         {
             typeParamEnv = new TypeEnvironment(_environment);
-
-            // First pass: define all type parameters without constraints
-            foreach (var tp in arrow.TypeParams)
-            {
-                var typeParam = new TypeInfo.TypeParameter(tp.Name.Lexeme, null, null, tp.IsConst, tp.Variance);
-                typeParamEnv.DefineTypeParameter(tp.Name.Lexeme, typeParam);
-            }
-
-            // Second pass: parse constraints/defaults (can reference other type parameters)
             using (new EnvironmentScope(this, typeParamEnv))
-            {
-                typeParams = [];
-                foreach (var tp in arrow.TypeParams)
-                {
-                    TypeInfo? constraint = ResolveAnnotation(tp.Constraint, tp.ConstraintNode);
-                    TypeInfo? defaultType = ResolveAnnotation(tp.Default, tp.DefaultNode);
-                    var typeParam = new TypeInfo.TypeParameter(tp.Name.Lexeme, constraint, defaultType, tp.IsConst, tp.Variance);
-                    typeParams.Add(typeParam);
-                    typeParamEnv.DefineTypeParameter(tp.Name.Lexeme, typeParam);
-                }
-            }
+                typeParams = BuildGenericTypeParameters(
+                    arrow.TypeParams,
+                    typeParamEnv);
         }
 
         // Parse 'this' type, parameter types, and return type in the type-parameter scope
@@ -1535,7 +1518,7 @@ public partial class TypeChecker
         var previousInferredYieldTypes = _inferredYieldTypes;
         int previousLoopDepth = _loopDepth;
         int previousSwitchDepth = _switchDepth;
-        var previousActiveLabels = new Dictionary<string, bool>(_activeLabels);
+        var previousActiveLabels = new Dictionary<string, ActiveLabel>(_activeLabels);
 
         bool inferringArrowReturn = returnType is TypeInfo.Inferred;
         _environment = arrowEnv;
@@ -2209,8 +2192,17 @@ public partial class TypeChecker
         TypeEnvironment classEnv = new(_environment);
         if (classTypeParams != null)
         {
-            foreach (var tp in classTypeParams)
-                classEnv.DefineTypeParameter(tp.Name, tp);
+            for (int i = 0; i < classTypeParams.Count; i++)
+            {
+                if (classExpr.TypeParams is { } declarations &&
+                    i < declarations.Count)
+                {
+                    DefineSourceTypeParameter(
+                        classEnv,
+                        declarations[i],
+                        classTypeParams[i]);
+                }
+            }
         }
         classEnv.Define("this", new TypeInfo.Instance(classTypeForBody));
         if (superclass != null)
@@ -2287,7 +2279,7 @@ public partial class TypeChecker
                 bool previousInGeneratorFunc = _inGeneratorFunction;
                 int previousLoopDepthFunc = _loopDepth;
                 int previousSwitchDepthFunc = _switchDepth;
-                var previousActiveLabelsFunc = new Dictionary<string, bool>(_activeLabels);
+                var previousActiveLabelsFunc = new Dictionary<string, ActiveLabel>(_activeLabels);
 
                 bool inferringMethodReturn = methodType.ReturnType is TypeInfo.Inferred;
                 _environment = methodEnv;
@@ -2417,7 +2409,7 @@ public partial class TypeChecker
                     TypeInfo? previousReturnAcc = _currentFunctionReturnType;
                     int previousLoopDepthAcc = _loopDepth;
                     int previousSwitchDepthAcc = _switchDepth;
-                    var previousActiveLabelsAcc = new Dictionary<string, bool>(_activeLabels);
+                    var previousActiveLabelsAcc = new Dictionary<string, ActiveLabel>(_activeLabels);
                     bool previousInStaticAcc = _inStaticMethod;
 
                     _environment = accessorEnv;

--- a/TypeSystem/TypeChecker.Namespaces.cs
+++ b/TypeSystem/TypeChecker.Namespaces.cs
@@ -22,22 +22,38 @@ public partial class TypeChecker
         TypeInfo.Namespace? existingNs = _environment.GetNamespace(name);
         Dictionary<string, TypeInfo> types;
         Dictionary<string, TypeInfo> values;
+        Dictionary<string, BindingSymbol> typeBindings;
+        Dictionary<string, BindingSymbol> valueBindings;
 
         if (existingNs != null)
         {
             // Declaration merging - start with existing members
             types = new Dictionary<string, TypeInfo>(existingNs.Types);
             values = new Dictionary<string, TypeInfo>(existingNs.Values);
+            typeBindings = existingNs.TypeBindings is null
+                ? []
+                : new Dictionary<string, BindingSymbol>(
+                    existingNs.TypeBindings);
+            valueBindings = existingNs.ValueBindings is null
+                ? []
+                : new Dictionary<string, BindingSymbol>(
+                    existingNs.ValueBindings);
         }
         else
         {
             // New namespace
             types = new Dictionary<string, TypeInfo>();
             values = new Dictionary<string, TypeInfo>();
+            typeBindings = [];
+            valueBindings = [];
         }
 
         // Create new scope for namespace body
         var namespaceEnv = new TypeEnvironment(_environment);
+        foreach (var (memberName, binding) in typeBindings)
+            namespaceEnv.DefineTypeBinding(memberName, binding);
+        foreach (var (memberName, binding) in valueBindings)
+            namespaceEnv.DefineValueBinding(memberName, binding);
 
         // For merged namespaces, propagate existing nested namespaces into the new scope
         // This allows GetNamespace() to find previously-defined nested namespaces
@@ -89,6 +105,12 @@ public partial class TypeChecker
                 {
                     CollectNamespaceMemberType(member, types);
                 }
+                CaptureNamespaceBindings(
+                    namespaceEnv,
+                    types,
+                    values,
+                    typeBindings,
+                    valueBindings);
                 // Self-bind THIS namespace's own name into its own body scope from the members
                 // collected so far, so a later nested-namespace member body checked in this same
                 // pass can reference the enclosing namespace by its own dotted name (`O.A.g()`
@@ -101,7 +123,15 @@ public partial class TypeChecker
                 // functions/vars enter `values` only in the second pass, so `O.outerFunc()` by the
                 // enclosing namespace's own name is not covered (the bare form works via #665). (#745)
                 _environment.DefineNamespace(name, new TypeInfo.Namespace(
-                    name, types.ToFrozenDictionary(), values.ToFrozenDictionary()));
+                    name,
+                    types.ToFrozenDictionary(),
+                    values.ToFrozenDictionary(),
+                    typeBindings.Count == 0
+                        ? null
+                        : typeBindings.ToFrozenDictionary(),
+                    valueBindings.Count == 0
+                        ? null
+                        : valueBindings.ToFrozenDictionary()));
             }
 
             // Second pass: fully type-check all members. In recovery mode, check each member
@@ -122,12 +152,51 @@ public partial class TypeChecker
                 {
                     CheckNamespaceMember(member, values);
                 }
+                CaptureNamespaceBindings(
+                    namespaceEnv,
+                    types,
+                    values,
+                    typeBindings,
+                    valueBindings);
             }
         }
 
         // Create namespace with frozen collections
-        var nsType = new TypeInfo.Namespace(name, types.ToFrozenDictionary(), values.ToFrozenDictionary());
+        var nsType = new TypeInfo.Namespace(
+            name,
+            types.ToFrozenDictionary(),
+            values.ToFrozenDictionary(),
+            typeBindings.Count == 0
+                ? null
+                : typeBindings.ToFrozenDictionary(),
+            valueBindings.Count == 0
+                ? null
+                : valueBindings.ToFrozenDictionary());
         _environment.DefineNamespace(name, nsType);
+    }
+
+    private static void CaptureNamespaceBindings(
+        TypeEnvironment environment,
+        IReadOnlyDictionary<string, TypeInfo> types,
+        IReadOnlyDictionary<string, TypeInfo> values,
+        Dictionary<string, BindingSymbol> typeBindings,
+        Dictionary<string, BindingSymbol> valueBindings)
+    {
+        foreach (string memberName in types.Keys)
+        {
+            if (environment.GetLocalTypeSymbol(memberName) is { } typeBinding)
+                typeBindings[memberName] = typeBinding;
+            if (environment.GetLocalValueBinding(memberName) is { } valueBinding)
+                valueBindings[memberName] = valueBinding;
+        }
+
+        foreach (string memberName in values.Keys)
+        {
+            if (environment.GetLocalValueBinding(memberName) is { } valueBinding)
+                valueBindings[memberName] = valueBinding;
+            if (environment.GetLocalTypeSymbol(memberName) is { } typeBinding)
+                typeBindings[memberName] = typeBinding;
+        }
     }
 
     /// <summary>
@@ -308,10 +377,15 @@ public partial class TypeChecker
             throw new TypeCheckException(
                 $"Type Error at line {path[0].Line}: Namespace '{path[0].Lexeme}' is not defined.", tsCode: "TS2503");
         }
+        if (_environment.GetValueBinding(path[0].Lexeme) is { } rootValue)
+            Bindings.Bind(path[0], CurrentSourceDocument, rootValue);
+        if (_environment.GetTypeSymbol(path[0].Lexeme) is { } rootType)
+            Bindings.Bind(path[0], CurrentSourceDocument, rootType);
 
         // Walk the path until the last element
         for (int i = 1; i < path.Count - 1; i++)
         {
+            BindNamespaceMemberFacets(currentNs, path[i]);
             var memberType = currentNs.GetMember(path[i].Lexeme);
             if (memberType is TypeInfo.Namespace nestedNs)
             {
@@ -331,6 +405,7 @@ public partial class TypeChecker
 
         // Get the final member
         Token finalMember = path[^1];
+        BindNamespaceMemberFacets(currentNs, finalMember);
         TypeInfo? resolvedType = currentNs.Values.GetValueOrDefault(finalMember.Lexeme)
             ?? currentNs.Types.GetValueOrDefault(finalMember.Lexeme);
 
@@ -357,5 +432,15 @@ public partial class TypeChecker
         if (isValue)
             RegisterValueDeclaration(importAlias.AliasName);
         _environment.DefineImportAlias(aliasName, resolvedType, isValue);
+    }
+
+    private void BindNamespaceMemberFacets(
+        TypeInfo.Namespace namespaceType,
+        Token member)
+    {
+        if (namespaceType.GetValueBinding(member.Lexeme) is { } valueBinding)
+            Bindings.Bind(member, CurrentSourceDocument, valueBinding);
+        if (namespaceType.GetTypeBinding(member.Lexeme) is { } typeBinding)
+            Bindings.Bind(member, CurrentSourceDocument, typeBinding);
     }
 }

--- a/TypeSystem/TypeChecker.Properties.Helpers.cs
+++ b/TypeSystem/TypeChecker.Properties.Helpers.cs
@@ -172,11 +172,28 @@ public partial class TypeChecker
         // Expression-space lookup must prefer the value facet when a namespace
         // exports both a type and a value with the same name (for example
         // `interface Intl.PluralRules` plus `const Intl.PluralRules`).
-        var memberType = nsType.Values.GetValueOrDefault(memberName.Lexeme)
-            ?? nsType.Types.GetValueOrDefault(memberName.Lexeme);
-        if (memberType != null)
+        if (nsType.Values.GetValueOrDefault(memberName.Lexeme)
+            is { } valueMember)
         {
-            return memberType;
+            if (nsType.GetValueBinding(memberName.Lexeme) is { } valueBinding)
+                Bindings.Bind(
+                    memberName,
+                    CurrentSourceDocument,
+                    valueBinding);
+            return valueMember;
+        }
+        if (nsType.Types.GetValueOrDefault(memberName.Lexeme)
+            is { } typeMember)
+        {
+            BindingSymbol? binding =
+                nsType.GetValueBinding(memberName.Lexeme)
+                ?? nsType.GetTypeBinding(memberName.Lexeme);
+            if (binding is not null)
+                Bindings.Bind(
+                    memberName,
+                    CurrentSourceDocument,
+                    binding);
+            return typeMember;
         }
         throw new TypeCheckException($" '{memberName.Lexeme}' does not exist on namespace '{nsType.Name}'.", tsCode: "TS2694");
     }

--- a/TypeSystem/TypeChecker.Statements.AliasValidation.cs
+++ b/TypeSystem/TypeChecker.Statements.AliasValidation.cs
@@ -70,6 +70,7 @@ public partial class TypeChecker
                     infer.Line, tsCode: "TS1338");
 
             case NamedTypeNode { TypeArguments: null } bare:
+                BindTypeUse(bare);
                 // A name that is only bound as an infer of an enclosing conditional, referenced
                 // from a position where infers are not in scope (check type, false branch).
                 // Restricted to KNOWN infer names — general unknown-name TS2304 is parked (the
@@ -85,6 +86,7 @@ public partial class TypeChecker
                 return;
 
             case NamedTypeNode { TypeArguments: { } argNodes } genericRef:
+                BindTypeUse(genericRef);
                 ValidateGenericReferenceArguments(genericRef, argNodes);
                 foreach (var arg in argNodes)
                     ValidateAliasBodyNode(arg, inferLegal, infersOutOfScope);
@@ -108,6 +110,7 @@ public partial class TypeChecker
                         $" Type '{TryToTypeInfo(mapped.Constraint)}' is not assignable to type 'string | number | symbol'.",
                         mapped.Line, tsCode: "TS2322");
                 }
+                _ = TryResolveMappedType(mapped);
                 foreach (var child in TypeNodeChildren(node))
                     ValidateAliasBodyNode(child, inferLegal, infersOutOfScope);
                 return;
@@ -150,7 +153,17 @@ public partial class TypeChecker
                         TypeInfo? constraint = infer.Constraint is { } cNode ? TryToTypeInfo(cNode) : null;
                         if (constraint is null && positional is not null)
                             positional.TryGetValue(infer.Name, out constraint);
-                        trueEnv.DefineTypeParameter(infer.Name, new TypeInfo.TypeParameter(infer.Name, constraint));
+                        TypeInfo inferred =
+                            new TypeInfo.TypeParameter(infer.Name, constraint);
+                        if (infer.NameToken is { } nameToken)
+                            DefineSourceTypeParameter(
+                                trueEnv,
+                                nameToken,
+                                inferred);
+                        else
+                            trueEnv.DefineTypeParameter(
+                                infer.Name,
+                                inferred);
                     }
                 }
                 if (conditional.CheckType is NamedTypeNode { TypeArguments: null } checkRef &&

--- a/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -763,8 +763,17 @@ public partial class TypeChecker
         // For generic classes, add type parameters to class scope
         if (classTypeParams != null)
         {
-            foreach (var tp in classTypeParams)
-                classEnv.DefineTypeParameter(tp.Name, tp);
+            for (int i = 0; i < classTypeParams.Count; i++)
+            {
+                if (classStmt.TypeParams is { } declarations &&
+                    i < declarations.Count)
+                {
+                    DefineSourceTypeParameter(
+                        classEnv,
+                        declarations[i],
+                        classTypeParams[i]);
+                }
+            }
         }
         classEnv.Define("this", new TypeInfo.Instance(classTypeForBody));
         if (superclass != null)
@@ -899,7 +908,7 @@ public partial class TypeChecker
                 bool previousInGeneratorFunc = _inGeneratorFunction;
                 int previousLoopDepthFunc = _loopDepth;
                 int previousSwitchDepthFunc = _switchDepth;
-                var previousActiveLabelsFunc = new Dictionary<string, bool>(_activeLabels);
+                var previousActiveLabelsFunc = new Dictionary<string, ActiveLabel>(_activeLabels);
 
                 bool inferringMethodReturn = methodType.ReturnType is TypeInfo.Inferred;
                 _environment = methodEnv;
@@ -1046,7 +1055,7 @@ public partial class TypeChecker
                     TypeInfo? previousReturnAcc = _currentFunctionReturnType;
                     int previousLoopDepthAcc = _loopDepth;
                     int previousSwitchDepthAcc = _switchDepth;
-                    var previousActiveLabelsAcc = new Dictionary<string, bool>(_activeLabels);
+                    var previousActiveLabelsAcc = new Dictionary<string, ActiveLabel>(_activeLabels);
                     bool previousInStaticAcc = _inStaticMethod;
 
                     _environment = accessorEnv;
@@ -1272,13 +1281,10 @@ public partial class TypeChecker
         TypeEnvironment classTypeEnv = new(_environment);
         if (classStmt.TypeParams != null && classStmt.TypeParams.Count > 0)
         {
-            foreach (var tp in classStmt.TypeParams)
-            {
-                TypeInfo? constraint = ResolveAnnotation(tp.Constraint, tp.ConstraintNode);
-                TypeInfo? defaultType = ResolveAnnotation(tp.Default, tp.DefaultNode);
-                var typeParam = new TypeInfo.TypeParameter(tp.Name.Lexeme, constraint, defaultType, tp.IsConst, tp.Variance);
-                classTypeEnv.DefineTypeParameter(tp.Name.Lexeme, typeParam);
-            }
+            using (new EnvironmentScope(this, classTypeEnv))
+                BuildGenericTypeParameters(
+                    classStmt.TypeParams,
+                    classTypeEnv);
         }
 
         // Create mutable class early so self-references in method return types work.

--- a/TypeSystem/TypeChecker.Statements.Functions.cs
+++ b/TypeSystem/TypeChecker.Statements.Functions.cs
@@ -18,7 +18,17 @@ public partial class TypeChecker
     private List<TypeInfo.TypeParameter> BuildGenericTypeParameters(List<TypeParam> decls, TypeEnvironment env)
     {
         foreach (var tp in decls)
-            env.DefineTypeParameter(tp.Name.Lexeme, new TypeInfo.TypeParameter(tp.Name.Lexeme, null, null, tp.IsConst, tp.Variance));
+        {
+            DefineSourceTypeParameter(
+                env,
+                tp,
+                new TypeInfo.TypeParameter(
+                    tp.Name.Lexeme,
+                    null,
+                    null,
+                    tp.IsConst,
+                    tp.Variance));
+        }
 
         List<TypeInfo.TypeParameter> result = [];
         for (int pass = 0; pass < decls.Count; pass++)
@@ -30,7 +40,7 @@ public partial class TypeChecker
                 TypeInfo? defaultType = ResolveAnnotation(tp.Default, tp.DefaultNode);
                 var typeParam = new TypeInfo.TypeParameter(tp.Name.Lexeme, constraint, defaultType, tp.IsConst, tp.Variance);
                 result.Add(typeParam);
-                env.DefineTypeParameter(tp.Name.Lexeme, typeParam);
+                DefineSourceTypeParameter(env, tp, typeParam);
             }
         }
         return result;
@@ -143,8 +153,23 @@ public partial class TypeChecker
         // references inside the body resolve and the inferred return is expressed in those terms.
         if (typeParams is { Count: > 0 })
         {
-            foreach (var tp in typeParams)
-                funcEnv.DefineTypeParameter(tp.Name, tp);
+            for (int i = 0; i < typeParams.Count; i++)
+            {
+                if (funcStmt.TypeParams is { } declarations &&
+                    i < declarations.Count)
+                {
+                    DefineSourceTypeParameter(
+                        funcEnv,
+                        declarations[i],
+                        typeParams[i]);
+                }
+                else
+                {
+                    funcEnv.DefineTypeParameter(
+                        typeParams[i].Name,
+                        typeParams[i]);
+                }
+            }
         }
         CheckFunctionBodyAndInferReturn(
             funcStmt, funcEnv, paramTypes, requiredParams, hasRest,
@@ -701,7 +726,7 @@ public partial class TypeChecker
         bool previousInGenerator = _inGeneratorFunction;
         int previousLoopDepth = _loopDepth;
         int previousSwitchDepth = _switchDepth;
-        var previousActiveLabels = new Dictionary<string, bool>(_activeLabels);
+        var previousActiveLabels = new Dictionary<string, ActiveLabel>(_activeLabels);
         bool previousRecoveryMode = _recoveryMode;
 
         var previousInferredReturnTypes = _inferredReturnTypes;

--- a/TypeSystem/TypeChecker.Statements.Interfaces.cs
+++ b/TypeSystem/TypeChecker.Statements.Interfaces.cs
@@ -160,7 +160,7 @@ public partial class TypeChecker
             foreach (var tp in interfaceStmt.TypeParams)
             {
                 var typeParam = new TypeInfo.TypeParameter(tp.Name.Lexeme, null, null, tp.IsConst, tp.Variance);
-                interfaceTypeEnv.DefineTypeParameter(tp.Name.Lexeme, typeParam);
+                DefineSourceTypeParameter(interfaceTypeEnv, tp, typeParam);
             }
 
             // Second pass: parse constraints (which may reference other type parameters)
@@ -184,7 +184,7 @@ public partial class TypeChecker
                     var typeParam = new TypeInfo.TypeParameter(tp.Name.Lexeme, constraint, defaultType, tp.IsConst, tp.Variance);
                     interfaceTypeParams.Add(typeParam);
                     // Redefine with the actual constraint
-                    interfaceTypeEnv.DefineTypeParameter(tp.Name.Lexeme, typeParam);
+                    DefineSourceTypeParameter(interfaceTypeEnv, tp, typeParam);
                 }
             }
         }
@@ -329,28 +329,10 @@ public partial class TypeChecker
         TypeEnvironment interfaceTypeEnv = new(_environment);
         if (interfaceStmt.TypeParams != null && interfaceStmt.TypeParams.Count > 0)
         {
-            interfaceTypeParams = [];
-
-            // First pass: define all type parameters without constraints so they can reference each other
-            foreach (var tp in interfaceStmt.TypeParams)
-            {
-                var typeParam = new TypeInfo.TypeParameter(tp.Name.Lexeme, null, null, tp.IsConst, tp.Variance);
-                interfaceTypeEnv.DefineTypeParameter(tp.Name.Lexeme, typeParam);
-            }
-
-            // Second pass: parse constraints (which may reference other type parameters, including themselves)
             using (new EnvironmentScope(this, interfaceTypeEnv))
-            {
-                foreach (var tp in interfaceStmt.TypeParams)
-                {
-                    TypeInfo? constraint = ResolveAnnotation(tp.Constraint, tp.ConstraintNode);
-                    TypeInfo? defaultType = ResolveAnnotation(tp.Default, tp.DefaultNode);
-                    var typeParam = new TypeInfo.TypeParameter(tp.Name.Lexeme, constraint, defaultType, tp.IsConst, tp.Variance);
-                    interfaceTypeParams.Add(typeParam);
-                    // Redefine with the actual constraint
-                    interfaceTypeEnv.DefineTypeParameter(tp.Name.Lexeme, typeParam);
-                }
-            }
+                interfaceTypeParams = BuildGenericTypeParameters(
+                    interfaceStmt.TypeParams,
+                    interfaceTypeEnv);
         }
 
         // Use interfaceTypeEnv for member type resolution so T resolves correctly
@@ -772,24 +754,6 @@ public partial class TypeChecker
     }
 
     /// <summary>
-    /// Parses type parameters from a signature into TypeInfo.TypeParameter list.
-    /// </summary>
-    private List<TypeInfo.TypeParameter>? ParseSignatureTypeParams(List<TypeParam>? typeParams)
-    {
-        if (typeParams == null || typeParams.Count == 0)
-            return null;
-
-        List<TypeInfo.TypeParameter> result = [];
-        foreach (var tp in typeParams)
-        {
-            TypeInfo? constraint = ResolveAnnotation(tp.Constraint, tp.ConstraintNode);
-            TypeInfo? defaultType = ResolveAnnotation(tp.Default, tp.DefaultNode);
-            result.Add(new TypeInfo.TypeParameter(tp.Name.Lexeme, constraint, defaultType, tp.IsConst, tp.Variance));
-        }
-        return result;
-    }
-
-    /// <summary>
     /// Views a class's instance shape (fields, methods, getters — own and inherited) as an
     /// interface, for `interface I extends SomeClass`.
     /// </summary>
@@ -878,12 +842,8 @@ public partial class TypeChecker
         var env = new TypeEnvironment(parent);
         if (typeParams is { Count: > 0 })
         {
-            foreach (var tp in typeParams)
-                env.DefineTypeParameter(tp.Name.Lexeme, new TypeInfo.TypeParameter(tp.Name.Lexeme));
             using (new EnvironmentScope(this, env))
-                sigTypeParams = ParseSignatureTypeParams(typeParams);
-            foreach (var tp in sigTypeParams!)
-                env.DefineTypeParameter(tp.Name, tp);
+                sigTypeParams = BuildGenericTypeParameters(typeParams, env);
         }
         else
         {

--- a/TypeSystem/TypeChecker.Statements.cs
+++ b/TypeSystem/TypeChecker.Statements.cs
@@ -69,7 +69,11 @@ public partial class TypeChecker
             isOnLoop = true;
         }
 
-        _activeLabels[labelName] = isOnLoop;
+        BindingSymbol labelSymbol = Bindings.Declare(
+            stmt.Label,
+            CurrentSourceDocument,
+            BindingNamespace.Label);
+        _activeLabels[labelName] = new ActiveLabel(isOnLoop, labelSymbol);
         try
         {
             CheckStmt(stmt.Statement);
@@ -1117,10 +1121,14 @@ public partial class TypeChecker
         if (stmt.Label != null)
         {
             string labelName = stmt.Label.Lexeme;
-            if (!_activeLabels.ContainsKey(labelName))
+            if (!_activeLabels.TryGetValue(labelName, out var activeLabel))
             {
                 throw new TypeCheckException($"Label '{labelName}' not found", tsCode: "TS1116");
             }
+            Bindings.Bind(
+                stmt.Label,
+                CurrentSourceDocument,
+                activeLabel.Symbol);
         }
         else
         {
@@ -1155,14 +1163,18 @@ public partial class TypeChecker
         if (stmt.Label != null)
         {
             string labelName = stmt.Label.Lexeme;
-            if (!_activeLabels.TryGetValue(labelName, out bool isOnLoop))
+            if (!_activeLabels.TryGetValue(labelName, out var activeLabel))
             {
                 throw new TypeCheckException($"Label '{labelName}' not found", tsCode: "TS1116");
             }
-            if (!isOnLoop)
+            if (!activeLabel.IsOnLoop)
             {
                 throw new TypeOperationException($"Cannot continue to non-loop label '{labelName}'", tsCode: "TS1116");
             }
+            Bindings.Bind(
+                stmt.Label,
+                CurrentSourceDocument,
+                activeLabel.Symbol);
         }
         else
         {

--- a/TypeSystem/TypeChecker.TypeNodes.cs
+++ b/TypeSystem/TypeChecker.TypeNodes.cs
@@ -29,7 +29,7 @@ public partial class TypeChecker
             // identical semantics by construction, with none of the scanning hazards strings
             // have for COMPOSITE types. Never routes back through ToTypeInfo(string).
             case NamedTypeNode { TypeArguments: null } named:
-                BindTypeUse(named.NameToken, named.Name);
+                BindTypeUse(named);
                 return ResolveTypeName(named.Name);
 
             // Generic references resolve their argument nodes and hand off to the shared
@@ -38,7 +38,7 @@ public partial class TypeChecker
             // errors). ResolveGenericType owns the built-ins-before-aliases shadowing precedence.
             case NamedTypeNode { TypeArguments: { } argNodes } named:
             {
-                BindTypeUse(named.NameToken, named.Name);
+                BindTypeUse(named);
                 List<TypeInfo> typeArgs = new(argNodes.Count);
                 foreach (var argNode in argNodes)
                 {
@@ -134,7 +134,17 @@ public partial class TypeChecker
                 {
                     var inferEnv = new TypeEnvironment(_environment);
                     foreach (var inf in clauseInfers)
-                        inferEnv.DefineTypeParameter(inf.Name, new TypeInfo.InferredTypeParameter(inf.Name));
+                    {
+                        TypeInfo inferred =
+                            new TypeInfo.InferredTypeParameter(inf.Name);
+                        if (inf.NameToken is { } nameToken)
+                            DefineSourceTypeParameter(
+                                inferEnv,
+                                nameToken,
+                                inferred);
+                        else
+                            inferEnv.DefineTypeParameter(inf.Name, inferred);
+                    }
                     using (new EnvironmentScope(this, inferEnv))
                     {
                         extendsType = TryToTypeInfo(conditional.ExtendsType);
@@ -448,7 +458,12 @@ public partial class TypeChecker
 
         // First pass: declare every name unconstrained.
         foreach (var tp in typeParameters)
-            typeParamEnv.DefineTypeParameter(tp.Name.Lexeme, new TypeInfo.TypeParameter(tp.Name.Lexeme));
+        {
+            DefineSourceTypeParameter(
+                typeParamEnv,
+                tp,
+                new TypeInfo.TypeParameter(tp.Name.Lexeme));
+        }
 
         var typeParams = new List<TypeInfo.TypeParameter>();
         TypeInfo? bodyType;
@@ -461,7 +476,7 @@ public partial class TypeChecker
                 TypeInfo? defaultType = ResolveAnnotation(tp.Default, tp.DefaultNode);
                 var resolved = new TypeInfo.TypeParameter(tp.Name.Lexeme, constraint, defaultType);
                 typeParams.Add(resolved);
-                typeParamEnv.DefineTypeParameter(tp.Name.Lexeme, resolved);
+                DefineSourceTypeParameter(typeParamEnv, tp, resolved);
             }
 
             bodyType = TryToTypeInfo(body);
@@ -488,16 +503,30 @@ public partial class TypeChecker
 
         _openTypeVariablesInScope ??= new HashSet<string>(StringComparer.Ordinal);
         bool openVarAdded = _openTypeVariablesInScope.Add(mapped.ParamName);
+        var mappedEnv = new TypeEnvironment(_environment);
+        TypeInfo mappedParameter = new TypeInfo.TypeParameter(mapped.ParamName);
+        if (mapped.ParamToken is { } parameterToken)
+            DefineSourceTypeParameter(mappedEnv, parameterToken, mappedParameter);
+        else
+            mappedEnv.DefineTypeParameter(mapped.ParamName, mappedParameter);
         try
         {
-            TypeInfo? asClause = null;
-            if (mapped.AsClause is { } asNode)
+            using (new EnvironmentScope(this, mappedEnv))
             {
-                if (TryToTypeInfo(asNode) is not { } resolvedAs) return null;
-                asClause = resolvedAs;
+                TypeInfo? asClause = null;
+                if (mapped.AsClause is { } asNode)
+                {
+                    if (TryToTypeInfo(asNode) is not { } resolvedAs) return null;
+                    asClause = resolvedAs;
+                }
+                if (TryToTypeInfo(mapped.ValueType) is not { } valueType) return null;
+                return new TypeInfo.MappedType(
+                    mapped.ParamName,
+                    constraint,
+                    valueType,
+                    modifiers,
+                    asClause);
             }
-            if (TryToTypeInfo(mapped.ValueType) is not { } valueType) return null;
-            return new TypeInfo.MappedType(mapped.ParamName, constraint, valueType, modifiers, asClause);
         }
         finally
         {

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -722,6 +722,7 @@ public partial class TypeChecker
 
     // Error recovery support
     private readonly DiagnosticCollector _diagnostics = new();
+    private CancellationToken _cancellationToken;
 
     /// <summary>
     /// When &gt; 0, <see cref="RecordTypeError(TypeCheckException)"/> and its overload are no-ops.
@@ -783,12 +784,16 @@ public partial class TypeChecker
         if (!_recoveryMode)
         {
             foreach (Stmt statement in statements)
+            {
+                ThrowIfCancellationRequested();
                 CheckStmt(statement);
+            }
             return;
         }
 
         foreach (Stmt statement in statements)
         {
+            ThrowIfCancellationRequested();
             if (_diagnostics.HitErrorLimit) return;
             int? saved = _currentStatementLine;
             _currentStatementLine = TryGetStmtLine(statement) ?? saved;
@@ -810,6 +815,19 @@ public partial class TypeChecker
         _filePath = filePath;
         return this;
     }
+
+    /// <summary>
+    /// Supplies cooperative cancellation for editor checks. The checker observes it between
+    /// declarations, statements, and module passes without changing compiler callers.
+    /// </summary>
+    public TypeChecker WithCancellation(CancellationToken cancellationToken)
+    {
+        _cancellationToken = cancellationToken;
+        return this;
+    }
+
+    private void ThrowIfCancellationRequested() =>
+        _cancellationToken.ThrowIfCancellationRequested();
 
     /// <summary>
     /// Marks this checker as running a worker_threads worker script, so the
@@ -1078,6 +1096,7 @@ public partial class TypeChecker
         _implicitAnyReported = null;
         _compatibilityCheckDepth = 0;
         _narrowingContextStack.Clear();
+        ThrowIfCancellationRequested();
 
         // Module/top-level declarations live in their own declared-type frame so that
         // GetDeclaredType / IsDeclaredTypeTracked treat them like function locals (#743).
@@ -1157,15 +1176,19 @@ public partial class TypeChecker
 
         // Pre-register type declarations
         PreRegisterTypeDeclarations(statements);
+        ThrowIfCancellationRequested();
 
         // Hoist class declarations (as Any for forward references in function bodies)
         HoistClassDeclarations(statements);
+        ThrowIfCancellationRequested();
 
         // Hoist function declarations
         HoistFunctionDeclarations(statements);
+        ThrowIfCancellationRequested();
 
         // Hoist var declarations (pre-define as any for forward reference support)
         HoistVarDeclarations(statements);
+        ThrowIfCancellationRequested();
 
         // Hoist let/const declarations (pre-define as any so an earlier function body can
         // forward-reference a later block-scoped binding — #533)
@@ -1173,6 +1196,7 @@ public partial class TypeChecker
 
         foreach (Stmt statement in statements)
         {
+            ThrowIfCancellationRequested();
             if (_diagnostics.HitErrorLimit)
             {
                 _recoveryMode = false;
@@ -1424,6 +1448,7 @@ public partial class TypeChecker
         {
             foreach (var module in modules)
             {
+                ThrowIfCancellationRequested();
                 _currentModule = module;
                 // Attribute diagnostics to the module being checked — without
                 // this, errors raised inside module sources (including built-in
@@ -1469,6 +1494,7 @@ public partial class TypeChecker
         {
             foreach (var module in augmentationOrder)
             {
+                ThrowIfCancellationRequested();
                 foreach (var augmentation in module.GlobalAugmentations)
                 {
                     try { CheckAndMergeGlobalMember(augmentation); }
@@ -1484,6 +1510,7 @@ public partial class TypeChecker
         // Second pass: type-check each module with imports resolved
         foreach (var module in modules)
         {
+            ThrowIfCancellationRequested();
             if (module.IsTypeChecked)
             {
                 continue;
@@ -1516,6 +1543,7 @@ public partial class TypeChecker
                     // Check all statements with error recovery
                     foreach (var stmt in module.Statements)
                     {
+                        ThrowIfCancellationRequested();
                         // Fallback line for diagnostics whose throw-site doesn't carry one, mirroring
                         // the script path (CheckWithRecovery). Without it, module-mode errors render
                         // with no location (#468).
@@ -1576,6 +1604,7 @@ public partial class TypeChecker
                         // Third pass: check all statements with error recovery
                         foreach (var stmt in module.Statements)
                         {
+                            ThrowIfCancellationRequested();
                             // Fallback line for diagnostics whose throw-site doesn't carry one, mirroring
                             // the script path (CheckWithRecovery). Without it, module-mode errors render
                             // with no location (#468).

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -138,14 +138,68 @@ public partial class TypeChecker
         bool mergeWithLocal = false) =>
         RegisterTypeDeclaration(_environment, declaration, mergeWithLocal);
 
-    private void BindTypeUse(Token? use, string name)
+    private void DefineSourceTypeParameter(
+        TypeEnvironment environment,
+        TypeParam declaration,
+        TypeInfo typeParameter)
     {
-        if (use is null)
+        BindingSymbol symbol = Bindings.Declare(
+            declaration.Name,
+            CurrentSourceDocument,
+            BindingNamespace.Type,
+            environment.GetLocalTypeSymbol(declaration.Name.Lexeme));
+        environment.DefineTypeBinding(declaration.Name.Lexeme, symbol);
+        environment.DefineTypeParameter(declaration.Name.Lexeme, typeParameter);
+    }
+
+    private void DefineSourceTypeParameter(
+        TypeEnvironment environment,
+        Token declaration,
+        TypeInfo typeParameter)
+    {
+        BindingSymbol symbol = Bindings.Declare(
+            declaration,
+            CurrentSourceDocument,
+            BindingNamespace.Type,
+            environment.GetLocalTypeSymbol(declaration.Lexeme));
+        environment.DefineTypeBinding(declaration.Lexeme, symbol);
+        environment.DefineTypeParameter(declaration.Lexeme, typeParameter);
+    }
+
+    private void BindTypeUse(NamedTypeNode named)
+    {
+        if (named.NameToken is null)
             return;
 
-        string rootName = name.Split('.', 2)[0];
+        string rootName = named.Name.Split('.', 2)[0];
         if (_environment.GetTypeSymbol(rootName) is { } symbol)
-            Bindings.Bind(use, CurrentSourceDocument, symbol);
+            Bindings.Bind(named.NameToken, CurrentSourceDocument, symbol);
+
+        if (named.NameTokens is not { Count: > 1 } tokens ||
+            _environment.GetNamespace(rootName) is not { } currentNamespace)
+        {
+            return;
+        }
+
+        for (int i = 1; i < tokens.Count; i++)
+        {
+            Token member = tokens[i];
+            BindingSymbol? memberSymbol =
+                currentNamespace.GetTypeBinding(member.Lexeme)
+                ?? currentNamespace.GetValueBinding(member.Lexeme);
+            if (memberSymbol is not null)
+                Bindings.Bind(member, CurrentSourceDocument, memberSymbol);
+
+            if (currentNamespace.Types.GetValueOrDefault(member.Lexeme)
+                is TypeInfo.Namespace nested)
+            {
+                currentNamespace = nested;
+            }
+            else
+            {
+                break;
+            }
+        }
     }
 
     /// <summary>
@@ -969,7 +1023,9 @@ public partial class TypeChecker
     private bool _inGeneratorFunction = false;
 
     // Track active labels for labeled statements (label name -> isOnLoop)
-    private readonly Dictionary<string, bool> _activeLabels = [];
+    private sealed record ActiveLabel(bool IsOnLoop, BindingSymbol Symbol);
+
+    private readonly Dictionary<string, ActiveLabel> _activeLabels = [];
 
     // Track pending overload signatures for top-level functions
     private readonly Dictionary<string, List<TypeInfo.Function>> _pendingOverloadSignatures = [];
@@ -1979,7 +2035,16 @@ public partial class TypeChecker
         string name, ParsedModule module)
     {
         var members = module.ExportedTypes.ToFrozenDictionary();
-        return new TypeInfo.Namespace(name, members, members);
+        return new TypeInfo.Namespace(
+            name,
+            members,
+            members,
+            module.ExportedTypeBindings.Count == 0
+                ? null
+                : module.ExportedTypeBindings.ToFrozenDictionary(),
+            module.ExportedValueBindings.Count == 0
+                ? null
+                : module.ExportedValueBindings.ToFrozenDictionary());
     }
 
     /// <summary>

--- a/TypeSystem/TypeEnvironment.cs
+++ b/TypeSystem/TypeEnvironment.cs
@@ -223,8 +223,27 @@ public class TypeEnvironment : ScopeChain<TypeInfo, TypeEnvironment>
             foreach (var (k, v) in ns.Values)
                 mergedValues[k] = v;
 
+            var mergedTypeBindings = existing.TypeBindings is null
+                ? new Dictionary<string, BindingSymbol>()
+                : new Dictionary<string, BindingSymbol>(existing.TypeBindings);
+            if (ns.TypeBindings is not null)
+                foreach (var (k, v) in ns.TypeBindings)
+                    mergedTypeBindings[k] = v;
+
+            var mergedValueBindings = existing.ValueBindings is null
+                ? new Dictionary<string, BindingSymbol>()
+                : new Dictionary<string, BindingSymbol>(existing.ValueBindings);
+            if (ns.ValueBindings is not null)
+                foreach (var (k, v) in ns.ValueBindings)
+                    mergedValueBindings[k] = v;
+
             // Create new namespace with merged collections
-            var mergedNs = new TypeInfo.Namespace(name, mergedTypes.ToFrozenDictionary(), mergedValues.ToFrozenDictionary());
+            var mergedNs = new TypeInfo.Namespace(
+                name,
+                mergedTypes.ToFrozenDictionary(),
+                mergedValues.ToFrozenDictionary(),
+                mergedTypeBindings.Count == 0 ? null : mergedTypeBindings.ToFrozenDictionary(),
+                mergedValueBindings.Count == 0 ? null : mergedValueBindings.ToFrozenDictionary());
             _namespaces[name] = mergedNs;
             _values[name] = mergedNs;
             _types[name] = mergedNs;

--- a/TypeSystem/TypeInfo.cs
+++ b/TypeSystem/TypeInfo.cs
@@ -663,7 +663,9 @@ public abstract record TypeInfo
     public record Namespace(
         string Name,
         FrozenDictionary<string, TypeInfo> Types,   // Classes, interfaces, enums, nested namespaces
-        FrozenDictionary<string, TypeInfo> Values   // Functions, variables
+        FrozenDictionary<string, TypeInfo> Values,  // Functions, variables
+        FrozenDictionary<string, BindingSymbol>? TypeBindings = null,
+        FrozenDictionary<string, BindingSymbol>? ValueBindings = null
     ) : TypeInfo
     {
         /// <summary>
@@ -675,6 +677,12 @@ public abstract record TypeInfo
             if (Values.TryGetValue(name, out var value)) return value;
             return null;
         }
+
+        public BindingSymbol? GetTypeBinding(string name) =>
+            TypeBindings?.GetValueOrDefault(name);
+
+        public BindingSymbol? GetValueBinding(string name) =>
+            ValueBindings?.GetValueOrDefault(name);
 
         public override string ToString() => $"namespace {Name}";
     }

--- a/docs/debugging-typescript.md
+++ b/docs/debugging-typescript.md
@@ -18,7 +18,9 @@ reach into the SharpTS runtime carry working symbols too. Keep the `.pdb` beside
 Breakpoints bind and stepping follows executable TypeScript statements, in ordinary functions,
 class members, module top level, `async` functions, and generators — the state machines go through
 the same emission path, so their `MoveNext` bodies carry line information for the statements you
-wrote. Imported modules resolve to their own files.
+wrote. Portable-PDB state-machine mappings and async suspension/resume records let managed
+debuggers present kickoff methods and step across `await` without exposing raw plumbing. Imported
+modules resolve to their own files.
 
 Statements the compiler synthesized are marked hidden and stepped over rather than attributed to a
 nearby line: the `var` declarations hoisting moves to the top of a body, the aliases left where a
@@ -44,8 +46,10 @@ the static fields of `$Program` rather than in the locals window.
 
 *Locals of `async` functions and generators* are hoisted into the state machine's fields so they
 survive suspension, so they appear as fields of the `<name>d__N` frame instead of as locals of
-`MoveNext`. Presenting them as locals again needs the portable-PDB custom debug information that
-describes a state machine's hoisted-variable mapping, which is a follow-up.
+`MoveNext`. The generated state-machine and display-class names are stable, and their fields retain
+the source binding names. Reconstructing every hoisted field as an ordinary locals-window entry
+would require additional debugger-specific hoisted-local metadata and remains outside the accepted
+v1 behavior.
 
 ### Stepping and the bundled stdlib
 
@@ -58,13 +62,15 @@ through the stdlib stays readable, and turning Just My Code off lets you step in
 The emitted runtime helpers need no such marking: they carry no debug information at all, which
 already puts them outside user code.
 
+State-machine and closure types are marked compiler-generated. Their infrastructure methods
+(`MoveNext`, enumerator plumbing, and `SetStateMachine`) are non-user code, while their portable
+PDB mapping still takes a debugger back to the source-level async or generator function.
+
 One consequence worth knowing: because the stdlib travels in the PDB with its source embedded,
 importing a large module makes the `.pdb` noticeably bigger. It costs nothing at run time and
 nothing in the assembly; only the symbol file grows.
 
-Not yet done: async and generator stepping fidelity — the state machines carry line information,
-but not the custom debug information that makes a debugger present an `await` as a single step.
-Interpreter debugging is out of scope.
+Interpreter debugging remains out of scope.
 
 ## Editor setup
 
@@ -104,9 +110,10 @@ both locate `app.pdb` beside `app.dll` and open the `.ts` files it names.
 
 `SharpTS.Tests/Compilation/DebugSymbolsTests.cs` asserts the symbol *metadata* thoroughly —
 documents and checksums, sequence points and the lines they land on, named locals, lexical scope
-nesting, and a CodeView identity that still matches after the reference rewriter. What no automated
-test covers is a debugger actually stopping, so run this by hand when changing statement emission,
-the span model, or the symbol pipeline.
+nesting, state-machine mappings, async suspension/resume records, generated-code attributes, and a
+CodeView identity that still matches after the reference rewriter. What no automated test covers is
+a debugger actually stopping, so run this by hand when changing statement emission, the span model,
+or the symbol pipeline.
 
 Scripting `vsdbg` for this is not an option: it is licensed for use only with Visual Studio and
 VS Code, and enforces that with a handshake its own clients answer. Automating this would mean

--- a/docs/language-server.md
+++ b/docs/language-server.md
@@ -1,0 +1,118 @@
+# SharpTS language server
+
+`sharpts-lsp` is a standard language server over stdio. It provides SharpTS-specific .NET interop
+diagnostics, hover, completion, signature help, and quick fixes in every mode. Its full mode also
+provides document symbols, definition, references, and completeness-gated rename for standalone
+editors.
+
+## Install and launch
+
+Install the separately packaged tool:
+
+```bash
+dotnet tool install --global SharpTS.LanguageServer
+```
+
+The default is appropriate for an editor where SharpTS is the only TypeScript language server:
+
+```bash
+sharpts-lsp
+```
+
+The equivalent explicit launch is:
+
+```bash
+sharpts-lsp --language-features full --diagnostics sharpts-only
+```
+
+Configure any LSP client with:
+
+- command: `sharpts-lsp`
+- file types: TypeScript and TSX
+- transport: stdio
+- project root: the nearest `tsconfig.json`, `sharpts.json`, or workspace root
+
+For example, Neovim 0.11 can register it as:
+
+```lua
+vim.lsp.config.sharpts = {
+  cmd = { "sharpts-lsp", "--language-features", "full" },
+  filetypes = { "typescript", "typescriptreact" },
+  root_markers = { "tsconfig.json", "sharpts.json", ".git" },
+}
+vim.lsp.enable("sharpts")
+```
+
+Helix can launch the same server with:
+
+```toml
+[language-server.sharpts]
+command = "sharpts-lsp"
+args = ["--language-features", "full"]
+```
+
+Then add `sharpts` to the `language-servers` list for the `typescript` and `tsx` language entries.
+If another TypeScript server is active, use the coexistence mode below to avoid duplicate general
+navigation.
+
+## Coexisting with another TypeScript server
+
+VS Code's SharpTS extension starts the bundled server in `interop-only` mode because VS Code's
+built-in `tsserver` already owns ordinary TypeScript navigation:
+
+```bash
+sharpts-lsp --language-features interop-only
+```
+
+This mode still advertises the features unique to SharpTS:
+
+- .NET interop diagnostics;
+- decorator/member hover, completion, and signature help;
+- structured quick fixes for safe interop corrections.
+
+It does not advertise document symbols, definition, references, or rename. The feature mode is
+fixed during LSP initialization; restart the server to change it.
+
+## Diagnostics
+
+`--diagnostics` accepts:
+
+- `sharpts-only` (default): publish interop and other SharpTS-specific diagnostics without
+  duplicating `tsserver`;
+- `all`: also publish the full SharpTS parser/type-checker result;
+- `off`: publish no diagnostics and clear existing results.
+
+Clients may change this live with `workspace/didChangeConfiguration`:
+
+```json
+{
+  "settings": {
+    "sharpts": {
+      "diagnostics": "all"
+    }
+  }
+}
+```
+
+VS Code exposes the same value as `sharpts.diagnostics`.
+
+## Project and .NET references
+
+The server discovers workspace `tsconfig.json` files and their in-workspace project references.
+Use these launch options for CLR metadata:
+
+```bash
+sharpts-lsp --project ./MyApp.csproj
+sharpts-lsp -r ./lib/MyInterop.dll -r ./lib/Another.dll
+sharpts-lsp --sdk-path /path/to/reference/assemblies
+```
+
+A `sharpts.json` reference manifest found from the workspace root is also honored. Referenced
+assembly outputs are reloaded safely when they change.
+
+## Rename safety
+
+Full mode produces a rename edit only when the server has loaded every configured project root and
+project reference needed for the selected semantic binding. It deliberately refuses rename for an
+incomplete graph rather than returning a partial cross-file edit. General object/class
+property-member rename is not currently offered.

--- a/docs/plans/lsp-server.md
+++ b/docs/plans/lsp-server.md
@@ -1,12 +1,11 @@
 # Plan: Replace the LspBridge with a real Language Server (Direction B)
 
-**Status:** In progress. Landed: Phase 0, Phase 1 (interop analyzer + project refs),
-LspBridge teardown, Phase 2 (decorator hover, completion, CLR-type-name completion,
-signatureHelp), Phase 3 (extension rewrite), Phase 4a (token-based interop navigation),
-source spans and document symbols, plus the first Phase 4b slice: checker-resolved local-value
-go-to-definition. The server lives in the separate `SharpTS.LanguageServer` executable /
-`sharpts-lsp` tool, keeping OmniSharp out of the core package. Remaining: type-namespace and
-cross-module definition, references, safe rename, and Phase 5 lifecycle/polish.
+**Status:** Implemented. Phases 0–5 have landed: interop analysis and IntelliSense, the
+`vscode-languageclient` extension, source spans, complete supported semantic navigation domains,
+completeness-gated workspace rename, versioned workspace lifecycle and diagnostics, structured
+interop quick fixes, and standalone-editor documentation. The server lives in the separate
+`SharpTS.LanguageServer` executable / `sharpts-lsp` tool, keeping OmniSharp out of the core
+package. General property/member navigation remains the deliberate scope boundary described below.
 **Author:** investigation + design pass, 2026-06-22
 **Decision:** Throw away the bespoke `LspBridge` JSON protocol and the hand-rolled
 VS Code providers. Stand up a genuine LSP server over SharpTS's own
@@ -288,9 +287,12 @@ results.
 The server advertises these features only in `--language-features full`; the VS Code extension
 continues to launch `interop-only`, leaving ordinary TypeScript navigation to `tsserver`.
 
-Still required for the complete navigation milestone: safe rename and the remaining type/member
-domains (notably type parameters and qualified namespace/property members). Property/member
-definition remains deliberately absent until it can resolve a complete semantic domain.
+Safe rename uses the same semantic identities and refuses to produce a `WorkspaceEdit` unless all
+configured roots and project references for the affected domain loaded successfully. Type
+parameters, labels, namespace imports, qualified namespace members, and type/value facets are
+covered. General object/class property-member navigation and rename remain deliberately absent:
+that larger semantic domain is not required for the scoped standalone-navigation milestone, and
+partial edits would be unsafe.
 
 ---
 
@@ -303,22 +305,28 @@ definition remains deliberately absent until it can resolve a complete semantic 
 - **Severity:** map `DiagnosticSeverity` → LSP `DiagnosticSeverity`.
 - Set `code` from `Diagnostic.Code`/`TsCode` and `source = "sharpts"` so users can
   tell our diagnostics from `tsserver`'s.
+- Interop diagnostics with a safe fix carry versioned JSON `data` describing the edit. The
+  `textDocument/codeAction` handler consumes that structure directly; it never reparses localized
+  or revised diagnostic message text.
 
 ---
 
 ## 7. Concurrency, lifecycle & performance
-- **Debounce** document-change checks (~250–300 ms) and **cancel** in-flight checks
-  via the per-request `CancellationToken` OmniSharp supplies. (Today's providers
-  ignore cancellation entirely and use 30 s timeouts.)
-- **Scope re-checks** to the module graph reachable from the changed/open files;
-  don't re-check the whole workspace on every keystroke.
-- **WorkspaceContext** owns one `AssemblyReferenceLoader` per workspace, built from
-  `sharpts.projectFile`/`additionalReferences` via `CsprojParser`. Reload it on a
-  file-watcher event for the `.csproj` or the referenced `bin/` outputs (replaces the
-  current "config changed → please restart the bridge" prompt).
-- No incremental type-checking exists; full parse+check per change is the model.
-  Acceptable for typical files with debounce; flagged as a risk (§10) for very large
-  module graphs.
+- `DocumentStore` keeps immutable text + version snapshots, applies incremental changes, rejects
+  stale updates, and captures one atomic overlay for each request.
+- Document checks are debounced and replace a per-workspace cancellation source. Cancellation is
+  observed between lex/parse/interop/type-check stages and inside long-running checker work.
+- `DiagnosticsService` caches source text, tokens, AST, spans, interop diagnostics, and the
+  optional full type-check result by exact document version.
+- `DocumentDependencyGraph` maintains forward and reverse edges. A dependency signature change
+  invalidates and republishes affected open importers, including clearing diagnostics that became
+  stale.
+- `sharpts.diagnostics` is honored at startup and through live
+  `workspace/didChangeConfiguration`; `off` clears published diagnostics immediately.
+- `ReloadingAssemblyReferenceLoader` detects changed reference outputs and atomically swaps in a
+  new metadata context while retaining old contexts for in-flight requests.
+- Whole-file checking remains the model. The versioned caches, graph scoping, debounce, and
+  cancellation avoid repeated stale work without introducing an unproven incremental tree checker.
 
 ---
 
@@ -396,16 +404,17 @@ single-file binary so non-VS-Code editors don't need the full SDK.
   member hover for `@DotNetType` members (declarations token-based; usages via the type
   checker's `TypeMap`, mapping the receiver's class name back to the binding). No parser
   surgery, no record-equality risk. ~7 tests + e2e (precise columns, declaration + usage hover).
-- 🟨 **Phase 4b — standalone general navigation.** Reference-keyed source spans, document
+- ✅ **Phase 4b — standalone general navigation.** Reference-keyed source spans, document
   symbols, semantic value/type binding identities, and module-aware go-to-definition through
   imports/re-exports have landed. The inverse binding index, configured-project reverse graph,
   closed-importer references, multi-config/project-reference workspace expansion, and explicit
-  graph-completeness boundaries have also landed. Safe rename, type-parameter navigation, and
-  qualified member navigation remain. VS Code stays in `interop-only`; these capabilities are for
-  standalone clients.
-- ⬜ **Phase 5 — Polish & reach.** Multi-editor docs; `dotnet tool`/self-contained
-  packaging; debounce/cancellation; config→server wiring (`sharpts.diagnostics`);
-  loader reload on `.csproj`/`bin` change; STATUS.md/README updates. **NOT YET DONE.**
+  graph-completeness boundaries have also landed. Safe rename, type-parameter/label navigation,
+  and qualified namespace-member navigation complete the supported domains. VS Code stays in
+  `interop-only`; these capabilities are for standalone clients.
+- ✅ **Phase 5 — Polish & reach.** The separately packaged `SharpTS.LanguageServer` dotnet tool,
+  [multi-editor setup](../language-server.md), versioned snapshots/caches,
+  debounce/cancellation, reverse diagnostic invalidation, live `sharpts.diagnostics` wiring,
+  safe metadata-loader reload, and structured interop code actions are implemented.
 
 ---
 

--- a/vscode-sharpts/package.json
+++ b/vscode-sharpts/package.json
@@ -41,6 +41,16 @@
           },
           "default": [],
           "description": "Additional assembly paths to load for @DotNetType resolution."
+        },
+        "sharpts.diagnostics": {
+          "type": "string",
+          "enum": [
+            "sharpts-only",
+            "all",
+            "off"
+          ],
+          "default": "sharpts-only",
+          "description": "Diagnostics published by SharpTS. The default avoids duplicating tsserver diagnostics."
         }
       }
     },

--- a/vscode-sharpts/src/extension.ts
+++ b/vscode-sharpts/src/extension.ts
@@ -36,7 +36,14 @@ export async function activate(context: vscode.ExtensionContext) {
     // here is the .NET interop surface — diagnostics, hover, completion, signature help — and
     // nothing tsserver already provides. The standalone `sharpts-lsp` tool defaults to full
     // navigation instead, for editors with no TypeScript server of their own.
-    const args = [serverDll, '--language-features', 'interop-only'];
+    const diagnostics = config.get<string>('diagnostics') || 'sharpts-only';
+    const args = [
+        serverDll,
+        '--language-features',
+        'interop-only',
+        '--diagnostics',
+        diagnostics
+    ];
     const projectFile = config.get<string>('projectFile');
     if (projectFile) {
         args.push('--project', projectFile);


### PR DESCRIPTION
## Summary

- complete completeness-gated workspace rename and the remaining semantic navigation domains
- add versioned snapshots, debounce/cancellation, cached analysis, reverse diagnostic invalidation, live diagnostics policy, and safe assembly reload
- add state-machine/debugger metadata, stable generated-code presentation, async stepping records, and debugger-compatible PDB document/path metadata
- add structured interop quick fixes in both LSP feature modes
- update editor/debugger status and standalone Neovim/Helix setup documentation

Advances #1306 through all remaining code priorities. The documented real-debugger smoke checklist remains an external validation item: both tested netcoredbg builds failed on a Roslyn-generated C# control program in this environment, while the portable-PDB metadata and compatibility regressions are covered automatically.

## Validation

- `dotnet test SharpTS.sln --no-restore --filter "Category!=LiveNetwork&Category!=LoadSensitive"` (16,272 passed)
- `dotnet test SharpTS.Test262/SharpTS.Test262.csproj --configuration Release --no-restore` (186 passed, 4 diagnostic skips)
- `dotnet test SharpTS.TypeScriptConformance/SharpTS.TypeScriptConformance.csproj --configuration Release --no-restore` (45 passed)
- `npm run compile` in `vscode-sharpts`
- `dotnet pack SharpTS.LanguageServer/SharpTS.LanguageServer.csproj --configuration Release --no-restore`
- real LSP initialize handshakes advertise `quickfix` in both `interop-only` and `full` modes
