### PR TITLE
Improve interpreted Test262 parity for Array and String

### DIFF
--- a/Execution/Interpreter.Calls.cs
+++ b/Execution/Interpreter.Calls.cs
@@ -1066,6 +1066,13 @@ public partial class Interpreter
         if (right is SharpTSBooleanNamespace)
             return IsBoxedPrimitiveOfType(left, "Boolean");
 
+        // The Function global is represented by a namespace-style callable
+        // rather than SharpTSBuiltInConstructor. OrdinaryHasInstance for it
+        // accepts every callable guest value, including declarations,
+        // expressions/arrows, classes, and native built-ins.
+        if (right is SharpTSFunctionGlobal)
+            return left is ISharpTSCallable;
+
         // Bare-value constructors for the built-in binary types (ArrayBuffer,
         // SharedArrayBuffer, DataView, typed arrays) are plain ISharpTSCallables,
         // so they carry their own instance predicate (#334).

--- a/Execution/Interpreter.Calls.cs
+++ b/Execution/Interpreter.Calls.cs
@@ -1127,7 +1127,8 @@ public partial class Interpreter
         // Real arrays AND the Array.prototype dict itself satisfy the check
         // (ECMA-262 23.1.3 — Array.prototype is itself an Array exotic object).
         if (right is SharpTSArrayGlobal)
-            return left is SharpTSArray || left is SharpTSArrayPrototype;
+            return left is SharpTSArray and not SharpTSArguments
+                || left is SharpTSArrayPrototype;
 
         // Constructor-function instanceof (JS `new Func()` pattern).
         // An object is `instanceof Func` when any link in its prototype

--- a/Execution/Interpreter.Expressions.cs
+++ b/Execution/Interpreter.Expressions.cs
@@ -1277,6 +1277,12 @@ public partial class Interpreter
             regexSet.SetBySymbol(regexSetSym, value);
             return RuntimeValue.FromBoxed(value);
         }
+        if (obj is SharpTSRegExp regexStringSet)
+        {
+            regexStringSet.SetProperty(
+                PropertyKeyConverter.ToPropertyKeyString(index), value);
+            return RuntimeValue.FromBoxed(value);
+        }
 
         // Built-in callables expose `name` / `length` as non-writable own
         // properties (ECMA-262 §17). Index assignment to those should silently

--- a/Execution/Interpreter.Operators.cs
+++ b/Execution/Interpreter.Operators.cs
@@ -724,6 +724,8 @@ public partial class Interpreter
     internal string ToStringForBuiltInArgument(object? value)
     {
         ThrowIfSymbolStringCoercion(value);
+        if (value is SharpTSArray array)
+            return ArrayBuiltIns.ToJsString(this, array);
         if (value is not SharpTSObject obj)
             return Stringify(value);
 

--- a/Runtime/BuiltIns/ArrayBuiltIns.cs
+++ b/Runtime/BuiltIns/ArrayBuiltIns.cs
@@ -1,6 +1,7 @@
 using SharpTS.Compilation;
 using SharpTS.Execution;
 using SharpTS.Runtime;
+using SharpTS.Runtime.Exceptions;
 using SharpTS.Runtime.Types;
 
 namespace SharpTS.Runtime.BuiltIns;
@@ -23,15 +24,15 @@ public static class ArrayBuiltIns
             // §23.1.3. thisArg is forwarded as the callback's `this`.
             // CallbackIterator.Create reads args[1] and BindThis-es a
             // SharpTSFunction callback when present.
-            .MethodV2("map", 1, 2, specLength: 1, MapV2)
-            .MethodV2("filter", 1, 2, specLength: 1, FilterV2)
-            .MethodV2("forEach", 1, 2, specLength: 1, ForEachV2)
-            .MethodV2("find", 1, 2, specLength: 1, FindV2)
-            .MethodV2("findIndex", 1, 2, specLength: 1, FindIndexV2)
-            .MethodV2("some", 1, 2, specLength: 1, SomeV2)
-            .MethodV2("every", 1, 2, specLength: 1, EveryV2)
-            .MethodV2("reduce", 1, 2, ReduceV2)
-            .MethodV2("reduceRight", 1, 2, ReduceRightV2)
+            .MethodV2("map", 0, int.MaxValue, specLength: 1, MapV2)
+            .MethodV2("filter", 0, int.MaxValue, specLength: 1, FilterV2)
+            .MethodV2("forEach", 0, int.MaxValue, specLength: 1, ForEachV2)
+            .MethodV2("find", 0, int.MaxValue, specLength: 1, FindV2)
+            .MethodV2("findIndex", 0, int.MaxValue, specLength: 1, FindIndexV2)
+            .MethodV2("some", 0, int.MaxValue, specLength: 1, SomeV2)
+            .MethodV2("every", 0, int.MaxValue, specLength: 1, EveryV2)
+            .MethodV2("reduce", 0, int.MaxValue, specLength: 1, ReduceV2)
+            .MethodV2("reduceRight", 0, int.MaxValue, specLength: 1, ReduceRightV2)
             .MethodV2("includes", 1, IncludesV2)
             .MethodV2("indexOf", 1, 2, IndexOfV2)
             .MethodV2("lastIndexOf", 1, 2, LastIndexOfV2)
@@ -43,13 +44,13 @@ public static class ArrayBuiltIns
             .MethodV2("concat", 0, int.MaxValue, specLength: 1, ConcatV2)
             .MethodV2("reverse", 0, ReverseV2)
             .MethodV2("flat", 0, 1, FlatV2)
-            .MethodV2("flatMap", 1, 2, specLength: 1, FlatMapV2)
+            .MethodV2("flatMap", 0, int.MaxValue, specLength: 1, FlatMapV2)
             .MethodV2("sort", 0, 1, specLength: 1, SortV2)
             .MethodV2("toSorted", 0, 1, specLength: 1, ToSortedV2)
             .MethodV2("splice", 0, int.MaxValue, specLength: 2, SpliceV2)
             .MethodV2("toSpliced", 0, int.MaxValue, specLength: 2, ToSplicedV2)
-            .MethodV2("findLast", 1, 2, specLength: 1, FindLastV2)
-            .MethodV2("findLastIndex", 1, 2, specLength: 1, FindLastIndexV2)
+            .MethodV2("findLast", 0, int.MaxValue, specLength: 1, FindLastV2)
+            .MethodV2("findLastIndex", 0, int.MaxValue, specLength: 1, FindLastIndexV2)
             .MethodV2("toReversed", 0, ToReversedV2)
             .MethodV2("with", 2, WithV2)
             .MethodV2("at", 1, AtV2)
@@ -800,8 +801,7 @@ public static class ArrayBuiltIns
         // ECMA-262 23.1.3.24: skip holes. Initial accumulator, if none supplied,
         // is the first PRESENT element. TypeError if the array has no present
         // elements and no initial value is provided.
-        var callback = args[0].ToObject() as ISharpTSCallable
-            ?? throw new Exception("Runtime Error: reduce requires a function argument.");
+        var callback = RequireCallable(args, "reduce");
 
         int len = arr.Length;
         int startIndex = 0;
@@ -820,7 +820,7 @@ public static class ArrayBuiltIns
                 if (arr.HasIndex(i)) { firstPresent = i; break; }
             }
             if (firstPresent < 0)
-                throw new Exception("TypeError: Reduce of empty array with no initial value.");
+                throw TypeError("Reduce of empty array with no initial value");
             accumulator = arr[firstPresent];
             startIndex = firstPresent + 1;
         }
@@ -851,8 +851,7 @@ public static class ArrayBuiltIns
     private static RuntimeValue ReduceRightV2(Interpreter interp, SharpTSArray arr, ReadOnlySpan<RuntimeValue> args)
     {
         // ECMA-262 23.1.3.25: skip holes; symmetric to reduce.
-        var callback = args[0].ToObject() as ISharpTSCallable
-            ?? throw new Exception("Runtime Error: reduceRight requires a function argument.");
+        var callback = RequireCallable(args, "reduceRight");
 
         int len = arr.Length;
         int startIndex;
@@ -871,7 +870,7 @@ public static class ArrayBuiltIns
                 if (arr.HasIndex(i)) { lastPresent = i; break; }
             }
             if (lastPresent < 0)
-                throw new Exception("TypeError: Reduce of empty array with no initial value.");
+                throw TypeError("Reduce of empty array with no initial value");
             accumulator = arr[lastPresent];
             startIndex = lastPresent - 1;
         }
@@ -928,6 +927,19 @@ public static class ArrayBuiltIns
     {
         return obj is SharpTSUndefined;
     }
+
+    private static ISharpTSCallable RequireCallable(
+        ReadOnlySpan<RuntimeValue> args,
+        string methodName)
+    {
+        if (args.Length > 0 && args[0].ToObject() is ISharpTSCallable callback)
+            return callback;
+
+        throw TypeError($"{methodName} callback must be callable");
+    }
+
+    private static ThrowException TypeError(string message)
+        => new(new SharpTSTypeError(message));
 
     private static bool IsEqual(object? a, object? b)
     {
@@ -989,8 +1001,10 @@ public static class ArrayBuiltIns
 
         public static CallbackIterator Create(List<object?> args, SharpTSArray arr, string methodName)
         {
-            var callback = args[0] as ISharpTSCallable
-                ?? throw new Exception($"Runtime Error: {methodName} requires a function argument.");
+            var callback = args.Count > 0 ? args[0] as ISharpTSCallable : null;
+            if (callback is null)
+                throw TypeError($"{methodName} callback must be callable");
+
             // ECMA-262 §23.1.3 callback methods accept (cb, thisArg). If thisArg
             // is supplied, re-bind regular functions and function expressions.
             // Arrow functions (HasOwnThis=false) ignore the binding per spec.
@@ -1001,8 +1015,7 @@ public static class ArrayBuiltIns
 
         public static CallbackIterator CreateFromRV(ReadOnlySpan<RuntimeValue> args, SharpTSArray arr, string methodName)
         {
-            var callback = args[0].ToObject() as ISharpTSCallable
-                ?? throw new Exception($"Runtime Error: {methodName} requires a function argument.");
+            var callback = RequireCallable(args, methodName);
             if (args.Length >= 2)
                 callback = BindCallbackThis(callback, args[1].ToObject());
             return new CallbackIterator(callback, RuntimeValue.FromObject(arr));

--- a/Runtime/BuiltIns/ArrayStaticBuiltIns.cs
+++ b/Runtime/BuiltIns/ArrayStaticBuiltIns.cs
@@ -14,7 +14,8 @@ public static class ArrayStaticBuiltIns
         {
             "isArray" => BuiltInMethod.CreateV2("isArray", 1, static (_, _, args) =>
             {
-                return RuntimeValue.FromBoolean(args[0].ToObject() is SharpTSArray);
+                return RuntimeValue.FromBoolean(
+                    args[0].ToObject() is SharpTSArray and not SharpTSArguments);
             }),
             "from" => BuiltInMethod.CreateV2("from", 1, 2, static (interpreter, _, args) =>
             {

--- a/Runtime/BuiltIns/StringBuiltIns.cs
+++ b/Runtime/BuiltIns/StringBuiltIns.cs
@@ -32,9 +32,9 @@ public static class StringBuiltIns
             .MethodV2("endsWith", 0, int.MaxValue, specLength: 1, EndsWithV2)
             .MethodV2("slice", 0, int.MaxValue, specLength: 2, SliceV2)
             .MethodV2("substr", 0, int.MaxValue, specLength: 2, SubstrV2)
-            .MethodV2("repeat", 1, RepeatV2)
-            .MethodV2("padStart", 1, 2, PadStartV2)
-            .MethodV2("padEnd", 1, 2, PadEndV2)
+            .MethodV2("repeat", 0, int.MaxValue, specLength: 1, RepeatV2)
+            .MethodV2("padStart", 0, int.MaxValue, specLength: 1, PadStartV2)
+            .MethodV2("padEnd", 0, int.MaxValue, specLength: 1, PadEndV2)
             .MethodV2("charCodeAt", 0, int.MaxValue, specLength: 1, CharCodeAtV2)
             .MethodV2("codePointAt", 0, int.MaxValue, specLength: 1, CodePointAtV2)
             .MethodV2("concat", 0, int.MaxValue, specLength: 1, ConcatV2)
@@ -43,8 +43,8 @@ public static class StringBuiltIns
             .MethodV2("trimEnd", 0, TrimEndV2)
             .MethodV2("replaceAll", 2, ReplaceAllV2)
             .MethodV2("at", 0, int.MaxValue, specLength: 1, AtV2)
-            .MethodV2("normalize", 0, 1, NormalizeV2)
-            .MethodV2("localeCompare", 1, LocaleCompareV2)
+            .MethodV2("normalize", 0, int.MaxValue, specLength: 0, NormalizeV2)
+            .MethodV2("localeCompare", 0, int.MaxValue, specLength: 1, LocaleCompareV2)
             // ECMA-262 §22.1.3.28/.31: String.prototype.toString and valueOf both
             // return thisStringValue. Needed so `(new String("x")).toString()` and
             // ToPrimitive(string-wrapper) unwrap to the primitive instead of
@@ -230,20 +230,20 @@ public static class StringBuiltIns
         return RuntimeValue.FromString(result.ToString());
     }
 
-    private static RuntimeValue FromCharCodeV2(Interpreter _, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue FromCharCodeV2(Interpreter interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
         if (args.Length == 0) return RuntimeValue.EmptyString;
 
         if (args.Length == 1)
         {
-            var code = (int)NumArg(args[0]);
+            var code = (int)NumArg(interpreter, args[0]);
             return RuntimeValue.FromString(((char)(code & 0xFFFF)).ToString());
         }
 
         var chars = new char[args.Length];
         for (int i = 0; i < args.Length; i++)
         {
-            var code = (int)NumArg(args[i]);
+            var code = (int)NumArg(interpreter, args[i]);
             chars[i] = (char)(code & 0xFFFF);
         }
         return RuntimeValue.FromString(new string(chars));
@@ -254,10 +254,12 @@ public static class StringBuiltIns
     /// boxed <c>new Number(x)</c> wrapper) through the interpreter's ToNumber so
     /// it unwraps to its primitive instead of throwing on <c>AsNumber()</c> (#708).
     /// </summary>
-    private static double NumArg(RuntimeValue rv)
-        => rv.Kind == ValueKind.Number ? rv.AsNumber() : Interpreter.ToNumber(rv.ToObject());
+    private static double NumArg(Interpreter interpreter, RuntimeValue rv)
+        => rv.Kind == ValueKind.Number
+            ? rv.AsNumber()
+            : interpreter.ToNumberWithPrimitive(rv.ToObject());
 
-    private static RuntimeValue FromCodePointV2(Interpreter _, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue FromCodePointV2(Interpreter interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
         if (args.Length == 0) return RuntimeValue.EmptyString;
 
@@ -266,9 +268,10 @@ public static class StringBuiltIns
         {
             // ECMA-262 §22.1.2.2: each code point must be an integral Number in
             // [0, 0x10FFFF]; NaN / Infinity / fractional values throw RangeError.
-            var num = NumArg(arg);
+            var num = NumArg(interpreter, arg);
             if (!double.IsInteger(num) || num < 0 || num > 0x10FFFF)
-                throw new Exception($"RangeError: Invalid code point {num}");
+                throw new ThrowException(new SharpTSRangeError(
+                    $"Invalid code point {num}"));
             AppendCodePoint(sb, (int)num);
         }
         return RuntimeValue.FromString(sb.ToString());
@@ -395,10 +398,17 @@ public static class StringBuiltIns
         return RuntimeValue.FromString(str.Substring(start, length));
     }
 
-    private static RuntimeValue RepeatV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue RepeatV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
     {
-        var count = (int)args[0].AsNumber();
-        if (count < 0) throw new Exception("Runtime Error: Invalid count value for repeat()");
+        double rawCount = IntegerArgument(interpreter, args, 0, 0);
+        if (rawCount < 0 || double.IsPositiveInfinity(rawCount))
+            throw new ThrowException(new SharpTSRangeError(
+                "Invalid count value for repeat"));
+        if (rawCount > int.MaxValue
+            || (str.Length > 0 && rawCount > int.MaxValue / str.Length))
+            throw new ThrowException(new SharpTSRangeError(
+                "Invalid string length"));
+        int count = (int)rawCount;
         if (count == 0 || str.Length == 0) return RuntimeValue.EmptyString;
         if (count == 1) return RuntimeValue.FromString(str);
         return RuntimeValue.FromString(string.Create(str.Length * count, (str, count), static (span, state) =>
@@ -451,11 +461,14 @@ public static class StringBuiltIns
         return RuntimeValue.FromString(str[(int)position].ToString());
     }
 
-    private static RuntimeValue PadStartV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue PadStartV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
     {
-        var targetLength = (int)args[0].AsNumber();
-        var padString = args.Length > 1 ? args[1].AsString() : " ";
-        if (targetLength <= str.Length || padString.Length == 0) return RuntimeValue.FromString(str);
+        int targetLength = PadTargetLength(interpreter, args);
+        if (targetLength <= str.Length) return RuntimeValue.FromString(str);
+        string padString = args.Length < 2 || args[1].IsUndefined
+            ? " "
+            : StringArgument(interpreter, args, 1);
+        if (padString.Length == 0) return RuntimeValue.FromString(str);
         var padLength = targetLength - str.Length;
         return RuntimeValue.FromString(string.Create(targetLength, (str, padString, padLength), static (span, state) =>
         {
@@ -472,11 +485,14 @@ public static class StringBuiltIns
         }));
     }
 
-    private static RuntimeValue PadEndV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue PadEndV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
     {
-        var targetLength = (int)args[0].AsNumber();
-        var padString = args.Length > 1 ? args[1].AsString() : " ";
-        if (targetLength <= str.Length || padString.Length == 0) return RuntimeValue.FromString(str);
+        int targetLength = PadTargetLength(interpreter, args);
+        if (targetLength <= str.Length) return RuntimeValue.FromString(str);
+        string padString = args.Length < 2 || args[1].IsUndefined
+            ? " "
+            : StringArgument(interpreter, args, 1);
+        if (padString.Length == 0) return RuntimeValue.FromString(str);
         var padLength = targetLength - str.Length;
         return RuntimeValue.FromString(string.Create(targetLength, (str, padString, padLength), static (span, state) =>
         {
@@ -532,35 +548,40 @@ public static class StringBuiltIns
         return RuntimeValue.FromString(str.Replace(search, replacement));
     }
 
-    private static RuntimeValue NormalizeV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue NormalizeV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
     {
-        var form = args.Length > 0 && args[0].IsString ? args[0].AsString() : "NFC";
+        string form = args.Length == 0 || args[0].IsUndefined
+            ? "NFC"
+            : StringArgument(interpreter, args, 0);
         var normForm = form switch
         {
             "NFC" => System.Text.NormalizationForm.FormC,
             "NFD" => System.Text.NormalizationForm.FormD,
             "NFKC" => System.Text.NormalizationForm.FormKC,
             "NFKD" => System.Text.NormalizationForm.FormKD,
-            _ => throw new Exception($"RangeError: The normalization form should be one of NFC, NFD, NFKC, NFKD.")
+            _ => throw new ThrowException(new SharpTSRangeError(
+                "The normalization form should be one of NFC, NFD, NFKC, NFKD"))
         };
         return RuntimeValue.FromString(str.Normalize(normForm));
     }
 
-    private static RuntimeValue LocaleCompareV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue LocaleCompareV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
     {
-        var that = args[0].AsString();
+        string that = StringArgument(interpreter, args, 0);
         var result = string.Compare(str, that, StringComparison.CurrentCulture);
         return RuntimeValue.FromNumber(result < 0 ? -1 : result > 0 ? 1 : 0);
     }
 
-    private static RuntimeValue ConcatV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue ConcatV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
     {
         if (args.Length == 0) return RuntimeValue.FromString(str);
-        if (args.Length == 1) return RuntimeValue.FromString(string.Concat(str, args[0].AsString()));
+        if (args.Length == 1)
+            return RuntimeValue.FromString(string.Concat(
+                str, StringArgument(interpreter, args, 0)));
         var sb = new StringBuilder(str);
-        foreach (var arg in args)
+        for (int i = 0; i < args.Length; i++)
         {
-            sb.Append(arg.AsString());
+            sb.Append(StringArgument(interpreter, args, i));
         }
         return RuntimeValue.FromString(sb.ToString());
     }
@@ -624,6 +645,18 @@ public static class StringBuiltIns
         if (position < 0)
             return (int)Math.Max(length + position, 0);
         return ClampPosition(position, length);
+    }
+
+    private static int PadTargetLength(
+        Interpreter interpreter,
+        ReadOnlySpan<RuntimeValue> args)
+    {
+        double targetLength = IntegerArgument(interpreter, args, 0, 0);
+        if (targetLength <= 0) return 0;
+        if (targetLength > int.MaxValue)
+            throw new ThrowException(new SharpTSRangeError(
+                "Invalid string length"));
+        return (int)targetLength;
     }
 
     #endregion

--- a/Runtime/BuiltIns/StringBuiltIns.cs
+++ b/Runtime/BuiltIns/StringBuiltIns.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using SharpTS.Execution;
 using SharpTS.Runtime;
+using SharpTS.Runtime.Exceptions;
 using SharpTS.Runtime.Types;
 
 namespace SharpTS.Runtime.BuiltIns;
@@ -10,12 +11,12 @@ public static class StringBuiltIns
     private static readonly BuiltInTypeMemberLookup<string> _lookup =
         BuiltInTypeBuilder<string>.ForInstanceType()
             .Property("length", s => (double)s.Length)
-            .MethodV2("charAt", 1, CharAtV2)
-            // Spec lengths (ECMA-262 §22.1.3): substring/slice/split/substr
-            // all take two optional args, so spec length is 2 even though
-            // MinArity is 1. concat is variadic with spec length 1.
-            .MethodV2("substring", 1, 2, specLength: 2, SubstringV2)
-            .MethodV2("indexOf", 1, 2, IndexOfV2)
+            .MethodV2("charAt", 0, int.MaxValue, specLength: 1, CharAtV2)
+            // Spec lengths (ECMA-262 §22.1.3) are metadata, independent of
+            // runtime argument acceptance: JavaScript methods coerce omitted
+            // values and ignore extras. concat is variadic with spec length 1.
+            .MethodV2("substring", 0, int.MaxValue, specLength: 2, SubstringV2)
+            .MethodV2("indexOf", 0, int.MaxValue, specLength: 1, IndexOfV2)
             .MethodV2("toUpperCase", 0, ToUpperCaseV2)
             .MethodV2("toLowerCase", 0, ToLowerCaseV2)
             .MethodV2("toLocaleUpperCase", 0, ToUpperCaseV2)
@@ -26,22 +27,22 @@ public static class StringBuiltIns
             .MethodV2("match", 1, MatchV2)
             .MethodV2("matchAll", 1, MatchAllV2)
             .MethodV2("search", 1, SearchV2)
-            .MethodV2("includes", 1, IncludesV2)
-            .MethodV2("startsWith", 1, StartsWithV2)
-            .MethodV2("endsWith", 1, EndsWithV2)
-            .MethodV2("slice", 1, 2, specLength: 2, SliceV2)
-            .MethodV2("substr", 1, 2, specLength: 2, SubstrV2)
+            .MethodV2("includes", 0, int.MaxValue, specLength: 1, IncludesV2)
+            .MethodV2("startsWith", 0, int.MaxValue, specLength: 1, StartsWithV2)
+            .MethodV2("endsWith", 0, int.MaxValue, specLength: 1, EndsWithV2)
+            .MethodV2("slice", 0, int.MaxValue, specLength: 2, SliceV2)
+            .MethodV2("substr", 0, int.MaxValue, specLength: 2, SubstrV2)
             .MethodV2("repeat", 1, RepeatV2)
             .MethodV2("padStart", 1, 2, PadStartV2)
             .MethodV2("padEnd", 1, 2, PadEndV2)
-            .MethodV2("charCodeAt", 1, CharCodeAtV2)
-            .MethodV2("codePointAt", 1, CodePointAtV2)
+            .MethodV2("charCodeAt", 0, int.MaxValue, specLength: 1, CharCodeAtV2)
+            .MethodV2("codePointAt", 0, int.MaxValue, specLength: 1, CodePointAtV2)
             .MethodV2("concat", 0, int.MaxValue, specLength: 1, ConcatV2)
-            .MethodV2("lastIndexOf", 1, LastIndexOfV2)
+            .MethodV2("lastIndexOf", 0, int.MaxValue, specLength: 1, LastIndexOfV2)
             .MethodV2("trimStart", 0, TrimStartV2)
             .MethodV2("trimEnd", 0, TrimEndV2)
             .MethodV2("replaceAll", 2, ReplaceAllV2)
-            .MethodV2("at", 1, AtV2)
+            .MethodV2("at", 0, int.MaxValue, specLength: 1, AtV2)
             .MethodV2("normalize", 0, 1, NormalizeV2)
             .MethodV2("localeCompare", 1, LocaleCompareV2)
             // ECMA-262 §22.1.3.28/.31: String.prototype.toString and valueOf both
@@ -296,34 +297,29 @@ public static class StringBuiltIns
 
     #region V2 Implementations (RuntimeValue — no boxing)
 
-    private static RuntimeValue CharAtV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue CharAtV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
     {
-        var index = (int)args[0].AsNumber();
-        if (index < 0 || index >= str.Length) return RuntimeValue.EmptyString;
-        return RuntimeValue.FromString(str[index].ToString());
+        double position = IntegerArgument(interpreter, args, 0, 0);
+        if (position < 0 || position >= str.Length) return RuntimeValue.EmptyString;
+        return RuntimeValue.FromString(str[(int)position].ToString());
     }
 
-    private static RuntimeValue SubstringV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue SubstringV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
     {
-        var start = Math.Max(0, (int)args[0].AsNumber());
-        var end = args.Length > 1 ? (int)args[1].AsNumber() : str.Length;
-        if (start >= str.Length) return RuntimeValue.EmptyString;
-        if (end > str.Length) end = str.Length;
-        if (end <= start) return RuntimeValue.EmptyString;
+        int start = ClampPosition(IntegerArgument(interpreter, args, 0, 0), str.Length);
+        int end = args.Length < 2 || args[1].IsUndefined
+            ? str.Length
+            : ClampPosition(IntegerArgument(interpreter, args, 1, 0), str.Length);
+        if (start > end) (start, end) = (end, start);
         return RuntimeValue.FromString(str.Substring(start, end - start));
     }
 
-    private static RuntimeValue IndexOfV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue IndexOfV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
     {
-        var search = args[0].AsString();
-        // ECMA-262 §22.1.3.9: fromIndex is clamped to [0, length]
-        int fromIndex = 0;
-        if (args.Length >= 2 && !args[1].IsUndefined)
-        {
-            double n = args[1].AsNumber();
-            fromIndex = double.IsNaN(n) ? 0 : (int)Math.Max(0, Math.Min(n, str.Length));
-        }
-        return RuntimeValue.FromNumber(str.IndexOf(search, fromIndex));
+        string search = StringArgument(interpreter, args, 0);
+        int fromIndex = ClampPosition(IntegerArgument(interpreter, args, 1, 0), str.Length);
+        return RuntimeValue.FromNumber(
+            str.IndexOf(search, fromIndex, StringComparison.Ordinal));
     }
 
     private static RuntimeValue ToUpperCaseV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
@@ -335,34 +331,54 @@ public static class StringBuiltIns
     private static RuntimeValue TrimV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
         => RuntimeValue.FromString(str.Trim());
 
-    private static RuntimeValue IncludesV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoolean(str.Contains(args[0].AsString()));
-
-    private static RuntimeValue StartsWithV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoolean(str.StartsWith(args[0].AsString()));
-
-    private static RuntimeValue EndsWithV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoolean(str.EndsWith(args[0].AsString()));
-
-    private static RuntimeValue SliceV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue IncludesV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
     {
-        var start = (int)args[0].AsNumber();
-        var end = args.Length > 1 ? (int)args[1].AsNumber() : str.Length;
-        if (start < 0) start = Math.Max(0, str.Length + start);
-        if (end < 0) end = Math.Max(0, str.Length + end);
-        start = Math.Min(start, str.Length);
-        end = Math.Min(end, str.Length);
+        string search = SearchStringArgument(interpreter, args, "includes");
+        int position = ClampPosition(IntegerArgument(interpreter, args, 1, 0), str.Length);
+        return RuntimeValue.FromBoolean(
+            str.IndexOf(search, position, StringComparison.Ordinal) >= 0);
+    }
+
+    private static RuntimeValue StartsWithV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
+    {
+        string search = SearchStringArgument(interpreter, args, "startsWith");
+        int position = ClampPosition(IntegerArgument(interpreter, args, 1, 0), str.Length);
+        return position + search.Length <= str.Length
+            ? RuntimeValue.FromBoolean(
+                str.AsSpan(position, search.Length).SequenceEqual(search))
+            : RuntimeValue.False;
+    }
+
+    private static RuntimeValue EndsWithV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
+    {
+        string search = SearchStringArgument(interpreter, args, "endsWith");
+        int end = args.Length < 2 || args[1].IsUndefined
+            ? str.Length
+            : ClampPosition(IntegerArgument(interpreter, args, 1, 0), str.Length);
+        int start = end - search.Length;
+        return start >= 0
+            ? RuntimeValue.FromBoolean(
+                str.AsSpan(start, search.Length).SequenceEqual(search))
+            : RuntimeValue.False;
+    }
+
+    private static RuntimeValue SliceV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
+    {
+        int start = RelativePosition(
+            IntegerArgument(interpreter, args, 0, 0), str.Length);
+        int end = args.Length < 2 || args[1].IsUndefined
+            ? str.Length
+            : RelativePosition(
+                IntegerArgument(interpreter, args, 1, 0), str.Length);
         if (end <= start) return RuntimeValue.EmptyString;
         return RuntimeValue.FromString(str.Substring(start, end - start));
     }
 
     // Legacy String.prototype.substr(start[, length]) — Annex B §B.2.2.1
-    private static RuntimeValue SubstrV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue SubstrV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
     {
-        double startArg = args[0].AsNumber();
-        int start = double.IsNaN(startArg) ? 0 : (int)startArg;
-        if (start < 0) start = Math.Max(0, str.Length + start);
-        if (start > str.Length) return RuntimeValue.EmptyString;
+        int start = RelativePosition(
+            IntegerArgument(interpreter, args, 0, 0), str.Length);
 
         int length;
         if (args.Length < 2 || args[1].IsUndefined)
@@ -371,8 +387,8 @@ public static class StringBuiltIns
         }
         else
         {
-            double lenArg = args[1].AsNumber();
-            length = double.IsNaN(lenArg) ? 0 : (int)lenArg;
+            double lengthArg = IntegerArgument(interpreter, args, 1, 0);
+            length = ClampPosition(lengthArg, str.Length - start);
         }
         if (length <= 0) return RuntimeValue.EmptyString;
         length = Math.Min(length, str.Length - start);
@@ -394,15 +410,30 @@ public static class StringBuiltIns
         }));
     }
 
-    private static RuntimeValue CharCodeAtV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue CharCodeAtV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
     {
-        var index = (int)args[0].AsNumber();
-        if (index < 0 || index >= str.Length) return RuntimeValue.NaN;
-        return RuntimeValue.FromNumber(str[index]);
+        double position = IntegerArgument(interpreter, args, 0, 0);
+        if (position < 0 || position >= str.Length) return RuntimeValue.NaN;
+        return RuntimeValue.FromNumber(str[(int)position]);
     }
 
-    private static RuntimeValue LastIndexOfV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromNumber(str.LastIndexOf(args[0].AsString()));
+    private static RuntimeValue LastIndexOfV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
+    {
+        string search = StringArgument(interpreter, args, 0);
+        double rawPosition = args.Length < 2 || args[1].IsUndefined
+            ? double.PositiveInfinity
+            : interpreter.ToNumberWithPrimitive(args[1].ToObject());
+        rawPosition = double.IsNaN(rawPosition)
+            ? double.PositiveInfinity
+            : ToIntegerOrInfinity(rawPosition);
+        int position = ClampPosition(rawPosition, str.Length);
+        int start = Math.Min(position, str.Length - search.Length);
+        if (start < 0) return RuntimeValue.FromNumber(-1);
+        if (search.Length == 0) return RuntimeValue.FromNumber(position);
+        int searchEnd = Math.Min(str.Length, start + search.Length);
+        return RuntimeValue.FromNumber(
+            str.AsSpan(0, searchEnd).LastIndexOf(search));
+    }
 
     private static RuntimeValue TrimStartV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
         => RuntimeValue.FromString(str.TrimStart());
@@ -410,12 +441,14 @@ public static class StringBuiltIns
     private static RuntimeValue TrimEndV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
         => RuntimeValue.FromString(str.TrimEnd());
 
-    private static RuntimeValue AtV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue AtV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
     {
-        var index = (int)args[0].AsNumber();
-        if (index < 0) index = str.Length + index;
-        if (index < 0 || index >= str.Length) return RuntimeValue.Undefined;
-        return RuntimeValue.FromString(str[index].ToString());
+        double relativeIndex = IntegerArgument(interpreter, args, 0, 0);
+        double position = relativeIndex >= 0
+            ? relativeIndex
+            : str.Length + relativeIndex;
+        if (position < 0 || position >= str.Length) return RuntimeValue.Undefined;
+        return RuntimeValue.FromString(str[(int)position].ToString());
     }
 
     private static RuntimeValue PadStartV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
@@ -460,10 +493,11 @@ public static class StringBuiltIns
         }));
     }
 
-    private static RuntimeValue CodePointAtV2(Interpreter _, string str, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue CodePointAtV2(Interpreter interpreter, string str, ReadOnlySpan<RuntimeValue> args)
     {
-        var index = (int)args[0].AsNumber();
-        if (index < 0 || index >= str.Length) return RuntimeValue.Undefined;
+        double position = IntegerArgument(interpreter, args, 0, 0);
+        if (position < 0 || position >= str.Length) return RuntimeValue.Undefined;
+        int index = (int)position;
         if (char.IsHighSurrogate(str[index]) && index + 1 < str.Length && char.IsLowSurrogate(str[index + 1]))
             return RuntimeValue.FromNumber(char.ConvertToUtf32(str[index], str[index + 1]));
         return RuntimeValue.FromNumber(str[index]);
@@ -529,6 +563,67 @@ public static class StringBuiltIns
             sb.Append(arg.AsString());
         }
         return RuntimeValue.FromString(sb.ToString());
+    }
+
+    private static object? ArgumentOrUndefined(
+        ReadOnlySpan<RuntimeValue> args,
+        int index)
+        => index < args.Length
+            ? args[index].ToObject()
+            : SharpTSUndefined.Instance;
+
+    private static string StringArgument(
+        Interpreter interpreter,
+        ReadOnlySpan<RuntimeValue> args,
+        int index)
+        => interpreter.ToStringForBuiltInArgument(
+            ArgumentOrUndefined(args, index));
+
+    private static string SearchStringArgument(
+        Interpreter interpreter,
+        ReadOnlySpan<RuntimeValue> args,
+        string methodName)
+    {
+        object? value = ArgumentOrUndefined(args, 0);
+        if (value is SharpTSRegExp)
+            throw new ThrowException(new SharpTSTypeError(
+                $"String.prototype.{methodName} does not accept a RegExp"));
+        return interpreter.ToStringForBuiltInArgument(value);
+    }
+
+    private static double IntegerArgument(
+        Interpreter interpreter,
+        ReadOnlySpan<RuntimeValue> args,
+        int index,
+        double defaultValue)
+    {
+        if (index >= args.Length)
+            return defaultValue;
+
+        double number = interpreter.ToNumberWithPrimitive(args[index].ToObject());
+        return ToIntegerOrInfinity(number);
+    }
+
+    private static double ToIntegerOrInfinity(double number)
+    {
+        if (double.IsNaN(number) || number == 0) return 0;
+        if (double.IsInfinity(number)) return number;
+        return Math.Truncate(number);
+    }
+
+    private static int ClampPosition(double position, int length)
+    {
+        if (position <= 0) return 0;
+        if (position >= length) return length;
+        return (int)position;
+    }
+
+    private static int RelativePosition(double position, int length)
+    {
+        if (position == double.NegativeInfinity) return 0;
+        if (position < 0)
+            return (int)Math.Max(length + position, 0);
+        return ClampPosition(position, length);
     }
 
     #endregion

--- a/Runtime/Types/SharpTSArguments.cs
+++ b/Runtime/Types/SharpTSArguments.cs
@@ -1,0 +1,12 @@
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Array-like storage for a function's arguments object.
+/// </summary>
+/// <remarks>
+/// Reuses <see cref="SharpTSArray"/>'s indexed-property implementation, while
+/// retaining the distinct ECMAScript identity needed by Object.prototype.toString,
+/// Array.isArray, and instanceof Array.
+/// </remarks>
+public sealed class SharpTSArguments(IEnumerable<object?> arguments)
+    : SharpTSArray(arguments);

--- a/Runtime/Types/SharpTSArrayGlobal.cs
+++ b/Runtime/Types/SharpTSArrayGlobal.cs
@@ -228,136 +228,28 @@ internal sealed class ArrayPrototypeMethodWrapper : ISharpTSCallable
     private static bool TryMaterializeArrayLike(object? receiver, Interp interpreter, out SharpTSArray tempArr)
     {
         tempArr = null!;
-        switch (receiver)
+        if (receiver is null or SharpTSUndefined)
+            return false;
+
+        // LengthOfArrayLike and indexed HasProperty/Get are deliberately
+        // routed through the interpreter's generic property operations. Array
+        // prototype methods are generic: Date, RegExp, JSON, Error, Function,
+        // boxed primitives, and ordinary records all participate once user
+        // code gives them a length and indexed properties.
+        object? rawLen = interpreter.GetProperty(receiver, "length");
+        long len = ToLength(rawLen, interpreter);
+        len = Math.Min(len, 1 << 20);
+        var list = new List<object?>((int)len);
+        for (int i = 0; i < len; i++)
         {
-            case SharpTSObject obj:
-            {
-                // Read `length` — invoking an accessor getter if one is defined
-                // (Object.defineProperty(obj, "length", { get: ... })). Per spec,
-                // a throwing length getter aborts the whole method; we propagate
-                // by letting the ThrowException escape to the caller.
-                object? rawLen = ReadArrayLikeProperty(obj, "length", interpreter);
-                // When the wrapper has no own `length` (absent = SharpTSUndefined),
-                // walk the prototype chain. A boxed Number/Boolean primitive
-                // (ToObject result) carries __primitiveType but no own indexed
-                // elements — consult *.prototype extras.
-                if (rawLen is null or SharpTSUndefined)
-                    rawLen = GetBoxedPrimitiveProtoExtra(obj, "length", interpreter);
-                long len = ToLength(rawLen);
-                len = Math.Min(len, 1 << 20);
-                var list = new List<object?>((int)len);
-                for (int i = 0; i < len; i++)
-                {
-                    var key = i.ToString();
-                    if (obj.HasGetter(key))
-                        list.Add(ReadArrayLikeProperty(obj, key, interpreter));
-                    else if (obj.HasProperty(key))
-                        list.Add(obj.GetProperty(key));
-                    else
-                        list.Add(GetBoxedPrimitiveProtoExtra(obj, key, interpreter) ?? ArrayHole.Instance);
-                }
-                tempArr = new SharpTSArray(list);
-                return true;
-            }
-            case SharpTSMath math:
-            {
-                // Math is an extensible namespace object — Test262 tests set
-                // `Math.length` and `Math[i]` before invoking Array.prototype.*
-                // on Math, expecting array-like semantics.
-                long len = ToLength(math.HasExtra("length") ? math.TryGetExtra("length") : null);
-                len = Math.Min(len, 1 << 20);
-                var list = new List<object?>((int)len);
-                for (int i = 0; i < len; i++)
-                {
-                    var key = i.ToString();
-                    list.Add(math.HasExtra(key) ? math.TryGetExtra(key) : ArrayHole.Instance);
-                }
-                tempArr = new SharpTSArray(list);
-                return true;
-            }
-            case SharpTSNumberPrototype numProto:
-            {
-                long len = ToLength(numProto.HasExtra("length") ? numProto.TryGetExtra("length") : null);
-                len = Math.Min(len, 1 << 20);
-                var list = new List<object?>((int)len);
-                for (int i = 0; i < len; i++)
-                {
-                    var key = i.ToString();
-                    list.Add(numProto.HasExtra(key) ? numProto.TryGetExtra(key) : ArrayHole.Instance);
-                }
-                tempArr = new SharpTSArray(list);
-                return true;
-            }
-            case SharpTSBooleanPrototype boolProto:
-            {
-                long len = ToLength(boolProto.HasExtra("length") ? boolProto.TryGetExtra("length") : null);
-                len = Math.Min(len, 1 << 20);
-                var list = new List<object?>((int)len);
-                for (int i = 0; i < len; i++)
-                {
-                    var key = i.ToString();
-                    list.Add(boolProto.HasExtra(key) ? boolProto.TryGetExtra(key) : ArrayHole.Instance);
-                }
-                tempArr = new SharpTSArray(list);
-                return true;
-            }
-            case SharpTSStringPrototype strProto:
-            {
-                long len = ToLength(strProto.HasExtra("length") ? strProto.TryGetExtra("length") : null);
-                len = Math.Min(len, 1 << 20);
-                var list = new List<object?>((int)len);
-                for (int i = 0; i < len; i++)
-                {
-                    var key = i.ToString();
-                    list.Add(strProto.HasExtra(key) ? strProto.TryGetExtra(key) : ArrayHole.Instance);
-                }
-                tempArr = new SharpTSArray(list);
-                return true;
-            }
-            // A primitive string receiver never reaches here: Call() runs it
-            // through ToObject first, so it arrives as a boxed String wrapper
-            // (SharpTSObject with `length` + indexed char slots) handled by the
-            // SharpTSObject case above.
-            default:
-                return false;
+            string key = i.ToString(
+                System.Globalization.CultureInfo.InvariantCulture);
+            list.Add(interpreter.HasProperty(receiver, key)
+                ? interpreter.GetProperty(receiver, key)
+                : ArrayHole.Instance);
         }
-    }
-
-    /// <summary>
-    /// Returns the extra property value from the matching primitive prototype when
-    /// <paramref name="obj"/> is a boxed primitive wrapper produced by ToObject,
-    /// or null if the property is absent or the object is not a boxed primitive.
-    /// Used to implement ECMA-262 LengthOfArrayLike/Get prototype-chain walk for
-    /// Number and Boolean wrappers whose own property bags carry no indexed state.
-    /// </summary>
-    private static object? GetBoxedPrimitiveProtoExtra(SharpTSObject obj, string name, Interp interpreter)
-    {
-        if (!obj.HasProperty("__primitiveType")) return null;
-        // Per-realm prototypes: read the boxed primitive's prototype extras off
-        // this realm's instance, not the shared singleton, so they match what
-        // guest `Number.prototype.x = …` wrote in the same realm.
-        return obj.GetProperty("__primitiveType") switch
-        {
-            "Number"  => interpreter.GetNumberPrototype().TryGetExtra(name),
-            "Boolean" => interpreter.GetBooleanPrototype().TryGetExtra(name),
-            "String"  => interpreter.GetStringPrototype().TryGetExtra(name),
-            _ => null
-        };
-    }
-
-    /// <summary>
-    /// Reads a property from a SharpTSObject, invoking an accessor getter if
-    /// present. Matches the `Get(O, P)` abstract operation used by
-    /// Array.prototype.* methods. If the getter throws, the exception
-    /// propagates — spec-compliant short-circuit for things like
-    /// <c>Object.defineProperty(obj, "length", { get: () => { throw ... } })</c>.
-    /// </summary>
-    private static object? ReadArrayLikeProperty(SharpTSObject obj, string name, Interp interpreter)
-    {
-        var getter = obj.GetGetter(name);
-        if (getter != null)
-            return getter.Call(interpreter, new List<object?>());
-        return obj.GetProperty(name);
+        tempArr = new SharpTSArray(list);
+        return true;
     }
 
     /// <summary>
@@ -386,18 +278,9 @@ internal sealed class ArrayPrototypeMethodWrapper : ISharpTSCallable
     /// non-negative integer length, clamped to <c>2^53 − 1</c>. NaN/negative
     /// input becomes 0; non-numeric strings parse to NaN → 0.
     /// </summary>
-    private static long ToLength(object? value)
+    private static long ToLength(object? value, Interp interpreter)
     {
-        double n = value switch
-        {
-            double d => d,
-            bool b => b ? 1.0 : 0.0,
-            string s => double.TryParse(s, System.Globalization.NumberStyles.Float,
-                System.Globalization.CultureInfo.InvariantCulture, out var parsed) ? parsed : double.NaN,
-            null => 0.0,
-            SharpTSUndefined => double.NaN,
-            _ => double.NaN,
-        };
+        double n = interpreter.ToNumberWithPrimitive(value);
         if (double.IsNaN(n) || n <= 0) return 0;
         if (double.IsPositiveInfinity(n)) return (1L << 53) - 1;
         return (long)Math.Min(Math.Truncate(n), (double)((1L << 53) - 1));

--- a/Runtime/Types/SharpTSFunction.cs
+++ b/Runtime/Types/SharpTSFunction.cs
@@ -587,7 +587,7 @@ public class SharpTSArrowFunction : ISharpTSCallable, ITypeCategorized
             }
         }
 
-        return null;
+        return SharpTSUndefined.Instance;
     }
 
     /// <summary>

--- a/Runtime/Types/SharpTSFunction.cs
+++ b/Runtime/Types/SharpTSFunction.cs
@@ -223,7 +223,7 @@ public class SharpTSFunction : ISharpTSCallable, ITypeCategorized
         // Materialized only when the body can observe it (ArgumentsUsage scan).
         if (ArgumentsUsage.UsesArguments(_declaration))
         {
-            environment.Define("arguments", new SharpTSArray(arguments));
+            environment.Define("arguments", new SharpTSArguments(arguments));
         }
 
         var result = interpreter.ExecuteBlock(_declaration.Body, environment);
@@ -332,7 +332,7 @@ public class SharpTSFunction : ISharpTSCallable, ITypeCategorized
         {
             var argsList = new List<object?>(arguments.Length);
             for (int i = 0; i < arguments.Length; i++) argsList.Add(arguments[i].ToObject());
-            environment.Define("arguments", new SharpTSArray(argsList));
+            environment.Define("arguments", new SharpTSArguments(argsList));
         }
 
         var result = interpreter.ExecuteBlock(_declaration.Body, environment);
@@ -555,7 +555,7 @@ public class SharpTSArrowFunction : ISharpTSCallable, ITypeCategorized
         // Materialized only when the body can observe it (ArgumentsUsage scan).
         if (HasOwnThis && ArgumentsUsage.UsesArguments(_declaration))
         {
-            environment.Define("arguments", new SharpTSArray(new List<object?>(arguments)));
+            environment.Define("arguments", new SharpTSArguments(new List<object?>(arguments)));
         }
 
         if (_declaration.ExpressionBody != null)
@@ -628,7 +628,7 @@ public class SharpTSArrowFunction : ISharpTSCallable, ITypeCategorized
         {
             var argsList = new List<object?>(arguments.Length);
             for (int i = 0; i < arguments.Length; i++) argsList.Add(arguments[i].ToObject());
-            environment.Define("arguments", new SharpTSArray(argsList));
+            environment.Define("arguments", new SharpTSArguments(argsList));
         }
 
         if (_declaration.ExpressionBody != null)

--- a/Runtime/Types/SharpTSObjectNamespace.cs
+++ b/Runtime/Types/SharpTSObjectNamespace.cs
@@ -86,11 +86,11 @@ public class SharpTSObjectNamespace : ISharpTSCallable
                 ["__primitiveType"] = "Symbol",
                 ["__primitiveValue"] = value,
             });
-        // Primitives (string/number/bool) — wrap in a plain object holding the primitive.
-        // Good enough for lodash's use case where the wrapper is iterated over, not read.
-        // A fuller implementation would materialize String/Number/Boolean wrapper objects.
-        if (value is string or double or int or long or bool)
-            return new SharpTSObject(new Dictionary<string, object?> { ["valueOf"] = value });
+        // Primitives use the same internal-slot wrappers as their dedicated
+        // constructors. This preserves Object(value)'s primitive identity for
+        // later ToPrimitive operations.
+        if (value is string or double or bool)
+            return BuiltInConstructorFactory.ToObject(value);
         return value;
     }
 

--- a/Runtime/Types/SharpTSObjectPrototype.cs
+++ b/Runtime/Types/SharpTSObjectPrototype.cs
@@ -162,6 +162,7 @@ public sealed class SharpTSObjectUnboundMethod : ISharpTSCallable
         if (target is bool) return "[object Boolean]";
         if (target is SharpTSArray) return "[object Array]";
         if (target is SharpTSMath) return "[object Math]";
+        if (target is SharpTSJSON) return "[object JSON]";
         // Function classification — any value `typeof` reports as "function"
         // must tag "[object Function]" (ECMA-262 20.1.3.6 step 7, IsCallable):
         // lodash's baseGetTag/isFunction classifies built-in constructors held

--- a/Runtime/Types/SharpTSObjectPrototype.cs
+++ b/Runtime/Types/SharpTSObjectPrototype.cs
@@ -160,6 +160,7 @@ public sealed class SharpTSObjectUnboundMethod : ISharpTSCallable
         if (target is string) return "[object String]";
         if (target is double or int) return "[object Number]";
         if (target is bool) return "[object Boolean]";
+        if (target is SharpTSArguments) return "[object Arguments]";
         if (target is SharpTSArray) return "[object Array]";
         if (target is SharpTSMath) return "[object Math]";
         if (target is SharpTSJSON) return "[object JSON]";

--- a/Runtime/Types/SharpTSPrimitiveNamespaces.cs
+++ b/Runtime/Types/SharpTSPrimitiveNamespaces.cs
@@ -169,33 +169,8 @@ internal sealed class StringPrototypeMethodWrapper : ISharpTSCallable
                 $"String.prototype.{_name} called on null or undefined"));
         }
 
-        var coerced = CoerceToString(_receiver);
+        var coerced = interpreter.ToStringForBuiltInArgument(_receiver);
         return _inner.Bind(coerced).Call(interpreter, arguments);
-    }
-
-    /// <summary>
-    /// ECMA-262 ToString abstract operation — mapped to the receiver types
-    /// our interpreter actually hands to string methods. Symbols throw
-    /// TypeError per spec (ToString(Symbol) is an abrupt completion).
-    /// </summary>
-    private static string CoerceToString(object? receiver)
-    {
-        if (receiver is SharpTSSymbol)
-            throw new ThrowException(new SharpTSTypeError(
-                "Cannot convert a Symbol value to a string"));
-        // Unwrap boxed String wrapper: `new String("x")` stores the primitive
-        // in __primitiveValue so String.prototype methods work on the wrapper.
-        if (receiver is SharpTSObject obj
-            && obj.GetProperty("__primitiveType") is string pt && pt == "String"
-            && obj.GetProperty("__primitiveValue") is string sv)
-            return sv;
-        return receiver switch
-        {
-            string s => s,
-            double d => SharpTS.Compilation.RuntimeTypes.Stringify(d),
-            bool b => b ? "true" : "false",
-            _ => receiver?.ToString() ?? "",
-        };
     }
 
     public override string ToString() => $"function {_name}() {{ [native code] }}";

--- a/SharpTS.Test262/Issue1279ParityTests.cs
+++ b/SharpTS.Test262/Issue1279ParityTests.cs
@@ -343,6 +343,22 @@ public sealed class Issue1279ParityTests
         => AssertPassInBothModes(relativePath);
 
     [Theory]
+    [InlineData("built-ins/String/fromCharCode/touint16-tonumber-throws-valueof.js")]
+    [InlineData("built-ins/String/fromCodePoint/to-number-conversions.js")]
+    [InlineData("built-ins/String/fromCodePoint/number-is-out-of-range.js")]
+    [InlineData("built-ins/String/prototype/concat/S15.5.4.6_A1_T1.js")]
+    [InlineData("built-ins/String/prototype/concat/S15.5.4.6_A1_T2.js")]
+    [InlineData("built-ins/String/prototype/localeCompare/15.5.4.9_3.js")]
+    [InlineData("built-ins/String/prototype/repeat/count-coerced-to-zero-returns-empty-string.js")]
+    [InlineData("built-ins/String/prototype/repeat/count-less-than-zero-throws.js")]
+    [InlineData("built-ins/String/prototype/padStart/fill-string-non-strings.js")]
+    [InlineData("built-ins/String/prototype/padEnd/normal-operation.js")]
+    [InlineData("built-ins/String/prototype/normalize/form-is-not-valid-throws.js")]
+    public void Remaining_string_methods_coerce_arguments_in_both_modes(
+        string relativePath)
+        => AssertPassInBothModes(relativePath);
+
+    [Theory]
     [InlineData("built-ins/Number/S15.7.5_A1_T01.js")]
     [InlineData("built-ins/Number/S15.7.5_A1_T03.js")]
     [InlineData("built-ins/Object/create/15.2.3.5-4-41.js")]

--- a/SharpTS.Test262/Issue1279ParityTests.cs
+++ b/SharpTS.Test262/Issue1279ParityTests.cs
@@ -285,6 +285,21 @@ public sealed class Issue1279ParityTests
         => AssertPassInBothModes(relativePath);
 
     [Theory]
+    [InlineData("built-ins/Array/prototype/map/15.4.4.19-1-9.js")]
+    [InlineData("built-ins/Array/prototype/map/15.4.4.19-1-11.js")]
+    [InlineData("built-ins/Array/prototype/map/15.4.4.19-1-12.js")]
+    [InlineData("built-ins/Array/prototype/map/15.4.4.19-1-13.js")]
+    [InlineData("built-ins/Array/prototype/map/15.4.4.19-1-14.js")]
+    [InlineData("built-ins/Array/prototype/reduceRight/15.4.4.22-1-11.js")]
+    [InlineData("built-ins/Array/prototype/filter/15.4.4.20-1-13.js")]
+    [InlineData("built-ins/Array/prototype/some/15.4.4.17-1-14.js")]
+    [InlineData("built-ins/Array/prototype/every/15.4.4.16-1-9.js")]
+    [InlineData("built-ins/Array/prototype/forEach/15.4.4.18-1-12.js")]
+    public void Array_prototype_methods_support_generic_receivers_in_both_modes(
+        string relativePath)
+        => AssertPassInBothModes(relativePath);
+
+    [Theory]
     [InlineData("built-ins/Number/S15.7.5_A1_T01.js")]
     [InlineData("built-ins/Number/S15.7.5_A1_T03.js")]
     [InlineData("built-ins/Object/create/15.2.3.5-4-41.js")]

--- a/SharpTS.Test262/Issue1279ParityTests.cs
+++ b/SharpTS.Test262/Issue1279ParityTests.cs
@@ -300,6 +300,18 @@ public sealed class Issue1279ParityTests
         => AssertPassInBothModes(relativePath);
 
     [Theory]
+    [InlineData("built-ins/Array/prototype/every/15.4.4.16-4-1.js")]
+    [InlineData("built-ins/Array/prototype/some/15.4.4.17-4-1.js")]
+    [InlineData("built-ins/Array/prototype/forEach/15.4.4.18-4-1.js")]
+    [InlineData("built-ins/Array/prototype/map/15.4.4.19-4-1.js")]
+    [InlineData("built-ins/Array/prototype/filter/15.4.4.20-4-1.js")]
+    [InlineData("built-ins/Array/prototype/reduce/15.4.4.21-4-1.js")]
+    [InlineData("built-ins/Array/prototype/reduceRight/15.4.4.22-4-1.js")]
+    public void Array_callback_methods_throw_TypeError_in_both_modes(
+        string relativePath)
+        => AssertPassInBothModes(relativePath);
+
+    [Theory]
     [InlineData("built-ins/Number/S15.7.5_A1_T01.js")]
     [InlineData("built-ins/Number/S15.7.5_A1_T03.js")]
     [InlineData("built-ins/Object/create/15.2.3.5-4-41.js")]

--- a/SharpTS.Test262/Issue1279ParityTests.cs
+++ b/SharpTS.Test262/Issue1279ParityTests.cs
@@ -312,6 +312,20 @@ public sealed class Issue1279ParityTests
         => AssertPassInBothModes(relativePath);
 
     [Theory]
+    [InlineData("built-ins/Array/isArray/15.4.3.2-1-13.js")]
+    [InlineData("built-ins/Array/prototype/every/15.4.4.16-1-15.js")]
+    [InlineData("built-ins/Array/prototype/some/15.4.4.17-1-15.js")]
+    [InlineData("built-ins/Array/prototype/forEach/15.4.4.18-1-15.js")]
+    [InlineData("built-ins/Array/prototype/map/15.4.4.19-1-15.js")]
+    [InlineData("built-ins/Array/prototype/filter/15.4.4.20-1-15.js")]
+    [InlineData("built-ins/Array/prototype/reduce/15.4.4.21-1-15.js")]
+    [InlineData("built-ins/Array/prototype/reduceRight/15.4.4.22-1-15.js")]
+    [InlineData("built-ins/Object/prototype/toString/Object.prototype.toString.call-arguments.js")]
+    public void Arguments_objects_have_distinct_identity_in_both_modes(
+        string relativePath)
+        => AssertPassInBothModes(relativePath);
+
+    [Theory]
     [InlineData("built-ins/Number/S15.7.5_A1_T01.js")]
     [InlineData("built-ins/Number/S15.7.5_A1_T03.js")]
     [InlineData("built-ins/Object/create/15.2.3.5-4-41.js")]

--- a/SharpTS.Test262/Issue1279ParityTests.cs
+++ b/SharpTS.Test262/Issue1279ParityTests.cs
@@ -326,6 +326,23 @@ public sealed class Issue1279ParityTests
         => AssertPassInBothModes(relativePath);
 
     [Theory]
+    [InlineData("built-ins/String/prototype/charAt/S15.5.4.4_A1.1.js")]
+    [InlineData("built-ins/String/prototype/charAt/pos-coerce-string.js")]
+    [InlineData("built-ins/String/prototype/charCodeAt/S15.5.4.5_A1.1.js")]
+    [InlineData("built-ins/String/prototype/codePointAt/return-abrupt-from-object-pos-to-integer.js")]
+    [InlineData("built-ins/String/prototype/indexOf/searchstring-tostring.js")]
+    [InlineData("built-ins/String/prototype/lastIndexOf/S15.5.4.8_A4_T3.js")]
+    [InlineData("built-ins/String/prototype/includes/coerced-values-of-position.js")]
+    [InlineData("built-ins/String/prototype/startsWith/searchstring-found-with-position.js")]
+    [InlineData("built-ins/String/prototype/endsWith/coerced-values-of-position.js")]
+    [InlineData("built-ins/String/prototype/endsWith/searchstring-is-regexp-throws.js")]
+    [InlineData("built-ins/String/prototype/slice/S15.5.4.13_A1_T1.js")]
+    [InlineData("built-ins/String/prototype/substring/S15.5.4.15_A2_T4.js")]
+    public void String_character_and_search_methods_coerce_arguments_in_both_modes(
+        string relativePath)
+        => AssertPassInBothModes(relativePath);
+
+    [Theory]
     [InlineData("built-ins/Number/S15.7.5_A1_T01.js")]
     [InlineData("built-ins/Number/S15.7.5_A1_T03.js")]
     [InlineData("built-ins/Object/create/15.2.3.5-4-41.js")]


### PR DESCRIPTION
## Summary
- generalize Array.prototype receivers and preserve callback receiver identity
- surface guest TypeErrors for invalid Array callbacks and distinguish arguments objects from arrays
- implement JavaScript coercion and optional-argument semantics across String character, search, padding, normalization, and code-point methods

## Results
- interpreted Test262 passes: 6077 -> 6592 (+515)
- failures: 3098 -> 2770 (-328)
- runtime errors: 1317 -> 1130 (-187)
- baseline regressions: 0

## Validation
- focused cross-mode Test262 parity pins: 49 passing cases across the five batches
- nearby SharpTS tests: Array batch 197/197; arguments batch 199/199; String batches 167/167
- complete interpreted Test262 baseline sweep: 11,384 cases, 515 new passes, 0 regressions

Part of #1279.