### PR TITLE
chore(deps): NickNa.PEPacker 1.0.3, and pin what the rewrite must preserve

### DIFF
--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -303,8 +303,11 @@ public class EmittedRuntime
 
     // Marker attribute applied to a user function-expression / `this`-bearing arrow method whose
     // first emitted parameter is the synthetic `__this` receiver slot. $TSFunction reads it back via
-    // IsDefined so it can detect that slot without the parameter name (a --ref-asm rewrite strips
-    // parameter names, breaking the name-based check and shifting value-call arguments). (#738)
+    // IsDefined instead of matching on the parameter name, which keeps the check independent of the
+    // Param table: a --ref-asm rewrite that mis-resolved a method's parameter list would otherwise
+    // break the name-based check and shift value-call arguments by one. (NickNa.PEPacker carries
+    // parameter names across the rewrite as of 1.0.3; the attribute keeps this independent of that.)
+    // (#738)
     public TypeBuilder ExpectsThisAttrType { get; set; } = null!;
     public ConstructorBuilder ExpectsThisAttrCtor { get; set; } = null!;
 

--- a/Compilation/ILCompiler.Functions.cs
+++ b/Compilation/ILCompiler.Functions.cs
@@ -1353,8 +1353,9 @@ public partial class ILCompiler
     /// Marks a method whose first emitted parameter is the synthetic <c>__this</c> receiver slot
     /// (a user function expression or <c>this</c>-bearing arrow) with the <c>$ExpectsThis</c>
     /// attribute, so <c>$TSFunction</c> can detect that slot via <c>IsDefined</c> instead of the
-    /// parameter name — which a <c>--ref-asm</c> rewrite strips, otherwise shifting value-call
-    /// arguments by one. No-op when the runtime attribute is unavailable. (#738)
+    /// parameter name. That keeps the check independent of the <c>Param</c> table: a
+    /// <c>--ref-asm</c> rewrite that mis-resolved a method's parameter list would otherwise shift
+    /// value-call arguments by one. No-op when the runtime attribute is unavailable. (#738)
     /// </summary>
     internal void MarkExpectsThis(MethodBuilder method)
     {

--- a/Compilation/TypeProvider.cs
+++ b/Compilation/TypeProvider.cs
@@ -10,8 +10,10 @@ namespace SharpTS.Compilation;
 /// </summary>
 /// <remarks>
 /// Uses typeof() directly for fast compilation. The AssemblyReferenceRewriter (from the
-/// NickNa.PEPacker package) is used as a post-processing step when --ref-asm is enabled
-/// to rewrite System.Private.CoreLib references to SDK reference assemblies.
+/// NickNa.PEPacker package) is used as a post-processing step to rewrite System.Private.CoreLib
+/// references to SDK reference assemblies. It runs when --ref-asm is enabled, and also whenever the
+/// emitted assembly references SharpTS regardless of that flag — see the `_useReferenceAssemblies ||
+/// hasSharpTsReference` condition in <see cref="ILCompiler.SaveArtifacts"/>.
 /// </remarks>
 public class TypeProvider
 {

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
-    <PackageVersion Include="NickNa.PEPacker" Version="1.0.2" />
+    <PackageVersion Include="NickNa.PEPacker" Version="1.0.3" />
     <PackageVersion Include="NuGet.Packaging" Version="7.3.1" />
     <PackageVersion Include="NuGet.Protocol" Version="7.3.1" />
     <PackageVersion Include="OmniSharp.Extensions.LanguageServer" Version="0.19.9" />

--- a/SharpTS.Tests/Compilation/ReferenceRewriteFidelityTests.cs
+++ b/SharpTS.Tests/Compilation/ReferenceRewriteFidelityTests.cs
@@ -1,0 +1,220 @@
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
+using PEPacker;
+using SharpTS.Compilation;
+using SharpTS.Modules;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.Compilation;
+
+/// <summary>
+/// Pins what the <c>--ref-asm</c> post-pass — <c>PEPacker.AssemblyReferenceRewriter</c> — must carry
+/// across unchanged. The rewriter rebuilds the whole metadata image, so anything it does not know how
+/// to copy vanishes from the output silently: the assembly still loads and still runs, which is
+/// exactly why the loss needs an assertion rather than a smoke test.
+/// </summary>
+/// <remarks>
+/// <para>These are guards against a dependency regression, not against SharpTS code. Both were live
+/// defects in NickNa.PEPacker 1.0.2 and were fixed in 1.0.3:</para>
+/// <list type="bullet">
+/// <item>the <c>Property</c>/<c>PropertyMap</c>/<c>MethodSemantics</c> tables were dropped entirely,
+/// which strips the property identity off generator state machines (<c>Current</c>), auto-accessors
+/// and <c>$IHasFields.Fields</c> — invisible to interface dispatch, visible to any .NET consumer
+/// reflecting over a compiled TypeScript assembly;</item>
+/// <item>the PE header was rebuilt with <c>PEHeaderBuilder.CreateExecutableHeader()</c> regardless of
+/// the source, so a rewritten library came back without <c>Characteristics.Dll</c>.</item>
+/// </list>
+/// <para>Row counts are compared against the pre-rewrite image rather than pinned to literals, so the
+/// test tracks whatever the compiler happens to emit for the fixture below.</para>
+/// </remarks>
+public class ReferenceRewriteFidelityTests
+{
+    /// <summary>
+    /// Shaped to populate the tables at issue: <c>accessor</c> and a getter give the class real
+    /// property rows, and the generator plus async generator each contribute a state machine with a
+    /// <c>Current</c> property and a <c>switch</c>-dispatched <c>MoveNext</c>.
+    /// </summary>
+    private const string Source = """
+        class Counter {
+            accessor total: number = 0;
+            #step: number;
+            constructor(step: number = 2) { this.#step = step; }
+            get step(): number { return this.#step; }
+            bump(): void { this.total = this.total + this.#step; }
+        }
+
+        function* seq(n: number) {
+            for (let i = 0; i < n; i++) yield i;
+        }
+
+        async function* aseq(n: number) {
+            for (let i = 0; i < n; i++) yield i * 10;
+        }
+
+        async function main() {
+            const c = new Counter();
+            c.bump();
+            let sum = 0;
+            for (const v of seq(3)) sum += v;
+            for await (const v of aseq(3)) sum += v;
+            console.log(c.total, c.step, sum);
+        }
+
+        main();
+        """;
+
+    /// <summary>
+    /// Every metadata table SharpTS's own output populates must come through the rewrite with the
+    /// same number of rows. <c>Property</c> and <c>MethodSemantics</c> are the ones that regressed;
+    /// the rest are here so a future table loss is caught by the same test.
+    /// </summary>
+    [Fact]
+    public void RewriteKeepsEveryMetadataTableRowCount()
+    {
+        byte[] before = Compile();
+        byte[] after = RewriteReferences(before);
+
+        TableIndex[] tables =
+        [
+            TableIndex.TypeDef, TableIndex.MethodDef, TableIndex.Field, TableIndex.Param,
+            TableIndex.Property, TableIndex.PropertyMap, TableIndex.Event, TableIndex.EventMap,
+            TableIndex.MethodSemantics, TableIndex.MethodImpl, TableIndex.InterfaceImpl,
+            TableIndex.NestedClass, TableIndex.GenericParam, TableIndex.GenericParamConstraint,
+            TableIndex.Constant, TableIndex.StandAloneSig, TableIndex.CustomAttribute,
+        ];
+
+        var expected = RowCounts(before, tables);
+        var actual = RowCounts(after, tables);
+
+        // Asserted as whole dictionaries so a failure names every table that moved at once.
+        Assert.Equal(expected, actual);
+
+        // Guards the guard: a fixture that stopped emitting properties would let the regression
+        // through while every count still matched at zero.
+        Assert.True(expected[TableIndex.Property] > 0, "fixture emitted no properties");
+        Assert.True(expected[TableIndex.MethodSemantics] > 0, "fixture emitted no method semantics");
+    }
+
+    /// <summary>
+    /// A rewritten library must still describe itself as a library. The runtime tolerates a missing
+    /// <c>Dll</c> bit, but <c>Assembly.LoadFrom</c> on some hosts and most PE tooling do not.
+    /// </summary>
+    [Fact]
+    public void RewritePreservesLibraryPeCharacteristics()
+    {
+        byte[] before = Compile();
+        byte[] after = RewriteReferences(before);
+
+        using var source = new PEReader(new MemoryStream(before, writable: false));
+        using var rewritten = new PEReader(new MemoryStream(after, writable: false));
+
+        Assert.True(source.PEHeaders.CoffHeader.Characteristics.HasFlag(Characteristics.Dll));
+        Assert.Equal(
+            source.PEHeaders.CoffHeader.Characteristics,
+            rewritten.PEHeaders.CoffHeader.Characteristics);
+        Assert.Equal(source.PEHeaders.CoffHeader.Machine, rewritten.PEHeaders.CoffHeader.Machine);
+        Assert.Equal(source.PEHeaders.PEHeader!.Subsystem, rewritten.PEHeaders.PEHeader!.Subsystem);
+    }
+
+    /// <summary>
+    /// The property rows have to keep naming the same members, not merely arrive in the same number,
+    /// and each accessor must still be reachable through <c>MethodSemantics</c>.
+    /// </summary>
+    [Fact]
+    public void RewriteKeepsPropertyNamesAndAccessorLinks()
+    {
+        byte[] before = Compile();
+        byte[] after = RewriteReferences(before);
+
+        Assert.Equal(PropertyAccessors(before), PropertyAccessors(after));
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    /// <summary>
+    /// Every <c>Type::Property</c> in the image mapped to the names of its accessor methods, which
+    /// only resolve when the <c>MethodSemantics</c> rows survived and still point at the right rows.
+    /// </summary>
+    private static SortedDictionary<string, string> PropertyAccessors(byte[] image)
+    {
+        using var peReader = new PEReader(new MemoryStream(image, writable: false));
+        var reader = peReader.GetMetadataReader();
+        var result = new SortedDictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var typeHandle in reader.TypeDefinitions)
+        {
+            var type = reader.GetTypeDefinition(typeHandle);
+            foreach (var propertyHandle in type.GetProperties())
+            {
+                var property = reader.GetPropertyDefinition(propertyHandle);
+                var accessors = property.GetAccessors();
+
+                string Name(MethodDefinitionHandle handle) => handle.IsNil
+                    ? "-"
+                    : reader.GetString(reader.GetMethodDefinition(handle).Name);
+
+                result[$"{reader.GetString(type.Name)}::{reader.GetString(property.Name)}"] =
+                    $"{Name(accessors.Getter)}/{Name(accessors.Setter)}";
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Sorted so the two sides compare in a fixed order regardless of how the table list is written.
+    /// </summary>
+    private static SortedDictionary<TableIndex, int> RowCounts(byte[] image, TableIndex[] tables)
+    {
+        using var peReader = new PEReader(new MemoryStream(image, writable: false));
+        var reader = peReader.GetMetadataReader();
+        return new SortedDictionary<TableIndex, int>(tables.ToDictionary(t => t, reader.GetTableRowCount));
+    }
+
+    /// <summary>
+    /// Compiles <see cref="Source"/> to a library image without the post-pass, so the rewrite can be
+    /// run against it explicitly and the two images compared.
+    /// </summary>
+    private static byte[] Compile()
+    {
+        var document = new SourceDocument(Path.Combine(Path.GetTempPath(), "fidelity.ts"), Source);
+        var statements = new Parser(new Lexer(Source).ScanTokens())
+            .WithSourceDocument(document)
+            .ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCode = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+
+        var compiler = new ILCompiler("fidelity", preserveConstEnums: false);
+        compiler.SetSourceDocument(document);
+        compiler.Compile(statements, typeMap, deadCode);
+
+        byte[] image = compiler.SaveToBytes();
+
+        // SaveArtifacts also rewrites when the output references SharpTS, which would leave nothing
+        // to compare against. The fixture is chosen to avoid that; fail loudly if it stops holding.
+        using var peReader = new PEReader(new MemoryStream(image, writable: false));
+        var reader = peReader.GetMetadataReader();
+        Assert.Contains(
+            "System.Private.CoreLib",
+            reader.AssemblyReferences.Select(h => reader.GetString(reader.GetAssemblyReference(h).Name)));
+
+        return image;
+    }
+
+    private static byte[] RewriteReferences(byte[] image)
+    {
+        string referenceAssemblies = SdkResolver.FindReferenceAssembliesPath()
+            ?? throw new InvalidOperationException("SDK reference assemblies are required for this test.");
+
+        using var source = new MemoryStream(image, writable: false);
+        using var rewriter = new AssemblyReferenceRewriter(source, referenceAssemblies);
+        rewriter.Rewrite();
+
+        using var output = new MemoryStream();
+        rewriter.Save(output);
+        return output.ToArray();
+    }
+}


### PR DESCRIPTION
Pins `NickNa.PEPacker` to 1.0.3 (published today). This is a correctness upgrade, not a version bump for its own sake.

## What 1.0.3 fixes for us

Three upstream defects were silently damaging our own output on the rewrite path — `--ref-asm`, or any program whose output references SharpTS.dll, which goes through the same pass (`ILCompiler.cs:1499`).

| Fixed upstream | How it hit SharpTS |
|---|---|
| IL decoder desync corrupting `switch`/`calli` bodies | We emit `OpCodes.Switch` in nine places — every async/generator `MoveNext` dispatch (`AsyncMoveNextEmitter`, `IteratorMoveNextEmitter`, `RuntimeEmitter.AsyncGenerator`, `AsyncArrowMoveNextEmitter`) plus `UnionTypeGenerator` |
| `Property`/`PropertyMap`/`Event`/`MethodSemantics` dropped wholesale | Every `DefineProperty` site lost its property identity: generator `Current`, `accessor` fields, class-expression accessors, `$IHasFields.Fields` |
| PE header rebuilt as `CreateExecutableHeader()` unconditionally | A rewritten library came back **without `Characteristics.Dll`**, discarding the `CreateLibraryHeader()` we explicitly ask for at `ILCompiler.cs:1476` |

Measured on a fixture with accessors plus a generator and an async generator: 1.0.2 rewrote **81 `Property` and 104 `MethodSemantics` rows down to 0** and stripped the `Dll` bit. None of it was visible — the assembly still loaded and still ran correctly, which is exactly why it went unnoticed.

## Changes

**`Directory.Packages.props`** — 1.0.2 → 1.0.3. Single central pin; nothing else references the package.

**New `SharpTS.Tests/Compilation/ReferenceRewriteFidelityTests.cs`** (3 tests) — the guard we lacked. Runs the real `AssemblyReferenceRewriter` over a compiled fixture and asserts row counts across 17 metadata tables, property names with their accessor links, and PE characteristics all come through unchanged. Row counts are compared against the pre-rewrite image rather than pinned to literals, so the tests track whatever the compiler happens to emit.

Verified non-vacuous: with the pin temporarily reverted to 1.0.2, **all three fail** — `Property` → `[]`, `ExecutableImage | Dll` → `ExecutableImage`. They pass on 1.0.3.

**Three stale comments corrected.** `EmittedRuntime.cs` and `ILCompiler.Functions.cs` both justified the `$ExpectsThis` marker attribute with "a `--ref-asm` rewrite strips parameter names." That is not true: 121/121 `Param` rows keep their names across the 1.0.3 rewrite, identical before and after. The attribute stays — keeping the receiver-slot check off the `Param` table is the more robust design and reverting to a name-based check would be a regression for no gain — but the stated reason now matches reality. `TypeProvider.cs` claimed the rewrite pass runs only under `--ref-asm`; it also runs whenever the output references SharpTS.

## No code became removable

Each candidate was checked rather than assumed:

- **`DebugDirectoryInjector`** (292 lines) — still required. 1.0.3's `Save()` still passes no `debugDirectoryBuilder` to `ManagedPEBuilder`, so the debug directory is still dropped and still needs re-attaching. Its doc comment remains accurate.
- **`PdbEmitter.VerifyMethodMappingPreserved`** — kept. Cheap per-build invariant check; upstream's own round-trip tests don't cover our specific emit shapes.
- **`$ExpectsThis`** — kept, per above.

## Worth knowing: the new fail-closed validation

1.0.3 makes `Rewrite()` throw `PEPackerException` when the input carries managed resources, native Win32 resources, exported/forwarded types, `DeclSecurity`, or uncompressed metadata, rather than silently dropping them. Safe for us today — there is no `AddManifestResource`/`nativeResources` anywhere in `Compilation/`, and the `--target exe` path bundles *after* the rewrite so the rewriter never sees an apphost image. But if resource embedding is ever added to compiled output, `--ref-asm` will start throwing. That's the better failure; just worth knowing where it comes from.

## Verification

- Full suite: **16258 / 16259 passed**. The single failure was `DnsRecordTypeTests.LiveSmoke_ResolveNs_Promise`, a live-network test that passed on re-run — a transient flake unrelated to this change. (A network-dependent test in the suite is a hermeticity problem regardless; left alone as out of scope here.)
- Rewriter-adjacent tests (fidelity, `DebugSymbolsTests`, `BundlerFactoryTests`, `SdkBundlerDetectorTests`, `ILVerificationTests`, `CliBundlerTests`): 133 / 133 pass on 1.0.3.
- End to end: `--compile --ref-asm --verify` passes ILVerify, the rewritten DLL runs correctly, and both `--bundler auto` (SDK) and `--bundler builtin` produce working executables.
