### PR TITLE
Native AOT: embed managed runtime handoff (#1324)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,18 @@ jobs:
       - name: Install Native AOT prerequisites
         run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
 
+      # The native compiler carries an ordinary AnyCPU SharpTS.dll for compiled
+      # programs that late-bind to interpreter/runtime features. This must be a
+      # separate first build: an assembly cannot embed itself while it is being
+      # compiled.
+      - name: Build managed runtime payload
+        run: |
+          dotnet publish SharpTS.csproj --configuration Release \
+            -p:PlatformTarget=AnyCPU \
+            -p:DebugType=None \
+            -p:DebugSymbols=false \
+            -o artifacts/managed-runtime
+
       - name: Publish Native AOT SharpTS
         run: |
           dotnet publish SharpTS.csproj --configuration Release -r linux-x64 \
@@ -157,6 +169,7 @@ jobs:
             -p:StackTraceSupport=true \
             -p:DebugType=None \
             -p:DebugSymbols=false \
+            -p:SharpTSManagedRuntimePayloadPath="$PWD/artifacts/managed-runtime/SharpTS.dll" \
             -o artifacts/native-aot
 
       - name: Compile and execute from the native host
@@ -183,6 +196,28 @@ jobs:
             -o "$scratch/features.dll"
           dotnet "$scratch/features.dll" > "$scratch/features.txt"
           grep -qx '2 2 33' "$scratch/features.txt"
+
+          # A soft-dependency compile extracts the embedded AnyCPU SharpTS.dll.
+          # Running eval proves this is a usable managed payload, not merely a
+          # resource/copy assertion.
+          mkdir "$scratch/softdep"
+          "$native" --compile Examples/AotCompileGate/softdep.ts --ref-asm \
+            -o "$scratch/softdep/softdep.dll"
+          test -f "$scratch/softdep/SharpTS.dll"
+          dotnet "$scratch/softdep/softdep.dll" > "$scratch/softdep.txt"
+          grep -qx '42' "$scratch/softdep.txt"
+
+          # fork needs a second compiler process and is deliberately absent from
+          # the native SKU. Fail before writing a misleading output assembly.
+          if "$native" --compile Examples/AotCompileGate/fork.ts \
+              -o "$scratch/fork.dll" 2> "$scratch/fork-error.txt"; then
+            echo "child_process.fork unexpectedly compiled under Native AOT"
+            exit 1
+          fi
+          grep -Fq \
+            'child_process.fork in compiled output is not available in the native SharpTS build' \
+            "$scratch/fork-error.txt"
+          test ! -f "$scratch/fork.dll"
 
           # Exercise PE-Packer from inside SharpTS's partial-trim closure too.
           "$native" --compile Examples/AotCompileGate/main.ts -t exe \

--- a/Compilation/RuntimeEmitter.ReflectionHelpers.cs
+++ b/Compilation/RuntimeEmitter.ReflectionHelpers.cs
@@ -38,9 +38,9 @@ public partial class RuntimeEmitter
     /// Defines a public static helper method on <paramref name="typeBuilder"/> whose
     /// body calls <c>RuntimeTypes.{methodName}</c> via the late-bound reflection idiom
     /// (<c>Type.GetType("…, SharpTS").GetMethod(name).Invoke(null, args)</c>).
-    /// All parameters and the return value are <c>object?</c>. No missing-runtime
-    /// guard is emitted — callers reach these paths only for features that record
-    /// <see cref="EmittedRuntime.RequireSharpTSRuntime"/>, so SharpTS.dll is co-located.
+    /// All parameters and the return value are <c>object?</c>. A missing-runtime
+    /// guard turns deployment mistakes into a named error instead of a null
+    /// reference exception.
     /// </summary>
     private MethodBuilder EmitReflectionHelper(TypeBuilder typeBuilder, string methodName, int argCount)
     {
@@ -71,10 +71,9 @@ public partial class RuntimeEmitter
     /// reference — box value types). Defaults to <c>ldarg i</c>.
     /// </param>
     /// <param name="onMissing">
-    /// When supplied, a <c>Type.GetType</c> null-check is emitted and this callback
-    /// provides the missing-runtime path; it must NOT fall through — end with
-    /// <c>ret</c> or <c>throw</c>. When null, no guard is emitted (the site relies on
-    /// RequireSharpTSRuntime co-locating SharpTS.dll, and fails with an NRE otherwise).
+    /// Provides a custom missing-runtime path; it must NOT fall through — end with
+    /// <c>ret</c> or <c>throw</c>. When null, a clear
+    /// <see cref="InvalidOperationException"/> is emitted.
     /// </param>
     private void EmitReflectionCall(ILGenerator il, string typeName, string methodName, int argCount,
         System.Action<int>? emitArg = null, System.Action? onMissing = null)
@@ -82,17 +81,26 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldstr, typeName);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetType", _types.String));
 
+        var typeLocal = il.DeclareLocal(_types.Type);
+        il.Emit(OpCodes.Stloc, typeLocal);
+        var typeOk = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, typeLocal);
+        il.Emit(OpCodes.Brtrue, typeOk);
         if (onMissing != null)
         {
-            var typeLocal = il.DeclareLocal(_types.Type);
-            il.Emit(OpCodes.Stloc, typeLocal);
-            var typeOk = il.DefineLabel();
-            il.Emit(OpCodes.Ldloc, typeLocal);
-            il.Emit(OpCodes.Brtrue, typeOk);
             onMissing();
-            il.MarkLabel(typeOk);
-            il.Emit(OpCodes.Ldloc, typeLocal);
         }
+        else
+        {
+            il.Emit(
+                OpCodes.Ldstr,
+                $"{methodName} requires the SharpTS runtime (SharpTS.dll). " +
+                "Recompile without --standalone or deploy SharpTS.dll next to the output.");
+            il.Emit(OpCodes.Newobj, _types.InvalidOperationExceptionCtorString);
+            il.Emit(OpCodes.Throw);
+        }
+        il.MarkLabel(typeOk);
+        il.Emit(OpCodes.Ldloc, typeLocal);
 
         il.Emit(OpCodes.Ldstr, methodName);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Type, "GetMethod", _types.String));

--- a/Examples/AotCompileGate/fork.ts
+++ b/Examples/AotCompileGate/fork.ts
@@ -1,0 +1,3 @@
+import { fork } from "node:child_process";
+
+fork("./child.ts");

--- a/Examples/AotCompileGate/softdep.ts
+++ b/Examples/AotCompileGate/softdep.ts
@@ -1,0 +1,1 @@
+console.log(eval("6 * 7"));

--- a/Program.cs
+++ b/Program.cs
@@ -745,6 +745,7 @@ static void EmitCompiledAssembly(string outputPath, bool preserveConstEnums, boo
             compiler.EmitDebugSymbols = outputOptions.EmitDebugSymbols;
             compileBody(compiler);
             PrintCompilerWarnings(compiler);
+            ValidateCompiledRuntimeRequirements(compiler);
             // Symbols belong beside the final executable, not beside the temporary DLL that gets
             // bundled into it.
             compiler.Save(tempDllPath, outputOptions.EmitDebugSymbols ? Path.ChangeExtension(outputPath, ".pdb") : null);
@@ -804,6 +805,7 @@ static void EmitCompiledAssembly(string outputPath, bool preserveConstEnums, boo
         compiler.EmitDebugSymbols = outputOptions.EmitDebugSymbols;
         compileBody(compiler);
         PrintCompilerWarnings(compiler);
+        ValidateCompiledRuntimeRequirements(compiler);
         compiler.Save(outputPath);
 
         GenerateRuntimeConfig(outputPath);
@@ -845,6 +847,18 @@ static void PrintCompilerWarnings(ILCompiler compiler)
     foreach (var warning in compiler.Warnings)
         Console.Error.WriteLine($"Warning: {warning}");
 }
+
+/// <summary>
+/// Rejects compiled features whose runtime model cannot work in the Native AOT SKU.
+/// <c>child_process.fork</c> starts a separate <c>dotnet exec SharpTS.dll</c> compiler
+/// process, so extracting the in-process managed soft-dependency is not sufficient.
+/// </summary>
+static void ValidateCompiledRuntimeRequirements(ILCompiler compiler)
+{
+    if (compiler.RequiredSharpTSRuntimeReasons.Contains("child_process.fork"))
+        RequireManagedBuild("child_process.fork in compiled output");
+}
+
 /// <summary>
 /// Co-locates SharpTS.dll with the compiled output when, and only when, the compilation emitted
 /// late binding into the SharpTS runtime whose normal execution needs it (eval, Proxy, Intl, vm,
@@ -869,20 +883,32 @@ static void CopySharpTSRuntimeIfNeeded(ILCompiler compiler, string outputPath, O
         return;
     }
 
-    var sharpTsPath = typeof(SharpTS.Execution.Interpreter).Assembly.Location;
     var outDir = Path.GetDirectoryName(Path.GetFullPath(outputPath));
-    if (string.IsNullOrEmpty(sharpTsPath) || !File.Exists(sharpTsPath) || outDir == null)
+    if (outDir == null)
     {
         if (!outputOptions.QuietMode)
-            Console.WriteLine($"Warning: could not locate SharpTS.dll to co-locate with output; features ({reasonList}) may fail at runtime.");
+            Console.WriteLine($"Warning: could not resolve the output directory; features ({reasonList}) may fail at runtime.");
         return;
     }
 
-    var destPath = Path.Combine(outDir, Path.GetFileName(sharpTsPath));
+    var sharpTsPath = typeof(SharpTS.Execution.Interpreter).Assembly.Location;
+    var destPath = Path.Combine(outDir, "SharpTS.dll");
     try
     {
-        if (!string.Equals(Path.GetFullPath(sharpTsPath), Path.GetFullPath(destPath), StringComparison.OrdinalIgnoreCase))
-            File.Copy(sharpTsPath, destPath, overwrite: true);
+        bool copiedFromManagedBuild = !string.IsNullOrEmpty(sharpTsPath) && File.Exists(sharpTsPath);
+        if (copiedFromManagedBuild)
+        {
+            if (!string.Equals(Path.GetFullPath(sharpTsPath), Path.GetFullPath(destPath), StringComparison.OrdinalIgnoreCase))
+                File.Copy(sharpTsPath, destPath, overwrite: true);
+        }
+        else if (!SharpTS.Runtime.EmbeddedManagedRuntime.TryExtractTo(destPath, out string? extractionError))
+        {
+            if (!outputOptions.QuietMode)
+                Console.WriteLine(
+                    $"Warning: could not extract the embedded SharpTS.dll ({extractionError}); " +
+                    $"features ({reasonList}) may fail at runtime.");
+            return;
+        }
 
         // child_process.fork() spawns a SEPARATE `dotnet exec SharpTS.dll <module>` process
         // (unlike Worker/eval which load SharpTS.dll in-process). That child needs SharpTS's
@@ -891,6 +917,8 @@ static void CopySharpTSRuntimeIfNeeded(ILCompiler compiler, string outputPath, O
         // need SharpTS.dll loaded in-process.
         if (reasons.Contains("child_process.fork"))
         {
+            // Native builds are rejected before Save by ValidateCompiledRuntimeRequirements.
+            // This closure copy is retained for the managed SKU.
             var sharpTsDir = Path.GetDirectoryName(sharpTsPath);
             if (!string.IsNullOrEmpty(sharpTsDir))
             {
@@ -913,7 +941,8 @@ static void CopySharpTSRuntimeIfNeeded(ILCompiler compiler, string outputPath, O
         if (!outputOptions.QuietMode)
         {
             var what = reasons.Contains("child_process.fork") ? "SharpTS runtime" : "SharpTS.dll";
-            Console.WriteLine($"Copied {what} next to output — required at runtime by: {reasonList}");
+            var action = copiedFromManagedBuild ? "Copied" : "Extracted embedded";
+            Console.WriteLine($"{action} {what} next to output — required at runtime by: {reasonList}");
         }
     }
     catch (Exception ex)

--- a/Runtime/EmbeddedManagedRuntime.cs
+++ b/Runtime/EmbeddedManagedRuntime.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+
+namespace SharpTS.Runtime;
+
+/// <summary>
+/// Extracts the managed SharpTS runtime carried by the Native AOT SKU. The
+/// payload is optional for ordinary developer builds and mandatory for release
+/// Native AOT publishes; see <c>SharpTSManagedRuntimePayloadPath</c>.
+/// </summary>
+internal static class EmbeddedManagedRuntime
+{
+    internal const string ResourceName = "SharpTS.ManagedRuntime.dll";
+
+    internal static bool TryExtractTo(string destinationPath, out string? error)
+    {
+        using Stream? payload = typeof(EmbeddedManagedRuntime).Assembly
+            .GetManifestResourceStream(ResourceName);
+        if (payload is null)
+        {
+            error = $"embedded resource '{ResourceName}' is not present";
+            return false;
+        }
+
+        string fullDestination = Path.GetFullPath(destinationPath);
+        string? destinationDirectory = Path.GetDirectoryName(fullDestination);
+        if (destinationDirectory is null)
+        {
+            error = $"could not resolve the output directory for '{destinationPath}'";
+            return false;
+        }
+
+        string temporaryPath = Path.Combine(
+            destinationDirectory,
+            $".{Path.GetFileName(fullDestination)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            Directory.CreateDirectory(destinationDirectory);
+            using (var destination = new FileStream(
+                temporaryPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None))
+            {
+                payload.CopyTo(destination);
+            }
+
+            File.Move(temporaryPath, fullDestination, overwrite: true);
+            error = null;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            try { File.Delete(temporaryPath); } catch { }
+            error = ex.Message;
+            return false;
+        }
+    }
+}

--- a/SharpTS.csproj
+++ b/SharpTS.csproj
@@ -32,6 +32,26 @@
     <TrimmerRootDescriptor Include="AotTrimmerRoots.xml" />
   </ItemGroup>
 
+  <!--
+    Native-SKU two-stage build input (#1324): first build the ordinary AnyCPU
+    SharpTS.dll, then pass its path to the Native AOT publish as
+    -p:SharpTSManagedRuntimePayloadPath=... . A project cannot embed the same
+    assembly that is currently being compiled, so the payload must be explicit.
+    Managed builds leave the property empty and continue co-locating their own
+    Assembly.Location as before.
+  -->
+  <ItemGroup Condition="'$(SharpTSManagedRuntimePayloadPath)' != ''">
+    <EmbeddedResource Include="$(SharpTSManagedRuntimePayloadPath)"
+                      LogicalName="SharpTS.ManagedRuntime.dll" />
+  </ItemGroup>
+
+  <Target Name="ValidateSharpTSManagedRuntimePayload"
+          BeforeTargets="PrepareResources"
+          Condition="'$(SharpTSManagedRuntimePayloadPath)' != ''">
+    <Error Condition="!Exists('$(SharpTSManagedRuntimePayloadPath)')"
+           Text="SharpTSManagedRuntimePayloadPath does not exist: $(SharpTSManagedRuntimePayloadPath)" />
+  </Target>
+
   <!-- White-box test access: a handful of regression tests drive internal
        runtime seams directly (e.g. WebStreamsHelpers.PipeTo + the event-loop
        Ref counter) to assert behavior that cannot be observed through guest

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -210,13 +210,17 @@ DLL loads and runs under JIT with correct stdout.
 SharpTS passes an explicit compatibility policy. Item 8 can choose
 `RetargetCoreLibOnly` when it begins deploying a genuine SharpTS reference.
 
-8. **Embed SharpTS.dll** as a resource; rewrite `Program.cs:838`
-   (`CopySharpTSRuntimeIfNeeded`) to extract to `AppContext.BaseDirectory`.
-   Coherent: compiled output already requires a runtime, so the target machine
-   has .NET. Restores the 14 soft-dep features. Pass non-null `onMissing` to
-   `EmitReflectionCall` (`RuntimeEmitter.ReflectionHelpers.cs:79`) so failures
-   are messages, not NREs. Keep `CopySharpTSRuntimeIfNeeded`. Drop
-   `child_process.fork` from the native SKU.
+8. **Managed runtime handoff: done.** A two-stage native build first produces
+   the ordinary AnyCPU `SharpTS.dll`, then passes it as
+   `SharpTSManagedRuntimePayloadPath`; the Native AOT binary embeds it as
+   `SharpTS.ManagedRuntime.dll`. `CopySharpTSRuntimeIfNeeded` preserves the
+   managed-SKU `Assembly.Location` copy and falls back to atomic resource
+   extraction for native builds. The native CI gate compiles and runs an
+   `eval()` soft-dependency program under CoreCLR, proving the extracted bytes
+   are usable, not merely present. Missing reflection targets now throw a named
+   deployment error instead of NRE. `child_process.fork` is rejected before
+   output is written in the native SKU because it needs a second compiler
+   process and full managed runtime closure.
 9. **PE-Packer integration:** 1.0.5 supplies `BundleRequest`,
    `IReferenceAssemblyIndex`, `ReferenceAction`, the embedded CoreLib-surface
    index, and the `MetadataReader` implementation. Remaining: embed supported
@@ -269,7 +273,7 @@ workers, MSBuild SDK (subprocess-only by design, verified), JSX.
 
 | # | Unknown | Status / next step |
 |---|---|---|
-| 1 | Cross-platform native compiler | win-arm64 passes locally; linux-x64 is a required CI smoke. Add the remaining release RIDs in Phase 3. |
+| 1 | Cross-platform native compiler | win-arm64 passes locally and linux-x64 passes CI, including managed-payload extraction. Add the remaining release RIDs in Phase 3. |
 | 2 | BCL interop preservation | Targeted roots work for the emit internals; define and test the supported `@DotNetType` surface, including the known dynamic-event edge. |
 | 3 | MLC-types-into-TypeBuilder latent JIT limitation | Conceded for the native SKU; file upstream separately. |
 | 4 | Native-emitted output metadata parity | Executed output and PE-Packer rewriting pass. Add a `MetadataDiffer` fixture if byte/table-level parity becomes release-blocking. |


### PR DESCRIPTION
Closes the Phase 3 managed-runtime handoff slice of #1324.

## What changed

- Adds an explicit two-stage Native AOT build input (`SharpTSManagedRuntimePayloadPath`) and embeds the ordinary AnyCPU `SharpTS.dll` as `SharpTS.ManagedRuntime.dll`.
- Preserves managed-SKU `Assembly.Location` co-location; Native AOT falls back to atomic resource extraction only when a compiled program actually records a SharpTS soft dependency.
- Makes missing late-bound runtime calls throw a named deployment error instead of an NRE.
- Rejects compiled `child_process.fork` from the native SKU before writing output.
- Extends the permanent Linux Native AOT gate to build the payload, compile an `eval()` program, extract `SharpTS.dll`, run the output under CoreCLR, and verify the fork failure contract.

## Validation

- `dotnet build SharpTS.Tests/SharpTS.Tests.csproj -c Release` — clean
- targeted standalone/runtime-dependency/bundler tests — 69/69
- full non-network managed suite — 16,258/16,258
- AOT analyzer ratchet — unchanged at 2,585
- local win-arm64 Native AOT two-stage publish — success
- native compile/extract/run soft dependency — prints `42`
- native compiled fork — named error, no output written

The embedded payload is 12.7 MB and raised the local native executable from about 82 MB to 95 MB.