### PR TITLE
Publish six Native AOT release assets (#1324)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -199,3 +199,151 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload "$GITHUB_REF_NAME" sharpts-${{ steps.version.outputs.VERSION }}-${{ matrix.rid }}.* --clobber
+
+  # Native SKU (#1324 Phase 3): a true Native AOT compiler/interpreter for the
+  # frozen straight-TypeScript surface. Each RID runs on its own architecture so
+  # every uploaded artifact is executed, not merely cross-compiled. The managed
+  # AnyCPU payload is built first and embedded for compiled eval/Proxy/Intl/vm/
+  # worker soft dependencies; compiled output still runs under CoreCLR.
+  native-binaries:
+    name: Native SKU (${{ matrix.rid }})
+    needs: publish
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { rid: win-x64,     os: windows-latest }
+          - { rid: win-arm64,   os: windows-11-vs2026-arm }
+          - { rid: linux-x64,   os: ubuntu-latest }
+          - { rid: linux-arm64, os: ubuntu-24.04-arm }
+          - { rid: osx-x64,     os: macos-15-intel }
+          - { rid: osx-arm64,   os: macos-latest }
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Extract version from tag
+        id: version
+        shell: bash
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Native AOT prerequisites
+        if: startsWith(matrix.rid, 'linux-')
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      # Two-stage build: an assembly cannot embed itself while it is being
+      # compiled. Keep this payload AnyCPU so a compiled output can move between
+      # architectures supported by its installed CoreCLR.
+      - name: Build managed runtime payload
+        shell: bash
+        run: |
+          dotnet publish SharpTS.csproj --configuration Release \
+            -p:PlatformTarget=AnyCPU \
+            -p:DebugType=None \
+            -p:DebugSymbols=false \
+            -p:Version=${{ steps.version.outputs.VERSION }} \
+            -o ./sku/managed-runtime
+
+      - name: Publish Native AOT binary
+        shell: bash
+        run: |
+          dotnet publish SharpTS.csproj --configuration Release \
+            -r ${{ matrix.rid }} \
+            -p:PublishAot=true \
+            -p:TrimMode=partial \
+            -p:IlcTrimMetadata=false \
+            -p:IlcGenerateCompleteTypeMetadata=true \
+            -p:StackTraceSupport=true \
+            -p:DebugType=None \
+            -p:DebugSymbols=false \
+            -p:Version=${{ steps.version.outputs.VERSION }} \
+            -p:SharpTSManagedRuntimePayloadPath="$PWD/sku/managed-runtime/SharpTS.dll" \
+            -o ./sku/${{ matrix.rid }}
+
+      - name: Smoke test native binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          rid=${{ matrix.rid }}
+          native="$PWD/sku/$rid/SharpTS"
+          [ -f "$native.exe" ] && native="$native.exe"
+          scratch="$(mktemp -d)"
+
+          # Interpreter + embedded stdlib/lib.d.ts resources.
+          "$native" Examples/AotCompileGate/main.ts > "$scratch/interpreted.txt"
+          grep -qx '42' "$scratch/interpreted.txt"
+
+          # An empty DOTNET_ROOT proves compile-time reference rewriting does not
+          # borrow an installed reference pack.
+          empty_dotnet_root="$(mktemp -d)"
+          DOTNET_ROOT="$empty_dotnet_root" "$native" --compile \
+            Examples/AotCompileGate/main.ts --ref-asm -o "$scratch/modules.dll"
+          dotnet "$scratch/modules.dll" > "$scratch/modules.txt"
+          diff -u "$scratch/interpreted.txt" "$scratch/modules.txt"
+
+          # Prove the embedded AnyCPU managed runtime is extractable and usable.
+          mkdir "$scratch/softdep"
+          "$native" --compile Examples/AotCompileGate/softdep.ts --ref-asm \
+            -o "$scratch/softdep/softdep.dll"
+          test -f "$scratch/softdep/SharpTS.dll"
+          dotnet "$scratch/softdep/softdep.dll" > "$scratch/softdep.txt"
+          grep -qx '42' "$scratch/softdep.txt"
+
+          case "$rid" in
+            osx-*)
+              # The built-in bundler intentionally refuses unsigned/unadjusted
+              # Mach-O output; keep that loss explicit in the native SKU.
+              if "$native" --compile Examples/AotCompileGate/main.ts -t exe \
+                  -o "$scratch/bundled" 2> "$scratch/bundle-error.txt"; then
+                echo "built-in macOS bundle unexpectedly succeeded"
+                exit 1
+              fi
+              grep -Fq 'cannot target' "$scratch/bundle-error.txt"
+              ;;
+            *)
+              # PE-Packer's embedded apphost must make bundle creation SDK-free.
+              DOTNET_ROOT="$empty_dotnet_root" "$native" --compile \
+                Examples/AotCompileGate/main.ts -t exe -o "$scratch/bundled"
+              [ -f "$scratch/bundled.exe" ] && bundled="$scratch/bundled.exe" \
+                || bundled="$scratch/bundled"
+              "$bundled" > "$scratch/bundled.txt"
+              diff -u "$scratch/interpreted.txt" "$scratch/bundled.txt"
+              ;;
+          esac
+
+      - name: Package archive
+        shell: bash
+        run: |
+          VERSION=${{ steps.version.outputs.VERSION }}
+          RID=${{ matrix.rid }}
+          mkdir staging
+          cp LICENSE README.md staging/
+          case "$RID" in
+            win-*)
+              cp "./sku/$RID/SharpTS.exe" staging/sharpts.exe
+              if command -v zip >/dev/null 2>&1; then
+                (cd staging && zip -r "../sharpts-native-$VERSION-$RID.zip" .)
+              else
+                (cd staging && 7z a "../sharpts-native-$VERSION-$RID.zip" .)
+              fi
+              ;;
+            *)
+              cp "./sku/$RID/SharpTS" staging/sharpts
+              chmod +x staging/sharpts
+              tar -C staging -czf "sharpts-native-$VERSION-$RID.tar.gz" .
+              ;;
+          esac
+
+      - name: Upload to GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "$GITHUB_REF_NAME" sharpts-native-${{ steps.version.outputs.VERSION }}-${{ matrix.rid }}.* --clobber

--- a/README.md
+++ b/README.md
@@ -72,12 +72,23 @@ SharpTS supports two execution modes:
 
 ### Prerequisites
 
-- **[.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0)** or later (required)
+- **NuGet/tool/MSBuild installs:** [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) or later
+- **GitHub Release binaries:** no .NET installation is required to run SharpTS
 - **Visual Studio 2026 18.0+** or **Visual Studio Code** (optional, for IDE support)
 
 **Note for MSBuild SDK users:** SharpTS.Sdk requires .NET 10 SDK and uses modern C# features for optimal performance.
 
 ### Installation
+
+**Download a no-.NET-required binary from GitHub Releases:**
+
+- `sharpts-<version>-<rid>` is the managed, self-contained SKU. Use it for the
+  full feature set, including third-party DLL/NuGet interop, `@DotNetType`,
+  `dotnet:` imports, `--verify`, and `--gen-decl`.
+- `sharpts-native-<version>-<rid>` is the Native AOT SKU. It starts faster and
+  does not extract a runtime, but has a frozen type universe: use the managed
+  SKU for third-party interop, verification/declaration generation, or compiled
+  `child_process.fork`. Built-in `--target exe` is Windows/Linux-only.
 
 **Install CLI tool from NuGet (recommended):**
 

--- a/SharpTS.csproj
+++ b/SharpTS.csproj
@@ -33,6 +33,18 @@
   </ItemGroup>
 
   <!--
+    PE-Packer's reflected Microsoft.NET.HostModel SDK path cannot run under
+    Native AOT. Its feature switch is application-level so the managed SKU
+    keeps SDK detection; the native SKU makes it a trim-time false constant
+    and uses PE-Packer's built-in bundler.
+  -->
+  <ItemGroup Condition="'$(PublishAot)' == 'true'">
+    <RuntimeHostConfigurationOption Include="PEPacker.EnableSdkBundler"
+                                    Value="false"
+                                    Trim="true" />
+  </ItemGroup>
+
+  <!--
     Native-SKU two-stage build input (#1324): first build the ordinary AnyCPU
     SharpTS.dll, then pass its path to the Native AOT publish as
     -p:SharpTSManagedRuntimePayloadPath=... . A project cannot embed the same

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -223,14 +223,19 @@ SharpTS passes an explicit compatibility policy. Item 8 can choose
    process and full managed runtime closure.
 9. **PE-Packer integration:** 1.0.5 supplies `BundleRequest`,
    `IReferenceAssemblyIndex`, `ReferenceAction`, the embedded CoreLib-surface
-   index, and the `MetadataReader` implementation. Remaining: embed supported
-   Windows/Linux apphost templates (#14). The built-in bundler stays
-   Windows/Linux-only until Mach-O adjustment + ad-hoc signing exist.
-10. **Release matrix:** 6 RIDs (win-x64/arm64, linux-x64/arm64, osx-x64/arm64);
-    budget ~268 billable min/tag on a private repo (macOS ×10). Toolchain
-    gotchas: `vswhere.exe` must be on PATH for ILC's link step on Windows
-    (hit 3/3 probes locally; GitHub images are fine); ILC peak RSS is an OOM
-    risk on 7 GB runners.
+   index, and the `MetadataReader` implementation. Six Windows/Linux apphosts
+   landed upstream in PE-Packer PR #33 after the 1.0.5 tag; SharpTS must consume
+   the next package release before tagging its native matrix. The built-in
+   bundler stays Windows/Linux-only until Mach-O adjustment + ad-hoc signing
+   exist.
+10. **Release matrix: wired.** Tagged releases build six Native AOT assets
+    (win-x64/arm64, linux-x64/arm64, osx-x64/arm64) on matching-architecture
+    GitHub runners. Every artifact runs interpret, managed compile, and embedded
+    runtime extraction smokes before upload. Windows/Linux also create and run a
+    PE-Packer executable with `DOTNET_ROOT` empty; macOS asserts the built-in
+    bundler's named Mach-O/signing refusal. The first tagged run remains the
+    cross-platform acceptance event. ILC peak RSS on the 7 GB macOS arm64
+    runner is the main operational risk.
 11. **SDK payload:** `SharpTS.Sdk/Sdk/Sdk.targets:92` drops the `dotnet`
     prefix; `Sdk.props:28-29` RID-selects the compiler exe; package goes
     RID-specific.

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -247,8 +247,9 @@ SharpTS passes an explicit compatibility policy. Item 8 can choose
     with the native SKU would silently lose the interop surface the SDK is
     designed to compile. It would also turn one portable package into six
     large payloads without removing a .NET prerequisite. A separate opt-in
-    native SDK package can be evaluated later if startup measurements justify it; the
-    standalone `sharpts-native-*` release assets remain the native distribution.
+    native SDK package can be evaluated later if startup measurements justify
+    it; the standalone `sharpts-native-*` release assets remain the native
+    distribution.
 12. *Optional:* replace `Packaging/` with ZIP + nuspec + HTTP PUT (~300
     lines); removes the NuGet.* closure.
 

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -240,9 +240,15 @@ SharpTS passes an explicit compatibility policy. Item 8 can choose
     bundler's named Mach-O/signing refusal. The first tagged run remains the
     cross-platform acceptance event. ILC peak RSS on the 7 GB macOS arm64
     runner is the main operational risk.
-11. **SDK payload:** `SharpTS.Sdk/Sdk/Sdk.targets:92` drops the `dotnet`
-    prefix; `Sdk.props:28-29` RID-selects the compiler exe; package goes
-    RID-specific.
+11. **SDK payload: keep the existing managed, RID-neutral compiler.** The
+    original RID-native proposal is rejected for the default SDK: invoking
+    `SharpTS.Sdk` already means running `dotnet build`, its targets pass the
+    project's full `ReferencePath` through `-r`, and replacing that compiler
+    with the native SKU would silently lose the interop surface the SDK is
+    designed to compile. It would also turn one portable package into six
+    large payloads without removing a .NET prerequisite. A separate opt-in
+    native SDK package can be evaluated later if startup measurements justify it; the
+    standalone `sharpts-native-*` release assets remain the native distribution.
 12. *Optional:* replace `Packaging/` with ZIP + nuspec + HTTP PUT (~300
     lines); removes the NuGet.* closure.
 

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -141,9 +141,11 @@ Plan against these numbers, not the originals:
   `BundleRequest`, `ReferencePolicy`, `IReferenceAssemblyIndex`, the
   `MetadataReader` implementation, and the 31.8 KB embedded net10 index are
   shipped. SharpTS now uses that index when `--sdk-path` is absent and passes
-  an explicit compatibility policy. Remaining PE-Packer work is apphost
-  embedding (#14, required only for SDK-free `--target exe`) and the optional
-  `SdkBundler` feature-switch size optimization (#21).
+  an explicit compatibility policy. The six Windows/Linux apphosts landed
+  after 1.0.5 in PR #33. PR #34 adds the optional `SdkBundler` feature switch;
+  SharpTS already sets its application-level trim option for Native AOT. Both
+  changes need the next PE-Packer package before SharpTS can tag its native
+  release.
 
 ### Phase 1 — interpreter correctness and speed (~2–3 weeks; wins on JIT too)
 
@@ -224,10 +226,12 @@ SharpTS passes an explicit compatibility policy. Item 8 can choose
 9. **PE-Packer integration:** 1.0.5 supplies `BundleRequest`,
    `IReferenceAssemblyIndex`, `ReferenceAction`, the embedded CoreLib-surface
    index, and the `MetadataReader` implementation. Six Windows/Linux apphosts
-   landed upstream in PE-Packer PR #33 after the 1.0.5 tag; SharpTS must consume
-   the next package release before tagging its native matrix. The built-in
-   bundler stays Windows/Linux-only until Mach-O adjustment + ad-hoc signing
-   exist.
+   landed upstream in PE-Packer PR #33 after the 1.0.5 tag; PR #34 makes the
+   reflected SDK bundler removable from Native AOT images. SharpTS sets
+   `PEPacker.EnableSdkBundler=false` as a trim-time application switch and must
+   consume the next package release before tagging its native matrix. The
+   built-in bundler stays Windows/Linux-only until Mach-O adjustment + ad-hoc
+   signing exist.
 10. **Release matrix: wired.** Tagged releases build six Native AOT assets
     (win-x64/arm64, linux-x64/arm64, osx-x64/arm64) on matching-architecture
     GitHub runners. Every artifact runs interpret, managed compile, and embedded
@@ -278,8 +282,8 @@ workers, MSBuild SDK (subprocess-only by design, verified), JSX.
 
 | # | Unknown | Status / next step |
 |---|---|---|
-| 1 | Cross-platform native compiler | win-arm64 passes locally and linux-x64 passes CI, including managed-payload extraction. Add the remaining release RIDs in Phase 3. |
+| 1 | Cross-platform native compiler | win-arm64 passes locally and linux-x64 passes CI, including managed-payload extraction. The six-RID release matrix is wired; its first tagged run is the remaining acceptance event. |
 | 2 | BCL interop preservation | Targeted roots work for the emit internals; define and test the supported `@DotNetType` surface, including the known dynamic-event edge. |
 | 3 | MLC-types-into-TypeBuilder latent JIT limitation | Conceded for the native SKU; file upstream separately. |
 | 4 | Native-emitted output metadata parity | Executed output and PE-Packer rewriting pass. Add a `MetadataDiffer` fixture if byte/table-level parity becomes release-blocking. |
-| 5 | SDK-free `--target exe` | Reference rewriting is SDK-free in 1.0.5; executable generation still needs an apphost path or PE-Packer #14. |
+| 5 | SDK-free `--target exe` | PE-Packer #14 is merged and the SharpTS release smoke requires an empty `DOTNET_ROOT`; consume the next PE-Packer package before tagging. |


### PR DESCRIPTION
Advances Phase 3 of #1324 by adding the Native AOT GitHub Release matrix.

## What changed

- Publishes six native assets: win-x64/arm64, linux-x64/arm64, osx-x64/arm64.
- Uses matching-architecture hosted runners so every uploaded binary is executed rather than merely cross-compiled.
- Performs the two-stage build needed to embed the AnyCPU managed SharpTS runtime.
- Smokes interpretation, SDK-free reference rewriting, managed output execution, and soft-dependency extraction on every RID.
- Windows/Linux create and execute a PE-Packer bundle with `DOTNET_ROOT` empty; macOS verifies the named built-in-bundler refusal.
- Sets `PEPacker.EnableSdkBundler=false` only for Native AOT, allowing ILC to remove PE-Packer's reflected SDK path while managed behavior stays unchanged.
- Documents the managed vs Native AOT release asset choice in README.

## Validation

- publish workflow parses as YAML
- managed SharpTS build is clean
- release commands are the same two-stage/native commands already passing in the permanent linux-x64 gate and locally on win-arm64
- the first tagged run is intentionally the six-platform acceptance event

## Release dependency

PE-Packer apphost embedding (#33) and the Native AOT feature switch (#34) landed after v1.0.5. This workflow can merge now, but **do not tag a SharpTS release until the next PE-Packer package is published and SharpTS updates to it**; the Windows/Linux empty-`DOTNET_ROOT` bundle smoke deliberately enforces that ordering.

## SDK boundary

`SharpTS.Sdk` remains managed and RID-neutral by design. It already runs under `dotnet build`, passes the project's full `ReferencePath` through `-r`, and therefore needs the managed compiler's full interop behavior. Replacing it with six native payloads would be a breaking semantic change without removing a .NET prerequisite. Native distribution remains the standalone `sharpts-native-*` release assets; an opt-in native SDK package can be considered later only if measurements justify it.