### PR TITLE
Consume PE-Packer 1.0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,10 @@ jobs:
           test ! -f "$scratch/fork.dll"
 
           # Exercise PE-Packer from inside SharpTS's partial-trim closure too.
-          "$native" --compile Examples/AotCompileGate/main.ts -t exe \
+          # The same empty DOTNET_ROOT used above also proves executable creation
+          # comes from PE-Packer's embedded apphost rather than the runner's SDK.
+          DOTNET_ROOT="$empty_dotnet_root" "$native" --compile \
+            Examples/AotCompileGate/main.ts -t exe \
             -o "$scratch/modules"
           "$scratch/modules" > "$scratch/bundled.txt"
           diff -u "$scratch/interpreted.txt" "$scratch/bundled.txt"

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
-    <PackageVersion Include="NickNa.PEPacker" Version="1.0.5" />
+    <PackageVersion Include="NickNa.PEPacker" Version="1.0.6" />
     <PackageVersion Include="NuGet.Packaging" Version="7.3.1" />
     <PackageVersion Include="NuGet.Protocol" Version="7.3.1" />
     <PackageVersion Include="OmniSharp.Extensions.LanguageServer" Version="0.19.9" />

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -136,16 +136,15 @@ Plan against these numbers, not the originals:
   `child_process.fork` from a compiled soft-dep program still shells
   `dotnet exec SharpTS.dll`, so it needs .NET installed regardless of SKU
   (Phase 1 item 3 / Phase 3 item 8 territory).
-- **PE-Packer Phases A/B + embedded reference index: done and released in
-  1.0.5.** The package is AOT-analyzer-clean and has its own native smoke job;
+- **PE-Packer Native AOT work: done and released in 1.0.6.** The package is
+  AOT-analyzer-clean and has its own native smoke job;
   `BundleRequest`, `ReferencePolicy`, `IReferenceAssemblyIndex`, the
   `MetadataReader` implementation, and the 31.8 KB embedded net10 index are
   shipped. SharpTS now uses that index when `--sdk-path` is absent and passes
-  an explicit compatibility policy. The six Windows/Linux apphosts landed
-  after 1.0.5 in PR #33. PR #34 adds the optional `SdkBundler` feature switch;
-  SharpTS already sets its application-level trim option for Native AOT. Both
-  changes need the next PE-Packer package before SharpTS can tag its native
-  release.
+  an explicit compatibility policy. Six embedded Windows/Linux apphosts make
+  executable creation SDK-free, and the `SdkBundler` feature switch removes
+  its reflected SDK path from SharpTS's native image. SharpTS pins 1.0.6 and
+  sets the switch only for Native AOT.
 
 ### Phase 1 — interpreter correctness and speed (~2–3 weeks; wins on JIT too)
 
@@ -223,15 +222,14 @@ SharpTS passes an explicit compatibility policy. Item 8 can choose
    deployment error instead of NRE. `child_process.fork` is rejected before
    output is written in the native SKU because it needs a second compiler
    process and full managed runtime closure.
-9. **PE-Packer integration:** 1.0.5 supplies `BundleRequest`,
+9. **PE-Packer integration: done in 1.0.6.** The package supplies `BundleRequest`,
    `IReferenceAssemblyIndex`, `ReferenceAction`, the embedded CoreLib-surface
-   index, and the `MetadataReader` implementation. Six Windows/Linux apphosts
-   landed upstream in PE-Packer PR #33 after the 1.0.5 tag; PR #34 makes the
-   reflected SDK bundler removable from Native AOT images. SharpTS sets
-   `PEPacker.EnableSdkBundler=false` as a trim-time application switch and must
-   consume the next package release before tagging its native matrix. The
-   built-in bundler stays Windows/Linux-only until Mach-O adjustment + ad-hoc
-   signing exist.
+   index, the `MetadataReader` implementation, six Windows/Linux apphosts, and
+   the feature-switched SDK bundler. SharpTS sets
+   `PEPacker.EnableSdkBundler=false` as a trim-time application switch. The
+   permanent and release smokes create executables with `DOTNET_ROOT` empty.
+   The built-in bundler stays Windows/Linux-only until Mach-O adjustment +
+   ad-hoc signing exist.
 10. **Release matrix: wired.** Tagged releases build six Native AOT assets
     (win-x64/arm64, linux-x64/arm64, osx-x64/arm64) on matching-architecture
     GitHub runners. Every artifact runs interpret, managed compile, and embedded
@@ -293,4 +291,4 @@ workers, MSBuild SDK (subprocess-only by design, verified), JSX.
 | 2 | BCL interop preservation | Targeted roots work for the emit internals; define and test the supported `@DotNetType` surface, including the known dynamic-event edge. |
 | 3 | MLC-types-into-TypeBuilder latent JIT limitation | Conceded for the native SKU; file upstream separately. |
 | 4 | Native-emitted output metadata parity | Executed output and PE-Packer rewriting pass. Add a `MetadataDiffer` fixture if byte/table-level parity becomes release-blocking. |
-| 5 | SDK-free `--target exe` | PE-Packer #14 is merged and the SharpTS release smoke requires an empty `DOTNET_ROOT`; consume the next PE-Packer package before tagging. |
+| 5 | SDK-free `--target exe` | Closed by PE-Packer 1.0.6. Both the permanent and release smokes require bundle creation with an empty `DOTNET_ROOT`. |


### PR DESCRIPTION
## Summary

- update SharpTS to the released NickNa.PEPacker 1.0.6 package
- make the permanent Native AOT smoke create its target executable with an empty DOTNET_ROOT, proving the embedded apphost path
- record the completed PE-Packer Native AOT integration in the implementation plan

## Validation

- focused package-sensitive suite: 159 passed, 0 failed
- local win-arm64 Native AOT publish restored NickNa.PEPacker 1.0.6
- native interpreter output: 42
- native compiler created and ran a 355,651-byte executable with an empty DOTNET_ROOT; output: 42
- native image contains zero InvokeSdkBundler occurrences

Advances #1324 and completes the SharpTS side of nickna/PE-Packer#20.