### PR TITLE
Isolate managed emitted-shape reflection for Native AOT

### DIFF
--- a/.github/aot-warning-baseline.json
+++ b/.github/aot-warning-baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "total": 151,
+  "total": 139,
   "codes": [
     {
       "code": "IL2026",
@@ -20,7 +20,7 @@
     },
     {
       "code": "IL2070",
-      "count": 61
+      "count": 58
     },
     {
       "code": "IL2072",
@@ -28,7 +28,7 @@
     },
     {
       "code": "IL2075",
-      "count": 68
+      "count": 59
     },
     {
       "code": "IL3050",
@@ -50,7 +50,7 @@
     },
     {
       "area": "Runtime",
-      "count": 64
+      "count": 52
     },
     {
       "area": "TypeSystem",
@@ -62,6 +62,16 @@
       "file": "Compilation/AttributeMapper.cs",
       "code": "IL2057",
       "count": 1
+    },
+    {
+      "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
+      "code": "IL2060",
+      "count": 2
+    },
+    {
+      "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
+      "code": "IL2070",
+      "count": 3
     },
     {
       "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
@@ -109,16 +119,6 @@
       "count": 3
     },
     {
-      "file": "Runtime/RuntimeCallableDispatcher.cs",
-      "code": "IL2070",
-      "count": 2
-    },
-    {
-      "file": "Runtime/Types/CompiledMessagePortBridge.cs",
-      "code": "IL2075",
-      "count": 4
-    },
-    {
       "file": "Runtime/Types/SharpTSAbortSignal.cs",
       "code": "IL2075",
       "count": 1
@@ -146,7 +146,7 @@
     {
       "file": "Runtime/Types/SharpTSProxy.cs",
       "code": "IL2075",
-      "count": 4
+      "count": 3
     },
     {
       "file": "Runtime/Types/StructuredClone.cs",
@@ -166,27 +166,7 @@
     {
       "file": "Runtime/Types/VmModule.cs",
       "code": "IL2075",
-      "count": 2
-    },
-    {
-      "file": "Runtime/Types/WebStreamsHelpers.cs",
-      "code": "IL2070",
       "count": 1
-    },
-    {
-      "file": "Runtime/Types/WebStreamsHelpers.cs",
-      "code": "IL2075",
-      "count": 3
-    },
-    {
-      "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
-      "code": "IL2070",
-      "count": 3
-    },
-    {
-      "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
-      "code": "IL2060",
-      "count": 2
     },
     {
       "file": "Runtime/DotNet/DotNetExtensionMethodResolver.cs",
@@ -196,6 +176,16 @@
     {
       "file": "Runtime/DotNet/DotNetDelegateShim.cs",
       "code": "IL3050",
+      "count": 2
+    },
+    {
+      "file": "Runtime/DotNet/DotNetDelegateShim.cs",
+      "code": "IL2075",
+      "count": 1
+    },
+    {
+      "file": "Runtime/DotNet/DotNetDelegateShim.cs",
+      "code": "IL2070",
       "count": 2
     },
     {
@@ -249,18 +239,18 @@
       "count": 1
     },
     {
-      "file": "Compilation/RuntimeTypes.Json.cs",
-      "code": "IL2075",
-      "count": 5
-    },
-    {
       "file": "TypeSystem/DotNetTypeSynthesizer.cs",
       "code": "IL2070",
       "count": 4
     },
     {
-      "file": "Compilation/RuntimeTypes.Objects.cs",
-      "code": "IL2070",
+      "file": "Compilation/RuntimeTypes.Json.cs",
+      "code": "IL2075",
+      "count": 5
+    },
+    {
+      "file": "Compilation/RuntimeTypes.Promise.cs",
+      "code": "IL2075",
       "count": 3
     },
     {
@@ -309,18 +299,8 @@
       "count": 2
     },
     {
-      "file": "Runtime/DotNet/DotNetDelegateShim.cs",
+      "file": "Compilation/RuntimeTypes.Objects.cs",
       "code": "IL2070",
-      "count": 2
-    },
-    {
-      "file": "Runtime/DotNet/DotNetDelegateShim.cs",
-      "code": "IL2075",
-      "count": 1
-    },
-    {
-      "file": "Compilation/RuntimeTypes.Promise.cs",
-      "code": "IL2075",
       "count": 3
     },
     {

--- a/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
@@ -525,8 +525,14 @@ public static class VmModuleInterpreter
             case Dictionary<string, object?> dict:
                 return dict.TryGetValue(key, out var val) ? val : null;
             default:
-                // Emitted $Object / other shapes — reflect on a "Fields" dictionary.
-                var fieldsProp = options.GetType().GetProperty("Fields");
+                // Compiler-emitted $Object uses the managed-shape boundary.
+                // Preserve other CLR "Fields" shapes for managed .NET interop.
+                var type = options.GetType();
+                var fieldsProp = ManagedEmittedShapeReflection.IsShape(
+                        type, ManagedEmittedShape.Object)
+                    ? ManagedEmittedShapeReflection.GetPublicProperty(
+                        type, ManagedEmittedShape.Object, "Fields")
+                    : type.GetProperty("Fields");
                 if (fieldsProp?.GetValue(options) is IEnumerable<KeyValuePair<string, object?>> fields)
                 {
                     foreach (var kv in fields)

--- a/Runtime/RuntimeCallableDispatcher.cs
+++ b/Runtime/RuntimeCallableDispatcher.cs
@@ -80,16 +80,20 @@ public static class RuntimeCallableDispatcher
         // dispatch via reflection on InvokeWithThis (which understands the
         // synthetic __this first-parameter contract).
         var type = callable.GetType();
-        if (type.Name is "$TSFunction" or "$BoundTSFunction")
+        if (ManagedEmittedShapeReflection.IsShape(type, ManagedEmittedShape.Function))
         {
             var invokeWithThis = _invokeWithThisCache.GetOrAdd(type, t =>
-                t.GetMethod("InvokeWithThis", [typeof(object), typeof(object[])]));
+                ManagedEmittedShapeReflection.GetPublicMethod(
+                    t, ManagedEmittedShape.Function, "InvokeWithThis",
+                    [typeof(object), typeof(object[])]));
             if (invokeWithThis != null)
             {
                 return invokeWithThis.Invoke(callable, new object?[] { null, args });
             }
 
-            var invoke = _invokeCache.GetOrAdd(type, t => t.GetMethod("Invoke", [typeof(object[])]));
+            var invoke = _invokeCache.GetOrAdd(type, t =>
+                ManagedEmittedShapeReflection.GetPublicMethod(
+                    t, ManagedEmittedShape.Function, "Invoke", [typeof(object[])]));
             if (invoke != null)
             {
                 return invoke.Invoke(callable, new object?[] { args });
@@ -116,7 +120,8 @@ public static class RuntimeCallableDispatcher
         if (value is Func<object?[], object?>) return true;
         if (value is Action<object?[]>) return true;
         if (value is Delegate) return true;
-        return value.GetType().Name is "$TSFunction" or "$BoundTSFunction";
+        return ManagedEmittedShapeReflection.IsShape(
+            value.GetType(), ManagedEmittedShape.Function);
     }
 
     /// <summary>

--- a/Runtime/Types/CompiledMessagePortBridge.cs
+++ b/Runtime/Types/CompiledMessagePortBridge.cs
@@ -76,7 +76,9 @@ public sealed class CompiledMessagePortBridge : SharpTSEventEmitter
     /// Detected by type name (the type cannot be referenced from SharpTS.dll), the same
     /// approach <see cref="StructuredClone"/> uses for <c>$ArrayBuffer</c>/<c>$SharedArrayBuffer</c>.
     /// </summary>
-    public static bool IsEmittedMessagePort(object? value) => value?.GetType().Name == "$MessagePort";
+    public static bool IsEmittedMessagePort(object? value) =>
+        value != null && ManagedEmittedShapeReflection.IsShape(
+            value.GetType(), ManagedEmittedShape.MessagePort);
 
     /// <summary>
     /// Adopts a transferred compiled <c>$MessagePort</c> into a worker-usable bridge.
@@ -88,11 +90,13 @@ public sealed class CompiledMessagePortBridge : SharpTSEventEmitter
     {
         var type = compiledPort.GetType();
 
-        var postMessage = type.GetMethod("PostMessage", [typeof(object)])
+        var postMessage = ManagedEmittedShapeReflection.GetPublicMethod(
+                type, ManagedEmittedShape.MessagePort, "PostMessage", [typeof(object)])
             ?? throw new StructuredClone.DataCloneError(
                 "Cannot transfer $MessagePort: no PostMessage(object) method (emitted shape changed?)");
 
-        var pendingField = type.GetField("_pending", BindingFlags.NonPublic | BindingFlags.Instance)
+        var pendingField = ManagedEmittedShapeReflection.GetNonPublicInstanceField(
+                type, ManagedEmittedShape.MessagePort, "_pending")
             ?? throw new StructuredClone.DataCloneError(
                 "Cannot transfer $MessagePort: no _pending field (emitted shape changed?)");
 
@@ -100,11 +104,13 @@ public sealed class CompiledMessagePortBridge : SharpTSEventEmitter
             throw new StructuredClone.DataCloneError(
                 "Cannot transfer $MessagePort: _pending is not a ConcurrentQueue<object>");
 
-        var onEnqueueField = type.GetField("_onEnqueue", BindingFlags.NonPublic | BindingFlags.Instance)
+        var onEnqueueField = ManagedEmittedShapeReflection.GetNonPublicInstanceField(
+                type, ManagedEmittedShape.MessagePort, "_onEnqueue")
             ?? throw new StructuredClone.DataCloneError(
                 "Cannot transfer $MessagePort: no _onEnqueue field (emitted shape changed?)");
 
-        var markTransferred = type.GetMethod("MarkTransferredAcrossThreads", Type.EmptyTypes)
+        var markTransferred = ManagedEmittedShapeReflection.GetPublicMethod(
+                type, ManagedEmittedShape.MessagePort, "MarkTransferredAcrossThreads", Type.EmptyTypes)
             ?? throw new StructuredClone.DataCloneError(
                 "Cannot transfer $MessagePort: no MarkTransferredAcrossThreads method (emitted shape changed?)");
         // Flags this port AND its (compiled, still parent-side) partner cross-thread, so a

--- a/Runtime/Types/ManagedEmittedShapeReflection.cs
+++ b/Runtime/Types/ManagedEmittedShapeReflection.cs
@@ -1,0 +1,106 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Reflection boundary for types emitted into a compiled SharpTS program.
+/// Those types live in the output assembly and therefore cannot be referenced
+/// directly from <c>SharpTS.dll</c>.
+/// </summary>
+/// <remarks>
+/// A compiler-emitted object can only enter these hybrid runtime paths after
+/// its output assembly has been loaded by CoreCLR. Native AOT cannot load that
+/// managed assembly into the SharpTS process, so the boundary rejects native
+/// execution before inspecting the emitted shape. The closed
+/// <see cref="ManagedEmittedShape"/> set keeps these suppressions from becoming
+/// a general-purpose escape hatch for arbitrary .NET interop reflection.
+/// </remarks>
+internal static class ManagedEmittedShapeReflection
+{
+    private const string TrimJustification =
+        "The type is validated as a known SharpTS compiler-emitted managed shape, and the " +
+        "boundary rejects Native AOT before reflection. Emitted output assemblies are loaded " +
+        "only by the managed SharpTS SKU.";
+
+    internal static bool IsShape(Type type, ManagedEmittedShape shape)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        return shape switch
+        {
+            ManagedEmittedShape.Object => type.Name == "$Object",
+            ManagedEmittedShape.Function => type.Name is "$TSFunction" or "$BoundTSFunction",
+            ManagedEmittedShape.WritableStream => type.Name == "$WritableStream",
+            ManagedEmittedShape.MessagePort => type.Name == "$MessagePort",
+            _ => false
+        };
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static MethodInfo? GetPublicMethod(
+        Type type,
+        ManagedEmittedShape shape,
+        string name,
+        Type[] parameterTypes)
+    {
+        RequireManagedShape(type, shape);
+        return type.GetMethod(name, parameterTypes);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static PropertyInfo? GetPublicProperty(
+        Type type,
+        ManagedEmittedShape shape,
+        string name)
+    {
+        RequireManagedShape(type, shape);
+        return type.GetProperty(name);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static FieldInfo? GetNonPublicInstanceField(
+        Type type,
+        ManagedEmittedShape shape,
+        string name)
+    {
+        RequireManagedShape(type, shape);
+        return type.GetField(name, BindingFlags.NonPublic | BindingFlags.Instance);
+    }
+
+    private static void RequireManagedShape(Type type, ManagedEmittedShape shape)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+
+        if (!IsShape(type, shape))
+        {
+            throw new ArgumentException(
+                $"Type '{type.FullName}' is not the expected compiler-emitted {DisplayName(shape)} shape.",
+                nameof(type));
+        }
+
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            throw new PlatformNotSupportedException(
+                $"Bridging compiler-emitted {DisplayName(shape)} objects is not available " +
+                "in the native SharpTS build — use the managed build.");
+        }
+    }
+
+    private static string DisplayName(ManagedEmittedShape shape) => shape switch
+    {
+        ManagedEmittedShape.Object => "$Object",
+        ManagedEmittedShape.Function => "$TSFunction/$BoundTSFunction",
+        ManagedEmittedShape.WritableStream => "$WritableStream",
+        ManagedEmittedShape.MessagePort => "$MessagePort",
+        _ => shape.ToString()
+    };
+}
+
+internal enum ManagedEmittedShape
+{
+    Object,
+    Function,
+    WritableStream,
+    MessagePort
+}

--- a/Runtime/Types/SharpTSAsyncLocalStorage.cs
+++ b/Runtime/Types/SharpTSAsyncLocalStorage.cs
@@ -135,10 +135,12 @@ public class SharpTSAsyncLocalStorage
     /// </summary>
     private static object? InvokeCallback(Interp? interpreter, object? callback, List<object?> args)
     {
-        if (callback is ISharpTSCallable callable)
-            return callable.Call(interpreter!, args);
+        if (RuntimeCallableDispatcher.IsCallable(callback))
+            return RuntimeCallableDispatcher.Invoke(interpreter, callback, args.ToArray());
 
-        // Compiled mode: use reflection to find Invoke(object[]) on emitted types
+        // Preserve the managed .NET interop fallback for arbitrary objects
+        // exposing Invoke(object[]). Its warning remains until that native
+        // interop surface is defined.
         var invokeMethod = callback?.GetType().GetMethod("Invoke", [typeof(object?[])]);
         if (invokeMethod != null)
             return invokeMethod.Invoke(callback, [args.ToArray()]);

--- a/Runtime/Types/SharpTSKeyObject.cs
+++ b/Runtime/Types/SharpTSKeyObject.cs
@@ -363,32 +363,31 @@ public class SharpTSKeyObject : ISharpTSPropertyAccessor
         string? type = null;
         string? format = null;
 
-        // Extract type and format from options if provided
-        if (options is SharpTSObject obj)
+        // StreamFields is the shared adapter for interpreter objects,
+        // dictionaries, and compiler-emitted $Object values.
+        if (StreamFields.TryGet(options, "type", out var typeValue) &&
+            typeValue is string typeString)
+            type = typeString;
+        if (StreamFields.TryGet(options, "format", out var formatValue) &&
+            formatValue is string formatString)
+            format = formatString;
+
+        // Preserve the managed .NET interop fallback for custom options
+        // objects exposing GetProperty(string). Compiler-emitted $Object
+        // values have already gone through the guarded StreamFields path.
+        if (options != null &&
+            !ManagedEmittedShapeReflection.IsShape(
+                options.GetType(), ManagedEmittedShape.Object) &&
+            options is not SharpTSObject &&
+            options is not IDictionary<string, object?>)
         {
-            if (obj.Fields.TryGetValue("type", out var t) && t is string ts)
-                type = ts;
-            if (obj.Fields.TryGetValue("format", out var f) && f is string fs)
-                format = fs;
-        }
-        else if (options is Dictionary<string, object?> dict)
-        {
-            if (dict.TryGetValue("type", out var t) && t is string ts)
-                type = ts;
-            if (dict.TryGetValue("format", out var f) && f is string fs)
-                format = fs;
-        }
-        else if (options != null)
-        {
-            // Try reflection for compiled $Object
-            var optionsType = options.GetType();
-            var getPropertyMethod = optionsType.GetMethod("GetProperty", [typeof(string)]);
+            var getPropertyMethod = options.GetType().GetMethod("GetProperty", [typeof(string)]);
             if (getPropertyMethod != null)
             {
-                var typeVal = getPropertyMethod.Invoke(options, ["type"]);
-                if (typeVal is string ts) type = ts;
-                var formatVal = getPropertyMethod.Invoke(options, ["format"]);
-                if (formatVal is string fs) format = fs;
+                if (getPropertyMethod.Invoke(options, ["type"]) is string reflectedType)
+                    type = reflectedType;
+                if (getPropertyMethod.Invoke(options, ["format"]) is string reflectedFormat)
+                    format = reflectedFormat;
             }
         }
 

--- a/Runtime/Types/SharpTSProxy.cs
+++ b/Runtime/Types/SharpTSProxy.cs
@@ -68,17 +68,13 @@ public class SharpTSProxy : ISharpTSCallable
         if (value == null || value is SharpTSUndefined)
             return null;
 
-        // ISharpTSCallable (interpreter mode)
-        if (value is ISharpTSCallable)
+        if (RuntimeCallableDispatcher.IsCallable(value))
             return value;
 
-        // Check for compiled function types (TSFunction, Func<>, etc.) via Invoke method
+        // Preserve the managed .NET interop fallback for arbitrary callable
+        // objects. Known compiler-emitted functions are handled above.
         var invokeMethod = value.GetType().GetMethod("Invoke");
         if (invokeMethod != null)
-            return value;
-
-        // Func<object?[], object?> delegate
-        if (value is Func<object?[], object?>)
             return value;
 
         throw new Exception($"Runtime Error: Proxy handler trap '{trapName}' is not a function.");
@@ -89,42 +85,15 @@ public class SharpTSProxy : ISharpTSCallable
     /// </summary>
     private object? InvokeTrap(object trap, Interpreter? interp, List<object?> args)
     {
-        if (trap is ISharpTSCallable callable)
-            return callable.Call(interp!, args);
+        if (RuntimeCallableDispatcher.IsCallable(trap))
+            return RuntimeCallableDispatcher.Invoke(interp, trap, args.ToArray());
 
-        // Func<object?[], object?> delegate
-        if (trap is Func<object?[], object?> func)
-            return func(args.ToArray());
-
-        // Try Invoke(params object?[]) for TSFunction and similar compiled types
+        // Managed .NET interop fallback for arbitrary Invoke-shaped objects.
+        // The emitted function path above no longer needs to inspect its
+        // private _method field because InvokeWithThis owns that contract.
         var invokeMethod = trap.GetType().GetMethod("Invoke");
         if (invokeMethod != null)
-        {
-            // TSFunction.Invoke() takes params object?[] and handles argument conversion internally.
-            // Object method shorthands in compiled mode have a __this parameter as the first arg.
-            // We need to check the underlying method's parameter list to see if we need to prepend
-            // a null __this arg so the trap args align correctly.
-            var argsArray = args.ToArray();
-
-            var methodField = trap.GetType().GetField("_method",
-                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            if (methodField != null)
-            {
-                var mi = (System.Reflection.MethodInfo)methodField.GetValue(trap)!;
-                var parameters = mi.GetParameters();
-                // Check if the first parameter is __this (object method shorthand pattern)
-                if (parameters.Length > 0 && parameters[0].Name == "__this")
-                {
-                    // Prepend null for __this
-                    var extended = new object?[argsArray.Length + 1];
-                    extended[0] = null;
-                    Array.Copy(argsArray, 0, extended, 1, argsArray.Length);
-                    argsArray = extended;
-                }
-            }
-
-            return invokeMethod.Invoke(trap, [argsArray]);
-        }
+            return invokeMethod.Invoke(trap, [args.ToArray()]);
 
         throw new Exception("Runtime Error: Cannot invoke proxy trap.");
     }

--- a/Runtime/Types/VmContext.cs
+++ b/Runtime/Types/VmContext.cs
@@ -66,8 +66,15 @@ public static class VmContext
         }
         else if (contextObject != null)
         {
-            // Fallback: handle emitted $Object and other types with a Fields property
-            var fieldsProp = contextObject.GetType().GetProperty("Fields");
+            // Compiler-emitted $Object uses the managed-shape boundary. Preserve
+            // the existing arbitrary CLR "Fields" fallback for .NET interop;
+            // that path remains part of the separate native interop policy.
+            var type = contextObject.GetType();
+            var fieldsProp = ManagedEmittedShapeReflection.IsShape(
+                    type, ManagedEmittedShape.Object)
+                ? ManagedEmittedShapeReflection.GetPublicProperty(
+                    type, ManagedEmittedShape.Object, "Fields")
+                : type.GetProperty("Fields");
             if (fieldsProp?.GetValue(contextObject) is IEnumerable<KeyValuePair<string, object?>> fields)
             {
                 foreach (var kv in fields)
@@ -93,8 +100,15 @@ public static class VmContext
             if (value == null || value is ISharpTSCallable || value is BuiltInMethod)
                 continue;
 
-            // Check for Invoke(object[]) method — signature of emitted $TSFunction
-            var invokeMethod = value.GetType().GetMethod("Invoke", [typeof(object[])]);
+            // Compiler-emitted functions use the managed-shape boundary. Keep
+            // accepting arbitrary CLR Invoke(object[]) objects for managed
+            // interop until the native interop surface is defined.
+            var type = value.GetType();
+            var invokeMethod = ManagedEmittedShapeReflection.IsShape(
+                    type, ManagedEmittedShape.Function)
+                ? ManagedEmittedShapeReflection.GetPublicMethod(
+                    type, ManagedEmittedShape.Function, "Invoke", [typeof(object[])])
+                : type.GetMethod("Invoke", [typeof(object[])]);
             if (invokeMethod != null)
             {
                 props[key] = new CompiledCallableAdapter(value, invokeMethod);
@@ -125,9 +139,15 @@ public static class VmContext
         }
         else if (contextObject != null)
         {
-            // Fallback: handle emitted $Object via reflection on SetProperty method
-            var setMethod = contextObject.GetType().GetMethod("SetProperty",
-                [typeof(string), typeof(object)]);
+            // Compiler-emitted $Object uses the managed-shape boundary. Preserve
+            // custom CLR SetProperty shapes as the managed interop fallback.
+            var type = contextObject.GetType();
+            var setMethod = ManagedEmittedShapeReflection.IsShape(
+                    type, ManagedEmittedShape.Object)
+                ? ManagedEmittedShapeReflection.GetPublicMethod(
+                    type, ManagedEmittedShape.Object, "SetProperty",
+                    [typeof(string), typeof(object)])
+                : type.GetMethod("SetProperty", [typeof(string), typeof(object)]);
             if (setMethod != null)
             {
                 foreach (var name in originalProperties.Keys)

--- a/Runtime/Types/VmModule.cs
+++ b/Runtime/Types/VmModule.cs
@@ -228,12 +228,23 @@ public abstract class VmModuleBase
             throw new Exception("TypeError: callback is not a function");
 
         var type = callable.GetType();
-        if (type.Name is "$TSFunction" or "$BoundTSFunction")
+        if (ManagedEmittedShapeReflection.IsShape(type, ManagedEmittedShape.Function))
         {
-            var withThis = type.GetMethod("InvokeWithThis", [typeof(object), typeof(object[])]);
+            var withThis = ManagedEmittedShapeReflection.GetPublicMethod(
+                type, ManagedEmittedShape.Function, "InvokeWithThis",
+                [typeof(object), typeof(object[])]);
             if (withThis != null)
                 return withThis.Invoke(callable, [thisArg, args]);
+
+            var emittedInvoke = ManagedEmittedShapeReflection.GetPublicMethod(
+                type, ManagedEmittedShape.Function, "Invoke", [typeof(object[])]);
+            if (emittedInvoke != null)
+                return emittedInvoke.Invoke(callable, [args]);
         }
+
+        // Managed .NET interop also accepts an arbitrary object exposing
+        // Invoke(object[]). Keep that reflection visible to the analyzer until
+        // the native interop policy is defined.
         var invoke = type.GetMethod("Invoke", [typeof(object[])]);
         if (invoke != null)
             return invoke.Invoke(callable, [args]);

--- a/Runtime/Types/WebStreamsHelpers.cs
+++ b/Runtime/Types/WebStreamsHelpers.cs
@@ -28,8 +28,17 @@ internal static class StreamFields
         {
             return dict.TryGetValue(name, out value);
         }
-        // Compiled-mode $Object: reflect the Fields property.
-        var prop = _fieldsPropCache.GetOrAdd(target.GetType(), t => t.GetProperty("Fields"));
+        // Compiled-mode $Object: reflect the Fields property through the
+        // managed-emitted-shape boundary. Other CLR objects are not part of
+        // this adapter's documented contract.
+        var targetType = target.GetType();
+        if (!ManagedEmittedShapeReflection.IsShape(targetType, ManagedEmittedShape.Object))
+        {
+            return false;
+        }
+        var prop = _fieldsPropCache.GetOrAdd(targetType, t =>
+            ManagedEmittedShapeReflection.GetPublicProperty(
+                t, ManagedEmittedShape.Object, "Fields"));
         if (prop != null && prop.GetValue(target) is IDictionary<string, object?> reflected)
         {
             return reflected.TryGetValue(name, out value);
@@ -108,7 +117,8 @@ internal static class WebStreamsHelpers
         {
             return PipeTo(interp, source, ws, opts);
         }
-        if (dest != null && dest.GetType().Name == "$WritableStream")
+        if (dest != null && ManagedEmittedShapeReflection.IsShape(
+                dest.GetType(), ManagedEmittedShape.WritableStream))
         {
             return PipeToEmittedWritable(interp, source, dest, opts);
         }
@@ -123,11 +133,14 @@ internal static class WebStreamsHelpers
     private static SharpTSPromise PipeToEmittedWritable(Interp interp, SharpTSReadableStream source, object dest, object? opts)
     {
         var destType = dest.GetType();
-        var writeMethod = destType.GetMethod("Write", [typeof(object)])
+        var writeMethod = ManagedEmittedShapeReflection.GetPublicMethod(
+                destType, ManagedEmittedShape.WritableStream, "Write", [typeof(object)])
             ?? throw new Exception("$WritableStream.Write not found");
-        var closeMethod = destType.GetMethod("Close", System.Type.EmptyTypes)
+        var closeMethod = ManagedEmittedShapeReflection.GetPublicMethod(
+                destType, ManagedEmittedShape.WritableStream, "Close", Type.EmptyTypes)
             ?? throw new Exception("$WritableStream.Close not found");
-        var abortMethod = destType.GetMethod("Abort", [typeof(object)])
+        var abortMethod = ManagedEmittedShapeReflection.GetPublicMethod(
+                destType, ManagedEmittedShape.WritableStream, "Abort", [typeof(object)])
             ?? throw new Exception("$WritableStream.Abort not found");
 
         bool preventClose = false, preventAbort = false, preventCancel = false;

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -123,10 +123,15 @@ Plan against these numbers, not the originals:
   dropped by roughly 1 MB at that checkpoint. Routing the remaining
   compiler-owned array and emitted-base-type shapes, explicitly guarding the
   managed in-memory compiler, and replacing attribute-default activation
-  lowered the inventory to 151. The current image is 93,462,528 bytes, 987,648
-  bytes (1.05%) smaller than the original 2,585-warning image. CI pins total,
-  per-code, per-area, and per-file/code counts, so both increases and category
-  swaps fail until the same PR updates the explained baseline.
+  lowered the inventory to 151. Isolating reflection over known
+  compiler-emitted managed shapes (`$Object`, `$TSFunction`/
+  `$BoundTSFunction`, `$WritableStream`, and `$MessagePort`) behind a closed,
+  Native-AOT-guarded boundary then lowered it to 139. That boundary added
+  37,888 bytes (0.041%) to the win-arm64 image: the current measurement is
+  93,500,416 bytes, still 949,760 bytes (1.01%) smaller than the original
+  2,585-warning image. CI pins total, per-code, per-area, and per-file/code
+  counts, so both increases and category swaps fail until the same PR updates
+  the explained baseline.
 - **Ship the managed SKU:** `dotnet publish -r <rid> --self-contained
   -p:PublishSingleFile=true`. Prerequisite (~30 min): confirm embedded
   resources (stdlib modules, `lib.*.d.ts`) load under single-file extraction.
@@ -167,16 +172,16 @@ Plan against these numbers, not the originals:
   its reflected SDK path from SharpTS's native image. SharpTS pins 1.0.6 and
   sets the switch only for Native AOT.
 
-### Residual analyzer inventory (151)
+### Residual analyzer inventory (139)
 
-The cleanup tranches removed 2,434 of 2,585 warnings (94.2%) without broad
+The cleanup tranches removed 2,446 of 2,585 warnings (94.6%) without broad
 `DynamicallyAccessedMembers` annotations. What remains is no longer one
 mechanical problem:
 
 | Analyzer | Count | Primary meaning now |
 |---|---:|---|
-| IL2075 | 68 | Reflection from a returned/derived `Type`: emitted runtime duck typing, compiler inspection of user types, and private Reflection.Emit validation |
-| IL2070 | 61 | Reflection on parameters: external .NET interop, declaration discovery, and dynamic runtime dispatch |
+| IL2075 | 59 | Reflection from a returned/derived `Type`: generic managed runtime duck typing, compiler inspection of user types, and private Reflection.Emit validation |
+| IL2070 | 58 | Reflection on parameters: external .NET interop, declaration discovery, and dynamic runtime dispatch |
 | IL2026 | 1 | The dynamic .NET type registry resolving a user-supplied type name |
 | IL3050 | 14 | Runtime generic/array/delegate construction where Native AOT needs a precompiled shape |
 | Other flow warnings | 7 | Two each IL2055/IL2057/IL2060 and one IL2072, concentrated in dynamic interop/type synthesis |
@@ -195,12 +200,17 @@ The remaining work is split at three ownership boundaries:
    native image by 6.55%. Define the supported native BCL surface and root only
    that surface; guard third-party and unavailable generic shapes.
 3. **Generated/runtime reflection.** `RuntimeTypes` and object helpers reflect
-   over SharpTS-emitted managed types. Separate code that only runs later under
-   CoreCLR from code reachable in the native interpreter, then put exact
-   suppressions or generated accessors at that boundary. `ILLabelValidator`
-   and the generator spill reader are a distinct refactor: they inspect
-   private Reflection.Emit implementation fields and should eventually track
-   their state explicitly instead.
+   over SharpTS-emitted managed types. The four name-stable shapes used by
+   hybrid managed execution now go through
+   `ManagedEmittedShapeReflection`: its exact suppressions are restricted to a
+   closed shape enum and it rejects Native AOT before reflection. VM fallbacks
+   that intentionally accept arbitrary CLR `Fields`, `Invoke`, or
+   `SetProperty` shapes remain unsuppressed and belong to the dynamic interop
+   policy. Other emitted user-class shapes have arbitrary names and still need
+   a trustworthy marker or generated accessor. `ILLabelValidator` and the
+   generator spill reader are a distinct refactor: they inspect private
+   Reflection.Emit implementation fields and should eventually track their
+   state explicitly instead.
 
 Analyzer zero is not itself the goal. The target is zero unexplained warnings:
 each residual warning should end at a tested metadata seam, a feature guard, or


### PR DESCRIPTION
## Summary

- add a closed reflection boundary for known compiler-emitted managed shapes
- reject those hybrid bridges under Native AOT before reflection
- route `$Object`, `$TSFunction`/`$BoundTSFunction`, `$WritableStream`, and `$MessagePort` through the boundary
- keep arbitrary CLR `Fields`/`Invoke`/`SetProperty` fallbacks visible for the separate native interop policy
- replace Proxy's private `$TSFunction._method` inspection with the public callable dispatcher contract
- lower the analyzer baseline from 151 to 139 warnings

## Verification

- `scripts/aot-analyzer-report.ps1 -SkipBuild -EnforceBaseline`
- focused worker/streams/VM/dispatcher tests: 329 passed
- focused Proxy/async-hooks/crypto/dispatcher tests: 178 passed
- win-arm64 Native AOT publish and interpreter smoke: passed
- native image: 93,500,416 bytes (+37,888 / 0.041% from the prior checkpoint; still -949,760 / 1.01% from the original baseline)

The full test suite was also attempted. This Windows host's `HttpListener` returned `The handle is invalid`, causing unrelated HTTP/fetch failures and the run to time out. The affected focused suites above are green.
