### PR TITLE
Isolate remaining emitted-shape reflection

### DIFF
--- a/.github/aot-warning-baseline.json
+++ b/.github/aot-warning-baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "total": 139,
+  "total": 116,
   "codes": [
     {
       "code": "IL2026",
@@ -28,7 +28,7 @@
     },
     {
       "code": "IL2075",
-      "count": 59
+      "count": 36
     },
     {
       "code": "IL3050",
@@ -38,7 +38,7 @@
   "areas": [
     {
       "area": "Compilation",
-      "count": 69
+      "count": 55
     },
     {
       "area": "Declaration",
@@ -50,7 +50,7 @@
     },
     {
       "area": "Runtime",
-      "count": 52
+      "count": 43
     },
     {
       "area": "TypeSystem",
@@ -62,11 +62,6 @@
       "file": "Compilation/AttributeMapper.cs",
       "code": "IL2057",
       "count": 1
-    },
-    {
-      "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
-      "code": "IL2060",
-      "count": 2
     },
     {
       "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
@@ -119,17 +114,7 @@
       "count": 3
     },
     {
-      "file": "Runtime/Types/SharpTSAbortSignal.cs",
-      "code": "IL2075",
-      "count": 1
-    },
-    {
       "file": "Runtime/Types/SharpTSAsyncLocalStorage.cs",
-      "code": "IL2075",
-      "count": 1
-    },
-    {
-      "file": "Runtime/Types/SharpTSIntlDateTimeFormat.cs",
       "code": "IL2075",
       "count": 1
     },
@@ -149,11 +134,6 @@
       "count": 3
     },
     {
-      "file": "Runtime/Types/StructuredClone.cs",
-      "code": "IL2075",
-      "count": 4
-    },
-    {
       "file": "Runtime/Types/TSFunctionCallableAdapter.cs",
       "code": "IL2075",
       "count": 1
@@ -169,24 +149,24 @@
       "count": 1
     },
     {
+      "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
+      "code": "IL2060",
+      "count": 2
+    },
+    {
+      "file": "TypeSystem/DotNetTypeSynthesizer.cs",
+      "code": "IL2070",
+      "count": 4
+    },
+    {
       "file": "Runtime/DotNet/DotNetExtensionMethodResolver.cs",
       "code": "IL2075",
       "count": 2
     },
     {
       "file": "Runtime/DotNet/DotNetDelegateShim.cs",
-      "code": "IL3050",
-      "count": 2
-    },
-    {
-      "file": "Runtime/DotNet/DotNetDelegateShim.cs",
       "code": "IL2075",
       "count": 1
-    },
-    {
-      "file": "Runtime/DotNet/DotNetDelegateShim.cs",
-      "code": "IL2070",
-      "count": 2
     },
     {
       "file": "Compilation/AttributeMapper.cs",
@@ -224,44 +204,19 @@
       "count": 10
     },
     {
-      "file": "Compilation/RuntimeTypes.Arrays.cs",
-      "code": "IL2075",
-      "count": 4
-    },
-    {
-      "file": "Compilation/RuntimeTypes.Dns.cs",
-      "code": "IL2075",
-      "count": 1
-    },
-    {
-      "file": "Compilation/RuntimeTypes.Exceptions.cs",
-      "code": "IL2075",
-      "count": 1
-    },
-    {
-      "file": "TypeSystem/DotNetTypeSynthesizer.cs",
-      "code": "IL2070",
-      "count": 4
-    },
-    {
       "file": "Compilation/RuntimeTypes.Json.cs",
       "code": "IL2075",
-      "count": 5
+      "count": 1
     },
     {
-      "file": "Compilation/RuntimeTypes.Promise.cs",
-      "code": "IL2075",
+      "file": "Compilation/RuntimeTypes.Objects.cs",
+      "code": "IL2070",
       "count": 3
     },
     {
       "file": "Compilation/RuntimeTypes.Reflection.cs",
       "code": "IL2070",
       "count": 6
-    },
-    {
-      "file": "Compilation/RuntimeTypes.Utilities.cs",
-      "code": "IL2075",
-      "count": 1
     },
     {
       "file": "Compilation/UnionTypeHelper.cs",
@@ -284,11 +239,6 @@
       "count": 1
     },
     {
-      "file": "Runtime/BuiltIns/ObjectBuiltIns.RuntimeDescriptors.cs",
-      "code": "IL2075",
-      "count": 3
-    },
-    {
       "file": "Runtime/DotNet/DotNetClass.cs",
       "code": "IL2072",
       "count": 1
@@ -299,9 +249,14 @@
       "count": 2
     },
     {
-      "file": "Compilation/RuntimeTypes.Objects.cs",
+      "file": "Runtime/DotNet/DotNetDelegateShim.cs",
       "code": "IL2070",
-      "count": 3
+      "count": 2
+    },
+    {
+      "file": "Runtime/DotNet/DotNetDelegateShim.cs",
+      "code": "IL3050",
+      "count": 2
     },
     {
       "file": "TypeSystem/DotNetTypeSynthesizer.cs",

--- a/Compilation/RuntimeTypes.Arrays.cs
+++ b/Compilation/RuntimeTypes.Arrays.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+using SharpTS.Runtime.Types;
 
 namespace SharpTS.Compilation;
 
@@ -37,37 +37,12 @@ public static partial class RuntimeTypes
         {
             return Enumerable.Range(0, list.Count).Select(i => (object?)i.ToString()).ToList();
         }
-        // For compiled class instances, get keys from typed backing fields AND _fields dictionary
-        if (obj != null)
+        // Compiler-emitted $Object and class instances expose a combined
+        // typed-field + expando dictionary through their $IHasFields contract.
+        if (obj != null &&
+            ManagedEmittedShapeReflection.TryGetFields(obj, out var fields))
         {
-            List<object?> keys = [];
-            var type = obj.GetType();
-
-            // Get typed backing fields (fields starting with __)
-            foreach (var backingField in type.GetFields(BindingFlags.NonPublic | BindingFlags.Instance))
-            {
-                if (backingField.Name.StartsWith("__"))
-                {
-                    // Extract property name by removing __ prefix
-                    string propName = backingField.Name[2..];
-                    keys.Add(propName);
-                }
-            }
-
-            // Also get keys from _fields dictionary (for dynamic properties and generic type fields)
-            var fieldsField = type.GetField("_fields", BindingFlags.NonPublic | BindingFlags.Instance);
-            if (fieldsField != null && fieldsField.GetValue(obj) is Dictionary<string, object?> fields)
-            {
-                foreach (var key in fields.Keys)
-                {
-                    if (!keys.Contains(key))
-                    {
-                        keys.Add(key);
-                    }
-                }
-            }
-
-            return keys;
+            return fields!.Keys.Select(k => (object?)k).ToList();
         }
         return [];
     }
@@ -93,37 +68,12 @@ public static partial class RuntimeTypes
             names.Add("length");
             return names;
         }
-        // For compiled class instances, get names from typed backing fields AND _fields dictionary
-        if (obj != null)
+        // Compiler-emitted $Object and class instances expose all string-keyed
+        // own fields through their $IHasFields contract.
+        if (obj != null &&
+            ManagedEmittedShapeReflection.TryGetFields(obj, out var fields))
         {
-            List<object?> names = [];
-            var type = obj.GetType();
-
-            // Get typed backing fields (fields starting with __)
-            foreach (var backingField in type.GetFields(BindingFlags.NonPublic | BindingFlags.Instance))
-            {
-                if (backingField.Name.StartsWith("__"))
-                {
-                    // Extract property name by removing __ prefix
-                    string propName = backingField.Name[2..];
-                    names.Add(propName);
-                }
-            }
-
-            // Also get names from _fields dictionary (for dynamic properties and generic type fields)
-            var fieldsField = type.GetField("_fields", BindingFlags.NonPublic | BindingFlags.Instance);
-            if (fieldsField != null && fieldsField.GetValue(obj) is Dictionary<string, object?> fields)
-            {
-                foreach (var key in fields.Keys)
-                {
-                    if (!names.Contains(key))
-                    {
-                        names.Add(key);
-                    }
-                }
-            }
-
-            return names;
+            return fields!.Keys.Select(k => (object?)k).ToList();
         }
         return [];
     }

--- a/Compilation/RuntimeTypes.Dns.cs
+++ b/Compilation/RuntimeTypes.Dns.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Sockets;
+using SharpTS.Runtime;
 using SharpTS.Runtime.BuiltIns.Modules;
 
 namespace SharpTS.Compilation;
@@ -274,17 +275,8 @@ public static partial class RuntimeTypes
     /// </summary>
     private static void InvokeCallback(object callback, object?[] args)
     {
-        if (callback is Delegate del)
-        {
-            del.DynamicInvoke(new object?[] { args });
-            return;
-        }
-
-        // Emitted TSFunction: look for Invoke(object[]) method
-        var invokeMethod = callback.GetType().GetMethod("Invoke",
-            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance,
-            null, [typeof(object?[])], null);
-        invokeMethod?.Invoke(callback, [args]);
+        if (RuntimeCallableDispatcher.IsCallable(callback))
+            RuntimeCallableDispatcher.Invoke(null, callback, args);
     }
 
     private static string[] ExtractStringArray(object? value)

--- a/Compilation/RuntimeTypes.Exceptions.cs
+++ b/Compilation/RuntimeTypes.Exceptions.cs
@@ -13,13 +13,21 @@ public static partial class RuntimeTypes
 
     public static object WrapException(Exception ex)
     {
-        // Check for PromiseRejectedException (emitted $PromiseRejectedException or runtime type)
-        // which carries the original rejection reason value (e.g. a raw string from Promise.reject("msg"))
-        var reasonProp = ex.GetType().GetProperty("Reason");
-        if (reasonProp != null)
+        // Promise rejection exceptions carry the original rejection value
+        // (for example, a raw string from Promise.reject("msg")).
+        if (ex is SharpTSPromiseRejectedException runtimeRejection)
         {
-            var reason = reasonProp.GetValue(ex);
-            if (reason != null) return reason;
+            return runtimeRejection.Reason ?? new SharpTSError(ex.Message);
+        }
+
+        var type = ex.GetType();
+        if (ManagedEmittedShapeReflection.IsShape(
+                type, ManagedEmittedShape.PromiseRejectedException))
+        {
+            var reasonProperty = ManagedEmittedShapeReflection.GetPublicProperty(
+                type, ManagedEmittedShape.PromiseRejectedException, "Reason");
+            if (reasonProperty?.GetValue(ex) is { } reason)
+                return reason;
         }
 
         // Wrap a host-originated exception as a real Error so guest `catch` sees a

--- a/Compilation/RuntimeTypes.Json.cs
+++ b/Compilation/RuntimeTypes.Json.cs
@@ -1,21 +1,10 @@
 using System.Text.Json;
+using SharpTS.Runtime.Types;
 
 namespace SharpTS.Compilation;
 
 public static partial class RuntimeTypes
 {
-    /// <summary>
-    /// Converts a PascalCase property name to camelCase for JSON serialization.
-    /// </summary>
-    private static string ToCamelCase(string pascalCase)
-    {
-        if (string.IsNullOrEmpty(pascalCase))
-            return pascalCase;
-        if (char.IsLower(pascalCase[0]))
-            return pascalCase;
-        return char.ToLowerInvariant(pascalCase[0]) + pascalCase[1..];
-    }
-
     #region JSON Methods
 
     public static object? JsonParse(object? text)
@@ -204,11 +193,12 @@ public static partial class RuntimeTypes
             return toJsonMethod.Invoke(value, null);
         }
 
-        // Check for toJSON in _fields dictionary (for objects with callable toJSON property)
-        var fieldsField = type.GetField("_fields", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        if (fieldsField?.GetValue(value) is Dictionary<string, object?> fields)
+        // Check for toJSON in the compiler-emitted $IHasFields dictionary
+        // (for objects with a callable toJSON data property).
+        if (ManagedEmittedShapeReflection.TryGetFields(value, out var fields))
         {
-            if (fields.TryGetValue("toJSON", out var toJsonFunc) && toJsonFunc is TSFunction func)
+            if (fields!.TryGetValue("toJSON", out var toJsonFunc) &&
+                toJsonFunc is TSFunction func)
             {
                 return func.Invoke();
             }
@@ -230,9 +220,8 @@ public static partial class RuntimeTypes
                                    type.GetGenericTypeDefinition() == typeof(Dictionary<,>)))
             return false;
 
-        // Check for _fields field (indicates a compiled class instance)
-        var fieldsField = type.GetField("_fields", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        return fieldsField != null;
+        return ManagedEmittedShapeReflection.IsShape(
+            type, ManagedEmittedShape.HasFields);
     }
 
     /// <summary>
@@ -240,36 +229,18 @@ public static partial class RuntimeTypes
     /// </summary>
     private static string StringifyClassInstance(object value, TSFunction? replacer, HashSet<string>? allowedKeys, string indentStr, int depth)
     {
-        var type = value.GetType();
         Dictionary<string, object?> allFields = [];
-        HashSet<string> seenKeys = [];
-
-        // Get values from typed backing fields (fields starting with __)
-        // Property names are stored as PascalCase but JSON output should use camelCase
-        foreach (var backingField in type.GetFields(System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance))
+        if (!ManagedEmittedShapeReflection.TryGetFields(value, out var fields))
         {
-            if (backingField.Name.StartsWith("__"))
-            {
-                string pascalName = backingField.Name[2..];
-                string camelName = ToCamelCase(pascalName);
-                seenKeys.Add(pascalName);  // Track PascalCase for dedup with _fields
-                if (allowedKeys == null || allowedKeys.Contains(camelName))
-                {
-                    allFields[camelName] = backingField.GetValue(value);
-                }
-            }
+            throw new InvalidOperationException(
+                "StringifyClassInstance requires a compiler-emitted $IHasFields object.");
         }
 
-        // Also get from _fields dictionary (for dynamic properties and generic type fields)
-        var fieldsField = type.GetField("_fields", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        if (fieldsField?.GetValue(value) is Dictionary<string, object?> fields)
+        foreach (var kv in fields!)
         {
-            foreach (var kv in fields)
+            if (allowedKeys == null || allowedKeys.Contains(kv.Key))
             {
-                if (!seenKeys.Contains(kv.Key) && (allowedKeys == null || allowedKeys.Contains(kv.Key)))
-                {
-                    allFields[kv.Key] = kv.Value;
-                }
+                allFields[kv.Key] = kv.Value;
             }
         }
 

--- a/Compilation/RuntimeTypes.Promise.cs
+++ b/Compilation/RuntimeTypes.Promise.cs
@@ -1,3 +1,5 @@
+using SharpTS.Runtime;
+
 namespace SharpTS.Compilation;
 
 public static partial class RuntimeTypes
@@ -145,41 +147,17 @@ public static partial class RuntimeTypes
     }
 
     /// <summary>
-    /// Invokes a function-like object (TSFunction or emitted $TSFunction).
-    /// Uses duck typing to support both the SharpTS TSFunction class and the emitted type.
+    /// Invokes a recognised runtime callable with one argument.
     /// </summary>
     private static bool TryInvokeFunction(object? func, object? arg, out object? result)
     {
         result = null;
 
-        if (func == null)
+        if (!RuntimeCallableDispatcher.IsCallable(func))
             return false;
 
-        // Check for SharpTS.Compilation.TSFunction
-        if (func is TSFunction tsFunc)
-        {
-            result = tsFunc.Invoke(arg);
-            return true;
-        }
-
-        // Check for emitted $TSFunction or any type with an Invoke method
-        var invokeMethod = func.GetType().GetMethod("Invoke");
-        if (invokeMethod != null)
-        {
-            var parameters = invokeMethod.GetParameters();
-            // Handle params array signature: Invoke(params object?[] args)
-            if (parameters.Length == 1 && parameters[0].ParameterType == typeof(object[]))
-            {
-                result = invokeMethod.Invoke(func, [new object?[] { arg }]);
-            }
-            else
-            {
-                result = invokeMethod.Invoke(func, [arg]);
-            }
-            return true;
-        }
-
-        return false;
+        result = RuntimeCallableDispatcher.Invoke(null, func, arg);
+        return true;
     }
 
     /// <summary>
@@ -189,38 +167,21 @@ public static partial class RuntimeTypes
     {
         result = null;
 
-        if (func == null)
+        if (!RuntimeCallableDispatcher.IsCallable(func))
             return false;
 
-        // Check for SharpTS.Compilation.TSFunction
-        if (func is TSFunction tsFunc)
+        try
         {
-            result = tsFunc.Invoke();
+            result = RuntimeCallableDispatcher.Invoke(null, func);
             return true;
         }
-
-        // Check for emitted $TSFunction or any type with an Invoke method
-        var invokeMethod = func.GetType().GetMethod("Invoke");
-        if (invokeMethod != null)
+        catch (System.Reflection.TargetInvocationException ex)
         {
-            try
-            {
-                var parameters = invokeMethod.GetParameters();
-                // The emitted $TSFunction.Invoke has signature: Invoke(params object?[] args)
-                // We need to pass an empty array
-                result = invokeMethod.Invoke(func, [Array.Empty<object?>()]);
-                return true;
-            }
-            catch (System.Reflection.TargetInvocationException ex)
-            {
-                // Re-throw the inner exception for cleaner stack traces
-                if (ex.InnerException != null)
-                    throw ex.InnerException;
-                throw;
-            }
+            // Re-throw the inner exception for cleaner stack traces.
+            if (ex.InnerException != null)
+                throw ex.InnerException;
+            throw;
         }
-
-        return false;
     }
 
     /// <summary>
@@ -547,34 +508,11 @@ public static partial class RuntimeTypes
     {
         result = null;
 
-        if (func == null)
+        if (!RuntimeCallableDispatcher.IsCallable(func))
             return false;
 
-        // Check for SharpTS.Compilation.TSFunction
-        if (func is TSFunction tsFunc)
-        {
-            result = tsFunc.Invoke(arg1, arg2);
-            return true;
-        }
-
-        // Check for emitted $TSFunction or any type with an Invoke method
-        var invokeMethod = func.GetType().GetMethod("Invoke");
-        if (invokeMethod != null)
-        {
-            var parameters = invokeMethod.GetParameters();
-            // Handle params array signature: Invoke(params object?[] args)
-            if (parameters.Length == 1 && parameters[0].ParameterType == typeof(object[]))
-            {
-                result = invokeMethod.Invoke(func, [new object?[] { arg1, arg2 }]);
-            }
-            else
-            {
-                result = invokeMethod.Invoke(func, [arg1, arg2]);
-            }
-            return true;
-        }
-
-        return false;
+        result = RuntimeCallableDispatcher.Invoke(null, func, arg1, arg2);
+        return true;
     }
 
     /// <summary>

--- a/Compilation/RuntimeTypes.Utilities.cs
+++ b/Compilation/RuntimeTypes.Utilities.cs
@@ -1,3 +1,5 @@
+using SharpTS.Runtime;
+
 namespace SharpTS.Compilation;
 
 public static partial class RuntimeTypes
@@ -46,8 +48,7 @@ public static partial class RuntimeTypes
     /// Creates a TemplateStringsArray-like object with cooked/raw strings and calls the tag function.
     /// </summary>
     /// <remarks>
-    /// Handles both the compiler's TSFunction type and the emitted TSFunction type by using
-    /// reflection to find and invoke the Invoke method.
+    /// Handles the runtime's recognised managed and compiler-emitted callable shapes.
     /// For compiled mode, creates a List&lt;object?&gt; with a "raw" property that compiled code can access.
     /// </remarks>
     public static object? InvokeTaggedTemplate(
@@ -65,29 +66,12 @@ public static partial class RuntimeTypes
         args[0] = stringsArray;
         Array.Copy(expressions, 0, args, 1, expressions.Length);
 
-        // Invoke tag function
-        // Check if it's the compiler's TSFunction type
-        if (tag is TSFunction func)
-        {
-            return func.Invoke(args);
-        }
-
-        // Check if it's a Delegate
+        // Preserve Delegate.DynamicInvoke's params-array behavior for CLR delegates.
         if (tag is Delegate del)
-        {
             return del.DynamicInvoke(args);
-        }
 
-        // Check if it's the emitted TSFunction type (different type, same pattern)
-        // Use reflection to find and invoke the Invoke method
-        if (tag != null)
-        {
-            var invokeMethod = tag.GetType().GetMethod("Invoke", [typeof(object?[])]);
-            if (invokeMethod != null)
-            {
-                return invokeMethod.Invoke(tag, [args]);
-            }
-        }
+        if (RuntimeCallableDispatcher.IsCallable(tag))
+            return RuntimeCallableDispatcher.Invoke(null, tag, args);
 
         throw new Exception("TypeError: Tagged template tag must be a function.");
     }

--- a/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
@@ -529,9 +529,9 @@ public static class VmModuleInterpreter
                 // Preserve other CLR "Fields" shapes for managed .NET interop.
                 var type = options.GetType();
                 var fieldsProp = ManagedEmittedShapeReflection.IsShape(
-                        type, ManagedEmittedShape.Object)
+                        type, ManagedEmittedShape.HasFields)
                     ? ManagedEmittedShapeReflection.GetPublicProperty(
-                        type, ManagedEmittedShape.Object, "Fields")
+                        type, ManagedEmittedShape.HasFields, "Fields")
                     : type.GetProperty("Fields");
                 if (fieldsProp?.GetValue(options) is IEnumerable<KeyValuePair<string, object?>> fields)
                 {

--- a/Runtime/BuiltIns/ObjectBuiltIns.RuntimeDescriptors.cs
+++ b/Runtime/BuiltIns/ObjectBuiltIns.RuntimeDescriptors.cs
@@ -69,48 +69,18 @@ public static partial class ObjectBuiltIns
                 break;
 
             default:
-                // Try reflection for compiled class instances
-                var type = source.GetType();
-
-                // First, get typed backing fields (fields starting with __) for compiled class instances
-                foreach (var backingField in type.GetFields(System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance))
+                // Compiler-emitted classes expose a combined view of typed
+                // backing fields and expando properties through $IHasFields.
+                if (ManagedEmittedShapeReflection.TryGetFields(
+                        source, out var emittedFields))
                 {
-                    if (backingField.Name.StartsWith("__"))
+                    foreach (var kv in emittedFields!)
                     {
-                        string pascalName = backingField.Name[2..]; // Remove __ prefix
-                        // Convert PascalCase back to camelCase (how TypeScript originally named it)
-                        string propName = ToCamelCase(pascalName);
-                        target[propName] = backingField.GetValue(source);
-                    }
-                }
-
-                // Also check for _fields dictionary (for dynamically added properties)
-                var fieldsField = type.GetField("_fields", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-                if (fieldsField != null)
-                {
-                    var fieldsValue = fieldsField.GetValue(source);
-                    if (fieldsValue is System.Collections.IDictionary fieldsDict)
-                    {
-                        foreach (System.Collections.DictionaryEntry entry in fieldsDict)
-                        {
-                            target[entry.Key?.ToString() ?? ""] = entry.Value;
-                        }
+                        target[kv.Key] = kv.Value;
                     }
                 }
                 break;
         }
-    }
-
-    /// <summary>
-    /// Converts a PascalCase property name to camelCase.
-    /// </summary>
-    private static string ToCamelCase(string pascalCase)
-    {
-        if (string.IsNullOrEmpty(pascalCase))
-            return pascalCase;
-        if (char.IsLower(pascalCase[0]))
-            return pascalCase;
-        return char.ToLowerInvariant(pascalCase[0]) + pascalCase[1..];
     }
 
     /// <summary>
@@ -250,50 +220,29 @@ public static partial class ObjectBuiltIns
     private static SharpTSPropertyDescriptor? TryGetPropertyDescriptorViaReflection(object target, string propKey)
     {
         var type = target.GetType();
-        var methods = type.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
-
-        // Find HasProperty and GetProperty methods
-        System.Reflection.MethodInfo? hasPropertyMethod = null;
-        System.Reflection.MethodInfo? getPropertyMethod = null;
-
-        foreach (var m in methods)
+        if (!ManagedEmittedShapeReflection.IsShape(
+                type, ManagedEmittedShape.HasFields))
         {
-            if (m.Name == "HasProperty")
-            {
-                var parms = m.GetParameters();
-                if (parms.Length == 1 && parms[0].ParameterType == typeof(string))
-                {
-                    hasPropertyMethod = m;
-                }
-            }
-            else if (m.Name == "GetProperty")
-            {
-                var parms = m.GetParameters();
-                if (parms.Length == 1 && parms[0].ParameterType == typeof(string))
-                {
-                    getPropertyMethod = m;
-                }
-            }
+            return null;
         }
 
-        if (hasPropertyMethod != null && getPropertyMethod != null)
-        {
-            var hasProperty = (bool?)hasPropertyMethod.Invoke(target, [propKey]);
-            if (hasProperty != true)
-            {
-                return null;
-            }
+        var hasPropertyMethod = ManagedEmittedShapeReflection.GetPublicMethod(
+            type, ManagedEmittedShape.HasFields, "HasProperty", [typeof(string)]);
+        var getPropertyMethod = ManagedEmittedShapeReflection.GetPublicMethod(
+            type, ManagedEmittedShape.HasFields, "GetProperty", [typeof(string)]);
 
-            var value = getPropertyMethod.Invoke(target, [propKey]);
-            return new SharpTSPropertyDescriptor
-            {
-                Value = value,
-                Writable = true,
-                Enumerable = true,
-                Configurable = true
-            };
+        if (hasPropertyMethod?.Invoke(target, [propKey]) is not true ||
+            getPropertyMethod == null)
+        {
+            return null;
         }
 
-        return null;
+        return new SharpTSPropertyDescriptor
+        {
+            Value = getPropertyMethod.Invoke(target, [propKey]),
+            Writable = true,
+            Enumerable = true,
+            Configurable = true
+        };
     }
 }

--- a/Runtime/Types/ManagedEmittedShapeReflection.cs
+++ b/Runtime/Types/ManagedEmittedShapeReflection.cs
@@ -33,8 +33,23 @@ internal static class ManagedEmittedShapeReflection
             ManagedEmittedShape.Function => type.Name is "$TSFunction" or "$BoundTSFunction",
             ManagedEmittedShape.WritableStream => type.Name == "$WritableStream",
             ManagedEmittedShape.MessagePort => type.Name == "$MessagePort",
+            ManagedEmittedShape.ArrayBuffer => type.Name == "$ArrayBuffer",
+            ManagedEmittedShape.Date => type.Name == "$TSDate",
+            ManagedEmittedShape.PromiseRejectedException =>
+                type.Name == "$PromiseRejectedException",
+            ManagedEmittedShape.HasFields => HasAssemblyLocalFieldsContract(type),
             _ => false
         };
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    private static bool HasAssemblyLocalFieldsContract(Type type)
+    {
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+            return false;
+
+        return type.GetInterfaces().Any(i =>
+            i.Name == "$IHasFields" && i.Assembly == type.Assembly);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
@@ -68,6 +83,40 @@ internal static class ManagedEmittedShapeReflection
         return type.GetField(name, BindingFlags.NonPublic | BindingFlags.Instance);
     }
 
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static ConstructorInfo? GetPublicConstructor(
+        Type type,
+        ManagedEmittedShape shape,
+        Type[] parameterTypes)
+    {
+        RequireManagedShape(type, shape);
+        return type.GetConstructor(parameterTypes);
+    }
+
+    internal static bool TryGetFields(
+        object value,
+        out Dictionary<string, object?>? fields)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        var type = value.GetType();
+        if (!IsShape(type, ManagedEmittedShape.HasFields))
+        {
+            fields = null;
+            return false;
+        }
+
+        var property = GetPublicProperty(type, ManagedEmittedShape.HasFields, "Fields")
+            ?? throw new InvalidOperationException(
+                $"Compiler-emitted type '{type.FullName}' implements $IHasFields " +
+                "without its required Fields property.");
+
+        fields = property.GetValue(value) as Dictionary<string, object?>
+            ?? throw new InvalidOperationException(
+                $"Compiler-emitted type '{type.FullName}' returned an invalid Fields value.");
+        return true;
+    }
+
     private static void RequireManagedShape(Type type, ManagedEmittedShape shape)
     {
         ArgumentNullException.ThrowIfNull(type);
@@ -93,6 +142,10 @@ internal static class ManagedEmittedShapeReflection
         ManagedEmittedShape.Function => "$TSFunction/$BoundTSFunction",
         ManagedEmittedShape.WritableStream => "$WritableStream",
         ManagedEmittedShape.MessagePort => "$MessagePort",
+        ManagedEmittedShape.ArrayBuffer => "$ArrayBuffer",
+        ManagedEmittedShape.Date => "$TSDate",
+        ManagedEmittedShape.PromiseRejectedException => "$PromiseRejectedException",
+        ManagedEmittedShape.HasFields => "$IHasFields object",
         _ => shape.ToString()
     };
 }
@@ -102,5 +155,9 @@ internal enum ManagedEmittedShape
     Object,
     Function,
     WritableStream,
-    MessagePort
+    MessagePort,
+    ArrayBuffer,
+    Date,
+    PromiseRejectedException,
+    HasFields
 }

--- a/Runtime/Types/SharpTSAbortSignal.cs
+++ b/Runtime/Types/SharpTSAbortSignal.cs
@@ -1,4 +1,5 @@
 using SharpTS.Compilation;
+using SharpTS.Runtime;
 using SharpTS.Runtime.BuiltIns;
 using SharpTS.TypeSystem;
 using Interp = SharpTS.Execution.Interpreter;
@@ -171,12 +172,8 @@ public class SharpTSAbortSignal : ITypeCategorized
             return;
         }
 
-        // Reflection fallback for unknown callable types
-        var invokeMethod = listener.GetType().GetMethod("Invoke");
-        if (invokeMethod != null)
-        {
-            invokeMethod.Invoke(listener, [Array.Empty<object?>()]);
-        }
+        if (RuntimeCallableDispatcher.IsCallable(listener))
+            RuntimeCallableDispatcher.Invoke(interpreter, listener);
     }
 
     #region Static Factories

--- a/Runtime/Types/SharpTSIntlDateTimeFormat.cs
+++ b/Runtime/Types/SharpTSIntlDateTimeFormat.cs
@@ -575,10 +575,14 @@ public class SharpTSIntlDateTimeFormat : SharpTSIntlFormatterBase
         if (value is string s && DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
             return parsed;
 
-        // Handle emitted $TSDate type (compiled mode) via reflection
-        var getTimeMethod = value.GetType().GetMethod("GetTime");
-        if (getTimeMethod != null)
+        // Handle the compiler-emitted $TSDate managed shape.
+        var type = value.GetType();
+        if (ManagedEmittedShapeReflection.IsShape(type, ManagedEmittedShape.Date))
         {
+            var getTimeMethod = ManagedEmittedShapeReflection.GetPublicMethod(
+                    type, ManagedEmittedShape.Date, "GetTime", Type.EmptyTypes)
+                ?? throw new InvalidOperationException(
+                    "Compiler-emitted $TSDate has no GetTime method.");
             var result = getTimeMethod.Invoke(value, null);
             if (result is double epochMs)
                 return UnixEpoch.AddMilliseconds(epochMs).ToLocalTime();

--- a/Runtime/Types/SharpTSKeyObject.cs
+++ b/Runtime/Types/SharpTSKeyObject.cs
@@ -377,7 +377,7 @@ public class SharpTSKeyObject : ISharpTSPropertyAccessor
         // values have already gone through the guarded StreamFields path.
         if (options != null &&
             !ManagedEmittedShapeReflection.IsShape(
-                options.GetType(), ManagedEmittedShape.Object) &&
+                options.GetType(), ManagedEmittedShape.HasFields) &&
             options is not SharpTSObject &&
             options is not IDictionary<string, object?>)
         {

--- a/Runtime/Types/StructuredClone.cs
+++ b/Runtime/Types/StructuredClone.cs
@@ -114,9 +114,13 @@ public static class StructuredClone
         {
             interpBuffer.Detach();
         }
-        else if (buffer.GetType().Name == "$ArrayBuffer")
+        else if (ManagedEmittedShapeReflection.IsShape(
+                     buffer.GetType(), ManagedEmittedShape.ArrayBuffer))
         {
-            buffer.GetType().GetMethod("Detach")?.Invoke(buffer, null);
+            ManagedEmittedShapeReflection.GetPublicMethod(
+                    buffer.GetType(), ManagedEmittedShape.ArrayBuffer,
+                    "Detach", Type.EmptyTypes)
+                ?.Invoke(buffer, null);
         }
     }
 
@@ -487,18 +491,21 @@ public static class StructuredClone
         var type = source.GetType();
 
         // Get ByteLength property
-        var byteLengthProp = type.GetProperty("ByteLength");
+        var byteLengthProp = ManagedEmittedShapeReflection.GetPublicProperty(
+            type, ManagedEmittedShape.ArrayBuffer, "ByteLength");
         var byteLength = (int)(byteLengthProp?.GetValue(source) ?? 0);
 
         // Get the backing buffer via GetBuffer() method
-        var getBufferMethod = type.GetMethod("GetBuffer");
+        var getBufferMethod = ManagedEmittedShapeReflection.GetPublicMethod(
+            type, ManagedEmittedShape.ArrayBuffer, "GetBuffer", Type.EmptyTypes);
         var sourceBuffer = (byte[]?)getBufferMethod?.Invoke(source, null);
 
         if (sourceBuffer == null)
             throw new DataCloneError("Cannot clone ArrayBuffer: unable to access backing buffer");
 
         // Create new instance with same length
-        var ctor = type.GetConstructor([typeof(int)]);
+        var ctor = ManagedEmittedShapeReflection.GetPublicConstructor(
+            type, ManagedEmittedShape.ArrayBuffer, [typeof(int)]);
         if (ctor == null)
             throw new DataCloneError("Cannot clone ArrayBuffer: constructor not found");
 

--- a/Runtime/Types/VmContext.cs
+++ b/Runtime/Types/VmContext.cs
@@ -71,9 +71,9 @@ public static class VmContext
             // that path remains part of the separate native interop policy.
             var type = contextObject.GetType();
             var fieldsProp = ManagedEmittedShapeReflection.IsShape(
-                    type, ManagedEmittedShape.Object)
+                    type, ManagedEmittedShape.HasFields)
                 ? ManagedEmittedShapeReflection.GetPublicProperty(
-                    type, ManagedEmittedShape.Object, "Fields")
+                    type, ManagedEmittedShape.HasFields, "Fields")
                 : type.GetProperty("Fields");
             if (fieldsProp?.GetValue(contextObject) is IEnumerable<KeyValuePair<string, object?>> fields)
             {
@@ -143,9 +143,9 @@ public static class VmContext
             // custom CLR SetProperty shapes as the managed interop fallback.
             var type = contextObject.GetType();
             var setMethod = ManagedEmittedShapeReflection.IsShape(
-                    type, ManagedEmittedShape.Object)
+                    type, ManagedEmittedShape.HasFields)
                 ? ManagedEmittedShapeReflection.GetPublicMethod(
-                    type, ManagedEmittedShape.Object, "SetProperty",
+                    type, ManagedEmittedShape.HasFields, "SetProperty",
                     [typeof(string), typeof(object)])
                 : type.GetMethod("SetProperty", [typeof(string), typeof(object)]);
             if (setMethod != null)

--- a/Runtime/Types/WebStreamsHelpers.cs
+++ b/Runtime/Types/WebStreamsHelpers.cs
@@ -32,13 +32,14 @@ internal static class StreamFields
         // managed-emitted-shape boundary. Other CLR objects are not part of
         // this adapter's documented contract.
         var targetType = target.GetType();
-        if (!ManagedEmittedShapeReflection.IsShape(targetType, ManagedEmittedShape.Object))
+        if (!ManagedEmittedShapeReflection.IsShape(
+                targetType, ManagedEmittedShape.HasFields))
         {
             return false;
         }
         var prop = _fieldsPropCache.GetOrAdd(targetType, t =>
             ManagedEmittedShapeReflection.GetPublicProperty(
-                t, ManagedEmittedShape.Object, "Fields"));
+                t, ManagedEmittedShape.HasFields, "Fields"));
         if (prop != null && prop.GetValue(target) is IDictionary<string, object?> reflected)
         {
             return reflected.TryGetValue(name, out value);

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -127,11 +127,15 @@ Plan against these numbers, not the originals:
   compiler-emitted managed shapes (`$Object`, `$TSFunction`/
   `$BoundTSFunction`, `$WritableStream`, and `$MessagePort`) behind a closed,
   Native-AOT-guarded boundary then lowered it to 139. That boundary added
-  37,888 bytes (0.041%) to the win-arm64 image: the current measurement is
-  93,500,416 bytes, still 949,760 bytes (1.01%) smaller than the original
-  2,585-warning image. CI pins total, per-code, per-area, and per-file/code
-  counts, so both increases and category swaps fail until the same PR updates
-  the explained baseline.
+  37,888 bytes (0.041%) to the win-arm64 image. Extending the boundary to the
+  exact `$ArrayBuffer`, `$TSDate`, and `$PromiseRejectedException` shapes plus
+  the assembly-local `$IHasFields` contract, and routing recognised callable
+  shapes through `RuntimeCallableDispatcher`, lowered the inventory to 116.
+  The resulting image is 93,498,880 bytes: 1,536 bytes smaller than the prior
+  checkpoint and 951,296 bytes (1.01%) smaller than the original 2,585-warning
+  image. CI pins total, per-code, per-area, and per-file/code counts, so both
+  increases and category swaps fail until the same PR updates the explained
+  baseline.
 - **Ship the managed SKU:** `dotnet publish -r <rid> --self-contained
   -p:PublishSingleFile=true`. Prerequisite (~30 min): confirm embedded
   resources (stdlib modules, `lib.*.d.ts`) load under single-file extraction.
@@ -172,15 +176,15 @@ Plan against these numbers, not the originals:
   its reflected SDK path from SharpTS's native image. SharpTS pins 1.0.6 and
   sets the switch only for Native AOT.
 
-### Residual analyzer inventory (139)
+### Residual analyzer inventory (116)
 
-The cleanup tranches removed 2,446 of 2,585 warnings (94.6%) without broad
+The cleanup tranches removed 2,469 of 2,585 warnings (95.5%) without broad
 `DynamicallyAccessedMembers` annotations. What remains is no longer one
 mechanical problem:
 
 | Analyzer | Count | Primary meaning now |
 |---|---:|---|
-| IL2075 | 59 | Reflection from a returned/derived `Type`: generic managed runtime duck typing, compiler inspection of user types, and private Reflection.Emit validation |
+| IL2075 | 36 | Reflection from a returned/derived `Type`: dynamic .NET interop, generic managed runtime fallbacks, and private Reflection.Emit validation |
 | IL2070 | 58 | Reflection on parameters: external .NET interop, declaration discovery, and dynamic runtime dispatch |
 | IL2026 | 1 | The dynamic .NET type registry resolving a user-supplied type name |
 | IL3050 | 14 | Runtime generic/array/delegate construction where Native AOT needs a precompiled shape |
@@ -199,18 +203,19 @@ The remaining work is split at three ownership boundaries:
    member annotations were measured and rejected because they increased the
    native image by 6.55%. Define the supported native BCL surface and root only
    that surface; guard third-party and unavailable generic shapes.
-3. **Generated/runtime reflection.** `RuntimeTypes` and object helpers reflect
-   over SharpTS-emitted managed types. The four name-stable shapes used by
-   hybrid managed execution now go through
-   `ManagedEmittedShapeReflection`: its exact suppressions are restricted to a
-   closed shape enum and it rejects Native AOT before reflection. VM fallbacks
-   that intentionally accept arbitrary CLR `Fields`, `Invoke`, or
-   `SetProperty` shapes remain unsuppressed and belong to the dynamic interop
-   policy. Other emitted user-class shapes have arbitrary names and still need
-   a trustworthy marker or generated accessor. `ILLabelValidator` and the
-   generator spill reader are a distinct refactor: they inspect private
-   Reflection.Emit implementation fields and should eventually track their
-   state explicitly instead.
+3. **Generated/runtime reflection.** Known compiler-emitted managed shapes now
+   go through `ManagedEmittedShapeReflection`. Exact-name validation covers
+   `$Object`, callable, stream, message-port, array-buffer, date, and
+   promise-rejection shapes. Arbitrarily named emitted user classes are
+   validated by the `$IHasFields` interface defined in the same output assembly;
+   its public combined `Fields` view replaces private backing-field inspection.
+   The boundary's exact suppressions are restricted to a closed shape enum and
+   it rejects Native AOT before reflection. Recognised callbacks share
+   `RuntimeCallableDispatcher`; fallbacks that intentionally inspect arbitrary
+   CLR shapes remain unsuppressed and belong to the dynamic interop policy.
+   `ILLabelValidator` and the generator spill reader are the remaining distinct
+   refactor: they inspect private Reflection.Emit implementation fields and
+   should eventually track their state explicitly instead.
 
 Analyzer zero is not itself the goal. The target is zero unexplained warnings:
 each residual warning should end at a tested metadata seam, a feature guard, or


### PR DESCRIPTION
## Summary
- extend the managed emitted-shape boundary to ArrayBuffer, Date, promise-rejection, and assembly-local IHasFields contracts
- consume emitted class fields through the public combined Fields view and route recognised callbacks through RuntimeCallableDispatcher
- lower the AOT analyzer ratchet from 139 to 116 warnings and update the Native AOT plan

## Compatibility boundary
This intentionally recognises compiler-emitted shapes by their compiler-owned contracts instead of treating arbitrary CLR objects with matching Invoke, HasProperty, or GetProperty methods as TypeScript runtime objects. CLR Delegate handling and documented managed interop fallbacks remain supported.

## Verification
- dotnet test SharpTS.Tests/SharpTS.Tests.csproj --no-restore: 16,266 passed
- focused emitted-shape/runtime suites: 968 passed
- focused callback/DNS/Intl/exception suites: 463 passed
- AOT analyzer: 116 warnings (IL2075 59 -> 36; all other categories unchanged)
- win-arm64 Native AOT publish and Examples/AotCompileGate/main.ts smoke: 42
- native image: 93,498,880 bytes (1,536 bytes smaller than the prior checkpoint)