### PR TITLE
Isolate managed output runtime reflection

### DIFF
--- a/.github/aot-warning-baseline.json
+++ b/.github/aot-warning-baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "total": 102,
+  "total": 91,
   "codes": [
     {
       "code": "IL2026",
@@ -20,7 +20,7 @@
     },
     {
       "code": "IL2070",
-      "count": 58
+      "count": 49
     },
     {
       "code": "IL2072",
@@ -28,7 +28,7 @@
     },
     {
       "code": "IL2075",
-      "count": 22
+      "count": 20
     },
     {
       "code": "IL3050",
@@ -38,7 +38,7 @@
   "areas": [
     {
       "area": "Compilation",
-      "count": 41
+      "count": 30
     },
     {
       "area": "Declaration",
@@ -64,106 +64,6 @@
       "count": 1
     },
     {
-      "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
-      "code": "IL3050",
-      "count": 2
-    },
-    {
-      "file": "Runtime/DotNet/DotNetMarshaller.cs",
-      "code": "IL3050",
-      "count": 1
-    },
-    {
-      "file": "Runtime/DotNet/DotNetMethod.cs",
-      "code": "IL3050",
-      "count": 1
-    },
-    {
-      "file": "Runtime/DotNet/DotNetMethodResolver.cs",
-      "code": "IL3050",
-      "count": 1
-    },
-    {
-      "file": "Runtime/DotNet/DotNetOperatorResolver.cs",
-      "code": "IL2070",
-      "count": 3
-    },
-    {
-      "file": "Runtime/DotNet/DotNetTypeRegistry.cs",
-      "code": "IL2026",
-      "count": 1
-    },
-    {
-      "file": "Runtime/DotNet/DotNetTypeRegistry.cs",
-      "code": "IL2055",
-      "count": 2
-    },
-    {
-      "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
-      "code": "IL2070",
-      "count": 3
-    },
-    {
-      "file": "Runtime/DotNet/DotNetTypeRegistry.cs",
-      "code": "IL2057",
-      "count": 1
-    },
-    {
-      "file": "Runtime/Types/SharpTSAsyncLocalStorage.cs",
-      "code": "IL2075",
-      "count": 1
-    },
-    {
-      "file": "Runtime/Types/SharpTSKeyObject.cs",
-      "code": "IL2075",
-      "count": 1
-    },
-    {
-      "file": "Runtime/Types/SharpTSPropertyDescriptor.cs",
-      "code": "IL2075",
-      "count": 2
-    },
-    {
-      "file": "Runtime/Types/SharpTSProxy.cs",
-      "code": "IL2075",
-      "count": 3
-    },
-    {
-      "file": "Runtime/Types/TSFunctionCallableAdapter.cs",
-      "code": "IL2075",
-      "count": 1
-    },
-    {
-      "file": "Runtime/Types/VmContext.cs",
-      "code": "IL2075",
-      "count": 3
-    },
-    {
-      "file": "Runtime/Types/VmModule.cs",
-      "code": "IL2075",
-      "count": 1
-    },
-    {
-      "file": "Runtime/DotNet/DotNetTypeRegistry.cs",
-      "code": "IL3050",
-      "count": 3
-    },
-    {
-      "file": "TypeSystem/DotNetTypeSynthesizer.cs",
-      "code": "IL2070",
-      "count": 4
-    },
-    {
-      "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
-      "code": "IL2060",
-      "count": 2
-    },
-    {
-      "file": "Runtime/DotNet/DotNetDelegateShim.cs",
-      "code": "IL3050",
-      "count": 2
-    },
-    {
       "file": "Compilation/AttributeMapper.cs",
       "code": "IL2070",
       "count": 1
@@ -187,26 +87,6 @@
       "file": "Compilation/ILEmitter.Properties.External.cs",
       "code": "IL2070",
       "count": 12
-    },
-    {
-      "file": "Compilation/RuntimeTypes.Json.cs",
-      "code": "IL2075",
-      "count": 1
-    },
-    {
-      "file": "Compilation/RuntimeTypes.Objects.cs",
-      "code": "IL2070",
-      "count": 3
-    },
-    {
-      "file": "Runtime/DotNet/DotNetExtensionMethodResolver.cs",
-      "code": "IL2075",
-      "count": 2
-    },
-    {
-      "file": "Compilation/RuntimeTypes.Reflection.cs",
-      "code": "IL2070",
-      "count": 6
     },
     {
       "file": "Declaration/TypeInspector.cs",
@@ -244,9 +124,109 @@
       "count": 1
     },
     {
-      "file": "Compilation/UnionTypeHelper.cs",
+      "file": "Runtime/DotNet/DotNetDelegateShim.cs",
+      "code": "IL3050",
+      "count": 2
+    },
+    {
+      "file": "Runtime/DotNet/DotNetExtensionMethodResolver.cs",
+      "code": "IL2075",
+      "count": 2
+    },
+    {
+      "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
+      "code": "IL2060",
+      "count": 2
+    },
+    {
+      "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
+      "code": "IL2070",
+      "count": 3
+    },
+    {
+      "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
+      "code": "IL3050",
+      "count": 2
+    },
+    {
+      "file": "Runtime/DotNet/DotNetMarshaller.cs",
+      "code": "IL3050",
+      "count": 1
+    },
+    {
+      "file": "Runtime/DotNet/DotNetMethod.cs",
+      "code": "IL3050",
+      "count": 1
+    },
+    {
+      "file": "Runtime/DotNet/DotNetMethodResolver.cs",
+      "code": "IL3050",
+      "count": 1
+    },
+    {
+      "file": "Runtime/DotNet/DotNetOperatorResolver.cs",
+      "code": "IL2070",
+      "count": 3
+    },
+    {
+      "file": "Runtime/DotNet/DotNetTypeRegistry.cs",
+      "code": "IL2026",
+      "count": 1
+    },
+    {
+      "file": "Runtime/DotNet/DotNetTypeRegistry.cs",
+      "code": "IL2055",
+      "count": 2
+    },
+    {
+      "file": "Runtime/DotNet/DotNetTypeRegistry.cs",
+      "code": "IL2057",
+      "count": 1
+    },
+    {
+      "file": "Runtime/DotNet/DotNetTypeRegistry.cs",
+      "code": "IL3050",
+      "count": 3
+    },
+    {
+      "file": "Runtime/Types/SharpTSAsyncLocalStorage.cs",
       "code": "IL2075",
       "count": 1
+    },
+    {
+      "file": "Runtime/Types/SharpTSKeyObject.cs",
+      "code": "IL2075",
+      "count": 1
+    },
+    {
+      "file": "Runtime/Types/SharpTSPropertyDescriptor.cs",
+      "code": "IL2075",
+      "count": 2
+    },
+    {
+      "file": "Runtime/Types/SharpTSProxy.cs",
+      "code": "IL2075",
+      "count": 3
+    },
+    {
+      "file": "Runtime/Types/TSFunctionCallableAdapter.cs",
+      "code": "IL2075",
+      "count": 1
+    },
+    {
+      "file": "Runtime/Types/VmContext.cs",
+      "code": "IL2075",
+      "count": 3
+    },
+    {
+      "file": "Runtime/Types/VmModule.cs",
+      "code": "IL2075",
+      "count": 1
+    },
+    {
+      "file": "TypeSystem/DotNetTypeSynthesizer.cs",
+      "code": "IL2070",
+      "count": 4
     },
     {
       "file": "TypeSystem/DotNetTypeSynthesizer.cs",

--- a/Compilation/ManagedOutputRuntimeReflection.cs
+++ b/Compilation/ManagedOutputRuntimeReflection.cs
@@ -1,0 +1,92 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Reflection boundary for runtime operations performed by compiled SharpTS output.
+/// </summary>
+/// <remarks>
+/// Unlike <c>ManagedEmittedShapeReflection</c>, this boundary is intentionally open
+/// ended: managed output can contain user-defined types and can interoperate with
+/// third-party assemblies. Those operations execute under CoreCLR. A Native AOT
+/// SharpTS host can produce the managed output, but it cannot load that output back
+/// into its frozen process, so every entry point rejects native execution first.
+/// </remarks>
+internal static class ManagedOutputRuntimeReflection
+{
+    private const string TrimJustification =
+        "The reflected type belongs to compiled SharpTS output or its managed CLR " +
+        "interop closure. That code executes under CoreCLR, and this boundary rejects " +
+        "Native AOT before reflection. The Managed SKU intentionally preserves open-world " +
+        "third-party assembly interop.";
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static MethodInfo? GetPublicMethodByName(Type type, string name)
+    {
+        RequireManagedOutputRuntime();
+        return type.GetMethod(name);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static MethodInfo? GetMethodByName(
+        Type type,
+        string name,
+        BindingFlags bindingFlags)
+    {
+        RequireManagedOutputRuntime();
+        return type.GetMethod(name, bindingFlags);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static MethodInfo? GetMethodBySignature(
+        Type type,
+        string name,
+        BindingFlags bindingFlags,
+        Type[] parameterTypes)
+    {
+        RequireManagedOutputRuntime();
+        return type.GetMethod(name, bindingFlags, binder: null, parameterTypes, modifiers: null);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static FieldInfo? GetFieldByName(
+        Type type,
+        string name,
+        BindingFlags bindingFlags)
+    {
+        RequireManagedOutputRuntime();
+        return type.GetField(name, bindingFlags);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static ConstructorInfo? GetFirstPublicConstructor(Type type)
+    {
+        RequireManagedOutputRuntime();
+        var constructors = type.GetConstructors();
+        return constructors.Length > 0 ? constructors[0] : null;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static FieldInfo[] GetNonPublicInstanceFieldsWithPrefix(
+        Type type,
+        string prefix)
+    {
+        RequireManagedOutputRuntime();
+        return type.GetFields(BindingFlags.NonPublic | BindingFlags.Instance)
+            .Where(field => field.Name.StartsWith(prefix, StringComparison.Ordinal))
+            .ToArray();
+    }
+
+    private static void RequireManagedOutputRuntime()
+    {
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            throw new PlatformNotSupportedException(
+                "Executing compiled SharpTS runtime reflection is not available in the " +
+                "native SharpTS process — run the generated output under CoreCLR or use " +
+                "the managed SharpTS build.");
+        }
+    }
+}

--- a/Compilation/RuntimeTypes.Json.cs
+++ b/Compilation/RuntimeTypes.Json.cs
@@ -187,7 +187,10 @@ public static partial class RuntimeTypes
         var type = value.GetType();
 
         // Check for toJSON method on the object's type
-        var toJsonMethod = type.GetMethod("toJSON", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        var toJsonMethod = ManagedOutputRuntimeReflection.GetMethodByName(
+            type,
+            "toJSON",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
         if (toJsonMethod != null)
         {
             return toJsonMethod.Invoke(value, null);

--- a/Compilation/RuntimeTypes.Objects.cs
+++ b/Compilation/RuntimeTypes.Objects.cs
@@ -210,21 +210,24 @@ public static partial class RuntimeTypes
             var pascalName = name.Length > 0
                 ? char.ToUpperInvariant(name[0]) + name[1..]
                 : name;
-            var staticGetter = classType.GetMethod("get_" + pascalName, staticPublic);
+            var staticGetter = ManagedOutputRuntimeReflection.GetMethodByName(
+                classType, "get_" + pascalName, staticPublic);
             if (staticGetter != null)
             {
                 return ReflectionCache.GetInvoker(staticGetter).Invoke(null, default(Span<object?>));
             }
 
             // Static field with the user-declared name.
-            var staticField = classType.GetField(name, staticPublic);
+            var staticField = ManagedOutputRuntimeReflection.GetFieldByName(
+                classType, name, staticPublic);
             if (staticField != null)
             {
                 return staticField.GetValue(null);
             }
 
             // Static method — bind with null receiver so InvokeValue forwards args as-is.
-            var staticMethod = classType.GetMethod(name, staticPublic);
+            var staticMethod = ManagedOutputRuntimeReflection.GetMethodByName(
+                classType, name, staticPublic);
             if (staticMethod != null)
             {
                 return CreateBoundMethod(null!, staticMethod);

--- a/Compilation/RuntimeTypes.Reflection.cs
+++ b/Compilation/RuntimeTypes.Reflection.cs
@@ -44,7 +44,8 @@ public static partial class RuntimeTypes
             var cache = _getterCache.GetValue(type, _ => new ConcurrentDictionary<string, CacheEntry<MethodInfo>>());
             var entry = cache.GetOrAdd(propertyName, name => 
             {
-                var mi = type.GetMethod($"get_{char.ToUpperInvariant(name[0])}{name[1..]}");
+                var mi = ManagedOutputRuntimeReflection.GetPublicMethodByName(
+                    type, $"get_{char.ToUpperInvariant(name[0])}{name[1..]}");
                 return new CacheEntry<MethodInfo>(mi);
             });
             return entry.Value;
@@ -55,7 +56,8 @@ public static partial class RuntimeTypes
             var cache = _setterCache.GetValue(type, _ => new ConcurrentDictionary<string, CacheEntry<MethodInfo>>());
             var entry = cache.GetOrAdd(propertyName, name => 
             {
-                var mi = type.GetMethod($"set_{char.ToUpperInvariant(name[0])}{name[1..]}");
+                var mi = ManagedOutputRuntimeReflection.GetPublicMethodByName(
+                    type, $"set_{char.ToUpperInvariant(name[0])}{name[1..]}");
                 return new CacheEntry<MethodInfo>(mi);
             });
             return entry.Value;
@@ -66,7 +68,7 @@ public static partial class RuntimeTypes
             var cache = _methodCache.GetValue(type, _ => new ConcurrentDictionary<string, CacheEntry<MethodInfo>>());
             var entry = cache.GetOrAdd(methodName, name => 
             {
-                var mi = type.GetMethod(name);
+                var mi = ManagedOutputRuntimeReflection.GetPublicMethodByName(type, name);
                 return new CacheEntry<MethodInfo>(mi);
             });
             return entry.Value;
@@ -77,7 +79,11 @@ public static partial class RuntimeTypes
             var cache = _fieldCache.GetValue(type, _ => new ConcurrentDictionary<string, CacheEntry<FieldInfo>>());
             var entry = cache.GetOrAdd(fieldName, name => 
             {
-                var fi = type.GetField(name, BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public | BindingFlags.Static);
+                var fi = ManagedOutputRuntimeReflection.GetFieldByName(
+                    type,
+                    name,
+                    BindingFlags.NonPublic | BindingFlags.Instance |
+                    BindingFlags.Public | BindingFlags.Static);
                 return new CacheEntry<FieldInfo>(fi);
             });
             return entry.Value;
@@ -87,8 +93,7 @@ public static partial class RuntimeTypes
         {
             var entry = _constructorCache.GetValue(type, t => 
             {
-                var ctors = t.GetConstructors();
-                var ctor = ctors.Length > 0 ? ctors[0] : null;
+                var ctor = ManagedOutputRuntimeReflection.GetFirstPublicConstructor(t);
                 return new CacheEntry<ConstructorInfo>(ctor);
             });
             return entry.Value;
@@ -96,10 +101,10 @@ public static partial class RuntimeTypes
 
         public static FieldInfo[] GetBackingFields(Type type)
         {
-            return _backingFieldsCache.GetValue(type, t => 
-                t.GetFields(BindingFlags.NonPublic | BindingFlags.Instance)
-                 .Where(f => f.Name.StartsWith("__"))
-                 .ToArray());
+            return _backingFieldsCache.GetValue(
+                type,
+                t => ManagedOutputRuntimeReflection.GetNonPublicInstanceFieldsWithPrefix(
+                    t, "__"));
         }
 
         public static MethodInvoker GetInvoker(MethodBase method)

--- a/Compilation/UnionTypeHelper.cs
+++ b/Compilation/UnionTypeHelper.cs
@@ -43,9 +43,11 @@ public static class UnionTypeHelper
                 continue;
 
             // Find implicit conversion operator
-            var implicitOp = paramType.GetMethod("op_Implicit",
+            var implicitOp = ManagedOutputRuntimeReflection.GetMethodBySignature(
+                paramType,
+                "op_Implicit",
                 BindingFlags.Public | BindingFlags.Static,
-                null, [argType], null);
+                [argType]);
 
             if (implicitOp != null)
                 args[i] = implicitOp.Invoke(null, [args[i]]);

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -139,9 +139,16 @@ Plan against these numbers, not the originals:
   emission contract instead of private PersistedAssemblyBuilder fields. The
   resulting image is 93,400,064 bytes: 98,816 bytes smaller than the prior
   checkpoint and 1,050,112 bytes (1.11%) smaller than the original
-  2,585-warning image. CI pins total, per-code, per-area, and per-file/code
-  counts, so both increases and category swaps fail until the same PR updates
-  the explained baseline.
+  2,585-warning image. Routing reflection that belongs to the managed output
+  runtime through `ManagedOutputRuntimeReflection` then lowered the inventory
+  to 91. The boundary rejects Native AOT before reflection but deliberately
+  remains open-ended under CoreCLR, preserving user-defined and third-party
+  assembly interop in the Managed SKU. Against an exact unmodified-main
+  win-arm64 publish, the native image increased by 2,560 bytes (0.0027%) to
+  93,402,624 bytes; 2,048 bytes of that delta is the updated managed runtime
+  payload embedded in the native host. CI pins total, per-code, per-area, and
+  per-file/code counts, so both increases and category swaps fail until the
+  same PR updates the explained baseline.
 - **Ship the managed SKU:** `dotnet publish -r <rid> --self-contained
   -p:PublishSingleFile=true`. Prerequisite (~30 min): confirm embedded
   resources (stdlib modules, `lib.*.d.ts`) load under single-file extraction.
@@ -182,21 +189,21 @@ Plan against these numbers, not the originals:
   its reflected SDK path from SharpTS's native image. SharpTS pins 1.0.6 and
   sets the switch only for Native AOT.
 
-### Residual analyzer inventory (102)
+### Residual analyzer inventory (91)
 
-The cleanup tranches removed 2,483 of 2,585 warnings (96.1%) without broad
+The cleanup tranches removed 2,494 of 2,585 warnings (96.5%) without broad
 `DynamicallyAccessedMembers` annotations. What remains is no longer one
 mechanical problem:
 
 | Analyzer | Count | Primary meaning now |
 |---|---:|---|
-| IL2075 | 22 | Reflection from a returned/derived `Type`: dynamic .NET interop and generic managed runtime fallbacks |
-| IL2070 | 58 | Reflection on parameters: external .NET interop, declaration discovery, and dynamic runtime dispatch |
+| IL2075 | 20 | Reflection from a returned/derived `Type`: dynamic .NET interop and generic managed runtime fallbacks |
+| IL2070 | 49 | Reflection on parameters: external .NET interop, declaration discovery, and dynamic runtime dispatch |
 | IL2026 | 1 | The dynamic .NET type registry resolving a user-supplied type name |
 | IL3050 | 14 | Runtime generic/array/delegate construction where Native AOT needs a precompiled shape |
 | Other flow warnings | 7 | Two each IL2055/IL2057/IL2060 and one IL2072, concentrated in dynamic interop/type synthesis |
 
-The remaining work is split at three ownership boundaries:
+The remaining work is split at four ownership boundaries:
 
 1. **Managed-only feature guards (done for the current inventory).**
    In-process compiled-assembly execution, third-party executable assembly
@@ -204,12 +211,17 @@ The remaining work is split at three ownership boundaries:
    boundaries. MetadataLoadContext inspection has a narrow metadata-only
    justification. The one remaining IL2026 belongs to dynamic interop policy,
    not this bucket.
-2. **Dynamic .NET interop policy.** `TypeInspector`, the external-property/call
+2. **Structural CLR fallbacks.** Thirteen warnings preserve Managed-SKU
+   compatibility for arbitrary objects that happen to expose `Invoke`,
+   `Fields`, `GetProperty`, or `SetProperty`. Keep that open-world behavior in
+   the Managed SKU, but route it through one managed-only compatibility seam
+   and reject it predictably in Native AOT.
+3. **Dynamic .NET interop policy.** `TypeInspector`, the external-property/call
    emitters and `Runtime/DotNet` deliberately inspect arbitrary types. Broad
    member annotations were measured and rejected because they increased the
    native image by 6.55%. Define the supported native BCL surface and root only
    that surface; guard third-party and unavailable generic shapes.
-3. **Generated/runtime reflection (done for the current inventory).** Known
+4. **Generated/runtime reflection (done for the current inventory).** Known
    compiler-emitted managed shapes now go through
    `ManagedEmittedShapeReflection`. Exact-name validation covers
    `$Object`, callable, stream, message-port, array-buffer, date, and
@@ -218,8 +230,12 @@ The remaining work is split at three ownership boundaries:
    its public combined `Fields` view replaces private backing-field inspection.
    The boundary's exact suppressions are restricted to a closed shape enum and
    it rejects Native AOT before reflection. Recognised callbacks share
-   `RuntimeCallableDispatcher`; fallbacks that intentionally inspect arbitrary
-   CLR shapes remain unsuppressed and belong to the dynamic interop policy.
+   `RuntimeCallableDispatcher`. Reflection used by the generated managed
+   runtime is separately isolated in `ManagedOutputRuntimeReflection`: that
+   seam rejects the Native host but intentionally accepts arbitrary managed
+   output and third-party CLR types under CoreCLR. Fallbacks that intentionally
+   inspect arbitrary CLR objects outside those output-runtime helpers remain
+   unsuppressed and belong to item 2.
    The optional `ILLabelValidator` duplicate was removed rather than routing
    2,126 `GetILGenerator()` acquisitions across 250 files through a diagnostic
    wrapper; `PersistedAssemblyBuilder.GenerateMetadata` still rejects every

--- a/scripts/aot-analyzer-report.ps1
+++ b/scripts/aot-analyzer-report.ps1
@@ -144,13 +144,13 @@ $summary = [ordered]@{
             Group-Object file, code |
             ForEach-Object {
                 $first = $_.Group[0]
-                [ordered]@{
+                [pscustomobject][ordered]@{
                     file = $first.file
                     code = $first.code
                     count = $_.Count
                 }
             } |
-            Sort-Object file, code
+            Sort-Object -Property file,code
     )
 }
 


### PR DESCRIPTION
## Summary

- route reflection owned by compiled managed output through a Native-AOT-guarded ManagedOutputRuntimeReflection boundary
- keep that boundary deliberately open-world under CoreCLR so Managed SKU user and third-party assembly interop is unchanged
- lower the exact analyzer inventory from 102 to 91 and make per-file baseline ordering deterministic
- update the Native AOT plan with the remaining 13 structural CLR fallbacks and measured image impact

## Validation

- full managed suite: 16,266 passed
- focused managed output tests: 260 passed
- focused BCL and third-party interop tests: 171 passed
- analyzer ratchet: 91 warnings, exact baseline match; IL2070 58 to 49 and IL2075 22 to 20
- win-arm64 native smoke: interpretation, single/module compilation, generators, and embedded managed-runtime soft dependency all execute correctly
- exact win-arm64 size comparison against unmodified main: 93,400,064 to 93,402,624 bytes, +2,560 bytes / 0.0027%; 2,048 bytes is the updated embedded managed payload