### PR TITLE
Isolate managed structural CLR reflection

### DIFF
--- a/.github/aot-warning-baseline.json
+++ b/.github/aot-warning-baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "total": 91,
+  "total": 78,
   "codes": [
     {
       "code": "IL2026",
@@ -28,7 +28,7 @@
     },
     {
       "code": "IL2075",
-      "count": 20
+      "count": 7
     },
     {
       "code": "IL3050",
@@ -50,7 +50,7 @@
     },
     {
       "area": "Runtime",
-      "count": 43
+      "count": 30
     },
     {
       "area": "TypeSystem",
@@ -95,11 +95,6 @@
     },
     {
       "file": "Modules/DotNetExtensionImports.cs",
-      "code": "IL2075",
-      "count": 1
-    },
-    {
-      "file": "Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs",
       "code": "IL2075",
       "count": 1
     },
@@ -187,41 +182,6 @@
       "file": "Runtime/DotNet/DotNetTypeRegistry.cs",
       "code": "IL3050",
       "count": 3
-    },
-    {
-      "file": "Runtime/Types/SharpTSAsyncLocalStorage.cs",
-      "code": "IL2075",
-      "count": 1
-    },
-    {
-      "file": "Runtime/Types/SharpTSKeyObject.cs",
-      "code": "IL2075",
-      "count": 1
-    },
-    {
-      "file": "Runtime/Types/SharpTSPropertyDescriptor.cs",
-      "code": "IL2075",
-      "count": 2
-    },
-    {
-      "file": "Runtime/Types/SharpTSProxy.cs",
-      "code": "IL2075",
-      "count": 3
-    },
-    {
-      "file": "Runtime/Types/TSFunctionCallableAdapter.cs",
-      "code": "IL2075",
-      "count": 1
-    },
-    {
-      "file": "Runtime/Types/VmContext.cs",
-      "code": "IL2075",
-      "count": 3
-    },
-    {
-      "file": "Runtime/Types/VmModule.cs",
-      "code": "IL2075",
-      "count": 1
     },
     {
       "file": "TypeSystem/DotNetTypeSynthesizer.cs",

--- a/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
@@ -532,7 +532,7 @@ public static class VmModuleInterpreter
                         type, ManagedEmittedShape.HasFields)
                     ? ManagedEmittedShapeReflection.GetPublicProperty(
                         type, ManagedEmittedShape.HasFields, "Fields")
-                    : type.GetProperty("Fields");
+                    : ManagedStructuralClrReflection.GetPublicPropertyByName(type, "Fields");
                 if (fieldsProp?.GetValue(options) is IEnumerable<KeyValuePair<string, object?>> fields)
                 {
                     foreach (var kv in fields)

--- a/Runtime/Types/ManagedStructuralClrReflection.cs
+++ b/Runtime/Types/ManagedStructuralClrReflection.cs
@@ -1,0 +1,72 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Reflection boundary for Managed-SKU compatibility with arbitrary CLR objects
+/// that expose a SharpTS-recognised structural member.
+/// </summary>
+/// <remarks>
+/// These shapes are intentionally open ended so embedders and third-party assemblies
+/// can provide callable and object-like values without implementing SharpTS interfaces.
+/// Native AOT has a frozen type universe and cannot promise that arbitrary members were
+/// retained, so the boundary rejects native execution before inspecting the type.
+/// </remarks>
+internal static class ManagedStructuralClrReflection
+{
+    private const string TrimJustification =
+        "The Managed SKU intentionally supports open-world structural CLR objects from " +
+        "embedders and third-party assemblies. Native AOT is rejected before reflection; " +
+        "known SharpTS and compiler-emitted shapes are handled before this fallback.";
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static MethodInfo? GetPublicMethodByName(Type type, string name)
+    {
+        RequireManagedRuntime();
+        return type.GetMethod(name);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static MethodInfo? GetPublicMethodBySignature(
+        Type type,
+        string name,
+        Type[] parameterTypes)
+    {
+        RequireManagedRuntime();
+        return type.GetMethod(name, parameterTypes);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static MethodInfo? GetPublicInstanceMethodBySignature(
+        Type type,
+        string name,
+        Type[] parameterTypes)
+    {
+        RequireManagedRuntime();
+        return type.GetMethod(
+            name,
+            BindingFlags.Public | BindingFlags.Instance,
+            binder: null,
+            parameterTypes,
+            modifiers: null);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static PropertyInfo? GetPublicPropertyByName(Type type, string name)
+    {
+        RequireManagedRuntime();
+        return type.GetProperty(name);
+    }
+
+    private static void RequireManagedRuntime()
+    {
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            throw new PlatformNotSupportedException(
+                "Structural compatibility with arbitrary CLR objects is not available " +
+                "in the native SharpTS build — use a SharpTS-owned value or the managed build.");
+        }
+    }
+}

--- a/Runtime/Types/SharpTSAsyncLocalStorage.cs
+++ b/Runtime/Types/SharpTSAsyncLocalStorage.cs
@@ -139,9 +139,11 @@ public class SharpTSAsyncLocalStorage
             return RuntimeCallableDispatcher.Invoke(interpreter, callback, args.ToArray());
 
         // Preserve the managed .NET interop fallback for arbitrary objects
-        // exposing Invoke(object[]). Its warning remains until that native
-        // interop surface is defined.
-        var invokeMethod = callback?.GetType().GetMethod("Invoke", [typeof(object?[])]);
+        // exposing Invoke(object[]) through the managed-only structural seam.
+        var invokeMethod = callback == null
+            ? null
+            : ManagedStructuralClrReflection.GetPublicMethodBySignature(
+                callback.GetType(), "Invoke", [typeof(object?[])]);
         if (invokeMethod != null)
             return invokeMethod.Invoke(callback, [args.ToArray()]);
 

--- a/Runtime/Types/SharpTSKeyObject.cs
+++ b/Runtime/Types/SharpTSKeyObject.cs
@@ -381,7 +381,9 @@ public class SharpTSKeyObject : ISharpTSPropertyAccessor
             options is not SharpTSObject &&
             options is not IDictionary<string, object?>)
         {
-            var getPropertyMethod = options.GetType().GetMethod("GetProperty", [typeof(string)]);
+            var getPropertyMethod =
+                ManagedStructuralClrReflection.GetPublicMethodBySignature(
+                    options.GetType(), "GetProperty", [typeof(string)]);
             if (getPropertyMethod != null)
             {
                 if (getPropertyMethod.Invoke(options, ["type"]) is string reflectedType)

--- a/Runtime/Types/SharpTSPropertyDescriptor.cs
+++ b/Runtime/Types/SharpTSPropertyDescriptor.cs
@@ -194,7 +194,9 @@ public class SharpTSPropertyDescriptor
         var type = obj.GetType();
 
         // Try to get the GetProperty method
-        var getPropertyMethod = type.GetMethod("GetProperty", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance, null, [typeof(string)], null);
+        var getPropertyMethod =
+            ManagedStructuralClrReflection.GetPublicInstanceMethodBySignature(
+                type, "GetProperty", [typeof(string)]);
         if (getPropertyMethod == null)
         {
             return new SharpTSPropertyDescriptor();
@@ -202,9 +204,9 @@ public class SharpTSPropertyDescriptor
 
         // Probe presence via HasProperty(string) when the type exposes it, so an
         // explicit `value: undefined` is distinguished from an omitted value (#801).
-        var hasPropertyMethod = type.GetMethod("HasProperty",
-            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance,
-            null, [typeof(string)], null);
+        var hasPropertyMethod =
+            ManagedStructuralClrReflection.GetPublicInstanceMethodBySignature(
+                type, "HasProperty", [typeof(string)]);
 
         return Populate(
             name => hasPropertyMethod?.Invoke(obj, [name]) is bool b && b,

--- a/Runtime/Types/SharpTSProxy.cs
+++ b/Runtime/Types/SharpTSProxy.cs
@@ -73,7 +73,8 @@ public class SharpTSProxy : ISharpTSCallable
 
         // Preserve the managed .NET interop fallback for arbitrary callable
         // objects. Known compiler-emitted functions are handled above.
-        var invokeMethod = value.GetType().GetMethod("Invoke");
+        var invokeMethod = ManagedStructuralClrReflection.GetPublicMethodByName(
+            value.GetType(), "Invoke");
         if (invokeMethod != null)
             return value;
 
@@ -91,7 +92,8 @@ public class SharpTSProxy : ISharpTSCallable
         // Managed .NET interop fallback for arbitrary Invoke-shaped objects.
         // The emitted function path above no longer needs to inspect its
         // private _method field because InvokeWithThis owns that contract.
-        var invokeMethod = trap.GetType().GetMethod("Invoke");
+        var invokeMethod = ManagedStructuralClrReflection.GetPublicMethodByName(
+            trap.GetType(), "Invoke");
         if (invokeMethod != null)
             return invokeMethod.Invoke(trap, [args.ToArray()]);
 
@@ -215,7 +217,8 @@ public class SharpTSProxy : ISharpTSCallable
             // Compiled mode: target is a TSFunction, not ISharpTSCallable
             if (interp == null)
             {
-                var invokeMethod = _target.GetType().GetMethod("Invoke");
+                var invokeMethod = ManagedStructuralClrReflection.GetPublicMethodByName(
+                    _target.GetType(), "Invoke");
                 if (invokeMethod != null)
                     return invokeMethod.Invoke(_target, [args.ToArray()]);
             }

--- a/Runtime/Types/TSFunctionCallableAdapter.cs
+++ b/Runtime/Types/TSFunctionCallableAdapter.cs
@@ -81,7 +81,8 @@ public class TSFunctionCallableAdapter : ISharpTSCallable
         {
             _target = target;
             // Try to find an Invoke method
-            _invokeMethod = target.GetType().GetMethod("Invoke");
+            _invokeMethod = ManagedStructuralClrReflection.GetPublicMethodByName(
+                target.GetType(), "Invoke");
         }
 
         public int Arity() => 2;

--- a/Runtime/Types/VmContext.cs
+++ b/Runtime/Types/VmContext.cs
@@ -67,14 +67,14 @@ public static class VmContext
         else if (contextObject != null)
         {
             // Compiler-emitted $Object uses the managed-shape boundary. Preserve
-            // the existing arbitrary CLR "Fields" fallback for .NET interop;
-            // that path remains part of the separate native interop policy.
+            // the existing arbitrary CLR "Fields" fallback for managed interop
+            // through the structural compatibility seam.
             var type = contextObject.GetType();
             var fieldsProp = ManagedEmittedShapeReflection.IsShape(
                     type, ManagedEmittedShape.HasFields)
                 ? ManagedEmittedShapeReflection.GetPublicProperty(
                     type, ManagedEmittedShape.HasFields, "Fields")
-                : type.GetProperty("Fields");
+                : ManagedStructuralClrReflection.GetPublicPropertyByName(type, "Fields");
             if (fieldsProp?.GetValue(contextObject) is IEnumerable<KeyValuePair<string, object?>> fields)
             {
                 foreach (var kv in fields)
@@ -101,14 +101,15 @@ public static class VmContext
                 continue;
 
             // Compiler-emitted functions use the managed-shape boundary. Keep
-            // accepting arbitrary CLR Invoke(object[]) objects for managed
-            // interop until the native interop surface is defined.
+            // accepting arbitrary CLR Invoke(object[]) objects through the
+            // managed-only structural compatibility seam.
             var type = value.GetType();
             var invokeMethod = ManagedEmittedShapeReflection.IsShape(
                     type, ManagedEmittedShape.Function)
                 ? ManagedEmittedShapeReflection.GetPublicMethod(
                     type, ManagedEmittedShape.Function, "Invoke", [typeof(object[])])
-                : type.GetMethod("Invoke", [typeof(object[])]);
+                : ManagedStructuralClrReflection.GetPublicMethodBySignature(
+                    type, "Invoke", [typeof(object[])]);
             if (invokeMethod != null)
             {
                 props[key] = new CompiledCallableAdapter(value, invokeMethod);
@@ -147,7 +148,8 @@ public static class VmContext
                 ? ManagedEmittedShapeReflection.GetPublicMethod(
                     type, ManagedEmittedShape.HasFields, "SetProperty",
                     [typeof(string), typeof(object)])
-                : type.GetMethod("SetProperty", [typeof(string), typeof(object)]);
+                : ManagedStructuralClrReflection.GetPublicMethodBySignature(
+                    type, "SetProperty", [typeof(string), typeof(object)]);
             if (setMethod != null)
             {
                 foreach (var name in originalProperties.Keys)

--- a/Runtime/Types/VmModule.cs
+++ b/Runtime/Types/VmModule.cs
@@ -243,9 +243,10 @@ public abstract class VmModuleBase
         }
 
         // Managed .NET interop also accepts an arbitrary object exposing
-        // Invoke(object[]). Keep that reflection visible to the analyzer until
-        // the native interop policy is defined.
-        var invoke = type.GetMethod("Invoke", [typeof(object[])]);
+        // Invoke(object[]) through the managed-only structural compatibility
+        // seam.
+        var invoke = ManagedStructuralClrReflection.GetPublicMethodBySignature(
+            type, "Invoke", [typeof(object[])]);
         if (invoke != null)
             return invoke.Invoke(callable, [args]);
         throw new Exception("TypeError: callback is not a function");

--- a/SharpTS.Tests/RuntimeTests/ManagedStructuralClrReflectionTests.cs
+++ b/SharpTS.Tests/RuntimeTests/ManagedStructuralClrReflectionTests.cs
@@ -1,0 +1,69 @@
+using SharpTS.Runtime.Types;
+using Xunit;
+
+namespace SharpTS.Tests.RuntimeTests;
+
+/// <summary>
+/// Verifies that the managed runtime continues to accept open-world CLR shapes
+/// supplied by an assembly other than SharpTS.
+/// </summary>
+public sealed class ManagedStructuralClrReflectionTests
+{
+    [Fact]
+    public void VmContext_ExtractProperties_AcceptsExternalFieldsShape()
+    {
+        var external = new ExternalStructuralObject();
+        external.Fields["answer"] = 42.0;
+
+        var properties = VmContext.ExtractProperties(external);
+
+        Assert.Equal(42.0, properties["answer"]);
+    }
+
+    [Fact]
+    public void PropertyDescriptor_FromAnyObject_AcceptsExternalPropertyShape()
+    {
+        var external = new ExternalStructuralObject();
+        external.SetProperty("value", "external");
+        external.SetProperty("writable", true);
+
+        var descriptor = SharpTSPropertyDescriptor.FromAnyObject(external);
+
+        Assert.True(descriptor.HasValue);
+        Assert.Equal("external", descriptor.Value);
+        Assert.True(descriptor.HasWritable);
+        Assert.True(descriptor.Writable);
+        Assert.False(descriptor.HasEnumerable);
+    }
+
+    [Fact]
+    public void CallableAdapter_AcceptsExternalInvokeShape()
+    {
+        var callback = TSFunctionCallableAdapter.WrapCallback(
+            new ExternalStructuralObject());
+
+        var result = callback.Call(
+            interpreter: null!,
+            arguments: ["first", 2.0]);
+
+        Assert.Equal("first:2", result);
+    }
+
+    private sealed class ExternalStructuralObject
+    {
+        private readonly Dictionary<string, object?> _properties = new();
+
+        public Dictionary<string, object?> Fields { get; } = new();
+
+        public bool HasProperty(string name) => _properties.ContainsKey(name);
+
+        public object? GetProperty(string name) =>
+            _properties.GetValueOrDefault(name);
+
+        public void SetProperty(string name, object? value) =>
+            _properties[name] = value;
+
+        public object? Invoke(object?[] arguments) =>
+            $"{arguments[0]}:{arguments[1]:0}";
+    }
+}

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -146,9 +146,14 @@ Plan against these numbers, not the originals:
   assembly interop in the Managed SKU. Against an exact unmodified-main
   win-arm64 publish, the native image increased by 2,560 bytes (0.0027%) to
   93,402,624 bytes; 2,048 bytes of that delta is the updated managed runtime
-  payload embedded in the native host. CI pins total, per-code, per-area, and
-  per-file/code counts, so both increases and category swaps fail until the
-  same PR updates the explained baseline.
+  payload embedded in the native host. Routing the remaining arbitrary
+  `Invoke`/`Fields`/`GetProperty`/`SetProperty` compatibility paths through
+  `ManagedStructuralClrReflection` then lowered the inventory to 78. The seam
+  preserves open-world CLR objects in the Managed SKU and rejects Native AOT
+  before reflection. The win-arm64 image increased by 1,024 bytes (0.0011%)
+  to 93,403,648 bytes. CI pins total, per-code, per-area, and per-file/code
+  counts, so both increases and category swaps fail until the same PR updates
+  the explained baseline.
 - **Ship the managed SKU:** `dotnet publish -r <rid> --self-contained
   -p:PublishSingleFile=true`. Prerequisite (~30 min): confirm embedded
   resources (stdlib modules, `lib.*.d.ts`) load under single-file extraction.
@@ -189,21 +194,21 @@ Plan against these numbers, not the originals:
   its reflected SDK path from SharpTS's native image. SharpTS pins 1.0.6 and
   sets the switch only for Native AOT.
 
-### Residual analyzer inventory (91)
+### Residual analyzer inventory (78)
 
-The cleanup tranches removed 2,494 of 2,585 warnings (96.5%) without broad
-`DynamicallyAccessedMembers` annotations. What remains is no longer one
-mechanical problem:
+The cleanup tranches removed 2,507 of 2,585 warnings (97.0%) without broad
+`DynamicallyAccessedMembers` annotations. Every remaining warning now belongs
+to the dynamic .NET interop policy:
 
 | Analyzer | Count | Primary meaning now |
 |---|---:|---|
-| IL2075 | 20 | Reflection from a returned/derived `Type`: dynamic .NET interop and generic managed runtime fallbacks |
+| IL2075 | 7 | Reflection from a returned/derived `Type`: dynamic .NET constructors, delegates, and extension methods |
 | IL2070 | 49 | Reflection on parameters: external .NET interop, declaration discovery, and dynamic runtime dispatch |
 | IL2026 | 1 | The dynamic .NET type registry resolving a user-supplied type name |
 | IL3050 | 14 | Runtime generic/array/delegate construction where Native AOT needs a precompiled shape |
 | Other flow warnings | 7 | Two each IL2055/IL2057/IL2060 and one IL2072, concentrated in dynamic interop/type synthesis |
 
-The remaining work is split at four ownership boundaries:
+The work is split at four ownership boundaries:
 
 1. **Managed-only feature guards (done for the current inventory).**
    In-process compiled-assembly execution, third-party executable assembly
@@ -211,11 +216,11 @@ The remaining work is split at four ownership boundaries:
    boundaries. MetadataLoadContext inspection has a narrow metadata-only
    justification. The one remaining IL2026 belongs to dynamic interop policy,
    not this bucket.
-2. **Structural CLR fallbacks.** Thirteen warnings preserve Managed-SKU
-   compatibility for arbitrary objects that happen to expose `Invoke`,
-   `Fields`, `GetProperty`, or `SetProperty`. Keep that open-world behavior in
-   the Managed SKU, but route it through one managed-only compatibility seam
-   and reject it predictably in Native AOT.
+2. **Structural CLR fallbacks (done for the current inventory).** Arbitrary
+   objects that happen to expose `Invoke`, `Fields`, `GetProperty`, or
+   `SetProperty` now route through `ManagedStructuralClrReflection`. The seam
+   remains deliberately open-world under CoreCLR for embedders and third-party
+   assemblies, but rejects Native AOT before inspecting an arbitrary type.
 3. **Dynamic .NET interop policy.** `TypeInspector`, the external-property/call
    emitters and `Runtime/DotNet` deliberately inspect arbitrary types. Broad
    member annotations were measured and rejected because they increased the
@@ -233,9 +238,8 @@ The remaining work is split at four ownership boundaries:
    `RuntimeCallableDispatcher`. Reflection used by the generated managed
    runtime is separately isolated in `ManagedOutputRuntimeReflection`: that
    seam rejects the Native host but intentionally accepts arbitrary managed
-   output and third-party CLR types under CoreCLR. Fallbacks that intentionally
-   inspect arbitrary CLR objects outside those output-runtime helpers remain
-   unsuppressed and belong to item 2.
+   output and third-party CLR types under CoreCLR. Other arbitrary CLR
+   structural shapes route through the separate item 2 seam.
    The optional `ILLabelValidator` duplicate was removed rather than routing
    2,126 `GetILGenerator()` acquisitions across 250 files through a diagnostic
    wrapper; `PersistedAssemblyBuilder.GenerateMetadata` still rejects every


### PR DESCRIPTION
## Summary

- route 13 open-world CLR shape lookups through one managed-only reflection boundary
- preserve third-party and embedder structural objects in the Managed SKU while rejecting this fallback before reflection under Native AOT
- add separate-assembly regression coverage for Fields, property descriptors, and Invoke-shaped callbacks
- update the analyzer baseline and AOT plan from 91 warnings to 78

## Verification

- Release build: 0 warnings, 0 errors
- focused affected-feature tests: 743 passed
- managed structural regression tests: 3 passed
- full suite: 16,267 passed on the first run; the two unrelated live-I/O failures passed immediately on exact rerun (3 theory cases)
- analyzer baseline enforcement: exact 78 warnings; IL2075 reduced from 20 to 7 with no replacement warnings
- win-arm64 Native AOT publish and interpreted/compiled/feature/soft-dependency smoke: passed
- native image: 93,403,648 bytes, +1,024 bytes (+0.0011%) from merged main
- git diff --check: clean