### PR TITLE
Isolate managed runtime .NET interop

### DIFF
--- a/.github/aot-warning-baseline.json
+++ b/.github/aot-warning-baseline.json
@@ -1,38 +1,22 @@
 {
   "schemaVersion": 1,
-  "total": 78,
+  "total": 48,
   "codes": [
     {
-      "code": "IL2026",
-      "count": 1
-    },
-    {
-      "code": "IL2055",
-      "count": 2
-    },
-    {
       "code": "IL2057",
-      "count": 2
-    },
-    {
-      "code": "IL2060",
-      "count": 2
+      "count": 1
     },
     {
       "code": "IL2070",
-      "count": 49
-    },
-    {
-      "code": "IL2072",
-      "count": 1
+      "count": 41
     },
     {
       "code": "IL2075",
-      "count": 7
+      "count": 2
     },
     {
       "code": "IL3050",
-      "count": 14
+      "count": 4
     }
   ],
   "areas": [
@@ -47,10 +31,6 @@
     {
       "area": "Modules",
       "count": 1
-    },
-    {
-      "area": "Runtime",
-      "count": 30
     },
     {
       "area": "TypeSystem",
@@ -97,91 +77,6 @@
       "file": "Modules/DotNetExtensionImports.cs",
       "code": "IL2075",
       "count": 1
-    },
-    {
-      "file": "Runtime/DotNet/DotNetClass.cs",
-      "code": "IL2072",
-      "count": 1
-    },
-    {
-      "file": "Runtime/DotNet/DotNetClass.cs",
-      "code": "IL2075",
-      "count": 2
-    },
-    {
-      "file": "Runtime/DotNet/DotNetDelegateShim.cs",
-      "code": "IL2070",
-      "count": 2
-    },
-    {
-      "file": "Runtime/DotNet/DotNetDelegateShim.cs",
-      "code": "IL2075",
-      "count": 1
-    },
-    {
-      "file": "Runtime/DotNet/DotNetDelegateShim.cs",
-      "code": "IL3050",
-      "count": 2
-    },
-    {
-      "file": "Runtime/DotNet/DotNetExtensionMethodResolver.cs",
-      "code": "IL2075",
-      "count": 2
-    },
-    {
-      "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
-      "code": "IL2060",
-      "count": 2
-    },
-    {
-      "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
-      "code": "IL2070",
-      "count": 3
-    },
-    {
-      "file": "Runtime/DotNet/DotNetGenericMethodInference.cs",
-      "code": "IL3050",
-      "count": 2
-    },
-    {
-      "file": "Runtime/DotNet/DotNetMarshaller.cs",
-      "code": "IL3050",
-      "count": 1
-    },
-    {
-      "file": "Runtime/DotNet/DotNetMethod.cs",
-      "code": "IL3050",
-      "count": 1
-    },
-    {
-      "file": "Runtime/DotNet/DotNetMethodResolver.cs",
-      "code": "IL3050",
-      "count": 1
-    },
-    {
-      "file": "Runtime/DotNet/DotNetOperatorResolver.cs",
-      "code": "IL2070",
-      "count": 3
-    },
-    {
-      "file": "Runtime/DotNet/DotNetTypeRegistry.cs",
-      "code": "IL2026",
-      "count": 1
-    },
-    {
-      "file": "Runtime/DotNet/DotNetTypeRegistry.cs",
-      "code": "IL2055",
-      "count": 2
-    },
-    {
-      "file": "Runtime/DotNet/DotNetTypeRegistry.cs",
-      "code": "IL2057",
-      "count": 1
-    },
-    {
-      "file": "Runtime/DotNet/DotNetTypeRegistry.cs",
-      "code": "IL3050",
-      "count": 3
     },
     {
       "file": "TypeSystem/DotNetTypeSynthesizer.cs",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,17 @@ jobs:
             'loading .NET reference assemblies is not available in the native SharpTS build' \
             "$scratch/reference-error.txt"
 
+          # Dynamic .NET binding is deliberately Managed-SKU-only until the native
+          # SKU defines and roots a closed BCL interop contract.
+          if "$native" Examples/AotCompileGate/dotnet-interop.ts \
+              > "$scratch/dotnet-interop-error.txt" 2>&1; then
+            echo "dynamic .NET interop unexpectedly ran under Native AOT"
+            exit 1
+          fi
+          grep -Fq \
+            '.NET interop is not available in the native SharpTS build' \
+            "$scratch/dotnet-interop-error.txt"
+
           if "$native" --gen-decl System.String \
               > "$scratch/gen-decl-error.txt" 2>&1; then
             echo "declaration discovery unexpectedly ran under Native AOT"

--- a/Examples/AotCompileGate/dotnet-interop.ts
+++ b/Examples/AotCompileGate/dotnet-interop.ts
@@ -1,0 +1,3 @@
+import { StringBuilder } from "dotnet:System.Text.StringBuilder";
+
+console.log(new StringBuilder().append("unexpected").toString());

--- a/Modules/DotNetImports.cs
+++ b/Modules/DotNetImports.cs
@@ -57,6 +57,8 @@ public static class DotNetImports
     /// form is unsupported or a name cannot be resolved to a usable .NET type.</exception>
     public static void EnsureImports(ParsedModule module, Stmt.Import import)
     {
+        ManagedDotNetInterop.RequireManagedRuntime();
+
         if (import.DefaultImport != null)
         {
             throw new Exception(
@@ -109,6 +111,7 @@ public static class DotNetImports
     /// resolved to a usable public .NET type.</exception>
     public static Type ResolveExportType(string specifier, string name, Func<string, Type?>? resolve = null)
     {
+        ManagedDotNetInterop.RequireManagedRuntime();
         resolve ??= DotNetTypeRegistry.Resolve;
 
         if (specifier.Contains('/') || specifier.Contains('\\') || specifier.Contains('#') ||

--- a/Runtime/DotNet/DotNetClass.cs
+++ b/Runtime/DotNet/DotNetClass.cs
@@ -34,7 +34,8 @@ public sealed class DotNetClass : ISharpTSCallable, ITypeCategorized
 
     public int Arity()
     {
-        var ctors = Type.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+        var ctors = ManagedDotNetInterop.GetConstructors(
+            Type, BindingFlags.Public | BindingFlags.Instance);
         if (ctors.Length == 0) return 0;
         int min = int.MaxValue;
         foreach (var c in ctors)
@@ -50,10 +51,11 @@ public sealed class DotNetClass : ISharpTSCallable, ITypeCategorized
         // Value type default construction: treat `new Struct()` with zero args as default(T).
         if (Type.IsValueType && arguments.Count == 0)
         {
-            return new DotNetInstance(Activator.CreateInstance(Type)!, Type);
+            return new DotNetInstance(ManagedDotNetInterop.CreateInstance(Type)!, Type);
         }
 
-        var ctors = Type.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+        var ctors = ManagedDotNetInterop.GetConstructors(
+            Type, BindingFlags.Public | BindingFlags.Instance);
         if (ctors.Length == 0)
         {
             throw new Runtime.Exceptions.ThrowException(DotNetExceptionMapper.Map(

--- a/Runtime/DotNet/DotNetDelegateShim.cs
+++ b/Runtime/DotNet/DotNetDelegateShim.cs
@@ -37,7 +37,7 @@ internal static class DotNetDelegateShim
                 $"Type '{delegateType.FullName}' is not a delegate type.", nameof(delegateType));
         }
 
-        var invoke = delegateType.GetMethod("Invoke")
+        var invoke = ManagedDotNetInterop.GetMethod(delegateType, "Invoke")
             ?? throw new InvalidOperationException(
                 $"Delegate type '{delegateType.FullName}' has no Invoke method.");
 
@@ -59,7 +59,7 @@ internal static class DotNetDelegateShim
                     ? (Expression)Expression.Convert(pe, typeof(object))
                     : pe)
                 .ToArray();
-            argsArray = Expression.NewArrayInit(typeof(object), boxed);
+            argsArray = ManagedDotNetInterop.NewArrayInit(typeof(object), boxed);
         }
 
         var dispatchMethod = typeof(DotNetDelegateShim).GetMethod(
@@ -83,8 +83,7 @@ internal static class DotNetDelegateShim
             body = Expression.Convert(dispatchCall, invoke.ReturnType);
         }
 
-        var lambda = Expression.Lambda(delegateType, body, paramExprs);
-        return lambda.Compile();
+        return ManagedDotNetInterop.CompileLambda(delegateType, body, paramExprs);
     }
 
     /// <summary>
@@ -145,12 +144,13 @@ internal static class DotNetDelegateShim
                 $"Type '{delegateType.FullName}' is not a delegate type.", nameof(delegateType));
         }
 
-        var tsInvoke = tsFunction.GetType().GetMethod("Invoke", new[] { typeof(object[]) })
+        var tsInvoke = ManagedDotNetInterop.GetMethod(
+            tsFunction.GetType(), "Invoke", [typeof(object[])])
             ?? throw new InvalidOperationException(
                 $"Value of type '{tsFunction.GetType().FullName}' has no 'Invoke(object[])' method — " +
                 "expected the emitted $TSFunction shape.");
 
-        var delegateInvoke = delegateType.GetMethod("Invoke")
+        var delegateInvoke = ManagedDotNetInterop.GetMethod(delegateType, "Invoke")
             ?? throw new InvalidOperationException(
                 $"Delegate type '{delegateType.FullName}' has no Invoke method.");
 
@@ -180,7 +180,7 @@ internal static class DotNetDelegateShim
                 return (Expression)Expression.Call(wrapReturn, boxed,
                     Expression.Constant(pe.Type, typeof(Type)));
             }).ToArray();
-            argsArray = Expression.NewArrayInit(typeof(object), wrapped);
+            argsArray = ManagedDotNetInterop.NewArrayInit(typeof(object), wrapped);
         }
 
         // Call: tsFunction.Invoke(argsArray) — returns object.
@@ -212,6 +212,6 @@ internal static class DotNetDelegateShim
             body = Expression.Convert(converted, delegateInvoke.ReturnType);
         }
 
-        return Expression.Lambda(delegateType, body, paramExprs).Compile();
+        return ManagedDotNetInterop.CompileLambda(delegateType, body, paramExprs);
     }
 }

--- a/Runtime/DotNet/DotNetExtensionMethodResolver.cs
+++ b/Runtime/DotNet/DotNetExtensionMethodResolver.cs
@@ -15,8 +15,8 @@ internal static class DotNetExtensionMethodResolver
         var methods = new List<MethodInfo>();
         foreach (var container in containers)
         {
-            foreach (var method in container.GetMethods(
-                         BindingFlags.Public | BindingFlags.Static))
+            foreach (var method in ManagedDotNetInterop.GetMethods(
+                         container, BindingFlags.Public | BindingFlags.Static))
             {
                 if (!method.IsDefined(typeof(ExtensionAttribute), inherit: false) ||
                     !string.Equals(
@@ -45,8 +45,8 @@ internal static class DotNetExtensionMethodResolver
         var methods = new List<MethodInfo>();
         foreach (var container in containers)
         {
-            foreach (var method in container.GetMethods(
-                         BindingFlags.Public | BindingFlags.Static))
+            foreach (var method in ManagedDotNetInterop.GetMethods(
+                         container, BindingFlags.Public | BindingFlags.Static))
             {
                 if (!method.IsDefined(typeof(ExtensionAttribute), inherit: false) ||
                     !string.Equals(

--- a/Runtime/DotNet/DotNetGenericMethodInference.cs
+++ b/Runtime/DotNet/DotNetGenericMethodInference.cs
@@ -43,7 +43,8 @@ internal static class DotNetGenericMethodInference
                 return null;
             try
             {
-                return method.MakeGenericMethod(explicitTypeArguments.ToArray());
+                return ManagedDotNetInterop.MakeGenericMethod(
+                    method, explicitTypeArguments.ToArray());
             }
             catch (ArgumentException)
             {
@@ -92,7 +93,8 @@ internal static class DotNetGenericMethodInference
 
         try
         {
-            return method.MakeGenericMethod(
+            return ManagedDotNetInterop.MakeGenericMethod(
+                method,
                 genericArguments.Select(parameter => inferred[parameter]).ToArray());
         }
         catch (ArgumentException)
@@ -128,8 +130,8 @@ internal static class DotNetGenericMethodInference
 
         if (typeof(Delegate).IsAssignableFrom(pattern) &&
             typeof(Delegate).IsAssignableFrom(actual) &&
-            pattern.GetMethod("Invoke") is { } patternInvoke &&
-            actual.GetMethod("Invoke") is { } actualInvoke)
+            ManagedDotNetInterop.GetMethod(pattern, "Invoke") is { } patternInvoke &&
+            ManagedDotNetInterop.GetMethod(actual, "Invoke") is { } actualInvoke)
         {
             var patternParameters = patternInvoke.GetParameters();
             var actualParameters = actualInvoke.GetParameters();
@@ -172,7 +174,7 @@ internal static class DotNetGenericMethodInference
         if (actual.IsGenericType && actual.GetGenericTypeDefinition() == genericDefinition)
             return actual;
 
-        foreach (var interfaceType in actual.GetInterfaces())
+        foreach (var interfaceType in ManagedDotNetInterop.GetInterfaces(actual))
         {
             if (interfaceType.IsGenericType &&
                 interfaceType.GetGenericTypeDefinition() == genericDefinition)

--- a/Runtime/DotNet/DotNetMarshaller.cs
+++ b/Runtime/DotNet/DotNetMarshaller.cs
@@ -104,7 +104,7 @@ internal static class DotNetMarshaller
         if (value is SharpTSArray tsArray && targetType.IsArray)
         {
             var elementType = targetType.GetElementType()!;
-            var array = Array.CreateInstance(elementType, tsArray.Length);
+            var array = ManagedDotNetInterop.CreateArray(elementType, tsArray.Length);
             int idx = 0;
             foreach (var el in tsArray)
             {

--- a/Runtime/DotNet/DotNetMethod.cs
+++ b/Runtime/DotNet/DotNetMethod.cs
@@ -142,7 +142,8 @@ internal sealed class DotNetMethod : ISharpTSCallable
                 interpreter);
         }
 
-        var variadic = Array.CreateInstance(elementType, Math.Max(0, variadicCount));
+        var variadic = ManagedDotNetInterop.CreateArray(
+            elementType, Math.Max(0, variadicCount));
         for (int i = 0; i < variadicCount; i++)
         {
             variadic.SetValue(DotNetMarshaller.Convert(arguments[fixedCount + i], elementType, interpreter), i);

--- a/Runtime/DotNet/DotNetMethodResolver.cs
+++ b/Runtime/DotNet/DotNetMethodResolver.cs
@@ -233,7 +233,7 @@ internal static class DotNetMethodResolver
                     return typeof(object[]);
                 }
             }
-            return (elementType ?? typeof(object)).MakeArrayType();
+            return ManagedDotNetInterop.MakeArrayType(elementType ?? typeof(object));
         }
         return argument is DotNetInstance instance
             ? instance.Type

--- a/Runtime/DotNet/DotNetOperatorResolver.cs
+++ b/Runtime/DotNet/DotNetOperatorResolver.cs
@@ -17,7 +17,8 @@ internal static class DotNetOperatorResolver
             return [];
 
         return EnumerateDeclaringTypes(leftType, rightType)
-            .SelectMany(type => type.GetMethods(
+            .SelectMany(type => ManagedDotNetInterop.GetMethods(
+                type,
                 BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy))
             .Where(method =>
                 method.IsSpecialName &&
@@ -41,7 +42,8 @@ internal static class DotNetOperatorResolver
         if (name == null)
             return [];
 
-        return operandType.GetMethods(
+        return ManagedDotNetInterop.GetMethods(
+                operandType,
                 BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
             .Where(method =>
                 method.IsSpecialName &&
@@ -62,7 +64,8 @@ internal static class DotNetOperatorResolver
         if (name == null)
             return [];
 
-        return operandType.GetMethods(
+        return ManagedDotNetInterop.GetMethods(
+                operandType,
                 BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
             .Where(method =>
                 method.IsSpecialName &&

--- a/Runtime/DotNet/DotNetTypeRegistry.cs
+++ b/Runtime/DotNet/DotNetTypeRegistry.cs
@@ -25,9 +25,10 @@ public static class DotNetTypeRegistry
     /// </summary>
     public static Type? Resolve(string clrTypeName)
     {
+        ManagedDotNetInterop.RequireManagedRuntime();
         if (_cache.TryGetValue(clrTypeName, out var cached)) return cached;
 
-        var type = Type.GetType(clrTypeName, throwOnError: false);
+        var type = ManagedDotNetInterop.ResolveType(clrTypeName);
         if (type == null)
         {
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
@@ -36,7 +37,7 @@ public static class DotNetTypeRegistry
                 // missing dependency) must not poison resolution of unrelated types.
                 try
                 {
-                    type = assembly.GetType(clrTypeName, throwOnError: false);
+                    type = ManagedDotNetInterop.ResolveType(assembly, clrTypeName);
                 }
                 catch (Exception ex) when (ex is FileNotFoundException or FileLoadException or TypeLoadException or BadImageFormatException)
                 {
@@ -66,6 +67,7 @@ public static class DotNetTypeRegistry
     /// </param>
     public static Type? ResolveFriendly(string friendlyName, Func<string, Type?>? resolve = null)
     {
+        ManagedDotNetInterop.RequireManagedRuntime();
         ArgumentException.ThrowIfNullOrWhiteSpace(friendlyName);
         resolve ??= Resolve;
 
@@ -76,7 +78,7 @@ public static class DotNetTypeRegistry
         if (name.EndsWith("[]", StringComparison.Ordinal))
         {
             var element = ResolveFriendly(name[..^2], resolve);
-            return element?.MakeArrayType();
+            return element == null ? null : ManagedDotNetInterop.MakeArrayType(element);
         }
 
         if (name.EndsWith('?'))
@@ -84,7 +86,7 @@ public static class DotNetTypeRegistry
             var underlying = ResolveFriendly(name[..^1], resolve);
             if (underlying is not { IsValueType: true }) return null;
             var nullableDefinition = resolve("System.Nullable`1") ?? typeof(Nullable<>);
-            return nullableDefinition.MakeGenericType(underlying);
+            return ManagedDotNetInterop.MakeGenericType(nullableDefinition, underlying);
         }
 
         int genericStart = name.IndexOf('<');
@@ -118,7 +120,7 @@ public static class DotNetTypeRegistry
 
         try
         {
-            return definition.MakeGenericType(arguments);
+            return ManagedDotNetInterop.MakeGenericType(definition, arguments);
         }
         catch (ArgumentException ex)
         {
@@ -257,12 +259,13 @@ public static class DotNetTypeRegistry
     /// </summary>
     public static MethodInfo[] GetMethods(Type type, string jsName, bool isStatic)
     {
+        ManagedDotNetInterop.RequireManagedRuntime();
         return _methodCache.GetOrAdd((type, jsName, isStatic), static key =>
         {
             var (t, name, stat) = key;
             string pascal = ToPascalCase(name);
             var flags = BindingFlags.Public | (stat ? BindingFlags.Static : BindingFlags.Instance);
-            return t.GetMethods(flags)
+            return ManagedDotNetInterop.GetMethods(t, flags)
                 .Where(m =>
                     (m.Name == name || m.Name == pascal) &&
                     DotNetInteropClassifier.UnsupportedMethodReason(m) == null)
@@ -275,20 +278,23 @@ public static class DotNetTypeRegistry
     /// </summary>
     public static MemberInfo? GetPropertyOrField(Type type, string jsName, bool isStatic)
     {
+        ManagedDotNetInterop.RequireManagedRuntime();
         return _propertyOrFieldCache.GetOrAdd((type, jsName, isStatic), static key =>
         {
             var (t, name, stat) = key;
             string pascal = ToPascalCase(name);
             var flags = BindingFlags.Public | (stat ? BindingFlags.Static : BindingFlags.Instance);
 
-            var property = t.GetProperty(pascal, flags) ?? t.GetProperty(name, flags);
+            var property = ManagedDotNetInterop.GetProperty(t, pascal, flags) ??
+                           ManagedDotNetInterop.GetProperty(t, name, flags);
             if (property != null &&
                 DotNetInteropClassifier.UnsupportedSlotReason(property.PropertyType) == null)
             {
                 return property;
             }
 
-            var field = t.GetField(pascal, flags) ?? t.GetField(name, flags);
+            var field = ManagedDotNetInterop.GetField(t, pascal, flags) ??
+                        ManagedDotNetInterop.GetField(t, name, flags);
             return field != null &&
                    DotNetInteropClassifier.UnsupportedSlotReason(field.FieldType) == null
                 ? field
@@ -302,12 +308,14 @@ public static class DotNetTypeRegistry
     /// </summary>
     public static EventInfo? GetEvent(Type type, string jsName, bool isStatic)
     {
+        ManagedDotNetInterop.RequireManagedRuntime();
         return _eventCache.GetOrAdd((type, jsName, isStatic), static key =>
         {
             var (t, name, stat) = key;
             string pascal = ToPascalCase(name);
             var flags = BindingFlags.Public | (stat ? BindingFlags.Static : BindingFlags.Instance);
-            return t.GetEvent(pascal, flags) ?? t.GetEvent(name, flags);
+            return ManagedDotNetInterop.GetEvent(t, pascal, flags) ??
+                   ManagedDotNetInterop.GetEvent(t, name, flags);
         });
     }
 
@@ -316,10 +324,12 @@ public static class DotNetTypeRegistry
     /// </summary>
     internal static PropertyInfo[] GetIndexers(Type type, bool writable)
     {
+        ManagedDotNetInterop.RequireManagedRuntime();
         return _indexerCache.GetOrAdd((type, writable), static key =>
         {
             var (target, write) = key;
-            return target.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            return ManagedDotNetInterop.GetProperties(
+                    target, BindingFlags.Public | BindingFlags.Instance)
                 .Where(p => p.GetIndexParameters().Length == 1 &&
                             (write ? p.CanWrite : p.CanRead) &&
                             DotNetInteropClassifier.UnsupportedSlotReason(

--- a/Runtime/DotNet/ManagedDotNetInterop.cs
+++ b/Runtime/DotNet/ManagedDotNetInterop.cs
@@ -1,0 +1,170 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace SharpTS.Runtime.DotNet;
+
+/// <summary>
+/// Managed-only boundary for open-world .NET type resolution, reflection, and
+/// runtime-generated interop shapes.
+/// </summary>
+/// <remarks>
+/// The managed SKU intentionally supports BCL and third-party types that were
+/// unknown when SharpTS was built. Native AOT cannot retain or compile that
+/// unbounded type universe. Until a separately rooted native BCL contract is
+/// defined, every dynamic interop operation fails here before using metadata
+/// or constructing a runtime shape.
+/// </remarks>
+internal static class ManagedDotNetInterop
+{
+    internal const string ManagedBuildRequiredMessage =
+        ".NET interop is not available in the native SharpTS build — use the managed build.";
+
+    private const string TrimJustification =
+        "Open-world .NET interop is a Managed-SKU feature. The native build is rejected " +
+        "before inspecting arbitrary BCL, embedder, or third-party types.";
+
+    private const string DynamicCodeJustification =
+        "Open-world .NET interop is a Managed-SKU feature. The native build is rejected " +
+        "before constructing an array, generic, delegate, or other runtime-generated shape.";
+
+    internal static void RequireManagedRuntime()
+    {
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+            throw new PlatformNotSupportedException(ManagedBuildRequiredMessage);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2057", Justification = TrimJustification)]
+    internal static Type? ResolveType(string typeName)
+    {
+        RequireManagedRuntime();
+        return Type.GetType(typeName, throwOnError: false);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = TrimJustification)]
+    internal static Type? ResolveType(Assembly assembly, string typeName)
+    {
+        RequireManagedRuntime();
+        return assembly.GetType(typeName, throwOnError: false);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static MethodInfo[] GetMethods(Type type, BindingFlags flags)
+    {
+        RequireManagedRuntime();
+        return type.GetMethods(flags);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static MethodInfo? GetMethod(Type type, string name)
+    {
+        RequireManagedRuntime();
+        return type.GetMethod(name);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static MethodInfo? GetMethod(Type type, string name, Type[] parameterTypes)
+    {
+        RequireManagedRuntime();
+        return type.GetMethod(name, parameterTypes);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static ConstructorInfo[] GetConstructors(Type type, BindingFlags flags)
+    {
+        RequireManagedRuntime();
+        return type.GetConstructors(flags);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static PropertyInfo[] GetProperties(Type type, BindingFlags flags)
+    {
+        RequireManagedRuntime();
+        return type.GetProperties(flags);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static PropertyInfo? GetProperty(Type type, string name, BindingFlags flags)
+    {
+        RequireManagedRuntime();
+        return type.GetProperty(name, flags);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static FieldInfo? GetField(Type type, string name, BindingFlags flags)
+    {
+        RequireManagedRuntime();
+        return type.GetField(name, flags);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static EventInfo? GetEvent(Type type, string name, BindingFlags flags)
+    {
+        RequireManagedRuntime();
+        return type.GetEvent(name, flags);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
+    internal static Type[] GetInterfaces(Type type)
+    {
+        RequireManagedRuntime();
+        return type.GetInterfaces();
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = TrimJustification)]
+    internal static object? CreateInstance(Type type)
+    {
+        RequireManagedRuntime();
+        return Activator.CreateInstance(type);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2055", Justification = DynamicCodeJustification)]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = DynamicCodeJustification)]
+    internal static Type MakeGenericType(Type definition, params Type[] arguments)
+    {
+        RequireManagedRuntime();
+        return definition.MakeGenericType(arguments);
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2060", Justification = DynamicCodeJustification)]
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = DynamicCodeJustification)]
+    internal static MethodInfo MakeGenericMethod(MethodInfo definition, params Type[] arguments)
+    {
+        RequireManagedRuntime();
+        return definition.MakeGenericMethod(arguments);
+    }
+
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = DynamicCodeJustification)]
+    internal static Type MakeArrayType(Type elementType)
+    {
+        RequireManagedRuntime();
+        return elementType.MakeArrayType();
+    }
+
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = DynamicCodeJustification)]
+    internal static Array CreateArray(Type elementType, int length)
+    {
+        RequireManagedRuntime();
+        return Array.CreateInstance(elementType, length);
+    }
+
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = DynamicCodeJustification)]
+    internal static NewArrayExpression NewArrayInit(
+        Type elementType,
+        params Expression[] expressions)
+    {
+        RequireManagedRuntime();
+        return Expression.NewArrayInit(elementType, expressions);
+    }
+
+    [UnconditionalSuppressMessage("AOT", "IL3050", Justification = DynamicCodeJustification)]
+    internal static Delegate CompileLambda(
+        Type delegateType,
+        Expression body,
+        params ParameterExpression[] parameters)
+    {
+        RequireManagedRuntime();
+        return Expression.Lambda(delegateType, body, parameters).Compile();
+    }
+}

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -151,9 +151,14 @@ Plan against these numbers, not the originals:
   `ManagedStructuralClrReflection` then lowered the inventory to 78. The seam
   preserves open-world CLR objects in the Managed SKU and rejects Native AOT
   before reflection. The win-arm64 image increased by 1,024 bytes (0.0011%)
-  to 93,403,648 bytes. CI pins total, per-code, per-area, and per-file/code
-  counts, so both increases and category swaps fail until the same PR updates
-  the explained baseline.
+  to 93,403,648 bytes. Moving the open-world runtime .NET binder behind
+  `ManagedDotNetInterop` then lowered the inventory to 48. The Managed SKU
+  retains BCL, embedder, and third-party interop; the Native SKU now rejects
+  dynamic .NET binding with a tested diagnostic until a closed BCL contract is
+  designed and rooted. Trimming that binder closure reduced the win-arm64 image
+  by 9,216 bytes (0.0099%) to 93,394,432 bytes. CI pins total, per-code,
+  per-area, and per-file/code counts, so both increases and category swaps fail
+  until the same PR updates the explained baseline.
 - **Ship the managed SKU:** `dotnet publish -r <rid> --self-contained
   -p:PublishSingleFile=true`. Prerequisite (~30 min): confirm embedded
   resources (stdlib modules, `lib.*.d.ts`) load under single-file extraction.
@@ -194,19 +199,18 @@ Plan against these numbers, not the originals:
   its reflected SDK path from SharpTS's native image. SharpTS pins 1.0.6 and
   sets the switch only for Native AOT.
 
-### Residual analyzer inventory (78)
+### Residual analyzer inventory (48)
 
-The cleanup tranches removed 2,507 of 2,585 warnings (97.0%) without broad
+The cleanup tranches removed 2,537 of 2,585 warnings (98.1%) without broad
 `DynamicallyAccessedMembers` annotations. Every remaining warning now belongs
 to the dynamic .NET interop policy:
 
 | Analyzer | Count | Primary meaning now |
 |---|---:|---|
-| IL2075 | 7 | Reflection from a returned/derived `Type`: dynamic .NET constructors, delegates, and extension methods |
-| IL2070 | 49 | Reflection on parameters: external .NET interop, declaration discovery, and dynamic runtime dispatch |
-| IL2026 | 1 | The dynamic .NET type registry resolving a user-supplied type name |
-| IL3050 | 14 | Runtime generic/array/delegate construction where Native AOT needs a precompiled shape |
-| Other flow warnings | 7 | Two each IL2055/IL2057/IL2060 and one IL2072, concentrated in dynamic interop/type synthesis |
+| IL2075 | 2 | Reflection from a returned `Type`: compiled event delegates and extension imports |
+| IL2070 | 41 | Reflection on parameters: external IL emission, declaration discovery, and type synthesis |
+| IL2057 | 1 | A compiled custom-attribute type name resolved dynamically |
+| IL3050 | 4 | Array and delegate shapes synthesized for compile-time external-type modeling |
 
 The work is split at four ownership boundaries:
 
@@ -221,11 +225,22 @@ The work is split at four ownership boundaries:
    `SetProperty` now route through `ManagedStructuralClrReflection`. The seam
    remains deliberately open-world under CoreCLR for embedders and third-party
    assemblies, but rejects Native AOT before inspecting an arbitrary type.
-3. **Dynamic .NET interop policy.** `TypeInspector`, the external-property/call
-   emitters and `Runtime/DotNet` deliberately inspect arbitrary types. Broad
-   member annotations were measured and rejected because they increased the
-   native image by 6.55%. Define the supported native BCL surface and root only
-   that surface; guard third-party and unavailable generic shapes.
+3. **Dynamic .NET interop policy (runtime binder done).** The open-world
+   `Runtime/DotNet` binder now routes type resolution, member discovery,
+   construction, generic closure, array creation, marshalling, operators, and
+   delegate shims through `ManagedDotNetInterop`. CoreCLR retains the complete
+   BCL/embedder/third-party contract. Native AOT rejects the first dynamic
+   binding operation before reflection or runtime shape construction, and CI
+   executes that diagnostic. This is an intentional interim contract: define
+   and root a closed Native-SKU BCL surface separately if one is worth
+   supporting.
+
+   The remaining 48 warnings are the compile-time half of the same policy:
+   30 in external IL emission, nine in declaration inspection, eight in
+   external type synthesis, and one in extension imports. Broad member
+   annotations remain rejected because they increased the native image by
+   6.55%; these paths should use precise operations at the managed boundary
+   while retaining their current Managed-SKU behavior.
 4. **Generated/runtime reflection (done for the current inventory).** Known
    compiler-emitted managed shapes now go through
    `ManagedEmittedShapeReflection`. Exact-name validation covers


### PR DESCRIPTION
## Summary

- route the open-world Runtime/DotNet binder through one managed-only operation boundary
- preserve BCL, embedder, and third-party interop under CoreCLR
- reject dynamic .NET binding predictably in the Native SKU until a closed BCL surface is designed and rooted
- add a permanent native diagnostic smoke and update the analyzer baseline and AOT plan

## Verification

- Release build: 0 warnings, 0 errors
- focused managed interop suites: 164 passed, including third-party manifest assemblies
- complete CI-equivalent managed suite: 16,262 passed
- analyzer baseline: 78 to 48; Runtime area 30 to 0 with no replacement warnings
- win-arm64 native interpreted main: 42
- win-arm64 native compiled main: 42
- native features: 2 2 33
- native managed soft dependency: 42, payload extracted
- native dotnet import: exits 1 with the managed-build diagnostic
- native image: 93,394,432 bytes, 9,216 bytes smaller than merged main (-0.0099%)
- git diff --check: clean