### PR TITLE
Ratchet Native AOT publish diagnostics

### DIFF
--- a/.github/aot-publish-warning-baseline.json
+++ b/.github/aot-publish-warning-baseline.json
@@ -1,0 +1,178 @@
+{
+  "schemaVersion": 1,
+  "total": 72,
+  "project": {
+    "total": 56,
+    "codes": [
+      {
+        "code": "IL2067",
+        "count": 1
+      },
+      {
+        "code": "IL2070",
+        "count": 1
+      },
+      {
+        "code": "IL2075",
+        "count": 1
+      },
+      {
+        "code": "IL2080",
+        "count": 6
+      },
+      {
+        "code": "IL3050",
+        "count": 47
+      }
+    ],
+    "subjects": [
+      {
+        "code": "IL2067",
+        "subject": "SharpTS.Compilation.RuntimeTypes.CreateInstance(Object[],String)",
+        "count": 1
+      },
+      {
+        "code": "IL2070",
+        "subject": "SharpTS.Compilation.UnionTypeGenerator.GetImplicitConversion(Type,Type)",
+        "count": 1
+      },
+      {
+        "code": "IL2075",
+        "subject": "SharpTS.Compilation.RuntimeTypes.DisposeResource(Object,Object)",
+        "count": 1
+      },
+      {
+        "code": "IL2080",
+        "subject": "SharpTS.Compilation.RuntimeEmitter.EmitCryptoGetHashes(TypeBuilder,EmittedRuntime)",
+        "count": 1
+      },
+      {
+        "code": "IL2080",
+        "subject": "SharpTS.Compilation.RuntimeEmitter.EmitCryptoHashData(TypeBuilder,EmittedRuntime)",
+        "count": 2
+      },
+      {
+        "code": "IL2080",
+        "subject": "SharpTS.Compilation.RuntimeEmitter.EmitCryptoValidateHashName(TypeBuilder,EmittedRuntime)",
+        "count": 1
+      },
+      {
+        "code": "IL2080",
+        "subject": "SharpTS.Compilation.RuntimeEmitter.EmitWcDigest(TypeBuilder)",
+        "count": 1
+      },
+      {
+        "code": "IL2080",
+        "subject": "SharpTS.Compilation.RuntimeEmitter.EmitWcHmac(TypeBuilder)",
+        "count": 1
+      },
+      {
+        "code": "IL3050",
+        "subject": "SharpTS.Parsing.Visitors.AstNodeCatalog..cctor()",
+        "count": 47
+      }
+    ]
+  },
+  "external": {
+    "total": 16,
+    "codes": [
+      {
+        "code": "IL2026",
+        "count": 3
+      },
+      {
+        "code": "IL2104",
+        "count": 7
+      },
+      {
+        "code": "IL3000",
+        "count": 1
+      },
+      {
+        "code": "IL3001",
+        "count": 1
+      },
+      {
+        "code": "IL3053",
+        "count": 4
+      }
+    ],
+    "subjects": [
+      {
+        "code": "IL2026",
+        "subject": "System.Reflection.TypeLoading.RoAssembly.GetExportedTypes()",
+        "count": 1
+      },
+      {
+        "code": "IL2026",
+        "subject": "System.Reflection.TypeLoading.RoAssembly.GetTypes()",
+        "count": 2
+      },
+      {
+        "code": "IL2104",
+        "subject": "Assembly 'Newtonsoft.Json'",
+        "count": 1
+      },
+      {
+        "code": "IL2104",
+        "subject": "Assembly 'NuGet.Common'",
+        "count": 1
+      },
+      {
+        "code": "IL2104",
+        "subject": "Assembly 'NuGet.Configuration'",
+        "count": 1
+      },
+      {
+        "code": "IL2104",
+        "subject": "Assembly 'NuGet.Packaging'",
+        "count": 1
+      },
+      {
+        "code": "IL2104",
+        "subject": "Assembly 'NuGet.Protocol'",
+        "count": 1
+      },
+      {
+        "code": "IL2104",
+        "subject": "Assembly 'System.Reflection.MetadataLoadContext'",
+        "count": 1
+      },
+      {
+        "code": "IL2104",
+        "subject": "Assembly 'TextCopy'",
+        "count": 1
+      },
+      {
+        "code": "IL3000",
+        "subject": "NuGet.Packaging.Signing.FallbackCertificateBundleX509ChainFactory.GetThisAssemblyDirectoryPath()",
+        "count": 1
+      },
+      {
+        "code": "IL3001",
+        "subject": "System.Reflection.TypeLoading.Ecma.EcmaAssembly.GetManifestResourceStream(String)",
+        "count": 1
+      },
+      {
+        "code": "IL3053",
+        "subject": "Assembly 'Newtonsoft.Json'",
+        "count": 1
+      },
+      {
+        "code": "IL3053",
+        "subject": "Assembly 'System.Private.CoreLib'",
+        "count": 1
+      },
+      {
+        "code": "IL3053",
+        "subject": "Assembly 'System.Reflection.MetadataLoadContext'",
+        "count": 1
+      },
+      {
+        "code": "IL3053",
+        "subject": "Assembly 'TextCopy'",
+        "count": 1
+      }
+    ]
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
 
       - name: Publish Native AOT SharpTS
         run: |
+          set -o pipefail
           dotnet publish SharpTS.csproj --configuration Release -r linux-x64 \
             -p:PublishAot=true \
             -p:TrimMode=partial \
@@ -147,7 +148,19 @@ jobs:
             -p:DebugType=None \
             -p:DebugSymbols=false \
             -p:SharpTSManagedRuntimePayloadPath="$PWD/artifacts/managed-runtime/SharpTS.dll" \
-            -o artifacts/native-aot
+            -o artifacts/native-aot 2>&1 | tee artifacts/native-aot-publish.log
+
+      # SDK analyzers run before linking and therefore cannot see warnings
+      # introduced by ILC reachability or dependency closures. Exact-match only
+      # SharpTS-owned subjects; external diagnostics remain visible without
+      # making 10.0.x servicing changes fail the build.
+      - name: Enforce Native AOT publish warning inventory
+        shell: pwsh
+        run: |
+          ./scripts/aot-publish-warning-report.ps1 `
+            -LogPath artifacts/native-aot-publish.log `
+            -SummaryPath artifacts/native-aot-publish-warning-summary.json `
+            -EnforceBaseline
 
       - name: Compile and execute from the native host
         shell: bash
@@ -254,3 +267,13 @@ jobs:
             -o "$scratch/modules"
           "$scratch/modules" > "$scratch/bundled.txt"
           diff -u "$scratch/interpreted.txt" "$scratch/bundled.txt"
+
+      - name: Upload Native AOT publish diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-aot-publish-diagnostics
+          if-no-files-found: ignore
+          path: |
+            artifacts/native-aot-publish.log
+            artifacts/native-aot-publish-warning-summary.json

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -213,6 +213,34 @@ diagnostics; those are not silently represented by this source-analyzer
 baseline and must continue to be evaluated through the native publish/smoke
 gate.
 
+### Native publish inventory (72 on linux-x64)
+
+The SDK analyzer ratchet runs before linking, so it cannot see warnings
+introduced by ILC reachability or by the final dependency closure. The
+linux-x64 Native publish currently reports 72 warning lines: 56 owned by
+SharpTS and 16 from the framework or package dependencies.
+
+CI parses the publish log with `scripts/aot-publish-warning-report.ps1`.
+`.github/aot-publish-warning-baseline.json` exact-matches the SharpTS-owned
+code, subject, and count inventory. External diagnostics are summarized and
+archived but are informational: the workflow intentionally uses `10.0.x`, so
+SDK servicing can change framework and dependency diagnostics independently of
+SharpTS source.
+
+The next cleanup tranches are bounded:
+
+1. Replace the production reflection-backed `AstNodeCatalog` with a
+   reflection-free canonical list while retaining reflective exhaustiveness
+   validation in managed tests. This owns 47 repeated IL3050 lines.
+2. Resolve the remaining nine SharpTS warnings at their exact seams: six
+   closed crypto-emitter metadata lookups, the legacy `RuntimeTypes`
+   construction fallback, resource-disposal callable dispatch, and the
+   finalized-union conversion lookup.
+3. Re-measure before considering dependency replacement or isolation. The 16
+   external lines currently come from the NuGet/Newtonsoft packaging closure,
+   MetadataLoadContext, PrettyPrompt/TextCopy, and framework summaries. Zero
+   external warnings is not a correctness requirement.
+
 The work is split at four ownership boundaries:
 
 1. **Managed-only feature guards (done for the current inventory).**

--- a/scripts/aot-publish-warning-report.ps1
+++ b/scripts/aot-publish-warning-report.ps1
@@ -1,0 +1,205 @@
+param(
+    [string]$LogPath = "aot-publish.log",
+    [string]$SummaryPath = "aot-publish-warning-summary.json",
+    [string]$BaselinePath = ".github/aot-publish-warning-baseline.json",
+    [switch]$EnforceBaseline,
+    [switch]$UpdateBaseline
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ($EnforceBaseline -and $UpdateBaseline)
+{
+    throw "-EnforceBaseline and -UpdateBaseline are mutually exclusive."
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+
+function Resolve-RepoPath([string]$Path)
+{
+    if ([System.IO.Path]::IsPathRooted($Path))
+    {
+        return [System.IO.Path]::GetFullPath($Path)
+    }
+
+    return [System.IO.Path]::GetFullPath((Join-Path $repoRoot $Path))
+}
+
+function Get-WarningSubject([string]$Message)
+{
+    $separatorIndex = $Message.IndexOf(": ", [System.StringComparison]::Ordinal)
+    if ($separatorIndex -ge 0)
+    {
+        return $Message.Substring(0, $separatorIndex)
+    }
+
+    if ($Message -match "^Assembly '[^']+'")
+    {
+        return $Matches[0]
+    }
+
+    return $Message
+}
+
+function New-Inventory($Warnings)
+{
+    $items = @($Warnings)
+    return [ordered]@{
+        total = $items.Count
+        codes = @(
+            $items |
+                Group-Object code |
+                Sort-Object Name |
+                ForEach-Object {
+                    [ordered]@{ code = $_.Name; count = $_.Count }
+                }
+        )
+        subjects = @(
+            $items |
+                Group-Object code, subject |
+                ForEach-Object {
+                    $first = $_.Group[0]
+                    [pscustomobject][ordered]@{
+                        code = $first.code
+                        subject = $first.subject
+                        count = $_.Count
+                    }
+                } |
+                Sort-Object -Property code,subject
+        )
+    }
+}
+
+function ConvertTo-ComparisonRecords($Inventory)
+{
+    @(
+        "total|$($Inventory.total)"
+        $Inventory.codes | ForEach-Object {
+            "code|$($_.code)|$($_.count)"
+        }
+        $Inventory.subjects | ForEach-Object {
+            "subject|$($_.code)|$($_.subject)|$($_.count)"
+        }
+    )
+}
+
+$logFullPath = Resolve-RepoPath $LogPath
+$summaryFullPath = Resolve-RepoPath $SummaryPath
+$baselineFullPath = Resolve-RepoPath $BaselinePath
+
+if (-not (Test-Path -LiteralPath $logFullPath))
+{
+    throw "Native AOT publish log not found at '$logFullPath'."
+}
+
+$warningPattern = "warning (?<code>IL\d{4}): (?<message>.+)$"
+$projectSuffixPattern = "\s+\[[^\]]+\.csproj\]\s*$"
+$escapePattern = [char]27 + "\[[0-9;]*m"
+$parsedWarnings = [System.Collections.Generic.List[object]]::new()
+
+foreach ($rawLine in [System.IO.File]::ReadLines($logFullPath))
+{
+    $line = $rawLine -replace $escapePattern, ""
+    if ($line -notmatch $warningPattern)
+    {
+        continue
+    }
+
+    $code = $Matches.code
+    $message = ($Matches.message -replace $projectSuffixPattern, "").Trim()
+    $subject = Get-WarningSubject $message
+    $isProjectOwned =
+        $subject.StartsWith("SharpTS.", [System.StringComparison]::Ordinal) -or
+        $subject.Equals("Assembly 'SharpTS'", [System.StringComparison]::Ordinal)
+
+    $parsedWarnings.Add([pscustomobject]@{
+        code = $code
+        subject = $subject
+        owner = if ($isProjectOwned) { "project" } else { "external" }
+    })
+}
+
+$projectWarnings = @($parsedWarnings | Where-Object owner -eq "project")
+$externalWarnings = @($parsedWarnings | Where-Object owner -eq "external")
+$summary = [ordered]@{
+    schemaVersion = 1
+    total = $parsedWarnings.Count
+    project = New-Inventory $projectWarnings
+    external = New-Inventory $externalWarnings
+}
+
+$summaryDirectory = Split-Path -Parent $summaryFullPath
+if ($summaryDirectory)
+{
+    New-Item -ItemType Directory -Force -Path $summaryDirectory | Out-Null
+}
+$summaryJson = $summary | ConvertTo-Json -Depth 6
+[System.IO.File]::WriteAllText($summaryFullPath, $summaryJson + [Environment]::NewLine)
+
+Write-Host "Native AOT publish warnings: $($summary.total)"
+Write-Host "  SharpTS-owned: $($summary.project.total)"
+foreach ($entry in $summary.project.codes | Sort-Object count -Descending)
+{
+    Write-Host ("    {0,-7} {1,5}" -f $entry.code, $entry.count)
+}
+Write-Host "  External:      $($summary.external.total)"
+foreach ($entry in $summary.external.codes | Sort-Object count -Descending)
+{
+    Write-Host ("    {0,-7} {1,5}" -f $entry.code, $entry.count)
+}
+Write-Host "Summary: $summaryFullPath"
+Write-Host "Log:     $logFullPath"
+
+if ($UpdateBaseline)
+{
+    $baselineDirectory = Split-Path -Parent $baselineFullPath
+    if ($baselineDirectory)
+    {
+        New-Item -ItemType Directory -Force -Path $baselineDirectory | Out-Null
+    }
+    [System.IO.File]::WriteAllText(
+        $baselineFullPath,
+        $summaryJson + [Environment]::NewLine)
+    Write-Host "Updated baseline: $baselineFullPath"
+}
+
+if ($EnforceBaseline)
+{
+    if (-not (Test-Path -LiteralPath $baselineFullPath))
+    {
+        throw "Native AOT publish baseline not found at '$baselineFullPath'."
+    }
+
+    $baseline = Get-Content -LiteralPath $baselineFullPath -Raw | ConvertFrom-Json
+    $expectedProject = ConvertTo-ComparisonRecords $baseline.project
+    $actualProject = ConvertTo-ComparisonRecords ([pscustomobject]$summary.project)
+    $projectDifferences = @(Compare-Object $expectedProject $actualProject)
+    if ($projectDifferences.Count -ne 0)
+    {
+        Write-Error "SharpTS-owned Native AOT publish warnings differ from the committed baseline."
+        foreach ($difference in $projectDifferences)
+        {
+            $meaning = if ($difference.SideIndicator -eq "=>") { "actual" } else { "baseline" }
+            Write-Error "  [$meaning] $($difference.InputObject)"
+        }
+        throw "Update the baseline only in the PR that explains the project warning changes."
+    }
+
+    Write-Host "SharpTS-owned publish inventory matches '$baselineFullPath'."
+
+    $expectedExternal = ConvertTo-ComparisonRecords $baseline.external
+    $actualExternal = ConvertTo-ComparisonRecords ([pscustomobject]$summary.external)
+    $externalDifferences = @(Compare-Object $expectedExternal $actualExternal)
+    if ($externalDifferences.Count -ne 0)
+    {
+        Write-Warning (
+            "External Native AOT diagnostics differ from the observed baseline. " +
+            "This is informational because SDK and dependency servicing can change them.")
+        foreach ($difference in $externalDifferences)
+        {
+            $meaning = if ($difference.SideIndicator -eq "=>") { "actual" } else { "baseline" }
+            Write-Warning "  [$meaning] $($difference.InputObject)"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- capture the real Native AOT publish log and parse post-link IL diagnostics that the SDK analyzer job cannot see
- establish the green linux-x64 inventory at 72 lines: 56 SharpTS-owned and 16 framework/dependency diagnostics
- exact-match SharpTS warning codes, subjects, and counts while reporting external drift without failing on `10.0.x` servicing changes
- upload the publish log and structured summary from every Native CI run
- document the bounded 47-warning AST catalog tranche and nine-warning follow-up tranche

## Validation

- replayed the parser against green Linux Native job 30601656765: 72 total / 56 project / 16 external, exact baseline match
- fresh win-arm64 Native publish: 74 total / 56 project / 18 external; project baseline passed and the two Windows-only framework summaries were informational
- deliberately changed project total from 56 to 55: enforcement rejected the mismatch
- PowerShell syntax parser: clean
- `dotnet build SharpTS.csproj --configuration Release --no-restore`: 0 warnings, 0 errors
- win-arm64 Native image remains 93,376,000 bytes