### PR TITLE
Make the AST node catalog reflection-free

### DIFF
--- a/.github/aot-publish-warning-baseline.json
+++ b/.github/aot-publish-warning-baseline.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "total": 72,
+  "total": 25,
   "project": {
-    "total": 56,
+    "total": 9,
     "codes": [
       {
         "code": "IL2067",
@@ -19,10 +19,6 @@
       {
         "code": "IL2080",
         "count": 6
-      },
-      {
-        "code": "IL3050",
-        "count": 47
       }
     ],
     "subjects": [
@@ -65,11 +61,6 @@
         "code": "IL2080",
         "subject": "SharpTS.Compilation.RuntimeEmitter.EmitWcHmac(TypeBuilder)",
         "count": 1
-      },
-      {
-        "code": "IL3050",
-        "subject": "SharpTS.Parsing.Visitors.AstNodeCatalog..cctor()",
-        "count": 47
       }
     ]
   },

--- a/Parsing/Visitors/AstNodeCatalog.cs
+++ b/Parsing/Visitors/AstNodeCatalog.cs
@@ -1,22 +1,16 @@
-using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
-
 namespace SharpTS.Parsing.Visitors;
 
 /// <summary>
-/// The single canonical list of concrete AST node types, derived once from the <see cref="Expr"/>
-/// and <see cref="Stmt"/> record definitions in <c>Parsing/AST.cs</c>.
+/// The single canonical list of concrete AST node types declared by <see cref="Expr"/>
+/// and <see cref="Stmt"/> in <c>Parsing/AST.cs</c>.
 /// </summary>
 /// <remarks>
 /// <para>
-/// This is the convergence point for the AST dispatch tables (issue #1243, epic #1094). Every
-/// consumer that needs "the set of AST node kinds" reads it from here instead of re-deriving it:
-/// <see cref="NodeRegistry{TContext, TExprResult, TStmtResult}"/> uses it for exhaustiveness
-/// checks (<c>Freeze</c>/<c>FreezeAsync</c>) and handler auto-registration (<c>AutoRegister</c>),
-/// and the visitor-dispatch guard test validates <see cref="AstVisitorBase"/>'s switch against it.
-/// A new node added to <c>AST.cs</c> automatically appears here, so it cannot be silently omitted
-/// from a dispatch table without a loud failure (a startup exception from the registry, or a
-/// failing guard test for the visitor switch).
+/// This is the convergence point for the AST dispatch guard tests (issue #1243, epic #1094).
+/// Production dispatch uses compile-time switches; the managed test suite reflects the directly
+/// nested <see cref="Expr"/>/<see cref="Stmt"/> types and requires this catalog to match them
+/// exactly. A new node therefore requires an explicit catalog entry and dispatch arm in the same
+/// change, without retaining open-ended nested-type reflection in the Native AOT compiler.
 /// </para>
 /// <para>
 /// "Node type" is defined exactly as the dispatch tables historically defined it: a directly
@@ -28,15 +22,96 @@ namespace SharpTS.Parsing.Visitors;
 /// </remarks>
 public static class AstNodeCatalog
 {
-    /// <summary>Every concrete <see cref="Expr"/> node type, in reflection order.</summary>
-    public static readonly IReadOnlyList<Type> ExprTypes = CollectConcreteNodes(typeof(Expr));
+    /// <summary>Every concrete <see cref="Expr"/> node type, in declaration order.</summary>
+    public static readonly IReadOnlyList<Type> ExprTypes =
+    [
+        typeof(Expr.Comma),
+        typeof(Expr.DestructuringAssign),
+        typeof(Expr.Binary),
+        typeof(Expr.Logical),
+        typeof(Expr.NullishCoalescing),
+        typeof(Expr.Ternary),
+        typeof(Expr.Grouping),
+        typeof(Expr.Literal),
+        typeof(Expr.Unary),
+        typeof(Expr.Delete),
+        typeof(Expr.Variable),
+        typeof(Expr.Assign),
+        typeof(Expr.Call),
+        typeof(Expr.Get),
+        typeof(Expr.Set),
+        typeof(Expr.GetPrivate),
+        typeof(Expr.SetPrivate),
+        typeof(Expr.CallPrivate),
+        typeof(Expr.This),
+        typeof(Expr.New),
+        typeof(Expr.ArrayLiteral),
+        typeof(Expr.ObjectLiteral),
+        typeof(Expr.GetIndex),
+        typeof(Expr.SetIndex),
+        typeof(Expr.Super),
+        typeof(Expr.CompoundAssign),
+        typeof(Expr.CompoundSet),
+        typeof(Expr.CompoundSetIndex),
+        typeof(Expr.LogicalAssign),
+        typeof(Expr.LogicalSet),
+        typeof(Expr.LogicalSetIndex),
+        typeof(Expr.PrefixIncrement),
+        typeof(Expr.PostfixIncrement),
+        typeof(Expr.ArrowFunction),
+        typeof(Expr.TemplateLiteral),
+        typeof(Expr.TaggedTemplateLiteral),
+        typeof(Expr.Spread),
+        typeof(Expr.TypeAssertion),
+        typeof(Expr.Satisfies),
+        typeof(Expr.Await),
+        typeof(Expr.DynamicImport),
+        typeof(Expr.ImportMeta),
+        typeof(Expr.Yield),
+        typeof(Expr.RegexLiteral),
+        typeof(Expr.NonNullAssertion),
+        typeof(Expr.ClassExpr),
+    ];
 
-    /// <summary>Every concrete <see cref="Stmt"/> node type, in reflection order.</summary>
-    public static readonly IReadOnlyList<Type> StmtTypes = CollectConcreteNodes(typeof(Stmt));
-
-    private static IReadOnlyList<Type> CollectConcreteNodes(
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicNestedTypes)] Type baseType) =>
-        baseType.GetNestedTypes(BindingFlags.Public)
-            .Where(t => baseType.IsAssignableFrom(t) && !t.IsAbstract && t != baseType)
-            .ToArray();
+    /// <summary>Every concrete <see cref="Stmt"/> node type, in declaration order.</summary>
+    public static readonly IReadOnlyList<Type> StmtTypes =
+    [
+        typeof(Stmt.Expression),
+        typeof(Stmt.Var),
+        typeof(Stmt.Const),
+        typeof(Stmt.Function),
+        typeof(Stmt.Field),
+        typeof(Stmt.Accessor),
+        typeof(Stmt.AutoAccessor),
+        typeof(Stmt.Class),
+        typeof(Stmt.StaticBlock),
+        typeof(Stmt.Interface),
+        typeof(Stmt.Block),
+        typeof(Stmt.Sequence),
+        typeof(Stmt.Return),
+        typeof(Stmt.While),
+        typeof(Stmt.For),
+        typeof(Stmt.DoWhile),
+        typeof(Stmt.ForOf),
+        typeof(Stmt.ForIn),
+        typeof(Stmt.If),
+        typeof(Stmt.Break),
+        typeof(Stmt.Continue),
+        typeof(Stmt.LabeledStatement),
+        typeof(Stmt.Switch),
+        typeof(Stmt.TryCatch),
+        typeof(Stmt.Throw),
+        typeof(Stmt.TypeAlias),
+        typeof(Stmt.Enum),
+        typeof(Stmt.Namespace),
+        typeof(Stmt.ImportAlias),
+        typeof(Stmt.ImportRequire),
+        typeof(Stmt.Import),
+        typeof(Stmt.Export),
+        typeof(Stmt.FileDirective),
+        typeof(Stmt.Directive),
+        typeof(Stmt.DeclareModule),
+        typeof(Stmt.DeclareGlobal),
+        typeof(Stmt.Using),
+    ];
 }

--- a/SharpTS.Tests/RegistryTests/AstDispatchTests.cs
+++ b/SharpTS.Tests/RegistryTests/AstDispatchTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using SharpTS.Execution;
 using SharpTS.Parsing;
@@ -8,13 +9,14 @@ using Xunit;
 namespace SharpTS.Tests.RegistryTests;
 
 /// <summary>
-/// Guards the convergence of the AST dispatch tables onto <see cref="AstNodeCatalog"/> (issue #1243,
-/// epic #1094). The catalog is the single source of truth for the AST node set; these tests ensure
-/// none of the hand-maintained dispatch switches — <see cref="AstVisitorBase"/>, the interpreter's
-/// (<c>Interpreter.Dispatch.cs</c>), and the type checker's (<c>TypeChecker.Dispatch.cs</c>) — can
-/// silently omit a node the catalog knows about. The latter two replaced the reflection-built
-/// NodeRegistry tables (#1324): registration is now checked by the compiler (a missing Visit*
-/// method is a build error) and exhaustiveness by these probes.
+/// Guards the convergence of the AST dispatch tables onto <see cref="AstNodeCatalog"/> (issue
+/// #1243, epic #1094). Managed tests derive the actual node set through reflection and require the
+/// production catalog to match exactly; the reflection does not ship in the Native AOT compiler.
+/// These tests then ensure none of the hand-maintained dispatch switches —
+/// <see cref="AstVisitorBase"/>, the interpreter's (<c>Interpreter.Dispatch.cs</c>), and the type
+/// checker's (<c>TypeChecker.Dispatch.cs</c>) — can silently omit a catalogued node. The latter two
+/// replaced the reflection-built NodeRegistry tables (#1324): registration is now checked by the
+/// compiler (a missing Visit* method is a build error) and exhaustiveness by these probes.
 /// </summary>
 public class AstDispatchTests
 {
@@ -28,31 +30,23 @@ public class AstDispatchTests
     private sealed record UnknownStmt : Stmt;
 
     [Fact]
-    public void Catalog_is_populated_and_excludes_non_node_records()
+    public void Catalog_exactly_matches_concrete_nested_node_types()
     {
-        Assert.NotEmpty(AstNodeCatalog.ExprTypes);
-        Assert.NotEmpty(AstNodeCatalog.StmtTypes);
-
-        // Representative nodes are present.
-        Assert.Contains(typeof(Expr.Binary), AstNodeCatalog.ExprTypes);
-        Assert.Contains(typeof(Stmt.If), AstNodeCatalog.StmtTypes);
-
-        // Every entry is a concrete subtype of its base.
-        Assert.All(AstNodeCatalog.ExprTypes, t =>
-        {
-            Assert.True(typeof(Expr).IsAssignableFrom(t));
-            Assert.False(t.IsAbstract);
-        });
-        Assert.All(AstNodeCatalog.StmtTypes, t =>
-        {
-            Assert.True(typeof(Stmt).IsAssignableFrom(t));
-            Assert.False(t.IsAbstract);
-        });
+        Assert.Equal(CollectConcreteNodes(typeof(Expr)), AstNodeCatalog.ExprTypes);
+        Assert.Equal(CollectConcreteNodes(typeof(Stmt)), AstNodeCatalog.StmtTypes);
 
         // Helper records nested under the bases that are not dispatched nodes stay out.
         Assert.DoesNotContain(typeof(Expr.Property), AstNodeCatalog.ExprTypes);
         Assert.DoesNotContain(typeof(Stmt.Parameter), AstNodeCatalog.StmtTypes);
     }
+
+    private static Type[] CollectConcreteNodes(Type baseType) =>
+        baseType.GetNestedTypes(BindingFlags.Public)
+            .Where(type =>
+                baseType.IsAssignableFrom(type) &&
+                !type.IsAbstract &&
+                type != baseType)
+            .ToArray();
 
     [Fact]
     public void AstVisitorBase_dispatches_every_Expr_node()

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -161,7 +161,9 @@ Plan against these numbers, not the originals:
   inventory to zero. The win-arm64 image fell another 18,432 bytes (0.0197%)
   to 93,376,000 bytes. CI pins total, per-code, per-area, and per-file/code
   counts; the checked-in inventory is now empty, so any new project analyzer
-  warning fails the ratchet.
+  warning fails the ratchet. Replacing the reflection-built AST guard catalog
+  with a reflection-free public catalog then removed 47 post-link ILC warning
+  lines and reduced the image another 1,024 bytes to 93,374,976 bytes.
 - **Ship the managed SKU:** `dotnet publish -r <rid> --self-contained
   -p:PublishSingleFile=true`. Prerequisite (~30 min): confirm embedded
   resources (stdlib modules, `lib.*.d.ts`) load under single-file extraction.
@@ -213,11 +215,11 @@ diagnostics; those are not silently represented by this source-analyzer
 baseline and must continue to be evaluated through the native publish/smoke
 gate.
 
-### Native publish inventory (72 on linux-x64)
+### Native publish inventory (25 on linux-x64)
 
 The SDK analyzer ratchet runs before linking, so it cannot see warnings
 introduced by ILC reachability or by the final dependency closure. The
-linux-x64 Native publish currently reports 72 warning lines: 56 owned by
+linux-x64 Native publish currently reports 25 warning lines: nine owned by
 SharpTS and 16 from the framework or package dependencies.
 
 CI parses the publish log with `scripts/aot-publish-warning-report.ps1`.
@@ -227,19 +229,20 @@ archived but are informational: the workflow intentionally uses `10.0.x`, so
 SDK servicing can change framework and dependency diagnostics independently of
 SharpTS source.
 
-The next cleanup tranches are bounded:
+The former production reflection in `AstNodeCatalog` is now a public explicit
+type list. Managed tests still derive the true nested-node set reflectively and
+require exact declaration-order equality, preserving the automatic
+exhaustiveness guard without shipping that reflection in the Native compiler.
+This removed 47 repeated IL3050 lines without suppressions.
 
-1. Replace the production reflection-backed `AstNodeCatalog` with a
-   reflection-free canonical list while retaining reflective exhaustiveness
-   validation in managed tests. This owns 47 repeated IL3050 lines.
-2. Resolve the remaining nine SharpTS warnings at their exact seams: six
-   closed crypto-emitter metadata lookups, the legacy `RuntimeTypes`
-   construction fallback, resource-disposal callable dispatch, and the
-   finalized-union conversion lookup.
-3. Re-measure before considering dependency replacement or isolation. The 16
-   external lines currently come from the NuGet/Newtonsoft packaging closure,
-   MetadataLoadContext, PrettyPrompt/TextCopy, and framework summaries. Zero
-   external warnings is not a correctness requirement.
+The remaining project cleanup is bounded to nine warnings: six closed
+crypto-emitter metadata lookups, the legacy `RuntimeTypes` construction
+fallback, resource-disposal callable dispatch, and the finalized-union
+conversion lookup. Re-measure after those before considering dependency
+replacement or isolation. The 16 external lines currently come from the
+NuGet/Newtonsoft packaging closure, MetadataLoadContext, PrettyPrompt/TextCopy,
+and framework summaries. Zero external warnings is not a correctness
+requirement.
 
 The work is split at four ownership boundaries:
 


### PR DESCRIPTION
## Summary

- preserve the public AstNodeCatalog API while replacing nested-type reflection with an explicit canonical type list
- retain automatic completeness and dispatch coverage by deriving the actual node set reflectively in managed tests
- remove all 47 AstNodeCatalog IL3050 publish warnings and ratchet the Linux Native publish baseline from 72 to 25 total warnings (56 to 9 project-owned)
- document the new baseline and measured Native image impact

## Validation

- source analyzer baseline: 0 project warnings
- full managed suite: 16,262 passed
- AST dispatch tests: 7 passed
- Windows arm64 Native publish: 9 project warnings; 18 external informational warnings
- Native smoke probes: interpreted output 42; compiled features output 2 2 33
- win-arm64 Native image: 93,374,976 bytes, 1,024 bytes smaller than merged main

Linux CI remains authoritative for the checked-in 25-warning publish baseline (9 project plus 16 external). No warnings are suppressed.