### PR TITLE
Eliminate the remaining SharpTS AOT publish warnings

### DIFF
--- a/.github/aot-publish-warning-baseline.json
+++ b/.github/aot-publish-warning-baseline.json
@@ -1,68 +1,10 @@
 {
   "schemaVersion": 1,
-  "total": 25,
+  "total": 16,
   "project": {
-    "total": 9,
-    "codes": [
-      {
-        "code": "IL2067",
-        "count": 1
-      },
-      {
-        "code": "IL2070",
-        "count": 1
-      },
-      {
-        "code": "IL2075",
-        "count": 1
-      },
-      {
-        "code": "IL2080",
-        "count": 6
-      }
-    ],
-    "subjects": [
-      {
-        "code": "IL2067",
-        "subject": "SharpTS.Compilation.RuntimeTypes.CreateInstance(Object[],String)",
-        "count": 1
-      },
-      {
-        "code": "IL2070",
-        "subject": "SharpTS.Compilation.UnionTypeGenerator.GetImplicitConversion(Type,Type)",
-        "count": 1
-      },
-      {
-        "code": "IL2075",
-        "subject": "SharpTS.Compilation.RuntimeTypes.DisposeResource(Object,Object)",
-        "count": 1
-      },
-      {
-        "code": "IL2080",
-        "subject": "SharpTS.Compilation.RuntimeEmitter.EmitCryptoGetHashes(TypeBuilder,EmittedRuntime)",
-        "count": 1
-      },
-      {
-        "code": "IL2080",
-        "subject": "SharpTS.Compilation.RuntimeEmitter.EmitCryptoHashData(TypeBuilder,EmittedRuntime)",
-        "count": 2
-      },
-      {
-        "code": "IL2080",
-        "subject": "SharpTS.Compilation.RuntimeEmitter.EmitCryptoValidateHashName(TypeBuilder,EmittedRuntime)",
-        "count": 1
-      },
-      {
-        "code": "IL2080",
-        "subject": "SharpTS.Compilation.RuntimeEmitter.EmitWcDigest(TypeBuilder)",
-        "count": 1
-      },
-      {
-        "code": "IL2080",
-        "subject": "SharpTS.Compilation.RuntimeEmitter.EmitWcHmac(TypeBuilder)",
-        "count": 1
-      }
-    ]
+    "total": 0,
+    "codes": [],
+    "subjects": []
   },
   "external": {
     "total": 16,

--- a/Compilation/RuntimeEmitter.CryptoHelpers.Hashing.cs
+++ b/Compilation/RuntimeEmitter.CryptoHelpers.Hashing.cs
@@ -323,12 +323,12 @@ public partial class RuntimeEmitter
 
         // Static family, then the platform-gated SHA-3/SHAKE members (#1062).
         // Mirrors CryptoAlgorithms.SupportedHashNames.
-        foreach (var (hash, impl, guarded, _) in _hashTable)
+        foreach (var (hash, _, isSupported, _) in _hashTable)
         {
             var skipLabel = il.DefineLabel();
-            if (guarded)
+            if (isSupported is not null)
             {
-                il.Emit(OpCodes.Call, impl.GetProperty("IsSupported")!.GetGetMethod()!);
+                il.Emit(OpCodes.Call, isSupported);
                 il.Emit(OpCodes.Brfalse, skipLabel);
             }
             il.Emit(OpCodes.Ldloc, listLocal);

--- a/Compilation/RuntimeEmitter.CryptoPrimitives.cs
+++ b/Compilation/RuntimeEmitter.CryptoPrimitives.cs
@@ -19,19 +19,27 @@ namespace SharpTS.Compilation;
 /// </remarks>
 public partial class RuntimeEmitter
 {
-    /// <summary>Digest table rows: name, one-shot HashData holder type, optional IsSupported gate, XOF default length.</summary>
-    private static readonly (string Name, Type Impl, bool Guarded, int XofDefault)[] _hashTable =
+    /// <summary>
+    /// Digest table rows: name, rooted one-shot HashData method, optional
+    /// IsSupported getter, and XOF default length.
+    /// </summary>
+    private static readonly (string Name, MethodInfo HashData, MethodInfo? IsSupported, int XofDefault)[] _hashTable =
     [
-        ("md5", typeof(MD5), false, -1),
-        ("sha1", typeof(SHA1), false, -1),
-        ("sha256", typeof(SHA256), false, -1),
-        ("sha384", typeof(SHA384), false, -1),
-        ("sha512", typeof(SHA512), false, -1),
-        ("sha3-256", typeof(SHA3_256), true, -1),
-        ("sha3-384", typeof(SHA3_384), true, -1),
-        ("sha3-512", typeof(SHA3_512), true, -1),
-        ("shake128", typeof(Shake128), true, 16),
-        ("shake256", typeof(Shake256), true, 32),
+        ("md5", ((Func<byte[], byte[]>)MD5.HashData).Method, null, -1),
+        ("sha1", ((Func<byte[], byte[]>)SHA1.HashData).Method, null, -1),
+        ("sha256", ((Func<byte[], byte[]>)SHA256.HashData).Method, null, -1),
+        ("sha384", ((Func<byte[], byte[]>)SHA384.HashData).Method, null, -1),
+        ("sha512", ((Func<byte[], byte[]>)SHA512.HashData).Method, null, -1),
+        ("sha3-256", ((Func<byte[], byte[]>)SHA3_256.HashData).Method,
+            typeof(SHA3_256).GetProperty(nameof(SHA3_256.IsSupported))!.GetMethod, -1),
+        ("sha3-384", ((Func<byte[], byte[]>)SHA3_384.HashData).Method,
+            typeof(SHA3_384).GetProperty(nameof(SHA3_384.IsSupported))!.GetMethod, -1),
+        ("sha3-512", ((Func<byte[], byte[]>)SHA3_512.HashData).Method,
+            typeof(SHA3_512).GetProperty(nameof(SHA3_512.IsSupported))!.GetMethod, -1),
+        ("shake128", ((Func<byte[], int, byte[]>)Shake128.HashData).Method,
+            typeof(Shake128).GetProperty(nameof(Shake128.IsSupported))!.GetMethod, 16),
+        ("shake256", ((Func<byte[], int, byte[]>)Shake256.HashData).Method,
+            typeof(Shake256).GetProperty(nameof(Shake256.IsSupported))!.GetMethod, 32),
     ];
 
     private void EmitCryptoPrimitivesClass(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
@@ -71,7 +79,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "ToLowerInvariant")!);
         il.Emit(OpCodes.Stloc, lowerLocal);
 
-        foreach (var (name, impl, guarded, _) in _hashTable)
+        foreach (var (name, _, isSupported, _) in _hashTable)
         {
             var nextLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldloc, lowerLocal);
@@ -79,10 +87,10 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", [_types.String, _types.String])!);
             il.Emit(OpCodes.Brfalse, nextLabel);
 
-            if (guarded)
+            if (isSupported is not null)
             {
                 var supportedLabel = il.DefineLabel();
-                il.Emit(OpCodes.Call, impl.GetProperty("IsSupported")!.GetGetMethod()!);
+                il.Emit(OpCodes.Call, isSupported);
                 il.Emit(OpCodes.Brtrue, supportedLabel);
                 il.Emit(OpCodes.Ldstr, $"Unsupported hash algorithm: {name} (not supported on this platform)");
                 il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ArgumentException, [_types.String])!);
@@ -124,7 +132,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.CryptoValidateHashName);
         il.Emit(OpCodes.Stloc, lowerLocal);
 
-        foreach (var (name, impl, _, xofDefault) in _hashTable)
+        foreach (var (name, hashData, _, xofDefault) in _hashTable)
         {
             var nextLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldloc, lowerLocal);
@@ -146,12 +154,12 @@ public partial class RuntimeEmitter
                 il.MarkLabel(useDefaultLabel);
                 il.Emit(OpCodes.Ldc_I4, xofDefault);
                 il.MarkLabel(callLabel);
-                il.Emit(OpCodes.Call, impl.GetMethod("HashData", [typeof(byte[]), typeof(int)])!);
+                il.Emit(OpCodes.Call, hashData);
             }
             else
             {
                 il.Emit(OpCodes.Ldarg_1);
-                il.Emit(OpCodes.Call, impl.GetMethod("HashData", [typeof(byte[])])!);
+                il.Emit(OpCodes.Call, hashData);
             }
             il.Emit(OpCodes.Ret);
 

--- a/Compilation/RuntimeEmitter.WebCrypto.cs
+++ b/Compilation/RuntimeEmitter.WebCrypto.cs
@@ -499,9 +499,14 @@ public partial class RuntimeEmitter
         var il = _wcDigest.GetILGenerator();
         var strEq = _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String);
 
-        (string Lower, Type Impl)[] impls =
-            [("sha1", typeof(SHA1)), ("sha256", typeof(SHA256)), ("sha384", typeof(SHA384)), ("sha512", typeof(SHA512))];
-        foreach (var (lower, impl) in impls)
+        (string Lower, MethodInfo HashData)[] impls =
+        [
+            ("sha1", ((Func<byte[], byte[]>)SHA1.HashData).Method),
+            ("sha256", ((Func<byte[], byte[]>)SHA256.HashData).Method),
+            ("sha384", ((Func<byte[], byte[]>)SHA384.HashData).Method),
+            ("sha512", ((Func<byte[], byte[]>)SHA512.HashData).Method),
+        ];
+        foreach (var (lower, hashData) in impls)
         {
             var next = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
@@ -509,7 +514,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Call, strEq);
             il.Emit(OpCodes.Brfalse, next);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, impl.GetMethod("HashData", [typeof(byte[])])!);
+            il.Emit(OpCodes.Call, hashData);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(next);
         }
@@ -525,9 +530,14 @@ public partial class RuntimeEmitter
         var il = _wcHmac.GetILGenerator();
         var strEq = _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String);
 
-        (string Lower, Type Impl)[] impls =
-            [("sha1", typeof(HMACSHA1)), ("sha256", typeof(HMACSHA256)), ("sha384", typeof(HMACSHA384)), ("sha512", typeof(HMACSHA512))];
-        foreach (var (lower, impl) in impls)
+        (string Lower, MethodInfo HashData)[] impls =
+        [
+            ("sha1", ((Func<byte[], byte[], byte[]>)HMACSHA1.HashData).Method),
+            ("sha256", ((Func<byte[], byte[], byte[]>)HMACSHA256.HashData).Method),
+            ("sha384", ((Func<byte[], byte[], byte[]>)HMACSHA384.HashData).Method),
+            ("sha512", ((Func<byte[], byte[], byte[]>)HMACSHA512.HashData).Method),
+        ];
+        foreach (var (lower, hashData) in impls)
         {
             var next = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
@@ -536,7 +546,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Brfalse, next);
             il.Emit(OpCodes.Ldarg_1);
             il.Emit(OpCodes.Ldarg_2);
-            il.Emit(OpCodes.Call, impl.GetMethod("HashData", [typeof(byte[]), typeof(byte[])])!);
+            il.Emit(OpCodes.Call, hashData);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(next);
         }

--- a/Compilation/RuntimeTypes.Methods.cs
+++ b/Compilation/RuntimeTypes.Methods.cs
@@ -68,42 +68,4 @@ public static partial class RuntimeTypes
     }
 
     #endregion
-
-    #region Instantiation
-
-    public static object? CreateInstance(object?[] args, string className)
-    {
-        if (_compiledTypes.TryGetValue(className, out var type))
-        {
-            try
-            {
-                // Find the constructor and pad args with nulls for default parameters
-                var ctor = ReflectionCache.GetConstructor(type);
-                if (ctor != null)
-                {
-                    var paramCount = ctor.GetParameters().Length;
-                    var invoker = ReflectionCache.GetInvoker(ctor);
-
-                    if (args.Length < paramCount)
-                    {
-                        var paddedArgs = new object?[paramCount];
-                        Array.Copy(args, paddedArgs, args.Length);
-                        return invoker.Invoke(null, new Span<object?>(paddedArgs));
-                    }
-                    
-                    // Invoker for constructor handles "obj" as null (for static ctors) or unused?
-                    // Actually for ConstructorInfo, invoker.Invoke returns the new instance
-                    return invoker.Invoke(null, new Span<object?>(args));
-                }
-                return Activator.CreateInstance(type);
-            }
-            catch
-            {
-                return null;
-            }
-        }
-        return null;
-    }
-
-    #endregion
 }

--- a/Compilation/RuntimeTypes.Utilities.cs
+++ b/Compilation/RuntimeTypes.Utilities.cs
@@ -167,8 +167,14 @@ public static partial class RuntimeTypes
         }
         else
         {
-            // Try reflection for other function types
-            var invokeMethod = disposeMethod.GetType().GetMethod("Invoke", [typeof(object?[])]);
+            // Compiled output and third-party managed callables remain
+            // open-world under CoreCLR. The boundary rejects Native AOT
+            // before inspecting an arbitrary runtime type.
+            var invokeMethod = ManagedOutputRuntimeReflection.GetMethodBySignature(
+                disposeMethod.GetType(),
+                "Invoke",
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance,
+                [typeof(object?[])]);
             invokeMethod?.Invoke(disposeMethod, [Array.Empty<object?>()]);
         }
     }

--- a/Compilation/RuntimeTypes.cs
+++ b/Compilation/RuntimeTypes.cs
@@ -152,7 +152,6 @@ public class TSFunction
 public static partial class RuntimeTypes
 {
     private static readonly System.Random _random = System.Random.Shared;
-    private static readonly Dictionary<string, Type> _compiledTypes = [];
 
     // Symbol-keyed property storage: object -> (symbol -> value)
     private static readonly ConditionalWeakTable<object, Dictionary<object, object?>> _symbolStorage = new();

--- a/Compilation/UnionTypeGenerator.cs
+++ b/Compilation/UnionTypeGenerator.cs
@@ -41,7 +41,8 @@ public class UnionTypeGenerator
 
     /// <summary>
     /// Gets the implicit conversion method from a source type to a union type.
-    /// Returns the MethodBuilder if not yet finalized, or the finalized MethodInfo.
+    /// The MethodBuilder remains valid after its declaring union is finalized,
+    /// so conversion metadata is always served from the generation-time map.
     /// </summary>
     public MethodInfo? GetImplicitConversion(Type unionType, Type fromType)
     {
@@ -50,14 +51,6 @@ public class UnionTypeGenerator
         // Check if we have a stored MethodBuilder for this conversion
         if (_implicitConversions.TryGetValue((key, fromType), out var methodBuilder))
             return methodBuilder;
-
-        // If finalized, try reflection
-        if (_finalizedUnions.TryGetValue(key, out var finalized))
-        {
-            return finalized.GetMethod("op_Implicit",
-                BindingFlags.Public | BindingFlags.Static,
-                null, [fromType], null);
-        }
 
         return null;
     }

--- a/SharpTS.Tests/Compilation/RuntimeTypesReflectionBoundaryTests.cs
+++ b/SharpTS.Tests/Compilation/RuntimeTypesReflectionBoundaryTests.cs
@@ -1,0 +1,34 @@
+using SharpTS.Compilation;
+using Xunit;
+
+namespace SharpTS.Tests.Compilation;
+
+public sealed class RuntimeTypesReflectionBoundaryTests
+{
+    private sealed class TSSymbol;
+
+    private sealed class ManagedCallable
+    {
+        public bool WasInvoked { get; private set; }
+
+        public object? Invoke(object?[] args)
+        {
+            Assert.Empty(args);
+            WasInvoked = true;
+            return null;
+        }
+    }
+
+    [Fact]
+    public void DisposeResource_PreservesOpenWorldManagedCallableSupport()
+    {
+        var resource = new object();
+        var disposeSymbol = new TSSymbol();
+        var callable = new ManagedCallable();
+
+        RuntimeTypes.SetIndex(resource, disposeSymbol, callable);
+        RuntimeTypes.DisposeResource(resource, disposeSymbol);
+
+        Assert.True(callable.WasInvoked);
+    }
+}

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -163,7 +163,10 @@ Plan against these numbers, not the originals:
   counts; the checked-in inventory is now empty, so any new project analyzer
   warning fails the ratchet. Replacing the reflection-built AST guard catalog
   with a reflection-free public catalog then removed 47 post-link ILC warning
-  lines and reduced the image another 1,024 bytes to 93,374,976 bytes.
+  lines and reduced the image another 1,024 bytes to 93,374,976 bytes. The
+  final nine project-owned ILC warnings were then eliminated without new
+  suppressions; the win-arm64 image fell another 8,192 bytes to 93,366,784
+  bytes.
 - **Ship the managed SKU:** `dotnet publish -r <rid> --self-contained
   -p:PublishSingleFile=true`. Prerequisite (~30 min): confirm embedded
   resources (stdlib modules, `lib.*.d.ts`) load under single-file extraction.
@@ -215,12 +218,12 @@ diagnostics; those are not silently represented by this source-analyzer
 baseline and must continue to be evaluated through the native publish/smoke
 gate.
 
-### Native publish inventory (25 on linux-x64)
+### Native publish inventory (16 on linux-x64)
 
 The SDK analyzer ratchet runs before linking, so it cannot see warnings
 introduced by ILC reachability or by the final dependency closure. The
-linux-x64 Native publish currently reports 25 warning lines: nine owned by
-SharpTS and 16 from the framework or package dependencies.
+linux-x64 Native publish now reports 16 warning lines, all from the framework
+or package dependencies. The project-owned inventory is empty.
 
 CI parses the publish log with `scripts/aot-publish-warning-report.ps1`.
 `.github/aot-publish-warning-baseline.json` exact-matches the SharpTS-owned
@@ -235,14 +238,20 @@ require exact declaration-order equality, preserving the automatic
 exhaustiveness guard without shipping that reflection in the Native compiler.
 This removed 47 repeated IL3050 lines without suppressions.
 
-The remaining project cleanup is bounded to nine warnings: six closed
-crypto-emitter metadata lookups, the legacy `RuntimeTypes` construction
-fallback, resource-disposal callable dispatch, and the finalized-union
-conversion lookup. Re-measure after those before considering dependency
-replacement or isolation. The 16 external lines currently come from the
-NuGet/Newtonsoft packaging closure, MetadataLoadContext, PrettyPrompt/TextCopy,
-and framework summaries. Zero external warnings is not a correctness
-requirement.
+The final project cleanup removed nine warning lines. Crypto emitters now keep
+exact `MethodInfo` values for the closed BCL `HashData` overloads and
+`IsSupported` getters instead of reflecting across algorithm `Type` values.
+The unwritten `RuntimeTypes` construction registry and its unreachable
+constructor fallback were deleted. Open-world resource-disposal callables use
+the existing managed-output reflection boundary, preserving third-party
+CoreCLR support while rejecting Native AOT before arbitrary type inspection.
+Finalized union conversions continue to use the generation-time
+`MethodBuilder` map, which remains valid after `CreateType`, so their
+unreachable reflective fallback was removed.
+
+The 16 external lines currently come from the NuGet/Newtonsoft packaging
+closure, MetadataLoadContext, PrettyPrompt/TextCopy, and framework summaries.
+Zero external warnings is not a correctness requirement.
 
 The work is split at four ownership boundaries:
 


### PR DESCRIPTION
## Summary

- replace open-ended crypto Type lookups with exact MethodInfo roots for the closed BCL HashData and IsSupported members
- remove the unwritten RuntimeTypes construction registry and its unreachable constructor fallback
- keep open-world resource disposal callable support under CoreCLR through the existing managed-output reflection boundary, with a focused third-party-shaped regression test
- remove the unreachable finalized-union reflection fallback and continue using the generation-time MethodBuilder map
- ratchet the Linux Native publish inventory from 25 to 16 total warnings and from 9 to 0 project-owned warnings

## Validation

- source AOT/trim/single-file analyzer inventory: 0 project warnings
- focused crypto, WebCrypto, using, and union tests: 95 passed
- managed-output disposal boundary regression: 1 passed
- full pre-existing managed suite: 16,269 passed
- win-arm64 Native publish: 0 project warnings; 18 external informational warnings
- native smoke probes: interpreted 42; compiled 42; features 2 2 33
- native crypto compile/run: getHashes includes sha256 and SHA-256 abc digest matches the standard vector
- win-arm64 Native image: 93,366,784 bytes, 8,192 bytes smaller than merged main

Linux CI is authoritative for the checked-in 16-warning external inventory. No new warning suppressions are added.