### PR TITLE
Harden the Examples corpus for Native AOT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,15 @@ jobs:
           "$scratch/modules" > "$scratch/bundled.txt"
           diff -u "$scratch/interpreted.txt" "$scratch/bundled.txt"
 
+      - name: Drive Examples corpus from the native host
+        shell: pwsh
+        run: |
+          ./Examples/test-examples.ps1 `
+            -SharpTSExe "$PWD/artifacts/native-aot/SharpTS" `
+            -NativeSku `
+            -Mode all `
+            -OutputFormat table
+
       - name: Upload Native AOT publish diagnostics
         if: always()
         uses: actions/upload-artifact@v4

--- a/Examples/test-examples.ps1
+++ b/Examples/test-examples.ps1
@@ -26,6 +26,10 @@
     set, the repo build step is skipped and every interpret/compile invocation runs
     through this binary.
 
+.PARAMETER NativeSku
+    Marks SharpTSExe as the Native AOT SKU. Examples that intentionally require
+    managed-only features such as dynamic .NET interop are skipped.
+
 .EXAMPLE
     .\test-examples.ps1
     Run all tests with default settings
@@ -39,7 +43,7 @@
     Test only interpreted mode and output JSON
 
 .EXAMPLE
-    .\test-examples.ps1 -SharpTSExe ..\publish\sharpts.exe
+    .\test-examples.ps1 -SharpTSExe ..\publish\sharpts.exe -NativeSku
     Drive a published binary over the full corpus (the native-SKU smoke job's entry point)
 #>
 
@@ -50,7 +54,8 @@ param(
     [ValidateSet("json", "table", "verbose")]
     [string]$OutputFormat = "table",
     [switch]$SkipCleanup,
-    [string]$SharpTSExe = ""
+    [string]$SharpTSExe = "",
+    [switch]$NativeSku
 )
 
 $ErrorActionPreference = "Stop"
@@ -61,6 +66,10 @@ if ($SharpTSExe) {
         exit 1
     }
     $SharpTSExe = (Resolve-Path $SharpTSExe).Path
+}
+elseif ($NativeSku) {
+    Write-Host "NativeSku requires SharpTSExe." -ForegroundColor Red
+    exit 1
 }
 
 # ========== Configuration ==========
@@ -381,12 +390,13 @@ const arrow = () => 42;
 
     "dotnet-types" = @{
         File = "dotnet-types.ts"
+        ManagedOnly = $true
         Tests = @(
             @{
                 Name = "DemonstrateDotNetInterop"
                 RequiresArgs = $false
                 Args = { @() }
-                # Runs clean in both modes. Overload dispatch (#51), delegate
+                # Runs clean in every managed mode. Overload dispatch (#51), delegate
                 # wrapping (#52), and event subscription (#53) all fixed;
                 # compiled DLLs are fully standalone (no SharpTS.dll needed).
                 Assertions = @(
@@ -767,10 +777,10 @@ function Invoke-AllTests {
             TestCases = @()
         }
 
-        # Example-level skip check (e.g., "npm install not run yet")
-        $exampleSkip = $false
-        $exampleSkipReason = $null
-        if ($example.Setup -and $example.SkipIf) {
+        # Example-level skip check (e.g., managed-only feature or npm install not run yet)
+        $exampleSkip = $NativeSku -and $example.ManagedOnly
+        $exampleSkipReason = if ($exampleSkip) { "requires the managed SharpTS SKU" } else { $null }
+        if (-not $exampleSkip -and $example.Setup -and $example.SkipIf) {
             $setupCtx = & $example.Setup
             if (& $example.SkipIf $setupCtx) {
                 $exampleSkip = $true
@@ -1003,7 +1013,8 @@ try {
         $buildResult = Invoke-ProcessWithTimeout -FilePath "dotnet" -Arguments @("build", "-c", "Debug") -Timeout $Script:BuildTimeout
         if (-not $buildResult.Success) {
             Write-Host "Build failed:" -ForegroundColor Red
-            Write-Host $buildResult.Error
+            if ($buildResult.Output) { Write-Host $buildResult.Output }
+            if ($buildResult.Error) { Write-Host $buildResult.Error }
             exit 1
         }
         Write-Host "Build completed." -ForegroundColor Green

--- a/SharpTS.Tests/TypeCheckerTests/OverloadResolutionTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/OverloadResolutionTests.cs
@@ -72,6 +72,35 @@ public class OverloadResolutionTests
 
     #endregion
 
+    #region Overload Scope Isolation
+
+    [Fact]
+    public void ModuleFunctions_DoNotConsumeSameNamedGlobalAmbientOverloads()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                export function open(path: string): void {
+                    console.log(path);
+                }
+
+                export function close(fd: number, callback: () => void): void {
+                    console.log(fd);
+                    callback();
+                }
+
+                open("file.txt");
+                close(42, () => console.log("closed"));
+                """,
+        };
+
+        var result = TestHarness.RunModulesInterpreted(files, "main.ts");
+
+        Assert.Equal("file.txt\n42\nclosed\n", result);
+    }
+
+    #endregion
+
     #region Most Specific Overload Selection
 
     [Fact]

--- a/TypeSystem/TypeChecker.Statements.Functions.cs
+++ b/TypeSystem/TypeChecker.Statements.Functions.cs
@@ -106,7 +106,8 @@ public partial class TypeChecker
         // each call site, so a call preceding the declaration types precisely instead of `any`.
         if (funcStmt.ReturnType != null || funcStmt.Body == null) return;
         string funcName = funcStmt.Name.Lexeme;
-        if (_pendingOverloadSignatures.ContainsKey(funcName)) return;
+        var overloadKey = (_environment, funcName);
+        if (_pendingOverloadSignatures.ContainsKey(overloadKey)) return;
         if (!_environment.IsDefinedLocally(funcName)) return;
 
         // Recognize our hoisted `any`-return placeholder: a non-generic function hoists as a plain
@@ -570,22 +571,23 @@ public partial class TypeChecker
         }
 
         var thisFuncType = new TypeInfo.Function(paramTypes, funcReturnType, requiredParams, hasRest, thisType, paramNames);
+        var overloadKey = (_environment, funcName);
 
         // Check if this is an overload signature (no body)
         if (funcStmt.Body == null)
         {
             // This is an overload signature - save for later
-            if (!_pendingOverloadSignatures.TryGetValue(funcName, out var signatures))
+            if (!_pendingOverloadSignatures.TryGetValue(overloadKey, out var signatures))
             {
                 signatures = [];
-                _pendingOverloadSignatures[funcName] = signatures;
+                _pendingOverloadSignatures[overloadKey] = signatures;
             }
             signatures.Add(thisFuncType);
 
             // Also save type parameters if this is a generic overload
             if (typeParams != null && typeParams.Count > 0)
             {
-                _pendingOverloadTypeParams[funcName] = typeParams;
+                _pendingOverloadTypeParams[overloadKey] = typeParams;
             }
 
             // Ambient (`declare function`): there is no implementation to come — the declaration
@@ -611,7 +613,7 @@ public partial class TypeChecker
         TypeInfo funcType;
 
         // Check if there are pending overload signatures for this function
-        if (_pendingOverloadSignatures.TryGetValue(funcName, out var pendingSignatures))
+        if (_pendingOverloadSignatures.TryGetValue(overloadKey, out var pendingSignatures))
         {
             // Validate implementation is compatible with all signatures
             foreach (var sig in pendingSignatures)
@@ -623,11 +625,11 @@ public partial class TypeChecker
             }
 
             // Check if we have type parameters (generic overloaded function)
-            if (_pendingOverloadTypeParams.TryGetValue(funcName, out var overloadTypeParams))
+            if (_pendingOverloadTypeParams.TryGetValue(overloadKey, out var overloadTypeParams))
             {
                 // Create generic overloaded function type
                 funcType = new TypeInfo.GenericOverloadedFunction(overloadTypeParams, pendingSignatures, thisFuncType);
-                _pendingOverloadTypeParams.Remove(funcName);
+                _pendingOverloadTypeParams.Remove(overloadKey);
             }
             else
             {
@@ -636,7 +638,7 @@ public partial class TypeChecker
             }
 
             // Clear pending signatures
-            _pendingOverloadSignatures.Remove(funcName);
+            _pendingOverloadSignatures.Remove(overloadKey);
         }
         else if (typeParams != null && typeParams.Count > 0)
         {

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -1038,11 +1038,12 @@ public partial class TypeChecker
 
     private readonly Dictionary<string, ActiveLabel> _activeLabels = [];
 
-    // Track pending overload signatures for top-level functions
-    private readonly Dictionary<string, List<TypeInfo.Function>> _pendingOverloadSignatures = [];
+    // Track pending overload signatures per lexical environment. Function names can repeat
+    // independently in the global scope, modules, and nested scopes.
+    private readonly Dictionary<(TypeEnvironment Environment, string Name), List<TypeInfo.Function>> _pendingOverloadSignatures = [];
 
     // Track type parameters for generic overloaded functions
-    private readonly Dictionary<string, List<TypeInfo.TypeParameter>> _pendingOverloadTypeParams = [];
+    private readonly Dictionary<(TypeEnvironment Environment, string Name), List<TypeInfo.TypeParameter>> _pendingOverloadTypeParams = [];
 
     // Decorator mode configuration
     private DecoratorMode _decoratorMode = DecoratorMode.None;

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -338,6 +338,11 @@ out of scope.
 ### The gate — passed
 
 `-SharpTSExe` was added to `Examples/test-examples.ps1` in Phase 1.
+`-NativeSku` now excludes only examples that deliberately exercise a
+Managed-SKU-only feature. The broader corpus is a permanent CI gate over all
+three paths: interpreted TypeScript, compiled DLL, and bundled executable.
+The local win-x64 baseline is 22 passed / 0 failed in each path; the two
+intentional skips are dynamic .NET interop and the uninstalled npm fixture.
 
 Results from the win-arm64 native probe, now preserved by the
 `native-aot-compile-smoke` linux-x64 CI job:
@@ -441,8 +446,8 @@ workers, MSBuild SDK (subprocess-only by design, verified), JSX.
   (`TestHarness.cs:357,610,959,1023`; `Test262Runner.cs:538,543`) — **they can
   never run AOT; keep them managed forever.**
 - The native SKU is gated by a subprocess smoke job: publish native, drive
-  `Examples/test-examples.ps1 -SharpTSExe <native>` over interpret + compile
-  modes, assert compiled DLLs run correctly under JIT.
+  `Examples/test-examples.ps1 -SharpTSExe <native> -NativeSku` over interpret,
+  compiled-DLL, and bundled-executable modes, and assert outputs in each path.
 - PE-Packer adds: an `IReferenceAssemblyIndex` fixture (no filesystem),
   runtimeconfig version/rollForward assertions, and its own native smoke job.
   Note its `MetadataRoundTripTests.cs:400` passes

--- a/stdlib/node/fs.ts
+++ b/stdlib/node/fs.ts
@@ -297,13 +297,17 @@ export function readdirSync(path: string, options?: any): any {
 const __S_IFMT = 0xf000, __S_IFREG = 0x8000, __S_IFDIR = 0x4000, __S_IFLNK = 0xa000,
     __S_IFBLK = 0x6000, __S_IFCHR = 0x2000, __S_IFIFO = 0x1000, __S_IFSOCK = 0xc000;
 
+function __trunc(x: number): number {
+    return x < 0 ? Math.ceil(x) : Math.floor(x);
+}
+
 class Stats {
     dev: any; ino: any; mode: any; nlink: any; uid: any; gid: any; rdev: any;
     size: any; blksize: any; blocks: any;
     atimeMs: any; mtimeMs: any; ctimeMs: any; birthtimeMs: any;
     atime: any; mtime: any; ctime: any; birthtime: any;
     constructor(r: any, big: boolean) {
-        const n = (x: number): any => big ? BigInt(Math.trunc(x)) : x;
+        const n = (x: number): any => big ? BigInt(__trunc(x)) : x;
         this.dev = n(r.dev); this.ino = n(r.ino); this.mode = n(r.mode);
         this.nlink = n(r.nlink); this.uid = n(r.uid); this.gid = n(r.gid); this.rdev = n(r.rdev);
         this.size = n(r.size); this.blksize = n(r.blksize); this.blocks = n(r.blocks);
@@ -312,10 +316,10 @@ class Stats {
         this.atime = new Date(r.atimeMs); this.mtime = new Date(r.mtimeMs);
         this.ctime = new Date(r.ctimeMs); this.birthtime = new Date(r.birthtimeMs);
         if (big) {
-            (this as any).atimeNs = BigInt(Math.trunc(r.atimeMs)) * 1000000n;
-            (this as any).mtimeNs = BigInt(Math.trunc(r.mtimeMs)) * 1000000n;
-            (this as any).ctimeNs = BigInt(Math.trunc(r.ctimeMs)) * 1000000n;
-            (this as any).birthtimeNs = BigInt(Math.trunc(r.birthtimeMs)) * 1000000n;
+            (this as any).atimeNs = BigInt(__trunc(r.atimeMs)) * 1000000n;
+            (this as any).mtimeNs = BigInt(__trunc(r.mtimeMs)) * 1000000n;
+            (this as any).ctimeNs = BigInt(__trunc(r.ctimeMs)) * 1000000n;
+            (this as any).birthtimeNs = BigInt(__trunc(r.birthtimeMs)) * 1000000n;
         }
     }
     isFile(): boolean { return (Number(this.mode) & __S_IFMT) === __S_IFREG; }
@@ -529,7 +533,7 @@ export function writevSync(fd: number, buffers: any[], position?: any): number {
 function __shapeStatfs(raw: any, options: any): any {
     const big = typeof options === 'object' && options !== null && !!options.bigint;
     if (!big) return raw;
-    const b = (x: number): any => BigInt(Math.trunc(x));
+    const b = (x: number): any => BigInt(__trunc(x));
     return {
         type: b(raw.type), bsize: b(raw.bsize), blocks: b(raw.blocks), bfree: b(raw.bfree),
         bavail: b(raw.bavail), files: b(raw.files), ffree: b(raw.ffree),
@@ -543,7 +547,7 @@ export function statfsSync(path: string, options?: any): any { return __shapeSta
 // `**` across segments. Matching walks the directory tree under cwd. ---
 
 /** Compiles one glob path-segment (`*`/`?`/literals) to an anchored RegExp. */
-function __globSegRegex(seg: string): RegExp {
+function __globSegRegex(seg: string): any {
     let re = '^';
     for (const ch of seg) {
         if (ch === '*') re += '[^/]*';

--- a/stdlib/node/url.ts
+++ b/stdlib/node/url.ts
@@ -1241,10 +1241,11 @@ export class URL {
 
     get searchParams(): URLSearchParams {
         if (this._searchParams == null) {
-            this._searchParams = new URLSearchParams(this._record.query || '');
-            (this._searchParams as any)._owner = this;
+            const params = new URLSearchParams(this._record.query || '');
+            this._searchParams = params;
+            (params as any)._owner = this;
         }
-        return this._searchParams;
+        return this._searchParams as any;
     }
 
     get hash(): string {


### PR DESCRIPTION
Advances #1324 by promoting the broader Examples corpus from an exploratory check to a permanent Native AOT gate.

## Changes
- Scope pending function overloads by lexical environment, preventing global DOM declarations from leaking into same-named module functions.
- Repair the fs and url stdlib typing issues exposed by the corpus.
- Add an explicit NativeSku harness mode that skips only Managed-SKU-only examples.
- Run interpreted, compiled-DLL, and bundled-executable Examples paths in Native AOT CI.
- Preserve full dynamic .NET and third-party assembly support in the Managed SKU.

## Validation
- dotnet test: 16,271 passed
- Managed Examples: 23 passed, 0 failed, 1 npm skip in interpreted and DLL modes
- Native win-x64 Examples: 22 passed, 0 failed, 2 intentional skips in interpreted, DLL, and executable modes
- Native AOT publish: 0 SharpTS-owned warnings