### PR TITLE
Harden the Native AOT release path from the #1324 review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,15 +136,14 @@ jobs:
             -p:DebugSymbols=false \
             -o artifacts/managed-runtime
 
+      # TrimMode/IlcTrimMetadata/IlcGenerateCompleteTypeMetadata/StackTraceSupport
+      # are owned by SharpTS.csproj behind PublishAot=true so local publishes get
+      # the same mandatory configuration as CI.
       - name: Publish Native AOT SharpTS
         run: |
           set -o pipefail
           dotnet publish SharpTS.csproj --configuration Release -r linux-x64 \
             -p:PublishAot=true \
-            -p:TrimMode=partial \
-            -p:IlcTrimMetadata=false \
-            -p:IlcGenerateCompleteTypeMetadata=true \
-            -p:StackTraceSupport=true \
             -p:DebugType=None \
             -p:DebugSymbols=false \
             -p:SharpTSManagedRuntimePayloadPath="$PWD/artifacts/managed-runtime/SharpTS.dll" \
@@ -180,12 +179,15 @@ jobs:
           dotnet "$scratch/modules.dll" > "$scratch/modules.txt"
           diff -u "$scratch/interpreted.txt" "$scratch/modules.txt"
 
-          # Accessors + sync/async generators exercise raw custom-attribute blobs,
-          # TypeBuilderInstantiation and MethodBuilderInstantiation.
+          # Accessors + sync/async generators exercise raw custom-attribute blobs
+          # and MethodBuilderInstantiation (async builder Start<TStateMachine>).
+          # The generic class/array/Promise<UserClass> section closes runtime open
+          # generics over TypeBuilder args, forcing the TypeBuilderInstantiation
+          # fallback — without it, only the async path's fallback ever executes.
           "$native" --compile Examples/AotCompileGate/features.ts --ref-asm \
             -o "$scratch/features.dll"
           dotnet "$scratch/features.dll" > "$scratch/features.txt"
-          grep -qx '2 2 33' "$scratch/features.txt"
+          grep -qx '2 2 33 7 11' "$scratch/features.txt"
 
           # Known CLR attribute mappings use closed constructor metadata and remain
           # available in the native compiler; only arbitrary @attribute("Type")
@@ -268,6 +270,9 @@ jobs:
           "$scratch/modules" > "$scratch/bundled.txt"
           diff -u "$scratch/interpreted.txt" "$scratch/bundled.txt"
 
+      # MinimumExecuted: the corpus currently executes ~22 cases per path × 3
+      # paths; 50 fails the job if a whole path (or most of the corpus) starts
+      # silently skipping, while leaving headroom for deliberate corpus edits.
       - name: Drive Examples corpus from the native host
         shell: pwsh
         run: |
@@ -275,6 +280,7 @@ jobs:
             -SharpTSExe "$PWD/artifacts/native-aot/SharpTS" `
             -NativeSku `
             -Mode all `
+            -MinimumExecuted 50 `
             -OutputFormat table
 
       - name: Upload Native AOT publish diagnostics

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,13 @@ jobs:
       # carries the tag — every known load-flake was fixed at the product level
       # (#1211/#1212/#1213) — but any future inherently-timing-dependent test gets
       # [Trait("Category","LoadSensitive")] and is excluded here automatically.
+      #
+      # Category!=npm excludes tests that run a real `npm install` against
+      # registry.npmjs.org (RealPackageSmokeTests) — same hermeticity policy as
+      # LiveNetwork; the host-literal guardrail can't see package-name installs.
+      # Run them on demand locally: dotnet test --filter "Category=npm"
       - name: Test
-        run: dotnet test --no-build --configuration Release --verbosity normal --filter "Category!=LiveNetwork&Category!=LoadSensitive"
+        run: dotnet test --no-build --configuration Release --verbosity normal --filter "Category!=LiveNetwork&Category!=LoadSensitive&Category!=npm"
         timeout-minutes: 10
 
   # AOT-compatibility ratchet (#1324 Track 0). Builds SharpTS.csproj with the

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,11 +51,12 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --configuration Release
 
-      # Same exclusion as ci.yml: LiveNetwork tests make real outbound DNS/HTTP
-      # calls and can false-red on runner network hiccups — which here would block
-      # a tagged release after build but before pack/push.
+      # Same exclusions as ci.yml: LiveNetwork tests make real outbound DNS/HTTP
+      # calls and npm tests run a real `npm install`; both can false-red on runner
+      # network hiccups — which here would block a tagged release after build but
+      # before pack/push.
       - name: Test
-        run: dotnet test --no-build --configuration Release --verbosity normal --filter "Category!=LiveNetwork&Category!=LoadSensitive"
+        run: dotnet test --no-build --configuration Release --verbosity normal --filter "Category!=LiveNetwork&Category!=LoadSensitive&Category!=npm"
 
       - name: Publish SharpTS for SDK bundling
         run: dotnet publish SharpTS.csproj --configuration Release --no-build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,30 @@
 name: Publish to NuGet
 
+# Ordering is the release gate: build/pack runs first, then every managed and
+# native artifact is published and smoke-tested, and only when all of them
+# succeed does the final `release` job push to NuGet and create the GitHub
+# Release with all twelve archives attached. A failing RID therefore blocks the
+# release instead of leaving a silently missing asset behind an already-public
+# package.
+#
+# workflow_dispatch is the dry-run mode: it exercises the full matrix (including
+# the six native RIDs and their runner labels) without publishing anything —
+# run it before the first real tag, and after runner-label or matrix changes.
 on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
+
+    outputs:
+      version: ${{ steps.version.outputs.VERSION }}
 
     steps:
       - uses: actions/checkout@v4
@@ -20,9 +34,16 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      - name: Extract version from tag
+      # Tag pushes release the tag's version; dispatch dry runs stamp a version
+      # that can never be mistaken for (or collide with) a real release.
+      - name: Determine version
         id: version
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "VERSION=0.0.0-dryrun.${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Restore dependencies
         run: dotnet restore
@@ -58,14 +79,12 @@ jobs:
           test -f "./nupkg/SharpTS.LanguageServer.${{ steps.version.outputs.VERSION }}.nupkg" || { echo "❌ SharpTS.LanguageServer package not found"; exit 1; }
           echo "✓ All packages created successfully"
 
-      - name: Push to NuGet
-        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v4
         with:
-          generate_release_notes: true
-          files: ./nupkg/*
+          name: nupkg
+          path: ./nupkg/*.nupkg
+          if-no-files-found: error
 
   # Managed SKU (#1324 Track 0): self-contained single-file binaries per RID,
   # attached to the GitHub Release. No .NET install required on the target
@@ -74,26 +93,26 @@ jobs:
   # installed .NET until Phase 1 moves it to Environment.ProcessPath.
   #
   # Runner selection: self-contained *managed* publishing is cross-RID capable,
-  # so everything could build on ubuntu — win-x64 gets a windows runner (and
-  # linux-x64 stays native on ubuntu) purely so the two most common RIDs are
-  # smoke-tested against the actual published binary before upload. macOS
+  # but four RIDs run on their own architecture so the published binary is
+  # executed before release (win/linux on x64 and arm64 runners). macOS
   # binaries are cross-published (macOS runner minutes bill at 10x); the SDK
   # ad-hoc-signs single-file Mach-O bundles during publish, but if Gatekeeper
   # still rejects a downloaded binary, `codesign -s - sharpts` re-signs it.
   binaries:
     name: Managed SKU (${{ matrix.rid }})
-    needs: publish
+    needs: build
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { rid: win-x64,     os: windows-latest, smoke: true }
-          - { rid: win-arm64,   os: ubuntu-latest,  smoke: false }
-          - { rid: linux-x64,   os: ubuntu-latest,  smoke: true }
-          - { rid: linux-arm64, os: ubuntu-latest,  smoke: false }
-          - { rid: osx-x64,     os: ubuntu-latest,  smoke: false }
-          - { rid: osx-arm64,   os: ubuntu-latest,  smoke: false }
+          - { rid: win-x64,     os: windows-latest,           smoke: true }
+          - { rid: win-arm64,   os: windows-11-vs2026-arm,    smoke: true }
+          - { rid: linux-x64,   os: ubuntu-latest,            smoke: true }
+          - { rid: linux-arm64, os: ubuntu-24.04-arm,         smoke: true }
+          - { rid: osx-x64,     os: ubuntu-latest,            smoke: false }
+          - { rid: osx-arm64,   os: ubuntu-latest,            smoke: false }
 
     steps:
       - uses: actions/checkout@v4
@@ -102,11 +121,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.0.x
-
-      - name: Extract version from tag
-        id: version
-        shell: bash
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
 
       # IncludeAllContentForSelfExtract (not just native libs): several managed-SKU
       # features need real files on disk behind Assembly.Location — --verify
@@ -130,7 +144,7 @@ jobs:
             -p:PublishSingleFile=true \
             -p:IncludeAllContentForSelfExtract=true \
             -p:PlatformTarget=AnyCPU \
-            -p:Version=${{ steps.version.outputs.VERSION }} \
+            -p:Version=${{ needs.build.outputs.version }} \
             -o ./sku/${{ matrix.rid }}
 
       # Embedded-resource smoke: the interpreter and compiler both depend on
@@ -173,14 +187,14 @@ jobs:
       - name: Package archive
         shell: bash
         run: |
-          VERSION=${{ steps.version.outputs.VERSION }}
+          VERSION=${{ needs.build.outputs.version }}
           RID=${{ matrix.rid }}
           mkdir staging
           cp LICENSE README.md staging/
           case "$RID" in
             win-*)
               cp ./sku/$RID/SharpTS.exe staging/sharpts.exe
-              # zip on ubuntu runners (win-arm64 cross-publish), 7z on windows.
+              # zip on ubuntu runners (cross-publish), 7z on windows.
               if command -v zip >/dev/null 2>&1; then
                 (cd staging && zip -r ../sharpts-$VERSION-$RID.zip .)
               else
@@ -194,11 +208,12 @@ jobs:
               ;;
           esac
 
-      - name: Upload to GitHub Release
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "$GITHUB_REF_NAME" sharpts-${{ steps.version.outputs.VERSION }}-${{ matrix.rid }}.* --clobber
+      - name: Upload archive artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: managed-${{ matrix.rid }}
+          path: sharpts-${{ needs.build.outputs.version }}-${{ matrix.rid }}.*
+          if-no-files-found: error
 
   # Native SKU (#1324 Phase 3): a true Native AOT compiler/interpreter for the
   # frozen straight-TypeScript surface. Each RID runs on its own architecture so
@@ -207,7 +222,7 @@ jobs:
   # worker soft dependencies; compiled output still runs under CoreCLR.
   native-binaries:
     name: Native SKU (${{ matrix.rid }})
-    needs: publish
+    needs: build
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -229,11 +244,6 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      - name: Extract version from tag
-        id: version
-        shell: bash
-        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
       - name: Install Native AOT prerequisites
         if: startsWith(matrix.rid, 'linux-')
         shell: bash
@@ -249,24 +259,36 @@ jobs:
             -p:PlatformTarget=AnyCPU \
             -p:DebugType=None \
             -p:DebugSymbols=false \
-            -p:Version=${{ steps.version.outputs.VERSION }} \
+            -p:Version=${{ needs.build.outputs.version }} \
             -o ./sku/managed-runtime
 
+      # The mandatory Native AOT metadata properties (TrimMode, IlcTrimMetadata,
+      # IlcGenerateCompleteTypeMetadata, StackTraceSupport) live in SharpTS.csproj
+      # behind PublishAot=true — a local `dotnet publish -p:PublishAot=true` gets
+      # the same working configuration as CI.
       - name: Publish Native AOT binary
         shell: bash
         run: |
+          set -o pipefail
           dotnet publish SharpTS.csproj --configuration Release \
             -r ${{ matrix.rid }} \
             -p:PublishAot=true \
-            -p:TrimMode=partial \
-            -p:IlcTrimMetadata=false \
-            -p:IlcGenerateCompleteTypeMetadata=true \
-            -p:StackTraceSupport=true \
             -p:DebugType=None \
             -p:DebugSymbols=false \
-            -p:Version=${{ steps.version.outputs.VERSION }} \
+            -p:Version=${{ needs.build.outputs.version }} \
             -p:SharpTSManagedRuntimePayloadPath="$PWD/sku/managed-runtime/SharpTS.dll" \
-            -o ./sku/${{ matrix.rid }}
+            -o ./sku/${{ matrix.rid }} 2>&1 | tee native-publish-${{ matrix.rid }}.log
+
+      # ILC closures differ per RID; a SharpTS-owned warning that only appears on
+      # one platform must fail that platform's release job, not ship silently.
+      # External diagnostics remain informational exactly as in ci.yml.
+      - name: Enforce Native AOT publish warning inventory
+        shell: pwsh
+        run: |
+          ./scripts/aot-publish-warning-report.ps1 `
+            -LogPath native-publish-${{ matrix.rid }}.log `
+            -SummaryPath native-publish-warning-summary-${{ matrix.rid }}.json `
+            -EnforceBaseline
 
       - name: Smoke test native binary
         shell: bash
@@ -277,8 +299,10 @@ jobs:
           [ -f "$native.exe" ] && native="$native.exe"
           scratch="$(mktemp -d)"
 
-          # Interpreter + embedded stdlib/lib.d.ts resources.
-          "$native" Examples/AotCompileGate/main.ts > "$scratch/interpreted.txt"
+          # Interpreter + embedded stdlib/lib.d.ts resources. tr -d '\r':
+          # Windows console output is CRLF, which breaks grep -qx exact-line
+          # matches and would make every capture differ from the POSIX RIDs.
+          "$native" Examples/AotCompileGate/main.ts | tr -d '\r' > "$scratch/interpreted.txt"
           grep -qx '42' "$scratch/interpreted.txt"
 
           # An empty DOTNET_ROOT proves compile-time reference rewriting does not
@@ -286,16 +310,75 @@ jobs:
           empty_dotnet_root="$(mktemp -d)"
           DOTNET_ROOT="$empty_dotnet_root" "$native" --compile \
             Examples/AotCompileGate/main.ts --ref-asm -o "$scratch/modules.dll"
-          dotnet "$scratch/modules.dll" > "$scratch/modules.txt"
+          dotnet "$scratch/modules.dll" | tr -d '\r' > "$scratch/modules.txt"
           diff -u "$scratch/interpreted.txt" "$scratch/modules.txt"
+
+          # Accessors, generators and generic shapes exercise raw custom-attribute
+          # blobs plus the TypeBuilderInstantiation and MethodBuilderInstantiation
+          # emit fallbacks on this RID's ILC closure.
+          "$native" --compile Examples/AotCompileGate/features.ts --ref-asm \
+            -o "$scratch/features.dll"
+          dotnet "$scratch/features.dll" | tr -d '\r' > "$scratch/features.txt"
+          grep -qx '2 2 33 7 11' "$scratch/features.txt"
 
           # Prove the embedded AnyCPU managed runtime is extractable and usable.
           mkdir "$scratch/softdep"
           "$native" --compile Examples/AotCompileGate/softdep.ts --ref-asm \
             -o "$scratch/softdep/softdep.dll"
           test -f "$scratch/softdep/SharpTS.dll"
-          dotnet "$scratch/softdep/softdep.dll" > "$scratch/softdep.txt"
+          dotnet "$scratch/softdep/softdep.dll" | tr -d '\r' > "$scratch/softdep.txt"
           grep -qx '42' "$scratch/softdep.txt"
+
+          # The Managed-SKU-only boundaries must refuse identically on every RID —
+          # same assertions as ci.yml's linux-x64 gate.
+          if "$native" --compile Examples/AotCompileGate/fork.ts \
+              -o "$scratch/fork.dll" 2> "$scratch/fork-error.txt"; then
+            echo "child_process.fork unexpectedly compiled under Native AOT"
+            exit 1
+          fi
+          grep -Fq \
+            'child_process.fork in compiled output is not available in the native SharpTS build' \
+            "$scratch/fork-error.txt"
+          test ! -f "$scratch/fork.dll"
+
+          if "$native" Examples/AotCompileGate/main.ts \
+              -r "$PWD/sku/managed-runtime/SharpTS.dll" \
+              > "$scratch/reference-error.txt" 2>&1; then
+            echo "third-party reference loading unexpectedly ran under Native AOT"
+            exit 1
+          fi
+          grep -Fq \
+            'loading .NET reference assemblies is not available in the native SharpTS build' \
+            "$scratch/reference-error.txt"
+
+          if "$native" Examples/AotCompileGate/dotnet-interop.ts \
+              > "$scratch/dotnet-interop-error.txt" 2>&1; then
+            echo "dynamic .NET interop unexpectedly ran under Native AOT"
+            exit 1
+          fi
+          grep -Fq \
+            '.NET interop is not available in the native SharpTS build' \
+            "$scratch/dotnet-interop-error.txt"
+
+          if "$native" --gen-decl System.String \
+              > "$scratch/gen-decl-error.txt" 2>&1; then
+            echo "declaration discovery unexpectedly ran under Native AOT"
+            exit 1
+          fi
+          grep -Fq -- \
+            '--gen-decl is not available in the native SharpTS build' \
+            "$scratch/gen-decl-error.txt"
+
+          if "$native" --compile Examples/AotCompileGate/main.ts --verify \
+              -o "$scratch/verify.dll" \
+              > "$scratch/verify-error.txt" 2>&1; then
+            echo "IL verification unexpectedly ran under Native AOT"
+            exit 1
+          fi
+          grep -Fq -- \
+            '--verify is not available in the native SharpTS build' \
+            "$scratch/verify-error.txt"
+          test ! -f "$scratch/verify.dll"
 
           case "$rid" in
             osx-*)
@@ -314,7 +397,7 @@ jobs:
                 Examples/AotCompileGate/main.ts -t exe -o "$scratch/bundled"
               [ -f "$scratch/bundled.exe" ] && bundled="$scratch/bundled.exe" \
                 || bundled="$scratch/bundled"
-              "$bundled" > "$scratch/bundled.txt"
+              "$bundled" | tr -d '\r' > "$scratch/bundled.txt"
               diff -u "$scratch/interpreted.txt" "$scratch/bundled.txt"
               ;;
           esac
@@ -322,7 +405,7 @@ jobs:
       - name: Package archive
         shell: bash
         run: |
-          VERSION=${{ steps.version.outputs.VERSION }}
+          VERSION=${{ needs.build.outputs.version }}
           RID=${{ matrix.rid }}
           mkdir staging
           cp LICENSE README.md staging/
@@ -342,8 +425,66 @@ jobs:
               ;;
           esac
 
-      - name: Upload to GitHub Release
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "$GITHUB_REF_NAME" sharpts-native-${{ steps.version.outputs.VERSION }}-${{ matrix.rid }}.* --clobber
+      - name: Upload archive artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.rid }}
+          path: sharpts-native-${{ needs.build.outputs.version }}-${{ matrix.rid }}.*
+          if-no-files-found: error
+
+      - name: Upload publish diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          # Not "native-<rid>": the release job downloads '{managed,native}-*'
+          # as release assets, and diagnostics must not ship in the release.
+          name: diagnostics-native-${{ matrix.rid }}
+          if-no-files-found: ignore
+          path: |
+            native-publish-${{ matrix.rid }}.log
+            native-publish-warning-summary-${{ matrix.rid }}.json
+
+  # Runs only for real tags, and only after every managed and native artifact
+  # has been built and smoke-tested. This is the single publish point: NuGet
+  # push plus the GitHub Release with all archives attached.
+  release:
+    needs: [build, binaries, native-binaries]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Download package artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: nupkg
+          path: ./nupkg
+
+      - name: Download managed archive artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: 'managed-*'
+          path: ./assets
+          merge-multiple: true
+
+      - name: Download native archive artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: 'native-*'
+          path: ./assets
+          merge-multiple: true
+
+      - name: Push to NuGet
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            ./nupkg/*
+            ./assets/*

--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ coverage*.xml
 
 # AI tools
 .claude/
+.codex/
 .agents/
 /.cursor/
 /.cursorrules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,9 +156,14 @@ public record MyNewExpr(Token Operator, Expr Operand) : Expr;
 public record MyNewStmt(Expr Value, Token Keyword) : Stmt;
 ```
 
-A registry (`Parsing/Visitors/NodeRegistry` + `AstNodeCatalog`) derives the
-node set by reflection and fails fast at startup if a visitor misses a node —
-so adding a node immediately tells you every dispatch site to extend.
+Dispatch is reflection-free (a Native AOT requirement): the node universe is
+the explicit, declaration-ordered list in `Parsing/Visitors/AstNodeCatalog.cs`,
+and each phase dispatches through a hand-ordered type switch
+(`AstVisitorBase`, `Interpreter.Dispatch.cs`, `TypeChecker.Dispatch.cs`).
+`SharpTS.Tests/RegistryTests/AstDispatchTests.cs` reflectively re-derives the
+true node set and drives every switch — so adding a node without extending the
+catalog and each dispatch site fails those tests with a message naming exactly
+what to edit.
 
 ### Error Messages
 

--- a/Compilation/CustomAttributeEncoder.cs
+++ b/Compilation/CustomAttributeEncoder.cs
@@ -60,8 +60,17 @@ internal static class CustomAttributeEncoder
 
         if (parameterType == typeof(Type))
         {
-            WriteSerString(w, SerializedTypeName((Type)value!));
+            // A null Type argument serializes as the null SerString (0xFF), like null strings.
+            WriteSerString(w, value is null ? null : SerializedTypeName((Type)value));
             return;
+        }
+
+        if (value is null)
+        {
+            // Value-type fixed args have no null encoding; the unboxing casts below
+            // would NRE with no context. Name the problem instead.
+            throw new ArgumentException(
+                $"CustomAttributeEncoder: null is not a valid fixed-arg value for parameter type '{parameterType}'.");
         }
 
         switch (Type.GetTypeCode(parameterType))

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -1515,7 +1515,7 @@ public partial class ILCompiler
         byte[] image;
         if (rewritingReferences)
         {
-            // PE-Packer 1.0.5 ships the complete net10 CoreLib-to-facade map as a compact
+            // PE-Packer (since 1.0.5) ships the complete net10 CoreLib-to-facade map as a compact
             // embedded index, so the normal path no longer needs an SDK/reference pack on disk.
             // Preserve --sdk-path as an explicit override for callers intentionally targeting a
             // particular reference pack.

--- a/Compilation/TypeProvider.cs
+++ b/Compilation/TypeProvider.cs
@@ -11,11 +11,25 @@ namespace SharpTS.Compilation;
 /// Provides type resolution for IL compilation using runtime types.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Uses typeof() directly for fast compilation. The AssemblyReferenceRewriter (from the
 /// NickNa.PEPacker package) is used as a post-processing step to rewrite System.Private.CoreLib
 /// references to SDK reference assemblies. It runs when --ref-asm is enabled, and also whenever the
 /// emitted assembly references SharpTS regardless of that flag — see the `_useReferenceAssemblies ||
 /// hasSharpTsReference` condition in <see cref="ILCompiler.SaveArtifacts"/>.
+/// </para>
+/// <para>
+/// This class is also a named Native AOT reflection seam, alongside
+/// <c>ManagedDotNetInterop</c>, <c>ManagedStructuralClrReflection</c>,
+/// <c>ManagedEmittedShapeReflection</c>, and <c>ManagedOutputRuntimeReflection</c> — but with a
+/// deliberately different policy: it carries suppressions and <em>no</em>
+/// IsDynamicCodeSupported guard, because its lookups run in the native compiler by design. The
+/// invariant that makes that safe is stated in <see cref="EmitMetadataLookupJustification"/>:
+/// every result is serialized into emitted IL as a metadata token, never invoked through
+/// reflection in the native host, and IlcGenerateCompleteTypeMetadata (mandatory, owned by
+/// SharpTS.csproj) keeps name-based lookups resolvable. Do not copy this suppression pattern to
+/// code whose reflection results are invoked — that belongs behind one of the guarded seams.
+/// </para>
 /// </remarks>
 public class TypeProvider
 {

--- a/Configuration/TsConfigDeclarationResolver.cs
+++ b/Configuration/TsConfigDeclarationResolver.cs
@@ -142,39 +142,21 @@ internal static class TsConfigDeclarationResolver
 
     private static IEnumerable<string> FindVisibleTypeRoots(string startDirectory)
     {
-        string[] ceilings =
-            new[]
-            {
-                Path.GetTempPath(),
-                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            }
-            .Where(path => !string.IsNullOrWhiteSpace(path))
-            .Select(path => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar))
-            .ToArray();
-        bool isStartDirectory = true;
         foreach (string directory in Ancestors(startDirectory))
         {
-            string normalized = directory.TrimEnd(Path.DirectorySeparatorChar);
-            if (!isStartDirectory && ceilings.Any(ceiling =>
-                    string.Equals(normalized, ceiling, StringComparison.OrdinalIgnoreCase)))
-            {
-                yield break;
-            }
-
             string root = Path.Combine(directory, "node_modules", "@types");
             if (Directory.Exists(root))
                 yield return Path.GetFullPath(root);
-            isStartDirectory = false;
         }
     }
 
     private static IEnumerable<string> Ancestors(string startDirectory)
     {
-        string? directory = Path.GetFullPath(startDirectory);
-        while (directory is not null)
+        for (string? directory = Path.GetFullPath(startDirectory);
+             directory is not null;
+             directory = FileDiscovery.AmbientParent(directory))
         {
             yield return directory;
-            directory = Path.GetDirectoryName(directory);
         }
     }
 }

--- a/Examples/AotCompileGate/features.ts
+++ b/Examples/AotCompileGate/features.ts
@@ -32,6 +32,15 @@ async function* asyncSequence(count: number) {
     }
 }
 
+// A runtime open generic closed over a user class (Task<Counter> from
+// Promise<Counter>) is the exact shape whose MakeGenericType throws
+// PlatformNotSupportedException under Native AOT — this function forces the
+// EmitGenerics TypeBuilderInstantiation fallback on every CI run. The async
+// machinery above only forces the MethodBuilderInstantiation fallback.
+async function make(step: number): Promise<Counter> {
+    return new Counter(step);
+}
+
 async function main() {
     const counter = new Counter();
     counter.bump();
@@ -44,7 +53,20 @@ async function main() {
         sum += value;
     }
 
-    console.log(counter.total, counter.step, sum);
+    const made = await make(7);
+
+    // A typed user-class array (List<Counter> from Counter[]) closes the other
+    // runtime open generic over a TypeBuilder argument.
+    const items: Counter[] = [new Counter(5), new Counter(6)];
+    for (const c of items) {
+        c.bump();
+    }
+    let totals = 0;
+    for (const c of items) {
+        totals += c.total;
+    }
+
+    console.log(counter.total, counter.step, sum, made.step, totals);
 }
 
 main();

--- a/Examples/test-examples.ps1
+++ b/Examples/test-examples.ps1
@@ -55,7 +55,12 @@ param(
     [string]$OutputFormat = "table",
     [switch]$SkipCleanup,
     [string]$SharpTSExe = "",
-    [switch]$NativeSku
+    [switch]$NativeSku,
+    # Fail unless at least this many test cases actually executed (passed or
+    # failed — skips don't count). The exit code otherwise reflects only
+    # failures, so a refactor that silently mass-skips the corpus would read as
+    # green. CI gates set this to just below the expected executed count.
+    [int]$MinimumExecuted = 0
 )
 
 $ErrorActionPreference = "Stop"
@@ -1039,6 +1044,11 @@ try {
 
     # Exit with appropriate code
     if ($results.FailedTests -gt 0) {
+        exit 1
+    }
+    $executed = $results.PassedTests + $results.FailedTests
+    if ($MinimumExecuted -gt 0 -and $executed -lt $MinimumExecuted) {
+        Write-Host "Only $executed test case(s) executed (minimum $MinimumExecuted); $($results.SkippedTests) skipped. A mass-skip must not pass the gate." -ForegroundColor Red
         exit 1
     }
     exit 0

--- a/Program.cs
+++ b/Program.cs
@@ -624,7 +624,9 @@ static void CompileFile(string inputPath, string outputPath, bool preserveConstE
         }
         else
         {
-            Console.WriteLine($"Error: {ex.Message}");
+            // Errors belong on stderr: release smokes (publish.yml) assert bundler
+            // refusals there, and compiled-output diffs must not see error text on stdout.
+            Console.Error.WriteLine($"Error: {ex.Message}");
         }
         Environment.Exit(1);
     }
@@ -786,8 +788,8 @@ static void EmitCompiledAssembly(string outputPath, bool preserveConstEnums, boo
             catch (Exception ex) when (bundlerMode != BundlerMode.Auto)
             {
                 var bundlerName = bundlerMode == BundlerMode.Sdk ? "SDK" : "built-in";
-                Console.WriteLine($"Error: {bundlerName} bundler failed: {ex.Message}");
-                Console.WriteLine($"The {bundlerName} bundler was explicitly requested. Use '--bundler auto' to allow fallback.");
+                Console.Error.WriteLine($"Error: {bundlerName} bundler failed: {ex.Message}");
+                Console.Error.WriteLine($"The {bundlerName} bundler was explicitly requested. Use '--bundler auto' to allow fallback.");
                 Environment.Exit(1);
             }
         }
@@ -907,6 +909,18 @@ static void CopySharpTSRuntimeIfNeeded(ILCompiler compiler, string outputPath, O
         }
         else if (!SharpTS.Runtime.EmbeddedManagedRuntime.TryExtractTo(destPath, out string? extractionError))
         {
+            // The native SKU has no Assembly.Location fallback — the embedded payload is
+            // the only soft-dependency mechanism. Silently shipping an output whose
+            // eval/Proxy/Intl/vm paths throw at runtime would be the one native-SKU
+            // limitation that doesn't fail fast; treat it like the others instead.
+            if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
+            {
+                Console.Error.WriteLine(
+                    $"Error: the compiled output requires the SharpTS runtime ({reasonList}), but the " +
+                    $"embedded SharpTS.dll could not be extracted ({extractionError}). " +
+                    "The output will not run until SharpTS.dll is placed next to it.");
+                Environment.Exit(1);
+            }
             if (!outputOptions.QuietMode)
                 Console.WriteLine(
                     $"Warning: could not extract the embedded SharpTS.dll ({extractionError}); " +

--- a/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/VmModuleInterpreter.cs
@@ -532,7 +532,7 @@ public static class VmModuleInterpreter
                         type, ManagedEmittedShape.HasFields)
                     ? ManagedEmittedShapeReflection.GetPublicProperty(
                         type, ManagedEmittedShape.HasFields, "Fields")
-                    : ManagedStructuralClrReflection.GetPublicPropertyByName(type, "Fields");
+                    : ManagedStructuralClrReflection.TryGetPublicPropertyByName(type, "Fields");
                 if (fieldsProp?.GetValue(options) is IEnumerable<KeyValuePair<string, object?>> fields)
                 {
                     foreach (var kv in fields)

--- a/Runtime/EmbeddedManagedRuntime.cs
+++ b/Runtime/EmbeddedManagedRuntime.cs
@@ -21,6 +21,13 @@ internal static class EmbeddedManagedRuntime
             return false;
         }
 
+        return TryExtractTo(payload, destinationPath, out error);
+    }
+
+    // Split from the resource lookup so the atomic-write behavior is unit-testable:
+    // ordinary managed test builds carry no embedded payload.
+    internal static bool TryExtractTo(Stream payload, string destinationPath, out string? error)
+    {
         string fullDestination = Path.GetFullPath(destinationPath);
         string? destinationDirectory = Path.GetDirectoryName(fullDestination);
         if (destinationDirectory is null)

--- a/Runtime/Types/ManagedEmittedShapeReflection.cs
+++ b/Runtime/Types/ManagedEmittedShapeReflection.cs
@@ -27,6 +27,14 @@ internal static class ManagedEmittedShapeReflection
     internal static bool IsShape(Type type, ManagedEmittedShape shape)
     {
         ArgumentNullException.ThrowIfNull(type);
+
+        // Native AOT cannot load an emitted output assembly, so no value in a native
+        // process is ever a compiler-emitted shape. Answering false here keeps every
+        // IsShape-gated probe consistent with the Get* methods (which reject native):
+        // the predicate must never say "yes" where the action would throw.
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+            return false;
+
         return shape switch
         {
             ManagedEmittedShape.Object => type.Name == "$Object",
@@ -121,18 +129,21 @@ internal static class ManagedEmittedShapeReflection
     {
         ArgumentNullException.ThrowIfNull(type);
 
-        if (!IsShape(type, shape))
-        {
-            throw new ArgumentException(
-                $"Type '{type.FullName}' is not the expected compiler-emitted {DisplayName(shape)} shape.",
-                nameof(type));
-        }
-
+        // Checked before the shape test: under native, IsShape answers false for
+        // everything, and an unguarded caller should get this named diagnostic
+        // rather than a confusing "not the expected shape" argument error.
         if (!RuntimeFeature.IsDynamicCodeSupported)
         {
             throw new PlatformNotSupportedException(
                 $"Bridging compiler-emitted {DisplayName(shape)} objects is not available " +
                 "in the native SharpTS build — use the managed build.");
+        }
+
+        if (!IsShape(type, shape))
+        {
+            throw new ArgumentException(
+                $"Type '{type.FullName}' is not the expected compiler-emitted {DisplayName(shape)} shape.",
+                nameof(type));
         }
     }
 

--- a/Runtime/Types/ManagedStructuralClrReflection.cs
+++ b/Runtime/Types/ManagedStructuralClrReflection.cs
@@ -11,40 +11,50 @@ namespace SharpTS.Runtime.Types;
 /// <remarks>
 /// These shapes are intentionally open ended so embedders and third-party assemblies
 /// can provide callable and object-like values without implementing SharpTS interfaces.
-/// Native AOT has a frozen type universe and cannot promise that arbitrary members were
-/// retained, so the boundary rejects native execution before inspecting the type.
+/// Every caller uses these lookups as a <em>probe</em> — "does this object happen to
+/// expose Invoke/Fields/GetProperty?" — with null handled by a fall-through path that
+/// raises the caller's own guest-level diagnostic. Under Native AOT the open structural
+/// universe is empty by construction (arbitrary CLR objects can only enter through the
+/// .NET interop boundary, which rejects native execution first), so the probes answer
+/// <c>null</c> there instead of throwing: a plain-TypeScript program running natively
+/// must see its ordinary "not a function"-style error, never a
+/// <see cref="PlatformNotSupportedException"/> about CLR reflection.
 /// </remarks>
 internal static class ManagedStructuralClrReflection
 {
     private const string TrimJustification =
         "The Managed SKU intentionally supports open-world structural CLR objects from " +
-        "embedders and third-party assemblies. Native AOT is rejected before reflection; " +
-        "known SharpTS and compiler-emitted shapes are handled before this fallback.";
+        "embedders and third-party assemblies. Native AOT never reaches the reflection: " +
+        "the probes return null there, and known SharpTS and compiler-emitted shapes " +
+        "are handled before this fallback.";
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
-    internal static MethodInfo? GetPublicMethodByName(Type type, string name)
+    internal static MethodInfo? TryGetPublicMethodByName(Type type, string name)
     {
-        RequireManagedRuntime();
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+            return null;
         return type.GetMethod(name);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
-    internal static MethodInfo? GetPublicMethodBySignature(
+    internal static MethodInfo? TryGetPublicMethodBySignature(
         Type type,
         string name,
         Type[] parameterTypes)
     {
-        RequireManagedRuntime();
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+            return null;
         return type.GetMethod(name, parameterTypes);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
-    internal static MethodInfo? GetPublicInstanceMethodBySignature(
+    internal static MethodInfo? TryGetPublicInstanceMethodBySignature(
         Type type,
         string name,
         Type[] parameterTypes)
     {
-        RequireManagedRuntime();
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+            return null;
         return type.GetMethod(
             name,
             BindingFlags.Public | BindingFlags.Instance,
@@ -54,19 +64,10 @@ internal static class ManagedStructuralClrReflection
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
-    internal static PropertyInfo? GetPublicPropertyByName(Type type, string name)
-    {
-        RequireManagedRuntime();
-        return type.GetProperty(name);
-    }
-
-    private static void RequireManagedRuntime()
+    internal static PropertyInfo? TryGetPublicPropertyByName(Type type, string name)
     {
         if (!RuntimeFeature.IsDynamicCodeSupported)
-        {
-            throw new PlatformNotSupportedException(
-                "Structural compatibility with arbitrary CLR objects is not available " +
-                "in the native SharpTS build — use a SharpTS-owned value or the managed build.");
-        }
+            return null;
+        return type.GetProperty(name);
     }
 }

--- a/Runtime/Types/SharpTSAsyncLocalStorage.cs
+++ b/Runtime/Types/SharpTSAsyncLocalStorage.cs
@@ -142,7 +142,7 @@ public class SharpTSAsyncLocalStorage
         // exposing Invoke(object[]) through the managed-only structural seam.
         var invokeMethod = callback == null
             ? null
-            : ManagedStructuralClrReflection.GetPublicMethodBySignature(
+            : ManagedStructuralClrReflection.TryGetPublicMethodBySignature(
                 callback.GetType(), "Invoke", [typeof(object?[])]);
         if (invokeMethod != null)
             return invokeMethod.Invoke(callback, [args.ToArray()]);

--- a/Runtime/Types/SharpTSKeyObject.cs
+++ b/Runtime/Types/SharpTSKeyObject.cs
@@ -382,7 +382,7 @@ public class SharpTSKeyObject : ISharpTSPropertyAccessor
             options is not IDictionary<string, object?>)
         {
             var getPropertyMethod =
-                ManagedStructuralClrReflection.GetPublicMethodBySignature(
+                ManagedStructuralClrReflection.TryGetPublicMethodBySignature(
                     options.GetType(), "GetProperty", [typeof(string)]);
             if (getPropertyMethod != null)
             {

--- a/Runtime/Types/SharpTSPropertyDescriptor.cs
+++ b/Runtime/Types/SharpTSPropertyDescriptor.cs
@@ -195,7 +195,7 @@ public class SharpTSPropertyDescriptor
 
         // Try to get the GetProperty method
         var getPropertyMethod =
-            ManagedStructuralClrReflection.GetPublicInstanceMethodBySignature(
+            ManagedStructuralClrReflection.TryGetPublicInstanceMethodBySignature(
                 type, "GetProperty", [typeof(string)]);
         if (getPropertyMethod == null)
         {
@@ -205,7 +205,7 @@ public class SharpTSPropertyDescriptor
         // Probe presence via HasProperty(string) when the type exposes it, so an
         // explicit `value: undefined` is distinguished from an omitted value (#801).
         var hasPropertyMethod =
-            ManagedStructuralClrReflection.GetPublicInstanceMethodBySignature(
+            ManagedStructuralClrReflection.TryGetPublicInstanceMethodBySignature(
                 type, "HasProperty", [typeof(string)]);
 
         return Populate(

--- a/Runtime/Types/SharpTSProxy.cs
+++ b/Runtime/Types/SharpTSProxy.cs
@@ -73,7 +73,7 @@ public class SharpTSProxy : ISharpTSCallable
 
         // Preserve the managed .NET interop fallback for arbitrary callable
         // objects. Known compiler-emitted functions are handled above.
-        var invokeMethod = ManagedStructuralClrReflection.GetPublicMethodByName(
+        var invokeMethod = ManagedStructuralClrReflection.TryGetPublicMethodByName(
             value.GetType(), "Invoke");
         if (invokeMethod != null)
             return value;
@@ -92,7 +92,7 @@ public class SharpTSProxy : ISharpTSCallable
         // Managed .NET interop fallback for arbitrary Invoke-shaped objects.
         // The emitted function path above no longer needs to inspect its
         // private _method field because InvokeWithThis owns that contract.
-        var invokeMethod = ManagedStructuralClrReflection.GetPublicMethodByName(
+        var invokeMethod = ManagedStructuralClrReflection.TryGetPublicMethodByName(
             trap.GetType(), "Invoke");
         if (invokeMethod != null)
             return invokeMethod.Invoke(trap, [args.ToArray()]);
@@ -217,7 +217,7 @@ public class SharpTSProxy : ISharpTSCallable
             // Compiled mode: target is a TSFunction, not ISharpTSCallable
             if (interp == null)
             {
-                var invokeMethod = ManagedStructuralClrReflection.GetPublicMethodByName(
+                var invokeMethod = ManagedStructuralClrReflection.TryGetPublicMethodByName(
                     _target.GetType(), "Invoke");
                 if (invokeMethod != null)
                     return invokeMethod.Invoke(_target, [args.ToArray()]);

--- a/Runtime/Types/TSFunctionCallableAdapter.cs
+++ b/Runtime/Types/TSFunctionCallableAdapter.cs
@@ -81,7 +81,7 @@ public class TSFunctionCallableAdapter : ISharpTSCallable
         {
             _target = target;
             // Try to find an Invoke method
-            _invokeMethod = ManagedStructuralClrReflection.GetPublicMethodByName(
+            _invokeMethod = ManagedStructuralClrReflection.TryGetPublicMethodByName(
                 target.GetType(), "Invoke");
         }
 

--- a/Runtime/Types/VmContext.cs
+++ b/Runtime/Types/VmContext.cs
@@ -74,7 +74,7 @@ public static class VmContext
                     type, ManagedEmittedShape.HasFields)
                 ? ManagedEmittedShapeReflection.GetPublicProperty(
                     type, ManagedEmittedShape.HasFields, "Fields")
-                : ManagedStructuralClrReflection.GetPublicPropertyByName(type, "Fields");
+                : ManagedStructuralClrReflection.TryGetPublicPropertyByName(type, "Fields");
             if (fieldsProp?.GetValue(contextObject) is IEnumerable<KeyValuePair<string, object?>> fields)
             {
                 foreach (var kv in fields)
@@ -108,7 +108,7 @@ public static class VmContext
                     type, ManagedEmittedShape.Function)
                 ? ManagedEmittedShapeReflection.GetPublicMethod(
                     type, ManagedEmittedShape.Function, "Invoke", [typeof(object[])])
-                : ManagedStructuralClrReflection.GetPublicMethodBySignature(
+                : ManagedStructuralClrReflection.TryGetPublicMethodBySignature(
                     type, "Invoke", [typeof(object[])]);
             if (invokeMethod != null)
             {
@@ -148,7 +148,7 @@ public static class VmContext
                 ? ManagedEmittedShapeReflection.GetPublicMethod(
                     type, ManagedEmittedShape.HasFields, "SetProperty",
                     [typeof(string), typeof(object)])
-                : ManagedStructuralClrReflection.GetPublicMethodBySignature(
+                : ManagedStructuralClrReflection.TryGetPublicMethodBySignature(
                     type, "SetProperty", [typeof(string), typeof(object)]);
             if (setMethod != null)
             {

--- a/Runtime/Types/VmModule.cs
+++ b/Runtime/Types/VmModule.cs
@@ -245,7 +245,7 @@ public abstract class VmModuleBase
         // Managed .NET interop also accepts an arbitrary object exposing
         // Invoke(object[]) through the managed-only structural compatibility
         // seam.
-        var invoke = ManagedStructuralClrReflection.GetPublicMethodBySignature(
+        var invoke = ManagedStructuralClrReflection.TryGetPublicMethodBySignature(
             type, "Invoke", [typeof(object[])]);
         if (invoke != null)
             return invoke.Invoke(callable, [args]);

--- a/SharpTS.Tests/Architecture/AotSeamArchitectureTests.cs
+++ b/SharpTS.Tests/Architecture/AotSeamArchitectureTests.cs
@@ -1,0 +1,146 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace SharpTS.Tests.Architecture;
+
+/// <summary>
+/// Source-level architecture guards for the Native AOT reflection seams (#1324).
+/// The analyzer ratchet pins the warning inventory at zero, but it is satisfied
+/// by any suppression — these tests make the seam routing itself a build
+/// failure, so a new raw emit-path generic instantiation (which would throw
+/// PlatformNotSupportedException in the native compiler) or a resurrected
+/// CustomAttributeBuilder call cannot land by copy-pasting a suppression.
+/// </summary>
+public class AotSeamArchitectureTests
+{
+    // Implementation files that legitimately contain the raw calls the rest of
+    // the codebase must route through them.
+    private static readonly string[] MakeGenericImplementationFiles =
+    [
+        Path.Combine("Compilation", "EmitGenerics.cs"),
+        Path.Combine("Runtime", "DotNet", "ManagedDotNetInterop.cs"),
+    ];
+
+    // Qualifiers that route through a seam: EmitGenerics (emit path, with the
+    // TypeBuilderInstantiation/MethodBuilderInstantiation AOT fallbacks),
+    // TypeProvider instances (conventionally `_types`, pure delegation to
+    // EmitGenerics), and ManagedDotNetInterop (interpreter open-world binder,
+    // guarded by IsDynamicCodeSupported).
+    private static readonly Regex RoutedMakeGeneric =
+        new(@"\b(EmitGenerics|_types|ManagedDotNetInterop)\.MakeGeneric(Type|Method)\(", RegexOptions.Compiled);
+
+    private static readonly Regex AnyMakeGeneric =
+        new(@"\.MakeGeneric(Type|Method)\(", RegexOptions.Compiled);
+
+    private static readonly Regex CustomAttributeBuilderUse =
+        new(@"\bnew\s+CustomAttributeBuilder\b|\bCustomAttributeBuilder\s+\w|\(CustomAttributeBuilder\b", RegexOptions.Compiled);
+
+    [Fact]
+    public void MakeGeneric_calls_route_through_a_seam()
+    {
+        var offenders = new List<string>();
+        foreach (var (file, relative) in EnumerateProductSources())
+        {
+            bool isImplementationFile = MakeGenericImplementationFiles.Any(impl =>
+                relative.Equals(impl, StringComparison.OrdinalIgnoreCase));
+            if (isImplementationFile)
+                continue;
+
+            foreach (var (line, number) in CodeLines(file))
+            {
+                if (!AnyMakeGeneric.IsMatch(line))
+                    continue;
+                if (RoutedMakeGeneric.IsMatch(line))
+                    continue;
+                offenders.Add($"{relative}:{number}: {line.Trim()}");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "Raw MakeGenericType/MakeGenericMethod call sites found. Route them through " +
+            "EmitGenerics (emit path) or ManagedDotNetInterop (interpreter interop) so the " +
+            "Native AOT fallback/guard applies:\n" + string.Join('\n', offenders));
+    }
+
+    [Fact]
+    public void CustomAttributeBuilder_stays_retired()
+    {
+        // CustomAttributeBuilder cannot run in the Native AOT compiler; every emit
+        // site was converted to CustomAttributeEncoder's raw ECMA-335 blobs (#1324
+        // Phase 2). Non-comment references may not come back.
+        var offenders = new List<string>();
+        foreach (var (file, relative) in EnumerateProductSources())
+        {
+            foreach (var (line, number) in CodeLines(file))
+            {
+                if (CustomAttributeBuilderUse.IsMatch(line))
+                    offenders.Add($"{relative}:{number}: {line.Trim()}");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "CustomAttributeBuilder usage found; emit attribute blobs through " +
+            "CustomAttributeEncoder instead:\n" + string.Join('\n', offenders));
+    }
+
+    /// <summary>
+    /// Enumerates the .cs sources compiled into SharpTS.dll: every source
+    /// directory under the repo root except test/benchmark/tool projects,
+    /// build output, and vendored/scratch trees.
+    /// </summary>
+    private static IEnumerable<(string FullPath, string Relative)> EnumerateProductSources()
+    {
+        string root = FindRepoRoot();
+        string[] excludedTopLevel =
+        [
+            "SharpTS.Tests", "SharpTS.Test262", "SharpTS.Test262.Worker",
+            "SharpTS.TypeScriptConformance", "SharpTS.Microbenchmarks",
+            "SharpTS.Sdk", "SharpTS.Sdk.Tasks", "SharpTS.LanguageServer",
+            "Examples", "benchmarks", "stdlib", "docs", "scripts", "external",
+        ];
+
+        foreach (var file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(root, file);
+            var segments = relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+            if (segments[0].StartsWith('.'))
+                continue; // .git, .codex, .claude worktrees
+            if (excludedTopLevel.Contains(segments[0], StringComparer.OrdinalIgnoreCase))
+                continue;
+            if (segments.Contains("bin", StringComparer.OrdinalIgnoreCase) ||
+                segments.Contains("obj", StringComparer.OrdinalIgnoreCase))
+                continue;
+
+            yield return (file, relative);
+        }
+    }
+
+    /// <summary>Yields non-comment source lines with their 1-based line numbers.</summary>
+    private static IEnumerable<(string Line, int Number)> CodeLines(string file)
+    {
+        int number = 0;
+        foreach (var line in File.ReadLines(file))
+        {
+            number++;
+            var trimmed = line.TrimStart();
+            if (trimmed.StartsWith("//", StringComparison.Ordinal))
+                continue;
+            yield return (line, number);
+        }
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "SharpTS.csproj")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            "Could not locate the repository root (SharpTS.csproj) above " + AppContext.BaseDirectory);
+    }
+}

--- a/SharpTS.Tests/Compilation/CustomAttributeEncoderTests.cs
+++ b/SharpTS.Tests/Compilation/CustomAttributeEncoderTests.cs
@@ -1,0 +1,172 @@
+using System.Reflection;
+using SharpTS.Compilation;
+using Xunit;
+
+namespace SharpTS.Tests.Compilation;
+
+/// <summary>
+/// Byte-exact assertions for the ECMA-335 §II.23.3 blob writer. The encoder
+/// replaced CustomAttributeBuilder for the Native AOT compiler (#1324 Phase 2);
+/// a wrong byte here produces metadata other tools misread, so the expected
+/// blobs are written out literally.
+/// </summary>
+public class CustomAttributeEncoderTests
+{
+    private static ConstructorInfo Ctor<TAttribute>(params Type[] parameters) =>
+        typeof(TAttribute).GetConstructor(parameters)
+            ?? throw new InvalidOperationException(
+                $"{typeof(TAttribute).Name} has no ({string.Join(", ", parameters.Select(p => p.Name))}) constructor.");
+
+    [Fact]
+    public void Parameterless_attribute_is_prolog_plus_zero_named_args()
+    {
+        var blob = CustomAttributeEncoder.Encode(Ctor<SerializableAttribute>());
+
+        Assert.Equal(new byte[] { 0x01, 0x00, 0x00, 0x00 }, blob);
+        Assert.Equal(CustomAttributeEncoder.EmptyBlob, blob);
+    }
+
+    [Fact]
+    public void String_argument_is_packed_length_prefixed_utf8()
+    {
+        var blob = CustomAttributeEncoder.Encode(Ctor<ObsoleteAttribute>(typeof(string)), "old");
+
+        Assert.Equal(
+            new byte[]
+            {
+                0x01, 0x00,             // prolog
+                0x03, (byte)'o', (byte)'l', (byte)'d',
+                0x00, 0x00,             // named-arg count
+            },
+            blob);
+    }
+
+    [Fact]
+    public void Null_string_argument_is_the_null_serstring_marker()
+    {
+        var blob = CustomAttributeEncoder.Encode(Ctor<ObsoleteAttribute>(typeof(string)), (string?)null);
+
+        Assert.Equal(new byte[] { 0x01, 0x00, 0xFF, 0x00, 0x00 }, blob);
+    }
+
+    [Fact]
+    public void String_over_0x7F_bytes_uses_the_two_byte_packed_length()
+    {
+        string value = new('x', 0x80);
+        var blob = CustomAttributeEncoder.Encode(Ctor<ObsoleteAttribute>(typeof(string)), value);
+
+        Assert.Equal(0x01, blob[0]);
+        Assert.Equal(0x00, blob[1]);
+        // §II.23.2: 0x80 encodes as 0x80 0x80 (high bit set + 14-bit big-endian value).
+        Assert.Equal(0x80, blob[2]);
+        Assert.Equal(0x80, blob[3]);
+        Assert.Equal(2 + 2 + 0x80 + 2, blob.Length);
+    }
+
+    [Fact]
+    public void Bool_and_string_arguments_encode_in_parameter_order()
+    {
+        var blob = CustomAttributeEncoder.Encode(
+            Ctor<ObsoleteAttribute>(typeof(string), typeof(bool)), "m", true);
+
+        Assert.Equal(
+            new byte[]
+            {
+                0x01, 0x00,
+                0x01, (byte)'m',
+                0x01,                   // bool true
+                0x00, 0x00,
+            },
+            blob);
+    }
+
+    [Fact]
+    public void Enum_argument_serializes_as_its_underlying_integer()
+    {
+        var blob = CustomAttributeEncoder.Encode(
+            Ctor<AttributeUsageAttribute>(typeof(AttributeTargets)), AttributeTargets.Class);
+
+        Assert.Equal(
+            new byte[]
+            {
+                0x01, 0x00,
+                0x04, 0x00, 0x00, 0x00, // AttributeTargets.Class = 4, int32 little-endian
+                0x00, 0x00,
+            },
+            blob);
+    }
+
+    [Fact]
+    public void Type_argument_serializes_as_assembly_qualified_serstring()
+    {
+        var blob = CustomAttributeEncoder.Encode(
+            Ctor<System.ComponentModel.TypeConverterAttribute>(typeof(Type)), typeof(int));
+
+        // prolog + packed length + UTF-8 AQN + zero named args.
+        string expectedName = typeof(int).AssemblyQualifiedName!;
+        Assert.Equal(0x01, blob[0]);
+        var text = System.Text.Encoding.UTF8.GetString(blob, 3, blob.Length - 5);
+        Assert.Equal(expectedName, text);
+    }
+
+    [Fact]
+    public void Null_type_argument_is_the_null_serstring_marker()
+    {
+        var blob = CustomAttributeEncoder.Encode(
+            Ctor<System.ComponentModel.TypeConverterAttribute>(typeof(Type)), (Type?)null);
+
+        Assert.Equal(new byte[] { 0x01, 0x00, 0xFF, 0x00, 0x00 }, blob);
+    }
+
+    [Fact]
+    public void Null_value_type_argument_is_a_named_error_not_an_NRE()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            CustomAttributeEncoder.Encode(
+                Ctor<ObsoleteAttribute>(typeof(string), typeof(bool)), "m", null));
+
+        Assert.Contains("null is not a valid fixed-arg value", ex.Message);
+        Assert.Contains("Boolean", ex.Message);
+    }
+
+    [Fact]
+    public void Argument_count_mismatch_is_rejected()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            CustomAttributeEncoder.Encode(Ctor<ObsoleteAttribute>(typeof(string))));
+    }
+
+    [Fact]
+    public void Round_trips_through_a_persisted_assembly()
+    {
+        // End-to-end fidelity: the blob applied via SetCustomAttribute must read
+        // back with identical constructor arguments.
+        var ab = new System.Reflection.Emit.PersistedAssemblyBuilder(
+            new AssemblyName("CaBlobRoundTrip"), typeof(object).Assembly);
+        var type = ab.DefineDynamicModule("m").DefineType("T", TypeAttributes.Public);
+        var ctor = Ctor<ObsoleteAttribute>(typeof(string), typeof(bool));
+        type.SetCustomAttribute(ctor, CustomAttributeEncoder.Encode(ctor, "gone", true));
+        type.CreateType();
+
+        using var ms = new MemoryStream();
+        ab.Save(ms);
+        ms.Position = 0;
+
+        using var pe = new System.Reflection.PortableExecutable.PEReader(ms);
+        var reader = System.Reflection.Metadata.PEReaderExtensions.GetMetadataReader(pe);
+        var attribute = reader.CustomAttributes
+            .Select(reader.GetCustomAttribute)
+            .Single(a => a.Parent.Kind == System.Reflection.Metadata.HandleKind.TypeDefinition);
+        var blob = reader.GetBlobBytes(attribute.Value);
+
+        Assert.Equal(
+            new byte[]
+            {
+                0x01, 0x00,
+                0x04, (byte)'g', (byte)'o', (byte)'n', (byte)'e',
+                0x01,
+                0x00, 0x00,
+            },
+            blob);
+    }
+}

--- a/SharpTS.Tests/IntegrationTests/CliDeclarationEmitTests.cs
+++ b/SharpTS.Tests/IntegrationTests/CliDeclarationEmitTests.cs
@@ -216,7 +216,8 @@ public class CliDeclarationEmitTests
             dir.Path);
 
         Assert.Equal(1, result.ExitCode);
-        Assert.Contains("is not portable to TypeScript consumers", result.StandardOutput);
+        // Compile errors print to stderr (release smokes and MSBuild both parse it there).
+        Assert.Contains("is not portable to TypeScript consumers", result.StandardError);
         Assert.False(File.Exists(dir.GetPath("main.d.ts")));
     }
 }

--- a/SharpTS.Tests/RuntimeTests/EmbeddedManagedRuntimeTests.cs
+++ b/SharpTS.Tests/RuntimeTests/EmbeddedManagedRuntimeTests.cs
@@ -1,0 +1,114 @@
+using System.Text;
+using SharpTS.Runtime;
+using Xunit;
+
+namespace SharpTS.Tests.RuntimeTests;
+
+/// <summary>
+/// Pins the atomic-extraction behavior of the Native SKU's embedded managed
+/// runtime payload (#1324). CI's native smoke proves the end-to-end path; these
+/// tests pin the write discipline (temp + rename, overwrite, cleanup) that only
+/// misbehaves in conditions the smoke never creates.
+/// </summary>
+public class EmbeddedManagedRuntimeTests : IDisposable
+{
+    private readonly string _dir = Directory.CreateTempSubdirectory("sharpts-emr-").FullName;
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private static MemoryStream Payload(string content) =>
+        new(Encoding.UTF8.GetBytes(content));
+
+    [Fact]
+    public void Extracts_payload_bytes_to_destination()
+    {
+        string dest = Path.Combine(_dir, "SharpTS.dll");
+
+        bool ok = EmbeddedManagedRuntime.TryExtractTo(Payload("payload-v1"), dest, out var error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.Equal("payload-v1", File.ReadAllText(dest));
+    }
+
+    [Fact]
+    public void Overwrites_a_stale_destination()
+    {
+        string dest = Path.Combine(_dir, "SharpTS.dll");
+        File.WriteAllText(dest, "stale-old-version");
+
+        bool ok = EmbeddedManagedRuntime.TryExtractTo(Payload("fresh"), dest, out var error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.Equal("fresh", File.ReadAllText(dest));
+    }
+
+    [Fact]
+    public void Creates_missing_destination_directories()
+    {
+        string dest = Path.Combine(_dir, "nested", "deeper", "SharpTS.dll");
+
+        bool ok = EmbeddedManagedRuntime.TryExtractTo(Payload("x"), dest, out var error);
+
+        Assert.True(ok);
+        Assert.Null(error);
+        Assert.True(File.Exists(dest));
+    }
+
+    [Fact]
+    public void Leaves_no_temp_file_behind_on_success()
+    {
+        string dest = Path.Combine(_dir, "SharpTS.dll");
+
+        Assert.True(EmbeddedManagedRuntime.TryExtractTo(Payload("x"), dest, out _));
+
+        Assert.Equal([dest], Directory.GetFiles(_dir));
+    }
+
+    [Fact]
+    public void Failed_extraction_reports_error_and_cleans_up_its_temp_file()
+    {
+        string dest = Path.Combine(_dir, "SharpTS.dll");
+        File.WriteAllText(dest, "in-use");
+
+        // Windows: an open handle without FileShare.Delete makes the final
+        // File.Move fail — the case a running compiled program creates.
+        using (File.Open(dest, FileMode.Open, FileAccess.Read, FileShare.Read))
+        {
+            bool ok = EmbeddedManagedRuntime.TryExtractTo(Payload("new"), dest, out var error);
+
+            if (OperatingSystem.IsWindows())
+            {
+                Assert.False(ok);
+                Assert.NotNull(error);
+            }
+            else
+            {
+                // POSIX rename over an open file succeeds; both outcomes must
+                // leave no temp litter, asserted below.
+                Assert.True(ok);
+            }
+        }
+
+        Assert.Equal([dest], Directory.GetFiles(_dir));
+    }
+
+    [Fact]
+    public void Missing_embedded_resource_is_a_named_error()
+    {
+        // Ordinary managed test builds embed no payload (it is a Native AOT
+        // publish input), so the resource-based overload reports exactly that.
+        string dest = Path.Combine(_dir, "SharpTS.dll");
+
+        bool ok = EmbeddedManagedRuntime.TryExtractTo(dest, out var error);
+
+        Assert.False(ok);
+        Assert.Contains("SharpTS.ManagedRuntime.dll", error);
+        Assert.Contains("not present", error);
+        Assert.False(File.Exists(dest));
+    }
+}

--- a/SharpTS.Tests/TypeCheckerTests/ClassHoistingTests.cs
+++ b/SharpTS.Tests/TypeCheckerTests/ClassHoistingTests.cs
@@ -1,0 +1,56 @@
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.TypeCheckerTests;
+
+/// <summary>
+/// The plain <see cref="TypeChecker.Check(List{Stmt})"/> entry point must hoist class
+/// declarations exactly like <see cref="TypeChecker.CheckWithRecovery(List{Stmt})"/> does,
+/// so a function body can forward-reference a class declared later in the same file — a
+/// common pattern in CJS libraries. Check() is the live path for workers and Test262.
+/// </summary>
+public class ClassHoistingTests
+{
+    private static List<Stmt> Parse(string source)
+    {
+        var lexer = new Lexer(source);
+        var tokens = lexer.ScanTokens();
+        var parser = new Parser(tokens);
+        return parser.ParseOrThrow();
+    }
+
+    [Fact]
+    public void Check_ForwardClassValueReferenceFromFunctionBody_Passes()
+    {
+        var source = """
+            function make(): Later {
+                return new Later(7);
+            }
+            class Later {
+                constructor(public n: number) {}
+            }
+            const item: Later = make();
+            console.log(item.n);
+            """;
+
+        var typeMap = new TypeChecker().Check(Parse(source));
+
+        Assert.NotNull(typeMap);
+    }
+
+    [Fact]
+    public void Check_ForwardExportedClassValueReference_Passes()
+    {
+        var source = """
+            function make(): Later {
+                return new Later();
+            }
+            export class Later {}
+            """;
+
+        var typeMap = new TypeChecker().Check(Parse(source));
+
+        Assert.NotNull(typeMap);
+    }
+}

--- a/SharpTS.csproj
+++ b/SharpTS.csproj
@@ -33,6 +33,22 @@
   </ItemGroup>
 
   <!--
+    Mandatory Native AOT metadata configuration (#1324). These are not tuning
+    knobs: TypeProvider resolves framework members by name at compile time, and
+    without partial trim + complete, untrimmed type metadata those lookups
+    return null inside the native compiler ("Could not resolve type: …").
+    Owning them here means any `dotnet publish -p:PublishAot=true` — local or
+    CI — produces a working native SKU; workflows must not re-specify them.
+  -->
+  <PropertyGroup Condition="'$(PublishAot)' == 'true'">
+    <TrimMode>partial</TrimMode>
+    <IlcTrimMetadata>false</IlcTrimMetadata>
+    <IlcGenerateCompleteTypeMetadata>true</IlcGenerateCompleteTypeMetadata>
+    <!-- file:line guest stack traces are part of the native SKU's contract. -->
+    <StackTraceSupport>true</StackTraceSupport>
+  </PropertyGroup>
+
+  <!--
     PE-Packer's reflected Microsoft.NET.HostModel SDK path cannot run under
     Native AOT. Its feature switch is application-level so the managed SKU
     keeps SDK detection; the native SKU makes it a trim-time false constant
@@ -62,7 +78,61 @@
           Condition="'$(SharpTSManagedRuntimePayloadPath)' != ''">
     <Error Condition="!Exists('$(SharpTSManagedRuntimePayloadPath)')"
            Text="SharpTSManagedRuntimePayloadPath does not exist: $(SharpTSManagedRuntimePayloadPath)" />
+    <ValidateAnyCpuAssembly AssemblyPath="$(SharpTSManagedRuntimePayloadPath)" />
   </Target>
+
+  <!--
+    The embedded payload is the ONLY soft-dependency mechanism the native SKU
+    has (there is no Assembly.Location to copy from), so a native publish
+    without it would produce a compiler whose soft-dep outputs throw at
+    runtime. Fail the publish instead; probing builds can opt out explicitly.
+  -->
+  <Target Name="RequireManagedRuntimePayloadForNativeAot"
+          BeforeTargets="PrepareResources"
+          Condition="'$(PublishAot)' == 'true' and '$(SharpTSManagedRuntimePayloadPath)' == '' and '$(SharpTSAllowMissingManagedRuntimePayload)' != 'true'">
+    <Error Text="A Native AOT publish requires -p:SharpTSManagedRuntimePayloadPath=&lt;path to an AnyCPU SharpTS.dll&gt; (build it first: dotnet publish SharpTS.csproj -c Release -p:PlatformTarget=AnyCPU -o &lt;dir&gt;). Compiled soft-dependency programs (eval, Proxy, Intl, vm) extract this payload at compile time. Pass -p:SharpTSAllowMissingManagedRuntimePayload=true to build a probe binary without it." />
+  </Target>
+
+  <!--
+    An arch-stamped payload (PE Machine AMD64/ARM64 instead of AnyCPU's I386)
+    loads only under a matching-architecture CoreCLR — a reproduced failure:
+    x64-stamped SharpTS.dll co-located next to compiled output fails with
+    "SharpTS runtime not present" under an arm64 dotnet. Catch it at embed time.
+  -->
+  <UsingTask TaskName="ValidateAnyCpuAssembly"
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <AssemblyPath ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Code Type="Fragment" Language="cs"><![CDATA[
+        using (var stream = File.OpenRead(AssemblyPath))
+        using (var reader = new BinaryReader(stream))
+        {
+            stream.Position = 0x3C;
+            stream.Position = reader.ReadUInt32(); // e_lfanew -> "PE\0\0"
+            if (reader.ReadUInt32() != 0x00004550)
+            {
+                Log.LogError("SharpTSManagedRuntimePayloadPath is not a PE file: {0}", AssemblyPath);
+            }
+            else
+            {
+                ushort machine = reader.ReadUInt16();
+                // AnyCPU managed assemblies are stamped IMAGE_FILE_MACHINE_I386.
+                if (machine != 0x014C)
+                {
+                    Log.LogError(
+                        "SharpTSManagedRuntimePayloadPath must be an AnyCPU assembly (PE Machine I386), " +
+                        "but '{0}' has Machine 0x{1:X4}. Rebuild the payload with -p:PlatformTarget=AnyCPU.",
+                        AssemblyPath, machine);
+                }
+            }
+        }
+      ]]></Code>
+    </Task>
+  </UsingTask>
 
   <!-- White-box test access: a handful of regression tests drive internal
        runtime seams directly (e.g. WebStreamsHelpers.PipeTo + the event-loop

--- a/TypeSystem/TypeChecker.Generics.Inference.cs
+++ b/TypeSystem/TypeChecker.Generics.Inference.cs
@@ -73,13 +73,13 @@ public partial class TypeChecker
                         {
                             if (!actualRecord.Fields.ContainsKey(fieldName))
                             {
-                                throw new TypeCheckException($" Type Error: Inferred type '{inferredType}' does not satisfy constraint '{tp.Constraint}' for type parameter '{tp.Name}' - missing required property '{fieldName}'.", tsCode: "TS2344");
+                                throw new TypeCheckException($"Inferred type '{inferredType}' does not satisfy constraint '{tp.Constraint}' for type parameter '{tp.Name}' - missing required property '{fieldName}'.", tsCode: "TS2344");
                             }
                         }
                     }
                     else if (!IsCompatible(substitutedConstraint, inferredType))
                     {
-                        throw new TypeCheckException($" Type Error: Inferred type '{inferredType}' does not satisfy constraint '{tp.Constraint}' for type parameter '{tp.Name}'.", tsCode: "TS2344");
+                        throw new TypeCheckException($"Inferred type '{inferredType}' does not satisfy constraint '{tp.Constraint}' for type parameter '{tp.Name}'.", tsCode: "TS2344");
                     }
                 }
                 result.Add(inferredType);

--- a/TypeSystem/TypeChecker.cs
+++ b/TypeSystem/TypeChecker.cs
@@ -1108,6 +1108,9 @@ public partial class TypeChecker
         // This ensures types are available when parsing function signatures during hoisting
         PreRegisterTypeDeclarations(statements);
 
+        // Hoist class declarations (as Any for forward references in function bodies)
+        HoistClassDeclarations(statements);
+
         // Hoist function declarations (now type references will resolve correctly)
         HoistFunctionDeclarations(statements);
 

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -265,7 +265,14 @@ The work is split at four ownership boundaries:
    objects that happen to expose `Invoke`, `Fields`, `GetProperty`, or
    `SetProperty` now route through `ManagedStructuralClrReflection`. The seam
    remains deliberately open-world under CoreCLR for embedders and third-party
-   assemblies, but rejects Native AOT before inspecting an arbitrary type.
+   assemblies. Under Native AOT its `TryGet*` probes answer `null` (the open
+   structural universe is empty there by construction — arbitrary CLR objects
+   can only enter through the .NET interop boundary, which rejects native
+   first), so interpreter fall-through paths raise their ordinary guest-level
+   "not a function"-style errors instead of a reflection
+   PlatformNotSupportedException. `ManagedEmittedShapeReflection.IsShape` is
+   consistent with this: it answers false for every shape under native, so a
+   predicate can never say "yes" where the action would throw.
 3. **Dynamic .NET interop policy (done for the current inventory).** The open-world
    `Runtime/DotNet` binder now routes type resolution, member discovery,
    construction, generic closure, array creation, marshalling, operators, and
@@ -314,14 +321,16 @@ out of scope.
 
 ### Phase 1 — interpreter correctness and speed (~2–3 weeks; wins on JIT too)
 
-1. **Source-generate the `NodeRegistry` dispatch table**
-   (`Parsing/Visitors/NodeRegistry.cs:385-412` `Expression.Lambda().Compile()`;
-   reflective auto-registration at :344/:360 and
-   `AstNodeCatalog.cs:31-40`; consumers `TypeCheckerRegistry.cs:19`,
-   `InterpreterRegistry.cs:27`). Measured: 16.8 ns / 0 B per dispatch vs
-   31.6 ns on today's JIT and 173.2 ns / 248 B under AOT — a strict win
-   regardless of AOT. Also removes the `TrimmerRootAssembly` need and the
-   47→80 MB trim inflation.
+1. **Replace the `NodeRegistry` dispatch table. Shipped as hand-written type
+   switches, not a source generator:** `NodeRegistry` was deleted; the node
+   universe is the explicit declaration-ordered `AstNodeCatalog` list and each
+   phase dispatches via a hot-first type switch (`AstVisitorBase`,
+   `Interpreter.Dispatch.cs`, `TypeChecker.Dispatch.cs`), with exhaustiveness
+   pinned by `SharpTS.Tests/RegistryTests/AstDispatchTests.cs` (reflective
+   re-derivation + order-sensitive equality + all-switch probes). Measured at
+   decision time: 16.8 ns / 0 B per dispatch vs 31.6 ns on the old JIT path
+   and 173.2 ns / 248 B under AOT — a strict win regardless of AOT. Also
+   removed the `TrimmerRootAssembly` need and the 47→80 MB trim inflation.
 2. **JSON:** four `JsonSerializerContext`s (`TsConfigJson`, `SharpTsManifest`,
    `PackageJson`, `ProjectBuildState`); hand-rolled ECMA-262 §25.5.2.2 string
    escaper for `Runtime/BuiltIns/JSONBuiltIns.cs:287,464`; `Utf8JsonWriter`
@@ -349,7 +358,9 @@ Results from the win-arm64 native probe, now preserved by the
 
 1. **Both compiler pipelines pass.** A native SharpTS host compiles and runs
    single-file input plus a two-file module graph. The focused fixture covers
-   accessors, generators and async generators, producing `2 2 33`.
+   accessors, generators, async generators, a `Promise<UserClass>` and a typed
+   user-class array (the runtime-open-generic-over-`TypeBuilder` shapes that
+   force the `TypeBuilderInstantiation` fallback), producing `2 2 33 7 11`.
 2. **No deps.json is required** for root-flat additional assemblies. Measured
    and recorded in PE-Packer issue #18.
 3. **PE-Packer passes inside SharpTS's partial-trim closure.** Native SharpTS
@@ -362,15 +373,19 @@ Results from the win-arm64 native probe, now preserved by the
    ECMA-335 blob consumed by the supported `SetCustomAttribute(ConstructorInfo,
    byte[])` overloads; every `CustomAttributeBuilder` emit site is converted.
 5. **Generic emit seams: done.** Every emit-path `MakeGenericType` and
-   `MakeGenericMethod` routes through `EmitGenerics`. Native AOT falls back to
-   the targeted, rooted `TypeBuilderInstantiation` and
-   `MethodBuilderInstantiation` factories; the native smoke fixture exercises
-   both on every CI run.
-6. **Build config:** `-p:TrimMode=partial -p:IlcTrimMetadata=false
-   -p:IlcGenerateCompleteTypeMetadata=true` (mandatory — TypeProvider's name
-   lookups return null otherwise), plus `[DynamicDependency]` keep-alives for
-   `AsyncTaskMethodBuilder<>` (`TypeProvider.cs:242-251`), `MethodInvoker`
-   (:141), `ManualResetValueTaskSourceCore<>` (:265-274).
+   `MakeGenericMethod` routes through `EmitGenerics` (routing pinned by
+   `SharpTS.Tests/Architecture/AotSeamArchitectureTests.cs`). Native AOT falls
+   back to the targeted, rooted `TypeBuilderInstantiation` and
+   `MethodBuilderInstantiation` factories; `features.ts` exercises both on
+   every CI run (`Promise<UserClass>`/typed-array shapes for the former, the
+   async builder's `Start<TStateMachine>` for the latter).
+6. **Build config: owned by `SharpTS.csproj`.** `TrimMode=partial`,
+   `IlcTrimMetadata=false`, `IlcGenerateCompleteTypeMetadata=true`, and
+   `StackTraceSupport=true` are set behind `PublishAot=true` in the project
+   file (mandatory — TypeProvider's name lookups return null otherwise), so a
+   local `dotnet publish -p:PublishAot=true` matches CI. The reflection-emit
+   internals the fallbacks reach are kept alive by `AotTrimmerRoots.xml`
+   (a targeted `TrimmerRootDescriptor`, not `[DynamicDependency]`).
 7. **Grind the remaining phases.** This is where the schedule slack goes.
 
 **Exit criterion:** native exe compiles the `Examples/` corpus; every output
@@ -401,14 +416,19 @@ SharpTS passes an explicit compatibility policy. Item 8 can choose
    permanent and release smokes create executables with `DOTNET_ROOT` empty.
    The built-in bundler stays Windows/Linux-only until Mach-O adjustment +
    ad-hoc signing exist.
-10. **Release matrix: wired.** Tagged releases build six Native AOT assets
-    (win-x64/arm64, linux-x64/arm64, osx-x64/arm64) on matching-architecture
-    GitHub runners. Every artifact runs interpret, managed compile, and embedded
-    runtime extraction smokes before upload. Windows/Linux also create and run a
-    PE-Packer executable with `DOTNET_ROOT` empty; macOS asserts the built-in
-    bundler's named Mach-O/signing refusal. The first tagged run remains the
-    cross-platform acceptance event. ILC peak RSS on the 7 GB macOS arm64
-    runner is the main operational risk.
+10. **Release matrix: wired, and it gates the publish.** Tagged releases build
+    six Native AOT assets (win-x64/arm64, linux-x64/arm64, osx-x64/arm64) on
+    matching-architecture GitHub runners. Every artifact runs interpret,
+    managed compile, embedded runtime extraction, the five Managed-SKU-only
+    refusal assertions, and the per-RID publish-warning ratchet. Windows/Linux
+    also create and run a PE-Packer executable with `DOTNET_ROOT` empty; macOS
+    asserts the built-in bundler's named Mach-O/signing refusal. The NuGet push
+    and GitHub Release run in a final job that requires every managed and
+    native artifact job to succeed — a failing RID blocks the release rather
+    than leaving a missing asset behind a published package. `publish.yml`
+    also accepts `workflow_dispatch` as a no-publish dry run of the full
+    matrix; run it before the first real tag to validate the runner labels.
+    ILC peak RSS on the 7 GB macOS arm64 runner is the main operational risk.
 11. **SDK payload: keep the existing managed, RID-neutral compiler.** The
     original RID-native proposal is rejected for the default SDK: invoking
     `SharpTS.Sdk` already means running `dotnet build`, its targets pass the
@@ -458,7 +478,7 @@ workers, MSBuild SDK (subprocess-only by design, verified), JSX.
 
 | # | Unknown | Status / next step |
 |---|---|---|
-| 1 | Cross-platform native compiler | win-arm64 passes locally and linux-x64 passes CI, including managed-payload extraction. The six-RID release matrix is wired; its first tagged run is the remaining acceptance event. |
+| 1 | Cross-platform native compiler | win-arm64 passes locally and linux-x64 passes CI, including managed-payload extraction. The six-RID release matrix is wired and gates the publish; validate it with a `workflow_dispatch` dry run, then the first tagged run is the remaining acceptance event. |
 | 2 | BCL interop preservation | Targeted roots work for the emit internals; define and test the supported `@DotNetType` surface, including the known dynamic-event edge. |
 | 3 | MLC-types-into-TypeBuilder latent JIT limitation | Conceded for the native SKU; file upstream separately. |
 | 4 | Native-emitted output metadata parity | Executed output and PE-Packer rewriting pass. Add a `MetadataDiffer` fixture if byte/table-level parity becomes release-blocking. |

--- a/scripts/aot-analyzer-report.ps1
+++ b/scripts/aot-analyzer-report.ps1
@@ -207,13 +207,16 @@ if ($EnforceBaseline)
     $differences = @(Compare-Object $expectedRecords $actualRecords)
     if ($differences.Count -ne 0)
     {
-        Write-Error "AOT analyzer inventory differs from the committed baseline."
+        # Write-Host, not Write-Error: under ErrorActionPreference=Stop the first
+        # Write-Error would terminate before the per-record diff prints, leaving
+        # only the headline in the job log.
+        Write-Host "AOT analyzer inventory differs from the committed baseline:"
         foreach ($difference in $differences)
         {
             $meaning = if ($difference.SideIndicator -eq "=>") { "actual" } else { "baseline" }
-            Write-Error "  [$meaning] $($difference.InputObject)"
+            Write-Host "  [$meaning] $($difference.InputObject)"
         }
-        throw "Run scripts/aot-analyzer-report.ps1 -UpdateBaseline only in the PR that explains the warning changes."
+        throw "AOT analyzer inventory differs from the committed baseline. Run scripts/aot-analyzer-report.ps1 -UpdateBaseline only in the PR that explains the warning changes."
     }
 
     Write-Host "Analyzer inventory matches '$baselineFullPath'."

--- a/scripts/aot-publish-warning-report.ps1
+++ b/scripts/aot-publish-warning-report.ps1
@@ -172,18 +172,37 @@ if ($EnforceBaseline)
     }
 
     $baseline = Get-Content -LiteralPath $baselineFullPath -Raw | ConvertFrom-Json
+
+    # Parse-sanity floor: an empty parse is indistinguishable from a clean
+    # publish, so a localized runner or a diagnostic-format change would
+    # otherwise read as green. When the committed baseline says warnings must
+    # exist, parsing zero lines means the parser saw nothing it understood —
+    # fail loudly instead of silently matching the empty project inventory.
+    $baselineExpectsWarnings = ([int]$baseline.project.total + [int]$baseline.external.total) -gt 0
+    if ($parsedWarnings.Count -eq 0 -and $baselineExpectsWarnings)
+    {
+        throw (
+            "Parsed zero 'warning ILnnnn:' lines from '$logFullPath', but the committed baseline " +
+            "expects $([int]$baseline.project.total + [int]$baseline.external.total). Either the log is not a " +
+            "Native AOT publish log, the publish output is localized (set DOTNET_CLI_UI_LANGUAGE=en), " +
+            "or the diagnostic format changed and the parser needs updating.")
+    }
+
     $expectedProject = ConvertTo-ComparisonRecords $baseline.project
     $actualProject = ConvertTo-ComparisonRecords ([pscustomobject]$summary.project)
     $projectDifferences = @(Compare-Object $expectedProject $actualProject)
     if ($projectDifferences.Count -ne 0)
     {
-        Write-Error "SharpTS-owned Native AOT publish warnings differ from the committed baseline."
+        # Write-Host, not Write-Error: under ErrorActionPreference=Stop the first
+        # Write-Error would terminate before the per-record diff prints, leaving
+        # only the headline in the job log.
+        Write-Host "SharpTS-owned Native AOT publish warnings differ from the committed baseline:"
         foreach ($difference in $projectDifferences)
         {
             $meaning = if ($difference.SideIndicator -eq "=>") { "actual" } else { "baseline" }
-            Write-Error "  [$meaning] $($difference.InputObject)"
+            Write-Host "  [$meaning] $($difference.InputObject)"
         }
-        throw "Update the baseline only in the PR that explains the project warning changes."
+        throw "SharpTS-owned Native AOT publish warnings differ from the committed baseline. Update the baseline only in the PR that explains the project warning changes."
     }
 
     Write-Host "SharpTS-owned publish inventory matches '$baselineFullPath'."


### PR DESCRIPTION
## Summary

An architectural review of the #1324 epic (before the first tagged release) confirmed the design is sound but found a handful of concrete defects and unenforced guarantees. This PR fixes all of them.

### Release blockers

- **Compile errors print to stderr.** The generic compile-error branch in `Program.cs` and the explicit-bundler failure branch wrote to stdout. The tag-time macOS native smoke greps **stderr** for PE-Packer's Mach-O refusal (`cannot target`), so the first `osx-*` release job would have failed on a stream mismatch. One test asserted the old stdout behavior and was updated to the new contract.
- **`publish.yml` now validates before it publishes.** Previously the `publish` job pushed NuGet and created the GitHub Release *first*, and the artifact matrices merely uploaded afterwards — a failing RID left a silently missing asset behind an already-public package. New shape: `build` (pack + test) → `binaries` + `native-binaries` (all twelve artifact smokes) → tag-only `release` job that pushes NuGet and attaches every archive. Also:
  - `workflow_dispatch` runs the full matrix as a **no-publish dry run** (`0.0.0-dryrun.N` versions) — run it once before the first real tag to validate the `windows-11-vs2026-arm` / `macos-15-intel` runner labels.
  - win-arm64/linux-arm64 **managed** artifacts now build and smoke on real arm runners instead of shipping never-executed cross-publishes.
  - Native release smokes gain the five Managed-SKU-only refusal assertions (fork, `-r`, .NET interop, `--gen-decl`, `--verify`), `features.ts`, the **per-RID publish-warning ratchet**, and CRLF normalization so `grep -qx` works on Windows RIDs.

### Native-SKU behavior fixes

- **`ManagedStructuralClrReflection` probes return `null` under Native AOT instead of throwing.** Every call site (Proxy traps, `FromAnyObject`, vm context, KeyObject export…) is a structural *probe* with its own guest-level fall-through error, and the open CLR universe is empty by construction in a native process (arbitrary CLR objects can only enter via the .NET interop boundary, which rejects native first). A plain-TypeScript program running natively now gets its ordinary `"…is not a function"` error, never a reflection `PlatformNotSupportedException`. Methods renamed `TryGet*` to make the probe semantics explicit.
- **`ManagedEmittedShapeReflection.IsShape` answers false for every shape under native**, so `RuntimeCallableDispatcher.IsCallable`/`Invoke` can no longer disagree (predicate said yes, action threw). `RequireManagedShape` checks native before shape so unguarded callers get the clear named diagnostic.
- **Native-SKU extraction failure of the embedded managed runtime is now fatal** instead of warning-and-continue — it is the only soft-dependency mechanism the native SKU has, and it was the one native limitation that didn't fail fast.

### Guardrails

- **Mandatory AOT flags own their home in `SharpTS.csproj`** behind `PublishAot=true` (`TrimMode=partial`, `IlcTrimMetadata=false`, `IlcGenerateCompleteTypeMetadata=true`, `StackTraceSupport=true`); ci.yml/publish.yml no longer duplicate them, and a local `dotnet publish -p:PublishAot=true` matches CI instead of producing a broken binary.
- **Payload validation:** a Native AOT publish without `SharpTSManagedRuntimePayloadPath` is a build error (opt-out: `SharpTSAllowMissingManagedRuntimePayload=true` for probe builds), and the payload's PE Machine word must be AnyCPU/I386 — the arch-stamped-payload failure mode was previously reproduced in the wild ("SharpTS runtime not present" under a different arch's dotnet).
- **`features.ts` now forces the `TypeBuilderInstantiation` fallback** (`Promise<Counter>` + typed `Counter[]` close runtime open generics over `TypeBuilder` args). Previously only the async builder's `MethodBuilderInstantiation` fallback executed in CI, despite comments claiming both. Both gates assert the new `2 2 33 7 11` output.
- **Architecture tests** (`SharpTS.Tests/Architecture/`) pin the seam routing: raw `MakeGenericType`/`MakeGenericMethod` outside `EmitGenerics`/`TypeProvider`/`ManagedDotNetInterop`, or any resurrected `CustomAttributeBuilder` use, fail the suite — a copy-pasted suppression can no longer satisfy the analyzer ratchet while breaking the native compiler.
- **`CustomAttributeEncoder`** gets byte-exact §II.23.3 blob tests plus a persisted-assembly round trip; null `Type` args now encode as the 0xFF null SerString and null value-type args throw a named error instead of NRE. **`EmbeddedManagedRuntime`**'s atomic-write discipline (temp + rename, overwrite, cleanup, locked destination) is unit-tested via a stream overload split from the resource lookup.
- **Ratchet scripts** print their per-record diff before failing (`Write-Error` under `ErrorActionPreference=Stop` terminated before the detail printed) and fail on a zero-line parse when the baseline expects warnings — closing the silent-green vector from localized runner output or diagnostic-format drift.
- **`test-examples.ps1 -MinimumExecuted`** fails the corpus gate if executed (non-skipped) cases drop below a floor (CI: 50 ≈ losing a whole path), so a refactor that mass-skips can't go green.
- **Docs:** `TypeProvider` is documented as the fifth, deliberately unguarded seam with its invariant stated; stale `NodeRegistry` references in `CONTRIBUTING.md` and `docs/plans/native-aot.md` rewritten to describe the shipped catalog + dispatch-switch design; `native-aot.md` updated for the flag ownership, gated release flow, and probe semantics.

### Known follow-up (not in this PR)

The extraction/co-location path ships only `SharpTS.dll`, no dependency closure — `eval`/`vm` code reaching zlib needs `ZstdSharp.dll`, which the test harness copies explicitly but production does not. Which dependencies the soft-dep contract promises is a design decision; deliberately left for its own issue.

## Test plan

- [x] Full suite: 16,283/16,283 pass (`Category!=LiveNetwork&LoadSensitive`)
- [x] `scripts/aot-analyzer-report.ps1 -EnforceBaseline` — inventory still exactly zero
- [x] `features.ts` interpreted + compiled under JIT both print `2 2 33 7 11`
- [x] csproj gates exercised locally: AnyCPU payload accepted; arch-stamped payload rejected (caught the arm64 apphost at `0xAA64`); `PublishAot=true` without payload rejected with guidance
- [x] Ratchet scripts exercised against synthetic logs: diff detail prints, empty parse fails
- [x] Both workflow files YAML-validated
- [ ] After merge: trigger the `publish.yml` `workflow_dispatch` dry run to validate the six native runner labels before the first tag

Part of #1324.