### PR TITLE
Fix Test262 Error intrinsic cross-realm pollution

### DIFF
--- a/Execution/Interpreter.Calls.cs
+++ b/Execution/Interpreter.Calls.cs
@@ -1190,7 +1190,7 @@ public partial class Interpreter
         if (left is SharpTSError error && targetClass is SharpTSErrorClass)
         {
             // Walk the error type hierarchy: TypeError extends Error, etc.
-            var errorName = error.Name; // e.g. "TypeError"
+            var errorName = error.ErrorTypeName; // e.g. "TypeError"
             var targetName = targetClass.Name; // e.g. "Error"
             if (errorName == targetName) return true;
             // All built-in error subtypes extend Error

--- a/Execution/Interpreter.Properties.cs
+++ b/Execution/Interpreter.Properties.cs
@@ -825,6 +825,13 @@ public partial class Interpreter
     /// </summary>
     private RuntimeValue EvaluateGetOnBuiltInRV(TypeCategory category, object obj, string memberName)
     {
+        // Native errors created by runtime helpers carry their built-in name but
+        // not a constructor reference. Resolve `constructor` through this realm;
+        // the old process-static SharpTSErrorClass registry leaked the latest
+        // interpreter's constructor into every other interpreter in the process.
+        if (obj is SharpTSError nativeError && memberName == "constructor")
+            return RuntimeValue.FromObject(GetErrorClass(nativeError.ErrorTypeName));
+
         // JS functions are objects — surface user-set properties before
         // falling through to built-in members (e.g. `bind`, `call`).
         if (obj is SharpTSFunction fn)

--- a/Execution/Interpreter.Realm.cs
+++ b/Execution/Interpreter.Realm.cs
@@ -45,7 +45,8 @@ public partial class Interpreter
     /// <summary>
     /// The names of every global constant and built-in singleton, for REPL autocomplete.
     /// </summary>
-    internal static IEnumerable<string> GlobalNames => _globalConstants.Keys;
+    internal static IEnumerable<string> GlobalNames
+        => _globalConstants.Keys.Concat(BuiltInNames.ErrorTypeNames);
 
     // The process-wide RegExp constructor singleton (a SharpTSBuiltInConstructor),
     // resolved once from the static globals table. ECMA-262 §22.2.6.1 requires
@@ -80,16 +81,6 @@ public partial class Interpreter
         foreach (var typedArrayName in BuiltInNames.TypedArrayNames)
         {
             globals[typedArrayName] = WorkerBuiltIns.GetTypedArrayConstructor(typedArrayName);
-        }
-
-        // Add Error constructors as global class variables
-        // This enables typeof Error, class MyError extends Error, const E = Error, etc.
-        var errorClass = new Runtime.Types.SharpTSErrorClass("Error", null);
-        globals[BuiltInNames.Error] = errorClass;
-        foreach (var errorTypeName in BuiltInNames.ErrorTypeNames)
-        {
-            if (errorTypeName != "Error")
-                globals[errorTypeName] = new Runtime.Types.SharpTSErrorClass(errorTypeName, errorClass);
         }
 
         // Bare `Array` reference — needed for Array.prototype.X.apply() patterns
@@ -295,6 +286,11 @@ public partial class Interpreter
     /// </summary>
     internal bool TryGetRealmIntrinsic(string name, out object? value)
     {
+        if (BuiltInNames.IsErrorTypeName(name))
+        {
+            value = GetErrorClass(name);
+            return true;
+        }
         if (name == "Object")
         {
             value = GetObjectNamespace();
@@ -337,7 +333,8 @@ public partial class Interpreter
     /// method identity holds (<c>Math.max === Math.max</c>).
     /// </summary>
     internal static bool IsRealmIntrinsicName(string name)
-        => name is "Object" or "Math" or "JSON" or "String" or "Number" or "Boolean";
+        => name is "Object" or "Math" or "JSON" or "String" or "Number" or "Boolean"
+            || BuiltInNames.IsErrorTypeName(name);
 
     // Per-realm String/Number/Boolean.prototype. Each is an extensible ECMA-262
     // object carrying a guest-writable _extras bag, so — like Math and
@@ -362,6 +359,7 @@ public partial class Interpreter
     private Runtime.Types.SharpTSNumberNamespace? _numberNamespace;
     private Runtime.Types.SharpTSBooleanNamespace? _booleanNamespace;
     private Runtime.Types.SharpTSPromisePrototype? _promisePrototype;
+    private Dictionary<string, Runtime.Types.SharpTSErrorClass>? _errorClasses;
     // Each prototype is linked back to this realm's constructor object on creation, so
     // `String.prototype.constructor === String` holds — both sides resolve per-realm.
     internal Runtime.Types.SharpTSStringPrototype GetStringPrototype()
@@ -379,6 +377,31 @@ public partial class Interpreter
     internal Runtime.Types.SharpTSBooleanNamespace GetBooleanNamespace() => _booleanNamespace ??= new();
     internal Runtime.Types.SharpTSPromisePrototype GetPromisePrototype() => _promisePrototype ??= new();
 
+    /// <summary>
+    /// Returns this realm's Error constructor. Error constructors and their prototype
+    /// objects are ordinary mutable objects, so sharing them through the process-wide
+    /// globals table lets one program's prototype writes leak into every later program
+    /// hosted by the same Test262 worker.
+    /// </summary>
+    internal Runtime.Types.SharpTSErrorClass GetErrorClass(string errorTypeName)
+    {
+        if (_errorClasses is null)
+        {
+            var errorClass = new Runtime.Types.SharpTSErrorClass(BuiltInNames.Error, null);
+            _errorClasses = new Dictionary<string, Runtime.Types.SharpTSErrorClass>(StringComparer.Ordinal)
+            {
+                [BuiltInNames.Error] = errorClass,
+            };
+            foreach (var name in BuiltInNames.ErrorTypeNames)
+            {
+                if (name != BuiltInNames.Error)
+                    _errorClasses[name] = new Runtime.Types.SharpTSErrorClass(name, errorClass);
+            }
+        }
+
+        return _errorClasses[errorTypeName];
+    }
+
     // Per-realm globalThis. The global object holds guest-assigned properties
     // (`globalThis.x = …`), which must stay realm-local and not race across
     // worker threads, so each Interpreter owns its own — like RegExp.prototype
@@ -389,7 +412,9 @@ public partial class Interpreter
     // `global` alias resolve here (see LookupVariableRV), and sloppy-mode `this`
     // binds to it.
     private Runtime.Types.SharpTSGlobalThis? _globalThis;
-    internal Runtime.Types.SharpTSGlobalThis GlobalThis => _globalThis ??= new Runtime.Types.SharpTSGlobalThis();
+    internal Runtime.Types.SharpTSGlobalThis GlobalThis => _globalThis ??=
+        new Runtime.Types.SharpTSGlobalThis(name =>
+            TryGetRealmIntrinsic(name, out var intrinsic) ? intrinsic : null);
 
     /// <summary>
     /// Resolves <c>String</c>/<c>Number</c>/<c>Boolean</c><c>.prototype</c> to

--- a/Runtime/BuiltIns/ErrorBuiltIns.cs
+++ b/Runtime/BuiltIns/ErrorBuiltIns.cs
@@ -59,13 +59,10 @@ public static class ErrorBuiltIns
             "cause" => receiver.HasCause ? receiver.Cause : Types.SharpTSUndefined.Instance,
             "code" when receiver.Code is not null => receiver.Code,
             "syscall" when receiver.Syscall is not null => receiver.Syscall,
-            // err.constructor must be === to the global Error/TypeError/... class
-            // so Test262's assert.throws identity check passes. Native
-            // SharpTSError instances (thrown from C# runtime code) don't track
-            // their class ref directly — look it up by name in the registry
-            // populated when SharpTSErrorClass instances are created at
-            // interpreter startup.
-            "constructor" => Types.SharpTSErrorClass.GetBuiltInClass(receiver.Name),
+            // Native SharpTSError instances need the current Interpreter to
+            // resolve their realm-owned constructor. Interpreter.Properties
+            // handles this member before entering the process-wide registry.
+            "constructor" => null,
             "toString" => BuiltInMethod.CreateV2("toString", 0, static (_, recv, _) =>
                 RuntimeValue.FromString(((SharpTSError)recv.ToObject()!).ToString())),
 

--- a/Runtime/BuiltIns/ObjectBuiltIns.cs
+++ b/Runtime/BuiltIns/ObjectBuiltIns.cs
@@ -1507,7 +1507,7 @@ public static partial class ObjectBuiltIns
         SharpTSInstance inst => inst.RuntimeClass.Prototype,
         // Native errors raised from C# carry only their type name; resolve it back to the
         // same constructor the global `TypeError` identifier yields so the prototypes match.
-        SharpTSError err => SharpTSErrorClass.GetBuiltInClass(err.Name)?.Prototype,
+        SharpTSError err => interp?.GetErrorClass(err.ErrorTypeName).Prototype,
         // ECMA-262 §23.1.3: ordinary Array exotic objects have Array.prototype as their
         // [[Prototype]]. Subclass instances keep their class chain instead.
         SharpTSArraySubclassInstance sub => sub.Klass,

--- a/Runtime/BuiltIns/ReflectBuiltIns.cs
+++ b/Runtime/BuiltIns/ReflectBuiltIns.cs
@@ -438,6 +438,7 @@ public static class ReflectBuiltIns
             or SharpTS.Runtime.Types.NumberPrototypeMethodWrapper
             or SharpTS.Runtime.Types.BooleanPrototypeMethodWrapper
             or SharpTS.Runtime.Types.SharpTSObjectUnboundMethod
+            or SharpTS.Runtime.Types.ErrorToStringCallable
             or BoundFunction
             or BuiltInMethod { IsConstructor: false })
             return true;

--- a/Runtime/Types/SharpTSError.cs
+++ b/Runtime/Types/SharpTSError.cs
@@ -15,6 +15,13 @@ public class SharpTSError : ITypeCategorized
     public TypeCategory RuntimeCategory => TypeCategory.Error;
 
     /// <summary>
+    /// The immutable built-in brand used for constructor/prototype identity.
+    /// Unlike the guest-visible <see cref="Name"/>, assigning <c>error.name</c>
+    /// must not change which intrinsic constructor created the error.
+    /// </summary>
+    internal string ErrorTypeName { get; }
+
+    /// <summary>
     /// The name of the error type (e.g., "Error", "TypeError", "RangeError").
     /// </summary>
     public string Name { get; set; }
@@ -69,6 +76,7 @@ public class SharpTSError : ITypeCategorized
     /// <param name="message">The error message.</param>
     protected SharpTSError(string name, string? message)
     {
+        ErrorTypeName = name;
         Name = name;
         Message = message ?? "";
         Stack = CaptureStackTrace();

--- a/Runtime/Types/SharpTSErrorClass.cs
+++ b/Runtime/Types/SharpTSErrorClass.cs
@@ -23,27 +23,6 @@ public class SharpTSErrorClass : SharpTSClass
     private readonly string _errorTypeName;
 
     /// <summary>
-    /// Global registry of built-in Error constructor classes keyed by error
-    /// type name. Populated lazily on construction. Native <see cref="SharpTSError"/>
-    /// instances (thrown from C# via <see cref="Exceptions.ThrowException"/>)
-    /// don't know their class reference directly; this registry lets
-    /// <c>ErrorBuiltIns.GetMember</c> resolve <c>.constructor</c> back to the
-    /// same <see cref="SharpTSErrorClass"/> instance that the global
-    /// <c>TypeError</c>/<c>RangeError</c>/... identifier resolves to, so
-    /// <c>err.constructor === TypeError</c> holds. Single-interpreter
-    /// assumption is acceptable — Test262 and the REPL both use a single
-    /// interpreter per run.
-    /// </summary>
-    private static readonly Dictionary<string, SharpTSErrorClass> _builtInRegistry = new(StringComparer.Ordinal);
-
-    /// <summary>
-    /// Returns the registered built-in Error constructor for the given type
-    /// name (e.g. "TypeError"), or null if none has been registered.
-    /// </summary>
-    public static SharpTSErrorClass? GetBuiltInClass(string errorTypeName)
-        => _builtInRegistry.TryGetValue(errorTypeName, out var cls) ? cls : null;
-
-    /// <summary>
     /// Creates a built-in Error constructor class (Error, TypeError, etc.) with no user-defined methods.
     /// </summary>
     public SharpTSErrorClass(string errorTypeName, SharpTSErrorClass? superclass)
@@ -59,7 +38,6 @@ public class SharpTSErrorClass : SharpTSClass
             staticProperties: [])
     {
         _errorTypeName = errorTypeName;
-        _builtInRegistry[errorTypeName] = this;
     }
 
     /// <summary>
@@ -221,15 +199,31 @@ public class SharpTSErrorClass : SharpTSClass
 /// <summary>
 /// Built-in toString() callable for Error instances.
 /// </summary>
-internal sealed class ErrorToStringCallable : ISharpTSCallable, IInstanceBindable
+internal sealed class ErrorToStringCallable : ISharpTSCallable, IInstanceBindable,
+    Runtime.BuiltIns.IBuiltInFunctionMetadata
 {
     private SharpTSInstance? _boundInstance;
+    private readonly Runtime.BuiltIns.BuiltInFunctionMetadata _metadata;
+
+    public ErrorToStringCallable()
+        : this(new Runtime.BuiltIns.BuiltInFunctionMetadata())
+    {
+    }
+
+    private ErrorToStringCallable(Runtime.BuiltIns.BuiltInFunctionMetadata metadata)
+    {
+        _metadata = metadata;
+    }
+
+    public string FunctionName => "toString";
+    public bool HasMetadataProperty(string name) => _metadata.Has(name);
+    public bool DeleteMetadataProperty(string name) => _metadata.Delete(name);
 
     public int Arity() => 0;
 
     public ISharpTSCallable BindTo(SharpTSInstance instance)
     {
-        return new ErrorToStringCallable { _boundInstance = instance };
+        return new ErrorToStringCallable(_metadata) { _boundInstance = instance };
     }
 
     public object? Call(Interpreter interpreter, List<object?> arguments)

--- a/Runtime/Types/SharpTSGlobalThis.cs
+++ b/Runtime/Types/SharpTSGlobalThis.cs
@@ -27,10 +27,14 @@ public sealed class SharpTSGlobalThis : ISharpTSPropertyAccessor
     /// User-assigned properties on globalThis.
     /// </summary>
     private readonly Dictionary<string, object?> _properties = new();
+    private readonly Func<string, object?>? _realmIntrinsicResolver;
 
     // internal (not private) so each Interpreter can construct its own realm
     // global object; only the _properties bag differs between instances.
-    internal SharpTSGlobalThis() { }
+    internal SharpTSGlobalThis(Func<string, object?>? realmIntrinsicResolver = null)
+    {
+        _realmIntrinsicResolver = realmIntrinsicResolver;
+    }
 
     /// <summary>
     /// True if guest code has assigned an own (user) property with this name.
@@ -62,6 +66,13 @@ public sealed class SharpTSGlobalThis : ISharpTSPropertyAccessor
         if (_properties.TryGetValue(name, out var value))
         {
             return value;
+        }
+
+        // An Interpreter-backed global object resolves mutable intrinsics from
+        // its owning realm so bare `Error` and `globalThis.Error` share identity.
+        if (_realmIntrinsicResolver?.Invoke(name) is { } realmIntrinsic)
+        {
+            return realmIntrinsic;
         }
 
         // Delegate to BuiltInRegistry for built-in namespaces (Math, JSON, etc.)
@@ -163,6 +174,8 @@ public sealed class SharpTSGlobalThis : ISharpTSPropertyAccessor
         if (name == "globalThis") return true;
         if (_properties.ContainsKey(name)) return true;
 
+        if (_realmIntrinsicResolver?.Invoke(name) is not null) return true;
+
         // Check if it's a built-in singleton
         var singleton = BuiltInRegistry.Instance.GetSingleton(name);
         if (singleton != null) return true;
@@ -196,6 +209,8 @@ public sealed class SharpTSGlobalThis : ISharpTSPropertyAccessor
             yield return "Number";
             yield return "String";
             yield return "Boolean";
+            foreach (var errorTypeName in BuiltInNames.ErrorTypeNames)
+                yield return errorTypeName;
             yield return "Symbol";
             yield return "Promise";
             yield return "process";

--- a/SharpTS.Test262/Issue1279ParityTests.cs
+++ b/SharpTS.Test262/Issue1279ParityTests.cs
@@ -790,6 +790,44 @@ public sealed class Issue1279ParityTests
     public void Built_in_metadata_deletion_does_not_outlive_the_program(string relativePath)
         => AssertPassInBothModes(relativePath);
 
+    /// <summary>
+    /// Issue #1326: Error constructors used to live in the process-static globals table.
+    /// A test that replaced Error.prototype.toString therefore changed the callable and
+    /// descriptor observed by later Interpreter instances in the same persistent worker.
+    /// </summary>
+    [Fact]
+    public void Error_prototype_mutation_does_not_outlive_the_program()
+    {
+        var root = Test262Paths.TryFindRoot();
+        if (root is null)
+        {
+            _output.WriteLine("external/test262 not initialized");
+            return;
+        }
+
+        var testDir = Test262Paths.TestDir(root);
+        var runner = new Test262Runner(
+            root, TimeSpan.FromSeconds(15), useNonCollectibleLoad: true);
+        string[] relativePaths =
+        [
+            "built-ins/Error/prototype/S15.11.4_A2.js",
+            "built-ins/Error/prototype/toString/length.js",
+            "built-ins/Error/prototype/toString/name.js",
+            "built-ins/Error/prototype/toString/not-a-constructor.js",
+            "built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-169.js",
+        ];
+
+        foreach (var relativePath in relativePaths)
+        {
+            var result = runner.RunOne(
+                Path.Combine(testDir, relativePath), Test262ExecutionMode.Interpreted);
+            _output.WriteLine($"Interpreted {relativePath} -> {result.Outcome}: {result.Message}");
+            Assert.True(
+                result.Outcome == Test262Outcome.Pass,
+                $"Interpreted {relativePath} -> {result.Outcome}: {result.Message}");
+        }
+    }
+
     private void AssertPassInBothModes(string relativePath)
     {
         foreach (var mode in new[]

--- a/SharpTS.Test262/baselines/interpreted.txt
+++ b/SharpTS.Test262/baselines/interpreted.txt
@@ -3179,8 +3179,8 @@ test/built-ins/Error/prototype/toString/S15.11.4.4_A2.js Pass
 test/built-ins/Error/prototype/toString/called-as-function.js RuntimeError
 test/built-ins/Error/prototype/toString/invalid-receiver.js Fail
 test/built-ins/Error/prototype/toString/length.js Pass
-test/built-ins/Error/prototype/toString/name.js Fail
-test/built-ins/Error/prototype/toString/not-a-constructor.js Fail
+test/built-ins/Error/prototype/toString/name.js Pass
+test/built-ins/Error/prototype/toString/not-a-constructor.js Pass
 test/built-ins/Error/prototype/toString/prop-desc.js Fail
 test/built-ins/Error/prototype/toString/tostring-get-throws.js Fail
 test/built-ins/Error/prototype/toString/tostring-message-throws-symbol.js Fail

--- a/SharpTS.Tests/GlobalThisTests.cs
+++ b/SharpTS.Tests/GlobalThisTests.cs
@@ -171,11 +171,10 @@ public class GlobalThisTests
         Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\n", result);
     }
 
-    // Compiled-only: the runtime sentinel routes constructor reads to real .NET
-    // Type tokens, so `root.Error === Error` holds (#271). The interpreter's
-    // SharpTSGlobalThis returns a distinct Error representation for this identity,
-    // which is an independent pre-existing quirk outside this fix's scope.
-    [Theory, CompiledOnlyData]
+    // Error constructors are realm-owned in interpreted mode and runtime type
+    // tokens in compiled mode; either way globalThis and the bare identifier
+    // must resolve to the same constructor object (#271, #1326).
+    [Theory, ModeData]
     public void GlobalThis_ValuePosition_ResolvesErrorConstructorIdentity(ExecutionMode mode)
     {
         var result = TestHarness.Run("""


### PR DESCRIPTION
## Summary

- move the interpreted Error constructor hierarchy and mutable prototypes into each Interpreter realm
- preserve Error constructor/prototype identity through globalThis and native runtime errors
- give Error.prototype.toString correct function metadata and non-constructor behavior
- add the same-worker regression for the order-dependent Test262 cluster and update the two new-pass baseline entries

## Verification

- dotnet test SharpTS.Tests/SharpTS.Tests.csproj: 16,293 passed
- focused Test262 same-worker regression passed
- 58 Error tests produced zero differences between forward and reverse execution order and matched the interpreted baseline

Closes #1326