### PR TITLE
feat(aot): support closed-world .NET interop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,15 +235,23 @@ jobs:
             'loading .NET reference assemblies is not available in the native SharpTS build' \
             "$scratch/reference-error.txt"
 
-          # Dynamic .NET binding is deliberately Managed-SKU-only until the native
-          # SKU defines and roots a closed BCL interop contract.
-          if "$native" Examples/AotCompileGate/dotnet-interop.ts \
+          # The official native SKU exposes a curated, linker-rooted BCL catalog
+          # through both execution paths. The universe remains closed: an import
+          # outside that catalog must fail before arbitrary reflection.
+          "$native" Examples/AotCompileGate/dotnet-interop.ts \
+            > "$scratch/dotnet-interop.txt"
+          grep -qx 'native-dotnet-42' "$scratch/dotnet-interop.txt"
+          "$native" --compile Examples/AotCompileGate/dotnet-interop.ts --ref-asm \
+            -o "$scratch/dotnet-interop.dll"
+          dotnet "$scratch/dotnet-interop.dll" > "$scratch/dotnet-interop-compiled.txt"
+          diff -u "$scratch/dotnet-interop.txt" "$scratch/dotnet-interop-compiled.txt"
+
+          if "$native" Examples/AotCompileGate/dotnet-interop-unknown.ts \
               > "$scratch/dotnet-interop-error.txt" 2>&1; then
-            echo "dynamic .NET interop unexpectedly ran under Native AOT"
+            echo "an unregistered .NET type unexpectedly ran under Native AOT"
             exit 1
           fi
-          grep -Fq \
-            '.NET interop is not available in the native SharpTS build' \
+          grep -Fq 'not present in this native SharpTS catalog' \
             "$scratch/dotnet-interop-error.txt"
 
           if "$native" --gen-decl System.String \
@@ -287,6 +295,29 @@ jobs:
             -Mode all `
             -MinimumExecuted 50 `
             -OutputFormat table
+
+      - name: Publish and exercise a custom native interop host
+        shell: bash
+        run: |
+          set -euo pipefail
+          scratch="$(mktemp -d)"
+          dotnet publish Examples/NativeInteropHost/NativeInteropHost.csproj \
+            --configuration Release -r linux-x64 \
+            -o "$scratch/host"
+          "$scratch/host/NativeInteropHost" \
+            Examples/NativeInteropHost/custom-interop.ts > "$scratch/interpreted.txt"
+          grep -qx 'changed' "$scratch/interpreted.txt"
+          grep -qx '42 42 counter' "$scratch/interpreted.txt"
+          grep -qx '3' "$scratch/interpreted.txt"
+
+          mkdir "$scratch/output"
+          "$scratch/host/NativeInteropHost" --compile \
+            Examples/NativeInteropHost/custom-interop.ts --ref-asm \
+            -o "$scratch/output/custom.dll"
+          test -f "$scratch/output/NativeInteropExample.dll"
+          test ! -f "$scratch/output/System.Runtime.dll"
+          dotnet "$scratch/output/custom.dll" > "$scratch/compiled.txt"
+          diff -u "$scratch/interpreted.txt" "$scratch/compiled.txt"
 
       - name: Upload Native AOT publish diagnostics
         if: always()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,6 +77,7 @@ jobs:
           ls -lh ./nupkg/
           test -f "./nupkg/SharpTS.${{ steps.version.outputs.VERSION }}.nupkg" || { echo "❌ SharpTS package not found"; exit 1; }
           test -f "./nupkg/SharpTS.Sdk.${{ steps.version.outputs.VERSION }}.nupkg" || { echo "❌ SharpTS.Sdk package not found"; exit 1; }
+          test -f "./nupkg/SharpTS.Hosting.${{ steps.version.outputs.VERSION }}.nupkg" || { echo "❌ SharpTS.Hosting package not found"; exit 1; }
           test -f "./nupkg/SharpTS.LanguageServer.${{ steps.version.outputs.VERSION }}.nupkg" || { echo "❌ SharpTS.LanguageServer package not found"; exit 1; }
           echo "✓ All packages created successfully"
 
@@ -352,13 +353,21 @@ jobs:
             'loading .NET reference assemblies is not available in the native SharpTS build' \
             "$scratch/reference-error.txt"
 
-          if "$native" Examples/AotCompileGate/dotnet-interop.ts \
+          "$native" Examples/AotCompileGate/dotnet-interop.ts \
+            | tr -d '\r' > "$scratch/dotnet-interop.txt"
+          grep -qx 'native-dotnet-42' "$scratch/dotnet-interop.txt"
+          "$native" --compile Examples/AotCompileGate/dotnet-interop.ts --ref-asm \
+            -o "$scratch/dotnet-interop.dll"
+          dotnet "$scratch/dotnet-interop.dll" | tr -d '\r' \
+            > "$scratch/dotnet-interop-compiled.txt"
+          diff -u "$scratch/dotnet-interop.txt" "$scratch/dotnet-interop-compiled.txt"
+
+          if "$native" Examples/AotCompileGate/dotnet-interop-unknown.ts \
               > "$scratch/dotnet-interop-error.txt" 2>&1; then
-            echo "dynamic .NET interop unexpectedly ran under Native AOT"
+            echo "an unregistered .NET type unexpectedly ran under Native AOT"
             exit 1
           fi
-          grep -Fq \
-            '.NET interop is not available in the native SharpTS build' \
+          grep -Fq 'not present in this native SharpTS catalog' \
             "$scratch/dotnet-interop-error.txt"
 
           if "$native" --gen-decl System.String \

--- a/Examples/AotCompileGate/dotnet-interop-unknown.ts
+++ b/Examples/AotCompileGate/dotnet-interop-unknown.ts
@@ -1,0 +1,3 @@
+import { FileInfo } from "dotnet:System.IO.FileInfo";
+
+console.log(new FileInfo("not-created.txt").name);

--- a/Examples/AotCompileGate/dotnet-interop.ts
+++ b/Examples/AotCompileGate/dotnet-interop.ts
@@ -1,3 +1,8 @@
-import { StringBuilder } from "dotnet:System.Text.StringBuilder";
+import { StringBuilder } from "dotnet:System.Text";
+import { List } from "dotnet:System.Collections.Generic.List<number>";
 
-console.log(new StringBuilder().append("unexpected").toString());
+const text = new StringBuilder().append("native-dotnet-");
+const values = new List();
+values.add(40);
+values.add(42);
+console.log(text.append(values[1]).toString());

--- a/Examples/NativeInteropHost/Library/Counter.cs
+++ b/Examples/NativeInteropHost/Library/Counter.cs
@@ -1,0 +1,20 @@
+namespace NativeInteropExample;
+
+public sealed class Counter(int value)
+{
+    public int Value { get; private set; } = value;
+
+    public string Label = "counter";
+
+    public event EventHandler? Changed;
+
+    public int Increment(int amount)
+    {
+        Value += amount;
+        Changed?.Invoke(this, EventArgs.Empty);
+        return Value;
+    }
+
+    public static List<Counter> CreateMany(int count) =>
+        Enumerable.Range(0, count).Select(value => new Counter(value)).ToList();
+}

--- a/Examples/NativeInteropHost/Library/NativeInteropExample.csproj
+++ b/Examples/NativeInteropHost/Library/NativeInteropExample.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <AssemblyName>NativeInteropExample</AssemblyName>
+  </PropertyGroup>
+</Project>

--- a/Examples/NativeInteropHost/NativeInteropHost.csproj
+++ b/Examples/NativeInteropHost/NativeInteropHost.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\SharpTS.Hosting\buildTransitive\SharpTS.Hosting.props" />
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <PublishAot>true</PublishAot>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="Library\**" />
+    <None Remove="Library\**" />
+    <ProjectReference Include="Library\NativeInteropExample.csproj"
+                      AdditionalProperties="PublishAot=false;RuntimeIdentifier=" />
+    <Reference Include="SharpTS"
+               HintPath="..\..\bin\$(Configuration)\net10.0\SharpTS.dll"
+               Private="true" />
+
+    <SharpTSNativeInteropType Include="NativeInteropExample.Counter"
+                              Assembly="NativeInteropExample"
+                              Alias="Counter" />
+    <SharpTSNativeInteropType Include="System.Collections.Generic.List&lt;NativeInteropExample.Counter&gt;"
+                              Assembly="NativeInteropExample"
+                              Alias="CounterList" />
+  </ItemGroup>
+
+  <!-- Repository-template plumbing. Consumers use the SharpTS.Hosting package,
+       whose lib/net10.0 payload supplies this reference. -->
+  <Target Name="BuildRepositorySharpTSHostingLibrary" BeforeTargets="ResolveReferences">
+    <MSBuild Projects="..\..\SharpTS.csproj"
+             Targets="Build"
+             Properties="Configuration=$(Configuration);PublishAot=false;RuntimeIdentifier=" />
+  </Target>
+
+  <Import Project="..\..\SharpTS.Hosting\buildTransitive\SharpTS.Hosting.targets" />
+</Project>

--- a/Examples/NativeInteropHost/NativeInteropHost.csproj
+++ b/Examples/NativeInteropHost/NativeInteropHost.csproj
@@ -25,10 +25,12 @@
   </ItemGroup>
 
   <!-- Repository-template plumbing. Consumers use the SharpTS.Hosting package,
-       whose lib/net10.0 payload supplies this reference. -->
-  <Target Name="BuildRepositorySharpTSHostingLibrary" BeforeTargets="ResolveReferences">
+       whose lib/net10.0 payload supplies this reference. Restore explicitly so
+       this example also publishes from a clean checkout, without relying on a
+       previous solution or SharpTS build to have produced project.assets.json. -->
+  <Target Name="BuildRepositorySharpTSHostingLibrary" BeforeTargets="ResolveAssemblyReferences">
     <MSBuild Projects="..\..\SharpTS.csproj"
-             Targets="Build"
+             Targets="Restore;Build"
              Properties="Configuration=$(Configuration);PublishAot=false;RuntimeIdentifier=" />
   </Target>
 

--- a/Examples/NativeInteropHost/Program.cs
+++ b/Examples/NativeInteropHost/Program.cs
@@ -1,0 +1,3 @@
+return SharpTSCli.Run(
+    args,
+    SharpTS.Generated.GeneratedNativeDotNetCatalog.Instance);

--- a/Examples/NativeInteropHost/README.md
+++ b/Examples/NativeInteropHost/README.md
@@ -1,0 +1,21 @@
+# Native AOT host with custom .NET interop
+
+This is the repository smoke fixture and a copyable host template. The project
+declares a closed interop type set with `SharpTSNativeInteropType`, publishes a
+Native AOT executable, and starts the ordinary SharpTS CLI with the generated
+catalog.
+
+For an installed package, replace the repository imports/project reference with:
+
+```xml
+<PackageReference Include="SharpTS.Hosting" Version="..." />
+```
+
+Keep interop implementations in class libraries. Set each item's `Assembly`
+metadata to that library's assembly name; the build embeds its managed DLL and
+copy-local dependency closure so `--compile` can deploy them beside its output.
+
+```powershell
+dotnet publish -c Release -r win-x64
+./bin/Release/net10.0/win-x64/publish/NativeInteropHost.exe custom-interop.ts
+```

--- a/Examples/NativeInteropHost/custom-interop.ts
+++ b/Examples/NativeInteropHost/custom-interop.ts
@@ -1,0 +1,8 @@
+import { Counter } from "dotnet:NativeInteropExample.Counter";
+
+const counter = new Counter(40);
+counter.addEventListener("Changed", () => console.log("changed"));
+console.log(counter.increment(2), counter.value, counter.label);
+
+const counters = Counter.createMany(3);
+console.log(counters.count);

--- a/Modules/DotNetImports.cs
+++ b/Modules/DotNetImports.cs
@@ -57,8 +57,6 @@ public static class DotNetImports
     /// form is unsupported or a name cannot be resolved to a usable .NET type.</exception>
     public static void EnsureImports(ParsedModule module, Stmt.Import import)
     {
-        ManagedDotNetInterop.RequireManagedRuntime();
-
         if (import.DefaultImport != null)
         {
             throw new Exception(
@@ -111,7 +109,6 @@ public static class DotNetImports
     /// resolved to a usable public .NET type.</exception>
     public static Type ResolveExportType(string specifier, string name, Func<string, Type?>? resolve = null)
     {
-        ManagedDotNetInterop.RequireManagedRuntime();
         resolve ??= DotNetTypeRegistry.Resolve;
 
         if (specifier.Contains('/') || specifier.Contains('\\') || specifier.Contains('#') ||
@@ -172,6 +169,17 @@ public static class DotNetImports
         // Namespace form: resolve each named import as Namespace.Name.
         var type = ResolvePublic($"{specifier}.{name}", resolve);
         if (type != null) return type;
+
+        if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported &&
+            NativeDotNetInterop.Catalog != null)
+        {
+            string requestedType = specifier.EndsWith($".{name}", StringComparison.Ordinal)
+                ? specifier
+                : $"{specifier}.{name}";
+            throw new Exception(
+                $"Module Error: {ManagedDotNetInterop.NativeCatalogRequiredMessage} " +
+                $"Requested type: '{requestedType}'.");
+        }
 
         throw new Exception(
             $"Module Error: cannot resolve '{name}' from 'dotnet:{specifier}': neither a type " +

--- a/Program.cs
+++ b/Program.cs
@@ -53,7 +53,20 @@ using SharpTS.Packaging;
 using SharpTS.Parsing;
 using SharpTS.Projects;
 using SharpTS.References;
+using SharpTS.Runtime.DotNet;
 using SharpTS.TypeSystem;
+
+return SharpTSCli.Run(args);
+
+/// <summary>Reusable SharpTS command-line host used by the stock and custom Native AOT executables.</summary>
+public static class SharpTSCli
+{
+public static int Run(string[] args, INativeDotNetCatalog? nativeInteropCatalog = null)
+{
+if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
+{
+    NativeDotNetInterop.Configure(nativeInteropCatalog ?? DefaultNativeDotNetCatalog.Instance);
+}
 
 // Initialize fork IPC if this process was spawned via child_process.fork()
 SharpTS.Runtime.Types.ForkIpcClient.TryInitialize();
@@ -66,18 +79,17 @@ switch (command)
 {
     case ParsedCommand.Help:
         PrintHelp();
-        return;
+        return 0;
 
     case ParsedCommand.Version:
         Console.WriteLine($"sharpts {GetVersion()}");
-        return;
+        return 0;
 
     case ParsedCommand.Error error:
         Console.WriteLine(error.Message);
         if (error.ShowCompileUsage)
             PrintCompileUsage();
-        Environment.Exit(error.ExitCode);
-        break;
+        return error.ExitCode;
 
     case ParsedCommand.Project project:
         try
@@ -89,7 +101,7 @@ switch (command)
                 var (resolvedOptions, _) = ApplyTsConfig(
                     project.Options, Path.GetDirectoryName(projectPath) ?? ".");
                 PrintResolvedConfig(resolvedOptions, project.Options.Strictness, projectConfig);
-                return;
+                return Environment.ExitCode;
             }
 
             Environment.ExitCode = project.Options.Watch
@@ -128,7 +140,7 @@ switch (command)
         if (replOptions.ShowConfig)
         {
             PrintResolvedConfig(replOptions, repl.Options.Strictness, replConfig);
-            return;
+            return Environment.ExitCode;
         }
         var replRefs = LoadDotNetReferences(Environment.CurrentDirectory, replOptions.References);
         if (replRefs.ManifestPath != null)
@@ -146,7 +158,7 @@ switch (command)
         if (scriptOptions.ShowConfig)
         {
             PrintResolvedConfig(scriptOptions, script.Options.Strictness, scriptConfig);
-            return;
+            return Environment.ExitCode;
         }
         RunFile(script.ScriptPath, scriptOptions, script.ScriptArgs, scriptConfig);
         break;
@@ -157,7 +169,7 @@ switch (command)
         if (compileOptions.ShowConfig)
         {
             PrintResolvedConfig(compileOptions, compile.GlobalOptions.Strictness, compileConfig);
-            return;
+            return Environment.ExitCode;
         }
         if (compile.CompileOptions.VerifyIL)
             RequireManagedBuild("--verify"); // ILVerifier resolves the BCL from typeof(object).Assembly.Location — no BCL on disk in a native build
@@ -185,6 +197,9 @@ switch (command)
         RequireManagedBuild("--gen-decl"); // DiscoveryGenerator needs Assembly.LoadFrom; the by-name fallback returns truncated metadata
         GenerateDeclarations(genDecl.TypeOrAssembly, genDecl.OutputPath, genDecl.Json, genDecl.References);
         break;
+}
+
+return Environment.ExitCode;
 }
 
 /// <summary>
@@ -988,14 +1003,38 @@ static void CopySharpTSRuntimeIfNeeded(ILCompiler compiler, string outputPath, O
     Justification = "Native AOT rejects third-party reference loading before compilation; this dependency walk is reachable only after a managed host loaded those assemblies.")]
 static void CopyExternalReferencesIfNeeded(ILCompiler compiler, ReferenceSet externalRefs, string outputPath, OutputOptions outputOptions)
 {
-    if (externalRefs.IsEmpty)
-        return;
-
     if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
     {
-        RequireManagedBuild(".NET references in compiled output");
+        if (compiler.ExternalInteropAssemblies.Count == 0)
+            return;
+
+        string? outputDirectory = Path.GetDirectoryName(Path.GetFullPath(outputPath));
+        if (outputDirectory is null)
+            throw new InvalidOperationException($"Could not resolve the output directory for '{outputPath}'.");
+
+        if (outputOptions.Standalone)
+        {
+            if (!outputOptions.QuietMode)
+                Console.WriteLine(
+                    "Note: output uses native-host .NET interop assemblies; --standalone set, " +
+                    "so their managed payloads were not extracted.");
+            return;
+        }
+
+        INativeDotNetCatalog catalog = NativeDotNetInterop.Catalog
+            ?? throw new PlatformNotSupportedException(ManagedDotNetInterop.ManagedBuildRequiredMessage);
+        IReadOnlyList<string> extracted = catalog.ExtractAssemblyPayloads(outputDirectory);
+        if (extracted.Count > 0 && !outputOptions.QuietMode)
+        {
+            Console.WriteLine(
+                $"Extracted {extracted.Count} native-host .NET interop " +
+                $"assembl{(extracted.Count == 1 ? "y" : "ies")} next to output");
+        }
         return;
     }
+
+    if (externalRefs.IsEmpty)
+        return;
 
     // Which reference DLLs did the compilation actually bind types from?
     var used = new List<ResolvedReference>();
@@ -1431,3 +1470,4 @@ static void PrintCompileUsage()
 }
 
 record OutputOptions(bool MsBuildErrors, bool QuietMode, bool Standalone = false, bool EmitDebugSymbols = false);
+}

--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ SharpTS supports two execution modes:
   full feature set, including third-party DLL/NuGet interop, `@DotNetType`,
   `dotnet:` imports, `--verify`, and `--gen-decl`.
 - `sharpts-native-<version>-<rid>` is the Native AOT SKU. It starts faster and
-  does not extract a runtime, but has a frozen type universe: use the managed
-  SKU for third-party interop, verification/declaration generation, or compiled
-  `child_process.fork`. Built-in `--target exe` is Windows/Linux-only.
+  does not extract a runtime. Its frozen type universe includes a curated BCL
+  interop profile; use `SharpTS.Hosting` to publish a custom native executable
+  with application types. Verification/declaration generation and compiled
+  `child_process.fork` remain managed-only. Built-in `--target exe` is
+  Windows/Linux-only.
 
 **Install CLI tool from NuGet (recommended):**
 
@@ -133,6 +135,38 @@ sharpts script.ts
 sharpts --compile script.ts
 dotnet script.dll
 ```
+
+### Native AOT .NET interop
+
+The official native binaries support a closed BCL profile (including strings,
+`StringBuilder`, dates/times, `Guid`, numeric conversion/math, environment and
+console APIs, tasks, selected enums, and closed numeric list/dictionary shapes).
+An import outside that catalog fails with a named error instead of attempting
+open-world reflection.
+
+For application or third-party types, create a small Native AOT host with the
+`SharpTS.Hosting` package and declare the exact closed types at build time:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="SharpTS.Hosting" Version="..." />
+  <ProjectReference Include="MyCompany.Library.csproj" />
+  <SharpTSNativeInteropType Include="MyCompany.Widget"
+                            Assembly="MyCompany.Library"
+                            Alias="Widget" />
+</ItemGroup>
+```
+
+```csharp
+return SharpTSCli.Run(
+    args,
+    SharpTS.Generated.GeneratedNativeDotNetCatalog.Instance);
+```
+
+The generated catalog roots constructors, methods, properties, fields, events,
+and declared closed generics. The selected managed assembly and its non-framework
+copy-local dependency closure are embedded so both interpretation and
+`--compile` work. See `Examples/NativeInteropHost` for a complete project.
 
 Add `-g` to emit a portable PDB and debug the original `.ts` source. See
 [Debugging compiled TypeScript](docs/debugging-typescript.md).

--- a/Runtime/DotNet/DotNetDelegateShim.cs
+++ b/Runtime/DotNet/DotNetDelegateShim.cs
@@ -37,6 +37,17 @@ internal static class DotNetDelegateShim
                 $"Type '{delegateType.FullName}' is not a delegate type.", nameof(delegateType));
         }
 
+        // Native AOT cannot synthesize an arbitrary delegate shape. The official
+        // catalog carries direct adapters for the callback shapes exposed by its
+        // BCL profile; generated custom hosts add equivalent strongly typed thunks.
+        if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
+        {
+            if (TryCreateCatalogedDelegate(delegateType, callable, interpreter, out Delegate? cataloged))
+                return cataloged;
+            throw new PlatformNotSupportedException(
+                $"Delegate shape '{delegateType.FullName}' is not present in this native SharpTS catalog.");
+        }
+
         var invoke = ManagedDotNetInterop.GetMethod(delegateType, "Invoke")
             ?? throw new InvalidOperationException(
                 $"Delegate type '{delegateType.FullName}' has no Invoke method.");
@@ -84,6 +95,37 @@ internal static class DotNetDelegateShim
         }
 
         return ManagedDotNetInterop.CompileLambda(delegateType, body, paramExprs);
+    }
+
+    private static bool TryCreateCatalogedDelegate(
+        Type delegateType,
+        ISharpTSCallable callable,
+        Interpreter interpreter,
+        [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Delegate? result)
+    {
+        if (delegateType == typeof(Action))
+            result = (Action)(() => Dispatch(callable, interpreter, typeof(void), []));
+        else if (delegateType == typeof(Action<string>))
+            result = (Action<string>)(value => Dispatch(callable, interpreter, typeof(void), [value]));
+        else if (delegateType == typeof(Action<double>))
+            result = (Action<double>)(value => Dispatch(callable, interpreter, typeof(void), [value]));
+        else if (delegateType == typeof(Func<string>))
+            result = (Func<string>)(() => (string)Dispatch(callable, interpreter, typeof(string), [])!);
+        else if (delegateType == typeof(Predicate<double>))
+            result = (Predicate<double>)(value =>
+                (bool)Dispatch(callable, interpreter, typeof(bool), [value])!);
+        else if (delegateType == typeof(Comparison<double>))
+            result = (Comparison<double>)((left, right) =>
+                (int)Dispatch(callable, interpreter, typeof(int), [left, right])!);
+        else if (delegateType == typeof(EventHandler))
+            result = (EventHandler)((sender, eventArgs) =>
+                Dispatch(callable, interpreter, typeof(void), [sender, eventArgs]));
+        else if (delegateType == typeof(UnhandledExceptionEventHandler))
+            result = (UnhandledExceptionEventHandler)((sender, eventArgs) =>
+                Dispatch(callable, interpreter, typeof(void), [sender, eventArgs]));
+        else
+            result = null;
+        return result != null;
     }
 
     /// <summary>

--- a/Runtime/DotNet/DotNetTypeRegistry.cs
+++ b/Runtime/DotNet/DotNetTypeRegistry.cs
@@ -25,11 +25,10 @@ public static class DotNetTypeRegistry
     /// </summary>
     public static Type? Resolve(string clrTypeName)
     {
-        ManagedDotNetInterop.RequireManagedRuntime();
         if (_cache.TryGetValue(clrTypeName, out var cached)) return cached;
 
         var type = ManagedDotNetInterop.ResolveType(clrTypeName);
-        if (type == null)
+        if (type == null && System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
         {
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
@@ -67,11 +66,18 @@ public static class DotNetTypeRegistry
     /// </param>
     public static Type? ResolveFriendly(string friendlyName, Func<string, Type?>? resolve = null)
     {
-        ManagedDotNetInterop.RequireManagedRuntime();
         ArgumentException.ThrowIfNullOrWhiteSpace(friendlyName);
-        resolve ??= Resolve;
 
         string name = friendlyName.Trim();
+        if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported &&
+            NativeDotNetInterop.Catalog is { } nativeCatalog)
+        {
+            return nativeCatalog.TryResolveType(name, out Type? catalogType)
+                ? catalogType
+                : null;
+        }
+
+        resolve ??= Resolve;
         if (TryResolveAlias(name, out var alias))
             return resolve(alias.FullName!) ?? alias;
 
@@ -259,7 +265,7 @@ public static class DotNetTypeRegistry
     /// </summary>
     public static MethodInfo[] GetMethods(Type type, string jsName, bool isStatic)
     {
-        ManagedDotNetInterop.RequireManagedRuntime();
+        ManagedDotNetInterop.RequireManagedRuntime(type);
         return _methodCache.GetOrAdd((type, jsName, isStatic), static key =>
         {
             var (t, name, stat) = key;
@@ -278,7 +284,7 @@ public static class DotNetTypeRegistry
     /// </summary>
     public static MemberInfo? GetPropertyOrField(Type type, string jsName, bool isStatic)
     {
-        ManagedDotNetInterop.RequireManagedRuntime();
+        ManagedDotNetInterop.RequireManagedRuntime(type);
         return _propertyOrFieldCache.GetOrAdd((type, jsName, isStatic), static key =>
         {
             var (t, name, stat) = key;
@@ -308,7 +314,7 @@ public static class DotNetTypeRegistry
     /// </summary>
     public static EventInfo? GetEvent(Type type, string jsName, bool isStatic)
     {
-        ManagedDotNetInterop.RequireManagedRuntime();
+        ManagedDotNetInterop.RequireManagedRuntime(type);
         return _eventCache.GetOrAdd((type, jsName, isStatic), static key =>
         {
             var (t, name, stat) = key;
@@ -324,7 +330,7 @@ public static class DotNetTypeRegistry
     /// </summary>
     internal static PropertyInfo[] GetIndexers(Type type, bool writable)
     {
-        ManagedDotNetInterop.RequireManagedRuntime();
+        ManagedDotNetInterop.RequireManagedRuntime(type);
         return _indexerCache.GetOrAdd((type, writable), static key =>
         {
             var (target, write) = key;

--- a/Runtime/DotNet/ManagedDotNetInterop.cs
+++ b/Runtime/DotNet/ManagedDotNetInterop.cs
@@ -21,6 +21,10 @@ internal static class ManagedDotNetInterop
     internal const string ManagedBuildRequiredMessage =
         ".NET interop is not available in the native SharpTS build — use the managed build.";
 
+    internal const string NativeCatalogRequiredMessage =
+        ".NET interop type or member is not present in this native SharpTS catalog — " +
+        "use a custom native host that registers it, or use the managed build.";
+
     private const string TrimJustification =
         "Open-world .NET interop is a Managed-SKU feature. The native build is rejected " +
         "before inspecting arbitrary BCL, embedder, or third-party types.";
@@ -29,58 +33,93 @@ internal static class ManagedDotNetInterop
         "Open-world .NET interop is a Managed-SKU feature. The native build is rejected " +
         "before constructing an array, generic, delegate, or other runtime-generated shape.";
 
-    internal static void RequireManagedRuntime()
+    internal static void RequireManagedRuntime(Type? catalogType = null)
     {
-        if (!RuntimeFeature.IsDynamicCodeSupported)
-            throw new PlatformNotSupportedException(ManagedBuildRequiredMessage);
+        if (RuntimeFeature.IsDynamicCodeSupported)
+            return;
+
+        // Some runtime-provided MethodInfo shapes (notably closed generic BCL
+        // helpers) report no declaring type. Entry into those operations has
+        // already been gated by discovery on a cataloged owner; null must not
+        // turn that closed member into an apparent open-world request.
+        if (catalogType is null && NativeDotNetInterop.Catalog != null)
+            return;
+
+        if (catalogType != null && NativeDotNetInterop.IsAllowed(catalogType))
+            return;
+
+        throw new PlatformNotSupportedException(
+            NativeDotNetInterop.Catalog == null
+                ? ManagedBuildRequiredMessage
+                : $"{NativeCatalogRequiredMessage} Requested runtime type: '{catalogType?.FullName ?? catalogType?.ToString() ?? "<unknown>"}'.");
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2057", Justification = TrimJustification)]
     internal static Type? ResolveType(string typeName)
     {
-        RequireManagedRuntime();
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            if (NativeDotNetInterop.Catalog is { } catalog &&
+                catalog.TryResolveType(typeName, out Type? catalogType))
+            {
+                return catalogType;
+            }
+            throw new PlatformNotSupportedException(
+                NativeDotNetInterop.Catalog == null
+                    ? ManagedBuildRequiredMessage
+                    : $"{NativeCatalogRequiredMessage} Requested type: '{typeName}'.");
+        }
         return Type.GetType(typeName, throwOnError: false);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = TrimJustification)]
     internal static Type? ResolveType(Assembly assembly, string typeName)
     {
-        RequireManagedRuntime();
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            if (NativeDotNetInterop.Catalog is { } catalog &&
+                catalog.TryResolveType(typeName, out Type? catalogType))
+            {
+                return catalogType;
+            }
+            throw new PlatformNotSupportedException(
+                $"{NativeCatalogRequiredMessage} Requested type: '{typeName}'.");
+        }
         return assembly.GetType(typeName, throwOnError: false);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
     internal static MethodInfo[] GetMethods(Type type, BindingFlags flags)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(type);
         return type.GetMethods(flags);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
     internal static MethodInfo? GetMethod(Type type, string name)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(type);
         return type.GetMethod(name);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
     internal static MethodInfo? GetMethod(Type type, string name, Type[] parameterTypes)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(type);
         return type.GetMethod(name, parameterTypes);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
     internal static ConstructorInfo[] GetConstructors(Type type, BindingFlags flags)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(type);
         return type.GetConstructors(flags);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
     internal static ConstructorInfo? GetConstructor(Type type, Type[] parameterTypes)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(type);
         return type.GetConstructor(parameterTypes);
     }
 
@@ -90,7 +129,7 @@ internal static class ManagedDotNetInterop
         BindingFlags flags,
         Type[] parameterTypes)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(type);
         return type.GetConstructor(
             flags,
             binder: null,
@@ -101,56 +140,56 @@ internal static class ManagedDotNetInterop
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
     internal static PropertyInfo[] GetProperties(Type type, BindingFlags flags)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(type);
         return type.GetProperties(flags);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
     internal static PropertyInfo? GetProperty(Type type, string name, BindingFlags flags)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(type);
         return type.GetProperty(name, flags);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
     internal static FieldInfo? GetField(Type type, string name, BindingFlags flags)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(type);
         return type.GetField(name, flags);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
     internal static FieldInfo[] GetFields(Type type, BindingFlags flags)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(type);
         return type.GetFields(flags);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
     internal static EventInfo? GetEvent(Type type, string name, BindingFlags flags)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(type);
         return type.GetEvent(name, flags);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
     internal static EventInfo[] GetEvents(Type type, BindingFlags flags)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(type);
         return type.GetEvents(flags);
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2070", Justification = TrimJustification)]
     internal static Type[] GetInterfaces(Type type)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(type);
         return type.GetInterfaces();
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2067", Justification = TrimJustification)]
     internal static object? CreateInstance(Type type)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(type);
         return Activator.CreateInstance(type);
     }
 
@@ -158,7 +197,16 @@ internal static class ManagedDotNetInterop
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = DynamicCodeJustification)]
     internal static Type MakeGenericType(Type definition, params Type[] arguments)
     {
-        RequireManagedRuntime();
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            RequireManagedRuntime(definition);
+            if (NativeDotNetInterop.Catalog is { } catalog &&
+                catalog.TryGetConstructedGeneric(definition, arguments, out Type? constructed))
+            {
+                return constructed;
+            }
+            throw new PlatformNotSupportedException(NativeCatalogRequiredMessage);
+        }
         return definition.MakeGenericType(arguments);
     }
 
@@ -166,36 +214,124 @@ internal static class ManagedDotNetInterop
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = DynamicCodeJustification)]
     internal static MethodInfo MakeGenericMethod(MethodInfo definition, params Type[] arguments)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(definition.DeclaringType);
+        if (!RuntimeFeature.IsDynamicCodeSupported &&
+            arguments.Any(argument => !NativeDotNetInterop.IsAllowed(argument)))
+        {
+            throw new PlatformNotSupportedException(NativeCatalogRequiredMessage);
+        }
         return definition.MakeGenericMethod(arguments);
     }
 
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = DynamicCodeJustification)]
     internal static Type MakeArrayType(Type elementType)
     {
-        RequireManagedRuntime();
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            RequireManagedRuntime(elementType);
+            if (TryGetIntrinsicArrayType(elementType, out Type? intrinsicArray))
+                return intrinsicArray;
+            if (NativeDotNetInterop.Catalog is { } catalog &&
+                catalog.TryGetArrayType(elementType, out Type? arrayType))
+            {
+                return arrayType;
+            }
+            throw new PlatformNotSupportedException(NativeCatalogRequiredMessage);
+        }
         return elementType.MakeArrayType();
     }
 
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = DynamicCodeJustification)]
     internal static Type GetActionType(params Type[] parameterTypes)
     {
-        RequireManagedRuntime();
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            Type definition = parameterTypes.Length switch
+            {
+                0 => typeof(Action),
+                1 => typeof(Action<>),
+                2 => typeof(Action<,>),
+                3 => typeof(Action<,,>),
+                4 => typeof(Action<,,,>),
+                _ => throw new PlatformNotSupportedException(NativeCatalogRequiredMessage)
+            };
+            if (parameterTypes.Length == 0)
+                return NativeDotNetInterop.IsAllowed(definition)
+                    ? definition
+                    : throw new PlatformNotSupportedException(NativeCatalogRequiredMessage);
+            return MakeGenericType(definition, parameterTypes);
+        }
         return Expression.GetActionType(parameterTypes);
     }
 
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = DynamicCodeJustification)]
     internal static Type GetFuncType(params Type[] parameterAndReturnTypes)
     {
-        RequireManagedRuntime();
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            Type definition = parameterAndReturnTypes.Length switch
+            {
+                1 => typeof(Func<>),
+                2 => typeof(Func<,>),
+                3 => typeof(Func<,,>),
+                4 => typeof(Func<,,,>),
+                5 => typeof(Func<,,,,>),
+                _ => throw new PlatformNotSupportedException(NativeCatalogRequiredMessage)
+            };
+            return MakeGenericType(definition, parameterAndReturnTypes);
+        }
         return Expression.GetFuncType(parameterAndReturnTypes);
     }
 
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = DynamicCodeJustification)]
     internal static Array CreateArray(Type elementType, int length)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(elementType);
+        if (!RuntimeFeature.IsDynamicCodeSupported)
+        {
+            if (TryCreateIntrinsicArray(elementType, length, out Array? intrinsicArray))
+                return intrinsicArray;
+            INativeDotNetCatalog catalog = NativeDotNetInterop.Catalog
+                ?? throw new PlatformNotSupportedException(ManagedBuildRequiredMessage);
+            if (!catalog.TryGetArrayType(elementType, out _))
+                throw new PlatformNotSupportedException(NativeCatalogRequiredMessage);
+        }
         return Array.CreateInstance(elementType, length);
+    }
+
+    private static bool TryGetIntrinsicArrayType(
+        Type elementType,
+        [NotNullWhen(true)] out Type? arrayType)
+    {
+        arrayType = elementType == typeof(object) ? typeof(object[])
+            : elementType == typeof(string) ? typeof(string[])
+            : elementType == typeof(bool) ? typeof(bool[])
+            : elementType == typeof(char) ? typeof(char[])
+            : elementType == typeof(byte) ? typeof(byte[])
+            : elementType == typeof(int) ? typeof(int[])
+            : elementType == typeof(long) ? typeof(long[])
+            : elementType == typeof(float) ? typeof(float[])
+            : elementType == typeof(double) ? typeof(double[])
+            : null;
+        return arrayType != null;
+    }
+
+    private static bool TryCreateIntrinsicArray(
+        Type elementType,
+        int length,
+        [NotNullWhen(true)] out Array? array)
+    {
+        array = elementType == typeof(object) ? new object?[length]
+            : elementType == typeof(string) ? new string?[length]
+            : elementType == typeof(bool) ? new bool[length]
+            : elementType == typeof(char) ? new char[length]
+            : elementType == typeof(byte) ? new byte[length]
+            : elementType == typeof(int) ? new int[length]
+            : elementType == typeof(long) ? new long[length]
+            : elementType == typeof(float) ? new float[length]
+            : elementType == typeof(double) ? new double[length]
+            : null;
+        return array != null;
     }
 
     [UnconditionalSuppressMessage("AOT", "IL3050", Justification = DynamicCodeJustification)]
@@ -203,7 +339,7 @@ internal static class ManagedDotNetInterop
         Type elementType,
         params Expression[] expressions)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(elementType);
         return Expression.NewArrayInit(elementType, expressions);
     }
 
@@ -213,7 +349,7 @@ internal static class ManagedDotNetInterop
         Expression body,
         params ParameterExpression[] parameters)
     {
-        RequireManagedRuntime();
+        RequireManagedRuntime(delegateType);
         return Expression.Lambda(delegateType, body, parameters).Compile();
     }
 }

--- a/Runtime/DotNet/NativeDotNetCatalog.cs
+++ b/Runtime/DotNet/NativeDotNetCatalog.cs
@@ -1,0 +1,292 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace SharpTS.Runtime.DotNet;
+
+/// <summary>
+/// Closed set of CLR types whose metadata and native code are available to the
+/// Native AOT SharpTS process. Managed builds continue to use the open-world
+/// reflection provider and do not consult this catalog.
+/// </summary>
+public interface INativeDotNetCatalog
+{
+    internal const DynamicallyAccessedMemberTypes InteropMembers =
+        DynamicallyAccessedMemberTypes.PublicConstructors |
+        DynamicallyAccessedMemberTypes.PublicMethods |
+        DynamicallyAccessedMemberTypes.PublicProperties |
+        DynamicallyAccessedMemberTypes.PublicFields |
+        DynamicallyAccessedMemberTypes.PublicEvents |
+        DynamicallyAccessedMemberTypes.PublicNestedTypes;
+
+    /// <summary>Resolves a CLR or SharpTS-friendly type name from the closed catalog.</summary>
+    bool TryResolveType(
+        string typeName,
+        [NotNullWhen(true)] out Type? type);
+
+    /// <summary>Returns whether the exact runtime type belongs to the catalog.</summary>
+    bool Contains(Type type);
+
+    /// <summary>Finds a registered constructed generic type without creating one at runtime.</summary>
+    bool TryGetConstructedGeneric(
+        Type genericDefinition,
+        IReadOnlyList<Type> arguments,
+        [NotNullWhen(true)] out Type? type);
+
+    /// <summary>Finds a registered array type without creating one at runtime.</summary>
+    bool TryGetArrayType(
+        Type elementType,
+        [NotNullWhen(true)] out Type? type);
+
+    /// <summary>
+    /// Extracts the managed assembly payload closure selected by a custom host.
+    /// The official catalog has no payloads and returns an empty list.
+    /// </summary>
+    IReadOnlyList<string> ExtractAssemblyPayloads(string destinationDirectory);
+}
+
+/// <summary>
+/// Builder used by generated Native AOT host code. Calling <see cref="Add{T}"/>
+/// is the build-time contract that roots the selected type and all public member
+/// metadata required by the existing SharpTS binder.
+/// </summary>
+public sealed class NativeDotNetCatalogBuilder
+{
+    private readonly Dictionary<string, Type> _names = new(StringComparer.Ordinal);
+    private readonly HashSet<Type> _types = [];
+    private readonly Dictionary<string, string> _assemblyPayloads =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    public NativeDotNetCatalogBuilder Add<
+        [DynamicallyAccessedMembers(INativeDotNetCatalog.InteropMembers)] T>(
+        params string[] aliases)
+    {
+        AddCore(typeof(T), aliases);
+        return this;
+    }
+
+    public NativeDotNetCatalogBuilder Add(
+        [DynamicallyAccessedMembers(INativeDotNetCatalog.InteropMembers)] Type type,
+        params string[] aliases)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        AddCore(type, aliases);
+        return this;
+    }
+
+    public NativeDotNetCatalogBuilder AddEnum<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T>(
+        params string[] aliases) where T : struct, Enum
+    {
+        AddCore(typeof(T), aliases);
+        return this;
+    }
+
+    public NativeDotNetCatalogBuilder AddDelegate<T>(params string[] aliases)
+        where T : Delegate
+    {
+        AddCore(typeof(T), aliases);
+        return this;
+    }
+
+    public NativeDotNetCatalogBuilder AddStaticEventSurface<
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicProperties |
+            DynamicallyAccessedMemberTypes.PublicEvents)] T>(
+        params string[] aliases)
+    {
+        AddCore(typeof(T), aliases);
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a managed DLL embedded in the executable host. Generated host
+    /// code uses this for the selected interop assemblies and their dependencies.
+    /// </summary>
+    public NativeDotNetCatalogBuilder AddAssemblyPayload(
+        string fileName,
+        string resourceName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(resourceName);
+        _assemblyPayloads[Path.GetFileName(fileName)] = resourceName;
+        return this;
+    }
+
+    /// <summary>Adds the curated BCL profile shipped by the official native binary.</summary>
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050",
+        Justification = "The only enum shapes rooted here are compile-time-known closed enum types; Native AOT generates their value arrays.")]
+    public NativeDotNetCatalogBuilder AddDefaultTypes() =>
+        Add<string>("System.String")
+            .Add<System.Text.StringBuilder>()
+            .Add<Guid>()
+            .Add<DateTime>()
+            .Add<TimeSpan>()
+            .Add(typeof(Convert))
+            .Add(typeof(Math))
+            .Add(typeof(Environment))
+            .Add<Uri>()
+            .Add(typeof(Console))
+            .AddStaticEventSurface<AppDomain>()
+            .Add<System.Threading.Tasks.Task>()
+            .AddEnum<DayOfWeek>()
+            .AddEnum<Environment.SpecialFolder>()
+            .AddDelegate<EventHandler>()
+            .AddDelegate<UnhandledExceptionEventHandler>()
+            .AddDelegate<Action<double>>()
+            .AddDelegate<Predicate<double>>()
+            .AddDelegate<Comparison<double>>()
+            .Add<List<double>>("System.Collections.Generic.List<number>")
+            .Add<Dictionary<string, double>>("System.Collections.Generic.Dictionary<string, number>");
+
+    public INativeDotNetCatalog Build() =>
+        new NativeDotNetCatalog(
+            new Dictionary<string, Type>(_names, StringComparer.Ordinal),
+            [.. _types],
+            new Dictionary<string, string>(_assemblyPayloads, StringComparer.OrdinalIgnoreCase));
+
+    private void AddCore(
+        Type type,
+        IReadOnlyList<string> aliases)
+    {
+        _types.Add(type);
+        if (type.FullName is { } fullName)
+            _names[fullName] = type;
+        _names[type.Name] = type;
+        foreach (string alias in aliases)
+        {
+            if (!string.IsNullOrWhiteSpace(alias))
+                _names[alias.Trim()] = type;
+        }
+    }
+}
+
+internal sealed class NativeDotNetCatalog(
+    Dictionary<string, Type> names,
+    HashSet<Type> types,
+    Dictionary<string, string> assemblyPayloads) : INativeDotNetCatalog
+{
+    public bool TryResolveType(
+        string typeName,
+        [NotNullWhen(true)] out Type? type) => names.TryGetValue(typeName.Trim(), out type);
+
+    public bool Contains(Type type) => types.Contains(type);
+
+    public bool TryGetConstructedGeneric(
+        Type genericDefinition,
+        IReadOnlyList<Type> arguments,
+        [NotNullWhen(true)] out Type? type)
+    {
+        foreach (Type candidate in types)
+        {
+            if (!candidate.IsGenericType ||
+                candidate.GetGenericTypeDefinition() != genericDefinition)
+            {
+                continue;
+            }
+
+            Type[] candidateArguments = candidate.GetGenericArguments();
+            if (candidateArguments.Length == arguments.Count &&
+                candidateArguments.AsSpan().SequenceEqual(arguments.ToArray()))
+            {
+                type = candidate;
+                return true;
+            }
+        }
+
+        type = null;
+        return false;
+    }
+
+    public bool TryGetArrayType(
+        Type elementType,
+        [NotNullWhen(true)] out Type? type)
+    {
+        type = types.FirstOrDefault(candidate =>
+            candidate.IsArray && candidate.GetArrayRank() == 1 &&
+            candidate.GetElementType() == elementType);
+        return type != null;
+    }
+
+    public IReadOnlyList<string> ExtractAssemblyPayloads(string destinationDirectory)
+    {
+        if (assemblyPayloads.Count == 0)
+            return [];
+
+        string fullDestination = Path.GetFullPath(destinationDirectory);
+        Directory.CreateDirectory(fullDestination);
+        Assembly hostAssembly = Assembly.GetEntryAssembly()
+            ?? throw new InvalidOperationException(
+                "The Native .NET interop host entry assembly could not be resolved.");
+        var extracted = new List<string>(assemblyPayloads.Count);
+
+        foreach ((string fileName, string resourceName) in assemblyPayloads)
+        {
+            using Stream payload = hostAssembly.GetManifestResourceStream(resourceName)
+                ?? throw new InvalidOperationException(
+                    $"Native .NET interop payload resource '{resourceName}' is missing.");
+            string destinationPath = Path.Combine(fullDestination, fileName);
+            if (!global::SharpTS.Runtime.EmbeddedManagedRuntime.TryExtractTo(
+                    payload, destinationPath, out string? extractionError))
+            {
+                throw new IOException(
+                    $"Could not extract native .NET interop payload '{fileName}': {extractionError}");
+            }
+            extracted.Add(destinationPath);
+        }
+
+        return extracted;
+    }
+}
+
+/// <summary>Process-wide Native AOT catalog selected by the executable host.</summary>
+public static class NativeDotNetInterop
+{
+    private static INativeDotNetCatalog? _catalog;
+
+    public static INativeDotNetCatalog? Catalog => Volatile.Read(ref _catalog);
+
+    /// <summary>
+    /// Installs the immutable catalog before parsing or executing TypeScript.
+    /// Reinstalling the same instance is harmless; replacing it after binding has
+    /// started is rejected so process-wide caches cannot mix catalog identities.
+    /// </summary>
+    public static void Configure(INativeDotNetCatalog catalog)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        INativeDotNetCatalog? existing = Interlocked.CompareExchange(ref _catalog, catalog, null);
+        if (existing != null && !ReferenceEquals(existing, catalog))
+        {
+            throw new InvalidOperationException(
+                "The Native .NET interop catalog has already been configured for this process.");
+        }
+    }
+
+    internal static bool IsAllowed(Type type) =>
+        Catalog is { } catalog &&
+        (catalog.Contains(type) || IsIntrinsic(type));
+
+    internal static bool IsIntrinsic(Type type) =>
+        type.IsGenericParameter ||
+        (type.ContainsGenericParameters && !type.IsGenericTypeDefinition) ||
+        type == typeof(void) || type == typeof(object) || type == typeof(string) ||
+        type == typeof(bool) || type == typeof(char) ||
+        type == typeof(byte) || type == typeof(sbyte) ||
+        type == typeof(short) || type == typeof(ushort) ||
+        type == typeof(int) || type == typeof(uint) ||
+        type == typeof(long) || type == typeof(ulong) ||
+        type == typeof(float) || type == typeof(double) ||
+        type == typeof(decimal);
+}
+
+/// <summary>Curated catalog embedded in the official Native AOT release binary.</summary>
+public static class DefaultNativeDotNetCatalog
+{
+    public static INativeDotNetCatalog Instance { get; } = Create();
+
+    private static INativeDotNetCatalog Create() =>
+        new NativeDotNetCatalogBuilder()
+            .AddDefaultTypes()
+            .Build();
+}

--- a/Runtime/EmbeddedManagedRuntime.cs
+++ b/Runtime/EmbeddedManagedRuntime.cs
@@ -13,15 +13,24 @@ internal static class EmbeddedManagedRuntime
 
     internal static bool TryExtractTo(string destinationPath, out string? error)
     {
-        using Stream? payload = typeof(EmbeddedManagedRuntime).Assembly
-            .GetManifestResourceStream(ResourceName);
+        Assembly sharpTsAssembly = typeof(EmbeddedManagedRuntime).Assembly;
+        Stream? payload = sharpTsAssembly.GetManifestResourceStream(ResourceName);
         if (payload is null)
         {
-            error = $"embedded resource '{ResourceName}' is not present";
-            return false;
+            Assembly? entryAssembly = Assembly.GetEntryAssembly();
+            if (entryAssembly != null && entryAssembly != sharpTsAssembly)
+                payload = entryAssembly.GetManifestResourceStream(ResourceName);
         }
+        using (payload)
+        {
+            if (payload is null)
+            {
+                error = $"embedded resource '{ResourceName}' is not present";
+                return false;
+            }
 
-        return TryExtractTo(payload, destinationPath, out error);
+            return TryExtractTo(payload, destinationPath, out error);
+        }
     }
 
     // Split from the resource lookup so the atomic-write behavior is unit-testable:

--- a/SharpTS.Hosting/README.md
+++ b/SharpTS.Hosting/README.md
@@ -1,0 +1,27 @@
+# SharpTS.Hosting
+
+`SharpTS.Hosting` builds a Native AOT SharpTS executable with a closed, generated
+.NET interop catalog. It is for applications that need selected BCL or
+application-library types in `dotnet:` imports without enabling open-world
+reflection.
+
+Declare each allowed C# type as an MSBuild item. Set `Assembly` for types from a
+class library so its managed DLL and copy-local dependency closure are embedded
+for SharpTS `--compile` output:
+
+```xml
+<ItemGroup>
+  <SharpTSNativeInteropType Include="MyCompany.Widget"
+                            Assembly="MyCompany.Library"
+                            Alias="Widget" />
+</ItemGroup>
+```
+
+Start SharpTS from the generated catalog:
+
+```csharp
+return SharpTSCli.Run(args, SharpTS.Generated.GeneratedNativeDotNetCatalog.Instance);
+```
+
+Only the declared runtime types are bindable. Open-ended DLL loading, arbitrary
+generic construction, `--gen-decl`, and IL verification remain managed-only.

--- a/SharpTS.Hosting/SharpTS.Hosting.csproj
+++ b/SharpTS.Hosting/SharpTS.Hosting.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IsPackable>true</IsPackable>
+    <PackageId>SharpTS.Hosting</PackageId>
+    <Description>Native AOT hosting support for SharpTS with build-time generated, closed-world .NET interop catalogs.</Description>
+    <PackageTags>typescript;nativeaot;hosting;interop;dotnet</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+  </PropertyGroup>
+
+  <!-- SharpTS is a tool package, so the hosting package carries its managed
+       assembly as a normal compile-time library instead of depending on the
+       tool package's tools/ layout. -->
+  <ItemGroup>
+    <None Include="..\bin\$(Configuration)\net10.0\SharpTS.dll"
+          Pack="true"
+          PackagePath="lib\net10.0\"
+          Condition="Exists('..\bin\$(Configuration)\net10.0\SharpTS.dll')" />
+    <None Include="buildTransitive\**" Pack="true" PackagePath="buildTransitive\" />
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="..\LICENSE" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <!-- Runtime dependencies of the carried SharpTS.dll. -->
+  <ItemGroup>
+    <PackageReference Include="NickNa.PEPacker" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" />
+    <PackageReference Include="Microsoft.ILVerification" />
+    <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="PrettyPrompt" />
+    <PackageReference Include="ZstdSharp.Port" />
+  </ItemGroup>
+
+  <Target Name="EnsureHostingPayloadPresent" BeforeTargets="GenerateNuspec">
+    <Error Condition="!Exists('..\bin\$(Configuration)\net10.0\SharpTS.dll')"
+           Text="SharpTS.Hosting pack: SharpTS.dll is missing. Build SharpTS.csproj first." />
+  </Target>
+</Project>

--- a/SharpTS.Hosting/buildTransitive/SharpTS.Hosting.AotTrimmerRoots.xml
+++ b/SharpTS.Hosting/buildTransitive/SharpTS.Hosting.AotTrimmerRoots.xml
@@ -1,0 +1,7 @@
+<!-- Internal Reflection.Emit shapes used by SharpTS's Native-AOT compiler fallback. -->
+<linker>
+  <assembly fullname="System.Private.CoreLib">
+    <type fullname="System.Reflection.Emit.TypeBuilderInstantiation" preserve="all" />
+    <type fullname="System.Reflection.Emit.MethodBuilderInstantiation" preserve="all" />
+  </assembly>
+</linker>

--- a/SharpTS.Hosting/buildTransitive/SharpTS.Hosting.props
+++ b/SharpTS.Hosting/buildTransitive/SharpTS.Hosting.props
@@ -1,0 +1,18 @@
+<Project>
+  <PropertyGroup>
+    <SharpTSNativeInteropEnabled Condition="'$(SharpTSNativeInteropEnabled)' == ''">true</SharpTSNativeInteropEnabled>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(SharpTSNativeInteropEnabled)' == 'true' and '$(PublishAot)' == 'true'">
+    <TrimMode>partial</TrimMode>
+    <IlcTrimMetadata>false</IlcTrimMetadata>
+    <IlcGenerateCompleteTypeMetadata>true</IlcGenerateCompleteTypeMetadata>
+    <StackTraceSupport>true</StackTraceSupport>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(SharpTSNativeInteropEnabled)' == 'true' and '$(PublishAot)' == 'true'">
+    <RuntimeHostConfigurationOption Include="PEPacker.EnableSdkBundler"
+                                    Value="false"
+                                    Trim="true" />
+  </ItemGroup>
+</Project>

--- a/SharpTS.Hosting/buildTransitive/SharpTS.Hosting.targets
+++ b/SharpTS.Hosting/buildTransitive/SharpTS.Hosting.targets
@@ -18,15 +18,15 @@
 
   <UsingTask TaskName="ResolveSharpTSNativeInteropPayloads"
              TaskFactory="RoslynCodeTaskFactory"
-             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+             AssemblyFile="$([MSBuild]::NormalizePath('$(MSBuildToolsPath)', 'Microsoft.Build.Tasks.Core.dll'))">
     <ParameterGroup>
       <RootAssemblyNames ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" />
       <ReferencePaths ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
       <Payloads ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true" />
     </ParameterGroup>
     <Task>
-      <Reference Include="$(MSBuildToolsPath)\Sdks\Microsoft.NET.Sdk\tools\net472\System.Reflection.Metadata.dll" />
-      <Reference Include="$(MSBuildToolsPath)\Sdks\Microsoft.NET.Sdk\tools\net472\System.Collections.Immutable.dll" />
+      <Reference Include="$([MSBuild]::NormalizePath('$(MSBuildToolsPath)', 'Sdks/Microsoft.NET.Sdk/tools/net472/System.Reflection.Metadata.dll'))" />
+      <Reference Include="$([MSBuild]::NormalizePath('$(MSBuildToolsPath)', 'Sdks/Microsoft.NET.Sdk/tools/net472/System.Collections.Immutable.dll'))" />
       <Using Namespace="System" />
       <Using Namespace="System.Collections.Generic" />
       <Using Namespace="System.IO" />

--- a/SharpTS.Hosting/buildTransitive/SharpTS.Hosting.targets
+++ b/SharpTS.Hosting/buildTransitive/SharpTS.Hosting.targets
@@ -1,0 +1,143 @@
+<Project>
+  <!-- buildTransitive props are imported before the consuming project body, so
+       PublishAot may be declared too late for a props-time condition. Targets
+       are imported after the body and own the final Native AOT defaults. -->
+  <PropertyGroup Condition="'$(SharpTSNativeInteropEnabled)' == 'true' and '$(PublishAot)' == 'true'">
+    <TrimMode>partial</TrimMode>
+    <IlcTrimMetadata>false</IlcTrimMetadata>
+    <IlcGenerateCompleteTypeMetadata>true</IlcGenerateCompleteTypeMetadata>
+    <StackTraceSupport>true</StackTraceSupport>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(SharpTSNativeInteropEnabled)' == 'true' and '$(PublishAot)' == 'true'">
+    <RuntimeHostConfigurationOption Include="PEPacker.EnableSdkBundler"
+                                    Value="false"
+                                    Trim="true" />
+    <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)SharpTS.Hosting.AotTrimmerRoots.xml" />
+  </ItemGroup>
+
+  <UsingTask TaskName="ResolveSharpTSNativeInteropPayloads"
+             TaskFactory="RoslynCodeTaskFactory"
+             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <RootAssemblyNames ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="false" />
+      <ReferencePaths ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+      <Payloads ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Reference Include="$(MSBuildToolsPath)\Sdks\Microsoft.NET.Sdk\tools\net472\System.Reflection.Metadata.dll" />
+      <Reference Include="$(MSBuildToolsPath)\Sdks\Microsoft.NET.Sdk\tools\net472\System.Collections.Immutable.dll" />
+      <Using Namespace="System" />
+      <Using Namespace="System.Collections.Generic" />
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Linq" />
+      <Using Namespace="System.Reflection.Metadata" />
+      <Using Namespace="System.Reflection.PortableExecutable" />
+      <Using Namespace="Microsoft.Build.Framework" />
+      <Using Namespace="Microsoft.Build.Utilities" />
+      <Code Type="Fragment" Language="cs"><![CDATA[
+        var available = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (ITaskItem item in ReferencePaths ?? Array.Empty<ITaskItem>())
+        {
+            string path = item.GetMetadata("FullPath");
+            if (string.IsNullOrEmpty(path)) path = item.ItemSpec;
+            if (path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && File.Exists(path))
+                available[Path.GetFileNameWithoutExtension(path)] = path;
+        }
+
+        var rootNames = (RootAssemblyNames ?? Array.Empty<ITaskItem>())
+            .Select(item => item.ItemSpec)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .ToArray();
+        var roots = new HashSet<string>(rootNames, StringComparer.OrdinalIgnoreCase);
+        var queue = new Queue<string>(rootNames);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var payloads = new List<ITaskItem>();
+
+        while (queue.Count != 0)
+        {
+            string name = queue.Dequeue();
+            if (!seen.Add(name)) continue;
+            bool frameworkAssembly = name.Equals("mscorlib", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("netstandard", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("Microsoft.CSharp", StringComparison.OrdinalIgnoreCase)
+                || name.StartsWith("System.", StringComparison.OrdinalIgnoreCase)
+                || name.Equals("System", StringComparison.OrdinalIgnoreCase);
+            if (frameworkAssembly && !roots.Contains(name)) continue;
+            if (!available.TryGetValue(name, out string path))
+            {
+                Log.LogError("SharpTS native interop assembly '{0}' was not found in the copy-local reference closure.", name);
+                continue;
+            }
+
+            var payload = new TaskItem(path);
+            payload.SetMetadata("LogicalName", "SharpTS.NativeInterop.Assembly." + Path.GetFileName(path));
+            payloads.Add(payload);
+
+            using (var stream = File.OpenRead(path))
+            using (var pe = new PEReader(stream))
+            {
+                if (!pe.HasMetadata) continue;
+                MetadataReader reader = pe.GetMetadataReader();
+                foreach (AssemblyReferenceHandle handle in reader.AssemblyReferences)
+                {
+                    string dependency = reader.GetString(reader.GetAssemblyReference(handle).Name);
+                    if (available.ContainsKey(dependency)) queue.Enqueue(dependency);
+                }
+            }
+        }
+
+        Payloads = payloads.ToArray();
+      ]]></Code>
+    </Task>
+  </UsingTask>
+
+  <Target Name="PrepareSharpTSNativeInteropHost"
+          BeforeTargets="AssignTargetPaths;CoreCompile"
+          DependsOnTargets="ResolveReferences"
+          Condition="'$(SharpTSNativeInteropEnabled)' == 'true'">
+    <ItemGroup>
+      <_SharpTSNativeInteropRoot Include="@(SharpTSNativeInteropType)"
+                                 Condition="'%(SharpTSNativeInteropType.Assembly)' != ''" />
+    </ItemGroup>
+
+    <ResolveSharpTSNativeInteropPayloads
+        RootAssemblyNames="@(_SharpTSNativeInteropRoot->'%(Assembly)')"
+        ReferencePaths="@(ReferenceCopyLocalPaths)">
+      <Output TaskParameter="Payloads" ItemName="_SharpTSNativeInteropPayload" />
+    </ResolveSharpTSNativeInteropPayloads>
+
+    <ItemGroup>
+      <!-- A custom host can embed its referenced SharpTS.dll because it is not
+           compiling that assembly itself. This preserves compiler soft deps. -->
+      <_SharpTSManagedRuntime Include="@(ReferenceCopyLocalPaths)"
+                              Condition="'%(ReferenceCopyLocalPaths.Filename)%(ReferenceCopyLocalPaths.Extension)' == 'SharpTS.dll'" />
+      <EmbeddedResource Include="@(_SharpTSManagedRuntime)"
+                        LogicalName="SharpTS.ManagedRuntime.dll" />
+      <EmbeddedResource Include="@(_SharpTSNativeInteropPayload)"
+                        LogicalName="%(_SharpTSNativeInteropPayload.LogicalName)" />
+
+      <_SharpTSNativeInteropCatalogLine Include="// &lt;auto-generated /&gt;" />
+      <_SharpTSNativeInteropCatalogLine Include="namespace SharpTS.Generated%3B" />
+      <_SharpTSNativeInteropCatalogLine Include="public static class GeneratedNativeDotNetCatalog" />
+      <_SharpTSNativeInteropCatalogLine Include="{" />
+      <_SharpTSNativeInteropCatalogLine Include="    public static global::SharpTS.Runtime.DotNet.INativeDotNetCatalog Instance { get%3B } = Create()%3B" />
+      <_SharpTSNativeInteropCatalogLine Include="    private static global::SharpTS.Runtime.DotNet.INativeDotNetCatalog Create() =&gt;" />
+      <_SharpTSNativeInteropCatalogLine Include="        new global::SharpTS.Runtime.DotNet.NativeDotNetCatalogBuilder()" />
+      <_SharpTSNativeInteropCatalogLine Include="            .AddDefaultTypes()" />
+      <_SharpTSNativeInteropCatalogLine Include="            .Add(typeof(global::%(SharpTSNativeInteropType.Identity)), &quot;%(SharpTSNativeInteropType.Alias)&quot;)" />
+      <_SharpTSNativeInteropCatalogLine Include="            .AddAssemblyPayload(&quot;%(_SharpTSNativeInteropPayload.Filename)%(_SharpTSNativeInteropPayload.Extension)&quot;, &quot;%(_SharpTSNativeInteropPayload.LogicalName)&quot;)" />
+      <_SharpTSNativeInteropCatalogLine Include="            .Build()%3B" />
+      <_SharpTSNativeInteropCatalogLine Include="}" />
+    </ItemGroup>
+
+    <WriteLinesToFile File="$(IntermediateOutputPath)SharpTS.NativeInterop.g.cs"
+                      Lines="@(_SharpTSNativeInteropCatalogLine)"
+                      Overwrite="true"
+                      Encoding="UTF-8" />
+    <ItemGroup>
+      <Compile Include="$(IntermediateOutputPath)SharpTS.NativeInterop.g.cs" />
+      <FileWrites Include="$(IntermediateOutputPath)SharpTS.NativeInterop.g.cs" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/SharpTS.Tests/RuntimeTests/NativeDotNetCatalogTests.cs
+++ b/SharpTS.Tests/RuntimeTests/NativeDotNetCatalogTests.cs
@@ -1,0 +1,48 @@
+using SharpTS.Runtime.DotNet;
+using Xunit;
+
+namespace SharpTS.Tests.RuntimeTests;
+
+public sealed class NativeDotNetCatalogTests
+{
+    [Fact]
+    public void DefaultCatalog_ResolvesCuratedBclAndFriendlyGenericAliases()
+    {
+        INativeDotNetCatalog catalog = DefaultNativeDotNetCatalog.Instance;
+
+        Assert.True(catalog.TryResolveType("System.Text.StringBuilder", out Type? builder));
+        Assert.Equal(typeof(System.Text.StringBuilder), builder);
+        Assert.True(catalog.TryResolveType(
+            "System.Collections.Generic.List<number>", out Type? list));
+        Assert.Equal(typeof(List<double>), list);
+        Assert.False(catalog.TryResolveType("System.IO.FileInfo", out _));
+    }
+
+    [Fact]
+    public void Builder_TracksAliasesClosedGenericsAndArrays()
+    {
+        INativeDotNetCatalog catalog = new NativeDotNetCatalogBuilder()
+            .Add<Version>("SemVer")
+            .Add<List<Version>>()
+            .Add<Version[]>()
+            .Build();
+
+        Assert.True(catalog.TryResolveType("SemVer", out Type? version));
+        Assert.Equal(typeof(Version), version);
+        Assert.True(catalog.TryGetConstructedGeneric(
+            typeof(List<>), [typeof(Version)], out Type? list));
+        Assert.Equal(typeof(List<Version>), list);
+        Assert.True(catalog.TryGetArrayType(typeof(Version), out Type? array));
+        Assert.Equal(typeof(Version[]), array);
+    }
+
+    [Fact]
+    public void EmptyPayloadCatalog_ExtractsNothing()
+    {
+        INativeDotNetCatalog catalog = new NativeDotNetCatalogBuilder()
+            .Add<string>()
+            .Build();
+
+        Assert.Empty(catalog.ExtractAssemblyPayloads(Path.GetTempPath()));
+    }
+}

--- a/SharpTS.csproj
+++ b/SharpTS.csproj
@@ -186,6 +186,8 @@
     <None Remove="SharpTS.Sdk/**" />
     <Compile Remove="SharpTS.Sdk.Tasks/**" />
     <None Remove="SharpTS.Sdk.Tasks/**" />
+    <Compile Remove="SharpTS.Hosting/**" />
+    <None Remove="SharpTS.Hosting/**" />
     <Compile Remove="scripts/**" />
     <None Remove="scripts/**" />
     <Compile Remove="external/**" />

--- a/SharpTS.sln
+++ b/SharpTS.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpTS.Sdk.Tasks", "SharpT
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpTS.LanguageServer", "SharpTS.LanguageServer\SharpTS.LanguageServer.csproj", "{D421D97E-1F18-4707-92D4-D0CEDA62838F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpTS.Hosting", "SharpTS.Hosting\SharpTS.Hosting.csproj", "{A06A2ECD-7B23-4F02-B7A1-D52EC9FBE11B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -111,6 +113,18 @@ Global
 		{D421D97E-1F18-4707-92D4-D0CEDA62838F}.Release|x64.Build.0 = Release|Any CPU
 		{D421D97E-1F18-4707-92D4-D0CEDA62838F}.Release|x86.ActiveCfg = Release|Any CPU
 		{D421D97E-1F18-4707-92D4-D0CEDA62838F}.Release|x86.Build.0 = Release|Any CPU
+		{A06A2ECD-7B23-4F02-B7A1-D52EC9FBE11B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A06A2ECD-7B23-4F02-B7A1-D52EC9FBE11B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A06A2ECD-7B23-4F02-B7A1-D52EC9FBE11B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A06A2ECD-7B23-4F02-B7A1-D52EC9FBE11B}.Debug|x64.Build.0 = Debug|Any CPU
+		{A06A2ECD-7B23-4F02-B7A1-D52EC9FBE11B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A06A2ECD-7B23-4F02-B7A1-D52EC9FBE11B}.Debug|x86.Build.0 = Debug|Any CPU
+		{A06A2ECD-7B23-4F02-B7A1-D52EC9FBE11B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A06A2ECD-7B23-4F02-B7A1-D52EC9FBE11B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A06A2ECD-7B23-4F02-B7A1-D52EC9FBE11B}.Release|x64.ActiveCfg = Release|Any CPU
+		{A06A2ECD-7B23-4F02-B7A1-D52EC9FBE11B}.Release|x64.Build.0 = Release|Any CPU
+		{A06A2ECD-7B23-4F02-B7A1-D52EC9FBE11B}.Release|x86.ActiveCfg = Release|Any CPU
+		{A06A2ECD-7B23-4F02-B7A1-D52EC9FBE11B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/docs/plans/native-aot.md
+++ b/docs/plans/native-aot.md
@@ -273,15 +273,20 @@ The work is split at four ownership boundaries:
    PlatformNotSupportedException. `ManagedEmittedShapeReflection.IsShape` is
    consistent with this: it answers false for every shape under native, so a
    predicate can never say "yes" where the action would throw.
-3. **Dynamic .NET interop policy (done for the current inventory).** The open-world
+3. **Dynamic .NET interop policy (closed-world Native support shipped).** The open-world
    `Runtime/DotNet` binder now routes type resolution, member discovery,
    construction, generic closure, array creation, marshalling, operators, and
    delegate shims through `ManagedDotNetInterop`. CoreCLR retains the complete
-   BCL/embedder/third-party contract. Native AOT rejects the first dynamic
-   binding operation before reflection or runtime shape construction, and CI
-   executes that diagnostic. This is an intentional interim contract: define
-   and root a closed Native-SKU BCL surface separately if one is worth
-   supporting.
+   BCL/embedder/third-party contract. Native AOT now resolves through an
+   immutable `INativeDotNetCatalog`: the official binary carries a curated BCL
+   profile, while `SharpTS.Hosting` generates a custom profile from
+   `SharpTSNativeInteropType` MSBuild items. The catalog roots public interop
+   metadata, records closed generics/arrays, and rejects unregistered types
+   before arbitrary reflection. Selected custom class-library DLLs and their
+   non-framework copy-local closure are embedded in the native host and
+   extracted beside `--compile` output. CI exercises constructors, methods,
+   properties, fields, events, a closed generic, interpretation, compilation,
+   deployment extraction, and the unknown-type refusal.
 
    External IL emission, declaration inspection, external type synthesis,
    extension imports, and custom CLR attributes use the same operation-level
@@ -447,7 +452,7 @@ SharpTS passes an explicit compatibility policy. Item 8 can choose
 | Lost | Why | Disposition |
 |---|---|---|
 | `-r foo.dll` / sharpts.json `references` in the interpreter | no IL engine in a native process | by design — route to managed SKU with a clear error |
-| Third-party refs in `--compile` | MLC-types-into-`TypeBuilder` limitation (`ILCompiler.cs:426-431`), pre-existing on JIT | error now; recoverable iff the upstream limitation is fixed |
+| Ad-hoc third-party refs loaded with `-r` | Native AOT is closed-world and cannot load new executable code | use a `SharpTS.Hosting` custom build; its declared library types work in interpretation and `--compile` |
 | Value-type generic instantiation in BCL interop | `MethodInfo.Invoke` needs JIT for new value-type instantiations | document; reference-type instantiations work |
 | `--verify` | `ILVerifier.cs:154` needs `typeof(object).Assembly.Location`; no BCL on disk | hard-disable with named error |
 | `--gen-decl` | `DiscoveryGenerator.cs:68` `Assembly.LoadFrom`; by-name fallback returns truncated metadata | hard-disable with named error |
@@ -479,7 +484,7 @@ workers, MSBuild SDK (subprocess-only by design, verified), JSX.
 | # | Unknown | Status / next step |
 |---|---|---|
 | 1 | Cross-platform native compiler | win-arm64 passes locally and linux-x64 passes CI, including managed-payload extraction. The six-RID release matrix is wired and gates the publish; validate it with a `workflow_dispatch` dry run, then the first tagged run is the remaining acceptance event. |
-| 2 | BCL interop preservation | Targeted roots work for the emit internals; define and test the supported `@DotNetType` surface, including the known dynamic-event edge. |
+| 2 | BCL interop preservation | Closed: the official catalog and custom generated-host path are tested in both execution modes, including events and closed generics. Unknown types retain an explicit closed-world refusal. |
 | 3 | MLC-types-into-TypeBuilder latent JIT limitation | Conceded for the native SKU; file upstream separately. |
 | 4 | Native-emitted output metadata parity | Executed output and PE-Packer rewriting pass. Add a `MetadataDiffer` fixture if byte/table-level parity becomes release-blocking. |
 | 5 | SDK-free `--target exe` | Closed by PE-Packer 1.0.6. Both the permanent and release smokes require bundle creation with an empty `DOTNET_ROOT`. |


### PR DESCRIPTION
## Summary

- add a curated closed-world .NET interop catalog to the official Native AOT binaries
- add the SharpTS.Hosting package and MSBuild-generated catalogs for custom application types
- support constructors, methods, properties, fields, events, arrays, and registered closed generics without changing managed/JIT interop
- embed selected managed dependency closures so custom native hosts can produce deployable --compile output
- update CI and release workflows to exercise curated and custom Native AOT interop alongside the existing managed binaries

## Native limitation

Native AOT remains closed-world. Ad-hoc -r/sharpts.json assembly loading is still rejected; custom types must be declared in a SharpTS.Hosting build.

## Validation

- dotnet build SharpTS.sln -c Release --no-restore
- 16,273 non-network/non-load-sensitive/non-npm tests passed
- 94 focused catalog and .NET interop tests passed
- AOT/trim/single-file analyzer inventory: 0 warnings
- Native publish inventory: 0 SharpTS-owned warnings
- official native interpreter and --compile smoke: native-dotnet-42
- custom native host interpreter and --compile smoke, including event and closed generic coverage
- custom compiled output extracts only NativeInteropExample.dll
- win-x64 native image delta: 7,680 bytes (0.01%; budget 10%)