### PR TITLE
feat: add source execution host bridge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 Modules/TypeScriptLibResources/lib*.d.ts text eol=lf
 Modules/TypeScriptLibResources/LICENSE.txt text eol=lf whitespace=-trailing-space
 Modules/TypeScriptLibResources/SHA256SUMS text eol=lf
+*.sh text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,9 +219,8 @@ jobs:
             echo "child_process.fork unexpectedly compiled under Native AOT"
             exit 1
           fi
-          grep -Fq \
-            'child_process.fork in compiled output is not available in the native SharpTS build' \
-            "$scratch/fork-error.txt"
+          bash scripts/assert-managed-build-required.sh \
+            "$scratch/fork-error.txt" 'child_process.fork'
           test ! -f "$scratch/fork.dll"
 
           # Managed-only public boundaries must fail before their reflection/loader paths.
@@ -231,9 +230,8 @@ jobs:
             echo "third-party reference loading unexpectedly ran under Native AOT"
             exit 1
           fi
-          grep -Fq \
-            'loading .NET reference assemblies is not available in the native SharpTS build' \
-            "$scratch/reference-error.txt"
+          bash scripts/assert-managed-build-required.sh \
+            "$scratch/reference-error.txt" 'loading .NET reference assemblies'
 
           # The official native SKU exposes a curated, linker-rooted BCL catalog
           # through both execution paths. The universe remains closed: an import
@@ -259,9 +257,8 @@ jobs:
             echo "declaration discovery unexpectedly ran under Native AOT"
             exit 1
           fi
-          grep -Fq -- \
-            '--gen-decl is not available in the native SharpTS build' \
-            "$scratch/gen-decl-error.txt"
+          bash scripts/assert-managed-build-required.sh \
+            "$scratch/gen-decl-error.txt" '--gen-decl'
 
           if "$native" --compile Examples/AotCompileGate/main.ts --verify \
               -o "$scratch/verify.dll" \
@@ -269,9 +266,8 @@ jobs:
             echo "IL verification unexpectedly ran under Native AOT"
             exit 1
           fi
-          grep -Fq -- \
-            '--verify is not available in the native SharpTS build' \
-            "$scratch/verify-error.txt"
+          bash scripts/assert-managed-build-required.sh \
+            "$scratch/verify-error.txt" '--verify'
           test ! -f "$scratch/verify.dll"
 
           # Exercise PE-Packer from inside SharpTS's partial-trim closure too.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -338,9 +338,8 @@ jobs:
             echo "child_process.fork unexpectedly compiled under Native AOT"
             exit 1
           fi
-          grep -Fq \
-            'child_process.fork in compiled output is not available in the native SharpTS build' \
-            "$scratch/fork-error.txt"
+          bash scripts/assert-managed-build-required.sh \
+            "$scratch/fork-error.txt" 'child_process.fork'
           test ! -f "$scratch/fork.dll"
 
           if "$native" Examples/AotCompileGate/main.ts \
@@ -349,9 +348,8 @@ jobs:
             echo "third-party reference loading unexpectedly ran under Native AOT"
             exit 1
           fi
-          grep -Fq \
-            'loading .NET reference assemblies is not available in the native SharpTS build' \
-            "$scratch/reference-error.txt"
+          bash scripts/assert-managed-build-required.sh \
+            "$scratch/reference-error.txt" 'loading .NET reference assemblies'
 
           "$native" Examples/AotCompileGate/dotnet-interop.ts \
             | tr -d '\r' > "$scratch/dotnet-interop.txt"
@@ -375,9 +373,8 @@ jobs:
             echo "declaration discovery unexpectedly ran under Native AOT"
             exit 1
           fi
-          grep -Fq -- \
-            '--gen-decl is not available in the native SharpTS build' \
-            "$scratch/gen-decl-error.txt"
+          bash scripts/assert-managed-build-required.sh \
+            "$scratch/gen-decl-error.txt" '--gen-decl'
 
           if "$native" --compile Examples/AotCompileGate/main.ts --verify \
               -o "$scratch/verify.dll" \
@@ -385,9 +382,8 @@ jobs:
             echo "IL verification unexpectedly ran under Native AOT"
             exit 1
           fi
-          grep -Fq -- \
-            '--verify is not available in the native SharpTS build' \
-            "$scratch/verify-error.txt"
+          bash scripts/assert-managed-build-required.sh \
+            "$scratch/verify-error.txt" '--verify'
           test ! -f "$scratch/verify.dll"
 
           case "$rid" in

--- a/Compilation/CompilationService.cs
+++ b/Compilation/CompilationService.cs
@@ -17,7 +17,6 @@
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Loader;
-using System.Text.RegularExpressions;
 using SharpTS.Diagnostics;
 using SharpTS.Diagnostics.Exceptions;
 using SharpTS.Parsing;
@@ -46,7 +45,7 @@ namespace SharpTS.Compilation;
 public sealed record CompileOptions(
     DecoratorMode DecoratorMode = DecoratorMode.None,
     string? AssemblyName = null,
-    string FileName = "input.ts",
+    string FileName = CompilationService.DefaultSourceFileName,
     JsxParseOptions? Jsx = null);
 
 /// <summary>
@@ -71,7 +70,13 @@ public sealed record CompileResult(
     IReadOnlyList<Diagnostic> Diagnostics,
     byte[]? AssemblyBytes,
     long CompileTimeMs,
-    IReadOnlyCollection<string> RequiredSharpTSRuntimeReasons);
+    IReadOnlyCollection<string> RequiredSharpTSRuntimeReasons)
+{
+    /// <summary>
+    /// Stable deployment capabilities for hosts that persist <see cref="AssemblyBytes"/>.
+    /// </summary>
+    public SharpTSRuntimeRequirements RuntimeRequirements { get; init; }
+}
 
 /// <summary>
 /// Result of <see cref="CompilationService.Execute"/>.
@@ -89,13 +94,18 @@ public sealed record RunResult(
 /// </summary>
 public static class CompilationService
 {
+    /// <summary>Logical file name used for in-memory TypeScript source by default.</summary>
+    public const string DefaultSourceFileName = "input.ts";
+
     /// <summary>
     /// Compiles a TypeScript source string to an in-memory .NET assembly.
     /// Never writes to <see cref="Console"/>, never calls <see cref="Environment.Exit"/>,
     /// never touches the file system. All source-input problems (lex, parse, type,
     /// compile) are returned as <see cref="CompileResult.Diagnostics"/>, with the same
     /// multi-error recovery behavior as the CLI (<c>CheckWithRecovery</c>) and the same
-    /// <c>// @ts-ignore</c> / <c>// @ts-expect-error</c> line-directive handling.
+    /// <c>// @ts-ignore</c> / <c>// @ts-expect-error</c> line-directive handling. This API has
+    /// no module resolver, so all static, dynamic, and CommonJS module-loading forms are rejected
+    /// with a module diagnostic; use the module compilation pipeline for dependency graphs.
     /// </summary>
     public static CompileResult Compile(string source, CompileOptions? options = null)
     {
@@ -108,55 +118,32 @@ public static class CompilationService
 
         try
         {
-            // Lex. The Lexer reports errors by throwing raw Exceptions with the line
-            // embedded in the message ("... at line N") — convert to a ParseError
-            // diagnostic instead of letting it escape.
-            bool isTsx = options.FileName.EndsWith(".tsx", StringComparison.OrdinalIgnoreCase)
-                || options.FileName.EndsWith(".jsx", StringComparison.OrdinalIgnoreCase)
-                || options.Jsx is not null;
-            Lexer lexer;
-            List<Token> tokens;
-            try
-            {
-                lexer = new Lexer(source) { JsxTolerant = isTsx };
-                tokens = lexer.ScanTokens();
-            }
-            catch (Exception ex)
-            {
-                return Fail([LexErrorToDiagnostic(ex.Message, options.FileName)]);
-            }
+            var analysis = SingleSourceAnalyzer.Analyze(
+                source,
+                new SingleSourceAnalysisOptions(
+                    options.DecoratorMode,
+                    options.FileName,
+                    options.Jsx));
+            if (!analysis.Success)
+                return Fail(analysis.Diagnostics);
 
-            // Parse, with recovery — surfaces all parse errors, not just the first.
-            var parser = new Parser(tokens, options.DecoratorMode)
-                .WithFilePath(options.FileName);
-            if (isTsx)
-                parser.WithJsx(source, (options.Jsx ?? JsxParseOptions.Default).ApplyPragmas(lexer.Pragmas));
-            var parseResult = parser.Parse();
-            if (!parseResult.IsSuccess)
-                return Fail(parseResult.Diagnostics);
-
-            // Type check, with recovery, honoring // @ts-ignore / @ts-expect-error.
-            var checker = new TypeChecker().WithFilePath(options.FileName);
-            checker.SetDecoratorMode(options.DecoratorMode);
-            var typeResult = checker.CheckWithRecovery(parseResult.Statements);
-            var diagnostics = TypeCheckPolicy.ApplyLineDirectives(typeResult.Diagnostics, lexer.Pragmas);
-            if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
-                return Fail(diagnostics);
-
-            var deadCodeInfo = new DeadCodeAnalyzer(typeResult.TypeMap).Analyze(parseResult.Statements);
+            var deadCodeInfo = new DeadCodeAnalyzer(analysis.TypeMap!).Analyze(analysis.Statements);
 
             var compiler = new ILCompiler(assemblyName);
             compiler.SetDecoratorMode(options.DecoratorMode);
-            compiler.Compile(parseResult.Statements, typeResult.TypeMap, deadCodeInfo);
+            compiler.Compile(analysis.Statements, analysis.TypeMap!, deadCodeInfo);
             var bytes = compiler.SaveToBytes();
 
             stopwatch.Stop();
             return new CompileResult(
                 Success: true,
-                Diagnostics: diagnostics,
+                Diagnostics: analysis.Diagnostics,
                 AssemblyBytes: bytes,
                 CompileTimeMs: stopwatch.ElapsedMilliseconds,
-                RequiredSharpTSRuntimeReasons: compiler.RequiredSharpTSRuntimeReasons);
+                RequiredSharpTSRuntimeReasons: compiler.RequiredSharpTSRuntimeReasons)
+            {
+                RuntimeRequirements = compiler.RequiredSharpTSRuntimeRequirements
+            };
         }
         catch (SharpTSException ex)
         {
@@ -280,16 +267,4 @@ public static class CompilationService
         }
     }
 
-    /// <summary>
-    /// Converts a thrown Lexer message into a ParseError diagnostic, recovering the
-    /// line number from the conventional "... at line N" message suffix when present.
-    /// </summary>
-    private static Diagnostic LexErrorToDiagnostic(string message, string fileName)
-    {
-        var match = Regex.Match(message, @"\bat line (\d+)\b");
-        SourceLocation? location = match.Success && int.TryParse(match.Groups[1].Value, out var line)
-            ? new SourceLocation(fileName, line)
-            : null;
-        return Diagnostic.ParseError(message, location);
-    }
 }

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -34,10 +34,24 @@ public class EmittedRuntime
     public SortedSet<string> RequiredSharpTSRuntimeReasons { get; } = new(StringComparer.Ordinal);
 
     /// <summary>
+    /// Stable deployment capabilities corresponding to
+    /// <see cref="RequiredSharpTSRuntimeReasons"/>. Build logic must use these flags rather than
+    /// comparing human-readable reason strings.
+    /// </summary>
+    public SharpTSRuntimeRequirements RequiredSharpTSRuntimeRequirements { get; private set; }
+
+    /// <summary>
     /// Records that <paramref name="reason"/> emitted a SharpTS-runtime late-binding path that a
     /// normal execution will hit. Idempotent.
     /// </summary>
-    public void RequireSharpTSRuntime(string reason) => RequiredSharpTSRuntimeReasons.Add(reason);
+    public void RequireSharpTSRuntime(
+        string reason,
+        SharpTSRuntimeRequirements requirements = SharpTSRuntimeRequirements.RuntimeAssembly)
+    {
+        RequiredSharpTSRuntimeReasons.Add(reason);
+        RequiredSharpTSRuntimeRequirements |=
+            requirements | SharpTSRuntimeRequirements.RuntimeAssembly;
+    }
 
     /// <summary>
     /// Per-site hoisted regex-literal static fields (compiled-mode optimization),

--- a/Compilation/EmittedRuntime.cs
+++ b/Compilation/EmittedRuntime.cs
@@ -2668,6 +2668,10 @@ public class EmittedRuntime
     public MethodBuilder VmNewSourceTextModule { get; set; } = null!;
     public MethodBuilder VmNewSyntheticModule { get; set; } = null!;
 
+    // sharpts:execution trusted-host bridge
+    public MethodBuilder SourceExecutionRunJson { get; set; } = null!;
+    public MethodBuilder SourceExecutionConfigureUntrustedProcess { get; set; } = null!;
+
     // Pure-IL Web Streams emitted types. The original late-binding helpers
     // (CreateReadableStream/CreateWritableStream/etc.) were removed when
     // all five stream classes were migrated to pure IL.

--- a/Compilation/Emitters/Modules/ChildProcessModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/ChildProcessModuleEmitter.cs
@@ -309,7 +309,10 @@ public sealed class ChildProcessModuleEmitter : IBuiltInModuleEmitter
 
         // fork runs a child .ts module through the interpreter, which a standalone binary
         // can't do — co-locate SharpTS.dll (suppressed by --standalone, which then throws).
-        ctx.Runtime!.RequireSharpTSRuntime("child_process.fork");
+        ctx.Runtime!.RequireSharpTSRuntime(
+            "child_process.fork",
+            SharpTSRuntimeRequirements.FullDependencyClosure |
+            SharpTSRuntimeRequirements.ManagedCompilerHost);
 
         // Emit module path
         if (arguments.Count > 0)

--- a/Compilation/Emitters/Modules/SourceExecutionModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/SourceExecutionModuleEmitter.cs
@@ -60,10 +60,10 @@ public sealed class SourceExecutionModuleEmitter : IBuiltInModuleEmitter
 
     public bool TryEmitPropertyGet(IEmitterContext emitter, string propertyName)
     {
-        if (propertyName is not ("runSourceJson" or "configureUntrustedProcess"))
-            return false;
-        emitter.Context.IL.Emit(OpCodes.Ldnull);
-        return true;
+        // Both exports are methods. Returning false lets module initialization create a
+        // TSFunction wrapper around the registered runtime helper, so named imports,
+        // namespace imports, require(), aliases, and callback usage all remain first-class.
+        return false;
     }
 
     public bool IsExportedProperty(string memberName) => false;

--- a/Compilation/Emitters/Modules/SourceExecutionModuleEmitter.cs
+++ b/Compilation/Emitters/Modules/SourceExecutionModuleEmitter.cs
@@ -1,0 +1,70 @@
+using System.Reflection.Emit;
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation.Emitters.Modules;
+
+/// <summary>
+/// Emits the trusted <c>sharpts:execution</c> host bridge through a late-bound
+/// SharpTS runtime call, preserving the standalone-DLL constraint.
+/// </summary>
+public sealed class SourceExecutionModuleEmitter : IBuiltInModuleEmitter
+{
+    public string ModuleName => "sharpts:execution";
+
+    private static readonly string[] _exportedMembers =
+        ["runSourceJson", "configureUntrustedProcess"];
+
+    public IReadOnlyList<string> GetExportedMembers() => _exportedMembers;
+
+    public bool TryEmitMethodCall(IEmitterContext emitter, string methodName, List<Expr> arguments)
+    {
+        if (methodName == "configureUntrustedProcess")
+        {
+            var configureContext = emitter.Context;
+            if (arguments.Count > 0)
+            {
+                emitter.EmitExpression(arguments[0]);
+                emitter.EmitBoxIfNeeded(arguments[0]);
+            }
+            else
+            {
+                configureContext.IL.Emit(OpCodes.Ldnull);
+            }
+            configureContext.IL.Emit(
+                OpCodes.Call,
+                configureContext.Runtime!.SourceExecutionConfigureUntrustedProcess);
+            return true;
+        }
+
+        if (methodName != "runSourceJson")
+            return false;
+
+        var context = emitter.Context;
+        for (var index = 0; index < 3; index++)
+        {
+            if (arguments.Count > index)
+            {
+                emitter.EmitExpression(arguments[index]);
+                emitter.EmitBoxIfNeeded(arguments[index]);
+            }
+            else
+            {
+                context.IL.Emit(OpCodes.Ldnull);
+            }
+        }
+
+        context.IL.Emit(OpCodes.Call, context.Runtime!.SourceExecutionRunJson);
+        emitter.SetStackUnknown();
+        return true;
+    }
+
+    public bool TryEmitPropertyGet(IEmitterContext emitter, string propertyName)
+    {
+        if (propertyName is not ("runSourceJson" or "configureUntrustedProcess"))
+            return false;
+        emitter.Context.IL.Emit(OpCodes.Ldnull);
+        return true;
+    }
+
+    public bool IsExportedProperty(string memberName) => false;
+}

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -94,6 +94,12 @@ public partial class ILCompiler
         _runtime?.RequiredSharpTSRuntimeReasons ?? (IReadOnlyCollection<string>)Array.Empty<string>();
 
     /// <summary>
+    /// Stable deployment capabilities required by the emitted SharpTS runtime bridges.
+    /// </summary>
+    public SharpTSRuntimeRequirements RequiredSharpTSRuntimeRequirements =>
+        _runtime?.RequiredSharpTSRuntimeRequirements ?? SharpTSRuntimeRequirements.None;
+
+    /// <summary>
     /// Non-fatal compilation warnings (e.g. an unresolvable external .NET type).
     /// Collected instead of written to Console so embedders observe them and the
     /// compiler never interleaves with the compiled program's own output; the

--- a/Compilation/ILCompiler.cs
+++ b/Compilation/ILCompiler.cs
@@ -1056,6 +1056,7 @@ public partial class ILCompiler
         _builtInModuleEmitterRegistry.Register(new DgramModuleEmitter());
         _builtInModuleEmitterRegistry.Register(new ClusterModuleEmitter());
         _builtInModuleEmitterRegistry.Register(new VmModuleEmitter());
+        _builtInModuleEmitterRegistry.Register(new SourceExecutionModuleEmitter());
         // "async_hooks" migrated to stdlib/node/async_hooks.ts (TS class over primitive:async_hooks).
         _builtInModuleEmitterRegistry.Register(new AsyncHooksPrimitiveEmitter());
         // "tty" migrated to stdlib/node/tty.ts (pure-TS over primitive:tty).

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -1253,7 +1253,10 @@ public partial class RuntimeEmitter
 
         if (_features.UsesSourceExecution)
         {
-            runtime.RequireSharpTSRuntime("sharpts:execution module");
+            runtime.RequireSharpTSRuntime(
+                "sharpts:execution module",
+                SharpTSRuntimeRequirements.FullDependencyClosure |
+                SharpTSRuntimeRequirements.ManagedCompilerHost);
             EmitSourceExecutionMethods(typeBuilder, runtime);
         }
 

--- a/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -1251,6 +1251,12 @@ public partial class RuntimeEmitter
             EmitVmMethods(typeBuilder, runtime);
         }
 
+        if (_features.UsesSourceExecution)
+        {
+            runtime.RequireSharpTSRuntime("sharpts:execution module");
+            EmitSourceExecutionMethods(typeBuilder, runtime);
+        }
+
         // Web Streams API (stream/web) is now fully pure-IL emitted via
         // RuntimeEmitter.QueuingStrategy.cs / WritableStream.cs /
         // ReadableStream.cs / TransformStream.cs. No late-binding helper

--- a/Compilation/RuntimeEmitter.SourceExecution.cs
+++ b/Compilation/RuntimeEmitter.SourceExecution.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    private const string SourceExecutionServiceLateBoundName =
+        "SharpTS.Execution.SourceExecutionService, SharpTS";
+
+    private void EmitSourceExecutionMethods(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "SourceExecutionRunJson",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Object, _types.Object]);
+        runtime.SourceExecutionRunJson = method;
+        runtime.RegisterBuiltInModuleMethod("sharpts:execution", "runSourceJson", method);
+
+        var il = method.GetILGenerator();
+        EmitReflectionCall(
+            il,
+            SourceExecutionServiceLateBoundName,
+            "RunJson",
+            3);
+        il.Emit(OpCodes.Ret);
+
+        var configureMethod = typeBuilder.DefineMethod(
+            "SourceExecutionConfigureUntrustedProcess",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object]);
+        runtime.SourceExecutionConfigureUntrustedProcess = configureMethod;
+        runtime.RegisterBuiltInModuleMethod(
+            "sharpts:execution", "configureUntrustedProcess", configureMethod);
+
+        il = configureMethod.GetILGenerator();
+        EmitReflectionCall(
+            il,
+            SourceExecutionServiceLateBoundName,
+            "ConfigureUntrustedProcess",
+            1);
+        il.Emit(OpCodes.Ret);
+    }
+}

--- a/Compilation/RuntimeFeatureDetector.cs
+++ b/Compilation/RuntimeFeatureDetector.cs
@@ -64,6 +64,7 @@ public sealed class RuntimeFeatureDetector
             UsesOs = false,
             UsesChildProcess = false,
             UsesVm = false,
+            UsesSourceExecution = false,
             UsesTty = false,
             UsesPerf = false,
             UsesAbortController = false,
@@ -212,6 +213,8 @@ public sealed class RuntimeFeatureDetector
                 break;
             case "vm":
                 _set.UsesVm = true; break;
+            case "sharpts:execution":
+                _set.UsesSourceExecution = true; break;
             case "tty":
                 _set.UsesTty = true; break;
             case "perf_hooks":

--- a/Compilation/RuntimeFeatureSet.cs
+++ b/Compilation/RuntimeFeatureSet.cs
@@ -55,6 +55,7 @@ public sealed class RuntimeFeatureSet
     public bool UsesOs { get; set; } = true;                // 'os' module — os.freemem, os.loadavg, os.networkInterfaces
     public bool UsesChildProcess { get; set; } = true;      // 'child_process' module — spawn, exec, fork, execSync, etc.
     public bool UsesVm { get; set; } = true;                // 'vm' module — vm.runInNewContext, vm.compileFunction, etc.
+    public bool UsesSourceExecution { get; set; } = true;   // 'sharpts:execution' trusted-host bridge
     public bool UsesTty { get; set; } = true;               // 'tty' module / process.stdout.isTTY — just isatty(fd)
     public bool UsesPerf { get; set; } = true;              // performance.now() / performance.timeOrigin (host-tied primitive)
     public bool UsesAbortController { get; set; } = true;   // AbortController / AbortSignal identifiers

--- a/Compilation/SharpTSRuntimeRequirements.cs
+++ b/Compilation/SharpTSRuntimeRequirements.cs
@@ -1,0 +1,26 @@
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Deployment capabilities required by emitted code that late-binds into SharpTS.dll.
+/// Human-readable reasons are tracked separately for diagnostics; these flags are the stable
+/// machine contract used by hosts and the CLI to choose a deployment strategy.
+/// </summary>
+[Flags]
+public enum SharpTSRuntimeRequirements
+{
+    None = 0,
+
+    /// <summary>SharpTS.dll must be loadable beside the emitted assembly.</summary>
+    RuntimeAssembly = 1 << 0,
+
+    /// <summary>
+    /// SharpTS.dll plus its managed dependency closure and runtime metadata must be deployed.
+    /// </summary>
+    FullDependencyClosure = 1 << 1,
+
+    /// <summary>
+    /// The program must be emitted by the managed compiler SKU; Native AOT hosts cannot produce
+    /// a complete runnable deployment for this feature.
+    /// </summary>
+    ManagedCompilerHost = 1 << 2,
+}

--- a/Compilation/SingleSourceAnalyzer.cs
+++ b/Compilation/SingleSourceAnalyzer.cs
@@ -1,0 +1,164 @@
+using System.Text.RegularExpressions;
+using SharpTS.Diagnostics;
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Options shared by the single-source interpretation and compilation pipelines.
+/// </summary>
+internal sealed record SingleSourceAnalysisOptions(
+    DecoratorMode DecoratorMode,
+    string FileName,
+    JsxParseOptions? Jsx = null);
+
+/// <summary>
+/// The reusable front-end result for a source string that has no module resolver.
+/// </summary>
+internal sealed record SingleSourceAnalysisResult(
+    List<Stmt> Statements,
+    TypeMap? TypeMap,
+    IReadOnlyList<Diagnostic> Diagnostics,
+    bool HitErrorLimit = false)
+{
+    public bool Success =>
+        TypeMap is not null &&
+        Diagnostics.All(diagnostic => diagnostic.Severity != DiagnosticSeverity.Error);
+}
+
+/// <summary>
+/// Runs the canonical lexer, parser, and type-checker front end for APIs that accept one
+/// in-memory source string. Keeping this pipeline shared prevents interpreted and compiled
+/// embedding behavior from drifting (notably pragma and diagnostic handling).
+/// </summary>
+internal static class SingleSourceAnalyzer
+{
+    public static SingleSourceAnalysisResult Analyze(
+        string source,
+        SingleSourceAnalysisOptions options)
+    {
+        bool isTsx = options.FileName.EndsWith(".tsx", StringComparison.OrdinalIgnoreCase)
+            || options.FileName.EndsWith(".jsx", StringComparison.OrdinalIgnoreCase)
+            || options.Jsx is not null;
+
+        Lexer lexer;
+        List<Token> tokens;
+        try
+        {
+            lexer = new Lexer(source) { JsxTolerant = isTsx };
+            tokens = lexer.ScanTokens();
+        }
+        catch (Exception ex)
+        {
+            return new SingleSourceAnalysisResult(
+                [],
+                null,
+                [LexErrorToDiagnostic(ex.Message, options.FileName)]);
+        }
+
+        var parser = new Parser(tokens, options.DecoratorMode)
+            .WithFilePath(options.FileName);
+        if (isTsx)
+            parser.WithJsx(source, (options.Jsx ?? JsxParseOptions.Default).ApplyPragmas(lexer.Pragmas));
+
+        var parseResult = parser.Parse();
+        if (!parseResult.IsSuccess)
+        {
+            return new SingleSourceAnalysisResult(
+                parseResult.Statements,
+                null,
+                parseResult.Diagnostics,
+                parseResult.HitErrorLimit);
+        }
+
+        // These APIs deliberately have no ModuleResolver. Reject every module-loading form
+        // explicitly instead of relying on a later checker/runtime failure. Besides producing a
+        // stable diagnostic, this keeps the untrusted-source boundary intact if the checker gains
+        // more permissive single-file module behavior in the future.
+        var moduleDiagnostics = ModuleLoadingValidator.Validate(
+            parseResult.Statements,
+            options.FileName);
+        if (moduleDiagnostics.Count > 0)
+        {
+            return new SingleSourceAnalysisResult(
+                parseResult.Statements,
+                null,
+                moduleDiagnostics);
+        }
+
+        var checker = new TypeChecker().WithFilePath(options.FileName);
+        checker.SetDecoratorMode(options.DecoratorMode);
+        var typeResult = checker.CheckWithRecovery(parseResult.Statements);
+        var diagnostics = TypeCheckPolicy.ApplyLineDirectives(
+            typeResult.Diagnostics,
+            lexer.Pragmas);
+
+        return new SingleSourceAnalysisResult(
+            parseResult.Statements,
+            typeResult.TypeMap,
+            diagnostics,
+            typeResult.HitErrorLimit);
+    }
+
+    private static Diagnostic LexErrorToDiagnostic(string message, string fileName)
+    {
+        var match = Regex.Match(message, @"\bat line (\d+)\b");
+        SourceLocation? location = match.Success && int.TryParse(match.Groups[1].Value, out var line)
+            ? new SourceLocation(fileName, line)
+            : null;
+        return Diagnostic.ParseError(message, location);
+    }
+
+    private sealed class ModuleLoadingValidator(string fileName) : AstVisitorBase
+    {
+        private const string Message =
+            "Module loading is not available in the single-source embedding API.";
+
+        private readonly List<Diagnostic> _diagnostics = [];
+
+        public static IReadOnlyList<Diagnostic> Validate(
+            IEnumerable<Stmt> statements,
+            string fileName)
+        {
+            var validator = new ModuleLoadingValidator(fileName);
+            foreach (var statement in statements)
+                validator.Visit(statement);
+            return validator._diagnostics;
+        }
+
+        protected override void VisitImport(Stmt.Import stmt)
+        {
+            // The automatic JSX-runtime import is compiler-generated and does not grant source
+            // code access to the module loader.
+            if (!stmt.IsSynthesizedJsxRuntime)
+                Add(stmt.Keyword);
+        }
+
+        protected override void VisitImportRequire(Stmt.ImportRequire stmt) => Add(stmt.Keyword);
+
+        protected override void VisitExport(Stmt.Export stmt)
+        {
+            if (stmt.FromModulePath is not null)
+                Add(stmt.Keyword);
+            base.VisitExport(stmt);
+        }
+
+        protected override void VisitDynamicImport(Expr.DynamicImport expr)
+        {
+            Add(expr.Keyword);
+            base.VisitDynamicImport(expr);
+        }
+
+        protected override void VisitCall(Expr.Call expr)
+        {
+            if (expr.Callee is Expr.Variable variable && variable.Name.Lexeme == "require")
+                Add(variable.Name);
+            base.VisitCall(expr);
+        }
+
+        private void Add(Token token) => _diagnostics.Add(
+            Diagnostic.ModuleError(Message, new SourceLocation(fileName, token.Line)));
+    }
+}

--- a/Diagnostics/Diagnostic.cs
+++ b/Diagnostics/Diagnostic.cs
@@ -117,6 +117,11 @@ public record Diagnostic(
 
             DiagnosticCode.ConfigError => "Config Error",
 
+            // Unlike category-only diagnostics, this code is an automation contract: Native AOT
+            // workflows and embedders must be able to recognize it without parsing the message.
+            DiagnosticCode.ManagedBuildRequired =>
+                $"Error {DiagnosticCode.ManagedBuildRequired.ToSharpTSCode()}",
+
             _ => "Error"
         };
     }

--- a/Diagnostics/Diagnostic.cs
+++ b/Diagnostics/Diagnostic.cs
@@ -65,7 +65,7 @@ public record Diagnostic(
             DiagnosticSeverity.Info => "message",
             _ => "error"
         };
-        var code = $"SHARPTS{(int)Code:D3}";
+        var code = Code.ToSharpTSCode();
 
         return $"{file}({Line},{Column}): {severity} {code}: {Message}";
     }

--- a/Diagnostics/DiagnosticCode.cs
+++ b/Diagnostics/DiagnosticCode.cs
@@ -29,6 +29,12 @@ public enum DiagnosticCode
     /// <summary>General/unclassified error.</summary>
     General = 0,
 
+    /// <summary>
+    /// The requested operation is unavailable in the current runtime SKU and requires the
+    /// managed SharpTS build.
+    /// </summary>
+    ManagedBuildRequired = 7,
+
     // Type errors (1XX)
     /// <summary>Type checking error (general).</summary>
     TypeError = 1,
@@ -56,4 +62,11 @@ public enum DiagnosticCode
     // Runtime errors (6XX)
     /// <summary>Runtime error (general).</summary>
     RuntimeError = 6,
+}
+
+/// <summary>Formatting helpers for SharpTS's stable diagnostic identifiers.</summary>
+public static class DiagnosticCodeExtensions
+{
+    /// <summary>Formats a diagnostic code as its stable <c>SHARPTS###</c> identifier.</summary>
+    public static string ToSharpTSCode(this DiagnosticCode code) => $"SHARPTS{(int)code:D3}";
 }

--- a/Diagnostics/DiagnosticReporter.cs
+++ b/Diagnostics/DiagnosticReporter.cs
@@ -12,6 +12,7 @@
 //   SHARPTS004 - Compile Error (IL emission failures)
 //   SHARPTS005 - Config Error (invalid configuration, missing files)
 //   SHARPTS006 - Runtime Error (interpreter errors)
+//   SHARPTS007 - Managed build required (runtime SKU lacks the requested capability)
 //   SHARPTS000 - General Error (unclassified errors)
 //
 // =============================================================================

--- a/Diagnostics/Exceptions/ManagedBuildRequiredException.cs
+++ b/Diagnostics/Exceptions/ManagedBuildRequiredException.cs
@@ -1,0 +1,39 @@
+namespace SharpTS.Diagnostics.Exceptions;
+
+/// <summary>
+/// Signals that the current runtime SKU cannot provide a capability that is available from the
+/// managed SharpTS host. Carries the stable <c>SHARPTS007</c> diagnostic across service and CLI
+/// boundaries so callers never need to infer the condition from prose.
+/// </summary>
+public sealed class ManagedBuildRequiredException : SharpTSException
+{
+    /// <summary>Creates a managed-build-required diagnostic.</summary>
+    public ManagedBuildRequiredException(string feature, string? context = null)
+        : base(CreateDiagnostic(feature, context))
+    {
+    }
+
+    /// <summary>Creates a managed-build-required diagnostic with its underlying failure.</summary>
+    public ManagedBuildRequiredException(string feature, string? context, Exception innerException)
+        : base(CreateDiagnostic(feature, context), innerException)
+    {
+    }
+
+    /// <summary>
+    /// Creates the structured diagnostic for non-throwing CLI gates that terminate immediately.
+    /// </summary>
+    public static Diagnostic CreateDiagnostic(string feature, string? context = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(feature);
+
+        string message =
+            $"{feature} is not available in the native SharpTS build — use the managed build.";
+        if (!string.IsNullOrWhiteSpace(context))
+            message += $" {context}";
+
+        return new Diagnostic(
+            DiagnosticSeverity.Error,
+            DiagnosticCode.ManagedBuildRequired,
+            message);
+    }
+}

--- a/Execution/SourceExecutionJsonContext.cs
+++ b/Execution/SourceExecutionJsonContext.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace SharpTS.Execution;
+
+/// <summary>
+/// AOT-safe JSON metadata for the stable trusted-host execution protocol.
+/// </summary>
+[JsonSerializable(typeof(SourceExecutionResult))]
+internal sealed partial class SourceExecutionJsonContext : JsonSerializerContext;

--- a/Execution/SourceExecutionService.cs
+++ b/Execution/SourceExecutionService.cs
@@ -4,8 +4,8 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using SharpTS.Compilation;
+using SharpTS.Diagnostics;
 using SharpTS.Parsing;
-using SharpTS.TypeSystem;
 
 namespace SharpTS.Execution;
 
@@ -30,10 +30,14 @@ public sealed record SourceExecutionResult(
 /// <remarks>
 /// This service performs no file I/O and does not enforce a hard timeout. Untrusted-code hosts
 /// should invoke it inside an isolated child process and terminate that process when their wall
-/// clock or memory limit is reached.
+/// clock or memory limit is reached. Calls through this facade are serialized because compiled
+/// execution temporarily redirects process-wide console writers. Static imports, dynamic imports,
+/// re-exports, and CommonJS <c>require()</c> are rejected explicitly.
 /// </remarks>
 public static class SourceExecutionService
 {
+    private static readonly object ExecutionGate = new();
+
     /// <summary>The default maximum number of captured characters.</summary>
     public const int DefaultMaxOutputLength = 100 * 1024;
 
@@ -46,11 +50,14 @@ public static class SourceExecutionService
         if (blockedProxyUri is not string proxyUri || string.IsNullOrWhiteSpace(proxyUri))
             throw new ArgumentException("A blocked proxy URI is required.", nameof(blockedProxyUri));
 
-        AppContext.SetSwitch("SharpTS.RestrictProcessControl", true);
-        HttpClient.DefaultProxy = new WebProxy(proxyUri)
+        lock (ExecutionGate)
         {
-            BypassProxyOnLocal = false
-        };
+            AppContext.SetSwitch("SharpTS.RestrictProcessControl", true);
+            HttpClient.DefaultProxy = new WebProxy(proxyUri)
+            {
+                BypassProxyOnLocal = false
+            };
+        }
     }
 
     /// <summary>
@@ -63,32 +70,29 @@ public static class SourceExecutionService
         ArgumentNullException.ThrowIfNull(source);
         ValidateMaxOutputLength(maxOutputLength);
 
+        lock (ExecutionGate)
+            return InterpretCore(source, maxOutputLength);
+    }
+
+    private static SourceExecutionResult InterpretCore(string source, int maxOutputLength)
+    {
         using var output = new CappedTextWriter(maxOutputLength);
         var errors = new List<string>();
         long executionTimeMs = 0;
 
         try
         {
-            var lexer = new Lexer(source);
-            var tokens = lexer.ScanTokens();
-
-            var parser = new Parser(tokens, DecoratorMode.None);
-            var parseResult = parser.Parse();
-            if (!parseResult.IsSuccess)
+            var analysis = SingleSourceAnalyzer.Analyze(
+                source,
+                new SingleSourceAnalysisOptions(
+                    DecoratorMode.None,
+                    CompilationService.DefaultSourceFileName));
+            if (!analysis.Success)
             {
-                errors.AddRange(parseResult.Diagnostics.Select(diagnostic => diagnostic.ToString()));
-                if (parseResult.HitErrorLimit)
-                    errors.Add("Too many errors, stopping.");
-                return Result(false, output, errors, 0);
-            }
-
-            var checker = new TypeChecker();
-            checker.SetDecoratorMode(DecoratorMode.None);
-            var typeResult = checker.CheckWithRecovery(parseResult.Statements);
-            if (!typeResult.IsSuccess)
-            {
-                errors.AddRange(typeResult.Diagnostics.Select(diagnostic => diagnostic.ToString()));
-                if (typeResult.HitErrorLimit)
+                errors.AddRange(analysis.Diagnostics
+                    .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+                    .Select(diagnostic => diagnostic.ToString()));
+                if (analysis.HitErrorLimit)
                     errors.Add("Too many errors, stopping.");
                 return Result(false, output, errors, 0);
             }
@@ -97,10 +101,10 @@ public static class SourceExecutionService
             interpreter.SetDecoratorMode(DecoratorMode.None);
 
             var resolver = new VariableResolver(interpreter);
-            resolver.Resolve(parseResult.Statements);
+            resolver.Resolve(analysis.Statements);
 
             var stopwatch = Stopwatch.StartNew();
-            interpreter.Interpret(parseResult.Statements, typeResult.TypeMap);
+            interpreter.Interpret(analysis.Statements, analysis.TypeMap!);
             stopwatch.Stop();
             executionTimeMs = stopwatch.ElapsedMilliseconds;
 
@@ -129,6 +133,12 @@ public static class SourceExecutionService
         ArgumentNullException.ThrowIfNull(source);
         ValidateMaxOutputLength(maxOutputLength);
 
+        lock (ExecutionGate)
+            return CompileAndExecuteCore(source, maxOutputLength);
+    }
+
+    private static SourceExecutionResult CompileAndExecuteCore(string source, int maxOutputLength)
+    {
         using var output = new CappedTextWriter(maxOutputLength);
         var errors = new List<string>();
 
@@ -187,7 +197,9 @@ public static class SourceExecutionService
                 ? Interpret(sourceText, limit)
                 : throw new ArgumentException("Mode must be 'interpret' or 'compile'.", nameof(mode));
 
-        return JsonSerializer.Serialize(result);
+        return JsonSerializer.Serialize(
+            result,
+            SourceExecutionJsonContext.Default.SourceExecutionResult);
     }
 
     private static SourceExecutionResult Result(
@@ -208,7 +220,7 @@ public static class SourceExecutionService
     }
 
     /// <summary>
-    /// A synchronized writer that stops retaining guest output after the configured limit.
+    /// A synchronized writer that never retains more than the configured number of characters.
     /// Deriving directly from TextWriter ensures every WriteLine overload flows through the cap.
     /// </summary>
     private sealed class CappedTextWriter(int maxLength) : TextWriter
@@ -228,17 +240,9 @@ public static class SourceExecutionService
 
         public override void Write(char value)
         {
-            lock (_gate)
-            {
-                if (_capped)
-                    return;
-                if (_buffer.Length >= maxLength)
-                {
-                    Cap();
-                    return;
-                }
-                _buffer.Append(value);
-            }
+            Span<char> buffer = stackalloc char[1];
+            buffer[0] = value;
+            Write(buffer);
         }
 
         public override void Write(string? value)
@@ -261,21 +265,39 @@ public static class SourceExecutionService
             {
                 if (_capped)
                     return;
-                if (_buffer.Length + buffer.Length > maxLength)
+                if (buffer.Length > maxLength - _buffer.Length)
                 {
-                    Cap();
+                    Cap(buffer);
                     return;
                 }
                 _buffer.Append(buffer);
             }
         }
 
-        private void Cap()
+        private void Cap(ReadOnlySpan<char> overflow)
         {
             if (_capped)
                 return;
+
             _capped = true;
-            _buffer.Append(TruncationMarker);
+
+            // Keep the result at or below maxLength. When the limit can hold the marker,
+            // preserve the earliest output prefix and replace its tail with the marker. For
+            // very small limits, retaining guest output is more useful than a partial marker.
+            bool includeMarker = maxLength >= TruncationMarker.Length;
+            int contentLimit = includeMarker
+                ? maxLength - TruncationMarker.Length
+                : maxLength;
+
+            if (_buffer.Length > contentLimit)
+                _buffer.Length = contentLimit;
+
+            int remaining = contentLimit - _buffer.Length;
+            if (remaining > 0)
+                _buffer.Append(overflow[..Math.Min(remaining, overflow.Length)]);
+
+            if (includeMarker)
+                _buffer.Append(TruncationMarker);
         }
     }
 }

--- a/Execution/SourceExecutionService.cs
+++ b/Execution/SourceExecutionService.cs
@@ -1,0 +1,281 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Execution;
+
+/// <summary>
+/// The result of interpreting or compiling and executing one TypeScript source string.
+/// </summary>
+/// <param name="Success">True when analysis and execution completed without an error.</param>
+/// <param name="Output">Captured standard output and standard error from the program.</param>
+/// <param name="Errors">Formatted analysis or runtime errors.</param>
+/// <param name="ExecutionTimeMs">Wall-clock execution time, excluding analysis and compilation.</param>
+/// <param name="CompileTimeMs">Compilation time for compiled execution; null for interpretation.</param>
+public sealed record SourceExecutionResult(
+    bool Success,
+    string Output,
+    string[] Errors,
+    long ExecutionTimeMs,
+    long? CompileTimeMs = null);
+
+/// <summary>
+/// Public embedding facade for executing a single TypeScript source string with bounded output.
+/// </summary>
+/// <remarks>
+/// This service performs no file I/O and does not enforce a hard timeout. Untrusted-code hosts
+/// should invoke it inside an isolated child process and terminate that process when their wall
+/// clock or memory limit is reached.
+/// </remarks>
+public static class SourceExecutionService
+{
+    /// <summary>The default maximum number of captured characters.</summary>
+    public const int DefaultMaxOutputLength = 100 * 1024;
+
+    /// <summary>
+    /// Applies the process-wide controls expected by a child process that executes
+    /// untrusted single-source programs.
+    /// </summary>
+    public static void ConfigureUntrustedProcess(object? blockedProxyUri)
+    {
+        if (blockedProxyUri is not string proxyUri || string.IsNullOrWhiteSpace(proxyUri))
+            throw new ArgumentException("A blocked proxy URI is required.", nameof(blockedProxyUri));
+
+        AppContext.SetSwitch("SharpTS.RestrictProcessControl", true);
+        HttpClient.DefaultProxy = new WebProxy(proxyUri)
+        {
+            BypassProxyOnLocal = false
+        };
+    }
+
+    /// <summary>
+    /// Lexes, parses, type-checks, resolves, and interprets a source string with decorators disabled.
+    /// </summary>
+    public static SourceExecutionResult Interpret(
+        string source,
+        int maxOutputLength = DefaultMaxOutputLength)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ValidateMaxOutputLength(maxOutputLength);
+
+        using var output = new CappedTextWriter(maxOutputLength);
+        var errors = new List<string>();
+        long executionTimeMs = 0;
+
+        try
+        {
+            var lexer = new Lexer(source);
+            var tokens = lexer.ScanTokens();
+
+            var parser = new Parser(tokens, DecoratorMode.None);
+            var parseResult = parser.Parse();
+            if (!parseResult.IsSuccess)
+            {
+                errors.AddRange(parseResult.Diagnostics.Select(diagnostic => diagnostic.ToString()));
+                if (parseResult.HitErrorLimit)
+                    errors.Add("Too many errors, stopping.");
+                return Result(false, output, errors, 0);
+            }
+
+            var checker = new TypeChecker();
+            checker.SetDecoratorMode(DecoratorMode.None);
+            var typeResult = checker.CheckWithRecovery(parseResult.Statements);
+            if (!typeResult.IsSuccess)
+            {
+                errors.AddRange(typeResult.Diagnostics.Select(diagnostic => diagnostic.ToString()));
+                if (typeResult.HitErrorLimit)
+                    errors.Add("Too many errors, stopping.");
+                return Result(false, output, errors, 0);
+            }
+
+            using var interpreter = new Interpreter(output, output);
+            interpreter.SetDecoratorMode(DecoratorMode.None);
+
+            var resolver = new VariableResolver(interpreter);
+            resolver.Resolve(parseResult.Statements);
+
+            var stopwatch = Stopwatch.StartNew();
+            interpreter.Interpret(parseResult.Statements, typeResult.TypeMap);
+            stopwatch.Stop();
+            executionTimeMs = stopwatch.ElapsedMilliseconds;
+
+            if (interpreter.LastUncaughtError is { } uncaught)
+                errors.Add(uncaught.Message);
+
+            return Result(errors.Count == 0, output, errors, executionTimeMs);
+        }
+        catch (Exception ex)
+        {
+            errors.Add(ex.Message);
+            return Result(false, output, errors, executionTimeMs);
+        }
+    }
+
+    /// <summary>
+    /// Compiles a source string to an in-memory assembly and executes it with decorators disabled.
+    /// </summary>
+    /// <remarks>
+    /// Dynamic assembly execution requires a managed runtime. It is unavailable in Native AOT.
+    /// </remarks>
+    public static SourceExecutionResult CompileAndExecute(
+        string source,
+        int maxOutputLength = DefaultMaxOutputLength)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ValidateMaxOutputLength(maxOutputLength);
+
+        using var output = new CappedTextWriter(maxOutputLength);
+        var errors = new List<string>();
+
+        try
+        {
+            var compileResult = CompilationService.Compile(
+                source,
+                new CompileOptions(DecoratorMode.None));
+
+            if (!compileResult.Success)
+            {
+                errors.AddRange(compileResult.Diagnostics.Select(diagnostic => diagnostic.ToString()));
+                return Result(false, output, errors, 0, compileResult.CompileTimeMs);
+            }
+
+            var runResult = CompilationService.Execute(compileResult.AssemblyBytes!, output);
+            if (!runResult.Success && runResult.Error is not null)
+                errors.Add(runResult.Error);
+
+            return Result(
+                runResult.Success,
+                output,
+                errors,
+                runResult.ExecuteTimeMs,
+                compileResult.CompileTimeMs);
+        }
+        catch (Exception ex)
+        {
+            errors.Add(ex.Message);
+            return Result(false, output, errors, 0);
+        }
+    }
+
+    /// <summary>
+    /// JSON bridge used by the <c>sharpts:execution</c> module across the standalone
+    /// compiled-runtime boundary.
+    /// </summary>
+    public static string RunJson(object? source, object? mode, object? maxOutputLength)
+    {
+        if (source is not string sourceText || string.IsNullOrWhiteSpace(sourceText))
+            throw new ArgumentException("Source code cannot be empty.", nameof(source));
+
+        var requestedMode = mode?.ToString() ?? "interpret";
+        var limit = maxOutputLength switch
+        {
+            double number when double.IsFinite(number) && number == Math.Truncate(number)
+                && number >= 1 && number <= int.MaxValue => (int)number,
+            int number when number > 0 => number,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(maxOutputLength), maxOutputLength, "Maximum output length must be a positive integer.")
+        };
+
+        var result = requestedMode.Equals("compile", StringComparison.OrdinalIgnoreCase)
+            ? CompileAndExecute(sourceText, limit)
+            : requestedMode.Equals("interpret", StringComparison.OrdinalIgnoreCase)
+                ? Interpret(sourceText, limit)
+                : throw new ArgumentException("Mode must be 'interpret' or 'compile'.", nameof(mode));
+
+        return JsonSerializer.Serialize(result);
+    }
+
+    private static SourceExecutionResult Result(
+        bool success,
+        CappedTextWriter output,
+        List<string> errors,
+        long executionTimeMs,
+        long? compileTimeMs = null) =>
+        new(success, output.GetContent(), errors.ToArray(), executionTimeMs, compileTimeMs);
+
+    private static void ValidateMaxOutputLength(int maxOutputLength)
+    {
+        if (maxOutputLength <= 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(maxOutputLength),
+                maxOutputLength,
+                "Maximum output length must be greater than zero.");
+    }
+
+    /// <summary>
+    /// A synchronized writer that stops retaining guest output after the configured limit.
+    /// Deriving directly from TextWriter ensures every WriteLine overload flows through the cap.
+    /// </summary>
+    private sealed class CappedTextWriter(int maxLength) : TextWriter
+    {
+        private const string TruncationMarker = "\n[Output truncated]\n";
+        private readonly StringBuilder _buffer = new();
+        private readonly object _gate = new();
+        private bool _capped;
+
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public string GetContent()
+        {
+            lock (_gate)
+                return _buffer.ToString();
+        }
+
+        public override void Write(char value)
+        {
+            lock (_gate)
+            {
+                if (_capped)
+                    return;
+                if (_buffer.Length >= maxLength)
+                {
+                    Cap();
+                    return;
+                }
+                _buffer.Append(value);
+            }
+        }
+
+        public override void Write(string? value)
+        {
+            if (value is null)
+                return;
+            Write(value.AsSpan());
+        }
+
+        public override void Write(char[]? buffer, int index, int count)
+        {
+            if (buffer is null)
+                return;
+            Write(buffer.AsSpan(index, count));
+        }
+
+        public override void Write(ReadOnlySpan<char> buffer)
+        {
+            lock (_gate)
+            {
+                if (_capped)
+                    return;
+                if (_buffer.Length + buffer.Length > maxLength)
+                {
+                    Cap();
+                    return;
+                }
+                _buffer.Append(buffer);
+            }
+        }
+
+        private void Cap()
+        {
+            if (_capped)
+                return;
+            _capped = true;
+            _buffer.Append(TruncationMarker);
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -866,16 +866,18 @@ static void PrintCompilerWarnings(ILCompiler compiler)
 }
 
 /// <summary>
-/// Rejects compiled features whose runtime model cannot work in the Native AOT SKU.
-/// <c>child_process.fork</c> starts a separate <c>dotnet exec SharpTS.dll</c> compiler
-/// process, so extracting the in-process managed soft-dependency is not sufficient.
+/// Rejects compiled features whose typed deployment capabilities require the managed compiler
+/// SKU. Human-readable reason strings are diagnostic text only and never drive this decision.
 /// </summary>
 static void ValidateCompiledRuntimeRequirements(ILCompiler compiler)
 {
-    if (compiler.RequiredSharpTSRuntimeReasons.Contains("child_process.fork"))
-        RequireManagedBuild("child_process.fork in compiled output");
-    if (compiler.RequiredSharpTSRuntimeReasons.Contains("sharpts:execution module"))
-        RequireManagedBuild("sharpts:execution in compiled output");
+    if (compiler.RequiredSharpTSRuntimeRequirements.HasFlag(
+            SharpTSRuntimeRequirements.ManagedCompilerHost))
+    {
+        RequireManagedBuild(
+            $"compiled output requiring the managed SharpTS host " +
+            $"({string.Join(", ", compiler.RequiredSharpTSRuntimeReasons)})");
+    }
 }
 
 /// <summary>
@@ -949,8 +951,8 @@ static void CopySharpTSRuntimeIfNeeded(ILCompiler compiler, string outputPath, O
         // sharpts:execution embeds its compile-and-run facade in the current process.
         // Both execute compiler paths backed by SharpTS's managed dependency closure,
         // so co-locate the runtime files rather than copying only SharpTS.dll.
-        bool requiresFullRuntime = reasons.Contains("child_process.fork")
-            || reasons.Contains("sharpts:execution module");
+        bool requiresFullRuntime = compiler.RequiredSharpTSRuntimeRequirements.HasFlag(
+            SharpTSRuntimeRequirements.FullDependencyClosure);
         if (requiresFullRuntime)
         {
             // Native builds are rejected before Save by ValidateCompiledRuntimeRequirements.

--- a/Program.cs
+++ b/Program.cs
@@ -222,8 +222,7 @@ static void RequireManagedBuild(string feature)
 /// capability. Automation must match the code and feature context, not the mutable prose.
 /// </summary>
 internal static string FormatManagedBuildRequiredError(string feature) =>
-    $"Error {DiagnosticCode.ManagedBuildRequired.ToSharpTSCode()}: " +
-    $"{feature} is not available in the native SharpTS build — use the managed build.";
+    ManagedBuildRequiredException.CreateDiagnostic(feature).ToHumanFormat();
 
 /// <summary>
 /// Discovers tsconfig.json (or loads the one named by -p/--project) and folds it under the
@@ -419,6 +418,12 @@ static ReferenceSet LoadDotNetReferences(string startDirectory, IReadOnlyList<st
     try
     {
         return DotNetReferences.Load(startDirectory, cliReferences);
+    }
+    catch (SharpTSException ex)
+    {
+        new DiagnosticReporter().Report(ex.Diagnostic);
+        Environment.Exit(1);
+        throw; // unreachable
     }
     catch (Exception ex)
     {

--- a/Program.cs
+++ b/Program.cs
@@ -212,11 +212,18 @@ static void RequireManagedBuild(string feature)
 {
     if (!System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported)
     {
-        Console.Error.WriteLine(
-            $"Error: {feature} is not available in the native SharpTS build — use the managed build.");
+        Console.Error.WriteLine(FormatManagedBuildRequiredError(feature));
         Environment.Exit(1);
     }
 }
+
+/// <summary>
+/// Formats the stable CLI diagnostic used when a runtime SKU cannot provide a managed-only
+/// capability. Automation must match the code and feature context, not the mutable prose.
+/// </summary>
+internal static string FormatManagedBuildRequiredError(string feature) =>
+    $"Error {DiagnosticCode.ManagedBuildRequired.ToSharpTSCode()}: " +
+    $"{feature} is not available in the native SharpTS build — use the managed build.";
 
 /// <summary>
 /// Discovers tsconfig.json (or loads the one named by -p/--project) and folds it under the

--- a/Program.cs
+++ b/Program.cs
@@ -874,6 +874,8 @@ static void ValidateCompiledRuntimeRequirements(ILCompiler compiler)
 {
     if (compiler.RequiredSharpTSRuntimeReasons.Contains("child_process.fork"))
         RequireManagedBuild("child_process.fork in compiled output");
+    if (compiler.RequiredSharpTSRuntimeReasons.Contains("sharpts:execution module"))
+        RequireManagedBuild("sharpts:execution in compiled output");
 }
 
 /// <summary>
@@ -943,12 +945,13 @@ static void CopySharpTSRuntimeIfNeeded(ILCompiler compiler, string outputPath, O
             return;
         }
 
-        // child_process.fork() spawns a SEPARATE `dotnet exec SharpTS.dll <module>` process
-        // (unlike Worker/eval which load SharpTS.dll in-process). That child needs SharpTS's
-        // full runtime closure — its runtimeconfig.json, deps.json, and dependency DLLs — so
-        // co-locate the whole SharpTS bin directory next to the output. Other soft-deps only
-        // need SharpTS.dll loaded in-process.
-        if (reasons.Contains("child_process.fork"))
+        // child_process.fork() starts SharpTS as a separate compiler process, while
+        // sharpts:execution embeds its compile-and-run facade in the current process.
+        // Both execute compiler paths backed by SharpTS's managed dependency closure,
+        // so co-locate the runtime files rather than copying only SharpTS.dll.
+        bool requiresFullRuntime = reasons.Contains("child_process.fork")
+            || reasons.Contains("sharpts:execution module");
+        if (requiresFullRuntime)
         {
             // Native builds are rejected before Save by ValidateCompiledRuntimeRequirements.
             // This closure copy is retained for the managed SKU.
@@ -973,7 +976,7 @@ static void CopySharpTSRuntimeIfNeeded(ILCompiler compiler, string outputPath, O
 
         if (!outputOptions.QuietMode)
         {
-            var what = reasons.Contains("child_process.fork") ? "SharpTS runtime" : "SharpTS.dll";
+            var what = requiresFullRuntime ? "SharpTS runtime" : "SharpTS.dll";
             var action = copiedFromManagedBuild ? "Copied" : "Extracted embedded";
             Console.WriteLine($"{action} {what} next to output — required at runtime by: {reasonList}");
         }

--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@ string greeting = person.greet();        // Typed return values
 
 - [**Using .NET Types**](docs/dotnet-types.md) - Use .NET BCL and libraries from TypeScript
 - [**.NET Integration**](docs/dotnet-integration.md) - Consume compiled TypeScript from C#
+- [**Embedding SharpTS**](docs/embedding.md) - Run bounded source strings from managed or trusted TypeScript hosts
 - [**MSBuild SDK Guide**](docs/msbuild-sdk.md) - Integrate SharpTS into your .NET build process
 - [**Code Samples**](docs/code-samples.md) - Task-oriented snippets across both modes
 - [**Execution Modes**](docs/execution-modes.md) - Interpreter vs compiled: differences and trade-offs

--- a/References/DotNetReferences.cs
+++ b/References/DotNetReferences.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using SharpTS.Diagnostics.Exceptions;
 
 namespace SharpTS.References;
 
@@ -98,12 +99,12 @@ public static class DotNetReferences
         if (!RuntimeFeature.IsDynamicCodeSupported)
         {
             string origin = set.ManifestPath != null ? $" (manifest: '{set.ManifestPath}')" : "";
-            throw new Exception(
-                $"Error: failed to load reference assembl{(set.References.Count == 1 ? "y" : "ies")}{origin}:\n  " +
-                string.Join(
-                    "\n  ",
-                    set.References.Select(reference =>
-                        $"'{reference.Path}': loading .NET reference assemblies is not available in the native SharpTS build — use the managed build.")));
+            string requested = string.Join(
+                ", ",
+                set.References.Select(reference => $"'{reference.Path}'"));
+            throw new ManagedBuildRequiredException(
+                "loading .NET reference assemblies",
+                $"Requested reference{(set.References.Count == 1 ? "" : "s")}{origin}: {requested}.");
         }
 
         List<string>? failures = null;
@@ -122,11 +123,16 @@ public static class DotNetReferences
             // PlatformNotSupportedException: Assembly.LoadFrom under Native AOT — there is no IL
             // engine in a native process, so third-party references can never work there (#1324).
             // Fail with the routing message instead of an unhandled crash.
-            catch (Exception ex) when (ex is BadImageFormatException or FileLoadException or FileNotFoundException or PlatformNotSupportedException)
+            catch (PlatformNotSupportedException ex)
             {
-                (failures ??= []).Add(ex is PlatformNotSupportedException
-                    ? $"'{reference.Path}': loading .NET reference assemblies is not available in the native SharpTS build — use the managed build."
-                    : $"'{reference.Path}' could not be loaded: {ex.Message}");
+                throw new ManagedBuildRequiredException(
+                    "loading .NET reference assemblies",
+                    $"Requested reference: '{reference.Path}'.",
+                    ex);
+            }
+            catch (Exception ex) when (ex is BadImageFormatException or FileLoadException or FileNotFoundException)
+            {
+                (failures ??= []).Add($"'{reference.Path}' could not be loaded: {ex.Message}");
             }
         }
 

--- a/Runtime/BuiltIns/Modules/BuiltInModuleRegistry.cs
+++ b/Runtime/BuiltIns/Modules/BuiltInModuleRegistry.cs
@@ -47,6 +47,7 @@ public static class BuiltInModuleRegistry
         "dgram",
         "cluster",
         "vm",
+        "sharpts:execution",
         // "async_hooks" — migrated to stdlib/node/async_hooks.ts (TS class over primitive:async_hooks).
         // "tty" — migrated to stdlib/node/tty.ts (pure-TS over primitive:tty).
     ];

--- a/Runtime/BuiltIns/Modules/Interpreter/BuiltInModuleValues.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/BuiltInModuleValues.cs
@@ -57,6 +57,7 @@ public static class BuiltInModuleValues
             "dgram" => DgramModuleInterpreter.GetExports(),
             "cluster" => ClusterModuleInterpreter.GetExports(),
             "vm" => VmModuleInterpreter.GetExports(),
+            "sharpts:execution" => SourceExecutionModuleInterpreter.GetExports(),
             // "async_hooks" — migrated to stdlib/node/async_hooks.ts (TS class over primitive:async_hooks).
             // "tty" — migrated to stdlib/node/tty.ts (pure-TS over primitive:tty).
             _ => throw new Exception($"Unknown built-in module: {moduleName}")

--- a/Runtime/BuiltIns/Modules/Interpreter/SourceExecutionModuleInterpreter.cs
+++ b/Runtime/BuiltIns/Modules/Interpreter/SourceExecutionModuleInterpreter.cs
@@ -1,0 +1,38 @@
+using SharpTS.Execution;
+using SharpTS.Runtime.Types;
+
+namespace SharpTS.Runtime.BuiltIns.Modules.Interpreter;
+
+/// <summary>
+/// Trusted-host bridge for executing a source string through SharpTS's public embedding facade.
+/// </summary>
+public static class SourceExecutionModuleInterpreter
+{
+    public static Dictionary<string, object?> GetExports() => new()
+    {
+        ["runSourceJson"] = BuiltInMethod.CreateV2("runSourceJson", 3, 3, RunSourceJson),
+        ["configureUntrustedProcess"] = BuiltInMethod.CreateV2(
+            "configureUntrustedProcess", 1, 1, ConfigureUntrustedProcess)
+    };
+
+    private static RuntimeValue ConfigureUntrustedProcess(
+        Execution.Interpreter interpreter,
+        RuntimeValue receiver,
+        ReadOnlySpan<RuntimeValue> args)
+    {
+        SourceExecutionService.ConfigureUntrustedProcess(args[0].ToObject());
+        return RuntimeValue.Undefined;
+    }
+
+    private static RuntimeValue RunSourceJson(
+        Execution.Interpreter interpreter,
+        RuntimeValue receiver,
+        ReadOnlySpan<RuntimeValue> args)
+    {
+        var json = SourceExecutionService.RunJson(
+            args[0].ToObject(),
+            args[1].ToObject(),
+            args[2].ToObject());
+        return RuntimeValue.FromString(json);
+    }
+}

--- a/SharpTS.Tests/Architecture/AotSeamArchitectureTests.cs
+++ b/SharpTS.Tests/Architecture/AotSeamArchitectureTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using SharpTS.Diagnostics;
 using Xunit;
 
 namespace SharpTS.Tests.Architecture;
@@ -81,6 +82,24 @@ public class AotSeamArchitectureTests
         Assert.True(offenders.Count == 0,
             "CustomAttributeBuilder usage found; emit attribute blobs through " +
             "CustomAttributeEncoder instead:\n" + string.Join('\n', offenders));
+    }
+
+    [Fact]
+    public void NativeAot_workflows_use_the_stable_managed_build_diagnostic_guard()
+    {
+        string root = FindRepoRoot();
+        string guardPath = Path.Combine(root, "scripts", "assert-managed-build-required.sh");
+        string guard = File.ReadAllText(guardPath);
+        Assert.Contains(DiagnosticCode.ManagedBuildRequired.ToSharpTSCode(), guard);
+
+        foreach (string workflowName in new[] { "ci.yml", "publish.yml" })
+        {
+            string workflow = File.ReadAllText(
+                Path.Combine(root, ".github", "workflows", workflowName));
+            Assert.Contains("scripts/assert-managed-build-required.sh", workflow);
+            Assert.DoesNotContain(
+                "child_process.fork in compiled output is not available", workflow);
+        }
     }
 
     /// <summary>

--- a/SharpTS.Tests/Compilation/SourceExecutionServiceTests.cs
+++ b/SharpTS.Tests/Compilation/SourceExecutionServiceTests.cs
@@ -1,0 +1,132 @@
+using SharpTS.Execution;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.Compilation;
+
+[Collection("CompilationService")]
+public class SourceExecutionServiceTests
+{
+    [Fact]
+    public void Interpret_ValidSource_CapturesOutput()
+    {
+        var result = SourceExecutionService.Interpret("console.log('hello');");
+
+        Assert.True(result.Success);
+        Assert.Empty(result.Errors);
+        Assert.Equal("hello\n", Normalize(result.Output));
+        Assert.True(result.ExecutionTimeMs >= 0);
+        Assert.Null(result.CompileTimeMs);
+    }
+
+    [Fact]
+    public void Interpret_TypeErrors_ReturnFormattedErrors()
+    {
+        var result = SourceExecutionService.Interpret(
+            "let first: number = 'x';\nlet second: boolean = 42;");
+
+        Assert.False(result.Success);
+        Assert.Equal(2, result.Errors.Length);
+        Assert.All(result.Errors, error => Assert.Contains("Type Error", error));
+        Assert.Equal(0, result.ExecutionTimeMs);
+    }
+
+    [Fact]
+    public void Interpret_UncaughtGuestError_IsFailure()
+    {
+        var result = SourceExecutionService.Interpret("throw new Error('boom');");
+
+        Assert.False(result.Success);
+        Assert.Contains("boom", Assert.Single(result.Errors));
+        Assert.Contains("Runtime Error", result.Output);
+    }
+
+    [Fact]
+    public void CompileAndExecute_ValidSource_ReturnsBothTimings()
+    {
+        var result = SourceExecutionService.CompileAndExecute("console.log(6 * 7);");
+
+        Assert.True(result.Success);
+        Assert.Empty(result.Errors);
+        Assert.Equal("42\n", Normalize(result.Output));
+        Assert.True(result.ExecutionTimeMs >= 0);
+        Assert.NotNull(result.CompileTimeMs);
+        Assert.True(result.CompileTimeMs >= 0);
+    }
+
+    [Fact]
+    public void CompileAndExecute_RuntimeError_IsFailure()
+    {
+        var result = SourceExecutionService.CompileAndExecute("throw new Error('compiled boom');");
+
+        Assert.False(result.Success);
+        Assert.Contains("compiled boom", Assert.Single(result.Errors));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Execution_CapsOutput(bool compile)
+    {
+        const int limit = 16;
+        var result = compile
+            ? SourceExecutionService.CompileAndExecute("console.log('abcdefghijklmnopqrstuvwxyz');", limit)
+            : SourceExecutionService.Interpret("console.log('abcdefghijklmnopqrstuvwxyz');", limit);
+
+        Assert.True(result.Success);
+        Assert.Equal("\n[Output truncated]\n", Normalize(result.Output));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Execution_RejectsModuleImports(bool compile)
+    {
+        const string source = "import { readFileSync } from 'fs'; console.log(readFileSync('/etc/passwd'));";
+        var result = compile
+            ? SourceExecutionService.CompileAndExecute(source)
+            : SourceExecutionService.Interpret(source);
+
+        Assert.False(result.Success);
+        Assert.NotEmpty(result.Errors);
+    }
+
+    [Fact]
+    public void Execution_NeverWritesToHostConsole()
+    {
+        using var capture = AsyncLocalConsoleRedirector.Capture();
+
+        SourceExecutionService.Interpret("console.log('interpreted');");
+        SourceExecutionService.CompileAndExecute("console.log('compiled');");
+
+        Assert.Equal("", capture.GetOutput());
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Execution_RejectsInvalidOutputLimit(bool compile)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        {
+            if (compile)
+                SourceExecutionService.CompileAndExecute("console.log(1);", 0);
+            else
+                SourceExecutionService.Interpret("console.log(1);", 0);
+        });
+    }
+
+    [Fact]
+    public void RunJson_UsesStableProtocolCasing()
+    {
+        var json = SourceExecutionService.RunJson("console.log(42);", "interpret", 1024.0);
+
+        Assert.Contains("\"Success\":true", json);
+        Assert.Contains("\"Output\":\"42", json);
+        Assert.Contains("\"Errors\":[]", json);
+        Assert.Contains("\"ExecutionTimeMs\":", json);
+        Assert.Contains("\"CompileTimeMs\":null", json);
+    }
+
+    private static string Normalize(string value) => value.Replace("\r\n", "\n");
+}

--- a/SharpTS.Tests/Compilation/SourceExecutionServiceTests.cs
+++ b/SharpTS.Tests/Compilation/SourceExecutionServiceTests.cs
@@ -68,27 +68,52 @@ public class SourceExecutionServiceTests
     [InlineData(true)]
     public void Execution_CapsOutput(bool compile)
     {
-        const int limit = 16;
+        const int limit = 32;
         var result = compile
-            ? SourceExecutionService.CompileAndExecute("console.log('abcdefghijklmnopqrstuvwxyz');", limit)
-            : SourceExecutionService.Interpret("console.log('abcdefghijklmnopqrstuvwxyz');", limit);
+            ? SourceExecutionService.CompileAndExecute("console.log('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ');", limit)
+            : SourceExecutionService.Interpret("console.log('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ');", limit);
 
         Assert.True(result.Success);
-        Assert.Equal("\n[Output truncated]\n", Normalize(result.Output));
+        Assert.Equal("abcdefghijkl\n[Output truncated]\n", Normalize(result.Output));
+        Assert.True(result.Output.Length <= limit);
     }
 
     [Theory]
-    [InlineData(false)]
-    [InlineData(true)]
-    public void Execution_RejectsModuleImports(bool compile)
+    [InlineData(false, "import { readFileSync } from 'fs';")]
+    [InlineData(true, "import { readFileSync } from 'fs';")]
+    [InlineData(false, "import fs = require('fs');")]
+    [InlineData(true, "import fs = require('fs');")]
+    [InlineData(false, "require('fs');")]
+    [InlineData(true, "require('fs');")]
+    [InlineData(false, "import('fs');")]
+    [InlineData(true, "import('fs');")]
+    [InlineData(false, "export { readFileSync } from 'fs';")]
+    [InlineData(true, "export { readFileSync } from 'fs';")]
+    public void Execution_RejectsEveryModuleLoadingForm(bool compile, string source)
     {
-        const string source = "import { readFileSync } from 'fs'; console.log(readFileSync('/etc/passwd'));";
         var result = compile
             ? SourceExecutionService.CompileAndExecute(source)
             : SourceExecutionService.Interpret(source);
 
         Assert.False(result.Success);
-        Assert.NotEmpty(result.Errors);
+        Assert.Contains(result.Errors, error =>
+            error.Contains("Module loading is not available", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Execution_HonorsTypeScriptLineDirectives(bool compile)
+    {
+        const string source = "// @ts-ignore\nlet value: number = 'x'; console.log('ok');";
+
+        var result = compile
+            ? SourceExecutionService.CompileAndExecute(source)
+            : SourceExecutionService.Interpret(source);
+
+        Assert.True(result.Success);
+        Assert.Empty(result.Errors);
+        Assert.Equal("ok\n", Normalize(result.Output));
     }
 
     [Fact]
@@ -126,6 +151,23 @@ public class SourceExecutionServiceTests
         Assert.Contains("\"Errors\":[]", json);
         Assert.Contains("\"ExecutionTimeMs\":", json);
         Assert.Contains("\"CompileTimeMs\":null", json);
+    }
+
+    [Fact]
+    public async Task CompileAndExecute_ConcurrentCalls_DoNotCrossWireOutput()
+    {
+        var tasks = Enumerable.Range(0, 3)
+            .Select(index => Task.Run(() =>
+                SourceExecutionService.CompileAndExecute($"console.log('run-{index}');")))
+            .ToArray();
+
+        var results = await Task.WhenAll(tasks);
+
+        for (var index = 0; index < results.Length; index++)
+        {
+            Assert.True(results[index].Success);
+            Assert.Equal($"run-{index}\n", Normalize(results[index].Output));
+        }
     }
 
     private static string Normalize(string value) => value.Replace("\r\n", "\n");

--- a/SharpTS.Tests/CompilerTests/RuntimeDependencySignalTests.cs
+++ b/SharpTS.Tests/CompilerTests/RuntimeDependencySignalTests.cs
@@ -1,5 +1,7 @@
 using SharpTS.Compilation;
+using SharpTS.Modules;
 using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
 using SharpTS.TypeSystem;
 using Xunit;
 
@@ -96,5 +98,42 @@ public class RuntimeDependencySignalTests
             """);
         Assert.DoesNotContain("AbortSignal.any", reasons);
         Assert.Empty(reasons);
+    }
+
+    [Fact]
+    public void SourceExecution_RequiresManagedHostAndFullDependencyClosure()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"sharpts_execution_dep_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var entryPath = Path.Combine(tempDir, "main.ts");
+            File.WriteAllText(entryPath, """
+                import { runSourceJson } from "sharpts:execution";
+                console.log(runSourceJson("console.log(1);", "interpret", 1024));
+                """);
+
+            var resolver = new ModuleResolver(entryPath);
+            var entryModule = resolver.LoadModule(entryPath);
+            var modules = resolver.GetModulesInOrder(entryModule);
+            var typeMap = TestHarness.CheckModulesOrThrow(new TypeChecker(), modules, resolver);
+            var statements = modules.SelectMany(module => module.Statements).ToList();
+            var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+
+            var compiler = new ILCompiler("source_execution_dependency_test");
+            compiler.CompileModules(modules, resolver, typeMap, deadCodeInfo);
+
+            Assert.Contains("sharpts:execution module", compiler.RequiredSharpTSRuntimeReasons);
+            Assert.True(compiler.RequiredSharpTSRuntimeRequirements.HasFlag(
+                SharpTSRuntimeRequirements.RuntimeAssembly));
+            Assert.True(compiler.RequiredSharpTSRuntimeRequirements.HasFlag(
+                SharpTSRuntimeRequirements.FullDependencyClosure));
+            Assert.True(compiler.RequiredSharpTSRuntimeRequirements.HasFlag(
+                SharpTSRuntimeRequirements.ManagedCompilerHost));
+        }
+        finally
+        {
+            try { Directory.Delete(tempDir, recursive: true); } catch { }
+        }
     }
 }

--- a/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
+++ b/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
@@ -41,6 +41,7 @@ public class StandaloneDllTests
         // ZlibHelpers.cs / DnsPromises.cs — pruned: now pure IL, no SharpTS late binding
         "Compilation/RuntimeEmitter.ClusterHelpers.cs", // cluster bridges to ClusterCompiledBridge — workers run interpreted (requires SharpTS.dll co-located; suppressed by --standalone) — #1171
         "Compilation/RuntimeEmitter.VmHelpers.cs",             // vm module delegation to interpreter via reflection
+        "Compilation/RuntimeEmitter.SourceExecution.cs",       // sharpts:execution host bridge (requires the managed SharpTS runtime closure; suppressed by --standalone)
         "Compilation/RuntimeEmitter.DnsResolver.cs",           // dns.Resolver factory via RuntimeTypes
         "Compilation/RuntimeEmitter.Dns.cs",                   // setDefaultResultOrder best-effort sync to RuntimeTypes.DnsConfig (graceful no-op when SharpTS absent; standalone lookup ordering uses the emitted static) — #1072
         "Compilation/ILEmitter.Calls.ExternalInterop.cs",      // @DotNetType delegate shim + event subscription via DotNetDelegateShim/DotNetEventBinder

--- a/SharpTS.Tests/IntegrationTests/CliErrorTests.cs
+++ b/SharpTS.Tests/IntegrationTests/CliErrorTests.cs
@@ -9,6 +9,16 @@ namespace SharpTS.Tests.IntegrationTests;
 public class CliErrorTests
 {
     [Fact]
+    public void ManagedBuildRequiredError_UsesStableCodeAndFeatureContext()
+    {
+        var error = SharpTSCli.FormatManagedBuildRequiredError(
+            "compiled output requiring the managed SharpTS host (child_process.fork)");
+
+        Assert.StartsWith("Error SHARPTS007:", error);
+        Assert.Contains("child_process.fork", error);
+    }
+
+    [Fact]
     public void StandardFormat_OutputsErrorPrefix()
     {
         using var tempDir = CliTestHelper.CreateTempDirectory();

--- a/SharpTS.Tests/IntegrationTests/CliSourceExecutionTests.cs
+++ b/SharpTS.Tests/IntegrationTests/CliSourceExecutionTests.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace SharpTS.Tests.IntegrationTests;
+
+/// <summary>
+/// End-to-end deployment coverage for the managed source-execution bridge.
+/// </summary>
+public class CliSourceExecutionTests
+{
+    [Fact]
+    public void Compile_CopiesManagedClosure_AndRunsOutsideCompilerProcess()
+    {
+        using var tempDir = CliTestHelper.CreateTempDirectory();
+        var entryPath = tempDir.CreateFile("worker.ts", """
+            import * as execution from "sharpts:execution";
+            const run = execution.runSourceJson;
+            const result = JSON.parse(
+                run("console.log(40 + 2);", "compile", 1024)
+            );
+            console.log(result.Success);
+            console.log(result.Output.trim());
+            """);
+        var outputPath = tempDir.GetPath("worker.dll");
+
+        var compile = CliTestHelper.RunCli(
+            $"--no-tsconfig --compile \"{entryPath}\" -o \"{outputPath}\"",
+            tempDir.Path,
+            TimeSpan.FromSeconds(60));
+
+        Assert.Equal(0, compile.ExitCode);
+        Assert.Contains("Copied SharpTS runtime", compile.StandardOutput);
+        Assert.True(File.Exists(tempDir.GetPath("SharpTS.dll")));
+        Assert.True(File.Exists(tempDir.GetPath("SharpTS.deps.json")));
+        Assert.True(File.Exists(tempDir.GetPath("SharpTS.runtimeconfig.json")));
+        // A representative transitive dependency proves this is the managed closure,
+        // not only the bridge assembly.
+        Assert.True(File.Exists(tempDir.GetPath("NuGet.Protocol.dll")));
+
+        var run = RunDll(outputPath, tempDir.Path);
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Equal("true\n42\n", CliTestHelper.NormalizeOutput(run.Output));
+    }
+
+    private static (int ExitCode, string Output) RunDll(string dllPath, string workingDirectory)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", $"\"{dllPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDirectory
+        };
+
+        using var process = Process.Start(startInfo)!;
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(60_000))
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException("Compiled source-execution host did not exit within 60 seconds.");
+        }
+
+        return (process.ExitCode, stdoutTask.Result + stderrTask.Result);
+    }
+}

--- a/SharpTS.Tests/SdkTests/DiagnosticReporterTests.cs
+++ b/SharpTS.Tests/SdkTests/DiagnosticReporterTests.cs
@@ -1,4 +1,5 @@
 using SharpTS.Diagnostics;
+using SharpTS.Diagnostics.Exceptions;
 using Xunit;
 
 namespace SharpTS.Tests.SdkTests;
@@ -92,6 +93,19 @@ public class DiagnosticReporterTests
     public void DiagnosticCode_ManagedBuildRequired_HasStableIdentifier()
     {
         Assert.Equal("SHARPTS007", DiagnosticCode.ManagedBuildRequired.ToSharpTSCode());
+    }
+
+    [Fact]
+    public void ManagedBuildRequired_HumanFormat_IncludesStableIdentifier()
+    {
+        var diagnostic = ManagedBuildRequiredException.CreateDiagnostic(
+            "loading .NET reference assemblies",
+            "Requested reference: 'Example.dll'.");
+
+        Assert.Equal(DiagnosticCode.ManagedBuildRequired, diagnostic.Code);
+        Assert.StartsWith("Error SHARPTS007:", diagnostic.ToHumanFormat());
+        Assert.Contains("loading .NET reference assemblies", diagnostic.ToHumanFormat());
+        Assert.Contains("Example.dll", diagnostic.ToHumanFormat());
     }
 
     [Fact]

--- a/SharpTS.Tests/SdkTests/DiagnosticReporterTests.cs
+++ b/SharpTS.Tests/SdkTests/DiagnosticReporterTests.cs
@@ -89,6 +89,12 @@ public class DiagnosticReporterTests
     }
 
     [Fact]
+    public void DiagnosticCode_ManagedBuildRequired_HasStableIdentifier()
+    {
+        Assert.Equal("SHARPTS007", DiagnosticCode.ManagedBuildRequired.ToSharpTSCode());
+    }
+
+    [Fact]
     public void DiagnosticCode_TypeError_FormatsAs001()
     {
         var reporter = new DiagnosticReporter { MsBuildFormat = true };

--- a/SharpTS.Tests/SharedTests/SourceExecutionModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/SourceExecutionModuleTests.cs
@@ -48,4 +48,44 @@ public class SourceExecutionModuleTests
 
         Assert.Equal("true\n42\n0\ntrue\n", output.Replace("\r\n", "\n"));
     }
+
+    [Theory, ModeData]
+    public void Exports_AreFirstClassFunctions(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import * as execution from "sharpts:execution";
+                const run = execution.runSourceJson;
+                const configure = execution.configureUntrustedProcess;
+                const result = JSON.parse(run("console.log('first class');", "interpret", 1024));
+                console.log(typeof run);
+                console.log(typeof configure);
+                console.log(result.Output.trim());
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+
+        Assert.Equal("function\nfunction\nfirst class\n", output.Replace("\r\n", "\n"));
+    }
+
+    [Theory, ModeData]
+    public void CommonJsRequire_ExposesCallableFunctions(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.cjs"] = """
+                const execution = require("sharpts:execution");
+                const result = JSON.parse(
+                    execution.runSourceJson("console.log('required');", "interpret", 1024)
+                );
+                console.log(result.Output.trim());
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.cjs", mode);
+
+        Assert.Equal("required\n", output.Replace("\r\n", "\n"));
+    }
 }

--- a/SharpTS.Tests/SharedTests/SourceExecutionModuleTests.cs
+++ b/SharpTS.Tests/SharedTests/SourceExecutionModuleTests.cs
@@ -1,0 +1,51 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Proves that trusted TypeScript hosts can consume the source-execution bridge in
+/// both SharpTS execution modes without a hard SharpTS.dll metadata reference.
+/// </summary>
+[Collection("CompilationService")]
+public class SourceExecutionModuleTests
+{
+    [Theory, ModeData]
+    public void Interpret_IsCallableFromTypeScript(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { runSourceJson } from "sharpts:execution";
+                const result = JSON.parse(runSourceJson("console.log('nested interpret');", "interpret", 1024));
+                console.log(result.Success);
+                console.log(result.Output.trim());
+                console.log(result.Errors.length);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+
+        Assert.Equal("true\nnested interpret\n0\n", output.Replace("\r\n", "\n"));
+    }
+
+    [Theory, ModeData]
+    public void CompileAndExecute_IsCallableFromTypeScript(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["./main.ts"] = """
+                import { runSourceJson } from "sharpts:execution";
+                const result = JSON.parse(runSourceJson("console.log(40 + 2);", "compile", 1024));
+                console.log(result.Success);
+                console.log(result.Output.trim());
+                console.log(result.Errors.length);
+                console.log(result.CompileTimeMs !== null);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "./main.ts", mode);
+
+        Assert.Equal("true\n42\n0\ntrue\n", output.Replace("\r\n", "\n"));
+    }
+}

--- a/TypeSystem/BuiltInModuleTypes.System.cs
+++ b/TypeSystem/BuiltInModuleTypes.System.cs
@@ -766,6 +766,19 @@ public static partial class BuiltInModuleTypes
     // GetAsyncHooksModuleTypes removed — "async_hooks" is now implemented in
     // stdlib/node/async_hooks.ts; types flow from the TS source. See
     // GetAsyncHooksPrimitiveTypes for primitive:async_hooks.
+    public static Dictionary<string, TypeInfo> GetSourceExecutionModuleTypes()
+    {
+        return new Dictionary<string, TypeInfo>
+        {
+            ["runSourceJson"] = new TypeInfo.Function(
+                [TypeInfo.String.Shared, TypeInfo.String.Shared, TypeInfo.Primitive.Number],
+                TypeInfo.String.Shared),
+            ["configureUntrustedProcess"] = new TypeInfo.Function(
+                [TypeInfo.String.Shared],
+                TypeInfo.Void.Shared)
+        };
+    }
+
     public static Dictionary<string, TypeInfo> GetVmModuleTypes()
     {
         var anyType = TypeInfo.Any.Shared;

--- a/TypeSystem/BuiltInModuleTypes.cs
+++ b/TypeSystem/BuiltInModuleTypes.cs
@@ -531,6 +531,7 @@ public static partial class BuiltInModuleTypes
             "dgram" => GetDgramModuleTypes(),
             "cluster" => GetClusterModuleTypes(),
             "vm" => GetVmModuleTypes(),
+            "sharpts:execution" => GetSourceExecutionModuleTypes(),
             // "async_hooks" — migrated to stdlib/node/async_hooks.ts; types flow from the TS source.
             //   Primitive-layer types for primitive:async_hooks are in GetAsyncHooksPrimitiveTypes.
             "worker_threads" => GetWorkerThreadsModuleTypes(),

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -15,11 +15,19 @@ returns structured compiler diagnostics and never performs source-file I/O.
 single-source host. `Interpret()` runs the normal lexer, parser, recovery-mode
 type checker, resolver, and interpreter. `CompileAndExecute()` uses
 `CompilationService`. Both disable decorators, capture stdout and stderr, and
-stop retaining output at a caller-supplied character limit.
+stop retaining output at a caller-supplied character limit. The limit includes
+the truncation marker, so returned output never exceeds it.
+
+The single-source APIs have no module resolver. They explicitly reject static
+imports, re-exports, dynamic `import()`, TypeScript `import = require()`, and
+CommonJS `require()`. This is part of the untrusted-source boundary rather than
+an incidental type-checker failure.
 
 The service intentionally does not provide a hard timeout or memory sandbox.
 Hosts executing untrusted code must call it in a separate process and enforce
-wall-clock and memory limits by supervising that process.
+wall-clock and memory limits by supervising that process. Calls through the
+facade are serialized because compiled execution redirects process-wide console
+writers; a disposable worker process should execute one request at a time.
 
 ## Calling from a SharpTS program
 
@@ -42,6 +50,10 @@ and assigns `HttpClient.DefaultProxy` to the supplied blocking proxy. The module
 is a soft dependency on the managed SharpTS runtime. Compiled output automatically
 receives the complete SharpTS runtime closure; `--standalone` is therefore not
 valid for programs that use this module. Native AOT compiler hosts reject it.
+
+The proxy and signal settings are process-wide, permanent defense-in-depth
+controls. They do not replace OS- or container-level network and process
+isolation, and they do not affect non-HTTP networking APIs.
 
 The module is intended for trusted orchestration code. It is not itself a
 sandbox, and a host must not make it importable by the untrusted source being

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,0 +1,48 @@
+# Embedding SharpTS
+
+SharpTS exposes managed APIs for hosts that need to analyze or execute source
+without going through the command-line interface.
+
+## Compile and execute separately
+
+`SharpTS.Compilation.CompilationService` compiles a source string to an in-memory
+assembly and can execute those bytes through a collectible load context. It
+returns structured compiler diagnostics and never performs source-file I/O.
+
+## Execute one bounded source string
+
+`SharpTS.Execution.SourceExecutionService` is the higher-level facade for a
+single-source host. `Interpret()` runs the normal lexer, parser, recovery-mode
+type checker, resolver, and interpreter. `CompileAndExecute()` uses
+`CompilationService`. Both disable decorators, capture stdout and stderr, and
+stop retaining output at a caller-supplied character limit.
+
+The service intentionally does not provide a hard timeout or memory sandbox.
+Hosts executing untrusted code must call it in a separate process and enforce
+wall-clock and memory limits by supervising that process.
+
+## Calling from a SharpTS program
+
+Trusted TypeScript host programs can use the runtime-backed module:
+
+```typescript
+import {
+  configureUntrustedProcess,
+  runSourceJson
+} from "sharpts:execution";
+
+configureUntrustedProcess("http://blocked.invalid:9");
+const result = JSON.parse(
+  runSourceJson("console.log(6 * 7);", "compile", 100 * 1024)
+);
+```
+
+`configureUntrustedProcess()` enables SharpTS's cross-process signal restriction
+and assigns `HttpClient.DefaultProxy` to the supplied blocking proxy. The module
+is a soft dependency on the managed SharpTS runtime. Compiled output automatically
+receives the complete SharpTS runtime closure; `--standalone` is therefore not
+valid for programs that use this module. Native AOT compiler hosts reject it.
+
+The module is intended for trusted orchestration code. It is not itself a
+sandbox, and a host must not make it importable by the untrusted source being
+executed.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.302",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}

--- a/scripts/assert-managed-build-required.sh
+++ b/scripts/assert-managed-build-required.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <diagnostic-file> <feature-context>" >&2
+  exit 64
+fi
+
+diagnostic_file="$1"
+feature_context="$2"
+
+if ! grep -Fq 'SHARPTS007' "$diagnostic_file"; then
+  echo "expected managed-build-required diagnostic SHARPTS007" >&2
+  cat "$diagnostic_file" >&2
+  exit 1
+fi
+
+if ! grep -Fq -- "$feature_context" "$diagnostic_file"; then
+  echo "managed-build-required diagnostic omitted feature context: $feature_context" >&2
+  cat "$diagnostic_file" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- add `SourceExecutionService` for bounded interpretation and compile-and-run hosting
- expose the service through a trusted `sharpts:execution` built-in module in interpreted and compiled programs
- keep standalone compiled output decoupled from a hard SharpTS metadata reference through late binding
- copy the managed SharpTS dependency closure when the module is used and reject the unsupported Native AOT combination
- document the embedding API and add interpreter, compiler, standalone, failure, and output-cap regressions

## Motivation

This enables a SharpTS-compiled host to implement a source-execution worker in TypeScript without depending on SharpTS's internal lexer, parser, resolver, or interpreter types. The immediate consumer is `sharpts-www`, whose playground worker can now be compiled by SharpTS while retaining its process-isolation boundary and stdin/stdout protocol.

The embedding service deliberately does not replace the supervising process. Callers remain responsible for hard timeouts, cancellation, RSS limits, concurrency, and worker termination.

## Validation

- 83 focused `SourceExecution`, runtime-dependency, standalone DLL, and `CompilationService` tests passed
- standalone late-binding and dependency-copy tests passed
- downstream `sharpts-www` interpreted and compiled worker HTTP paths passed
- downstream hardened Linux container suite passed concurrency, RSS enforcement, rate limiting, malformed-worker recovery, shutdown, and provenance checks