### PR TITLE
Document conformance baselines as a public contract

### DIFF
--- a/SharpTS.Test262/BaselineContractTests.cs
+++ b/SharpTS.Test262/BaselineContractTests.cs
@@ -1,0 +1,21 @@
+using Xunit;
+
+namespace SharpTS.Test262;
+
+public class BaselineContractTests
+{
+    [Fact]
+    public void Header_IsVersionedAndPinsCorpus()
+    {
+        const string revision = "0123456789abcdef0123456789abcdef01234567";
+        Assert.StartsWith(
+            "# SharpTS baseline-format=1 suite=Test262 corpus=" + revision + " — ",
+            Test262Baseline.Header(revision));
+    }
+
+    [Fact]
+    public void Header_RejectsMalformedCorpusRevision()
+    {
+        Assert.Throws<ArgumentException>(() => Test262Baseline.Header("not-a-revision"));
+    }
+}

--- a/SharpTS.Test262/README.md
+++ b/SharpTS.Test262/README.md
@@ -47,6 +47,27 @@ Switches to the wide-sweep config and writes `wide-sweep-report.md` instead of d
 
 Skip reasons are appended to the bucket (`Skipped:async-done-deferred`) so the diff harness can tell different skip causes apart.
 
+## Baseline file contract
+
+The committed baselines are consumed outside this repository, including by the
+`sharpts-www` conformance explorer. The first and only comment line has this
+machine-readable shape:
+
+```text
+# SharpTS baseline-format=1 suite=Test262 corpus=<40-character-git-sha> — ...
+```
+
+Every remaining non-empty line is `<test-path> <Bucket[:reason]>`. Paths contain
+no spaces. The closed bucket vocabulary is `Pass`, `Fail`, `RuntimeError`,
+`ParseError`, `TypeCheckError`, `Timeout`, `HarnessError`, and
+`Skipped[:reason]`. Any format or vocabulary change must bump
+`baseline-format`; consumers must reject versions and buckets they do not know.
+
+Official aggregation uses every result except `Skipped:*` in the denominator.
+Only `Pass` contributes to the numerator. All other non-skipped buckets count as
+not passing, while skipped results are reported separately and never folded into
+the percentage.
+
 ## Layout
 
 | Path | Purpose |

--- a/SharpTS.Test262/Test262BaselineDiffer.cs
+++ b/SharpTS.Test262/Test262BaselineDiffer.cs
@@ -11,6 +11,15 @@ namespace SharpTS.Test262;
 /// </summary>
 public static class Test262Baseline
 {
+    public const int FormatVersion = 1;
+
+    public static string Header(string corpusRevision)
+    {
+        if (corpusRevision.Length != 40 || corpusRevision.Any(c => !char.IsAsciiHexDigit(c)))
+            throw new ArgumentException("Corpus revision must be a 40-character Git SHA.", nameof(corpusRevision));
+        return $"# SharpTS baseline-format={FormatVersion} suite=Test262 corpus={corpusRevision.ToLowerInvariant()} — do not hand-edit; regenerate with SHARPTS_TEST262_UPDATE_BASELINE=1.";
+    }
+
     public static IReadOnlyDictionary<string, string> Read(string path)
     {
         var dict = new SortedDictionary<string, string>(StringComparer.Ordinal);
@@ -28,12 +37,14 @@ public static class Test262Baseline
         return dict;
     }
 
-    public static void Write(string path, IEnumerable<(string RelPath, string Bucket)> entries)
+    public static void Write(string path, IEnumerable<(string RelPath, string Bucket)> entries,
+        string corpusRevision)
     {
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         var sorted = entries.OrderBy(e => e.RelPath, StringComparer.Ordinal).ToList();
         var sb = new StringBuilder();
-        sb.Append("# Test262 baseline — do not hand-edit. Regenerate with SHARPTS_TEST262_UPDATE_BASELINE=1.\n");
+        sb.Append(Header(corpusRevision));
+        sb.Append('\n');
         foreach (var (relPath, bucket) in sorted)
         {
             sb.Append(relPath);

--- a/SharpTS.Test262/Test262Paths.cs
+++ b/SharpTS.Test262/Test262Paths.cs
@@ -7,6 +7,26 @@ namespace SharpTS.Test262;
 /// </summary>
 public static class Test262Paths
 {
+    public static string GetCorpusRevision(string root)
+    {
+        var startInfo = new System.Diagnostics.ProcessStartInfo("git", "rev-parse HEAD")
+        {
+            WorkingDirectory = root,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        using var process = System.Diagnostics.Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Could not start git to resolve the Test262 corpus revision.");
+        var revision = process.StandardOutput.ReadToEnd().Trim();
+        var error = process.StandardError.ReadToEnd().Trim();
+        process.WaitForExit();
+        if (process.ExitCode != 0 || revision.Length != 40 || revision.Any(c => !char.IsAsciiHexDigit(c)))
+            throw new InvalidOperationException($"Could not resolve the Test262 corpus revision: {error}");
+        return revision.ToLowerInvariant();
+    }
+
     /// <summary>
     /// Walks up from <see cref="AppContext.BaseDirectory"/> looking for
     /// <c>external/test262/harness/sta.js</c>. Returns null when the submodule

--- a/SharpTS.Test262/Test262Tests.cs
+++ b/SharpTS.Test262/Test262Tests.cs
@@ -135,7 +135,8 @@ public abstract class Test262TestsBase
 
         if (updateBaseline || !File.Exists(baselinePath))
         {
-            Test262Baseline.Write(baselinePath, current.Select(kv => (kv.Key, kv.Value)));
+            Test262Baseline.Write(baselinePath, current.Select(kv => (kv.Key, kv.Value)),
+                Test262Paths.GetCorpusRevision(test262Root));
             _output.WriteLine($"[{mode}] wrote baseline → {baselinePath}");
             return;
         }

--- a/SharpTS.Test262/baselines/compiled.txt
+++ b/SharpTS.Test262/baselines/compiled.txt
@@ -1,4 +1,4 @@
-# Test262 baseline — do not hand-edit. Regenerate with SHARPTS_TEST262_UPDATE_BASELINE=1.
+# SharpTS baseline-format=1 suite=Test262 corpus=d5e73fc8d2c663554fb72e2380a8c2bc1a318a33 — do not hand-edit; regenerate with SHARPTS_TEST262_UPDATE_BASELINE=1.
 test/built-ins/Array/15.4.5-1.js Pass
 test/built-ins/Array/15.4.5.1-5-1.js Pass
 test/built-ins/Array/15.4.5.1-5-2.js Pass

--- a/SharpTS.Test262/baselines/interpreted.txt
+++ b/SharpTS.Test262/baselines/interpreted.txt
@@ -1,4 +1,4 @@
-# Test262 baseline — do not hand-edit. Regenerate with SHARPTS_TEST262_UPDATE_BASELINE=1.
+# SharpTS baseline-format=1 suite=Test262 corpus=d5e73fc8d2c663554fb72e2380a8c2bc1a318a33 — do not hand-edit; regenerate with SHARPTS_TEST262_UPDATE_BASELINE=1.
 test/built-ins/Array/15.4.5-1.js Pass
 test/built-ins/Array/15.4.5.1-5-1.js Pass
 test/built-ins/Array/15.4.5.1-5-2.js Pass

--- a/SharpTS.TypeScriptConformance/README.md
+++ b/SharpTS.TypeScriptConformance/README.md
@@ -47,7 +47,8 @@ Sandboxed runners can additionally set
 `SHARPTS_TSCONFORMANCE_BASELINE_OUTPUT` to a writable artifact path, then
 copy that generated file into `baselines/interpreted.txt`. Set it to `-` when
 the test host has no writable filesystem; entries are emitted to test output
-with a `baseline-entry:` prefix.
+with a `baseline-entry:` prefix and the versioned header with a
+`baseline-header:` prefix.
 
 ## Bucket model
 
@@ -65,6 +66,27 @@ Each test classifies into one of:
 `Skipped` carries a reason suffix (`Skipped:lib-drift`,
 `Skipped:directive:experimentaldecorators`, `Skipped:explicitly-skipped`) so
 the diff harness can tell different skip causes apart.
+
+## Baseline file contract
+
+The committed baseline is consumed outside this repository, including by the
+`sharpts-www` conformance explorer. Its first and only comment line has this
+machine-readable shape:
+
+```text
+# SharpTS baseline-format=1 suite=TypeScript corpus=<40-character-git-sha> — ...
+```
+
+Every remaining non-empty line is `<test-path> <Bucket[:reason]>`. Paths contain
+no spaces. The closed bucket vocabulary is `Pass`, `Fail`, `ParseError`,
+`TypeCheckError`, `HarnessError`, and `Skipped:<reason>`. Any format or
+vocabulary change must bump `baseline-format`; consumers must reject versions
+and buckets they do not know.
+
+Official aggregation uses every result except `Skipped:*` in the denominator.
+Only `Pass` contributes to the numerator. All other non-skipped buckets count as
+not passing, while skipped results are reported separately and never folded into
+the percentage.
 
 ## Match strategy
 

--- a/SharpTS.TypeScriptConformance/TypeScriptConformanceBaseline.cs
+++ b/SharpTS.TypeScriptConformance/TypeScriptConformanceBaseline.cs
@@ -11,6 +11,15 @@ namespace SharpTS.TypeScriptConformance;
 /// </summary>
 public static class TypeScriptConformanceBaseline
 {
+    public const int FormatVersion = 1;
+
+    public static string Header(string corpusRevision)
+    {
+        if (corpusRevision.Length != 40 || corpusRevision.Any(c => !char.IsAsciiHexDigit(c)))
+            throw new ArgumentException("Corpus revision must be a 40-character Git SHA.", nameof(corpusRevision));
+        return $"# SharpTS baseline-format={FormatVersion} suite=TypeScript corpus={corpusRevision.ToLowerInvariant()} — do not hand-edit; regenerate with SHARPTS_TSCONFORMANCE_UPDATE_BASELINE=1.";
+    }
+
     public static IReadOnlyDictionary<string, string> Read(string path)
     {
         var dict = new SortedDictionary<string, string>(StringComparer.Ordinal);
@@ -28,12 +37,14 @@ public static class TypeScriptConformanceBaseline
         return dict;
     }
 
-    public static void Write(string path, IEnumerable<(string RelPath, string Bucket)> entries)
+    public static void Write(string path, IEnumerable<(string RelPath, string Bucket)> entries,
+        string corpusRevision)
     {
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         var sorted = entries.OrderBy(e => e.RelPath, StringComparer.Ordinal).ToList();
         var sb = new StringBuilder();
-        sb.Append("# TS conformance baseline — do not hand-edit. Regenerate with SHARPTS_TSCONFORMANCE_UPDATE_BASELINE=1.\n");
+        sb.Append(Header(corpusRevision));
+        sb.Append('\n');
         foreach (var (relPath, bucket) in sorted)
         {
             sb.Append(relPath);

--- a/SharpTS.TypeScriptConformance/TypeScriptConformancePaths.cs
+++ b/SharpTS.TypeScriptConformance/TypeScriptConformancePaths.cs
@@ -7,6 +7,26 @@ namespace SharpTS.TypeScriptConformance;
 /// </summary>
 public static class TypeScriptConformancePaths
 {
+    public static string GetCorpusRevision(string root)
+    {
+        var startInfo = new System.Diagnostics.ProcessStartInfo("git", "rev-parse HEAD")
+        {
+            WorkingDirectory = root,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        using var process = System.Diagnostics.Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Could not start git to resolve the TypeScript corpus revision.");
+        var revision = process.StandardOutput.ReadToEnd().Trim();
+        var error = process.StandardError.ReadToEnd().Trim();
+        process.WaitForExit();
+        if (process.ExitCode != 0 || revision.Length != 40 || revision.Any(c => !char.IsAsciiHexDigit(c)))
+            throw new InvalidOperationException($"Could not resolve the TypeScript corpus revision: {error}");
+        return revision.ToLowerInvariant();
+    }
+
     /// <summary>
     /// Walks up from <see cref="AppContext.BaseDirectory"/> looking for
     /// <c>external/typescript/src/compiler/checker.ts</c> (a TS-repo-unique

--- a/SharpTS.TypeScriptConformance/TypeScriptConformanceRunnerTests.cs
+++ b/SharpTS.TypeScriptConformance/TypeScriptConformanceRunnerTests.cs
@@ -252,6 +252,15 @@ public class TypeScriptConformanceRunnerTests
 public class TypeScriptConformanceBaselineTests
 {
     [Fact]
+    public void Header_IsVersionedAndPinsCorpus()
+    {
+        const string revision = "0123456789abcdef0123456789abcdef01234567";
+        Assert.StartsWith(
+            "# SharpTS baseline-format=1 suite=TypeScript corpus=" + revision + " — ",
+            TypeScriptConformanceBaseline.Header(revision));
+    }
+
+    [Fact]
     public void EncodeBucket_PassWithNoSkipReason_JustOutcomeName()
     {
         var r = new TypeScriptConformanceResult(TypeScriptConformanceOutcome.Pass, null, null);

--- a/SharpTS.TypeScriptConformance/TypeScriptConformanceTests.cs
+++ b/SharpTS.TypeScriptConformance/TypeScriptConformanceTests.cs
@@ -102,6 +102,8 @@ public class TypeScriptConformanceTests
                 ?? baselinePath;
             if (baselineOutputPath == "-")
             {
+                _output.WriteLine("baseline-header:" + TypeScriptConformanceBaseline.Header(
+                    TypeScriptConformancePaths.GetCorpusRevision(root)));
                 foreach (var (path, bucket) in current)
                     _output.WriteLine($"baseline-entry:{path} {bucket}");
                 _output.WriteLine("wrote baseline → stdout");
@@ -109,7 +111,8 @@ public class TypeScriptConformanceTests
             else
             {
                 TypeScriptConformanceBaseline.Write(
-                    baselineOutputPath, current.Select(kv => (kv.Key, kv.Value)));
+                    baselineOutputPath, current.Select(kv => (kv.Key, kv.Value)),
+                    TypeScriptConformancePaths.GetCorpusRevision(root));
                 _output.WriteLine($"wrote baseline → {baselineOutputPath}");
             }
             return;

--- a/SharpTS.TypeScriptConformance/baselines/interpreted.txt
+++ b/SharpTS.TypeScriptConformance/baselines/interpreted.txt
@@ -1,4 +1,4 @@
-# TS conformance baseline — do not hand-edit. Regenerate with SHARPTS_TSCONFORMANCE_UPDATE_BASELINE=1.
+# SharpTS baseline-format=1 suite=TypeScript corpus=050880ce59e30b356b686bd3144efe24f875ebc8 — do not hand-edit; regenerate with SHARPTS_TSCONFORMANCE_UPDATE_BASELINE=1.
 tests/cases/conformance/Symbols/ES5SymbolProperty1.ts Pass
 tests/cases/conformance/Symbols/ES5SymbolProperty2.ts Pass
 tests/cases/conformance/Symbols/ES5SymbolProperty3.ts Fail


### PR DESCRIPTION
## Summary

- define a versioned, machine-readable baseline header for Test262 and TypeScript conformance files
- pin the originating corpus commit in every generated baseline header
- document the closed bucket vocabularies and official aggregation semantics
- update baseline generation to resolve corpus revisions automatically
- add focused contract coverage for the generated headers

## Motivation

This makes the committed conformance baselines safe for external consumers. It unblocks the generated conformance explorer tracked in https://github.com/nickna/sharpts-www/issues/6 and implements the public-contract work carried by #1280 section 7 and #1281 section 7 (originally #249).

Percentages are now explicitly defined as Pass divided by all non-skipped results. Every other non-skipped bucket counts as not passing, and skipped results are reported separately.

## Verification

- dotnet test SharpTS.Test262/SharpTS.Test262.csproj -c Debug --no-restore --filter FullyQualifiedName~BaselineContractTests
- dotnet test SharpTS.TypeScriptConformance/SharpTS.TypeScriptConformance.csproj -c Debug --no-restore --filter FullyQualifiedName~TypeScriptConformanceBaselineTests
- git diff --check origin/main...HEAD