### PR TITLE
feat: support Unix shebang lines in TypeScript files

### DIFF
--- a/Parsing/Lexer.cs
+++ b/Parsing/Lexer.cs
@@ -330,7 +330,11 @@ public class Lexer(string source)
                 AddToken(TokenType.AT);
                 break;
             case '#':
-                if (char.IsLetter(Peek()) || Peek() == '_' || Peek() == '$')
+                if (_start == 0 && Peek() == '!')
+                {
+                    SkipHashbang();
+                }
+                else if (char.IsLetter(Peek()) || Peek() == '_' || Peek() == '$')
                 {
                     PrivateIdentifier();
                 }
@@ -493,6 +497,27 @@ public class Lexer(string source)
         // _start already points to '#', consume identifier chars
         while (char.IsLetterOrDigit(Peek()) || Peek() == '_' || Peek() == '$') Advance();
         AddToken(TokenType.PRIVATE_IDENTIFIER);
+    }
+
+    /// <summary>
+    /// Skips a Unix hashbang at the very beginning of a source file. The leading '#'
+    /// has already been consumed; consume the rest of the line as trivia, including
+    /// its terminator, so the next token keeps its original offset and line number.
+    /// </summary>
+    private void SkipHashbang()
+    {
+        Advance(); // consume '!'
+        while (!IsAtEnd() && Peek() != '\r' && Peek() != '\n') Advance();
+
+        if (Match('\r'))
+        {
+            Match('\n');
+            _line++;
+        }
+        else if (Match('\n'))
+        {
+            _line++;
+        }
     }
 
     private void NumberLiteral()

--- a/README.md
+++ b/README.md
@@ -129,6 +129,19 @@ dismiss the list. Type `.help` for the dot-commands.
 sharpts script.ts
 ```
 
+On Unix-like systems, a TypeScript file can also be an executable script. Put the SharpTS
+hashbang at the very beginning of the file, then mark it executable:
+
+```typescript
+#!/usr/bin/env sharpts
+console.log("Hello from SharpTS");
+```
+
+```bash
+chmod +x hello.ts
+./hello.ts
+```
+
 **Compile to .NET assembly:**
 
 ```bash

--- a/SharpTS.Tests/Compilation/DebugSymbolsTests.cs
+++ b/SharpTS.Tests/Compilation/DebugSymbolsTests.cs
@@ -160,6 +160,16 @@ public class DebugSymbolsTests
         Assert.Equal([2, 3, 5], lines);
     }
 
+    [Fact]
+    public void HashbangKeepsFollowingSequencePointOnSecondLine()
+    {
+        const string source = "#!/usr/bin/env sharpts\nconsole.log(42);";
+
+        var lines = AllSequencePointLines(CompileTypeScript(source, emitDebugSymbols: true));
+
+        Assert.Equal([2], lines);
+    }
+
     /// <summary>
     /// A block or a <c>try</c> emits no instructions of its own, so the statement inside it must
     /// own the offset they would otherwise share — otherwise stepping lands on a brace.

--- a/SharpTS.Tests/IntegrationTests/CliShebangTests.cs
+++ b/SharpTS.Tests/IntegrationTests/CliShebangTests.cs
@@ -1,0 +1,66 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace SharpTS.Tests.IntegrationTests;
+
+public class CliShebangTests
+{
+    private const string Script = "#!/usr/bin/env sharpts\nconsole.log(\"Hello from SharpTS\");";
+
+    [Fact]
+    public void Execute_ShebangScript()
+    {
+        using var tempDir = CliTestHelper.CreateTempDirectory();
+        var scriptPath = tempDir.CreateFile("hello.ts", Script);
+
+        var result = CliTestHelper.RunCli($"--no-tsconfig \"{scriptPath}\"", tempDir.Path);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("Hello from SharpTS\n", result.StandardOutput);
+    }
+
+    [Fact]
+    public void Compile_ShebangScript_ProducesRunnableAssembly()
+    {
+        using var tempDir = CliTestHelper.CreateTempDirectory();
+        var scriptPath = tempDir.CreateFile("hello.ts", Script);
+
+        var compile = CliTestHelper.RunCli(
+            $"--no-tsconfig --compile \"{scriptPath}\"",
+            tempDir.Path);
+
+        Assert.Equal(0, compile.ExitCode);
+        var outputPath = tempDir.GetPath("hello.dll");
+        Assert.True(File.Exists(outputPath));
+
+        var run = RunDll(outputPath, tempDir.Path);
+        Assert.Equal(0, run.ExitCode);
+        Assert.Equal("Hello from SharpTS\n", run.StandardOutput);
+        Assert.Empty(run.StandardError);
+    }
+
+    private static CliTestHelper.CliResult RunDll(string dllPath, string workingDirectory)
+    {
+        var startInfo = new ProcessStartInfo("dotnet", $"\"{dllPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = workingDirectory
+        };
+
+        using var process = Process.Start(startInfo)!;
+        var stdoutTask = process.StandardOutput.ReadToEndAsync();
+        var stderrTask = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit((int)CliTestHelper.DefaultTimeout.TotalMilliseconds))
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException("Compiled shebang script did not exit within 30 seconds.");
+        }
+
+        return new CliTestHelper.CliResult(
+            process.ExitCode,
+            CliTestHelper.NormalizeOutput(stdoutTask.Result),
+            CliTestHelper.NormalizeOutput(stderrTask.Result));
+    }
+}

--- a/SharpTS.Tests/ParserTests/ShebangTests.cs
+++ b/SharpTS.Tests/ParserTests/ShebangTests.cs
@@ -1,0 +1,77 @@
+using SharpTS.Parsing;
+using Xunit;
+
+namespace SharpTS.Tests.ParserTests;
+
+public class ShebangTests
+{
+    private const string Hashbang = "#!/usr/bin/env sharpts";
+
+    [Theory]
+    [InlineData("\n")]
+    [InlineData("\r\n")]
+    [InlineData("\r")]
+    public void Lexer_HashbangPreservesFollowingTokenLocation(string lineTerminator)
+    {
+        string source = Hashbang + lineTerminator + "const answer = 42;";
+
+        var tokens = new Lexer(source).ScanTokens();
+
+        Assert.Equal(TokenType.CONST, tokens[0].Type);
+        Assert.Equal(2, tokens[0].Line);
+        Assert.Equal(Hashbang.Length + lineTerminator.Length, tokens[0].Start);
+    }
+
+    [Fact]
+    public void Lexer_FinalHashbangWithoutNewlineIsAccepted()
+    {
+        var tokens = new Lexer(Hashbang).ScanTokens();
+
+        Assert.Single(tokens);
+        Assert.Equal(TokenType.EOF, tokens[0].Type);
+        Assert.Equal(1, tokens[0].Line);
+    }
+
+    [Theory]
+    [InlineData(" #!/usr/bin/env sharpts\nconst answer = 42;")]
+    [InlineData("\uFEFF#!/usr/bin/env sharpts\nconst answer = 42;")]
+    [InlineData("\n#!/usr/bin/env sharpts\nconst answer = 42;")]
+    [InlineData("const before = 1;\n#!/usr/bin/env sharpts")]
+    public void Lexer_HashbangOutsideOffsetZeroIsRejected(string source)
+    {
+        var exception = Assert.Throws<Exception>(() => new Lexer(source).ScanTokens());
+
+        Assert.Contains("Unexpected character '#'", exception.Message);
+    }
+
+    [Fact]
+    public void Lexer_PrivateIdentifierStillLexesNormally()
+    {
+        var tokens = new Lexer("class Box { #value = 1; }").ScanTokens();
+
+        var privateIdentifier = Assert.Single(tokens, token => token.Type == TokenType.PRIVATE_IDENTIFIER);
+        Assert.Equal("#value", privateIdentifier.Lexeme);
+    }
+
+    [Fact]
+    public void Parser_AcceptsProgramAfterHashbang()
+    {
+        const string source = "#!/usr/bin/env sharpts\nconsole.log(42);";
+
+        var result = new Parser(new Lexer(source).ScanTokens()).Parse();
+
+        Assert.True(result.IsSuccess);
+        Assert.Single(result.Statements);
+    }
+
+    [Fact]
+    public void Parser_DiagnosticAfterHashbangReportsSecondLine()
+    {
+        const string source = "#!/usr/bin/env sharpts\nconst answer = ;";
+
+        var result = new Parser(new Lexer(source).ScanTokens()).Parse();
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(2, Assert.Single(result.Diagnostics).Line);
+    }
+}


### PR DESCRIPTION
## Summary
- treat an exact `#!` at source offset zero as lexer trivia
- preserve line numbers and absolute token offsets across LF, CRLF, CR, and EOF
- cover parser diagnostics, debug symbols, interpreted and compiled CLI execution, and private identifier regressions
- document executable TypeScript scripts on Unix-like systems

## Testing
- `dotnet build SharpTS.sln --no-restore` (0 warnings, 0 errors)
- focused shebang tests (14 passed)
- full suite (16,393 passed, 2 skipped; one transient compiled live-DNS smoke failure passed on isolated rerun)

Closes #1354