### PR TITLE
Fix SharpTS.Sdk base-SDK composition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,13 @@ jobs:
         run: dotnet test --no-build --configuration Release --verbosity normal --filter "Category!=LiveNetwork&Category!=LoadSensitive&Category!=npm"
         timeout-minutes: 10
 
+      # Exercise the SDK through its nupkg rather than repository-relative build
+      # outputs. The script uses a local-only feed, a clean package cache, and no
+      # global dotnet-tool directory on PATH.
+      - name: Packaged SDK smoke test
+        shell: pwsh
+        run: ./scripts/test-packaged-sdk.ps1
+
   # AOT-compatibility ratchet (#1324 Track 0). Builds SharpTS.csproj with the
   # AOT/trim/single-file analyzers compare the distinct IL#### inventory against
   # .github/aot-warning-baseline.json. The structured baseline pins total,

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,6 +81,13 @@ jobs:
           test -f "./nupkg/SharpTS.LanguageServer.${{ steps.version.outputs.VERSION }}.nupkg" || { echo "❌ SharpTS.LanguageServer package not found"; exit 1; }
           echo "✓ All packages created successfully"
 
+      - name: Smoke test packaged SDK
+        shell: pwsh
+        run: >-
+          ./scripts/test-packaged-sdk.ps1
+          -PackagePath "./nupkg/SharpTS.Sdk.${{ steps.version.outputs.VERSION }}.nupkg"
+          -PackageVersion "${{ steps.version.outputs.VERSION }}"
+
       - name: Upload package artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ dotnet tool install -g SharpTS
 </Project>
 ```
 
+`SharpTS.Sdk` composes with the installed `Microsoft.NET.Sdk` and invokes the
+compiler bundled in that exact NuGet package version. A separate global
+`sharpts` tool installation is not required for project builds.
+
 ### Usage
 
 **REPL Mode:**

--- a/SharpTS.Sdk/Sdk/Sdk.props
+++ b/SharpTS.Sdk/Sdk/Sdk.props
@@ -1,11 +1,21 @@
 <Project>
+  <!-- SharpTS.Sdk is a composing SDK: consumers need the standard .NET SDK
+       project system as well as the SharpTS compiler integration below. Import
+       the base props first so SharpTS defaults can build on its configuration. -->
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+
   <PropertyGroup>
     <!-- SDK identification marker -->
     <UsingSharpTSSdk>true</UsingSharpTSSdk>
 
-    <!-- Output configuration -->
-    <SharpTSOutputPath Condition="'$(SharpTSOutputPath)' == ''">$(OutputPath)</SharpTSOutputPath>
-    <SharpTSOutputFileName Condition="'$(SharpTSOutputFileName)' == ''">$(AssemblyName).dll</SharpTSOutputFileName>
+    <!-- Microsoft.NET.Sdk supplies the project system and reference resolution,
+         but SharpTS is the compiler and writes its product directly to the
+         configured output directory. Do not let Roslyn overwrite that assembly
+         or ask the common targets to copy a nonexistent C# intermediate output. -->
+    <SkipCompilerExecution>true</SkipCompilerExecution>
+    <SkipCopyBuildProduct>true</SkipCopyBuildProduct>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+    <UseAppHost>false</UseAppHost>
 
     <!-- tsconfig.json path (auto-detected or overridden) -->
     <SharpTSTsConfigPath Condition="'$(SharpTSTsConfigPath)' == ''">$(MSBuildProjectDirectory)\tsconfig.json</SharpTSTsConfigPath>

--- a/SharpTS.Sdk/Sdk/Sdk.targets
+++ b/SharpTS.Sdk/Sdk/Sdk.targets
@@ -1,4 +1,26 @@
 <Project>
+  <!-- Import the base targets before declaring SharpTS hooks. MSBuild evaluation
+       is order-dependent; this keeps the base SDK from overwriting the target
+       chain customizations declared later in this file. -->
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+
+  <!-- These defaults depend on values finalized by the consumer project and the
+       base SDK targets. Keeping them here avoids capturing an empty OutputPath
+       or AssemblyName during the early Sdk.props import. -->
+  <PropertyGroup>
+    <SharpTSOutputPath Condition="'$(SharpTSOutputPath)' == ''">$(OutputPath)</SharpTSOutputPath>
+    <SharpTSOutputFileName Condition="'$(SharpTSOutputFileName)' == ''">$(AssemblyName).dll</SharpTSOutputFileName>
+    <_SharpTSRuntimeConfigFileName>$([System.IO.Path]::ChangeExtension('$(SharpTSOutputFileName)', '.runtimeconfig.json'))</_SharpTSRuntimeConfigFileName>
+  </PropertyGroup>
+
+  <!-- Publish consumes @(IntermediateAssembly) as the primary build product.
+       Point it at the assembly emitted by SharpTS so the base SDK publishes the
+       real TypeScript output instead of looking for a Roslyn-produced obj file. -->
+  <ItemGroup>
+    <IntermediateAssembly Remove="@(IntermediateAssembly)" />
+    <IntermediateAssembly Include="$(SharpTSOutputPath)$(SharpTSOutputFileName)" />
+  </ItemGroup>
+
   <!-- Import the MSBuild tasks assembly -->
   <UsingTask TaskName="SharpTS.Sdk.Tasks.ReadTsConfigTask"
              AssemblyFile="$(SharpTSTasksAssembly)" />
@@ -105,9 +127,24 @@
   <Target Name="SharpTSClean" BeforeTargets="Clean">
     <Delete Files="$(SharpTSOutputPath)$(SharpTSOutputFileName)"
             Condition="Exists('$(SharpTSOutputPath)$(SharpTSOutputFileName)')" />
-    <Delete Files="$(SharpTSOutputPath)$(AssemblyName).runtimeconfig.json"
-            Condition="Exists('$(SharpTSOutputPath)$(AssemblyName).runtimeconfig.json')" />
+    <Delete Files="$(SharpTSOutputPath)$(_SharpTSRuntimeConfigFileName)"
+            Condition="Exists('$(SharpTSOutputPath)$(_SharpTSRuntimeConfigFileName)')" />
     <Message Importance="normal" Text="SharpTS: Cleaned output files" />
+  </Target>
+
+  <!-- The SharpTS compiler emits a runtimeconfig even when the consumer keeps
+       Microsoft.NET.Sdk's default Library OutputType. Add that compiler-owned
+       file to the standard publish set so the documented minimal project stays
+       runnable after `dotnet publish`. -->
+  <Target Name="_SharpTSAddRuntimeConfigToPublish"
+          AfterTargets="ComputeFilesToPublish"
+          Condition="Exists('$(SharpTSOutputPath)$(_SharpTSRuntimeConfigFileName)')">
+    <ItemGroup>
+      <ResolvedFileToPublish Include="$(SharpTSOutputPath)$(_SharpTSRuntimeConfigFileName)">
+        <RelativePath>$(_SharpTSRuntimeConfigFileName)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      </ResolvedFileToPublish>
+    </ItemGroup>
   </Target>
 
   <!-- Integrate with Build target chain -->

--- a/SharpTS.Sdk/SharpTS.Sdk.csproj
+++ b/SharpTS.Sdk/SharpTS.Sdk.csproj
@@ -17,7 +17,6 @@
     <!-- SDK package marker -->
     <DevelopmentDependency>true</DevelopmentDependency>
     <NoPackageAnalysis>true</NoPackageAnalysis>
-    <IsTool>true</IsTool>
   </PropertyGroup>
 
   <!-- SDK files -->

--- a/SharpTS.Sdk/readme.md
+++ b/SharpTS.Sdk/readme.md
@@ -2,6 +2,10 @@
 
 MSBuild SDK for compiling TypeScript directly to .NET assemblies using SharpTS.
 
+SharpTS.Sdk composes with the installed `Microsoft.NET.Sdk` and uses the
+compiler bundled in the selected package version. It does not require a global
+`sharpts` tool installation.
+
 ## Quick Start
 
 Create a new project file:

--- a/docs/msbuild-sdk.md
+++ b/docs/msbuild-sdk.md
@@ -2,6 +2,11 @@
 
 SharpTS provides an MSBuild SDK that integrates TypeScript-to-.NET compilation directly into your build process. Instead of running `sharpts --compile` manually, the SDK compiles your TypeScript automatically when you run `dotnet build`.
 
+The SDK composes with `Microsoft.NET.Sdk` to provide the standard restore,
+reference-resolution, build, rebuild, publish, and clean lifecycle. Compilation
+uses the SharpTS compiler bundled in the selected `SharpTS.Sdk` package, so the
+global `sharpts` tool is neither consulted nor required.
+
 ## Quick Start
 
 Create a project file:

--- a/scripts/test-packaged-sdk.ps1
+++ b/scripts/test-packaged-sdk.ps1
@@ -1,0 +1,222 @@
+[CmdletBinding()]
+param(
+    [string]$PackagePath,
+    [string]$PackageVersion = "0.0.0-sdk-smoke"
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) "sharpts-sdk-smoke-$([Guid]::NewGuid().ToString('N'))"
+$feedPath = Join-Path $tempRoot "feed"
+$consumerPath = Join-Path $tempRoot "consumer"
+$packagesPath = Join-Path $tempRoot "packages"
+$cliHomePath = Join-Path $tempRoot "cli-home"
+$publishPath = Join-Path $tempRoot "published"
+
+function Invoke-DotNet {
+    param(
+        [Parameter(Mandatory)] [string]$WorkingDirectory,
+        [Parameter(Mandatory)] [string[]]$Arguments,
+        [switch]$CaptureOutput
+    )
+
+    Push-Location $WorkingDirectory
+    try {
+        Write-Host "> dotnet $($Arguments -join ' ')"
+        if ($CaptureOutput) {
+            $lines = & dotnet @Arguments 2>&1
+            $exitCode = $LASTEXITCODE
+            $text = ($lines | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine
+            if ($text) {
+                Write-Host $text
+            }
+            if ($exitCode -ne 0) {
+                throw "dotnet $($Arguments -join ' ') failed with exit code $exitCode."
+            }
+            return $text
+        }
+
+        & dotnet @Arguments
+        if ($LASTEXITCODE -ne 0) {
+            throw "dotnet $($Arguments -join ' ') failed with exit code $LASTEXITCODE."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Assert-PathExists {
+    param([Parameter(Mandatory)] [string]$LiteralPath)
+    if (-not (Test-Path -LiteralPath $LiteralPath -PathType Leaf)) {
+        throw "Expected file was not created: $LiteralPath"
+    }
+}
+
+function Assert-SmokeOutput {
+    param([Parameter(Mandatory)] [string]$Output)
+    if ($Output -notmatch '(?m)^sdk-smoke-ok\r?$') {
+        throw "Packaged SDK output did not contain the expected TypeScript result."
+    }
+}
+
+$oldNuGetPackages = $env:NUGET_PACKAGES
+$oldCliHome = $env:DOTNET_CLI_HOME
+$oldPath = $env:PATH
+$oldTelemetry = $env:DOTNET_CLI_TELEMETRY_OPTOUT
+$oldFirstTimeExperience = $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+
+try {
+    New-Item -ItemType Directory -Force -Path $feedPath, $consumerPath | Out-Null
+
+    if ($PackagePath) {
+        $resolvedPackagePath = (Resolve-Path -LiteralPath $PackagePath).Path
+        $localPackagePath = Join-Path $feedPath (Split-Path $resolvedPackagePath -Leaf)
+        Copy-Item -LiteralPath $resolvedPackagePath -Destination $localPackagePath
+    }
+    else {
+        Invoke-DotNet -WorkingDirectory $repoRoot -Arguments @("restore")
+        Invoke-DotNet -WorkingDirectory $repoRoot -Arguments @(
+            "build", "SharpTS.Sdk.Tasks/SharpTS.Sdk.Tasks.csproj",
+            "--configuration", "Release", "--no-restore"
+        )
+        Invoke-DotNet -WorkingDirectory $repoRoot -Arguments @(
+            "publish", "SharpTS.csproj",
+            "--configuration", "Release", "--no-restore"
+        )
+        Invoke-DotNet -WorkingDirectory $repoRoot -Arguments @(
+            "pack", "SharpTS.Sdk/SharpTS.Sdk.csproj",
+            "--configuration", "Release", "--no-restore",
+            "-p:MinVerVersionOverride=$PackageVersion",
+            "--output", $feedPath
+        )
+        $localPackagePath = Join-Path $feedPath "SharpTS.Sdk.$PackageVersion.nupkg"
+    }
+
+    Assert-PathExists $localPackagePath
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($localPackagePath)
+    try {
+        $entries = @($archive.Entries | ForEach-Object { $_.FullName })
+        foreach ($requiredEntry in @(
+            "Sdk/Sdk.props",
+            "Sdk/Sdk.targets",
+            "build/SharpTS.Sdk.Tasks.dll",
+            "tools/net10.0/any/SharpTS.dll"
+        )) {
+            if ($entries -notcontains $requiredEntry) {
+                throw "SDK package is missing required entry '$requiredEntry'."
+            }
+        }
+
+        $nuspecEntry = $archive.Entries | Where-Object { $_.FullName -like "*.nuspec" } | Select-Object -First 1
+        if (-not $nuspecEntry) {
+            throw "SDK package does not contain a nuspec."
+        }
+        $reader = [System.IO.StreamReader]::new($nuspecEntry.Open())
+        try {
+            $nuspec = $reader.ReadToEnd()
+        }
+        finally {
+            $reader.Dispose()
+        }
+        if ($nuspec -match "DotnetTool") {
+            throw "SharpTS.Sdk is incorrectly marked as a DotnetTool package."
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+
+    $escapedFeedPath = [System.Security.SecurityElement]::Escape($feedPath)
+    Set-Content -LiteralPath (Join-Path $consumerPath "NuGet.Config") -Encoding utf8NoBOM -Value @"
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local" value="$escapedFeedPath" />
+  </packageSources>
+</configuration>
+"@
+    Set-Content -LiteralPath (Join-Path $consumerPath "Smoke.csproj") -Encoding utf8NoBOM -Value @"
+<Project Sdk="SharpTS.Sdk/$PackageVersion">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <AssemblyName>SharpTS.Sdk.Smoke</AssemblyName>
+    <SharpTSEntryPoint>main.ts</SharpTSEntryPoint>
+  </PropertyGroup>
+</Project>
+"@
+    Set-Content -LiteralPath (Join-Path $consumerPath "main.ts") -Encoding utf8NoBOM -Value 'console.log("sdk-smoke-ok");'
+    # The consumer lives outside the repository, so carry over the repository's
+    # supported .NET 10 SDK selection instead of inheriting an unrelated preview
+    # SDK that might also be installed on a developer or hosted runner.
+    Copy-Item -LiteralPath (Join-Path $repoRoot "global.json") -Destination (Join-Path $tempRoot "global.json")
+
+    $env:NUGET_PACKAGES = $packagesPath
+    $env:DOTNET_CLI_HOME = $cliHomePath
+    $env:DOTNET_CLI_TELEMETRY_OPTOUT = "1"
+    $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = "1"
+
+    # A global dotnet tool normally lives in ~/.dotnet/tools. Excluding that
+    # directory proves the SDK invokes its package-local compiler payload.
+    $pathSeparator = [Regex]::Escape([System.IO.Path]::PathSeparator)
+    $env:PATH = (($oldPath -split $pathSeparator) | Where-Object {
+        $_ -and $_ -notmatch '[/\\]\.dotnet[/\\]tools[/\\]?$'
+    }) -join [System.IO.Path]::PathSeparator
+    if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+        throw "dotnet was not available after removing global-tool directories from PATH."
+    }
+
+    $projectPath = Join-Path $consumerPath "Smoke.csproj"
+    $nugetConfigPath = Join-Path $consumerPath "NuGet.Config"
+    $buildOutput = Join-Path $consumerPath "bin/Release/net10.0/SharpTS.Sdk.Smoke.dll"
+    $runtimeConfig = Join-Path $consumerPath "bin/Release/net10.0/SharpTS.Sdk.Smoke.runtimeconfig.json"
+
+    Invoke-DotNet -WorkingDirectory $consumerPath -Arguments @(
+        "restore", $projectPath,
+        "--configfile", $nugetConfigPath,
+        "--packages", $packagesPath
+    )
+    Assert-PathExists (Join-Path $packagesPath "sharpts.sdk/$PackageVersion/tools/net10.0/any/SharpTS.dll")
+
+    Invoke-DotNet -WorkingDirectory $consumerPath -Arguments @(
+        "build", $projectPath, "--configuration", "Release", "--no-restore"
+    )
+    Assert-PathExists $buildOutput
+    Assert-PathExists $runtimeConfig
+    Assert-SmokeOutput (Invoke-DotNet -WorkingDirectory $consumerPath -Arguments @($buildOutput) -CaptureOutput)
+
+    Invoke-DotNet -WorkingDirectory $consumerPath -Arguments @(
+        "build", $projectPath, "--configuration", "Release", "--no-restore", "--target:Rebuild"
+    )
+    Assert-SmokeOutput (Invoke-DotNet -WorkingDirectory $consumerPath -Arguments @($buildOutput) -CaptureOutput)
+
+    Invoke-DotNet -WorkingDirectory $consumerPath -Arguments @(
+        "clean", $projectPath, "--configuration", "Release"
+    )
+    if ((Test-Path -LiteralPath $buildOutput) -or (Test-Path -LiteralPath $runtimeConfig)) {
+        throw "dotnet clean left SharpTS build outputs behind."
+    }
+
+    Invoke-DotNet -WorkingDirectory $consumerPath -Arguments @(
+        "publish", $projectPath, "--configuration", "Release", "--no-restore", "--output", $publishPath
+    )
+    $publishedAssembly = Join-Path $publishPath "SharpTS.Sdk.Smoke.dll"
+    Assert-PathExists $publishedAssembly
+    Assert-PathExists (Join-Path $publishPath "SharpTS.Sdk.Smoke.runtimeconfig.json")
+    Assert-SmokeOutput (Invoke-DotNet -WorkingDirectory $consumerPath -Arguments @($publishedAssembly) -CaptureOutput)
+
+    Write-Host "Packaged SharpTS.Sdk smoke test passed for version $PackageVersion."
+}
+finally {
+    $env:NUGET_PACKAGES = $oldNuGetPackages
+    $env:DOTNET_CLI_HOME = $oldCliHome
+    $env:PATH = $oldPath
+    $env:DOTNET_CLI_TELEMETRY_OPTOUT = $oldTelemetry
+    $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = $oldFirstTimeExperience
+
+    if (Test-Path -LiteralPath $tempRoot) {
+        Remove-Item -LiteralPath $tempRoot -Recurse -Force
+    }
+}


### PR DESCRIPTION
## Summary
- compose SharpTS.Sdk with Microsoft.NET.Sdk using explicit props and targets imports
- keep SharpTS as the sole compiler while integrating standard build, rebuild, publish, and clean behavior
- remove the incorrect SDK tool marker and document package-local compiler usage
- add a local-feed packaged SDK smoke test to CI and the release workflow

## Testing
- scripts/test-packaged-sdk.ps1
- packaged smoke test in prebuilt-package mode
- dotnet build --no-restore --configuration Release
- dotnet test --no-build --configuration Release --verbosity normal --filter "Category!=LiveNetwork&Category!=LoadSensitive&Category!=npm"
- PowerShell parser, workflow YAML parsing, and git diff --check

Fixes #1352