### PR TITLE
Harden NuGet publishing against partial releases

### DIFF
--- a/.github/nuget-packages.json
+++ b/.github/nuget-packages.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "documentedSdkVersion": "1.0.7",
+  "documentationFiles": [
+    "README.md",
+    "SharpTS.Sdk/readme.md",
+    "docs/msbuild-sdk.md",
+    "docs/dotnet-integration.md"
+  ],
+  "packages": [
+    { "id": "SharpTS.LanguageServer" },
+    { "id": "SharpTS.Hosting" },
+    { "id": "SharpTS.Sdk" },
+    { "id": "SharpTS" }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,10 @@ jobs:
         run: dotnet test --no-build --configuration Release --verbosity normal --filter "Category!=LiveNetwork&Category!=LoadSensitive&Category!=npm"
         timeout-minutes: 10
 
+      - name: Test NuGet release helper
+        shell: pwsh
+        run: ./scripts/test-nuget-release.ps1
+
       # Exercise the SDK through its nupkg rather than repository-relative build
       # outputs. The script uses a local-only feed, a clean package cache, and no
       # global dotnet-tool directory on PATH.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,10 @@ jobs:
       - name: Test
         run: dotnet test --no-build --configuration Release --verbosity normal --filter "Category!=LiveNetwork&Category!=LoadSensitive&Category!=npm"
 
+      - name: Test NuGet release helper
+        shell: pwsh
+        run: ./scripts/test-nuget-release.ps1
+
       - name: Publish SharpTS for SDK bundling
         run: dotnet publish SharpTS.csproj --configuration Release --no-build
 
@@ -69,7 +73,7 @@ jobs:
           echo "✓ All SDK dependencies found"
 
       - name: Pack packages
-        run: dotnet pack --no-build --configuration Release -p:Version=${{ steps.version.outputs.VERSION }} --output ./nupkg
+        run: dotnet pack --no-build --configuration Release -p:MinVerVersionOverride=${{ steps.version.outputs.VERSION }} --output ./nupkg
 
       - name: Verify packages created
         run: |
@@ -80,6 +84,17 @@ jobs:
           test -f "./nupkg/SharpTS.Hosting.${{ steps.version.outputs.VERSION }}.nupkg" || { echo "❌ SharpTS.Hosting package not found"; exit 1; }
           test -f "./nupkg/SharpTS.LanguageServer.${{ steps.version.outputs.VERSION }}.nupkg" || { echo "❌ SharpTS.LanguageServer package not found"; exit 1; }
           echo "✓ All packages created successfully"
+
+      # A new package ID must be onboarded on NuGet and added to the API key's
+      # scope before a tag can publish any established package. This also keeps
+      # every copyable SDK version in the docs pinned to a version NuGet serves.
+      - name: Preflight NuGet package IDs and documentation
+        shell: pwsh
+        run: >-
+          ./scripts/nuget-release.ps1
+          -Action Preflight
+          -Version "${{ steps.version.outputs.VERSION }}"
+          -PackageDirectory ./nupkg
 
       - name: Smoke test packaged SDK
         shell: pwsh
@@ -466,6 +481,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v4
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
@@ -491,8 +508,15 @@ jobs:
           path: ./assets
           merge-multiple: true
 
-      - name: Push to NuGet
-        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      - name: Push and verify NuGet packages
+        shell: pwsh
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: >-
+          ./scripts/nuget-release.ps1
+          -Action Publish
+          -Version "${{ needs.build.outputs.version }}"
+          -PackageDirectory ./nupkg
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,9 +13,9 @@
 
     <!-- Single version source of truth: MinVer derives the version from Git tags
          (prefix `v`) for every packable project, replacing the former hard-coded
-         <Version>. At release time CI passes -p:Version explicitly to `dotnet pack`
-         to pin the published artifacts to the exact tag (.github/workflows/publish.yml);
-         that override and MinVer agree because the tagged commit is HEAD. -->
+         <Version>. At release time CI passes -p:MinVerVersionOverride explicitly
+         to `dotnet pack` so tags and workflow-dispatch dry runs produce the exact
+         version selected by .github/workflows/publish.yml. -->
     <MinVerTagPrefix>v</MinVerTagPrefix>
 
     <!-- Shared package metadata -->

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ dotnet tool install -g SharpTS
 **Or use TypeScript in a .NET project:**
 
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.8">
+<Project Sdk="SharpTS.Sdk/1.0.7">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <SharpTSEntryPoint>src/main.ts</SharpTSEntryPoint>

--- a/SharpTS.Sdk/SharpTS.Sdk.csproj
+++ b/SharpTS.Sdk/SharpTS.Sdk.csproj
@@ -36,7 +36,7 @@
   <ItemGroup>
     <None Include="..\bin\Release\net10.0\publish\**"
           Pack="true"
-          PackagePath="tools\net10.0\any\"
+          PackagePath="tools/net10.0/any/"
           Condition="Exists('..\bin\Release\net10.0\publish\')" />
   </ItemGroup>
 

--- a/SharpTS.Sdk/SharpTS.Sdk.csproj
+++ b/SharpTS.Sdk/SharpTS.Sdk.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <None Include="..\SharpTS.Sdk.Tasks\bin\Release\net10.0\SharpTS.Sdk.Tasks.dll"
           Pack="true"
-          PackagePath="build\"
+          PackagePath="build"
           Condition="Exists('..\SharpTS.Sdk.Tasks\bin\Release\net10.0\SharpTS.Sdk.Tasks.dll')" />
   </ItemGroup>
 

--- a/SharpTS.Sdk/readme.md
+++ b/SharpTS.Sdk/readme.md
@@ -11,7 +11,7 @@ compiler bundled in the selected package version. It does not require a global
 Create a new project file:
 
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.0">
+<Project Sdk="SharpTS.Sdk/1.0.7">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <SharpTSEntryPoint>src/main.ts</SharpTSEntryPoint>
@@ -79,7 +79,7 @@ use `sharpts -p` or `sharpts --build` to type-check every `files`/`include` root
 ### Minimal Project
 
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.0">
+<Project Sdk="SharpTS.Sdk/1.0.7">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <SharpTSEntryPoint>src/main.ts</SharpTSEntryPoint>
@@ -90,7 +90,7 @@ use `sharpts -p` or `sharpts --build` to type-check every `files`/`include` root
 ### With Decorators
 
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.0">
+<Project Sdk="SharpTS.Sdk/1.0.7">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <SharpTSEntryPoint>src/app.ts</SharpTSEntryPoint>
@@ -113,7 +113,7 @@ myproject/
 
 `myproject.csproj`:
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.0">
+<Project Sdk="SharpTS.Sdk/1.0.7">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <!-- Entry point read from tsconfig.json files array -->
@@ -141,7 +141,7 @@ You can pin the SDK version in `global.json`:
 ```json
 {
   "msbuild-sdks": {
-    "SharpTS.Sdk": "1.0.0"
+    "SharpTS.Sdk": "1.0.7"
   }
 }
 ```

--- a/docs/dotnet-integration.md
+++ b/docs/dotnet-integration.md
@@ -250,7 +250,7 @@ Generated packages include:
 The easiest way to integrate SharpTS into your build is using the MSBuild SDK:
 
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.0">
+<Project Sdk="SharpTS.Sdk/1.0.7">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <SharpTSEntryPoint>src/main.ts</SharpTSEntryPoint>

--- a/docs/msbuild-sdk.md
+++ b/docs/msbuild-sdk.md
@@ -12,7 +12,7 @@ global `sharpts` tool is neither consulted nor required.
 Create a project file:
 
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.0">
+<Project Sdk="SharpTS.Sdk/1.0.7">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <SharpTSEntryPoint>src/main.ts</SharpTSEntryPoint>
@@ -36,7 +36,7 @@ dotnet bin/Debug/net10.0/MyProject.dll
 The SDK is distributed as a NuGet package. Reference it in your project file:
 
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.0">
+<Project Sdk="SharpTS.Sdk/1.0.7">
 ```
 
 ### Version Pinning with global.json
@@ -46,7 +46,7 @@ Pin the SDK version across your solution:
 ```json
 {
   "msbuild-sdks": {
-    "SharpTS.Sdk": "1.0.0"
+    "SharpTS.Sdk": "1.0.7"
   }
 }
 ```
@@ -64,7 +64,7 @@ Then use the SDK without a version number:
 ### Minimal Configuration
 
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.0">
+<Project Sdk="SharpTS.Sdk/1.0.7">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <SharpTSEntryPoint>src/main.ts</SharpTSEntryPoint>
@@ -75,7 +75,7 @@ Then use the SDK without a version number:
 ### Full Configuration
 
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.0">
+<Project Sdk="SharpTS.Sdk/1.0.7">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
 
@@ -201,7 +201,7 @@ This allows you to use tsconfig.json for IDE compatibility while overriding spec
 With this tsconfig.json, you can simplify your project file:
 
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.0">
+<Project Sdk="SharpTS.Sdk/1.0.7">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <!-- Entry point and options read from tsconfig.json -->
@@ -250,7 +250,7 @@ MyProject/
 ```
 
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.0">
+<Project Sdk="SharpTS.Sdk/1.0.7">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <SharpTSEntryPoint>src/main.ts</SharpTSEntryPoint>
@@ -296,7 +296,7 @@ MyProject/
 ```
 
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.0">
+<Project Sdk="SharpTS.Sdk/1.0.7">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <!-- Entry point read from tsconfig.json -->
@@ -450,7 +450,7 @@ If you're using manual pre-build targets, migrate to the SDK:
 ### After (SDK)
 
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.0">
+<Project Sdk="SharpTS.Sdk/1.0.7">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <SharpTSEntryPoint>src/main.ts</SharpTSEntryPoint>
@@ -472,7 +472,7 @@ If you're using manual pre-build targets, migrate to the SDK:
 
 ### SDK Not Found
 
-**Error:** `The SDK 'SharpTS.Sdk/1.0.0' could not be resolved`
+**Error:** `The SDK 'SharpTS.Sdk/1.0.7' could not be resolved`
 
 - Ensure the NuGet package is available (nuget.org or private feed)
 - Check your NuGet.config includes the correct package source
@@ -503,7 +503,7 @@ If you're using manual pre-build targets, migrate to the SDK:
 ### Console Application
 
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.0">
+<Project Sdk="SharpTS.Sdk/1.0.7">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
@@ -527,7 +527,7 @@ console.log("Fibonacci(10) =", fibonacci(10));
 ### Library with Decorators
 
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.0">
+<Project Sdk="SharpTS.Sdk/1.0.7">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <SharpTSEntryPoint>src/index.ts</SharpTSEntryPoint>
@@ -541,7 +541,7 @@ console.log("Fibonacci(10) =", fibonacci(10));
 ### With Custom Namespace
 
 ```xml
-<Project Sdk="SharpTS.Sdk/1.0.0">
+<Project Sdk="SharpTS.Sdk/1.0.7">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <SharpTSEntryPoint>src/library.ts</SharpTSEntryPoint>

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,88 @@
+# Release Operations
+
+SharpTS publishes several NuGet packages from one tag. NuGet does not provide a
+transaction that can atomically publish the complete set, so release safety
+comes from preflight checks, explicit idempotent pushes, and post-publish
+inventory verification.
+
+## Package manifest
+
+`.github/nuget-packages.json` is the source of truth for the expected package
+IDs, their deterministic push order, and the stable `SharpTS.Sdk` version used
+by copyable documentation examples. When adding a package:
+
+1. Onboard the package ID on NuGet separately from a release tag.
+   Publishing an approved prerelease package is the only reliable end-to-end
+   validation for a new ID and API-key scope.
+2. Confirm the release API key is scoped to the new ID. NuGet does not expose an
+   API that lets the workflow inspect an API key's package scopes.
+3. Add the ID to the manifest and run `./scripts/test-nuget-release.ps1`.
+4. Run the Publish workflow manually. Its dry run builds and packs the complete
+   set and runs the public-feed preflight without publishing.
+
+The tagged release is deliberately blocked if any manifest ID is not already
+registered. This prevents an untested new-package permission from publishing an
+established package first.
+
+## Normal release
+
+The Publish workflow builds and tests all artifacts before its release job. The
+release job pushes each package explicitly with `--skip-duplicate`, records a
+result for every package, and then queries NuGet until every manifest ID exposes
+the tag version. The job fails if any push failed or the final inventory remains
+incomplete.
+
+Rerunning a failed release is safe. Already published packages are skipped and
+missing packages are retried, allowing a partial release to converge without
+changing package files or versions.
+
+Only advance `documentedSdkVersion` and the matching documentation examples
+after that SDK version is publicly visible. The preflight rejects inconsistent
+pins and versions absent from NuGet.
+
+## Recovering a partial publish
+
+1. Record the tag, workflow run, expected IDs, successful pushes, and exact
+   errors before changing credentials.
+2. Verify package ownership in the NuGet Gallery and ensure the API key covers
+   every expected ID. Rotate or broaden the key through NuGet's normal secret
+   management process; never print or commit it.
+3. Reuse the original workflow artifact when available. Otherwise check out the
+   exact tag and rebuild with the same SDK and
+   `-p:MinVerVersionOverride=<tag-version>`.
+4. Inspect the resulting package IDs and versions before publication. Do not
+   substitute packages built from another commit.
+5. Push each missing package explicitly:
+
+   ```bash
+   dotnet nuget push <package> \
+     --source https://api.nuget.org/v3/index.json \
+     --api-key <key> \
+     --skip-duplicate
+   ```
+
+6. Query `https://api.nuget.org/v3-flatcontainer/<lowercase-id>/index.json` for
+   every expected ID and confirm the tag version appears.
+7. For a tag created before this hardening, rerun its original workflow only
+   after the manual inventory is complete so `--skip-duplicate` can reach the
+   GitHub release step. Future tags use the hardened inventory check directly.
+
+## v1.0.8 repair record
+
+Run `29182139378` published `SharpTS` 1.0.8, then received HTTP 403 for
+`SharpTS.LanguageServer`; the wildcard stopped before `SharpTS.Sdk`. The source
+tag's intended package set was `SharpTS`, `SharpTS.LanguageServer`, and
+`SharpTS.Sdk`. `SharpTS.Hosting` was introduced later and is intentionally not
+part of the v1.0.8 repair.
+
+As of the issue investigation, the public state is:
+
+| Package | v1.0.8 | Required action |
+| --- | --- | --- |
+| `SharpTS` | Published | None; `--skip-duplicate` makes retries safe. |
+| `SharpTS.Sdk` | Missing | Rebuild from tag `v1.0.8`, publish, and verify. |
+| `SharpTS.LanguageServer` | Unregistered | Resolve ownership/API-key policy, then either publish the tag artifact or document an intentional exception. |
+| `SharpTS.Hosting` | Not in tag | No v1.0.8 package is expected. Onboard before its first tagged release. |
+
+Until an operator completes that repair, copyable SDK examples remain pinned to
+the verified `SharpTS.Sdk` 1.0.7 release.

--- a/scripts/NuGetRelease.psm1
+++ b/scripts/NuGetRelease.psm1
@@ -1,0 +1,246 @@
+Set-StrictMode -Version Latest
+
+function Get-NuGetReleaseManifest {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)][string] $Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+        throw "NuGet release manifest not found: $Path"
+    }
+
+    $manifest = Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+    if ($manifest.schemaVersion -ne 1) {
+        throw "Unsupported NuGet release manifest schema version '$($manifest.schemaVersion)'."
+    }
+
+    $packageIds = @($manifest.packages | ForEach-Object { $_.id })
+    if ($packageIds.Count -eq 0 -or $packageIds -contains $null -or $packageIds -contains '') {
+        throw 'The NuGet release manifest must contain at least one package ID.'
+    }
+
+    $duplicates = @($packageIds | Group-Object | Where-Object Count -gt 1 | ForEach-Object Name)
+    if ($duplicates.Count -gt 0) {
+        throw "Duplicate package IDs in NuGet release manifest: $($duplicates -join ', ')"
+    }
+
+    if ([string]::IsNullOrWhiteSpace($manifest.documentedSdkVersion)) {
+        throw 'The NuGet release manifest must define documentedSdkVersion.'
+    }
+
+    return $manifest
+}
+
+function Get-NuGetPackageVersions {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string] $PackageId,
+        [Parameter(Mandatory)][string] $FlatContainerBaseUri
+    )
+
+    $baseUri = $FlatContainerBaseUri.TrimEnd('/')
+    $uri = "$baseUri/$($PackageId.ToLowerInvariant())/index.json"
+    $response = Invoke-RestMethod -Uri $uri -Method Get
+    return @($response.versions)
+}
+
+function Get-DocumentedSdkVersionErrors {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Manifest,
+        [Parameter(Mandatory)][string] $RepositoryRoot,
+        [Parameter(Mandatory)][scriptblock] $FetchPackageVersions,
+        [Parameter(Mandatory)][string] $FlatContainerBaseUri
+    )
+
+    $errors = [System.Collections.Generic.List[string]]::new()
+    $expectedVersion = [string]$Manifest.documentedSdkVersion
+    $versionPattern = 'SharpTS\.Sdk(?:/|"\s*:\s*")(?<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)'
+
+    foreach ($relativePath in @($Manifest.documentationFiles)) {
+        $path = Join-Path $RepositoryRoot $relativePath
+        if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+            $errors.Add("Documentation file not found: $relativePath")
+            continue
+        }
+
+        $matches = [regex]::Matches((Get-Content -LiteralPath $path -Raw), $versionPattern)
+        if ($matches.Count -eq 0) {
+            $errors.Add("No concrete SharpTS.Sdk version found in $relativePath")
+            continue
+        }
+
+        foreach ($match in $matches) {
+            $actualVersion = $match.Groups['version'].Value
+            if ($actualVersion -ne $expectedVersion) {
+                $errors.Add("$relativePath references SharpTS.Sdk/$actualVersion; expected $expectedVersion")
+            }
+        }
+    }
+
+    try {
+        $publishedVersions = @(& $FetchPackageVersions 'SharpTS.Sdk' $FlatContainerBaseUri)
+        if ($publishedVersions -notcontains $expectedVersion) {
+            $errors.Add("Documented SharpTS.Sdk version $expectedVersion is not published on NuGet")
+        }
+    }
+    catch {
+        $errors.Add("Could not verify documented SharpTS.Sdk version $expectedVersion on NuGet: $($_.Exception.Message)")
+    }
+
+    return $errors.ToArray()
+}
+
+function Assert-NuGetReleasePreflight {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Manifest,
+        [Parameter(Mandatory)][string] $PackageDirectory,
+        [Parameter(Mandatory)][string] $Version,
+        [Parameter(Mandatory)][string] $RepositoryRoot,
+        [string] $FlatContainerBaseUri = 'https://api.nuget.org/v3-flatcontainer',
+        [scriptblock] $FetchPackageVersions
+    )
+
+    if ($null -eq $FetchPackageVersions) {
+        $FetchPackageVersions = { param($PackageId, $BaseUri) Get-NuGetPackageVersions -PackageId $PackageId -FlatContainerBaseUri $BaseUri }
+    }
+
+    $errors = [System.Collections.Generic.List[string]]::new()
+    foreach ($package in @($Manifest.packages)) {
+        $packageId = [string]$package.id
+        $packagePath = Join-Path $PackageDirectory "$packageId.$Version.nupkg"
+        if (-not (Test-Path -LiteralPath $packagePath -PathType Leaf)) {
+            $errors.Add("Expected package artifact not found: $packagePath")
+        }
+
+        try {
+            $publishedVersions = @(& $FetchPackageVersions $packageId $FlatContainerBaseUri)
+            if ($publishedVersions.Count -eq 0) {
+                $errors.Add("Package ID '$packageId' is not registered on NuGet; onboard it and validate API-key scope before tagging a release")
+            }
+        }
+        catch {
+            $errors.Add("Package ID '$packageId' is not registered or NuGet could not be queried: $($_.Exception.Message)")
+        }
+    }
+
+    foreach ($documentationError in @(Get-DocumentedSdkVersionErrors `
+        -Manifest $Manifest `
+        -RepositoryRoot $RepositoryRoot `
+        -FetchPackageVersions $FetchPackageVersions `
+        -FlatContainerBaseUri $FlatContainerBaseUri)) {
+        $errors.Add($documentationError)
+    }
+
+    if ($errors.Count -gt 0) {
+        throw "NuGet release preflight failed:`n - $($errors -join "`n - ")"
+    }
+
+    Write-Host "NuGet release preflight passed for version $Version."
+}
+
+function Publish-NuGetPackages {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] $Manifest,
+        [Parameter(Mandatory)][string] $PackageDirectory,
+        [Parameter(Mandatory)][string] $Version,
+        [Parameter(Mandatory)][string] $ApiKey,
+        [string] $NuGetSource = 'https://api.nuget.org/v3/index.json',
+        [string] $FlatContainerBaseUri = 'https://api.nuget.org/v3-flatcontainer',
+        [ValidateRange(1, 100)][int] $VerificationAttempts = 12,
+        [ValidateRange(0, 300)][int] $VerificationDelaySeconds = 10,
+        [scriptblock] $PushPackage,
+        [scriptblock] $FetchPackageVersions,
+        [scriptblock] $Sleep
+    )
+
+    if ($null -eq $PushPackage) {
+        $PushPackage = {
+            param($PackagePath, $PackageId, $PackageVersion, $Key, $Source)
+            & dotnet nuget push $PackagePath --api-key $Key --source $Source --skip-duplicate
+            if ($LASTEXITCODE -ne 0) {
+                throw "dotnet nuget push exited with code $LASTEXITCODE"
+            }
+        }
+    }
+    if ($null -eq $FetchPackageVersions) {
+        $FetchPackageVersions = { param($PackageId, $BaseUri) Get-NuGetPackageVersions -PackageId $PackageId -FlatContainerBaseUri $BaseUri }
+    }
+    if ($null -eq $Sleep) {
+        $Sleep = { param($Seconds) Start-Sleep -Seconds $Seconds }
+    }
+
+    $pushFailures = [System.Collections.Generic.List[string]]::new()
+    foreach ($package in @($Manifest.packages)) {
+        $packageId = [string]$package.id
+        $packagePath = Join-Path $PackageDirectory "$packageId.$Version.nupkg"
+        Write-Host "::group::Push $packageId $Version"
+        try {
+            & $PushPackage $packagePath $packageId $Version $ApiKey $NuGetSource
+            Write-Host "PUSH SUCCEEDED: $packageId $Version"
+        }
+        catch {
+            $message = $_.Exception.Message
+            $pushFailures.Add("$packageId ${Version}: $message")
+            Write-Warning "PUSH FAILED: $packageId ${Version}: $message"
+        }
+        finally {
+            Write-Host '::endgroup::'
+        }
+    }
+
+    $inventory = @{}
+    for ($attempt = 1; $attempt -le $VerificationAttempts; $attempt++) {
+        $missing = [System.Collections.Generic.List[string]]::new()
+        foreach ($package in @($Manifest.packages)) {
+            $packageId = [string]$package.id
+            try {
+                $versions = @(& $FetchPackageVersions $packageId $FlatContainerBaseUri)
+                $isPublished = $versions -contains $Version
+                $inventory[$packageId] = if ($isPublished) { 'published' } else { 'missing' }
+                if (-not $isPublished) {
+                    $missing.Add($packageId)
+                }
+            }
+            catch {
+                $inventory[$packageId] = "query failed: $($_.Exception.Message)"
+                $missing.Add($packageId)
+            }
+        }
+
+        if ($missing.Count -eq 0) {
+            break
+        }
+
+        Write-Host "NuGet verification attempt $attempt/$VerificationAttempts missing: $($missing -join ', ')"
+        if ($attempt -lt $VerificationAttempts) {
+            & $Sleep $VerificationDelaySeconds
+        }
+    }
+
+    Write-Host "NuGet inventory for version ${Version}:"
+    foreach ($package in @($Manifest.packages)) {
+        $packageId = [string]$package.id
+        Write-Host " - $packageId`: $($inventory[$packageId])"
+    }
+
+    $inventoryFailures = @($Manifest.packages | Where-Object { $inventory[[string]$_.id] -ne 'published' } | ForEach-Object { [string]$_.id })
+    $failureMessages = [System.Collections.Generic.List[string]]::new()
+    foreach ($failure in $pushFailures) { $failureMessages.Add("Push failed: $failure") }
+    foreach ($packageId in $inventoryFailures) { $failureMessages.Add("Version $Version is not visible for $packageId") }
+
+    if ($failureMessages.Count -gt 0) {
+        throw "NuGet release did not complete:`n - $($failureMessages -join "`n - ")"
+    }
+
+    Write-Host "All expected NuGet packages expose version $Version."
+}
+
+Export-ModuleMember -Function @(
+    'Get-NuGetReleaseManifest',
+    'Get-NuGetPackageVersions',
+    'Get-DocumentedSdkVersionErrors',
+    'Assert-NuGetReleasePreflight',
+    'Publish-NuGetPackages'
+)

--- a/scripts/nuget-release.ps1
+++ b/scripts/nuget-release.ps1
@@ -1,0 +1,51 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('Preflight', 'Publish')]
+    [string] $Action,
+
+    [Parameter(Mandatory)]
+    [string] $Version,
+
+    [string] $PackageDirectory = './nupkg',
+    [string] $ManifestPath,
+    [string] $NuGetSource = 'https://api.nuget.org/v3/index.json',
+    [string] $FlatContainerBaseUri = 'https://api.nuget.org/v3-flatcontainer',
+    [ValidateRange(1, 100)][int] $VerificationAttempts = 12,
+    [ValidateRange(0, 300)][int] $VerificationDelaySeconds = 10
+)
+
+$ErrorActionPreference = 'Stop'
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+if ([string]::IsNullOrWhiteSpace($ManifestPath)) {
+    $ManifestPath = Join-Path $repositoryRoot '.github/nuget-packages.json'
+}
+
+Import-Module (Join-Path $PSScriptRoot 'NuGetRelease.psm1') -Force
+$manifest = Get-NuGetReleaseManifest -Path $ManifestPath
+
+Assert-NuGetReleasePreflight `
+    -Manifest $manifest `
+    -PackageDirectory $PackageDirectory `
+    -Version $Version `
+    -RepositoryRoot $repositoryRoot `
+    -FlatContainerBaseUri $FlatContainerBaseUri
+
+if ($Action -eq 'Preflight') {
+    return
+}
+
+$apiKey = $env:NUGET_API_KEY
+if ([string]::IsNullOrWhiteSpace($apiKey)) {
+    throw 'NUGET_API_KEY must be set for NuGet publication.'
+}
+
+Publish-NuGetPackages `
+    -Manifest $manifest `
+    -PackageDirectory $PackageDirectory `
+    -Version $Version `
+    -ApiKey $apiKey `
+    -NuGetSource $NuGetSource `
+    -FlatContainerBaseUri $FlatContainerBaseUri `
+    -VerificationAttempts $VerificationAttempts `
+    -VerificationDelaySeconds $VerificationDelaySeconds

--- a/scripts/test-nuget-release.ps1
+++ b/scripts/test-nuget-release.ps1
@@ -1,0 +1,222 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'NuGetRelease.psm1') -Force
+
+$script:passed = 0
+$script:failed = 0
+
+function Assert-True {
+    param([bool] $Condition, [string] $Message)
+    if (-not $Condition) { throw $Message }
+}
+
+function Assert-ThrowsContaining {
+    param([scriptblock] $Action, [string] $ExpectedText)
+    try {
+        & $Action
+    }
+    catch {
+        if ($_.Exception.Message -notlike "*$ExpectedText*") {
+            throw "Expected an error containing '$ExpectedText', got: $($_.Exception.Message)"
+        }
+        return
+    }
+    throw "Expected an error containing '$ExpectedText', but no error was thrown."
+}
+
+function Invoke-Test {
+    param([string] $Name, [scriptblock] $Test)
+    try {
+        & $Test
+        $script:passed++
+        Write-Host "PASS: $Name"
+    }
+    catch {
+        $script:failed++
+        Write-Error "FAIL: $Name`n$($_.Exception.Message)" -ErrorAction Continue
+    }
+}
+
+function New-TestFixture {
+    $root = Join-Path ([System.IO.Path]::GetTempPath()) "sharpts-nuget-release-$([guid]::NewGuid().ToString('N'))"
+    $packageDirectory = Join-Path $root 'nupkg'
+    $documentationDirectory = Join-Path $root 'docs'
+    New-Item -ItemType Directory -Path $packageDirectory, $documentationDirectory | Out-Null
+
+    $packageIds = @('SharpTS.LanguageServer', 'SharpTS.Hosting', 'SharpTS.Sdk', 'SharpTS')
+    $manifestData = [ordered]@{
+        schemaVersion = 1
+        documentedSdkVersion = '1.0.7'
+        documentationFiles = @('README.md', 'docs/sdk.md')
+        packages = @($packageIds | ForEach-Object { [ordered]@{ id = $_ } })
+    }
+    $manifestPath = Join-Path $root 'nuget-packages.json'
+    $manifestData | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $manifestPath
+    '<Project Sdk="SharpTS.Sdk/1.0.7">' | Set-Content -LiteralPath (Join-Path $root 'README.md')
+    '{ "msbuild-sdks": { "SharpTS.Sdk": "1.0.7" } }' | Set-Content -LiteralPath (Join-Path $root 'docs/sdk.md')
+    foreach ($packageId in $packageIds) {
+        'test package' | Set-Content -LiteralPath (Join-Path $packageDirectory "$packageId.2.0.0.nupkg")
+    }
+
+    return [pscustomobject]@{
+        Root = $root
+        PackageDirectory = $packageDirectory
+        Manifest = Get-NuGetReleaseManifest -Path $manifestPath
+        PackageIds = $packageIds
+    }
+}
+
+function New-PublishedVersionMap {
+    param([string[]] $PackageIds)
+    $result = @{}
+    foreach ($packageId in $PackageIds) {
+        $result[$packageId] = [System.Collections.ArrayList]@('1.0.7')
+    }
+    return $result
+}
+
+Invoke-Test 'preflight accepts complete registered package set and verified documentation' {
+    $fixture = New-TestFixture
+    try {
+        $published = New-PublishedVersionMap $fixture.PackageIds
+        $fetch = { param($PackageId, $BaseUri) @($published[$PackageId]) }.GetNewClosure()
+        Assert-NuGetReleasePreflight -Manifest $fixture.Manifest -PackageDirectory $fixture.PackageDirectory -Version '2.0.0' -RepositoryRoot $fixture.Root -FetchPackageVersions $fetch
+    }
+    finally {
+        Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+    }
+}
+
+Invoke-Test 'preflight rejects a missing package artifact' {
+    $fixture = New-TestFixture
+    try {
+        Remove-Item -LiteralPath (Join-Path $fixture.PackageDirectory 'SharpTS.Hosting.2.0.0.nupkg')
+        $published = New-PublishedVersionMap $fixture.PackageIds
+        $fetch = { param($PackageId, $BaseUri) @($published[$PackageId]) }.GetNewClosure()
+        Assert-ThrowsContaining {
+            Assert-NuGetReleasePreflight -Manifest $fixture.Manifest -PackageDirectory $fixture.PackageDirectory -Version '2.0.0' -RepositoryRoot $fixture.Root -FetchPackageVersions $fetch
+        } 'Expected package artifact not found'
+    }
+    finally {
+        Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+    }
+}
+
+Invoke-Test 'preflight gates an unregistered package ID before publication' {
+    $fixture = New-TestFixture
+    try {
+        $published = New-PublishedVersionMap $fixture.PackageIds
+        $published['SharpTS.LanguageServer'].Clear()
+        $fetch = { param($PackageId, $BaseUri) @($published[$PackageId]) }.GetNewClosure()
+        Assert-ThrowsContaining {
+            Assert-NuGetReleasePreflight -Manifest $fixture.Manifest -PackageDirectory $fixture.PackageDirectory -Version '2.0.0' -RepositoryRoot $fixture.Root -FetchPackageVersions $fetch
+        } 'onboard it and validate API-key scope'
+    }
+    finally {
+        Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+    }
+}
+
+Invoke-Test 'preflight rejects inconsistent documentation versions' {
+    $fixture = New-TestFixture
+    try {
+        '<Project Sdk="SharpTS.Sdk/9.9.9">' | Set-Content -LiteralPath (Join-Path $fixture.Root 'README.md')
+        $published = New-PublishedVersionMap $fixture.PackageIds
+        $fetch = { param($PackageId, $BaseUri) @($published[$PackageId]) }.GetNewClosure()
+        Assert-ThrowsContaining {
+            Assert-NuGetReleasePreflight -Manifest $fixture.Manifest -PackageDirectory $fixture.PackageDirectory -Version '2.0.0' -RepositoryRoot $fixture.Root -FetchPackageVersions $fetch
+        } 'expected 1.0.7'
+    }
+    finally {
+        Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+    }
+}
+
+Invoke-Test 'preflight rejects a documented SDK version absent from NuGet' {
+    $fixture = New-TestFixture
+    try {
+        $published = New-PublishedVersionMap $fixture.PackageIds
+        $published['SharpTS.Sdk'].Clear()
+        [void]$published['SharpTS.Sdk'].Add('1.0.6')
+        $fetch = { param($PackageId, $BaseUri) @($published[$PackageId]) }.GetNewClosure()
+        Assert-ThrowsContaining {
+            Assert-NuGetReleasePreflight -Manifest $fixture.Manifest -PackageDirectory $fixture.PackageDirectory -Version '2.0.0' -RepositoryRoot $fixture.Root -FetchPackageVersions $fetch
+        } 'Documented SharpTS.Sdk version 1.0.7 is not published on NuGet'
+    }
+    finally {
+        Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+    }
+}
+
+Invoke-Test 'publication retries until the complete inventory is visible' {
+    $fixture = New-TestFixture
+    try {
+        $published = New-PublishedVersionMap $fixture.PackageIds
+        $fetchCounts = @{}
+        $sleepCount = [pscustomobject]@{ Value = 0 }
+        $push = { param($PackagePath, $PackageId, $PackageVersion, $ApiKey, $Source) }.GetNewClosure()
+        $fetch = {
+            param($PackageId, $BaseUri)
+            $fetchCounts[$PackageId] = 1 + ($fetchCounts[$PackageId] ?? 0)
+            if ($fetchCounts[$PackageId] -ge 2 -and $published[$PackageId] -notcontains '2.0.0') {
+                [void]$published[$PackageId].Add('2.0.0')
+            }
+            @($published[$PackageId])
+        }.GetNewClosure()
+        $sleep = { param($Seconds) $sleepCount.Value++ }.GetNewClosure()
+
+        Publish-NuGetPackages -Manifest $fixture.Manifest -PackageDirectory $fixture.PackageDirectory -Version '2.0.0' -ApiKey 'test-key' -VerificationAttempts 2 -VerificationDelaySeconds 0 -PushPackage $push -FetchPackageVersions $fetch -Sleep $sleep
+
+        Assert-True ($sleepCount.Value -eq 1) 'Publication did not perform exactly one bounded retry.'
+    }
+    finally {
+        Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+    }
+}
+
+Invoke-Test 'partial publication reports every package and converges on rerun' {
+    $fixture = New-TestFixture
+    try {
+        $published = New-PublishedVersionMap $fixture.PackageIds
+        $pushAttempts = [System.Collections.Generic.List[string]]::new()
+        $firstRun = [pscustomobject]@{ Value = $true }
+        $push = {
+            param($PackagePath, $PackageId, $PackageVersion, $ApiKey, $Source)
+            $pushAttempts.Add($PackageId)
+            if ($firstRun.Value -and $pushAttempts.Count -eq 2) {
+                throw 'simulated permission failure'
+            }
+            if ($published[$PackageId] -notcontains $PackageVersion) {
+                [void]$published[$PackageId].Add($PackageVersion)
+            }
+        }.GetNewClosure()
+        $fetch = { param($PackageId, $BaseUri) @($published[$PackageId]) }.GetNewClosure()
+        $sleep = { param($Seconds) }.GetNewClosure()
+
+        Assert-ThrowsContaining {
+            Publish-NuGetPackages -Manifest $fixture.Manifest -PackageDirectory $fixture.PackageDirectory -Version '2.0.0' -ApiKey 'test-key' -VerificationAttempts 1 -VerificationDelaySeconds 0 -PushPackage $push -FetchPackageVersions $fetch -Sleep $sleep
+        } 'simulated permission failure'
+
+        Assert-True ($pushAttempts.Count -eq 4) 'The first run did not attempt every package after a failure.'
+        Assert-True ($published['SharpTS.LanguageServer'] -contains '2.0.0') 'The first package was not published.'
+        Assert-True ($published['SharpTS.Hosting'] -notcontains '2.0.0') 'The simulated failed package was unexpectedly published.'
+
+        $firstRun.Value = $false
+        Publish-NuGetPackages -Manifest $fixture.Manifest -PackageDirectory $fixture.PackageDirectory -Version '2.0.0' -ApiKey 'test-key' -VerificationAttempts 1 -VerificationDelaySeconds 0 -PushPackage $push -FetchPackageVersions $fetch -Sleep $sleep
+
+        Assert-True ($pushAttempts.Count -eq 8) 'The rerun did not attempt every package deterministically.'
+        foreach ($packageId in $fixture.PackageIds) {
+            Assert-True ($published[$packageId] -contains '2.0.0') "$packageId did not converge to version 2.0.0."
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $fixture.Root -Recurse -Force
+    }
+}
+
+Write-Host "NuGet release helper tests: $script:passed passed, $script:failed failed."
+if ($script:failed -gt 0) {
+    exit 1
+}


### PR DESCRIPTION
Closes #1353

## Summary
- replace wildcard NuGet publication with manifest-driven, explicit, rerunnable package pushes
- gate releases on registered package IDs and verified SharpTS.Sdk documentation pins
- verify every expected package/version through NuGet after publication with bounded retries and a complete inventory
- document new-package onboarding and v1.0.8 partial-release recovery
- correct workflow-dispatch package versioning to use MinVerVersionOverride

## Validation
- dotnet build --no-restore --configuration Release
- CI-equivalent dotnet test filter
- packaged SharpTS.Sdk smoke test
- 7 NuGet release helper tests, including simulated partial failure and convergent rerun
- workflow YAML parse and git diff --check
- exact-version four-package pack and live NuGet preflight

## Operational follow-up
No live NuGet packages are published by this PR. SharpTS.LanguageServer and SharpTS.Hosting must be onboarded and API-key scope validated by an authorized operator; the v1.0.8 SharpTS.Sdk repair remains documented in docs/releasing.md.