### PR TITLE
Unify function environment lowering across class and parameter paths

### DIFF
--- a/src/SharpTS/Compilation/CallHandlers/ClassExprStaticHandler.cs
+++ b/src/SharpTS/Compilation/CallHandlers/ClassExprStaticHandler.cs
@@ -26,8 +26,7 @@ public class ClassExprStaticHandler : ICallHandler
             return false;
 
         var il = emitter.IL;
-        var methodParams = exprStaticMethod.GetParameters();
-        emitter.EmitStaticCallArguments(call.Arguments, methodParams);
+        emitter.EmitStaticCallArguments(call.Arguments, exprStaticMethod);
         il.Emit(OpCodes.Call, exprStaticMethod);
         emitter.SetStackUnknown();
         return true;

--- a/src/SharpTS/Compilation/CallHandlers/ImportedClassStaticHandler.cs
+++ b/src/SharpTS/Compilation/CallHandlers/ImportedClassStaticHandler.cs
@@ -27,9 +27,9 @@ public class ImportedClassStaticHandler : ICallHandler
             return false;
 
         var il = emitter.IL;
-        var methodParams = callableMethod!.GetParameters();
-        emitter.EmitStaticCallArguments(call.Arguments, methodParams);
-        il.Emit(OpCodes.Call, callableMethod);
+        var targetMethod = callableMethod!;
+        emitter.EmitStaticCallArguments(call.Arguments, targetMethod);
+        il.Emit(OpCodes.Call, targetMethod);
         emitter.SetStackUnknown();
         return true;
     }

--- a/src/SharpTS/Compilation/CallHandlers/ThisStaticContextHandler.cs
+++ b/src/SharpTS/Compilation/CallHandlers/ThisStaticContextHandler.cs
@@ -32,9 +32,9 @@ public class ThisStaticContextHandler : ICallHandler
             return false;
 
         var il = emitter.IL;
-        var methodParams = thisStaticMethod!.GetParameters();
-        emitter.EmitStaticCallArguments(call.Arguments, methodParams);
-        il.Emit(OpCodes.Call, thisStaticMethod);
+        var targetMethod = thisStaticMethod!;
+        emitter.EmitStaticCallArguments(call.Arguments, targetMethod);
+        il.Emit(OpCodes.Call, targetMethod);
         emitter.SetStackUnknown();
         return true;
     }

--- a/src/SharpTS/Compilation/ClosureAnalyzer.cs
+++ b/src/SharpTS/Compilation/ClosureAnalyzer.cs
@@ -1067,7 +1067,11 @@ public class ClosureAnalyzer : AstVisitorBase
     /// </summary>
     private static bool ReferencesArgumentsIdentifierNonArrow(List<Stmt> stmts)
     {
-        var scanner = new ArgumentsRefScanner();
+        // A direct eval inside a nested arrow may reference the enclosing
+        // function's `arguments` binding without that identifier appearing in
+        // the parsed outer AST. Match the entry-environment scanner's conservative
+        // rule so capture discovery and prologue materialization cannot drift.
+        var scanner = new ArgumentsRefScanner(treatEvalReferenceAsUse: true);
         foreach (var s in stmts)
         {
             scanner.Visit(s);

--- a/src/SharpTS/Compilation/CompilationContext.Functions.cs
+++ b/src/SharpTS/Compilation/CompilationContext.Functions.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Reflection.Emit;
 
 namespace SharpTS.Compilation;
@@ -42,6 +43,14 @@ public partial class CompilationContext
     /// publish automatically — this set only matters for in-module direct dispatch.
     /// </summary>
     public HashSet<string>? FunctionsCapturingArguments { get; set; }
+
+    /// <summary>
+    /// Statically emitted class methods whose body observes the ECMAScript
+    /// <c>arguments</c> binding (including through a direct eval or nested arrow).
+    /// Static call lowering uses this to publish the untrimmed caller argument list
+    /// before invoking the fixed-arity CLR method.
+    /// </summary>
+    public HashSet<MethodBase>? MethodsCapturingArguments { get; set; }
 
     /// <summary>
     /// Applies the namespace prefix to an already module-qualified function name. A namespace

--- a/src/SharpTS/Compilation/Emitters/IEmitterContext.cs
+++ b/src/SharpTS/Compilation/Emitters/IEmitterContext.cs
@@ -109,7 +109,7 @@ public interface IEmitterContext
     /// evaluated and discarded, omitted slots are padded with JavaScript undefined when
     /// representable, and a trailing rest slot is packed into its runtime list marker.
     /// </summary>
-    void EmitStaticCallArguments(List<Expr> arguments, ParameterInfo[] targetParams);
+    void EmitStaticCallArguments(List<Expr> arguments, MethodBase targetMethod);
 
     /// <summary>
     /// True when evaluating any of <paramref name="args"/> can suspend the enclosing state machine

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -152,7 +152,15 @@ public abstract partial class ExpressionEmitterBase
                 shadowedByLocalBinding = false;
             }
 
-            if (!shadowedByLocalBinding && !isImportedFunction && Ctx.Functions.TryGetValue(resolvedFuncName, out var methodBuilder))
+            // Fixed-signature direct CLR calls cannot represent spread expansion
+            // without first materializing the runtime argument list. Route spread
+            // calls through the ordinary function-value path, which already expands
+            // iterables and publishes the exact caller arguments for `arguments`.
+            bool hasSpreadArguments = c.Arguments.Any(arg => arg is Expr.Spread);
+            bool hasKnownRestParameter =
+                Ctx.FunctionRestParams?.ContainsKey(resolvedFuncName) == true;
+            bool directCallSupportsArguments = !hasSpreadArguments || hasKnownRestParameter;
+            if (directCallSupportsArguments && !shadowedByLocalBinding && !isImportedFunction && Ctx.Functions.TryGetValue(resolvedFuncName, out var methodBuilder))
             {
                 MethodInfo targetMethod = methodBuilder;
 
@@ -796,11 +804,82 @@ public abstract partial class ExpressionEmitterBase
     /// source order; only declared slots are reloaded for a fixed signature, while a trailing
     /// <c>List&lt;object&gt;</c> rest marker receives the packed remainder.
     /// </summary>
-    public void EmitStaticCallArguments(List<Expr> arguments, ParameterInfo[] targetParams)
+    public void EmitStaticCallArguments(List<Expr> arguments, MethodBase targetMethod)
     {
+        var targetParams = targetMethod.GetParameters();
         int paramCount = targetParams.Length;
         bool hasRestParam = paramCount > 0 &&
             targetParams[paramCount - 1].ParameterType == typeof(List<object>);
+
+        bool publishesArguments =
+            Ctx.MethodsCapturingArguments?.Contains(targetMethod) == true &&
+            Ctx.Runtime?.CurrentArgumentsField != null;
+
+        // A fixed CLR signature has nowhere to carry JavaScript surplus values.
+        // When this callee observes `arguments`, evaluate into boxed temps, publish
+        // the exact caller list, then reload only the declared CLR slots. This is
+        // the class-method counterpart of direct function call lowering.
+        if (publishesArguments && !hasRestParam && !arguments.Any(arg => arg is Expr.Spread))
+        {
+            var argumentTemps = new LocalBuilder[arguments.Count];
+            for (int i = 0; i < arguments.Count; i++)
+            {
+                argumentTemps[i] = i < paramCount
+                    ? SpillConvertedArg(arguments[i], targetParams[i].ParameterType)
+                    : SpillBoxed(arguments[i]);
+            }
+
+            IL.Emit(OpCodes.Ldc_I4, arguments.Count);
+            IL.Emit(OpCodes.Newarr, Types.Object);
+            for (int i = 0; i < argumentTemps.Length; i++)
+            {
+                IL.Emit(OpCodes.Dup);
+                IL.Emit(OpCodes.Ldc_I4, i);
+                IL.Emit(OpCodes.Ldloc, argumentTemps[i]);
+                IL.Emit(OpCodes.Stelem_Ref);
+            }
+            IL.Emit(OpCodes.Stsfld, Ctx.Runtime!.CurrentArgumentsField);
+
+            for (int i = 0; i < Math.Min(arguments.Count, paramCount); i++)
+            {
+                IL.Emit(OpCodes.Ldloc, argumentTemps[i]);
+                EmitCoerceBoxedToType(targetParams[i].ParameterType);
+            }
+            for (int i = arguments.Count; i < paramCount; i++)
+                EmitOmittedArgument(targetParams[i].ParameterType);
+            return;
+        }
+
+        // Untyped/defaulted JavaScript parameters use object slots. For that
+        // common shape, a spread-expanded runtime array can feed both the
+        // `arguments` snapshot and the declared call slots without re-evaluation.
+        if (publishesArguments && !hasRestParam && targetParams.All(p => p.ParameterType == Types.Object))
+        {
+            var rawArguments = IL.DeclareLocal(Types.ObjectArray);
+            EmitArgsArrayWithSpread(arguments);
+            IL.Emit(OpCodes.Stloc, rawArguments);
+            IL.Emit(OpCodes.Ldloc, rawArguments);
+            IL.Emit(OpCodes.Stsfld, Ctx.Runtime!.CurrentArgumentsField);
+
+            for (int i = 0; i < paramCount; i++)
+            {
+                var missing = IL.DefineLabel();
+                var loaded = IL.DefineLabel();
+                IL.Emit(OpCodes.Ldloc, rawArguments);
+                IL.Emit(OpCodes.Ldlen);
+                IL.Emit(OpCodes.Conv_I4);
+                IL.Emit(OpCodes.Ldc_I4, i);
+                IL.Emit(OpCodes.Ble, missing);
+                IL.Emit(OpCodes.Ldloc, rawArguments);
+                IL.Emit(OpCodes.Ldc_I4, i);
+                IL.Emit(OpCodes.Ldelem_Ref);
+                IL.Emit(OpCodes.Br, loaded);
+                IL.MarkLabel(missing);
+                EmitOmittedArgument(targetParams[i].ParameterType);
+                IL.MarkLabel(loaded);
+            }
+            return;
+        }
 
         if (hasRestParam)
         {
@@ -1189,9 +1268,9 @@ public abstract partial class ExpressionEmitterBase
         string resolvedClassName = Ctx.ResolveClassName(classVar.Name.Lexeme);
         if (Ctx.ClassRegistry!.TryGetCallableStaticMethod(resolvedClassName, methodGet.Name.Lexeme, classBuilder, out var callableMethod))
         {
-            var staticMethodParams = callableMethod!.GetParameters();
-            EmitStaticCallArguments(c.Arguments, staticMethodParams);
-            IL.Emit(OpCodes.Call, callableMethod);
+            var targetMethod = callableMethod!;
+            EmitStaticCallArguments(c.Arguments, targetMethod);
+            IL.Emit(OpCodes.Call, targetMethod);
             SetStackUnknown();
             return true;
         }

--- a/src/SharpTS/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.ArrowFunctions.cs
@@ -1500,8 +1500,24 @@ public partial class ILCompiler
 
         var emitter = new ILEmitter(ctx);
 
-        // Emit default parameter checks
-        emitter.EmitDefaultParameters(arrow.Parameters, displayClass != null, arrow.HasOwnThis);
+        int environmentArgOffset = (displayClass != null ? 1 : 0) + (arrow.HasOwnThis ? 1 : 0);
+        _closures.ArrowParameterTypes.TryGetValue(arrow, out var environmentResolvedParamTypes);
+        var environmentParamTypes = new Type[arrow.Parameters.Count];
+        for (int i = 0; i < environmentParamTypes.Length; i++)
+            environmentParamTypes[i] = environmentResolvedParamTypes != null && i < environmentResolvedParamTypes.Length
+                ? environmentResolvedParamTypes[i] ?? _types.Object
+                : _types.Object;
+
+        EmitFunctionEnvironmentPrologue(
+            il,
+            ctx,
+            emitter,
+            arrow.Parameters,
+            arrow.BlockBody,
+            environmentParamTypes,
+            environmentArgOffset,
+            createsArgumentsBinding: arrow.HasOwnThis,
+            publishedArgsLeadingSkip: arrow.HasOwnThis ? 1 : 0);
 
         // Initialize captured parameters into the arrow scope display class.
         // This mirrors the equivalent code in ILCompiler.Functions.cs.
@@ -1534,32 +1550,6 @@ public partial class ILCompiler
                     il.Emit(OpCodes.Stfld, arrowDCField);
                 }
             }
-        }
-
-        // Bind the `arguments` array-like for function expressions (HasOwnThis=true).
-        // True arrows don't get their own `arguments` per ECMA-262. Matches the same
-        // prologue used by Stmt.Function compilation and fixes lodash-style wrappers
-        // like `function() { return fn.apply(this, arguments); }` emitted as arrows.
-        if (arrow.HasOwnThis && arrow.BlockBody != null && ReferencesArgumentsIdentifier(arrow.BlockBody))
-        {
-            // argBase aligns with the parameter-index layout above:
-            //   displayClass != null + HasOwnThis → params start at 2 (display, __this, params...)
-            //   displayClass != null + !HasOwnThis → params start at 1 (display, params...)
-            //   displayClass == null + HasOwnThis → params start at 1 (__this, params...)
-            //   displayClass == null + !HasOwnThis → params start at 0
-            int paramArgBase = (displayClass != null ? 1 : 0) + (arrow.HasOwnThis ? 1 : 0);
-            _closures.ArrowParameterTypes.TryGetValue(arrow, out var resolvedArrowParamTypes);
-            var argParamTypes = new Type[arrow.Parameters.Count];
-            for (int i = 0; i < argParamTypes.Length; i++)
-                argParamTypes[i] = resolvedArrowParamTypes != null && i < resolvedArrowParamTypes.Length
-                    ? resolvedArrowParamTypes[i] ?? _types.Object
-                    : _types.Object;
-            // HasOwnThis methods declare __this as an explicit parameter, which means
-            // $TSFunction.InvokeWithThis prepends the receiver into the args array
-            // before calling Invoke. Strip that leading slot when reading from the
-            // thread-static so `arguments` reflects only what the user passed.
-            int leadingSkip = arrow.HasOwnThis ? 1 : 0;
-            EmitArgumentsLocalPrologueCore(il, ctx, arrow.Parameters, argParamTypes, paramArgBase, leadingSkip);
         }
 
         if (arrow.ExpressionBody != null)

--- a/src/SharpTS/Compilation/ILCompiler.Classes.ClassExpressions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.ClassExpressions.cs
@@ -318,6 +318,7 @@ public partial class ILCompiler
         );
         _classExprs.Constructors[classExpr] = ctorBuilder;
         _classes.Constructors[className] = ctorBuilder;
+        RegisterArgumentsCapturingMethod(ctorBuilder, constructor?.Body);
         DefineClassPrototypeConstructor(typeBuilder);
 
         // Define static methods (computed symbol-keyed methods are handled by
@@ -339,6 +340,7 @@ public partial class ILCompiler
                 paramTypes
             );
             _classExprs.StaticMethods[classExpr][method.Name.Lexeme] = methodBuilder;
+            RegisterArgumentsCapturingMethod(methodBuilder, method.Body);
         }
 
         // Define instance methods (computed symbol-keyed methods are handled by
@@ -365,6 +367,7 @@ public partial class ILCompiler
                 paramTypes
             );
             _classExprs.InstanceMethods[classExpr][method.Name.Lexeme] = methodBuilder;
+            RegisterArgumentsCapturingMethod(methodBuilder, method.Body);
         }
 
         // Computed symbol-keyed methods (`*[Symbol.iterator]()` etc.) get synthetic uniquely-named
@@ -665,7 +668,15 @@ public partial class ILCompiler
                 ctx.DefineParameter(constructor.Parameters[i].Name.Lexeme, i + 1, paramType);
             }
 
-            emitter.EmitDefaultParameters(constructor.Parameters, true);
+            var constructorParamTypes = ctorBuilder.GetParameters().Select(p => p.ParameterType).ToArray();
+            EmitFunctionEnvironmentPrologue(
+                il,
+                ctx,
+                emitter,
+                constructor.Parameters,
+                constructor.Body,
+                constructorParamTypes,
+                argumentOffset: 1);
 
             if (constructor.Body != null)
             {
@@ -837,7 +848,15 @@ public partial class ILCompiler
         }
 
         var emitter = new ILEmitter(ctx);
-        emitter.EmitDefaultParameters(method.Parameters, true);
+        var environmentParamTypes = methodBuilder.GetParameters().Select(p => p.ParameterType).ToArray();
+        EmitFunctionEnvironmentPrologue(
+            il,
+            ctx,
+            emitter,
+            method.Parameters,
+            method.Body,
+            environmentParamTypes,
+            argumentOffset: 1);
 
         if (method.Body != null)
         {
@@ -914,7 +933,15 @@ public partial class ILCompiler
         }
 
         var emitter = new ILEmitter(ctx);
-        emitter.EmitDefaultParameters(method.Parameters, false);
+        var environmentParamTypes = methodBuilder.GetParameters().Select(p => p.ParameterType).ToArray();
+        EmitFunctionEnvironmentPrologue(
+            il,
+            ctx,
+            emitter,
+            method.Parameters,
+            method.Body,
+            environmentParamTypes,
+            argumentOffset: 0);
 
         if (method.Body != null)
         {

--- a/src/SharpTS/Compilation/ILCompiler.Classes.Constructors.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.Constructors.cs
@@ -342,7 +342,14 @@ public partial class ILCompiler
             // Value-type-defaulted params are widened to object by ParameterTypeResolver so the
             // prologue can observe the `$Undefined` sentinel. (#705)
             var ctorDefaultParamTypes = ctorBuilder.GetParameters().Select(p => p.ParameterType).ToArray();
-            emitter.EmitDefaultParameters(constructor.Parameters, isInstanceMethod: true, paramTypes: ctorDefaultParamTypes);
+            EmitFunctionEnvironmentPrologue(
+                il,
+                ctx,
+                emitter,
+                constructor.Parameters,
+                constructor.Body,
+                ctorDefaultParamTypes,
+                argumentOffset: 1);
 
             if (constructor.Body != null)
             {

--- a/src/SharpTS/Compilation/ILCompiler.Classes.Methods.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.Methods.cs
@@ -122,6 +122,7 @@ public partial class ILCompiler
             );
 
             _classes.Constructors[qualifiedClassName] = ctorBuilder;
+            RegisterArgumentsCapturingMethod(ctorBuilder, constructor?.Body);
         }
 
         // Initialize static methods dictionary for this class
@@ -162,6 +163,7 @@ public partial class ILCompiler
             );
 
             _classes.StaticMethods[qualifiedClassName][method.Name.Lexeme] = methodBuilder;
+            RegisterArgumentsCapturingMethod(methodBuilder, method.Body);
         }
 
         // Define instance methods (skip overload signatures with no body, and computed
@@ -202,6 +204,7 @@ public partial class ILCompiler
                 _classes.InstanceMethods[qualifiedClassName] = classMethods;
             }
             classMethods[method.Name.Lexeme] = methodBuilder;
+            RegisterArgumentsCapturingMethod(methodBuilder, method.Body);
 
             // Store the method builder for body emission later
             // Use typeBuilder.Name to match the lookup in EmitMethod
@@ -1049,26 +1052,15 @@ public partial class ILCompiler
             ctx.ILBuilder.BeginExceptionBlock();
         }
 
-        // If the body references `arguments`, emit the prologue that binds it
-        // to a List<object> of the declared parameters. Class methods have `this`
-        // at arg slot 0 and actual params at 1..N, which the prologue respects
-        // through the paramTypes array we already built (see EmitMethod above).
-        if (method.Body != null && ReferencesArgumentsIdentifier(method.Body))
-        {
-            // Use the method's param types (without the implicit `this`).
-            var resolvedParamTypes = methodBuilder.GetParameters()
-                .Select(p => p.ParameterType)
-                .ToArray();
-            EmitArgumentsLocalPrologueForInstanceMethod(il, ctx, method.Parameters, resolvedParamTypes);
-        }
-
-        // Apply parameter defaults (JS: a default fires when the argument is missing or
-        // explicit `undefined`). Class declarations historically skipped this entirely, so
-        // defaults never fired in compiled mode (omit → null/0, explicit undefined → NaN/cast
-        // error). ParameterTypeResolver widens defaulted params to an object slot
-        // so the prologue can observe the `$Undefined` sentinel and fire the default. (#705)
         var defaultParamTypes = methodBuilder.GetParameters().Select(p => p.ParameterType).ToArray();
-        emitter.EmitDefaultParameters(method.Parameters, isInstanceMethod: true, paramTypes: defaultParamTypes);
+        EmitFunctionEnvironmentPrologue(
+            il,
+            ctx,
+            emitter,
+            method.Parameters,
+            method.Body,
+            defaultParamTypes,
+            argumentOffset: 1);
 
         // Abstract methods have no body to emit
         if (method.Body != null)

--- a/src/SharpTS/Compilation/ILCompiler.Classes.Static.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.Static.cs
@@ -356,7 +356,14 @@ public partial class ILCompiler
         // Value-type-defaulted params are widened to an object slot by ParameterTypeResolver so
         // the prologue can observe the `$Undefined` sentinel. (#705)
         var staticDefaultParamTypes = methodBuilder.GetParameters().Select(p => p.ParameterType).ToArray();
-        emitter.EmitDefaultParameters(method.Parameters, isInstanceMethod: false, paramTypes: staticDefaultParamTypes);
+        EmitFunctionEnvironmentPrologue(
+            il,
+            ctx,
+            emitter,
+            method.Parameters,
+            method.Body,
+            staticDefaultParamTypes,
+            argumentOffset: 0);
 
         // Variables for @lock decorator support
         LocalBuilder? prevReentrancyLocal = null;

--- a/src/SharpTS/Compilation/ILCompiler.ContextFactories.cs
+++ b/src/SharpTS/Compilation/ILCompiler.ContextFactories.cs
@@ -52,6 +52,7 @@ public partial class ILCompiler
             // Function metadata
             FunctionRestParams = _functions.RestParams,
             FunctionsCapturingArguments = _functions.CapturingArguments,
+            MethodsCapturingArguments = _functions.MethodsCapturingArguments,
             FunctionGenericParams = _functions.GenericParams,
             IsGenericFunction = _functions.IsGeneric,
             // Enum tables

--- a/src/SharpTS/Compilation/ILCompiler.Functions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Functions.cs
@@ -415,11 +415,14 @@ public partial class ILCompiler
         var resolvedParamTypes = methodBuilder.GetParameters()
             .Select(p => p.ParameterType)
             .ToArray();
-        emitter.EmitDefaultParameters(
+        EmitFunctionEnvironmentPrologue(
+            il,
+            ctx,
+            emitter,
             funcStmt.Parameters,
-            isInstanceMethod: false,
-            hasOwnThis: false,
-            paramTypes: resolvedParamTypes);
+            funcStmt.Body,
+            resolvedParamTypes,
+            argumentOffset: 0);
 
         // Initialize captured parameters into the function display class. Runs
         // AFTER EmitDefaultParameters (which writes defaults back via Starg) so
@@ -444,16 +447,6 @@ public partial class ILCompiler
             }
         }
 
-        // If the body references `arguments`, materialize the JS-spec array-like
-        // from the declared parameters and bind it as a local. Arrow functions
-        // do NOT bind `arguments` (they inherit lexically), so we only do this
-        // for real function declarations — which is exactly what this method
-        // emits (see Phase6_EmitArrowAndStateMachineBodies for arrows).
-        if (ReferencesArgumentsIdentifier(funcStmt.Body))
-        {
-            EmitArgumentsLocalPrologue(il, ctx, funcStmt.Parameters, resolvedParamTypes);
-        }
-
         // Hoist inner function declarations (create TSFunction locals before other statements)
         EmitInnerFunctionHoisting(il, ctx, funcStmt.Body);
 
@@ -476,9 +469,9 @@ public partial class ILCompiler
 
     /// <summary>
     /// Returns true if the given statements reference the identifier
-    /// <c>arguments</c> anywhere in the AST (including nested arrow/function
-    /// bodies — since a nested arrow's <c>arguments</c> refers to the
-    /// enclosing non-arrow function's bindings per JS spec).
+    /// <c>arguments</c> anywhere in the AST, descending through nested arrows
+    /// (which inherit it) and stopping at nested non-arrow functions (which bind
+    /// their own).
     /// </summary>
     /// <remarks>
     /// Used by <see cref="EmitFunctionBody"/> to skip the prologue when the
@@ -489,7 +482,11 @@ public partial class ILCompiler
     /// </remarks>
     private static bool ReferencesArgumentsIdentifier(List<Stmt> stmts)
     {
-        var scanner = new ArgumentsReferenceScanner();
+        // Direct eval can mention `arguments` in a string literal that is absent
+        // from the surrounding AST. Stay conservative and create the binding for
+        // any function containing eval; static direct-eval lowering then resolves
+        // it through the same lexical local as an ordinary source reference.
+        var scanner = new Parsing.Visitors.ArgumentsRefScanner(treatEvalReferenceAsUse: true);
         foreach (var s in stmts)
         {
             scanner.Visit(s);
@@ -498,18 +495,42 @@ public partial class ILCompiler
         return false;
     }
 
-    private sealed class ArgumentsReferenceScanner : Parsing.Visitors.AstVisitorBase
+    private void RegisterArgumentsCapturingMethod(MethodBase method, List<Stmt>? body)
     {
-        public bool Found { get; private set; }
+        if (body != null && ReferencesArgumentsIdentifier(body))
+            _functions.MethodsCapturingArguments.Add(method);
+    }
 
-        protected override void VisitVariable(Expr.Variable expr)
+    /// <summary>
+    /// Emits the shared entry environment for an ECMAScript function-like body.
+    /// The caller argument snapshot is created before parameter defaults mutate CLR
+    /// argument slots; defaults then run in declaration order with later/current
+    /// parameters in TDZ. All synchronous function, class, constructor, and named
+    /// function-expression paths route through this method.
+    /// </summary>
+    private void EmitFunctionEnvironmentPrologue(
+        ILGenerator il,
+        CompilationContext ctx,
+        ILEmitter emitter,
+        List<Stmt.Parameter> parameters,
+        List<Stmt>? body,
+        Type[] paramTypes,
+        int argumentOffset,
+        bool createsArgumentsBinding = true,
+        int publishedArgsLeadingSkip = 0)
+    {
+        if (createsArgumentsBinding && body != null && ReferencesArgumentsIdentifier(body))
         {
-            if (expr.Name.Lexeme == "arguments")
-            {
-                Found = true;
-                ShouldContinue = false;
-            }
+            EmitArgumentsLocalPrologueCore(
+                il,
+                ctx,
+                parameters,
+                paramTypes,
+                argumentOffset,
+                publishedArgsLeadingSkip);
         }
+
+        emitter.EmitDefaultParameters(parameters, argumentOffset, paramTypes);
     }
 
     /// <summary>
@@ -520,34 +541,6 @@ public partial class ILCompiler
     /// of the <c>SharpTSFunction.Call</c> <c>environment.Define("arguments", ...)</c>
     /// binding in interpreter mode.
     /// </summary>
-    /// <remarks>
-    /// The list is populated from declared parameters only — callers that pass
-    /// more arguments than the function declares see those extras silently
-    /// dropped today (a pre-existing calling-convention limitation). Rest
-    /// parameters are inserted as a single List element per the current signature.
-    /// Real codebases already prefer <c>...rest</c> over <c>arguments</c>; this
-    /// covers the legacy-syntax compat case without adding a second call path.
-    /// </remarks>
-    private void EmitArgumentsLocalPrologue(
-        ILGenerator il,
-        CompilationContext ctx,
-        List<Stmt.Parameter> parameters,
-        Type[] paramTypes)
-        => EmitArgumentsLocalPrologueCore(il, ctx, parameters, paramTypes, argBase: 0, publishedArgsLeadingSkip: 0);
-
-    /// <summary>
-    /// Instance-method variant: `this` occupies arg slot 0, so parameters start
-    /// at slot 1. Same semantics as <see cref="EmitArgumentsLocalPrologue"/>.
-    /// </summary>
-    private void EmitArgumentsLocalPrologueForInstanceMethod(
-        ILGenerator il,
-        CompilationContext ctx,
-        List<Stmt.Parameter> parameters,
-        Type[] paramTypes)
-        // Instance methods receive `this` as the MethodInfo.Invoke target, not in the args
-        // array, so _currentArguments published by $TSFunction.Invoke has no leading skip.
-        => EmitArgumentsLocalPrologueCore(il, ctx, parameters, paramTypes, argBase: 1, publishedArgsLeadingSkip: 0);
-
     /// <param name="publishedArgsLeadingSkip">
     /// Number of leading elements of <c>$TSFunction._currentArguments</c> to skip when
     /// that thread-static is non-null. Non-zero for the function-expression / arrow-

--- a/src/SharpTS/Compilation/ILCompiler.InnerFunctions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.InnerFunctions.cs
@@ -567,8 +567,19 @@ public partial class ILCompiler
 
             var emitter = new ILEmitter(ctx);
 
-            // Emit default parameter checks
-            emitter.EmitDefaultParameters(func.Parameters, hasDisplayClass, hasOwnThis: false);
+            var environmentParamTypes = new Type[func.Parameters.Count];
+            for (int i = 0; i < environmentParamTypes.Length; i++)
+                environmentParamTypes[i] = innerParamTypes != null && i < innerParamTypes.Length
+                    ? innerParamTypes[i] ?? _types.Object
+                    : _types.Object;
+            EmitFunctionEnvironmentPrologue(
+                il,
+                ctx,
+                emitter,
+                func.Parameters,
+                func.Body,
+                environmentParamTypes,
+                argumentOffset: hasDisplayClass ? 1 : 0);
 
             // Initialize captured parameters into the scope display class (mirrors
             // EmitArrowBody). Runs AFTER EmitDefaultParameters (which writes defaults
@@ -597,26 +608,6 @@ public partial class ILCompiler
             // Emit function body
             if (func.Body != null)
             {
-                // Nested function declarations own their own `arguments`
-                // binding just like top-level declarations and function
-                // expressions. The main function emitter already installs
-                // this prologue; inner-function bodies need the equivalent
-                // instance/static arg-base variant.
-                if (ReferencesArgumentsIdentifier(func.Body))
-                {
-                    var resolvedArgumentTypes = new Type[func.Parameters.Count];
-                    for (int i = 0; i < resolvedArgumentTypes.Length; i++)
-                        resolvedArgumentTypes[i] = innerParamTypes != null && i < innerParamTypes.Length
-                            ? innerParamTypes[i] ?? _types.Object
-                            : _types.Object;
-                    if (hasDisplayClass)
-                        EmitArgumentsLocalPrologueForInstanceMethod(
-                            il, ctx, func.Parameters, resolvedArgumentTypes);
-                    else
-                        EmitArgumentsLocalPrologue(
-                            il, ctx, func.Parameters, resolvedArgumentTypes);
-                }
-
                 // Hoist inner functions within this inner function's body
                 EmitInnerFunctionHoisting(il, ctx, func.Body);
 

--- a/src/SharpTS/Compilation/ILCompiler.State.cs
+++ b/src/SharpTS/Compilation/ILCompiler.State.cs
@@ -118,6 +118,13 @@ public partial class ILCompiler
         /// during phase 7 (body emission).
         /// </summary>
         public HashSet<string> CapturingArguments { get; } = [];
+
+        /// <summary>
+        /// Class/constructor MethodBuilders whose JavaScript body needs an
+        /// <c>arguments</c> environment binding. Kept by builder identity so all
+        /// statically resolved class-call paths share the same decision.
+        /// </summary>
+        public HashSet<MethodBase> MethodsCapturingArguments { get; } = [];
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/ILEmitter.Calls.Constructors.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.Constructors.cs
@@ -146,6 +146,18 @@ public partial class ILEmitter
             targetCtor = EmitterTypeHelpers.ResolveConstructor(targetType, ctorBuilder);
         }
 
+        if (!isGeneric)
+        {
+            // Constructors are ordinary ECMAScript function environments too:
+            // reuse the class-call argument lowering so surplus values remain
+            // observable through `arguments`, spreads expand once, and omitted
+            // parameter slots receive the undefined sentinel before defaults run.
+            EmitStaticCallArguments(n.Arguments, ctorBuilder);
+            IL.Emit(OpCodes.Newobj, targetCtor);
+            SetStackUnknown();
+            return;
+        }
+
         var ctorParams = ctorBuilder.GetParameters();
         int expectedParamCount = ctorParams.Length;
 
@@ -281,33 +293,20 @@ public partial class ILEmitter
             Type[] typeArgs = n.TypeArgs.Select(ResolveTypeArg).ToArray();
             Type closedType = EmitGenerics.MakeGenericType(classExprTypeBuilder, typeArgs);
             ConstructorInfo closedCtor = EmitterTypeHelpers.ResolveConstructor(closedType, classExprCtor);
-            EmitClassExprCtorCall(closedCtor, closedCtor.GetParameters(), n);
+            EmitClassExprCtorCall(closedCtor, n);
             return;
         }
 
-        EmitClassExprCtorCall(classExprCtor, classExprCtor.GetParameters(), n);
+        EmitClassExprCtorCall(classExprCtor, n);
     }
 
     /// <summary>
     /// Emits argument conversion, default-fill, and the <c>Newobj</c> for a (possibly closed)
     /// class-expression constructor.
     /// </summary>
-    private void EmitClassExprCtorCall(ConstructorInfo ctor, ParameterInfo[] ctorParams, Expr.New n)
+    private void EmitClassExprCtorCall(ConstructorInfo ctor, Expr.New n)
     {
-        int expectedParamCount = ctorParams.Length;
-
-        for (int i = 0; i < n.Arguments.Count; i++)
-        {
-            EmitExpression(n.Arguments[i]);
-            if (i < ctorParams.Length)
-                EmitConversionForParameter(n.Arguments[i], ctorParams[i].ParameterType);
-            else
-                EmitBoxIfNeeded(n.Arguments[i]);
-        }
-
-        for (int i = n.Arguments.Count; i < expectedParamCount; i++)
-            EmitOmittedArgument(ctorParams[i].ParameterType);
-
+        EmitStaticCallArguments(n.Arguments, ctor);
         IL.Emit(OpCodes.Newobj, ctor);
         SetStackUnknown();
     }

--- a/src/SharpTS/Compilation/ILEmitter.Helpers.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Helpers.cs
@@ -45,8 +45,22 @@ public partial class ILEmitter
         bool isInstanceMethod,
         bool hasOwnThis = false,
         Type[]? paramTypes = null)
+        => EmitDefaultParameters(
+            parameters,
+            argumentOffset: (isInstanceMethod ? 1 : 0) + (hasOwnThis ? 1 : 0),
+            paramTypes: paramTypes);
+
+    /// <summary>
+    /// Offset-based parameter-default lowering used by the shared function
+    /// environment prologue. Unlike the compatibility overload, this directly
+    /// describes the emitted signature and therefore also covers display-class
+    /// and explicit-<c>this</c> prefixes without reconstructing their shape.
+    /// </summary>
+    internal void EmitDefaultParameters(
+        List<Stmt.Parameter> parameters,
+        int argumentOffset,
+        Type[]? paramTypes = null)
     {
-        int argOffset = (isInstanceMethod ? 1 : 0) + (hasOwnThis ? 1 : 0);
         var builder = _ctx.ILBuilder;
 
         for (int i = 0; i < parameters.Count; i++)
@@ -62,7 +76,7 @@ public partial class ILEmitter
             // This only defends a genuinely value-typed slot that reached here without that widening.
             if (paramTypes != null && paramTypes[i].IsValueType) continue;
 
-            int argIndex = i + argOffset;
+            int argIndex = i + argumentOffset;
 
             // JS spec: defaults fire only when the argument is `undefined` — missing
             // arguments are padded with the $Undefined singleton by call emitters.

--- a/src/SharpTS/Compilation/RuntimeEmitter.CallArgsPool.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.CallArgsPool.cs
@@ -22,8 +22,8 @@ public partial class RuntimeEmitter
     /// through <c>$TSFunction.Invoke → MethodInvoker.Invoke(target, Span&lt;object?&gt;)</c>.
     /// MethodInvoker reads values into the call frame and does not retain
     /// a reference. Compiled function bodies build their own
-    /// <c>arguments</c> object from declared parameters (see
-    /// <c>EmitArgumentsLocalPrologue</c>) rather than aliasing the args
+    /// <c>arguments</c> object through the shared function-environment prologue
+    /// rather than aliasing the args
     /// array, so cross-call reuse is sound.
     ///
     /// Arity ceiling: 1..4 covers the vast majority of real call sites.

--- a/tests/SharpTS.Tests/SharedTests/ArgumentsMagicVariableTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/ArgumentsMagicVariableTests.cs
@@ -10,10 +10,9 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 /// <remarks>
 /// Fix: interpreter binds <c>arguments</c> in <c>SharpTSFunction.Call</c> /
-/// <c>CallV2</c>; compiled mode emits a prologue (<c>ILCompiler.Functions
-/// .EmitArgumentsLocalPrologue</c>) that builds a <c>List&lt;object&gt;</c>
-/// from the declared parameters — spreading rest-param collections so each
-/// caller value occupies its own index. Arrow functions deliberately do NOT
+/// <c>CallV2</c>; compiled mode's shared function-environment prologue builds a
+/// <c>List&lt;object&gt;</c> from the exact caller arguments — spreading rest-param
+/// collections so each caller value occupies its own index. Arrow functions deliberately do NOT
 /// bind <c>arguments</c>: per JS spec they inherit from the enclosing
 /// non-arrow function via normal lexical scope.
 /// </remarks>
@@ -150,6 +149,81 @@ public class ArgumentsMagicVariableTests
     }
 
     [Theory, ModeData]
+    public void Arguments_ClassDeclarationAndExpressionMethodsSeeExactCallerList(ExecutionMode mode)
+    {
+        var source = @"
+            class Declared {
+                static collect() {
+                    console.log(arguments.length);
+                    console.log(arguments[0]);
+                    console.log(arguments[1]);
+                }
+            }
+            const Expressed = class {
+                collect() {
+                    console.log(arguments.length);
+                    console.log(arguments[0]);
+                    console.log(arguments[1]);
+                }
+                static collect() {
+                    console.log(arguments.length);
+                    console.log(arguments[0]);
+                    console.log(arguments[1]);
+                }
+            };
+            const tail = ['TC39'];
+            Declared.collect(42, ...tail);
+            new Expressed().collect(42, ...tail);
+            Expressed.collect(42, ...tail);
+        ";
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("2\n42\nTC39\n2\n42\nTC39\n2\n42\nTC39\n", output);
+    }
+
+    [Theory, ModeData]
+    public void Arguments_SnapshotsExplicitUndefinedBeforeParameterDefaults(ExecutionMode mode)
+    {
+        var source = @"
+            class C {
+                static inspect(value = 7) {
+                    console.log(arguments.length);
+                    console.log(typeof arguments[0]);
+                    console.log(value);
+                }
+            }
+            C.inspect(undefined);
+        ";
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1\nundefined\n7\n", output);
+    }
+
+    [Theory, ModeData]
+    public void Arguments_ConstructorsShareTheFunctionEnvironmentPrologue(ExecutionMode mode)
+    {
+        var source = @"
+            class Declared {
+                constructor(...unused: any[]) {
+                    console.log(arguments.length);
+                    console.log(arguments[0]);
+                }
+            }
+            const Expressed = class {
+                constructor(...unused: any[]) {
+                    console.log(arguments.length);
+                    console.log(arguments[0]);
+                }
+            };
+            new Declared(...[42]);
+            new Expressed(...['TC39']);
+        ";
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1\n42\n1\nTC39\n", output);
+    }
+
+    [Theory, ModeData]
     public void Arguments_IndexedTraversal(ExecutionMode mode)
     {
         // Indexed access through `arguments.length` is the legacy-JS variadic
@@ -195,14 +269,13 @@ public class ArgumentsMagicVariableTests
         Assert.Equal("7\n", output);
     }
 
-    [Theory, InterpretedOnlyData]
+    [Theory, ModeData]
     public void Arguments_VisibleToDirectEval(ExecutionMode mode)
     {
         // Direct eval runs against the live scope chain, so `arguments` must be
         // materialized even though the identifier never appears in the AST —
-        // the lazy-materialization scan treats any `eval` reference in the body
-        // as a conservative use. Interpreter-only: compiled eval is a separate
-        // soft-dependency feature.
+        // the shared environment scan treats any direct `eval` reference in the
+        // body as a conservative use in both execution modes.
         var source = @"
             function probe(a: number, b: number): any {
                 return eval('arguments.length');

--- a/tests/conformance/SharpTS.Test262/Issue1279ParityTests.cs
+++ b/tests/conformance/SharpTS.Test262/Issue1279ParityTests.cs
@@ -6466,6 +6466,31 @@ public void Promise_combinators_share_iterator_and_resolution_semantics(string r
     public void Static_class_method_function_objects_match_in_compiled_mode(string relativePath)
         => AssertPass(relativePath, Test262ExecutionMode.Compiled);
 
+    public static TheoryData<string> FunctionEnvironmentLoweringCompilerCases => new()
+    {
+        "language/arguments-object/func-decl-args-trailing-comma-spread-operator.js",
+        "language/arguments-object/cls-decl-meth-static-args-trailing-comma-multiple.js",
+        "language/arguments-object/cls-decl-meth-static-args-trailing-comma-null.js",
+        "language/arguments-object/cls-decl-meth-static-args-trailing-comma-single-args.js",
+        "language/arguments-object/cls-decl-meth-static-args-trailing-comma-spread-operator.js",
+        "language/arguments-object/cls-decl-meth-static-args-trailing-comma-undefined.js",
+        "language/arguments-object/cls-expr-meth-args-trailing-comma-multiple.js",
+        "language/arguments-object/cls-expr-meth-args-trailing-comma-null.js",
+        "language/arguments-object/cls-expr-meth-args-trailing-comma-single-args.js",
+        "language/arguments-object/cls-expr-meth-args-trailing-comma-spread-operator.js",
+        "language/arguments-object/cls-expr-meth-args-trailing-comma-undefined.js",
+        "language/arguments-object/cls-expr-meth-static-args-trailing-comma-multiple.js",
+        "language/arguments-object/cls-expr-meth-static-args-trailing-comma-null.js",
+        "language/arguments-object/cls-expr-meth-static-args-trailing-comma-single-args.js",
+        "language/arguments-object/cls-expr-meth-static-args-trailing-comma-spread-operator.js",
+        "language/arguments-object/cls-expr-meth-static-args-trailing-comma-undefined.js",
+    };
+
+    [Theory]
+    [MemberData(nameof(FunctionEnvironmentLoweringCompilerCases))]
+    public void Function_environment_lowering_is_shared_by_function_and_class_paths(string relativePath)
+        => AssertPass(relativePath, Test262ExecutionMode.Compiled);
+
     private void AssertPass(
         string relativePath,
         Test262ExecutionMode mode,


### PR DESCRIPTION
## Summary

- introduce one shared function-environment prologue for ordinary functions, inner functions, named expressions, class methods, static methods, and constructors
- snapshot exact caller arguments before parameter defaults and reuse the same lowering for class and constructor calls, including spread and surplus arguments
- align direct eval and closure analysis with conservative arguments binding discovery
- add shared-mode regression tests and 16 focused Test262 compiler cases

## Conformance impact

The focused function/eval/arguments/block-scope sweep drops compiled-mode deficits from 123 to 107, closing 16 stable Track B cases.

## Validation

- dotnet build SharpTS.sln -c Release --no-restore --nologo: passed, zero warnings/errors, IL verification passed
- focused shared compiler tests: 26/26 passed
- focused Test262 compiler cases: 16/16 passed
- GUI conformance suite: 83/83 passed
- core suite after the fix: 16,748 passed, 3 skipped; one unrelated socket timing failure passed its isolated two-mode rerun

Part of #1374.