### PR TITLE
Centralize reference and abrupt completion lowering

### DIFF
--- a/src/SharpTS/Compilation/CompoundOperatorHelper.cs
+++ b/src/SharpTS/Compilation/CompoundOperatorHelper.cs
@@ -26,6 +26,7 @@ public static class CompoundOperatorHelper
         TokenType.CARET_EQUAL => OpCodes.Xor,
         TokenType.LESS_LESS_EQUAL => OpCodes.Shl,
         TokenType.GREATER_GREATER_EQUAL => OpCodes.Shr,
+        TokenType.GREATER_GREATER_GREATER_EQUAL => OpCodes.Shr_Un,
         _ => null
     };
 
@@ -37,5 +38,6 @@ public static class CompoundOperatorHelper
         TokenType.PIPE_EQUAL or
         TokenType.CARET_EQUAL or
         TokenType.LESS_LESS_EQUAL or
-        TokenType.GREATER_GREATER_EQUAL;
+        TokenType.GREATER_GREATER_EQUAL or
+        TokenType.GREATER_GREATER_GREATER_EQUAL;
 }

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -1507,11 +1507,13 @@ public class EmittedRuntime
     public MethodBuilder InvokeIteratorNextWithSent { get; set; } = null!;      // Calls next(sent) forwarding resume value (#503)
     public MethodBuilder GetIteratorDone { get; set; } = null!;                 // Extracts done from result
     public MethodBuilder GetIteratorValue { get; set; } = null!;                // Extracts value from result
+    public MethodBuilder IteratorClose { get; set; } = null!;                   // IteratorClose(iterator, preserveThrowCompletion)
     public MethodBuilder IterateToList { get; set; } = null!;                   // Converts any iterable to List<object>
     public MethodBuilder IteratorWrapperMoveNextWithSent { get; set; } = null!; // $IteratorWrapper.MoveNextWithSent(sent) (#503)
 
     // Generator interface ($IGenerator extends IEnumerator<object> with Return/Throw)
     public TypeBuilder GeneratorInterfaceType { get; set; } = null!;
+    public MethodBuilder GeneratorIteratorMethod { get; set; } = null!;
     public MethodBuilder GeneratorReturnMethod { get; set; } = null!;
     public MethodBuilder GeneratorThrowMethod { get; set; } = null!;
     public MethodBuilder GeneratorNextMethod { get; set; } = null!;

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.Operators.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.Operators.cs
@@ -110,23 +110,24 @@ public abstract partial class ExpressionEmitterBase
 
     /// <summary>
     /// variable += value / variable -= value / etc.
-    /// Emits value first (safe for await/yield), loads current, applies op, stores result.
+    /// Resolves and reads the reference before evaluating the RHS, then applies
+    /// the shared boxed coercion/operator path and stores the result.
     /// </summary>
     protected virtual void EmitCompoundAssign(Expr.CompoundAssign ca)
     {
         string name = ca.Name.Lexeme;
 
-        // Emit value first — it may contain await/yield which clears the stack
-        EmitExpression(ca.Value);
-        EnsureBoxed();
-        var valueTemp = IL.DeclareLocal(typeof(object));
-        IL.Emit(OpCodes.Stloc, valueTemp);
-
-        // Load current variable value
+        // GetValue(left) precedes evaluation of the RHS. Spill it so a suspension
+        // in the RHS still occurs with an empty evaluation stack.
         EmitVariable(new Expr.Variable(ca.Name));
         EnsureBoxed();
+        var currentTemp = _helpers.SpillStoreObject();
 
-        // Load the RHS value back
+        EmitExpression(ca.Value);
+        EnsureBoxed();
+        var valueTemp = _helpers.SpillStoreObject();
+
+        IL.Emit(OpCodes.Ldloc, currentTemp);
         IL.Emit(OpCodes.Ldloc, valueTemp);
 
         // Apply compound operation (stack: [current, value] → [result])

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.cs
@@ -566,12 +566,17 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         // globalThis[key] = value → GlobalThisSetProperty(key, value)
         if (si.Object is Expr.Variable gtSetIdx && gtSetIdx.Name.Lexeme == "globalThis")
         {
+            // Evaluate the reference (base + key expression) before the RHS;
+            // ToPropertyKey remains deferred to the runtime store.
+            EmitExpression(si.Index);
+            EnsureBoxed();
+            var indexTemp = IL.DeclareLocal(typeof(object));
+            IL.Emit(OpCodes.Stloc, indexTemp);
             EmitExpression(si.Value);
             EnsureBoxed();
             var valueTemp = IL.DeclareLocal(typeof(object));
             IL.Emit(OpCodes.Stloc, valueTemp);
-            EmitExpression(si.Index);
-            EnsureBoxed();
+            IL.Emit(OpCodes.Ldloc, indexTemp);
             IL.Emit(OpCodes.Callvirt, Types.GetMethodNoParams(Types.Object, "ToString"));
             IL.Emit(OpCodes.Ldloc, valueTemp);
             IL.Emit(OpCodes.Call, Ctx.Runtime!.GlobalThisSetProperty);
@@ -580,10 +585,11 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             return;
         }
 
-        // Spill everything so an await inside any operand suspends with an empty stack.
-        var valueLocal = SpillBoxed(si.Value);
+        // Evaluate the reference before the RHS and spill each component so a
+        // suspension still occurs with an empty stack.
         var objLocal = SpillBoxed(si.Object);
         var idxLocal = SpillBoxed(si.Index);
+        var valueLocal = SpillBoxed(si.Value);
 
         // RequireObjectCoercible (PutValue): a null/undefined base throws a guest
         // TypeError ("Cannot set properties of undefined|null (setting '<key>')")

--- a/src/SharpTS/Compilation/GeneratorStateMachineBuilder.cs
+++ b/src/SharpTS/Compilation/GeneratorStateMachineBuilder.cs
@@ -82,6 +82,7 @@ public class GeneratorStateMachineBuilder : StateMachineBuilderBase, IIteratorSt
 
     // $IGenerator methods for return/throw support
     public MethodBuilder NextMethod { get; private set; } = null!;
+    public MethodBuilder IteratorMethod { get; private set; } = null!;
     public MethodBuilder ReturnMethod { get; private set; } = null!;
     public MethodBuilder ThrowMethod { get; private set; } = null!;
 
@@ -437,6 +438,16 @@ public class GeneratorStateMachineBuilder : StateMachineBuilderBase, IIteratorSt
     {
         // We need to emit an iterator result object with { value, done } properties
         // For simplicity, we'll use a Dictionary<string, object> as the result
+
+        IteratorMethod = _stateMachineType.DefineMethod(
+            "iterator",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
+            _types.Object,
+            Type.EmptyTypes);
+        var iteratorIL = IteratorMethod.GetILGenerator();
+        iteratorIL.Emit(OpCodes.Ldarg_0);
+        iteratorIL.Emit(OpCodes.Ret);
+        _stateMachineType.DefineMethodOverride(IteratorMethod, _runtime!.GeneratorIteratorMethod);
 
         // Re-entrancy flag: set only while the body runs inside MoveNext (see next()).
         // The single observable window for a guest call is re-entrancy — the generator

--- a/src/SharpTS/Compilation/ILEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Operators.cs
@@ -599,7 +599,8 @@ public partial class ILEmitter
             }
             else
             {
-                _resolver.TryStoreVariable(ca.Name.Lexeme);
+                if (!_resolver.TryStoreVariable(ca.Name.Lexeme))
+                    IL.Emit(OpCodes.Pop);
             }
             SetStackType(StackType.String);
             return;
@@ -636,81 +637,34 @@ public partial class ILEmitter
             }
             else
             {
-                _resolver.TryStoreVariable(ca.Name.Lexeme);
+                if (!_resolver.TryStoreVariable(ca.Name.Lexeme))
+                    IL.Emit(OpCodes.Pop);
             }
             SetStackUnknown();
             return;
         }
 
-        // Numeric compound assignment
-        bool isBitwise = CompoundOperatorHelper.IsBitwise(ca.Operator.Type);
-        bool isUnsignedShift = ca.Operator.Type == TokenType.GREATER_GREATER_GREATER_EQUAL;
+        // All remaining compound operators share the same boxed reference/coercion
+        // pipeline as async and generator bodies. This prevents stack-type hints
+        // from changing ToNumeric semantics or producing invalid IL for boxed
+        // primitive objects.
+        EmitVariable(new Expr.Variable(ca.Name));
+        EmitBoxIfNeeded(new Expr.Variable(ca.Name));
+        EmitExpression(ca.Value);
+        EmitBoxIfNeeded(ca.Value);
+        _helpers.EmitCompoundOperation(ca.Operator.Type, _ctx.Runtime!.Add);
 
-        if (isUnsignedShift)
-        {
-            // `x >>>= y`: route through JsToInt32 for spec-correct ToInt32, then Shr_Un with
-            // zero-extend to uint64 before Conv_R8 so bit 31 doesn't flip the result negative.
-            EmitVariable(new Expr.Variable(ca.Name));
-            EnsureBoxed();
-            IL.Emit(OpCodes.Call, _ctx.Runtime!.JsToInt32);
-
-            EmitExpression(ca.Value);
-            EnsureBoxed();
-            IL.Emit(OpCodes.Call, _ctx.Runtime!.JsToInt32);
-
-            IL.Emit(OpCodes.Ldc_I4, 0x1F);
-            IL.Emit(OpCodes.And);
-            IL.Emit(OpCodes.Shr_Un);
-            IL.Emit(OpCodes.Conv_U8);
-            IL.Emit(OpCodes.Conv_R8);
-        }
-        else
-        {
-            // Get current value as double — EnsureDouble() is stack-type-aware
-            // and avoids emitting Convert.ToDouble when the value is already unboxed.
-            EmitVariable(new Expr.Variable(ca.Name));
-            EnsureDouble();
-
-            if (isBitwise)
-            {
-                // Convert to int for bitwise operations
-                IL.Emit(OpCodes.Conv_I4);
-                EmitExpressionAsDouble(ca.Value);
-                IL.Emit(OpCodes.Conv_I4);
-            }
-            else
-            {
-                // Emit right side as double
-                EmitExpressionAsDouble(ca.Value);
-            }
-
-            // Emit the operator using centralized helper
-            var opcode = CompoundOperatorHelper.GetOpcode(ca.Operator.Type);
-            if (opcode.HasValue)
-            {
-                IL.Emit(opcode.Value);
-            }
-
-            if (isBitwise)
-            {
-                // Convert back to double
-                IL.Emit(OpCodes.Conv_R8);
-            }
-        }
-
-        // Store result — keep unboxed for typed double locals
         if (isTypedDouble && local != null)
         {
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.ConvertToNumber);
             IL.Emit(OpCodes.Dup);
             IL.Emit(OpCodes.Stloc, local);
             SetStackType(StackType.Double);
         }
         else
         {
-            IL.Emit(OpCodes.Box, _ctx.Types.Double);
             IL.Emit(OpCodes.Dup);
 
-            // Store result
             if (local != null)
             {
                 IL.Emit(OpCodes.Stloc, local);
@@ -721,7 +675,8 @@ public partial class ILEmitter
             }
             else
             {
-                _resolver.TryStoreVariable(ca.Name.Lexeme);
+                if (!_resolver.TryStoreVariable(ca.Name.Lexeme))
+                    IL.Emit(OpCodes.Pop);
             }
             SetStackUnknown();
         }
@@ -2171,18 +2126,18 @@ public partial class ILEmitter
             }
         }
 
-        // Compound assignment on object property: obj.prop += x
-        // 1. Get current value
-        // 2. Apply operation
-        // 3. Store back
-
-        // Get current value: GetProperty(obj, name)
+        // Resolve the property reference exactly once, then read it before
+        // evaluating the RHS. Reuse the spilled receiver for PutValue.
         EmitExpression(cs.Object);
         EmitBoxIfNeeded(cs.Object);
+        var objectLocal = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, objectLocal);
+
         // Compound assignment reads first → a nullish base throws the *read*-worded
         // guest TypeError before GetProperty (which would otherwise no-op) (#733).
         if (!IsNullPlaceholderGlobal(cs.Object))
-            EmitThrowIfUndefinedReceiverOnStack(cs.Name.Lexeme);
+            EmitThrowIfReceiverUndefined(objectLocal, cs.Name.Lexeme, isWrite: false);
+        IL.Emit(OpCodes.Ldloc, objectLocal);
         IL.Emit(OpCodes.Ldstr, cs.Name.Lexeme);
         IL.Emit(OpCodes.Call, _ctx.Runtime!.GetProperty);
 
@@ -2193,8 +2148,7 @@ public partial class ILEmitter
         var resultLocal = IL.DeclareLocal(_ctx.Types.Object);
         IL.Emit(OpCodes.Stloc, resultLocal);
 
-        EmitExpression(cs.Object);
-        EmitBoxIfNeeded(cs.Object);
+        IL.Emit(OpCodes.Ldloc, objectLocal);
         IL.Emit(OpCodes.Ldstr, cs.Name.Lexeme);
         IL.Emit(OpCodes.Ldloc, resultLocal);
         IL.Emit(OpCodes.Call, _ctx.Runtime!.SetProperty);
@@ -2311,34 +2265,17 @@ public partial class ILEmitter
 
     private void EmitCompoundOperation(TokenType opType, Expr value)
     {
-        // Stack has current value (object). Apply the operation.
-        if (opType == TokenType.PLUS_EQUAL && IsStringExpression(value))
-        {
-            // String concatenation - we know right side is a string at compile time.
-            // StringifyCoerce both operands: JS-compatible conversion (null →
-            // "null", undefined → "undefined") that throws TypeError for Symbol
-            // operands (§7.1.17) — String.Concat(object, object) did neither.
-            IL.Emit(OpCodes.Call, _ctx.Runtime!.StringifyCoerce);
-            EmitExpression(value);
-            EmitBoxIfNeeded(value);
-            IL.Emit(OpCodes.Call, _ctx.Runtime!.StringifyCoerce);
-            IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.String, "Concat", _ctx.Types.String, _ctx.Types.String));
-            return;
-        }
-
-        // For += with unknown types, use runtime Add which handles both string concat and numeric add
-        if (opType == TokenType.PLUS_EQUAL)
-        {
-            EmitExpression(value);
-            EmitBoxIfNeeded(value);
-            IL.Emit(OpCodes.Call, _ctx.Runtime!.Add);
-            return;
-        }
-
-        // Convert current value to number, apply the op in double/int space, re-box.
-        EmitUnboxToDouble();
-        EmitCompoundArithmeticDoubleOnStack(opType, value);
-        IL.Emit(OpCodes.Box, _ctx.Types.Double);
+        // Stack has the boxed current value. Spill both operands so variable,
+        // property, and index references all share the same coercion pipeline.
+        var left = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, left);
+        EmitExpression(value);
+        EmitBoxIfNeeded(value);
+        var right = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, right);
+        IL.Emit(OpCodes.Ldloc, left);
+        IL.Emit(OpCodes.Ldloc, right);
+        _helpers.EmitCompoundOperation(opType, _ctx.Runtime!.Add);
     }
 
     // The compound operators handled by the numeric path (arithmetic + bitwise) — i.e. those that

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -1098,12 +1098,15 @@ public partial class ILEmitter
         // globalThis[key] = value → GlobalThisSetProperty(key, value)
         if (si.Object is Expr.Variable gtSetIdx && gtSetIdx.Name.Lexeme == "globalThis")
         {
-            EmitExpression(si.Value);
+            EmitExpression(si.Index);
             EnsureBoxed();
+            var indexTemp = IL.DeclareLocal(_ctx.Types.Object);
+            IL.Emit(OpCodes.Stloc, indexTemp);
+            EmitExpression(si.Value);
+            EmitBoxIfNeeded(si.Value);
             var valueTemp = IL.DeclareLocal(_ctx.Types.Object);
             IL.Emit(OpCodes.Stloc, valueTemp);
-            EmitExpression(si.Index);
-            EmitBoxIfNeeded(si.Index);
+            IL.Emit(OpCodes.Ldloc, indexTemp);
             IL.Emit(OpCodes.Callvirt, _ctx.Types.GetMethod(_ctx.Types.Object, "ToString")!);
             IL.Emit(OpCodes.Ldloc, valueTemp);
             IL.Emit(OpCodes.Call, _ctx.Runtime!.GlobalThisSetProperty);
@@ -1334,12 +1337,7 @@ public partial class ILEmitter
             return;
         }
 
-        // No static type info: full generic dispatch
-        EmitExpression(si.Value);
-        EmitBoxIfNeeded(si.Value);
-        var valueLocalGeneric = IL.DeclareLocal(_ctx.Types.Object);
-        IL.Emit(OpCodes.Stloc, valueLocalGeneric);
-
+        // No static type info: evaluate the complete reference before the RHS.
         EmitExpression(si.Object);
         EmitBoxIfNeeded(si.Object);
         var objLocalGeneric = IL.DeclareLocal(_ctx.Types.Object);
@@ -1349,6 +1347,11 @@ public partial class ILEmitter
         EmitBoxIfNeeded(si.Index);
         var idxLocalGeneric = IL.DeclareLocal(_ctx.Types.Object);
         IL.Emit(OpCodes.Stloc, idxLocalGeneric);
+
+        EmitExpression(si.Value);
+        EmitBoxIfNeeded(si.Value);
+        var valueLocalGeneric = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, valueLocalGeneric);
 
         // RequireObjectCoercible (PutValue): a null/undefined base throws a guest
         // TypeError ("Cannot set properties of undefined|null (setting 'X')") (#733).

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -995,46 +995,83 @@ public partial class ILEmitter
             var iteratorObjLocal = IL.DeclareLocal(_ctx.Types.Object);
             IL.Emit(OpCodes.Stloc, iteratorObjLocal);
 
-            // Create $IteratorWrapper: new $IteratorWrapper(iteratorObj, typeof($Runtime))
-            IL.Emit(OpCodes.Ldloc, iteratorObjLocal);
-            IL.Emit(OpCodes.Ldtoken, _ctx.Runtime!.RuntimeType);
-            IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.Type, "GetTypeFromHandle"));
-            IL.Emit(OpCodes.Newobj, _ctx.Runtime!.IteratorWrapperCtor);
-
-            // Cast to IEnumerator and store
-            var enumLocal = IL.DeclareLocal(_ctx.Types.IEnumerator);
-            IL.Emit(OpCodes.Castclass, _ctx.Types.IEnumerator);
-            IL.Emit(OpCodes.Stloc, enumLocal);
-
             // Loop variable
             var loopVar = _ctx.Locals.DeclareLocal(f.Variable.Lexeme, _ctx.Types.Object);
-
-            // Get MoveNext and Current methods
-            var moveNext = _ctx.Types.GetMethod(_ctx.Types.IEnumerator, "MoveNext");
-            var current = _ctx.Types.GetProperty(_ctx.Types.IEnumerator, "Current")!.GetGetMethod()!;
+            var resultLocal = IL.DeclareLocal(_ctx.Types.Object);
+            var closeNeeded = IL.DeclareLocal(_ctx.Types.Boolean);
+            var throwing = IL.DeclareLocal(_ctx.Types.Boolean);
 
             builder.MarkLabel(iterStartLabel);
             EmitCancellationCheck();
 
-            // Call MoveNext
-            IL.Emit(OpCodes.Ldloc, enumLocal);
-            IL.Emit(OpCodes.Callvirt, moveNext);
-            builder.Emit_Brfalse(iterEndLabel);
+            // IteratorStep: errors from next()/done occur before the iteration's
+            // close region and therefore do not trigger IteratorClose.
+            IL.Emit(OpCodes.Ldloc, iteratorObjLocal);
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.InvokeIteratorNext);
+            IL.Emit(OpCodes.Stloc, resultLocal);
+            IL.Emit(OpCodes.Ldloc, resultLocal);
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.GetIteratorDone);
+            var bodyLabel = builder.DefineLabel("forof_iter_body");
+            builder.Emit_Brtrue(iterEndLabel);
+            builder.Emit_Br(bodyLabel);
 
-            // Get Current
-            IL.Emit(OpCodes.Ldloc, enumLocal);
-            IL.Emit(OpCodes.Callvirt, current);
+            // done=true is natural exhaustion and must not close the iterator.
+            builder.MarkLabel(iterEndLabel);
+            builder.Emit_Br(afterLoopLabel);
+
+            builder.MarkLabel(bodyLabel);
+            IL.Emit(OpCodes.Ldc_I4_1);
+            IL.Emit(OpCodes.Stloc, closeNeeded);
+            IL.Emit(OpCodes.Ldc_I4_0);
+            IL.Emit(OpCodes.Stloc, throwing);
+
+            var escapingTargets = new HashSet<Label>();
+            foreach (var loop in _ctx.LoopLabels)
+            {
+                escapingTargets.Add(loop.BreakLabel);
+                escapingTargets.Add(loop.ContinueLabel);
+            }
+
+            _ctx.ExceptionBlockDepth++;
+            builder.BeginExceptionBlock();
+
+            // IteratorValue and binding/body evaluation are protected: every
+            // abrupt exit closes, while a continue of this loop clears the flag.
+            IL.Emit(OpCodes.Ldloc, resultLocal);
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.GetIteratorValue);
             IL.Emit(OpCodes.Stloc, loopVar);
 
-            // Emit body
+            _iteratorLoopCompletionScopes.Push(new IteratorLoopCompletionScope(
+                closeNeeded, iterContinueLabel, escapingTargets));
             EmitStatement(f.Body);
+            _iteratorLoopCompletionScopes.Pop();
+
+            IL.Emit(OpCodes.Ldc_I4_0);
+            IL.Emit(OpCodes.Stloc, closeNeeded);
+            builder.Emit_Leave(iterContinueLabel);
+
+            builder.BeginCatchBlock(_ctx.Types.Exception);
+            IL.Emit(OpCodes.Pop);
+            IL.Emit(OpCodes.Ldc_I4_1);
+            IL.Emit(OpCodes.Stloc, throwing);
+            IL.Emit(OpCodes.Rethrow);
+
+            builder.BeginFinallyBlock();
+            var skipClose = builder.DefineLabel("forof_skip_close");
+            IL.Emit(OpCodes.Ldloc, closeNeeded);
+            builder.Emit_Brfalse(skipClose);
+            IL.Emit(OpCodes.Ldloc, iteratorObjLocal);
+            IL.Emit(OpCodes.Ldloc, throwing);
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.IteratorClose);
+            builder.MarkLabel(skipClose);
+            builder.EndExceptionBlock();
+            _ctx.ExceptionBlockDepth--;
 
             builder.MarkLabel(iterContinueLabel);
             builder.Emit_Br(iterStartLabel);
 
-            builder.MarkLabel(iterEndLabel);
+            // iterEndLabel was emitted above so natural completion can bypass close.
             _ctx.ExitLoop();
-            builder.Emit_Br(afterLoopLabel); // Skip the index-based path
         }
 
         // ===== Index-based fallback (for arrays, strings, etc.) =====
@@ -1242,36 +1279,74 @@ public partial class ILEmitter
     {
         var builder = _ctx.ILBuilder;
 
-        // Use IEnumerable.GetEnumerator()/MoveNext()/Current pattern for generators
-        var getEnumerator = _ctx.Types.GetMethod(_ctx.Types.IEnumerable, "GetEnumerator");
-        var moveNext = _ctx.Types.GetMethod(_ctx.Types.IEnumerator, "MoveNext");
-        var current = _ctx.Types.GetProperty(_ctx.Types.IEnumerator, "Current")!.GetGetMethod()!;
-
-        // Stack has the iterable (generator)
-        IL.Emit(OpCodes.Castclass, _ctx.Types.IEnumerable);
-        IL.Emit(OpCodes.Callvirt, getEnumerator);
-
-        var enumLocal = IL.DeclareLocal(_ctx.Types.IEnumerator);
-        IL.Emit(OpCodes.Stloc, enumLocal);
+        // Stack has the emitted generator. Drive it through the same iterator-result
+        // protocol as a custom iterator so abrupt loop completion is routed through
+        // the shared IteratorClose primitive (including generator.return()).
+        var generatorLocal = IL.DeclareLocal(_ctx.Runtime!.GeneratorInterfaceType);
+        IL.Emit(OpCodes.Castclass, _ctx.Runtime.GeneratorInterfaceType);
+        IL.Emit(OpCodes.Stloc, generatorLocal);
 
         // Loop variable
         var loopVar = _ctx.Locals.DeclareLocal(f.Variable.Lexeme, _ctx.Types.Object);
+        var resultLocal = IL.DeclareLocal(_ctx.Types.Object);
+        var closeNeeded = IL.DeclareLocal(_ctx.Types.Boolean);
+        var throwing = IL.DeclareLocal(_ctx.Types.Boolean);
 
         builder.MarkLabel(startLabel);
         EmitCancellationCheck();
 
-        // Call MoveNext
-        IL.Emit(OpCodes.Ldloc, enumLocal);
-        IL.Emit(OpCodes.Callvirt, moveNext);
-        builder.Emit_Brfalse(endLabel);
+        IL.Emit(OpCodes.Ldloc, generatorLocal);
+        IL.Emit(OpCodes.Ldsfld, _ctx.Runtime.UndefinedInstance);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime.GeneratorNextMethod);
+        IL.Emit(OpCodes.Stloc, resultLocal);
+        IL.Emit(OpCodes.Ldloc, resultLocal);
+        IL.Emit(OpCodes.Call, _ctx.Runtime.GetIteratorDone);
+        builder.Emit_Brtrue(endLabel);
 
-        // Get Current
-        IL.Emit(OpCodes.Ldloc, enumLocal);
-        IL.Emit(OpCodes.Callvirt, current);
+        IL.Emit(OpCodes.Ldc_I4_1);
+        IL.Emit(OpCodes.Stloc, closeNeeded);
+        IL.Emit(OpCodes.Ldc_I4_0);
+        IL.Emit(OpCodes.Stloc, throwing);
+
+        var escapingTargets = new HashSet<Label>();
+        foreach (var loop in _ctx.LoopLabels)
+        {
+            escapingTargets.Add(loop.BreakLabel);
+            escapingTargets.Add(loop.ContinueLabel);
+        }
+
+        _ctx.ExceptionBlockDepth++;
+        builder.BeginExceptionBlock();
+
+        IL.Emit(OpCodes.Ldloc, resultLocal);
+        IL.Emit(OpCodes.Call, _ctx.Runtime.GetIteratorValue);
         IL.Emit(OpCodes.Stloc, loopVar);
 
-        // Emit body
+        _iteratorLoopCompletionScopes.Push(new IteratorLoopCompletionScope(
+            closeNeeded, continueLabel, escapingTargets));
         EmitStatement(f.Body);
+        _iteratorLoopCompletionScopes.Pop();
+
+        IL.Emit(OpCodes.Ldc_I4_0);
+        IL.Emit(OpCodes.Stloc, closeNeeded);
+        builder.Emit_Leave(continueLabel);
+
+        builder.BeginCatchBlock(_ctx.Types.Exception);
+        IL.Emit(OpCodes.Pop);
+        IL.Emit(OpCodes.Ldc_I4_1);
+        IL.Emit(OpCodes.Stloc, throwing);
+        IL.Emit(OpCodes.Rethrow);
+
+        builder.BeginFinallyBlock();
+        var skipClose = builder.DefineLabel("forof_gen_skip_close");
+        IL.Emit(OpCodes.Ldloc, closeNeeded);
+        builder.Emit_Brfalse(skipClose);
+        IL.Emit(OpCodes.Ldloc, generatorLocal);
+        IL.Emit(OpCodes.Ldloc, throwing);
+        IL.Emit(OpCodes.Call, _ctx.Runtime.IteratorClose);
+        builder.MarkLabel(skipClose);
+        builder.EndExceptionBlock();
+        _ctx.ExceptionBlockDepth--;
 
         builder.MarkLabel(continueLabel);
         builder.Emit_Br(startLabel);
@@ -1731,7 +1806,19 @@ public partial class ILEmitter
             }
         }
 
-        if (_ctx.ExceptionBlockDepth > 0)
+        if (_abruptCompletionScopes.TryPeek(out var completion))
+        {
+            if (_ctx.ReturnValueLocal == null)
+            {
+                _ctx.ReturnValueLocal = IL.DeclareLocal(returnType);
+                _ctx.ReturnLabel = _ctx.ILBuilder.DefineLabel("deferred_return");
+            }
+            IL.Emit(OpCodes.Stloc, _ctx.ReturnValueLocal);
+            IL.Emit(OpCodes.Ldc_I4_1); // return completion
+            IL.Emit(OpCodes.Stloc, completion.Kind);
+            _ctx.ILBuilder.Emit_Leave(completion.RunFinally);
+        }
+        else if (_ctx.ExceptionBlockDepth > 0)
         {
             // Inside exception block: store value and leave
             // Use builder for Leave validation (ensures we're inside exception block)
@@ -1930,6 +2017,12 @@ public partial class ILEmitter
 
     protected override void EmitTryCatch(Stmt.TryCatch t)
     {
+        if (t.FinallyBlock != null)
+        {
+            EmitTryCatchFinally(t);
+            return;
+        }
+
         // Use ValidatedILBuilder for exception block operations - it tracks depth automatically
         // and validates proper Begin/End pairing
         var builder = _ctx.ILBuilder;
@@ -1945,22 +2038,26 @@ public partial class ILEmitter
         if (t.CatchBlock != null)
         {
             builder.BeginCatchBlock(_ctx.Types.Exception);
+            _ctx.Locals.EnterScope();
+            try
+            {
+                if (t.CatchParam != null)
+                {
+                    var exLocal = _ctx.Locals.DeclareLocal(t.CatchParam.Lexeme, _ctx.Types.Object);
+                    IL.Emit(OpCodes.Call, _ctx.Runtime!.WrapException);
+                    IL.Emit(OpCodes.Stloc, exLocal);
+                }
+                else
+                {
+                    IL.Emit(OpCodes.Pop);
+                }
 
-            if (t.CatchParam != null)
-            {
-                // Store exception
-                var exLocal = _ctx.Locals.DeclareLocal(t.CatchParam.Lexeme, _ctx.Types.Object);
-                IL.Emit(OpCodes.Call, _ctx.Runtime!.WrapException);
-                IL.Emit(OpCodes.Stloc, exLocal);
+                foreach (var stmt in t.CatchBlock)
+                    EmitStatement(stmt);
             }
-            else
+            finally
             {
-                IL.Emit(OpCodes.Pop);
-            }
-
-            foreach (var stmt in t.CatchBlock)
-            {
-                EmitStatement(stmt);
+                _ctx.Locals.ExitScope();
             }
         }
 
@@ -1975,6 +2072,145 @@ public partial class ILEmitter
 
         builder.EndExceptionBlock();
         _ctx.ExceptionBlockDepth--;
+    }
+
+    /// <summary>
+    /// Lowers JavaScript try/catch/finally through an explicit Completion record.
+    /// CLR finally handlers cannot transfer control, while ECMAScript finally may
+    /// replace an in-flight return, break, continue, or throw. Routing the pending
+    /// completion through ordinary IL after the protected region preserves that
+    /// distinction and composes for nested finally blocks.
+    /// </summary>
+    private void EmitTryCatchFinally(Stmt.TryCatch t)
+    {
+        var builder = _ctx.ILBuilder;
+        var runFinally = builder.DefineLabel("js_finally");
+        var afterFinally = builder.DefineLabel("js_finally_done");
+        var kind = IL.DeclareLocal(_ctx.Types.Int32); // 0 normal, 1 return, 2 throw, 3+ branch
+        var exception = IL.DeclareLocal(_ctx.Types.Exception);
+
+        IL.Emit(OpCodes.Ldc_I4_0);
+        IL.Emit(OpCodes.Stloc, kind);
+
+        var enclosingTargets = new HashSet<Label>();
+        foreach (var loop in _ctx.LoopLabels)
+        {
+            enclosingTargets.Add(loop.BreakLabel);
+            enclosingTargets.Add(loop.ContinueLabel);
+        }
+
+        var completion = new AbruptCompletionScope
+        {
+            RunFinally = runFinally,
+            Kind = kind,
+            Exception = exception,
+            EnclosingTargets = enclosingTargets
+        };
+        _abruptCompletionScopes.Push(completion);
+
+        // Outer catch converts any exception escaping either the try body or
+        // the JavaScript catch clause into a pending throw completion.
+        _ctx.ExceptionBlockDepth++;
+        builder.BeginExceptionBlock();
+
+        if (t.CatchBlock != null)
+        {
+            _ctx.ExceptionBlockDepth++;
+            builder.BeginExceptionBlock();
+            foreach (var stmt in t.TryBlock)
+                EmitStatement(stmt);
+
+            builder.BeginCatchBlock(_ctx.Types.Exception);
+            _ctx.Locals.EnterScope();
+            try
+            {
+                if (t.CatchParam != null)
+                {
+                    var exLocal = _ctx.Locals.DeclareLocal(t.CatchParam.Lexeme, _ctx.Types.Object);
+                    IL.Emit(OpCodes.Call, _ctx.Runtime!.WrapException);
+                    IL.Emit(OpCodes.Stloc, exLocal);
+                }
+                else
+                {
+                    IL.Emit(OpCodes.Pop);
+                }
+                foreach (var stmt in t.CatchBlock)
+                    EmitStatement(stmt);
+            }
+            finally
+            {
+                _ctx.Locals.ExitScope();
+            }
+            builder.EndExceptionBlock();
+            _ctx.ExceptionBlockDepth--;
+        }
+        else
+        {
+            foreach (var stmt in t.TryBlock)
+                EmitStatement(stmt);
+        }
+
+        builder.Emit_Leave(runFinally);
+        builder.BeginCatchBlock(_ctx.Types.Exception);
+        IL.Emit(OpCodes.Stloc, exception);
+        IL.Emit(OpCodes.Ldc_I4_2);
+        IL.Emit(OpCodes.Stloc, kind);
+        builder.Emit_Leave(runFinally);
+        builder.EndExceptionBlock();
+        _ctx.ExceptionBlockDepth--;
+
+        _abruptCompletionScopes.Pop();
+        builder.MarkLabel(runFinally);
+        foreach (var stmt in t.FinallyBlock!)
+            EmitStatement(stmt);
+
+        // A normal finally preserves and resumes the pending completion.
+        IL.Emit(OpCodes.Ldloc, kind);
+        builder.Emit_Brfalse(afterFinally);
+
+        if (_ctx.ReturnValueLocal != null)
+        {
+            var notReturn = builder.DefineLabel("js_finally_not_return");
+            IL.Emit(OpCodes.Ldloc, kind);
+            IL.Emit(OpCodes.Ldc_I4_1);
+            builder.Emit_Bne_Un(notReturn);
+            IL.Emit(OpCodes.Ldloc, _ctx.ReturnValueLocal);
+            if (_abruptCompletionScopes.TryPeek(out var outerCompletion))
+            {
+                IL.Emit(OpCodes.Stloc, _ctx.ReturnValueLocal);
+                IL.Emit(OpCodes.Ldc_I4_1);
+                IL.Emit(OpCodes.Stloc, outerCompletion.Kind);
+                builder.Emit_Leave(outerCompletion.RunFinally);
+            }
+            else if (_ctx.ExceptionBlockDepth > 0)
+            {
+                builder.Emit_Leave(_ctx.ReturnLabel);
+            }
+            else
+            {
+                IL.Emit(OpCodes.Ret);
+            }
+            builder.MarkLabel(notReturn);
+        }
+        var notThrow = builder.DefineLabel("js_finally_not_throw");
+        IL.Emit(OpCodes.Ldloc, kind);
+        IL.Emit(OpCodes.Ldc_I4_2);
+        builder.Emit_Bne_Un(notThrow);
+        IL.Emit(OpCodes.Ldloc, exception);
+        IL.Emit(OpCodes.Throw);
+
+        builder.MarkLabel(notThrow);
+        foreach (var (target, code) in completion.BranchCodes)
+        {
+            var next = builder.DefineLabel("js_finally_next_branch");
+            IL.Emit(OpCodes.Ldloc, kind);
+            IL.Emit(OpCodes.Ldc_I4, code);
+            builder.Emit_Bne_Un(next);
+            EmitBranchToLabel(target);
+            builder.MarkLabel(next);
+        }
+
+        builder.MarkLabel(afterFinally);
     }
 
     protected override void EmitThrow(Stmt.Throw t)

--- a/src/SharpTS/Compilation/ILEmitter.cs
+++ b/src/SharpTS/Compilation/ILEmitter.cs
@@ -34,6 +34,32 @@ public partial class ILEmitter : StatementEmitterBase, IEmitterContext
 {
     private readonly CompilationContext _ctx;
     private readonly LocalVariableResolver _resolver;
+    private readonly Stack<AbruptCompletionScope> _abruptCompletionScopes = [];
+    private readonly Stack<IteratorLoopCompletionScope> _iteratorLoopCompletionScopes = [];
+
+    private sealed class AbruptCompletionScope
+    {
+        private int _nextBranchCode = 3;
+
+        public required Label RunFinally { get; init; }
+        public required LocalBuilder Kind { get; init; }
+        public required LocalBuilder Exception { get; init; }
+        public required HashSet<Label> EnclosingTargets { get; init; }
+        public Dictionary<Label, int> BranchCodes { get; } = [];
+
+        public int GetBranchCode(Label target)
+        {
+            if (BranchCodes.TryGetValue(target, out int code)) return code;
+            code = _nextBranchCode++;
+            BranchCodes[target] = code;
+            return code;
+        }
+    }
+
+    private sealed record IteratorLoopCompletionScope(
+        LocalBuilder CloseNeeded,
+        Label ContinueTarget,
+        HashSet<Label> EscapingTargets);
 
     // Abstract property implementations for ExpressionEmitterBase
     protected override ILGenerator IL => _ctx.IL;
@@ -116,6 +142,36 @@ public partial class ILEmitter : StatementEmitterBase, IEmitterContext
     {
         // Use builder for branch validation - it enforces Leave vs Br rules
         var builder = _ctx.ILBuilder;
+        if (_abruptCompletionScopes.TryPeek(out var completion))
+        {
+            // A loop/switch introduced inside this try remains inside the protected
+            // region. Only a target that existed on entry escapes and therefore
+            // needs to run the JavaScript finally block.
+            if (completion.EnclosingTargets.Contains(target))
+            {
+                IL.Emit(OpCodes.Ldc_I4, completion.GetBranchCode(target));
+                IL.Emit(OpCodes.Stloc, completion.Kind);
+                builder.Emit_Leave(completion.RunFinally);
+                return;
+            }
+        }
+        if (_iteratorLoopCompletionScopes.TryPeek(out var iteratorCompletion))
+        {
+            if (iteratorCompletion.EscapingTargets.Contains(target))
+            {
+                if (target.Equals(iteratorCompletion.ContinueTarget))
+                {
+                    IL.Emit(OpCodes.Ldc_I4_0);
+                    IL.Emit(OpCodes.Stloc, iteratorCompletion.CloseNeeded);
+                }
+                builder.Emit_Leave(target);
+                return;
+            }
+
+            // The target belongs to a loop/switch nested inside this iteration.
+            builder.Emit_Br(target);
+            return;
+        }
         if (_ctx.ExceptionBlockDepth > 0)
             builder.Emit_Leave(target);
         else

--- a/src/SharpTS/Compilation/RuntimeEmitter.Generator.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Generator.cs
@@ -23,6 +23,17 @@ public partial class RuntimeEmitter
         );
         runtime.GeneratorInterfaceType = interfaceBuilder;
 
+        // @@iterator() returns the generator itself. GetIteratorFunction exposes
+        // this MethodInfo for dynamically typed generator values, allowing for-of
+        // and every other consumer to use the ordinary iterator protocol path.
+        var iteratorMethod = interfaceBuilder.DefineMethod(
+            "iterator",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Abstract | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
+            _types.Object,
+            Type.EmptyTypes
+        );
+        runtime.GeneratorIteratorMethod = iteratorMethod;
+
         // Define next(object value) method: object next(object value)
         // Wraps MoveNext + Current into a single call returning an iterator result.
         // The value argument becomes the result of the resumed yield (ECMA-262

--- a/src/SharpTS/Compilation/RuntimeEmitter.Iterator.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Iterator.cs
@@ -392,6 +392,103 @@ public partial class RuntimeEmitter
         EmitInvokeIteratorNext(typeBuilder, runtime);
         EmitInvokeIteratorNextWithSent(typeBuilder, runtime);
         EmitGetIteratorFunction(typeBuilder, runtime);
+        EmitIteratorClose(typeBuilder, runtime);
+    }
+
+    /// <summary>
+    /// Emits the shared IteratorClose primitive used by every compiled consumer.
+    /// When an existing throw completion is being propagated, failures produced
+    /// while retrieving/calling <c>return</c> are suppressed as required by
+    /// ECMA-262 §7.4.11; normal completions propagate those failures.
+    /// </summary>
+    private void EmitIteratorClose(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "IteratorClose",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            [_types.Object, _types.Boolean]);
+        runtime.IteratorClose = method;
+
+        var il = method.GetILGenerator();
+        var returnMethod = il.DeclareLocal(_types.Object);
+        var closeResult = il.DeclareLocal(_types.Object);
+        var lookupReturn = il.DefineLabel();
+        var validateResult = il.DefineLabel();
+        var finishTry = il.DefineLabel();
+        var done = il.DefineLabel();
+        var resultIsObject = il.DefineLabel();
+
+        // A throw completion wins over every abrupt completion produced by
+        // IteratorClose. A small catch around the normal algorithm preserves it.
+        il.BeginExceptionBlock();
+
+        // Emitted generators expose return through $IGenerator rather than an
+        // own-property dictionary. Keep that representation detail inside the
+        // shared close primitive so every iterator consumer observes the same
+        // GeneratorResumeAbrupt semantics.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.GeneratorInterfaceType);
+        il.Emit(OpCodes.Brfalse, lookupReturn);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.GeneratorInterfaceType);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Callvirt, runtime.GeneratorReturnMethod);
+        il.Emit(OpCodes.Stloc, closeResult);
+        il.Emit(OpCodes.Br, validateResult);
+
+        il.MarkLabel(lookupReturn);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "return");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Stloc, returnMethod);
+
+        il.Emit(OpCodes.Ldloc, returnMethod);
+        il.Emit(OpCodes.Brfalse, finishTry);
+        il.Emit(OpCodes.Ldloc, returnMethod);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, finishTry);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, returnMethod);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
+        il.Emit(OpCodes.Stloc, closeResult);
+
+        // IteratorClose requires the return method's result to be an Object.
+        il.MarkLabel(validateResult);
+        il.Emit(OpCodes.Ldloc, closeResult);
+        il.Emit(OpCodes.Brfalse, resultIsObject);
+        il.Emit(OpCodes.Ldloc, closeResult);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, resultIsObject);
+        il.Emit(OpCodes.Ldloc, closeResult);
+        il.Emit(OpCodes.Isinst, _types.Double);
+        il.Emit(OpCodes.Brtrue, resultIsObject);
+        il.Emit(OpCodes.Ldloc, closeResult);
+        il.Emit(OpCodes.Isinst, _types.Boolean);
+        il.Emit(OpCodes.Brtrue, resultIsObject);
+        il.Emit(OpCodes.Ldloc, closeResult);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Brfalse, finishTry);
+        il.MarkLabel(resultIsObject);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Iterator .return() must return an object");
+
+        il.MarkLabel(finishTry);
+        il.Emit(OpCodes.Leave, done);
+        il.BeginCatchBlock(_types.Exception);
+        var propagateCloseError = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Brfalse, propagateCloseError);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Leave, done);
+        il.MarkLabel(propagateCloseError);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Rethrow);
+        il.EndExceptionBlock();
+        il.MarkLabel(done);
+        il.Emit(OpCodes.Ret);
     }
 
     /// <summary>
@@ -588,6 +685,21 @@ public partial class RuntimeEmitter
         // if (obj == null) return undefined;
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brfalse, returnUndefinedLabel);
+
+        // Emitted generators are iterator objects, but their intrinsic
+        // @@iterator method lives on $IGenerator rather than in an own symbol
+        // dictionary. Return the interface MethodInfo; InvokeMethodValue binds
+        // the generator receiver and the method returns that receiver unchanged.
+        var notGeneratorIterator = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldsfld, runtime.SymbolIterator);
+        il.Emit(OpCodes.Bne_Un, notGeneratorIterator);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.GeneratorInterfaceType);
+        il.Emit(OpCodes.Brfalse, notGeneratorIterator);
+        EmitInstanceMethodInfoLiteral(il, runtime.GeneratorIteratorMethod, runtime.GeneratorInterfaceType);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notGeneratorIterator);
 
         // #1024: node:stream $Readable exposes [Symbol.asyncIterator] via GetAsyncIterator().
         // It carries no per-object symbol dict and isn't a user class, so hook it here:

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Exceptions.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Exceptions.cs
@@ -181,10 +181,48 @@ public partial class RuntimeEmitter
         // `catch` sees a proper Error instance — `e instanceof Error` is true and
         // `e.name` is "Error" rather than the .NET type name. Previously this returned
         // a plain { message, name=<.NET type> } dictionary. (#700)
-        // return new $Error(ex.Message)
+        // Runtime/interpreter bridges encode guest error identity in the message
+        // (for example "Runtime Error: ReferenceError: ..."). Recover that
+        // identity here after unwrapping reflection exceptions instead of
+        // collapsing every abrupt completion to a generic Error.
         il.MarkLabel(standardFallbackLabel);
+        var messageLocal = il.DeclareLocal(_types.String);
         il.Emit(OpCodes.Ldloc, exLocal);
         il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Exception, "Message").GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, messageLocal);
+
+        var messageReady = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, messageLocal);
+        il.Emit(OpCodes.Ldstr, "Runtime Error: ");
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "StartsWith", _types.String));
+        il.Emit(OpCodes.Brfalse, messageReady);
+        il.Emit(OpCodes.Ldloc, messageLocal);
+        il.Emit(OpCodes.Ldc_I4, "Runtime Error: ".Length);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "Substring", _types.Int32));
+        il.Emit(OpCodes.Stloc, messageLocal);
+        il.MarkLabel(messageReady);
+
+        void EmitGuestError(string name, ConstructorInfo constructor)
+        {
+            var next = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, messageLocal);
+            il.Emit(OpCodes.Ldstr, name + ":");
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "StartsWith", _types.String));
+            il.Emit(OpCodes.Brfalse, next);
+            il.Emit(OpCodes.Ldloc, messageLocal);
+            il.Emit(OpCodes.Newobj, constructor);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(next);
+        }
+
+        EmitGuestError("TypeError", runtime.TSTypeErrorCtor);
+        EmitGuestError("RangeError", runtime.TSRangeErrorCtor);
+        EmitGuestError("ReferenceError", runtime.TSReferenceErrorCtor);
+        EmitGuestError("SyntaxError", runtime.TSSyntaxErrorCtor);
+        EmitGuestError("URIError", runtime.TSURIErrorCtor);
+        EmitGuestError("EvalError", runtime.TSEvalErrorCtor);
+
+        il.Emit(OpCodes.Ldloc, messageLocal);
         il.Emit(OpCodes.Newobj, runtime.TSErrorCtorMessage);
         il.Emit(OpCodes.Ret);
     }

--- a/src/SharpTS/Compilation/RuntimeTypes.Exceptions.cs
+++ b/src/SharpTS/Compilation/RuntimeTypes.Exceptions.cs
@@ -13,6 +13,9 @@ public static partial class RuntimeTypes
 
     public static object WrapException(Exception ex)
     {
+        while (ex is System.Reflection.TargetInvocationException && ex.InnerException is not null)
+            ex = ex.InnerException;
+
         // Promise rejection exceptions carry the original rejection value
         // (for example, a raw string from Promise.reject("msg")).
         if (ex is SharpTSPromiseRejectedException runtimeRejection)
@@ -34,7 +37,21 @@ public static partial class RuntimeTypes
         // proper Error instance (`e instanceof Error`, `e.name === "Error"`) rather than
         // a bare { message, name=<.NET type> } object. Mirrors the emitted
         // $Runtime.WrapException standard fallback. (#700)
-        return new SharpTSError(ex.Message);
+        string message = ex.Message;
+        const string runtimePrefix = "Runtime Error: ";
+        if (message.StartsWith(runtimePrefix, StringComparison.Ordinal))
+            message = message[runtimePrefix.Length..];
+
+        return message switch
+        {
+            var m when m.StartsWith("TypeError:", StringComparison.Ordinal) => new SharpTSTypeError(m),
+            var m when m.StartsWith("RangeError:", StringComparison.Ordinal) => new SharpTSRangeError(m),
+            var m when m.StartsWith("ReferenceError:", StringComparison.Ordinal) => new SharpTSReferenceError(m),
+            var m when m.StartsWith("SyntaxError:", StringComparison.Ordinal) => new SharpTSSyntaxError(m),
+            var m when m.StartsWith("URIError:", StringComparison.Ordinal) => new SharpTSURIError(m),
+            var m when m.StartsWith("EvalError:", StringComparison.Ordinal) => new SharpTSEvalError(m),
+            _ => new SharpTSError(message)
+        };
     }
 
     #endregion

--- a/src/SharpTS/Compilation/StateMachineEmitHelpers.cs
+++ b/src/SharpTS/Compilation/StateMachineEmitHelpers.cs
@@ -1175,26 +1175,47 @@ public class StateMachineEmitHelpers
             return;
         }
 
-        // Get the opcode for this operator
+        // Both operands have already been evaluated and boxed. Spill them before
+        // coercion so every emitter follows the spec order: GetValue(left),
+        // GetValue(right), then ToNumeric on each operand. This also avoids using
+        // the global stack-type hint to guess the CLR shape of either operand.
+        var right = _il.DeclareLocal(_types.Object);
+        _il.Emit(OpCodes.Stloc, right);
+        var left = _il.DeclareLocal(_types.Object);
+        _il.Emit(OpCodes.Stloc, left);
+
         var opcode = CompoundOperatorHelper.GetOpcode(opType);
         if (opcode.HasValue)
         {
             if (CompoundOperatorHelper.IsBitwise(opType))
             {
-                // Bitwise operations need int32 conversion
-                EmitBitwiseBinary(opcode.Value);
+                _il.Emit(OpCodes.Ldloc, left);
+                _il.Emit(OpCodes.Call, _runtime!.JsToInt32);
+                _il.Emit(OpCodes.Ldloc, right);
+                _il.Emit(OpCodes.Call, _runtime.JsToInt32);
+                _il.Emit(opcode.Value);
+                if (opType == TokenType.GREATER_GREATER_GREATER_EQUAL)
+                    _il.Emit(OpCodes.Conv_U8);
+                _il.Emit(OpCodes.Conv_R8);
+                _il.Emit(OpCodes.Box, _types.Double);
             }
             else
             {
-                // Arithmetic operations use double conversion
-                EmitArithmeticBinary(opcode.Value);
+                _il.Emit(OpCodes.Ldloc, left);
+                _il.Emit(OpCodes.Call, _runtime!.ConvertToNumber);
+                _il.Emit(OpCodes.Ldloc, right);
+                _il.Emit(OpCodes.Call, _runtime.ConvertToNumber);
+                _il.Emit(opcode.Value);
+                _il.Emit(OpCodes.Box, _types.Double);
             }
         }
         else
         {
-            // Fallback for unsupported operators - use Add
-            EmitArithmeticBinary(OpCodes.Add);
+            _il.Emit(OpCodes.Ldloc, left);
+            _il.Emit(OpCodes.Ldloc, right);
+            EmitCallUnknown(runtimeAdd);
         }
+        SetStackUnknown();
     }
 
     /// <summary>

--- a/tests/conformance/SharpTS.Test262/Issue1279ParityTests.cs
+++ b/tests/conformance/SharpTS.Test262/Issue1279ParityTests.cs
@@ -6466,6 +6466,27 @@ public void Promise_combinators_share_iterator_and_resolution_semantics(string r
     public void Static_class_method_function_objects_match_in_compiled_mode(string relativePath)
         => AssertPass(relativePath, Test262ExecutionMode.Compiled);
 
+    public static TheoryData<string> ReferenceCompletionAndIteratorCloseCases => new()
+    {
+        "language/expressions/assignment/target-member-computed-reference.js",
+        "language/expressions/compound-assignment/11.13.2-1-s.js",
+        "language/expressions/compound-assignment/S11.13.2_A4.6_T1.1.js",
+        "language/expressions/compound-assignment/S11.13.2_A7.8_T1.js",
+        "language/statements/try/12.14-7.js",
+        "language/statements/try/completion-values-fn-finally-return.js",
+        "language/statements/for-of/iterator-close-via-break.js",
+        "language/statements/for-of/iterator-close-via-throw.js",
+        "language/statements/for-of/iterator-close-via-return.js",
+        "language/statements/for-of/iterator-close-non-throw-get-method-abrupt.js",
+        "language/statements/for-of/break-from-finally.js",
+        "language/statements/for-of/return-from-finally.js",
+    };
+
+    [Theory]
+    [MemberData(nameof(ReferenceCompletionAndIteratorCloseCases))]
+    public void Reference_completion_and_iterator_close_match_in_both_modes(string relativePath)
+        => AssertPassInBothModes(relativePath);
+
     public static TheoryData<string> FunctionEnvironmentLoweringCompilerCases => new()
     {
         "language/arguments-object/func-decl-args-trailing-comma-spread-operator.js",


### PR DESCRIPTION
## Summary
- centralize compiled compound-assignment coercion and preserve left-reference evaluation before RHS suspension
- lower `try`/`catch`/`finally` through explicit abrupt completions for return, throw, break, and continue
- add a shared emitted `IteratorClose`, route custom iterators and generators through it, and expose emitted generators through `@@iterator`
- preserve guest error identity when host/reflection exceptions cross compiled catch boundaries
- add focused dual-mode Test262 coverage for reference evaluation, coercion, finally completion, and iterator closing

## Test262 impact
Focused sweep over assignment, compound-assignment, for-of, and try:
- compiler-only deficits: **113 -> 32** (81 removed)
- compound-assignment: **36 -> 0**
- try: **22 -> 0**
- for-of: **29 -> 9**

The remaining focused deficits are pre-existing destructuring/TDZ, function-name inference, descriptor, and Map/Set live-iteration semantics.

## Validation
- `dotnet build SharpTS.sln --no-restore --configuration Release` (0 warnings/errors; both IL verification gates passed)
- `dotnet test tests/SharpTS.Tests/SharpTS.Tests.csproj --no-build --configuration Release --filter "Category!=LiveNetwork&Category!=LoadSensitive&Category!=npm"` (16,726 passed; 3 skipped)
- `dotnet test tests/gui-conformance/SharpTS.Gui.Conformance.Tests/SharpTS.Gui.Conformance.Tests.csproj --no-build --configuration Release --filter "Category!=LiveNetwork&Category!=LoadSensitive&Category!=npm"` (83 passed)
- focused issue #1374 Test262 theory (12 passed in both modes)
- focused compiled wide sweep (1,891 files; 687 compiled passes vs 605 interpreted passes)

Refs #1374