### PR TITLE
Complete Proxy/Reflect internal-method dispatch and invariants

### DIFF
--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -184,6 +184,7 @@ public class EmittedRuntime
     public MethodBuilder TypeOf { get; set; } = null!;
     public MethodBuilder InstanceOf { get; set; } = null!;
     public MethodBuilder HasIn { get; set; } = null!;
+    public MethodBuilder ProxyOrdinaryHas { get; set; } = null!;
 
     // Reflect metadata API
     public MethodBuilder ReflectDefineMetadata { get; set; } = null!;
@@ -718,6 +719,9 @@ public class EmittedRuntime
     public MethodBuilder ReflectApply { get; set; } = null!;
     public MethodBuilder ReflectConstruct { get; set; } = null!;
     public MethodBuilder ReflectSet { get; set; } = null!;
+    public MethodBuilder ReflectGet { get; set; } = null!;
+    public MethodBuilder ReflectDeleteProperty { get; set; } = null!;
+    public MethodBuilder ReflectPreventExtensions { get; set; } = null!;
     public MethodBuilder IsConstructorMethod { get; set; } = null!;
 
     // Resource disposal for using declarations

--- a/src/SharpTS/Compilation/Emitters/ProxyStaticEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/ProxyStaticEmitter.cs
@@ -48,6 +48,14 @@ public sealed class ProxyStaticEmitter : IStaticTypeEmitterStrategy
 
     public bool TryEmitStaticPropertyGet(IEmitterContext emitter, string propertyName)
     {
-        return false;
+        if (propertyName != "revocable") return false;
+        var ctx = emitter.Context;
+        ctx.Types.EmitLoadMethodInfo(ctx.IL, ctx.Runtime!.CreateRevocableProxy);
+        ctx.IL.Emit(OpCodes.Ldstr, "revocable");
+        ctx.IL.Emit(OpCodes.Ldc_I4_2);
+        ctx.IL.Emit(OpCodes.Call, ctx.Runtime.TSFunctionGetOrCreate);
+        return true;
     }
+
+    public bool HasStaticProperty(string memberName) => memberName == "revocable";
 }

--- a/src/SharpTS/Compilation/Emitters/ReflectStaticEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/ReflectStaticEmitter.cs
@@ -54,9 +54,6 @@ public sealed class ReflectStaticEmitter : IStaticTypeEmitterStrategy
 
             case "deleteProperty":
             {
-                // Reflect.deleteProperty(target, propertyKey) → bool
-                // Store target in local for frozen check after delete
-                var targetLocal = il.DeclareLocal(typeof(object));
                 if (arguments.Count > 0)
                 {
                     emitter.EmitExpression(arguments[0]);
@@ -64,7 +61,30 @@ public sealed class ReflectStaticEmitter : IStaticTypeEmitterStrategy
                 }
                 else
                     il.Emit(OpCodes.Ldnull);
-                il.Emit(OpCodes.Dup);
+
+                if (arguments.Count > 1)
+                {
+                    emitter.EmitExpression(arguments[1]);
+                    emitter.EmitBoxIfNeeded(arguments[1]);
+                }
+                else
+                    il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Call, ctx.Runtime!.ReflectDeleteProperty);
+                il.Emit(OpCodes.Box, typeof(bool));
+                return true;
+            }
+
+            case "get":
+            {
+                // Reflect.get(target, propertyKey, receiver?) → value
+                var targetLocal = il.DeclareLocal(ctx.Types.Object);
+                if (arguments.Count > 0)
+                {
+                    emitter.EmitExpression(arguments[0]);
+                    emitter.EmitBoxIfNeeded(arguments[0]);
+                }
+                else
+                    il.Emit(OpCodes.Ldnull);
                 il.Emit(OpCodes.Stloc, targetLocal);
 
                 if (arguments.Count > 1)
@@ -75,66 +95,21 @@ public sealed class ReflectStaticEmitter : IStaticTypeEmitterStrategy
                 else
                     il.Emit(OpCodes.Ldnull);
 
-                // Convert key to string and call DeleteProperty
-                il.Emit(OpCodes.Callvirt, typeof(object).GetMethod("ToString")!);
-                il.Emit(OpCodes.Call, ctx.Runtime!.DeleteProperty);
-                // DeleteProperty returns false for both frozen objects AND missing dict keys.
-                // For Reflect.deleteProperty, missing keys should return true (only frozen returns false).
-                var deleteResultLocal = il.DeclareLocal(typeof(bool));
-                il.Emit(OpCodes.Stloc, deleteResultLocal);
-
-                // If DeleteProperty returned true, just return true
-                var deleteTrueLabel = il.DefineLabel();
-                var deleteEndLabel = il.DefineLabel();
-                il.Emit(OpCodes.Ldloc, deleteResultLocal);
-                il.Emit(OpCodes.Brtrue, deleteTrueLabel);
-
-                // DeleteProperty returned false. Check if object is frozen or sealed.
-                // If frozen/sealed → return false; if neither → return true (key just didn't exist)
+                il.Emit(OpCodes.Call, ctx.Runtime!.ToJsString);
+                var keyLocal = il.DeclareLocal(ctx.Types.String);
+                il.Emit(OpCodes.Stloc, keyLocal);
                 il.Emit(OpCodes.Ldloc, targetLocal);
-                il.Emit(OpCodes.Call, ctx.Runtime!.PDSIsFrozen);
-                var isFrozenOrSealedLabel = il.DefineLabel();
-                il.Emit(OpCodes.Brtrue, isFrozenOrSealedLabel);
-                il.Emit(OpCodes.Ldloc, targetLocal);
-                il.Emit(OpCodes.Call, ctx.Runtime!.PDSIsSealed);
-                il.Emit(OpCodes.Brtrue, isFrozenOrSealedLabel);
-                // Not frozen/sealed: missing key → return true
-                il.Emit(OpCodes.Ldc_I4_1);
-                il.Emit(OpCodes.Br, deleteEndLabel);
-                il.MarkLabel(isFrozenOrSealedLabel);
-                // Frozen or sealed → return false
-                il.Emit(OpCodes.Ldc_I4_0);
-                il.Emit(OpCodes.Br, deleteEndLabel);
-
-                il.MarkLabel(deleteTrueLabel);
-                il.Emit(OpCodes.Ldc_I4_1);
-                il.MarkLabel(deleteEndLabel);
-                il.Emit(OpCodes.Box, typeof(bool));
-                return true;
-            }
-
-            case "get":
-            {
-                // Reflect.get(target, propertyKey, receiver?) → value
-                if (arguments.Count > 0)
+                il.Emit(OpCodes.Ldloc, keyLocal);
+                if (arguments.Count > 2)
                 {
-                    emitter.EmitExpression(arguments[0]);
-                    emitter.EmitBoxIfNeeded(arguments[0]);
+                    emitter.EmitExpression(arguments[2]);
+                    emitter.EmitBoxIfNeeded(arguments[2]);
                 }
                 else
-                    il.Emit(OpCodes.Ldnull);
-
-                if (arguments.Count > 1)
                 {
-                    emitter.EmitExpression(arguments[1]);
-                    emitter.EmitBoxIfNeeded(arguments[1]);
+                    il.Emit(OpCodes.Ldloc, targetLocal);
                 }
-                else
-                    il.Emit(OpCodes.Ldnull);
-
-                // Convert key to string, then use GetProperty(target, key)
-                il.Emit(OpCodes.Callvirt, typeof(object).GetMethod("ToString")!);
-                il.Emit(OpCodes.Call, ctx.Runtime!.GetProperty);
+                il.Emit(OpCodes.Call, ctx.Runtime.ReflectGet);
                 return true;
             }
 
@@ -247,9 +222,7 @@ public sealed class ReflectStaticEmitter : IStaticTypeEmitterStrategy
                 else
                     il.Emit(OpCodes.Ldnull);
 
-                il.Emit(OpCodes.Call, ctx.Runtime!.ObjectPreventExtensions);
-                il.Emit(OpCodes.Pop); // discard the returned object
-                il.Emit(OpCodes.Ldc_I4_1);
+                il.Emit(OpCodes.Call, ctx.Runtime!.ReflectPreventExtensions);
                 il.Emit(OpCodes.Box, typeof(bool));
                 return true;
             }

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.cs
@@ -2307,7 +2307,12 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
                 break;
             case TokenType.TYPEOF:
                 // typeof never throws on undeclared variables - returns "undefined"
-                if (u.Right is Expr.Variable tv && !IsKnownVariable(tv.Name.Lexeme))
+                if (u.Right is Expr.Variable { Name.Lexeme: "Proxy" })
+                {
+                    _helpers.IL.Emit(OpCodes.Ldstr, "function");
+                    _helpers.SetStackUnknown();
+                }
+                else if (u.Right is Expr.Variable tv && !IsKnownVariable(tv.Name.Lexeme))
                 {
                     _helpers.IL.Emit(OpCodes.Ldstr, "undefined");
                     _helpers.SetStackUnknown();

--- a/src/SharpTS/Compilation/ILEmitter.Expressions.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Expressions.cs
@@ -169,6 +169,20 @@ public partial class ILEmitter
             return;
         }
 
+        if (name == "Proxy")
+        {
+            // Value form of the %Proxy% constructor. Direct `new Proxy(...)`
+            // remains handled by the constructor emitter; this identity-stable
+            // wrapper supplies function branding and standard name/length
+            // metadata for reflection and aliases.
+            _ctx.Types.EmitLoadMethodInfo(IL, _ctx.Runtime!.CreateProxy);
+            IL.Emit(OpCodes.Ldstr, "Proxy");
+            IL.Emit(OpCodes.Ldc_I4_2);
+            IL.Emit(OpCodes.Call, _ctx.Runtime.TSFunctionGetOrCreate);
+            SetStackUnknown();
+            return;
+        }
+
         // JavaScript global constants (NaN/Infinity/undefined)
         if (TryEmitJsGlobalConstant(name)) return;
 

--- a/src/SharpTS/Compilation/ILEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Operators.cs
@@ -468,7 +468,11 @@ public partial class ILEmitter
 
             case TokenType.TYPEOF:
                 // typeof never throws on undeclared variables - returns "undefined"
-                if (u.Right is Expr.Variable tv && !IsKnownVariable(tv.Name.Lexeme))
+                if (u.Right is Expr.Variable { Name.Lexeme: "Proxy" })
+                {
+                    IL.Emit(OpCodes.Ldstr, "function");
+                }
+                else if (u.Right is Expr.Variable tv && !IsKnownVariable(tv.Name.Lexeme))
                 {
                     IL.Emit(OpCodes.Ldstr, "undefined");
                 }

--- a/src/SharpTS/Compilation/RuntimeEmitter.Arrays.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Arrays.cs
@@ -1155,6 +1155,18 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Callvirt, addToList);
         }
 
+        // Anonymous host delegates back Proxy revocation functions.  They are
+        // ECMAScript built-ins whose own keys are created in this order.
+        var notAnonymousDelegateForNamesLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.FuncObjectArrayToObject);
+        il.Emit(OpCodes.Brfalse, notAnonymousDelegateForNamesLabel);
+        AddName("length");
+        AddName("name");
+        il.Emit(OpCodes.Ldloc, namesLocal);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notAnonymousDelegateForNamesLabel);
+
         // Promise combinator element callbacks are anonymous built-in
         // functions. Their own string keys are ordered length, name.
         var notResolveCallbackForNamesLabel = il.DefineLabel();
@@ -1331,6 +1343,63 @@ public partial class RuntimeEmitter
         il.MarkLabel(dictKeysLoopEnd);
 
         il.MarkLabel(noFieldsDictLabel);
+
+        // Object-literal accessors live in $TSObject's getter/setter maps rather
+        // than its fields dictionary. They are nevertheless ordinary own
+        // properties and must participate in [[OwnPropertyKeys]]. Add both maps
+        // here (deduplicating getter/setter pairs); NormalizeOwnPropertyKeys
+        // below restores the required integer-index ordering.
+        void EmitLiteralAccessorNames(MethodInfo accessorMapGetter)
+        {
+            var doneLabel = il.DefineLabel();
+            var accessorDictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+            var accessorEnumeratorLocal = il.DeclareLocal(_types.IEnumeratorOfString);
+            var accessorKeyLocal = il.DeclareLocal(_types.String);
+            var accessorLoopLabel = il.DefineLabel();
+            var accessorLoopEndLabel = il.DefineLabel();
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.TSObjectType);
+            il.Emit(OpCodes.Brfalse, doneLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, runtime.TSObjectType);
+            il.Emit(OpCodes.Callvirt, accessorMapGetter);
+            il.Emit(OpCodes.Stloc, accessorDictLocal);
+            il.Emit(OpCodes.Ldloc, accessorDictLocal);
+            il.Emit(OpCodes.Brfalse, doneLabel);
+            il.Emit(OpCodes.Ldloc, accessorDictLocal);
+            il.Emit(OpCodes.Callvirt, _types.GetPropertyGetter(
+                _types.DictionaryStringObject, "Keys"));
+            il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(
+                _types.IEnumerableOfString, "GetEnumerator"));
+            il.Emit(OpCodes.Stloc, accessorEnumeratorLocal);
+
+            il.MarkLabel(accessorLoopLabel);
+            il.Emit(OpCodes.Ldloc, accessorEnumeratorLocal);
+            il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(
+                _types.IEnumerator, "MoveNext"));
+            il.Emit(OpCodes.Brfalse, accessorLoopEndLabel);
+            il.Emit(OpCodes.Ldloc, accessorEnumeratorLocal);
+            il.Emit(OpCodes.Callvirt, _types.GetPropertyGetter(
+                _types.IEnumeratorOfString, "Current"));
+            il.Emit(OpCodes.Stloc, accessorKeyLocal);
+            il.Emit(OpCodes.Ldloc, namesLocal);
+            il.Emit(OpCodes.Ldloc, accessorKeyLocal);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(
+                _types.ListOfObject, "Contains", _types.Object));
+            il.Emit(OpCodes.Brtrue, accessorLoopLabel);
+            il.Emit(OpCodes.Ldloc, namesLocal);
+            il.Emit(OpCodes.Ldloc, accessorKeyLocal);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(
+                _types.ListOfObject, "Add", _types.Object));
+            il.Emit(OpCodes.Br, accessorLoopLabel);
+
+            il.MarkLabel(accessorLoopEndLabel);
+            il.MarkLabel(doneLabel);
+        }
+
+        EmitLiteralAccessorNames(runtime.TSObjectGetGettersDict);
+        EmitLiteralAccessorNames(runtime.TSObjectGetSettersDict);
 
         // Append PDS extras (accessor-only own props + non-enumerable own
         // props installed via Object.defineProperty). Mirrors the dict path

--- a/src/SharpTS/Compilation/RuntimeEmitter.Functions.NewOp.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Functions.NewOp.cs
@@ -28,12 +28,7 @@ public partial class RuntimeEmitter
         // runtime.CurrentFunctionThisField below.
         var currentThisField = runtime.CurrentFunctionThisField;
 
-        var method = typeBuilder.DefineMethod(
-            "NewOnFunction",
-            MethodAttributes.Public | MethodAttributes.Static,
-            _types.Object,
-            [_types.Object, _types.ObjectArray]);
-        runtime.NewOnFunction = method;
+        var method = runtime.NewOnFunction;
 
         var il = method.GetILGenerator();
 
@@ -41,6 +36,45 @@ public partial class RuntimeEmitter
         var resultLocal = il.DeclareLocal(_types.Object);
         var prevThisLocal = il.DeclareLocal(_types.Object);
         var notCallableLocal = il.DeclareLocal(_types.Boolean);
+
+        var proxyLabel = il.DefineLabel();
+        var notProxyLabel = il.DefineLabel();
+        EmitProxyTypeCheck(
+            il, () => il.Emit(OpCodes.Ldarg_0), proxyLabel, notProxyLabel);
+        il.MarkLabel(proxyLabel);
+        EmitProxyMethodCallUnwrapped(
+            il, runtime, () => il.Emit(OpCodes.Ldarg_0),
+            "TrapConstructCompiled", () =>
+            {
+                il.Emit(OpCodes.Ldc_I4_4);
+                il.Emit(OpCodes.Newarr, _types.Object);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Stelem_Ref);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_1);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Stelem_Ref);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_2);
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Ldftn, runtime.NewOnFunction);
+                il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                    typeof(Func<object, object?[], object?>),
+                    _types.Object, _types.IntPtr)!);
+                il.Emit(OpCodes.Stelem_Ref);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_3);
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Ldftn, runtime.GetProperty);
+                il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                    typeof(Func<object, string, object?>),
+                    _types.Object, _types.IntPtr)!);
+                il.Emit(OpCodes.Stelem_Ref);
+            });
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notProxyLabel);
 
         // ECMA-262 §7.3.14 Construct: throw TypeError if callee is a $TSFunction
         // wrapping a built-in helper (declaring type == $Runtime). Catches

--- a/src/SharpTS/Compilation/RuntimeEmitter.Functions.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Functions.cs
@@ -340,7 +340,12 @@ public partial class RuntimeEmitter
     /// After dispatch, each branch emits <c>Ret</c>, so the caller is responsible for
     /// a fall-through path (e.g. <c>ldnull; ret</c>).
     /// </summary>
-    private void EmitDispatchToTarget(ILGenerator il, EmittedRuntime runtime, FieldBuilder targetField, LocalBuilder argsLocal)
+    private void EmitDispatchToTarget(
+        ILGenerator il,
+        EmittedRuntime runtime,
+        FieldBuilder targetField,
+        LocalBuilder argsLocal,
+        LocalBuilder? thisArgLocal = null)
     {
         // $TSFunction → target.Invoke(args)
         var notTSFunctionLabel = il.DefineLabel();
@@ -432,6 +437,75 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, runtime.BoundAnyFunctionInvoke);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notBAFLabel);
+
+        if (thisArgLocal != null)
+            EmitProxyInvokeWithThisFallback(
+                il, targetField, thisArgLocal, argsLocal);
+    }
+
+    private void EmitProxyInvokeWithThisFallback(
+        ILGenerator il,
+        FieldBuilder targetField,
+        LocalBuilder thisArgLocal,
+        LocalBuilder argsLocal)
+    {
+        var proxyLabel = il.DefineLabel();
+        var notProxyLabel = il.DefineLabel();
+        EmitProxyTypeCheck(
+            il,
+            () =>
+            {
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldfld, targetField);
+            },
+            proxyLabel,
+            notProxyLabel);
+
+        il.MarkLabel(proxyLabel);
+        var methodLocal = il.DeclareLocal(_types.MethodInfo);
+        var resultLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, targetField);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
+        il.Emit(OpCodes.Ldstr, "InvokeWithThis");
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.Type, "GetMethod", _types.String));
+        il.Emit(OpCodes.Stloc, methodLocal);
+
+        il.BeginExceptionBlock();
+        il.Emit(OpCodes.Ldloc, methodLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, targetField);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldloc, thisArgLocal);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldloc, argsLocal);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.MethodBase, "Invoke", _types.Object, _types.ObjectArray));
+        il.Emit(OpCodes.Stloc, resultLocal);
+        il.BeginCatchBlock(_types.TargetInvocationException);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(
+            _types.Exception, "InnerException").GetGetMethod()!);
+        var innerLocal = il.DeclareLocal(_types.Exception);
+        il.Emit(OpCodes.Stloc, innerLocal);
+        var rethrowOriginal = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, innerLocal);
+        il.Emit(OpCodes.Brfalse, rethrowOriginal);
+        il.Emit(OpCodes.Ldloc, innerLocal);
+        il.Emit(OpCodes.Throw);
+        il.MarkLabel(rethrowOriginal);
+        il.Emit(OpCodes.Rethrow);
+        il.EndExceptionBlock();
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(notProxyLabel);
     }
 
     /// <summary>
@@ -1186,8 +1260,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.BoundTSFunctionType);
         il.Emit(OpCodes.Brtrue, isBoundTSFunctionLabel);
 
-        // Non-TSFunction callables: dispatch via the shared helper (ignores thisArg).
-        EmitDispatchToTarget(il, runtime, targetField, callArgsLocal);
+        // Non-TSFunction callables, including proxies, retain thisArg.
+        EmitDispatchToTarget(
+            il, runtime, targetField, callArgsLocal, thisArgLocal);
 
         // Fall-through: unknown target type → return null
         il.Emit(OpCodes.Ldnull);
@@ -1398,8 +1473,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.BoundTSFunctionType);
         il.Emit(OpCodes.Brtrue, isBoundTSFunctionLabel);
 
-        // Non-TSFunction callables: dispatch via the shared helper (ignores thisArg).
-        EmitDispatchToTarget(il, runtime, targetField, callArgsLocal);
+        // Non-TSFunction callables, including proxies, retain thisArg.
+        EmitDispatchToTarget(
+            il, runtime, targetField, callArgsLocal, thisArgLocal);
 
         // Fall-through: unknown target type → return null
         il.Emit(OpCodes.Ldnull);

--- a/src/SharpTS/Compilation/RuntimeEmitter.HasOwnProperty.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.HasOwnProperty.cs
@@ -53,6 +53,38 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brfalse, falseLabel);
 
+        // Proxy hasOwnProperty is specified in terms of [[GetOwnProperty]],
+        // so it must dispatch the getOwnPropertyDescriptor trap and validate
+        // its result rather than inspecting the proxy wrapper itself.
+        var proxyLabel = il.DefineLabel();
+        var notProxyLabel = il.DefineLabel();
+        EmitProxyTypeCheck(
+            il, () => il.Emit(OpCodes.Ldarg_0), proxyLabel, notProxyLabel);
+        il.MarkLabel(proxyLabel);
+        EmitProxyGetOwnPropertyDescriptorCompiledCall(
+            il, runtime, () => il.Emit(OpCodes.Ldarg_0),
+            () => il.Emit(OpCodes.Ldarg_1));
+        var proxyDescriptorLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Stloc, proxyDescriptorLocal);
+        il.Emit(OpCodes.Ldloc, proxyDescriptorLocal);
+        il.Emit(OpCodes.Brfalse, falseLabel);
+        // Ordinary callbacks return the emitted runtime's $Undefined, while
+        // the SharpTS.dll-side invariant code may return SharpTSUndefined.
+        // Both represent an absent descriptor.
+        il.Emit(OpCodes.Ldloc, proxyDescriptorLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, falseLabel);
+        il.Emit(OpCodes.Ldloc, proxyDescriptorLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(
+            _types.Type, "Name").GetGetMethod()!);
+        il.Emit(OpCodes.Ldstr, "SharpTSUndefined");
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.String, "op_Equality", _types.String, _types.String));
+        il.Emit(OpCodes.Brtrue, falseLabel);
+        il.Emit(OpCodes.Br, trueLabel);
+        il.MarkLabel(notProxyLabel);
+
         // ECMA-262 §20.1.3.2 step 1: Let P be ? ToPropertyKey(V). For Symbol,
         // ToPropertyKey returns the symbol itself — NOT a string. Symbol keys
         // are stored in the per-object symbol dict (GetSymbolDict), so resolve
@@ -121,6 +153,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, functionOwnPropertyCheck);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.PromiseResolveCallbackType);
+        il.Emit(OpCodes.Brtrue, functionOwnPropertyCheck);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.FuncObjectArrayToObject);
         il.Emit(OpCodes.Brtrue, functionOwnPropertyCheck);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.PromiseRejectCallbackType);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.DeleteProperty.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.DeleteProperty.cs
@@ -143,7 +143,23 @@ public partial class RuntimeEmitter
 
         // Proxy check: uses obj.GetType().FullName comparison (no SharpTS.dll dependency)
         var notProxyLabel = il.DefineLabel();
-        EmitProxyDeleteCheck(il, () => il.Emit(OpCodes.Ldarg_0), () => il.Emit(OpCodes.Ldarg_1), notProxyLabel);
+        EmitProxyDeleteCheck(
+            il, runtime,
+            () => il.Emit(OpCodes.Ldarg_0),
+            () => il.Emit(OpCodes.Ldarg_1),
+            notProxyLabel);
+        if (strict)
+        {
+            // The proxy [[Delete]] boolean is subject to the surrounding
+            // delete expression's strictness. A false result becomes the
+            // required TypeError in strict code rather than escaping as false.
+            il.Emit(OpCodes.Brtrue, trueLabel);
+            EmitDeleteFail("' of proxy");
+        }
+        else
+        {
+            il.Emit(OpCodes.Ret);
+        }
 
         il.MarkLabel(notProxyLabel);
 
@@ -204,6 +220,30 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, trueLabel);
         il.MarkLabel(notGlobalObjectLabel);
 
+        // Consult the complete own descriptor before carrier-specific removal.
+        // Intrinsic properties such as array/string length, string indices,
+        // RegExp.lastIndex, and function prototype are synthesized by
+        // ObjectGetOwnPropertyDescriptor rather than necessarily living in PDS.
+        // Their non-configurable bit must still make [[Delete]] fail.
+        var ordinaryDeleteDescriptorLocal = il.DeclareLocal(_types.Object);
+        var ordinaryDeleteDescriptorAllowedLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.ObjectGetOwnPropertyDescriptor);
+        il.Emit(OpCodes.Stloc, ordinaryDeleteDescriptorLocal);
+        il.Emit(OpCodes.Ldloc, ordinaryDeleteDescriptorLocal);
+        il.Emit(OpCodes.Brfalse, ordinaryDeleteDescriptorAllowedLabel);
+        il.Emit(OpCodes.Ldloc, ordinaryDeleteDescriptorLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, ordinaryDeleteDescriptorAllowedLabel);
+        il.Emit(OpCodes.Ldloc, ordinaryDeleteDescriptorLocal);
+        il.Emit(OpCodes.Ldstr, "configurable");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Call, runtime.IsTruthy);
+        il.Emit(OpCodes.Brtrue, ordinaryDeleteDescriptorAllowedLabel);
+        EmitDeleteFail("' of object");
+        il.MarkLabel(ordinaryDeleteDescriptorAllowedLabel);
+
         // Check if $TSObject
         var sharpTSObjectLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
@@ -217,6 +257,9 @@ public partial class RuntimeEmitter
         var tsFunctionDelLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.TSFunctionType);
+        il.Emit(OpCodes.Brtrue, tsFunctionDelLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.FuncObjectArrayToObject);
         il.Emit(OpCodes.Brtrue, tsFunctionDelLabel);
 
         // $Array — `delete arr[i]` turns the slot into a hole. Must come
@@ -531,6 +574,28 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Call, _types.GetMethod(_types.Int64, "TryParse", _types.String, _types.Int64.MakeByRefType()));
             var tsArrDelNonNumericLabel = il.DefineLabel();
             il.Emit(OpCodes.Brfalse, tsArrDelNonNumericLabel);
+
+            // A write routed through Proxy/Reflect can install attributes for
+            // an indexed element in PDS. Delete both representations so a
+            // later [[GetOwnProperty]] cannot resurrect the removed index.
+            var tsArrIndexDescLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
+            var tsArrIndexDescriptorConfigurableLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
+            il.Emit(OpCodes.Stloc, tsArrIndexDescLocal);
+            il.Emit(OpCodes.Ldloc, tsArrIndexDescLocal);
+            il.Emit(OpCodes.Brfalse, tsArrIndexDescriptorConfigurableLabel);
+            il.Emit(OpCodes.Ldloc, tsArrIndexDescLocal);
+            il.Emit(OpCodes.Callvirt,
+                runtime.CompiledPropertyDescriptorConfigurable.GetGetMethod()!);
+            il.Emit(OpCodes.Brtrue, tsArrIndexDescriptorConfigurableLabel);
+            EmitDeleteFail("' of array");
+            il.MarkLabel(tsArrIndexDescriptorConfigurableLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, runtime.PDSDeleteProperty);
+            il.Emit(OpCodes.Pop);
 
             // arr.DeleteAt(idx); return true;
             il.Emit(OpCodes.Ldarg_0);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.cs
@@ -153,9 +153,11 @@ public partial class RuntimeEmitter
             proxyForDefineLabel,
             notProxyForDefineLabel);
         il.MarkLabel(proxyForDefineLabel);
-        EmitProxyMethodCall(il, () => il.Emit(OpCodes.Ldarg_0), "TrapDefinePropertyCompiled", () =>
+        EmitProxyMethodCallUnwrapped(
+            il, runtime, () => il.Emit(OpCodes.Ldarg_0),
+            "TrapDefinePropertyCompiled", () =>
         {
-            il.Emit(OpCodes.Ldc_I4_3);
+            il.Emit(OpCodes.Ldc_I4_7);
             il.Emit(OpCodes.Newarr, _types.Object);
             il.Emit(OpCodes.Dup);
             il.Emit(OpCodes.Ldc_I4_0);
@@ -173,6 +175,25 @@ public partial class RuntimeEmitter
                 typeof(Func<object, object, object, object?>),
                 _types.Object, _types.IntPtr)!);
             il.Emit(OpCodes.Stelem_Ref);
+            EmitDelegateArgument(3, runtime.ObjectGetOwnPropertyDescriptor,
+                typeof(Func<object, object, object?>));
+            EmitDelegateArgument(4, runtime.ObjectIsExtensible,
+                typeof(Func<object, bool>));
+            EmitDelegateArgument(5, runtime.GetProperty,
+                typeof(Func<object, string, object?>));
+            EmitDelegateArgument(6, runtime.HasOwnPropertyHelperMethod,
+                typeof(Func<object, string, bool>));
+
+            void EmitDelegateArgument(int slot, MethodInfo target, Type delegateType)
+            {
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4, slot);
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Ldftn, target);
+                il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                    delegateType, _types.Object, _types.IntPtr)!);
+                il.Emit(OpCodes.Stelem_Ref);
+            }
         });
         il.Emit(OpCodes.Unbox_Any, _types.Boolean);
         var proxyDefineSucceededLabel = il.DefineLabel();
@@ -763,6 +784,79 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, skipSynthExistingLabel);
         il.MarkLabel(notIntrinsicArrayLengthLabel);
 
+        // User constructor functions also have an intrinsic descriptor that
+        // is not initially stored in PDS: { writable:true, enumerable:false,
+        // configurable:false }. Preserve those attributes when OrdinarySet
+        // reaches DefineOwnProperty through a Proxy receiver.
+        var notIntrinsicFunctionPrototypeLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSFunctionType);
+        il.Emit(OpCodes.Brfalse, notIntrinsicFunctionPrototypeLabel);
+        il.Emit(OpCodes.Ldloc, propNameLocal);
+        il.Emit(OpCodes.Ldstr, "prototype");
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.String, "op_Equality", _types.String, _types.String));
+        il.Emit(OpCodes.Brfalse, notIntrinsicFunctionPrototypeLabel);
+        var intrinsicFunctionPrototypeValueLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "prototype");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Stloc, intrinsicFunctionPrototypeValueLocal);
+        il.Emit(OpCodes.Ldloc, intrinsicFunctionPrototypeValueLocal);
+        il.Emit(OpCodes.Brfalse, notIntrinsicFunctionPrototypeLabel);
+        il.Emit(OpCodes.Ldloc, intrinsicFunctionPrototypeValueLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, notIntrinsicFunctionPrototypeLabel);
+        il.Emit(OpCodes.Newobj, runtime.CompiledPropertyDescriptorCtor);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldloc, intrinsicFunctionPrototypeValueLocal);
+        il.Emit(OpCodes.Callvirt,
+            runtime.CompiledPropertyDescriptorValue.GetSetMethod()!);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Callvirt,
+            runtime.CompiledPropertyDescriptorEnumerable.GetSetMethod()!);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Callvirt,
+            runtime.CompiledPropertyDescriptorConfigurable.GetSetMethod()!);
+        il.Emit(OpCodes.Stloc, existingDescLocal);
+        il.Emit(OpCodes.Br, skipSynthExistingLabel);
+        il.MarkLabel(notIntrinsicFunctionPrototypeLabel);
+
+        // RegExp instances likewise expose intrinsic lastIndex outside PDS.
+        // Its descriptor is writable but non-enumerable/non-configurable.
+        if (_features.UsesRegExp)
+        {
+            var notIntrinsicRegExpLastIndexLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.TSRegExpType);
+            il.Emit(OpCodes.Brfalse, notIntrinsicRegExpLastIndexLabel);
+            il.Emit(OpCodes.Ldloc, propNameLocal);
+            il.Emit(OpCodes.Ldstr, "lastIndex");
+            il.Emit(OpCodes.Call, _types.GetMethod(
+                _types.String, "op_Equality", _types.String, _types.String));
+            il.Emit(OpCodes.Brfalse, notIntrinsicRegExpLastIndexLabel);
+            il.Emit(OpCodes.Newobj, runtime.CompiledPropertyDescriptorCtor);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldstr, "lastIndex");
+            il.Emit(OpCodes.Call, runtime.GetProperty);
+            il.Emit(OpCodes.Callvirt,
+                runtime.CompiledPropertyDescriptorValue.GetSetMethod()!);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Callvirt,
+                runtime.CompiledPropertyDescriptorEnumerable.GetSetMethod()!);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Callvirt,
+                runtime.CompiledPropertyDescriptorConfigurable.GetSetMethod()!);
+            il.Emit(OpCodes.Stloc, existingDescLocal);
+            il.Emit(OpCodes.Br, skipSynthExistingLabel);
+            il.MarkLabel(notIntrinsicRegExpLastIndexLabel);
+        }
+
         var receiverIsSynthableLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
@@ -1304,8 +1398,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Castclass, runtime.TSObjectType);
         il.Emit(OpCodes.Callvirt, runtime.TSObjectFieldsGetter);
         il.Emit(OpCodes.Ldloc, propNameLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "Remove", _types.String));
-        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.DictionaryStringObject, "set_Item"));
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(accessorCleanupNotTSObject);
@@ -1855,6 +1950,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.PromiseResolveCallbackType);
         il.Emit(OpCodes.Brtrue, functionDescriptorCheckLabel);
         il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.FuncObjectArrayToObject);
+        il.Emit(OpCodes.Brtrue, functionDescriptorCheckLabel);
+        il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.PromiseRejectCallbackType);
         il.Emit(OpCodes.Brfalse, notTSFunctionForDescLabel);
         il.MarkLabel(functionDescriptorCheckLabel);
@@ -1911,6 +2009,39 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, resultDictLocal);
         il.Emit(OpCodes.Br, endLabel);
         il.MarkLabel(notFnLengthLabel);
+
+        // Constructor functions have an own non-configurable `prototype`
+        // property. GetProperty supplies the stable cached prototype object
+        // for user functions and $Undefined for non-constructable built-ins.
+        var notFnPrototypeLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, propNameLocal);
+        il.Emit(OpCodes.Ldstr, "prototype");
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.String, "op_Equality", _types.String, _types.String));
+        il.Emit(OpCodes.Brfalse, notFnPrototypeLabel);
+        var functionPrototypeValueLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "prototype");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Stloc, functionPrototypeValueLocal);
+        il.Emit(OpCodes.Ldloc, functionPrototypeValueLocal);
+        il.Emit(OpCodes.Brfalse, returnNullLabel);
+        il.Emit(OpCodes.Ldloc, functionPrototypeValueLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, returnNullLabel);
+        il.Emit(OpCodes.Newobj, _types.DictionaryStringObjectCtor);
+        il.Emit(OpCodes.Stloc, resultDictLocal);
+        il.Emit(OpCodes.Ldloc, resultDictLocal);
+        il.Emit(OpCodes.Ldstr, "value");
+        il.Emit(OpCodes.Ldloc, functionPrototypeValueLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.DictionaryStringObject, "set_Item"));
+        EmitDescriptorBoolField(il, resultDictLocal, "writable", true);
+        EmitDescriptorBoolField(il, resultDictLocal, "enumerable", false);
+        EmitDescriptorBoolField(il, resultDictLocal, "configurable", false);
+        il.Emit(OpCodes.Ldloc, resultDictLocal);
+        il.Emit(OpCodes.Br, endLabel);
+        il.MarkLabel(notFnPrototypeLabel);
 
         // Other keys on a function: not own → null.
         il.Emit(OpCodes.Br, returnNullLabel);
@@ -2691,6 +2822,104 @@ public partial class RuntimeEmitter
 
         // Not a dictionary - check if it implements $IHasFields (class instances)
         il.MarkLabel(notDictLabel);
+
+        // Object-literal accessors live in $Object's getter/setter tables
+        // rather than PDS. Surface them as ordinary own accessor descriptors
+        // so Proxy [[Get]]/[[Set]] can preserve an explicit Receiver.
+        var notTSObjectAccessorLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSObjectType);
+        il.Emit(OpCodes.Brfalse, notTSObjectAccessorLabel);
+        var literalGetterLocal = il.DeclareLocal(_types.Object);
+        var literalSetterLocal = il.DeclareLocal(_types.Object);
+        var literalGetterDictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var literalSetterDictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var checkLiteralSetterLabel = il.DefineLabel();
+        var literalAccessorFoundLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSObjectType);
+        il.Emit(OpCodes.Callvirt, runtime.TSObjectGetGettersDict);
+        il.Emit(OpCodes.Stloc, literalGetterDictLocal);
+        il.Emit(OpCodes.Ldloc, literalGetterDictLocal);
+        il.Emit(OpCodes.Brfalse, checkLiteralSetterLabel);
+        il.Emit(OpCodes.Ldloc, literalGetterDictLocal);
+        il.Emit(OpCodes.Ldloc, propNameLocal);
+        il.Emit(OpCodes.Ldloca, literalGetterLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.DictionaryStringObject, "TryGetValue",
+            _types.String, _types.Object.MakeByRefType()));
+        il.Emit(OpCodes.Brtrue, literalAccessorFoundLabel);
+        il.MarkLabel(checkLiteralSetterLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSObjectType);
+        il.Emit(OpCodes.Callvirt, runtime.TSObjectGetSettersDict);
+        il.Emit(OpCodes.Stloc, literalSetterDictLocal);
+        il.Emit(OpCodes.Ldloc, literalSetterDictLocal);
+        il.Emit(OpCodes.Brfalse, notTSObjectAccessorLabel);
+        il.Emit(OpCodes.Ldloc, literalSetterDictLocal);
+        il.Emit(OpCodes.Ldloc, propNameLocal);
+        il.Emit(OpCodes.Ldloca, literalSetterLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.DictionaryStringObject, "TryGetValue",
+            _types.String, _types.Object.MakeByRefType()));
+        il.Emit(OpCodes.Brfalse, notTSObjectAccessorLabel);
+
+        il.MarkLabel(literalAccessorFoundLabel);
+        // Fetch the other half when the getter-side lookup found the key.
+        var literalOtherHalfDoneLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, literalSetterLocal);
+        il.Emit(OpCodes.Brtrue, literalOtherHalfDoneLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSObjectType);
+        il.Emit(OpCodes.Callvirt, runtime.TSObjectGetSettersDict);
+        il.Emit(OpCodes.Stloc, literalSetterDictLocal);
+        il.Emit(OpCodes.Ldloc, literalSetterDictLocal);
+        il.Emit(OpCodes.Brfalse, literalOtherHalfDoneLabel);
+        il.Emit(OpCodes.Ldloc, literalSetterDictLocal);
+        il.Emit(OpCodes.Ldloc, propNameLocal);
+        il.Emit(OpCodes.Ldloca, literalSetterLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.DictionaryStringObject, "TryGetValue",
+            _types.String, _types.Object.MakeByRefType()));
+        il.Emit(OpCodes.Pop);
+        il.MarkLabel(literalOtherHalfDoneLabel);
+
+        il.Emit(OpCodes.Newobj, _types.DictionaryStringObjectCtor);
+        il.Emit(OpCodes.Stloc, resultDictLocal);
+        void EmitLiteralAccessorSlot(string name, LocalBuilder slot)
+        {
+            var haveSlotLabel = il.DefineLabel();
+            var storeSlotLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, slot);
+            il.Emit(OpCodes.Brtrue, haveSlotLabel);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            il.Emit(OpCodes.Br, storeSlotLabel);
+            il.MarkLabel(haveSlotLabel);
+            il.Emit(OpCodes.Ldloc, slot);
+            il.MarkLabel(storeSlotLabel);
+            il.Emit(OpCodes.Stloc, valueLocal);
+            il.Emit(OpCodes.Ldloc, resultDictLocal);
+            il.Emit(OpCodes.Ldstr, name);
+            il.Emit(OpCodes.Ldloc, valueLocal);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(
+                _types.DictionaryStringObject, "set_Item"));
+        }
+        EmitLiteralAccessorSlot("get", literalGetterLocal);
+        EmitLiteralAccessorSlot("set", literalSetterLocal);
+        EmitDescriptorBoolField(il, resultDictLocal, "enumerable", true);
+        il.Emit(OpCodes.Ldloc, resultDictLocal);
+        il.Emit(OpCodes.Ldstr, "configurable");
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.PDSIsSealed);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ceq);
+        il.Emit(OpCodes.Box, _types.Boolean);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.DictionaryStringObject, "set_Item"));
+        il.Emit(OpCodes.Ldloc, resultDictLocal);
+        il.Emit(OpCodes.Br, endLabel);
+
+        il.MarkLabel(notTSObjectAccessorLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.IHasFieldsInterface);
         il.Emit(OpCodes.Brfalse, returnNullLabel);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.GetPropertyBranches.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.GetPropertyBranches.cs
@@ -1322,10 +1322,12 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, protoLocal);
         il.Emit(OpCodes.Brfalse, returnUndefinedLabel);
 
-        // Recursively call GetProperty(prototype, name) to check prototype chain
+        // Continue ordinary [[Get]] with the original dictionary as Receiver.
+        // This is observable when the prototype is a Proxy or accessor.
         il.Emit(OpCodes.Ldloc, protoLocal);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, method);  // Recursive call to GetProperty
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.ReflectGet);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(returnUndefinedLabel);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Index.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Index.cs
@@ -1049,16 +1049,60 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brfalse, nullLabel);
 
-        // Proxy check: uses obj.GetType().FullName comparison (no SharpTS.dll dependency)
-        var notProxyLabel = il.DefineLabel();
-        EmitProxySetIndexCheck(il, () => il.Emit(OpCodes.Ldarg_0), () => il.Emit(OpCodes.Ldarg_1), () => il.Emit(OpCodes.Ldarg_2), notProxyLabel);
-
-        il.MarkLabel(notProxyLabel);
+        if (_features.UsesProxy)
+        {
+            var notProxyLabel = il.DefineLabel();
+            EmitProxySetIndexCheck(
+                il, runtime,
+                () => il.Emit(OpCodes.Ldarg_0),
+                () => il.Emit(OpCodes.Ldarg_1),
+                () => il.Emit(OpCodes.Ldarg_2),
+                notProxyLabel);
+            il.MarkLabel(notProxyLabel);
+        }
 
         // Check if index is a symbol first (symbols work on any object type)
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Call, runtime.IsSymbolMethod);
         il.Emit(OpCodes.Brtrue, symbolKeyLabel);
+
+        // A missing indexed own property may resolve to an inherited Proxy.
+        // OrdinarySet must invoke that proxy's [[Set]] with the original
+        // receiver before any carrier-specific direct store below.
+        var noInheritedProxyLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.HasOwnPropertyHelperMethod);
+        il.Emit(OpCodes.Brtrue, noInheritedProxyLabel);
+        var indexPrototypeLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.ObjectGetPrototypeOf);
+        il.Emit(OpCodes.Stloc, indexPrototypeLocal);
+        il.Emit(OpCodes.Ldloc, indexPrototypeLocal);
+        il.Emit(OpCodes.Brfalse, noInheritedProxyLabel);
+        if (_features.UsesProxy)
+        {
+            var inheritedProxyLabel = il.DefineLabel();
+            var inheritedNotProxyLabel = il.DefineLabel();
+            EmitProxyTypeCheck(
+                il, () => il.Emit(OpCodes.Ldloc, indexPrototypeLocal),
+                inheritedProxyLabel, inheritedNotProxyLabel);
+            il.MarkLabel(inheritedProxyLabel);
+            EmitProxySetCompiledCall(
+                il, runtime,
+                () => il.Emit(OpCodes.Ldloc, indexPrototypeLocal),
+                () =>
+                {
+                    il.Emit(OpCodes.Ldarg_1);
+                    il.Emit(OpCodes.Call, runtime.ToJsString);
+                },
+                () => il.Emit(OpCodes.Ldarg_2),
+                () => il.Emit(OpCodes.Ldarg_0));
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(inheritedNotProxyLabel);
+        }
+        il.MarkLabel(noInheritedProxyLabel);
 
         // globalThis/global sentinel (#271): `root[stringKey] = v` stores into the
         // shared global-properties dictionary. Symbol keys fall through to the

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Invocation.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Invocation.cs
@@ -252,7 +252,12 @@ public partial class RuntimeEmitter
 
         // Proxy check: uses obj.GetType().FullName comparison (no SharpTS.dll dependency)
         var notProxyLabel = il.DefineLabel();
-        EmitProxyInvokeCheck(il, () => il.Emit(OpCodes.Ldarg_0), () => il.Emit(OpCodes.Ldarg_1), notProxyLabel);
+        EmitProxyInvokeCheck(
+            il, runtime,
+            () => il.Emit(OpCodes.Ldarg_0),
+            () => il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance),
+            () => il.Emit(OpCodes.Ldarg_1),
+            notProxyLabel);
 
         // ECMA-262 §7.3.13: invoking a non-callable throws TypeError. This was
         // a silent `return null` for years, which masked dispatch regressions
@@ -537,13 +542,7 @@ public partial class RuntimeEmitter
 
     private void EmitInvokeMethodValue(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        var method = typeBuilder.DefineMethod(
-            "InvokeMethodValue",
-            MethodAttributes.Public | MethodAttributes.Static,
-            _types.Object,
-            [_types.Object, _types.Object, _types.ObjectArray]  // receiver, function, args
-        );
-        runtime.InvokeMethodValue = method;
+        var method = runtime.InvokeMethodValue;
 
         var il = method.GetILGenerator();
         EmitStackGuard(il, runtime);
@@ -843,14 +842,14 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(notTypeCalleeLabel);
 
-        // Proxy apply trap check: if function is a proxy, call TrapApply
-        // TrapApply expects List<object?> so convert the object[] args
+        // Proxy apply trap check, preserving the method-call receiver.
         var notProxyLabel2 = il.DefineLabel();
-        EmitProxyInvokeCheck(il, () => il.Emit(OpCodes.Ldarg_1), () =>
-        {
-            il.Emit(OpCodes.Ldarg_2); // object[] args
-            il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, [typeof(IEnumerable<object>)])!);
-        }, notProxyLabel2);
+        EmitProxyInvokeCheck(
+            il, runtime,
+            () => il.Emit(OpCodes.Ldarg_1),
+            () => il.Emit(OpCodes.Ldarg_0),
+            () => il.Emit(OpCodes.Ldarg_2),
+            notProxyLabel2);
 
         il.MarkLabel(notProxyLabel2);
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -213,6 +213,7 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         var nullLabel = il.DefineLabel();
         var tryMethodLabel = il.DefineLabel();
+        var errorPrototypeLookupLabel = il.DefineLabel();
 
         // Declare locals upfront
         var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
@@ -390,6 +391,22 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(notDictLabel);
 
+        // A plain $Object has no generated typed members beyond its dynamic
+        // fields/accessor tables. Once those miss, continue through the shared
+        // receiver-aware prototype walk. Emitted subclasses still use their
+        // $IHasFields dispatch below.
+        var notPlainTSObjectLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSObjectType);
+        il.Emit(OpCodes.Brfalse, notPlainTSObjectLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
+        il.Emit(OpCodes.Ldtoken, runtime.TSObjectType);
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+        il.Emit(OpCodes.Beq, errorPrototypeLookupLabel);
+        il.MarkLabel(notPlainTSObjectLabel);
+
         // Check $IHasFields interface (covers user-defined classes and $Object subclasses with typed properties)
         var notHasFieldsLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
@@ -409,7 +426,6 @@ public partial class RuntimeEmitter
         // must continue directly on the JavaScript prototype chain: exposing
         // CLR methods here (notably $Error.ToString) would shadow mutable
         // Error.prototype properties.
-        var errorPrototypeLookupLabel = il.DefineLabel();
         var notErrorLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.TSErrorType);
@@ -737,7 +753,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Beq, noPrototypeLabel);
         il.Emit(OpCodes.Ldloc, prototypeLocal);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.ReflectGet);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(noPrototypeLabel);
@@ -1177,6 +1194,38 @@ public partial class RuntimeEmitter
             EmitStatsGetBranch(il, runtime, notStatsLabel);
             il.MarkLabel(notStatsLabel);
         }
+
+        // Host delegates are used for a handful of anonymous built-in
+        // functions (notably Proxy revocation functions).  Their CLR Invoke
+        // signature is an implementation detail: ECMAScript exposes an empty
+        // name and zero length, while call/apply/bind still use the ordinary
+        // callable wrappers.
+        var notAnonymousDelegateLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.FuncObjectArrayToObject);
+        il.Emit(OpCodes.Brfalse, notAnonymousDelegateLabel);
+        var anonymousDelegateNotLengthLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldstr, "length");
+        il.Emit(OpCodes.Call, _types.StringOpEquality);
+        il.Emit(OpCodes.Brfalse, anonymousDelegateNotLengthLabel);
+        il.Emit(OpCodes.Ldc_R8, 0.0);
+        il.Emit(OpCodes.Box, _types.Double);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(anonymousDelegateNotLengthLabel);
+        var anonymousDelegateNotNameLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldstr, "name");
+        il.Emit(OpCodes.Call, _types.StringOpEquality);
+        il.Emit(OpCodes.Brfalse, anonymousDelegateNotNameLabel);
+        il.Emit(OpCodes.Ldstr, string.Empty);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(anonymousDelegateNotNameLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.GetFunctionMethod);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notAnonymousDelegateLabel);
 
         // $TSFunction - check for bind/call/apply
         var notTSFunctionLabel = il.DefineLabel();

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Prototype.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Prototype.cs
@@ -176,10 +176,10 @@ public partial class RuntimeEmitter
             il, () => il.Emit(OpCodes.Ldarg_0),
             proxyForPreventExtensionsLabel, notProxyForPreventExtensionsLabel);
         il.MarkLabel(proxyForPreventExtensionsLabel);
-        EmitProxyMethodCall(il, () => il.Emit(OpCodes.Ldarg_0),
+        EmitProxyMethodCallUnwrapped(il, runtime, () => il.Emit(OpCodes.Ldarg_0),
             "TrapPreventExtensionsCompiled", () =>
             {
-                il.Emit(OpCodes.Ldc_I4_2);
+                il.Emit(OpCodes.Ldc_I4_3);
                 il.Emit(OpCodes.Newarr, _types.Object);
                 il.Emit(OpCodes.Dup);
                 il.Emit(OpCodes.Ldc_I4_0);
@@ -194,6 +194,13 @@ public partial class RuntimeEmitter
                 il.Emit(OpCodes.Ldftn, runtime.ObjectIsExtensible);
                 il.Emit(OpCodes.Newobj, _types.GetConstructor(
                     typeof(Func<object, bool>), _types.Object, _types.IntPtr));
+                il.Emit(OpCodes.Stelem_Ref);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_2);
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Ldftn, runtime.GetProperty);
+                il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                    typeof(Func<object, string, object?>), _types.Object, _types.IntPtr));
                 il.Emit(OpCodes.Stelem_Ref);
             });
         il.Emit(OpCodes.Unbox_Any, _types.Boolean);
@@ -275,13 +282,7 @@ public partial class RuntimeEmitter
     private void EmitObjectIsExtensible(TypeBuilder typeBuilder, EmittedRuntime runtime,
         FieldBuilder nonExtensibleObjectsField, FieldBuilder frozenObjectsField, FieldBuilder sealedObjectsField)
     {
-        var method = typeBuilder.DefineMethod(
-            "ObjectIsExtensible",
-            MethodAttributes.Public | MethodAttributes.Static,
-            _types.Boolean,
-            [_types.Object]
-        );
-        runtime.ObjectIsExtensible = method;
+        var method = runtime.ObjectIsExtensible;
 
         var il = method.GetILGenerator();
         var returnFalseLabel = il.DefineLabel();
@@ -317,6 +318,36 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, _types.Boolean);
         il.Emit(OpCodes.Brtrue, returnFalseLabel);
+
+        var proxyLabel = il.DefineLabel();
+        var notProxyLabel = il.DefineLabel();
+        EmitProxyTypeCheck(
+            il, () => il.Emit(OpCodes.Ldarg_0), proxyLabel, notProxyLabel);
+        il.MarkLabel(proxyLabel);
+        EmitProxyMethodCallUnwrapped(
+            il, runtime, () => il.Emit(OpCodes.Ldarg_0),
+            "TrapIsExtensibleCompiled", () =>
+            {
+                il.Emit(OpCodes.Ldc_I4_2);
+                il.Emit(OpCodes.Newarr, _types.Object);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Ldftn, runtime.ObjectIsExtensible);
+                il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                    typeof(Func<object, bool>), _types.Object, _types.IntPtr)!);
+                il.Emit(OpCodes.Stelem_Ref);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_1);
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Ldftn, runtime.GetProperty);
+                il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                    typeof(Func<object, string, object?>), _types.Object, _types.IntPtr)!);
+                il.Emit(OpCodes.Stelem_Ref);
+            });
+        il.Emit(OpCodes.Unbox_Any, _types.Boolean);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notProxyLabel);
 
         // Check $PropertyDescriptorStore.IsExtensible(obj) - fully standalone, no reflection
         il.MarkLabel(checkPropertyStoreLabel);
@@ -505,10 +536,10 @@ public partial class RuntimeEmitter
         EmitProxyTypeCheck(
             il, () => il.Emit(OpCodes.Ldarg_0), proxyForGpoLabel, notProxyForGpoLabel);
         il.MarkLabel(proxyForGpoLabel);
-        EmitProxyMethodCall(il, () => il.Emit(OpCodes.Ldarg_0),
+        EmitProxyMethodCallUnwrapped(il, runtime, () => il.Emit(OpCodes.Ldarg_0),
             "TrapGetPrototypeOfCompiled", () =>
             {
-                il.Emit(OpCodes.Ldc_I4_2);
+                il.Emit(OpCodes.Ldc_I4_3);
                 il.Emit(OpCodes.Newarr, _types.Object);
                 il.Emit(OpCodes.Dup);
                 il.Emit(OpCodes.Ldc_I4_0);
@@ -523,6 +554,13 @@ public partial class RuntimeEmitter
                 il.Emit(OpCodes.Ldftn, runtime.ObjectIsExtensible);
                 il.Emit(OpCodes.Newobj, _types.GetConstructor(
                     typeof(Func<object, bool>), _types.Object, _types.IntPtr));
+                il.Emit(OpCodes.Stelem_Ref);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_2);
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Ldftn, runtime.GetProperty);
+                il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                    typeof(Func<object, string, object?>), _types.Object, _types.IntPtr));
                 il.Emit(OpCodes.Stelem_Ref);
             });
         il.Emit(OpCodes.Ret);
@@ -919,10 +957,10 @@ public partial class RuntimeEmitter
         EmitProxyTypeCheck(
             il, () => il.Emit(OpCodes.Ldarg_0), proxyForSpoLabel, notProxyForSpoLabel);
         il.MarkLabel(proxyForSpoLabel);
-        EmitProxyMethodCall(il, () => il.Emit(OpCodes.Ldarg_0),
+        EmitProxyMethodCallUnwrapped(il, runtime, () => il.Emit(OpCodes.Ldarg_0),
             "TrapSetPrototypeOfCompiled", () =>
             {
-                il.Emit(OpCodes.Ldc_I4_4);
+                il.Emit(OpCodes.Ldc_I4_5);
                 il.Emit(OpCodes.Newarr, _types.Object);
                 il.Emit(OpCodes.Dup);
                 il.Emit(OpCodes.Ldc_I4_0);
@@ -948,6 +986,13 @@ public partial class RuntimeEmitter
                 il.Emit(OpCodes.Ldftn, runtime.ObjectGetPrototypeOf);
                 il.Emit(OpCodes.Newobj, _types.GetConstructor(
                     typeof(Func<object, object?>), _types.Object, _types.IntPtr));
+                il.Emit(OpCodes.Stelem_Ref);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_4);
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Ldftn, runtime.GetProperty);
+                il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                    typeof(Func<object, string, object?>), _types.Object, _types.IntPtr));
                 il.Emit(OpCodes.Stelem_Ref);
             });
         il.Emit(OpCodes.Unbox_Any, _types.Boolean);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.SetProperty.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.SetProperty.cs
@@ -592,11 +592,19 @@ public partial class RuntimeEmitter
 
         EmitGlobalThisSetRedirect(il, runtime);
 
-        // Proxy check: uses obj.GetType().FullName comparison (no SharpTS.dll dependency)
-        var notProxyLabel = il.DefineLabel();
-        EmitProxySetPropertyCheck(il, () => il.Emit(OpCodes.Ldarg_0), () => il.Emit(OpCodes.Ldarg_1), () => il.Emit(OpCodes.Ldarg_2), notProxyLabel);
-
-        il.MarkLabel(notProxyLabel);
+        // Proxy dispatch is omitted entirely from assemblies that do not use
+        // Proxy. Its receiver-aware ordinary-set helper is feature-gated too.
+        if (_features.UsesProxy)
+        {
+            var notProxyLabel = il.DefineLabel();
+            EmitProxySetPropertyCheck(
+                il, runtime,
+                () => il.Emit(OpCodes.Ldarg_0),
+                () => il.Emit(OpCodes.Ldarg_1),
+                () => il.Emit(OpCodes.Ldarg_2),
+                notProxyLabel);
+            il.MarkLabel(notProxyLabel);
+        }
 
         // OrdinarySetWithOwnDescriptor consults an inherited descriptor before
         // creating a new own property. This shared check covers intrinsic CLR
@@ -614,6 +622,27 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, inheritedSetPrototypeLocal);
         il.Emit(OpCodes.Ldloc, inheritedSetPrototypeLocal);
         il.Emit(OpCodes.Brfalse, inheritedSetContinueLabel);
+        // An inherited Proxy supplies [[Set]] itself; dispatch before probing
+        // the emitted descriptor store so its trap observes the original
+        // receiver (the object on which assignment began).
+        if (_features.UsesProxy)
+        {
+            var inheritedProxyLabel = il.DefineLabel();
+            var inheritedNotProxyLabel = il.DefineLabel();
+            EmitProxyTypeCheck(
+                il, () => il.Emit(OpCodes.Ldloc, inheritedSetPrototypeLocal),
+                inheritedProxyLabel, inheritedNotProxyLabel);
+            il.MarkLabel(inheritedProxyLabel);
+            EmitProxySetCompiledCall(
+                il, runtime,
+                () => il.Emit(OpCodes.Ldloc, inheritedSetPrototypeLocal),
+                () => il.Emit(OpCodes.Ldarg_1),
+                () => il.Emit(OpCodes.Ldarg_2),
+                () => il.Emit(OpCodes.Ldarg_0));
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(inheritedNotProxyLabel);
+        }
         var inheritedSetDescriptorLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
         il.Emit(OpCodes.Ldloc, inheritedSetPrototypeLocal);
         il.Emit(OpCodes.Ldarg_1);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Operators.cs
@@ -438,13 +438,15 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, targetProtoLocal);
         il.Emit(OpCodes.Brfalse, falseLabel);
 
-        // Walk: current = PDSGetPrototype(instance); while (current != null) {
+        // Walk through [[GetPrototypeOf]] so Proxy traps participate and their
+        // non-extensible-target invariant is enforced.
+        // current = ObjectGetPrototypeOf(instance); while (current != null) {
         //   if (current === F.prototype) return true;
         //   current = PDSGetPrototype(current); }
         // return false
         var currentLocal = il.DeclareLocal(_types.Object);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.PDSGetPrototype);
+        il.Emit(OpCodes.Call, runtime.ObjectGetPrototypeOf);
         il.Emit(OpCodes.Stloc, currentLocal);
 
         var loopLabel = il.DefineLabel();
@@ -457,9 +459,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, targetProtoLocal);
         il.Emit(OpCodes.Beq, trueLabel);
 
-        // current = PDSGetPrototype(current)
+        // current = current.[[GetPrototypeOf]]
         il.Emit(OpCodes.Ldloc, currentLocal);
-        il.Emit(OpCodes.Call, runtime.PDSGetPrototype);
+        il.Emit(OpCodes.Call, runtime.ObjectGetPrototypeOf);
         il.Emit(OpCodes.Stloc, currentLocal);
         il.Emit(OpCodes.Br, loopLabel);
 
@@ -633,6 +635,11 @@ public partial class RuntimeEmitter
             [_types.Object, _types.Object]
         );
         runtime.HasIn = method;
+        runtime.ProxyOrdinaryHas = typeBuilder.DefineMethod(
+            "ProxyOrdinaryHas",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Boolean,
+            [_types.Object, _types.Object]);
 
         var il = method.GetILGenerator();
         var falseLabel = il.DefineLabel();
@@ -655,6 +662,24 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, runtime.IsSymbolMethod);
         il.Emit(OpCodes.Brtrue, symbolKeyLabel);
+
+        // Ask [[GetOwnProperty]] before representation-specific fallbacks.
+        // This covers intrinsic own properties such as boxed-string indices,
+        // RegExp.lastIndex, and Function name/length.
+        var noOrdinaryOwnDescriptorLabel = il.DefineLabel();
+        var hasInDescriptorLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.ObjectGetOwnPropertyDescriptor);
+        il.Emit(OpCodes.Stloc, hasInDescriptorLocal);
+        il.Emit(OpCodes.Ldloc, hasInDescriptorLocal);
+        il.Emit(OpCodes.Brfalse, noOrdinaryOwnDescriptorLabel);
+        il.Emit(OpCodes.Ldloc, hasInDescriptorLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, noOrdinaryOwnDescriptorLabel);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(noOrdinaryOwnDescriptorLabel);
 
         // Use the shared HasProperty walk first for every ordinary property
         // key.  It covers own PDS-only accessors and prototype-chain entries
@@ -854,19 +879,41 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ret);
         }
 
-        // Symbol key path
+        // Symbol key path. Check the own symbol dictionary, then continue up
+        // [[Prototype]] so well-known symbol methods are inherited normally.
         il.MarkLabel(symbolKeyLabel);
-        // Get symbol dict and check if key exists
+        var symbolNotOwnLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Call, runtime.GetSymbolDictMethod);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryObjectObject, "ContainsKey", _types.Object));
+        il.Emit(OpCodes.Brfalse, symbolNotOwnLabel);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(symbolNotOwnLabel);
+        var symbolPrototypeLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.ObjectGetPrototypeOf);
+        il.Emit(OpCodes.Stloc, symbolPrototypeLocal);
+        il.Emit(OpCodes.Ldloc, symbolPrototypeLocal);
+        il.Emit(OpCodes.Brfalse, falseLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, symbolPrototypeLocal);
+        il.Emit(OpCodes.Call, runtime.HasIn);
         il.Emit(OpCodes.Ret);
 
         // Return false
         il.MarkLabel(falseLabel);
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Ret);
+
+        // SharpTSProxy's compiled callback uses the natural (target, key)
+        // order, while the emitted `in` helper uses (key, target).
+        var proxyOrdinaryHasIl = runtime.ProxyOrdinaryHas.GetILGenerator();
+        proxyOrdinaryHasIl.Emit(OpCodes.Ldarg_1);
+        proxyOrdinaryHasIl.Emit(OpCodes.Ldarg_0);
+        proxyOrdinaryHasIl.Emit(OpCodes.Call, runtime.HasIn);
+        proxyOrdinaryHasIl.Emit(OpCodes.Ret);
     }
 
     private void EmitAdd(TypeBuilder typeBuilder, EmittedRuntime runtime)

--- a/src/SharpTS/Compilation/RuntimeEmitter.Proxy.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Proxy.cs
@@ -92,8 +92,7 @@ public partial class RuntimeEmitter
         // ordinary Get implementation when the handler has no get trap.
         EmitProxyMethodCallUnwrapped(il, runtime, emitLoadObj, "TrapGetCompiled", () =>
         {
-            // new object[] { name, new Func<object,string,object>(GetProperty) }
-            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Ldc_I4_6);
             il.Emit(OpCodes.Newarr, _types.Object);
             il.Emit(OpCodes.Dup);
             il.Emit(OpCodes.Ldc_I4_0);
@@ -101,10 +100,35 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Stelem_Ref);
             il.Emit(OpCodes.Dup);
             il.Emit(OpCodes.Ldc_I4_1);
+            emitLoadObj();
+            il.Emit(OpCodes.Stelem_Ref);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldftn, runtime.ReflectGet);
+            il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                typeof(Func<object, string, object, object?>), _types.Object, _types.IntPtr));
+            il.Emit(OpCodes.Stelem_Ref);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4_3);
             il.Emit(OpCodes.Ldnull);
             il.Emit(OpCodes.Ldftn, runtime.GetProperty);
             il.Emit(OpCodes.Newobj, _types.GetConstructor(
                 typeof(Func<object, string, object?>), _types.Object, _types.IntPtr));
+            il.Emit(OpCodes.Stelem_Ref);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4_4);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldftn, runtime.GetFunctionMethod);
+            il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                typeof(Func<object, string, object?>), _types.Object, _types.IntPtr));
+            il.Emit(OpCodes.Stelem_Ref);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4_5);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldftn, runtime.ObjectGetOwnPropertyDescriptor);
+            il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                typeof(Func<object, object, object?>), _types.Object, _types.IntPtr));
             il.Emit(OpCodes.Stelem_Ref);
         });
         il.Emit(OpCodes.Ret);
@@ -114,29 +138,17 @@ public partial class RuntimeEmitter
     /// Emits a proxy-aware property set: checks if obj is a proxy and calls TrapSet(name, value, null),
     /// otherwise falls through to notProxyLabel.
     /// </summary>
-    internal void EmitProxySetPropertyCheck(ILGenerator il, Action emitLoadObj, Action emitLoadName, Action emitLoadValue, Label notProxyLabel)
+    internal void EmitProxySetPropertyCheck(
+        ILGenerator il, EmittedRuntime runtime, Action emitLoadObj,
+        Action emitLoadName, Action emitLoadValue, Label notProxyLabel)
     {
         var proxyLabel = il.DefineLabel();
         EmitProxyTypeCheck(il, emitLoadObj, proxyLabel, notProxyLabel);
 
         il.MarkLabel(proxyLabel);
-        // Call TrapSet(string prop, object? value, Interpreter? interp) via reflection
-        EmitProxyMethodCall(il, emitLoadObj, "TrapSet", () =>
-        {
-            // new object[] { name, value, null }
-            il.Emit(OpCodes.Ldc_I4_3);
-            il.Emit(OpCodes.Newarr, _types.Object);
-            il.Emit(OpCodes.Dup);
-            il.Emit(OpCodes.Ldc_I4_0);
-            emitLoadName();
-            il.Emit(OpCodes.Stelem_Ref);
-            il.Emit(OpCodes.Dup);
-            il.Emit(OpCodes.Ldc_I4_1);
-            emitLoadValue();
-            il.Emit(OpCodes.Stelem_Ref);
-            // [2] = null (Interpreter) - already null from Newarr
-        });
-        il.Emit(OpCodes.Pop); // TrapSet returns the value, but SetProperty is void
+        EmitProxySetCompiledCall(
+            il, runtime, emitLoadObj, emitLoadName, emitLoadValue, emitLoadObj);
+        il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
     }
 
@@ -155,8 +167,7 @@ public partial class RuntimeEmitter
         // implementation perform ordinary target lookup when the trap is absent.
         EmitProxyMethodCallUnwrapped(il, runtime, emitLoadObj, "TrapGetIndexCompiled", () =>
         {
-            // new object[] { index, new Func<object,object,object>(GetIndex) }
-            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Ldc_I4_4);
             il.Emit(OpCodes.Newarr, _types.Object);
             il.Emit(OpCodes.Dup);
             il.Emit(OpCodes.Ldc_I4_0);
@@ -169,6 +180,20 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Newobj, _types.GetConstructor(
                 typeof(Func<object, object, object?>), _types.Object, _types.IntPtr));
             il.Emit(OpCodes.Stelem_Ref);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldftn, runtime.GetProperty);
+            il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                typeof(Func<object, string, object?>), _types.Object, _types.IntPtr));
+            il.Emit(OpCodes.Stelem_Ref);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4_3);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldftn, runtime.ObjectGetOwnPropertyDescriptor);
+            il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                typeof(Func<object, object, object?>), _types.Object, _types.IntPtr));
+            il.Emit(OpCodes.Stelem_Ref);
         });
         il.Emit(OpCodes.Ret);
     }
@@ -176,38 +201,23 @@ public partial class RuntimeEmitter
     /// <summary>
     /// Emits a proxy-aware index set: checks if obj is a proxy and calls TrapSet(key.ToString(), value, null).
     /// </summary>
-    internal void EmitProxySetIndexCheck(ILGenerator il, Action emitLoadObj, Action emitLoadIndex, Action emitLoadValue, Label notProxyLabel)
+    internal void EmitProxySetIndexCheck(
+        ILGenerator il, EmittedRuntime runtime, Action emitLoadObj,
+        Action emitLoadIndex, Action emitLoadValue, Label notProxyLabel)
     {
         var proxyLabel = il.DefineLabel();
         EmitProxyTypeCheck(il, emitLoadObj, proxyLabel, notProxyLabel);
 
         il.MarkLabel(proxyLabel);
-        EmitProxyMethodCall(il, emitLoadObj, "TrapSet", () =>
-        {
-            // new object[] { index?.ToString() ?? "", value, null }
-            il.Emit(OpCodes.Ldc_I4_3);
-            il.Emit(OpCodes.Newarr, _types.Object);
-            il.Emit(OpCodes.Dup);
-            il.Emit(OpCodes.Ldc_I4_0);
-            emitLoadIndex();
-            var indexNullLabel = il.DefineLabel();
-            var indexEndLabel = il.DefineLabel();
-            il.Emit(OpCodes.Dup);
-            il.Emit(OpCodes.Brfalse, indexNullLabel);
-            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Object, "ToString"));
-            il.Emit(OpCodes.Br, indexEndLabel);
-            il.MarkLabel(indexNullLabel);
-            il.Emit(OpCodes.Pop);
-            il.Emit(OpCodes.Ldstr, "");
-            il.MarkLabel(indexEndLabel);
-            il.Emit(OpCodes.Stelem_Ref);
-            il.Emit(OpCodes.Dup);
-            il.Emit(OpCodes.Ldc_I4_1);
-            emitLoadValue();
-            il.Emit(OpCodes.Stelem_Ref);
-            // [2] = null (Interpreter) - already null from Newarr
-        });
-        il.Emit(OpCodes.Pop); // TrapSet returns value, SetIndex is void
+        EmitProxySetCompiledCall(
+            il, runtime, emitLoadObj,
+            () =>
+            {
+                emitLoadIndex();
+                il.Emit(OpCodes.Call, runtime.ToJsString);
+            },
+            emitLoadValue, emitLoadObj);
+        il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
     }
 
@@ -291,30 +301,36 @@ public partial class RuntimeEmitter
         il.MarkLabel(proxyLabel);
         EmitProxyMethodCallUnwrapped(il, runtime, emitLoadObj, "TrapHasCompiled", () =>
         {
-            // new object[] { keyString, new Func<object,string,bool>(HasArrayLikeProperty) }
-            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Ldc_I4_5);
             il.Emit(OpCodes.Newarr, _types.Object);
             il.Emit(OpCodes.Dup);
             il.Emit(OpCodes.Ldc_I4_0);
             emitLoadKey();
-            var keyNullLabel = il.DefineLabel();
-            var keyEndLabel = il.DefineLabel();
-            il.Emit(OpCodes.Dup);
-            il.Emit(OpCodes.Brfalse, keyNullLabel);
-            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Object, "ToString"));
-            il.Emit(OpCodes.Br, keyEndLabel);
-            il.MarkLabel(keyNullLabel);
-            il.Emit(OpCodes.Pop);
-            il.Emit(OpCodes.Ldstr, "");
-            il.MarkLabel(keyEndLabel);
             il.Emit(OpCodes.Stelem_Ref);
             il.Emit(OpCodes.Dup);
             il.Emit(OpCodes.Ldc_I4_1);
             il.Emit(OpCodes.Ldnull);
-            il.Emit(OpCodes.Ldftn, runtime.HasArrayLikeProperty);
+            il.Emit(OpCodes.Ldftn, runtime.ProxyOrdinaryHas);
             il.Emit(OpCodes.Newobj, _types.GetConstructor(
-                typeof(Func<object, string, bool>), _types.Object, _types.IntPtr));
+                typeof(Func<object, object, bool>), _types.Object, _types.IntPtr));
             il.Emit(OpCodes.Stelem_Ref);
+            EmitDelegateArgument(2, runtime.ObjectGetOwnPropertyDescriptor,
+                typeof(Func<object, object, object?>));
+            EmitDelegateArgument(3, runtime.ObjectIsExtensible,
+                typeof(Func<object, bool>));
+            EmitDelegateArgument(4, runtime.GetProperty,
+                typeof(Func<object, string, object?>));
+
+            void EmitDelegateArgument(int slot, MethodInfo target, Type delegateType)
+            {
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4, slot);
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Ldftn, target);
+                il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                    delegateType, _types.Object, _types.IntPtr)!);
+                il.Emit(OpCodes.Stelem_Ref);
+            }
         });
         // TrapHas returns object — apply truthy coercion (JS `in` coerces to boolean)
         il.Emit(OpCodes.Call, runtime.IsTruthy);
@@ -324,25 +340,44 @@ public partial class RuntimeEmitter
     /// Emits a proxy-aware delete check: checks if obj is a proxy and calls TrapDeleteProperty(name, null).
     /// Returns bool result.
     /// </summary>
-    internal void EmitProxyDeleteCheck(ILGenerator il, Action emitLoadObj, Action emitLoadName, Label notProxyLabel)
+    internal void EmitProxyDeleteCheck(
+        ILGenerator il, EmittedRuntime runtime, Action emitLoadObj,
+        Action emitLoadName, Label notProxyLabel)
     {
         var proxyLabel = il.DefineLabel();
         EmitProxyTypeCheck(il, emitLoadObj, proxyLabel, notProxyLabel);
 
         il.MarkLabel(proxyLabel);
-        EmitProxyMethodCall(il, emitLoadObj, "TrapDeleteProperty", () =>
+        EmitProxyMethodCallUnwrapped(
+            il, runtime, emitLoadObj, "TrapDeletePropertyCompiled", () =>
         {
-            // new object[] { name, null }
-            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Ldc_I4_5);
             il.Emit(OpCodes.Newarr, _types.Object);
             il.Emit(OpCodes.Dup);
             il.Emit(OpCodes.Ldc_I4_0);
             emitLoadName();
             il.Emit(OpCodes.Stelem_Ref);
-            // [1] = null (Interpreter) - already null from Newarr
+            EmitDelegateArgument(1, runtime.DeleteProperty,
+                typeof(Func<object, string, bool>));
+            EmitDelegateArgument(2, runtime.ObjectGetOwnPropertyDescriptor,
+                typeof(Func<object, object, object?>));
+            EmitDelegateArgument(3, runtime.ObjectIsExtensible,
+                typeof(Func<object, bool>));
+            EmitDelegateArgument(4, runtime.GetProperty,
+                typeof(Func<object, string, object?>));
+
+            void EmitDelegateArgument(int slot, MethodInfo target, Type delegateType)
+            {
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4, slot);
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Ldftn, target);
+                il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                    delegateType, _types.Object, _types.IntPtr)!);
+                il.Emit(OpCodes.Stelem_Ref);
+            }
         });
         il.Emit(OpCodes.Unbox_Any, _types.Boolean);
-        il.Emit(OpCodes.Ret);
     }
 
     private void DeclareProxyOwnKeysHelpers(
@@ -747,23 +782,43 @@ public partial class RuntimeEmitter
     /// <summary>
     /// Emits a proxy-aware invoke check: checks if callee is a proxy and calls TrapApply(null, argsList, null).
     /// </summary>
-    internal void EmitProxyInvokeCheck(ILGenerator il, Action emitLoadCallee, Action emitLoadArgs, Label notProxyLabel)
+    internal void EmitProxyInvokeCheck(
+        ILGenerator il, EmittedRuntime runtime, Action emitLoadCallee,
+        Action emitLoadThisArg, Action emitLoadArgs, Label notProxyLabel)
     {
         var proxyLabel = il.DefineLabel();
         EmitProxyTypeCheck(il, emitLoadCallee, proxyLabel, notProxyLabel);
 
         il.MarkLabel(proxyLabel);
-        EmitProxyMethodCall(il, emitLoadCallee, "TrapApply", () =>
+        EmitProxyMethodCallUnwrapped(
+            il, runtime, emitLoadCallee, "TrapApplyCompiled", () =>
         {
-            // new object[] { null (thisArg), argsList, null (Interpreter) }
-            il.Emit(OpCodes.Ldc_I4_3);
+            il.Emit(OpCodes.Ldc_I4_4);
             il.Emit(OpCodes.Newarr, _types.Object);
-            // [0] = null (thisArg) - already null from Newarr
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4_0);
+            emitLoadThisArg();
+            il.Emit(OpCodes.Stelem_Ref);
             il.Emit(OpCodes.Dup);
             il.Emit(OpCodes.Ldc_I4_1);
-            emitLoadArgs(); // Load the List<object?> args
+            emitLoadArgs();
             il.Emit(OpCodes.Stelem_Ref);
-            // [2] = null (Interpreter) - already null from Newarr
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldftn, runtime.InvokeMethodValue);
+            il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                typeof(Func<object, object, object?[], object?>),
+                _types.Object, _types.IntPtr)!);
+            il.Emit(OpCodes.Stelem_Ref);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldc_I4_3);
+            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldftn, runtime.GetProperty);
+            il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                typeof(Func<object, string, object?>),
+                _types.Object, _types.IntPtr)!);
+            il.Emit(OpCodes.Stelem_Ref);
         });
         il.Emit(OpCodes.Ret);
     }
@@ -785,33 +840,13 @@ public partial class RuntimeEmitter
 
         var il = method.GetILGenerator();
 
-        var targetNullLabel = il.DefineLabel();
-        var handlerNullLabel = il.DefineLabel();
-
-        // if (target == null) throw
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Brfalse, targetNullLabel);
-
-        // if (handler == null) throw
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Brfalse, handlerNullLabel);
+        EmitRequireProxyObject(il, runtime, 0, "target");
+        EmitRequireProxyObject(il, runtime, 1, "handler");
 
         // Late-bound construction of SharpTSProxy(target, handler) — soft dependency
         // on SharpTS.dll (the Proxy feature records RequireSharpTSRuntime).
         EmitReflectionCreateInstance(il, "SharpTS.Runtime.Types.SharpTSProxy, SharpTS", 2);
         il.Emit(OpCodes.Ret);
-
-        // target null - throw
-        il.MarkLabel(targetNullLabel);
-        il.Emit(OpCodes.Ldstr, "Runtime Error: Cannot create proxy with a non-object as target.");
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
-        il.Emit(OpCodes.Throw);
-
-        // handler null - throw
-        il.MarkLabel(handlerNullLabel);
-        il.Emit(OpCodes.Ldstr, "Runtime Error: Cannot create proxy with a non-object as handler.");
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
-        il.Emit(OpCodes.Throw);
     }
 
     /// <summary>
@@ -829,7 +864,45 @@ public partial class RuntimeEmitter
         runtime.CreateRevocableProxy = method;
 
         var il = method.GetILGenerator();
-        EmitReflectionCall(il, RuntimeTypesLateBoundName, "CreateRevocableProxy", 2);
+        EmitRequireProxyObject(il, runtime, 0, "target");
+        EmitRequireProxyObject(il, runtime, 1, "handler");
+        EmitReflectionCall(
+            il, RuntimeTypesLateBoundName, "CreateRevocableProxy", 3,
+            i =>
+            {
+                if (i < 2) il.Emit(OpCodes.Ldarg, i);
+                else il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            });
         il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitRequireProxyObject(
+        ILGenerator il, EmittedRuntime runtime, int argument, string role)
+    {
+        var invalid = il.DefineLabel();
+        var valid = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg, argument);
+        il.Emit(OpCodes.Brfalse, invalid);
+
+        Type[] primitiveTypes =
+        [
+            runtime.UndefinedType, _types.String, _types.Boolean,
+            _types.Byte, _types.SByte, _types.Int16, _types.UInt16,
+            _types.Int32, _types.UInt32, _types.Int64, _types.UInt64,
+            _types.Single, _types.Double, _types.Decimal, _types.BigInteger,
+            runtime.TSSymbolType,
+        ];
+        foreach (Type primitiveType in primitiveTypes)
+        {
+            il.Emit(OpCodes.Ldarg, argument);
+            il.Emit(OpCodes.Isinst, primitiveType);
+            il.Emit(OpCodes.Brtrue, invalid);
+        }
+        il.Emit(OpCodes.Br, valid);
+
+        il.MarkLabel(invalid);
+        GuestErrorEmitter.ThrowTypeError(
+            il, runtime, $"Cannot create proxy with a non-object as {role}");
+        il.MarkLabel(valid);
     }
 }

--- a/src/SharpTS/Compilation/RuntimeEmitter.Reflect.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Reflect.cs
@@ -5,6 +5,226 @@ namespace SharpTS.Compilation;
 
 public partial class RuntimeEmitter
 {
+    private void EmitReflectGet(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = runtime.ReflectGet;
+        var il = method.GetILGenerator();
+
+        var proxyLabel = il.DefineLabel();
+        var notProxyLabel = il.DefineLabel();
+        EmitProxyTypeCheck(
+            il, () => il.Emit(OpCodes.Ldarg_0), proxyLabel, notProxyLabel);
+        il.MarkLabel(proxyLabel);
+        EmitProxyMethodCallUnwrapped(
+            il, runtime, () => il.Emit(OpCodes.Ldarg_0),
+            "TrapGetCompiled", () =>
+            {
+                il.Emit(OpCodes.Ldc_I4_6);
+                il.Emit(OpCodes.Newarr, _types.Object);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Stelem_Ref);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_1);
+                il.Emit(OpCodes.Ldarg_2);
+                il.Emit(OpCodes.Stelem_Ref);
+                EmitDelegate(2, runtime.ReflectGet,
+                    typeof(Func<object, string, object, object?>));
+                EmitDelegate(3, runtime.GetProperty,
+                    typeof(Func<object, string, object?>));
+                EmitDelegate(4, runtime.GetFunctionMethod,
+                    typeof(Func<object, string, object?>));
+                EmitDelegate(5, runtime.ObjectGetOwnPropertyDescriptor,
+                    typeof(Func<object, object, object?>));
+
+                void EmitDelegate(int slot, MethodInfo target, Type delegateType)
+                {
+                    il.Emit(OpCodes.Dup);
+                    il.Emit(OpCodes.Ldc_I4, slot);
+                    il.Emit(OpCodes.Ldnull);
+                    il.Emit(OpCodes.Ldftn, target);
+                    il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                        delegateType, _types.Object, _types.IntPtr)!);
+                    il.Emit(OpCodes.Stelem_Ref);
+                }
+            });
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(notProxyLabel);
+        var descriptorLocal = il.DeclareLocal(_types.Object);
+        var ordinaryGetLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.ObjectGetOwnPropertyDescriptor);
+        il.Emit(OpCodes.Stloc, descriptorLocal);
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Brfalse, ordinaryGetLabel);
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, ordinaryGetLabel);
+
+        var noGetterFieldLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Ldstr, "get");
+        il.Emit(OpCodes.Call, runtime.HasOwnPropertyHelperMethod);
+        il.Emit(OpCodes.Brfalse, noGetterFieldLabel);
+        var getterLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Ldstr, "get");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Stloc, getterLocal);
+        var undefinedGetterLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, getterLocal);
+        il.Emit(OpCodes.Brfalse, undefinedGetterLabel);
+        il.Emit(OpCodes.Ldloc, getterLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, undefinedGetterLabel);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldloc, getterLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(undefinedGetterLabel);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(noGetterFieldLabel);
+        il.MarkLabel(ordinaryGetLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitReflectDeleteProperty(
+        TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "ReflectDeleteProperty",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Boolean,
+            [_types.Object, _types.Object]);
+        runtime.ReflectDeleteProperty = method;
+        var il = method.GetILGenerator();
+        var keyLocal = il.DeclareLocal(_types.String);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
+        il.Emit(OpCodes.Stloc, keyLocal);
+
+        var proxyLabel = il.DefineLabel();
+        var notProxyLabel = il.DefineLabel();
+        EmitProxyTypeCheck(
+            il, () => il.Emit(OpCodes.Ldarg_0), proxyLabel, notProxyLabel);
+        il.MarkLabel(proxyLabel);
+        EmitProxyMethodCallUnwrapped(
+            il, runtime, () => il.Emit(OpCodes.Ldarg_0),
+            "TrapDeletePropertyCompiled", () =>
+            {
+                il.Emit(OpCodes.Ldc_I4_5);
+                il.Emit(OpCodes.Newarr, _types.Object);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ldloc, keyLocal);
+                il.Emit(OpCodes.Stelem_Ref);
+                EmitDelegate(1, runtime.DeleteProperty,
+                    typeof(Func<object, string, bool>));
+                EmitDelegate(2, runtime.ObjectGetOwnPropertyDescriptor,
+                    typeof(Func<object, object, object?>));
+                EmitDelegate(3, runtime.ObjectIsExtensible,
+                    typeof(Func<object, bool>));
+                EmitDelegate(4, runtime.GetProperty,
+                    typeof(Func<object, string, object?>));
+
+                void EmitDelegate(int slot, MethodInfo target, Type delegateType)
+                {
+                    il.Emit(OpCodes.Dup);
+                    il.Emit(OpCodes.Ldc_I4, slot);
+                    il.Emit(OpCodes.Ldnull);
+                    il.Emit(OpCodes.Ldftn, target);
+                    il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                        delegateType, _types.Object, _types.IntPtr)!);
+                    il.Emit(OpCodes.Stelem_Ref);
+                }
+            });
+        il.Emit(OpCodes.Unbox_Any, _types.Boolean);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(notProxyLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Call, runtime.DeleteProperty);
+        var deletedLabel = il.DefineLabel();
+        il.Emit(OpCodes.Brtrue, deletedLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Call, runtime.ObjectGetOwnPropertyDescriptor);
+        var descriptorLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Stloc, descriptorLocal);
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Brfalse, deletedLabel);
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, deletedLabel);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(deletedLabel);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitReflectPreventExtensions(
+        TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "ReflectPreventExtensions",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Boolean,
+            [_types.Object]);
+        runtime.ReflectPreventExtensions = method;
+        var il = method.GetILGenerator();
+
+        var proxyLabel = il.DefineLabel();
+        var notProxyLabel = il.DefineLabel();
+        EmitProxyTypeCheck(
+            il, () => il.Emit(OpCodes.Ldarg_0), proxyLabel, notProxyLabel);
+        il.MarkLabel(proxyLabel);
+        EmitProxyMethodCallUnwrapped(
+            il, runtime, () => il.Emit(OpCodes.Ldarg_0),
+            "TrapPreventExtensionsCompiled", () =>
+            {
+                il.Emit(OpCodes.Ldc_I4_3);
+                il.Emit(OpCodes.Newarr, _types.Object);
+                EmitDelegate(0, runtime.ObjectPreventExtensions,
+                    typeof(Func<object, object?>));
+                EmitDelegate(1, runtime.ObjectIsExtensible,
+                    typeof(Func<object, bool>));
+                EmitDelegate(2, runtime.GetProperty,
+                    typeof(Func<object, string, object?>));
+
+                void EmitDelegate(int slot, MethodInfo target, Type delegateType)
+                {
+                    il.Emit(OpCodes.Dup);
+                    il.Emit(OpCodes.Ldc_I4, slot);
+                    il.Emit(OpCodes.Ldnull);
+                    il.Emit(OpCodes.Ldftn, target);
+                    il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                        delegateType, _types.Object, _types.IntPtr)!);
+                    il.Emit(OpCodes.Stelem_Ref);
+                }
+            });
+        il.Emit(OpCodes.Unbox_Any, _types.Boolean);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(notProxyLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.ObjectPreventExtensions);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+    }
+
     /// <summary>
     /// Emits ReflectSet: (object target, object key, object? value, object receiver) → bool.
     /// Preserves the receiver for Proxy/OrdinarySet observable operations.
@@ -43,6 +263,104 @@ public partial class RuntimeEmitter
             () => il.Emit(OpCodes.Ldarg_3));
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notProxyTargetLabel);
+
+        // OrdinarySetWithOwnDescriptor: an own accessor on the target invokes
+        // its setter with Receiver, rather than defining a data property on
+        // Receiver. This is the forwarding path used when a Proxy has no set
+        // trap and is also observable through Object.create(proxy).
+        var targetDescriptorLocal = il.DeclareLocal(_types.Object);
+        var targetDescriptorMissingLabel = il.DefineLabel();
+        var ordinaryDataSetLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Call, runtime.ObjectGetOwnPropertyDescriptor);
+        il.Emit(OpCodes.Stloc, targetDescriptorLocal);
+        il.Emit(OpCodes.Ldloc, targetDescriptorLocal);
+        il.Emit(OpCodes.Brfalse, targetDescriptorMissingLabel);
+        il.Emit(OpCodes.Ldloc, targetDescriptorLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, targetDescriptorMissingLabel);
+
+        var noSetterFieldLabel = il.DefineLabel();
+        var checkTargetDataDescriptorLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, targetDescriptorLocal);
+        il.Emit(OpCodes.Ldstr, "set");
+        il.Emit(OpCodes.Call, runtime.HasOwnPropertyHelperMethod);
+        il.Emit(OpCodes.Brfalse, noSetterFieldLabel);
+        var setterLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldloc, targetDescriptorLocal);
+        il.Emit(OpCodes.Ldstr, "set");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Stloc, setterLocal);
+        var hasSetterLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, setterLocal);
+        il.Emit(OpCodes.Brfalse, hasSetterLabel);
+        il.Emit(OpCodes.Ldloc, setterLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        var invokeSetterLabel = il.DefineLabel();
+        il.Emit(OpCodes.Brfalse, invokeSetterLabel);
+        il.MarkLabel(hasSetterLabel);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(invokeSetterLabel);
+        il.Emit(OpCodes.Ldarg_3);
+        il.Emit(OpCodes.Ldloc, setterLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(noSetterFieldLabel);
+        il.Emit(OpCodes.Ldloc, targetDescriptorLocal);
+        il.Emit(OpCodes.Ldstr, "get");
+        il.Emit(OpCodes.Call, runtime.HasOwnPropertyHelperMethod);
+        il.Emit(OpCodes.Brfalse, checkTargetDataDescriptorLabel);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+
+        // A present, non-writable data descriptor makes OrdinarySet return
+        // false. This covers intrinsic descriptors such as RegExp.global,
+        // String wrapper indices/length, and function name/length.
+        il.MarkLabel(checkTargetDataDescriptorLabel);
+        il.Emit(OpCodes.Ldloc, targetDescriptorLocal);
+        il.Emit(OpCodes.Ldstr, "writable");
+        il.Emit(OpCodes.Call, runtime.HasOwnPropertyHelperMethod);
+        il.Emit(OpCodes.Brfalse, ordinaryDataSetLabel);
+        il.Emit(OpCodes.Ldloc, targetDescriptorLocal);
+        il.Emit(OpCodes.Ldstr, "writable");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Call, runtime.IsTruthy);
+        il.Emit(OpCodes.Brtrue, ordinaryDataSetLabel);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+
+        // No own descriptor: continue OrdinarySet on the target prototype,
+        // retaining the original Receiver. This is how inherited read-only
+        // accessors such as RegExp.prototype.global reject assignment.
+        il.MarkLabel(targetDescriptorMissingLabel);
+        var targetPrototypeLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.ObjectGetPrototypeOf);
+        il.Emit(OpCodes.Stloc, targetPrototypeLocal);
+        il.Emit(OpCodes.Ldloc, targetPrototypeLocal);
+        il.Emit(OpCodes.Brfalse, ordinaryDataSetLabel);
+        il.Emit(OpCodes.Ldloc, targetPrototypeLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, ordinaryDataSetLabel);
+        il.Emit(OpCodes.Ldloc, targetPrototypeLocal);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldarg_3);
+        il.Emit(OpCodes.Call, runtime.ReflectSet);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(ordinaryDataSetLabel);
 
         // Check if target is frozen
         il.Emit(OpCodes.Ldarg_0);
@@ -92,6 +410,19 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, descriptorReadyLabel);
 
         il.MarkLabel(receiverMissingLabel);
+
+        // Creating a new Receiver property is rejected when Receiver is not
+        // extensible. Return the OrdinarySet boolean rather than routing into
+        // Object.defineProperty and turning this normal false result into a
+        // thrown TypeError (Reflect.set must expose the boolean).
+        il.Emit(OpCodes.Ldarg_3);
+        il.Emit(OpCodes.Call, runtime.ObjectIsExtensible);
+        var receiverExtensibleLabel = il.DefineLabel();
+        il.Emit(OpCodes.Brtrue, receiverExtensibleLabel);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(receiverExtensibleLabel);
+
         il.Emit(OpCodes.Newobj, _types.DictionaryStringObjectCtor);
         il.Emit(OpCodes.Stloc, descriptorLocal);
         void EmitTrueDescriptorField(string name)
@@ -149,6 +480,48 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(notNullLabel);
 
+        // Reflect returns the proxy [[SetPrototypeOf]] boolean directly. Do
+        // not preflight [[IsExtensible]]: the proxy algorithm calls it only
+        // after a truthy trap result, and that ordering is observable.
+        var proxyLabel = il.DefineLabel();
+        var notProxyLabel = il.DefineLabel();
+        EmitProxyTypeCheck(
+            il, () => il.Emit(OpCodes.Ldarg_0), proxyLabel, notProxyLabel);
+        il.MarkLabel(proxyLabel);
+        EmitProxyMethodCallUnwrapped(
+            il, runtime, () => il.Emit(OpCodes.Ldarg_0),
+            "TrapSetPrototypeOfCompiled", () =>
+            {
+                il.Emit(OpCodes.Ldc_I4_5);
+                il.Emit(OpCodes.Newarr, _types.Object);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Stelem_Ref);
+                EmitDelegate(1, runtime.ObjectSetPrototypeOf,
+                    typeof(Func<object, object?, object?>));
+                EmitDelegate(2, runtime.ObjectIsExtensible,
+                    typeof(Func<object, bool>));
+                EmitDelegate(3, runtime.ObjectGetPrototypeOf,
+                    typeof(Func<object, object?>));
+                EmitDelegate(4, runtime.GetProperty,
+                    typeof(Func<object, string, object?>));
+
+                void EmitDelegate(int slot, MethodInfo target, Type delegateType)
+                {
+                    il.Emit(OpCodes.Dup);
+                    il.Emit(OpCodes.Ldc_I4, slot);
+                    il.Emit(OpCodes.Ldnull);
+                    il.Emit(OpCodes.Ldftn, target);
+                    il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                        delegateType, _types.Object, _types.IntPtr)!);
+                    il.Emit(OpCodes.Stelem_Ref);
+                }
+            });
+        il.Emit(OpCodes.Unbox_Any, _types.Boolean);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notProxyLabel);
+
         // Check if not extensible → return false
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, runtime.ObjectIsExtensible);
@@ -198,6 +571,60 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         var resultLocal = il.DeclareLocal(_types.Boolean);
 
+        // Proxy [[DefineOwnProperty]] returns the trap boolean directly, but
+        // invariant violations and abrupt trap completions must propagate.
+        // Do this before the ordinary Object.defineProperty wrapper below,
+        // whose catch converts only ordinary definition rejection to false.
+        var reflectDefineKeyLocal = il.DeclareLocal(_types.String);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
+        il.Emit(OpCodes.Stloc, reflectDefineKeyLocal);
+        var proxyDefineLabel = il.DefineLabel();
+        var ordinaryDefineLabel = il.DefineLabel();
+        EmitProxyTypeCheck(
+            il, () => il.Emit(OpCodes.Ldarg_0),
+            proxyDefineLabel, ordinaryDefineLabel);
+        il.MarkLabel(proxyDefineLabel);
+        EmitProxyMethodCallUnwrapped(
+            il, runtime, () => il.Emit(OpCodes.Ldarg_0),
+            "TrapDefinePropertyCompiled", () =>
+            {
+                il.Emit(OpCodes.Ldc_I4_7);
+                il.Emit(OpCodes.Newarr, _types.Object);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ldloc, reflectDefineKeyLocal);
+                il.Emit(OpCodes.Stelem_Ref);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_1);
+                il.Emit(OpCodes.Ldarg_2);
+                il.Emit(OpCodes.Stelem_Ref);
+                EmitDelegate(2, runtime.ObjectDefineProperty,
+                    typeof(Func<object, object, object, object?>));
+                EmitDelegate(3, runtime.ObjectGetOwnPropertyDescriptor,
+                    typeof(Func<object, object, object?>));
+                EmitDelegate(4, runtime.ObjectIsExtensible,
+                    typeof(Func<object, bool>));
+                EmitDelegate(5, runtime.GetProperty,
+                    typeof(Func<object, string, object?>));
+                EmitDelegate(6, runtime.HasOwnPropertyHelperMethod,
+                    typeof(Func<object, string, bool>));
+
+                void EmitDelegate(int slot, MethodInfo target, Type delegateType)
+                {
+                    il.Emit(OpCodes.Dup);
+                    il.Emit(OpCodes.Ldc_I4, slot);
+                    il.Emit(OpCodes.Ldnull);
+                    il.Emit(OpCodes.Ldftn, target);
+                    il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                        delegateType, _types.Object, _types.IntPtr)!);
+                    il.Emit(OpCodes.Stelem_Ref);
+                }
+            });
+        il.Emit(OpCodes.Unbox_Any, _types.Boolean);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(ordinaryDefineLabel);
+
         // try { ObjectDefineProperty(target, key, descriptor); return true; }
         // catch { return false; }
         il.BeginExceptionBlock();
@@ -236,20 +663,77 @@ public partial class RuntimeEmitter
 
         var il = method.GetILGenerator();
         var resultLocal = il.DeclareLocal(_types.ListOfObject);
-        var notNullLabel = il.DefineLabel();
+        var validTargetLabel = il.DefineLabel();
+        var invalidTargetLabel = il.DefineLabel();
 
         // Create result list
         il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, _types.EmptyTypes));
         il.Emit(OpCodes.Stloc, resultLocal);
 
-        // Check if target is null
+        // Reflect methods require an Object target; unlike Object.ownKeys-like
+        // helpers they do not apply ToObject to primitives.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Brtrue, notNullLabel);
-        // Return empty list
-        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Brfalse, invalidTargetLabel);
+        Type[] primitiveTargetTypes =
+        [
+            runtime.UndefinedType, _types.String, _types.Boolean,
+            _types.Byte, _types.SByte, _types.Int16, _types.UInt16,
+            _types.Int32, _types.UInt32, _types.Int64, _types.UInt64,
+            _types.Single, _types.Double, _types.Decimal, _types.BigInteger,
+            runtime.TSSymbolType,
+        ];
+        foreach (Type primitiveType in primitiveTargetTypes)
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, primitiveType);
+            il.Emit(OpCodes.Brtrue, invalidTargetLabel);
+        }
+        il.Emit(OpCodes.Br, validTargetLabel);
+        il.MarkLabel(invalidTargetLabel);
+        GuestErrorEmitter.ThrowTypeError(
+            il, runtime, "Reflect.ownKeys called on non-object");
+        il.MarkLabel(validTargetLabel);
+
+        // Reflect.ownKeys consumes the complete [[OwnPropertyKeys]] list. A
+        // proxy trap may freely interleave strings and Symbols, so dispatch it
+        // once and return that validated list verbatim. Splitting this through
+        // getOwnPropertyNames/getOwnPropertySymbols would both invoke the trap
+        // twice and reorder the result by key kind.
+        var notProxyLabel = il.DefineLabel();
+        var proxyLabel = il.DefineLabel();
+        EmitProxyTypeCheck(
+            il, () => il.Emit(OpCodes.Ldarg_0), proxyLabel, notProxyLabel);
+        il.MarkLabel(proxyLabel);
+        EmitProxyOwnKeysCompiledCall(
+            il, runtime, () => il.Emit(OpCodes.Ldarg_0));
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notProxyLabel);
+
+        // OrdinaryOwnPropertyKeys already applies canonical array-index order,
+        // preserves chronological string order, and appends Symbols. Reuse it
+        // for every ordinary carrier instead of rebuilding dictionaries here.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.GetOrdinaryOwnPropertyKeys);
         il.Emit(OpCodes.Ret);
 
-        il.MarkLabel(notNullLabel);
+        // Anonymous revocation functions are represented as Func<object[],object>.
+        // Their own-key order follows OrdinaryOwnPropertyKeys for functions:
+        // length before name.
+        var notDelegateFunctionLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.FuncObjectArrayToObject);
+        il.Emit(OpCodes.Brfalse, notDelegateFunctionLabel);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ldstr, "length");
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.ListOfObject, "Add", _types.Object));
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ldstr, "name");
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.ListOfObject, "Add", _types.Object));
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notDelegateFunctionLabel);
 
         // Check if target is Dictionary<string, object?>
         var isDictLabel = il.DefineLabel();
@@ -405,27 +889,10 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(gotArgsLabel);
 
-        // Check if target is TSFunction
-        var isTsFunctionLabel = il.DefineLabel();
-        var notTsFunctionLabel = il.DefineLabel();
-
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSFunctionType);
-        il.Emit(OpCodes.Brtrue, isTsFunctionLabel);
-
-        // Not a TSFunction - try InvokeValue
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldloc, argsLocal);
-        il.Emit(OpCodes.Call, runtime.InvokeValue);
-        il.Emit(OpCodes.Ret);
-
-        // Is a TSFunction - use InvokeWithThis
-        il.MarkLabel(isTsFunctionLabel);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSFunctionType);
         il.Emit(OpCodes.Ldarg_1); // thisArg
+        il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldloc, argsLocal);
-        il.Emit(OpCodes.Callvirt, runtime.TSFunctionInvokeWithThis);
+        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
         il.Emit(OpCodes.Ret);
     }
 
@@ -472,6 +939,32 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notUndefinedLabel);
+
+        // A Proxy has [[Construct]] exactly when its (possibly nested) target
+        // does. Revocation is observable and must throw here.
+        var proxyLabel = il.DefineLabel();
+        var notProxyLabel = il.DefineLabel();
+        EmitProxyTypeCheck(
+            il, () => il.Emit(OpCodes.Ldarg_0), proxyLabel, notProxyLabel);
+        il.MarkLabel(proxyLabel);
+        EmitProxyMethodCallUnwrapped(
+            il, runtime, () => il.Emit(OpCodes.Ldarg_0),
+            "HasConstructableTarget", () =>
+            {
+                il.Emit(OpCodes.Ldc_I4_1);
+                il.Emit(OpCodes.Newarr, _types.Object);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Ldftn, runtime.IsConstructorMethod);
+                il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                    typeof(Func<object, bool>),
+                    _types.Object, _types.IntPtr)!);
+                il.Emit(OpCodes.Stelem_Ref);
+            });
+        il.Emit(OpCodes.Unbox_Any, _types.Boolean);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notProxyLabel);
 
         // System.Type (class reference) → true
         var notTypeLabel = il.DefineLabel();
@@ -666,6 +1159,46 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(gotArgsLabel);
 
+        var proxyTargetLabel = il.DefineLabel();
+        var notProxyTargetLabel = il.DefineLabel();
+        EmitProxyTypeCheck(
+            il, () => il.Emit(OpCodes.Ldarg_0),
+            proxyTargetLabel, notProxyTargetLabel);
+        il.MarkLabel(proxyTargetLabel);
+        EmitProxyMethodCallUnwrapped(
+            il, runtime, () => il.Emit(OpCodes.Ldarg_0),
+            "TrapConstructCompiled", () =>
+            {
+                il.Emit(OpCodes.Ldc_I4_4);
+                il.Emit(OpCodes.Newarr, _types.Object);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ldloc, argsLocal);
+                il.Emit(OpCodes.Stelem_Ref);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_1);
+                il.Emit(OpCodes.Ldloc, newTargetLocal);
+                il.Emit(OpCodes.Stelem_Ref);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_2);
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Ldftn, runtime.NewOnFunction);
+                il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                    typeof(Func<object, object?[], object?>),
+                    _types.Object, _types.IntPtr)!);
+                il.Emit(OpCodes.Stelem_Ref);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Ldc_I4_3);
+                il.Emit(OpCodes.Ldnull);
+                il.Emit(OpCodes.Ldftn, runtime.GetProperty);
+                il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                    typeof(Func<object, string, object?>),
+                    _types.Object, _types.IntPtr)!);
+                il.Emit(OpCodes.Stelem_Ref);
+            });
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notProxyTargetLabel);
+
         // Check if target is a System.Type (compiled class reference)
         var isTypeLabel = il.DefineLabel();
         var notTypeLabel = il.DefineLabel();
@@ -674,10 +1207,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, _types.Type);
         il.Emit(OpCodes.Brtrue, isTypeLabel);
 
-        // Not a Type - use InvokeValue which handles TSFunction, BoundTSFunction, etc.
+        // Not a Type - use the ordinary function-construction protocol.
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldloc, argsLocal);
-        il.Emit(OpCodes.Call, runtime.InvokeValue);
+        il.Emit(OpCodes.Call, runtime.NewOnFunction);
         il.Emit(OpCodes.Ret);
 
         // Is a Type - use Activator.CreateInstance(type, args)

--- a/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -784,6 +784,12 @@ public partial class RuntimeEmitter
         // hasOwnProperty + isPrototypeOf helpers — must come before
         // GetFunctionMethod so the corresponding arms can return $TSFunction
         // wrappers.
+        runtime.ObjectIsExtensible = typeBuilder.DefineMethod(
+            "ObjectIsExtensible",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Boolean,
+            [_types.Object]);
+        DeclareObjectGetOwnPropertyDescriptor(typeBuilder, runtime);
         EmitHasOwnPropertyHelper(typeBuilder, runtime);
         // propertyIsEnumerable shares HasOwn's plumbing (PDS lookup + dict
         // fallback) so emit it immediately after.
@@ -830,6 +836,16 @@ public partial class RuntimeEmitter
         // their normalization path consumes arbitrary iterables. Reserve the
         // method token now and fill its body in EmitIteratorMethodsAdvanced.
         DeclareIterateToList(typeBuilder, runtime);
+        runtime.InvokeMethodValue = typeBuilder.DefineMethod(
+            "InvokeMethodValue",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Object, _types.ObjectArray]);
+        runtime.ReflectGet = typeBuilder.DefineMethod(
+            "ReflectGet",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.String, _types.Object]);
         EmitInvokeValue(typeBuilder, runtime);
         EmitInvokeMethodValue(typeBuilder, runtime);
         EmitGetFieldsProperty(typeBuilder, runtime);
@@ -901,9 +917,6 @@ public partial class RuntimeEmitter
         // String.raw lives here so its body can read `template.raw` via
         // GetProperty and ToString-coerce substitutions via ToJsString.
         EmitStringRaw(typeBuilder, runtime);
-        // Strict Proxy [[Set]] captures this descriptor callback before the
-        // public Object descriptor APIs receive their bodies below.
-        DeclareObjectGetOwnPropertyDescriptor(typeBuilder, runtime);
         EmitSetProperty(typeBuilder, runtime);
         EmitSetPropertyStrict(typeBuilder, runtime);
         EmitDeleteProperty(typeBuilder, runtime);
@@ -1012,10 +1025,18 @@ public partial class RuntimeEmitter
         // the already-defined shared helper here.
         // Proxy [[Set]] forwarding also uses the receiver-aware ordinary-set
         // helper even when guest code never names the Reflect object.
+        // ReflectGet is also the receiver-preserving ordinary [[Get]] helper
+        // used by prototype recursion in GetProperty, so its reserved method
+        // must always receive a body even when guest code never names Reflect.
+        EmitReflectGet(typeBuilder, runtime);
         if (_features.UsesReflect || _features.UsesProxy)
+        {
             EmitReflectSet(typeBuilder, runtime);
+        }
         if (_features.UsesReflect)
         {
+            EmitReflectDeleteProperty(typeBuilder, runtime);
+            EmitReflectPreventExtensions(typeBuilder, runtime);
             EmitReflectSetPrototypeOf(typeBuilder, runtime, prototypeStoreField, nonExtensibleObjectsField);
             EmitReflectDefineProperty(typeBuilder, runtime);
             EmitReflectOwnKeys(typeBuilder, runtime);

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSObject.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSObject.cs
@@ -273,6 +273,46 @@ public partial class RuntimeEmitter
         var foundLabel = il.DefineLabel();
         var noGetterLabel = il.DefineLabel();
 
+        // Object.defineProperty descriptors are authoritative over the fast
+        // field/accessor maps. Probe PDS first so an ordering placeholder left
+        // in _fields after a data-to-accessor transition is never observable.
+        var noPdsGetterLabel = il.DefineLabel();
+        var noPdsDescriptorLabel = il.DefineLabel();
+        var pdsGetterLocal = il.DeclareLocal(_types.Object);
+        var pdsDescriptorLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloca, pdsGetterLocal);
+        il.Emit(OpCodes.Call, runtime.PDSTryGetGetter);
+        il.Emit(OpCodes.Brfalse, noPdsGetterLabel);
+        il.Emit(OpCodes.Ldloc, pdsGetterLocal);
+        il.Emit(OpCodes.Castclass, runtime.TSFunctionType);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, EmitGenerics.MakeGenericMethod(
+            _types.GetMethod(typeof(Array), "Empty"), _types.Object));
+        il.Emit(OpCodes.Callvirt, runtime.TSFunctionInvokeWithThis);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(noPdsGetterLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
+        il.Emit(OpCodes.Stloc, pdsDescriptorLocal);
+        il.Emit(OpCodes.Ldloc, pdsDescriptorLocal);
+        il.Emit(OpCodes.Brfalse, noPdsDescriptorLabel);
+        var pdsDataDescriptorLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, pdsDescriptorLocal);
+        il.Emit(OpCodes.Callvirt,
+            runtime.CompiledPropertyDescriptorSetter.GetGetMethod()!);
+        il.Emit(OpCodes.Brfalse, pdsDataDescriptorLabel);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(pdsDataDescriptorLabel);
+        il.Emit(OpCodes.Ldloc, pdsDescriptorLocal);
+        il.Emit(OpCodes.Callvirt,
+            runtime.CompiledPropertyDescriptorValue.GetGetMethod()!);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(noPdsDescriptorLabel);
+
         // First, check for a getter
         // if (_getters != null && _getters.TryGetValue(name, out getter))
         //     return ((TSFunction)getter).InvokeWithThis(this, Array.Empty<object>())
@@ -650,17 +690,38 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldfld, _tsObjectIsSealedField);
         il.Emit(OpCodes.Brtrue, falseReturnLabel);
 
-        // return _fields.Remove(name)
+        // Remove every representation of the ordinary own property. Object
+        // literal accessors are stored separately from data fields, and a
+        // getter/setter pair still denotes one property.
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, _tsObjectFieldsField);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "Remove", [_types.String])!);
+        il.Emit(OpCodes.Pop);
+        EmitRemoveAccessorEntry(il, _tsObjectGettersField);
+        EmitRemoveAccessorEntry(il, _tsObjectSettersField);
+        il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Ret);
 
         // return false for frozen/sealed
         il.MarkLabel(falseReturnLabel);
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Ret);
+
+        void EmitRemoveAccessorEntry(ILGenerator generator, FieldBuilder field)
+        {
+            var noMapLabel = generator.DefineLabel();
+            generator.Emit(OpCodes.Ldarg_0);
+            generator.Emit(OpCodes.Ldfld, field);
+            generator.Emit(OpCodes.Brfalse, noMapLabel);
+            generator.Emit(OpCodes.Ldarg_0);
+            generator.Emit(OpCodes.Ldfld, field);
+            generator.Emit(OpCodes.Ldarg_1);
+            generator.Emit(OpCodes.Callvirt, _types.GetMethod(
+                _types.DictionaryStringObject, "Remove", [_types.String])!);
+            generator.Emit(OpCodes.Pop);
+            generator.MarkLabel(noMapLabel);
+        }
     }
 
     private void EmitTSObjectDeletePropertyStrict(TypeBuilder typeBuilder, EmittedRuntime runtime)
@@ -722,13 +783,33 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Ret);
 
-        // Not frozen/sealed - return _fields.Remove(name)
+        // Not frozen/sealed - remove data/accessor storage and report success
+        // even when the property was already absent.
         il.MarkLabel(notSealedLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, _tsObjectFieldsField);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "Remove", [_types.String])!);
+        il.Emit(OpCodes.Pop);
+        EmitRemoveStrictAccessorEntry(il, _tsObjectGettersField);
+        EmitRemoveStrictAccessorEntry(il, _tsObjectSettersField);
+        il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Ret);
+
+        void EmitRemoveStrictAccessorEntry(ILGenerator generator, FieldBuilder field)
+        {
+            var noMapLabel = generator.DefineLabel();
+            generator.Emit(OpCodes.Ldarg_0);
+            generator.Emit(OpCodes.Ldfld, field);
+            generator.Emit(OpCodes.Brfalse, noMapLabel);
+            generator.Emit(OpCodes.Ldarg_0);
+            generator.Emit(OpCodes.Ldfld, field);
+            generator.Emit(OpCodes.Ldarg_1);
+            generator.Emit(OpCodes.Callvirt, _types.GetMethod(
+                _types.DictionaryStringObject, "Remove", [_types.String])!);
+            generator.Emit(OpCodes.Pop);
+            generator.MarkLabel(noMapLabel);
+        }
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/RuntimeEmitter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Reflection.Emit;
 
 namespace SharpTS.Compilation;
@@ -406,6 +407,14 @@ public partial class RuntimeEmitter
             EmitFsWatcherClass(moduleBuilder, runtime);
             EmitStatWatcherClass(moduleBuilder, runtime);
         }
+
+        // Reflect.construct and Proxy [[Construct]] need this token while the
+        // main $Runtime body is emitted. Its body is filled after $Runtime.
+        runtime.NewOnFunction = _runtimeTypeBuilder!.DefineMethod(
+            "NewOnFunction",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.ObjectArray]);
 
         // Emit $Runtime class with all helper methods
         EmitRuntimeClass(moduleBuilder, runtime);

--- a/src/SharpTS/Compilation/RuntimeTypes.Proxy.cs
+++ b/src/SharpTS/Compilation/RuntimeTypes.Proxy.cs
@@ -22,7 +22,8 @@ public static partial class RuntimeTypes
     /// <summary>
     /// Creates a revocable Proxy. Returns a Dictionary with "proxy" and "revoke" keys.
     /// </summary>
-    public static object CreateRevocableProxy(object? target, object? handler)
+    public static object CreateRevocableProxy(
+        object? target, object? handler, object? undefined)
     {
         if (target == null)
             throw new Exception("Runtime Error: Cannot create proxy with a non-object as target.");
@@ -38,7 +39,7 @@ public static partial class RuntimeTypes
                 revoked = true;
                 proxy.Revoke();
             }
-            return null;
+            return undefined;
         };
 
         return new Dictionary<string, object?>

--- a/src/SharpTS/Runtime/BuiltIns/ObjectBuiltIns.cs
+++ b/src/SharpTS/Runtime/BuiltIns/ObjectBuiltIns.cs
@@ -1122,7 +1122,9 @@ public static partial class ObjectBuiltIns
             {
                 Value = compiledDesc.Value,
                 Get = compiledDesc.Getter as ISharpTSCallable,
+                RawGet = compiledDesc.Getter,
                 Set = compiledDesc.Setter as ISharpTSCallable,
+                RawSet = compiledDesc.Setter,
                 Writable = compiledDesc.Writable,
                 Enumerable = compiledDesc.Enumerable,
                 Configurable = compiledDesc.Configurable
@@ -1499,6 +1501,7 @@ public static partial class ObjectBuiltIns
         if (interpreter.TryGetDescriptorField(descObj, "get", out var g))
         {
             descriptor.HasGet = true;
+            descriptor.RawGet = g;
             descriptor.Get = g switch
             {
                 SharpTSUndefined => null,
@@ -1510,6 +1513,7 @@ public static partial class ObjectBuiltIns
         if (interpreter.TryGetDescriptorField(descObj, "set", out var s))
         {
             descriptor.HasSet = true;
+            descriptor.RawSet = s;
             descriptor.Set = s switch
             {
                 SharpTSUndefined => null,

--- a/src/SharpTS/Runtime/RuntimeCallableDispatcher.cs
+++ b/src/SharpTS/Runtime/RuntimeCallableDispatcher.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using SharpTS.Runtime.BuiltIns;
 using SharpTS.Runtime.Types;
 using Interp = SharpTS.Execution.Interpreter;
@@ -56,13 +57,27 @@ public static class RuntimeCallableDispatcher
     /// or no recognised shape matches.
     /// </summary>
     public static object? Invoke(Interp? interpreter, object? callable, params object?[] args)
+        => InvokeWithThis(interpreter, callable, null, args);
+
+    /// <summary>
+    /// Invokes a callable with an explicit JavaScript receiver. This is the
+    /// cross-runtime equivalent of Call(F, thisArgument, argumentsList).
+    /// </summary>
+    public static object? InvokeWithThis(
+        Interp? interpreter,
+        object? callable,
+        object? thisArg,
+        params object?[] args)
     {
         if (callable is null) return null;
 
         switch (callable)
         {
             case ISharpTSCallable tsCallable:
-                return tsCallable.Call(interpreter!, args.ToList());
+                return interpreter != null
+                    ? FunctionBuiltIns.CallWithThis(
+                        interpreter, tsCallable, thisArg, args.ToList())
+                    : tsCallable.Call(null!, args.ToList());
 
             case SharpTS.Compilation.TSFunction tsFunc:
                 return tsFunc.Invoke(args);
@@ -88,7 +103,8 @@ public static class RuntimeCallableDispatcher
                     [typeof(object), typeof(object[])]));
             if (invokeWithThis != null)
             {
-                return invokeWithThis.Invoke(callable, new object?[] { null, args });
+                return InvokeReflected(
+                    invokeWithThis, callable, [thisArg, args]);
             }
 
             var invoke = _invokeCache.GetOrAdd(type, t =>
@@ -96,16 +112,39 @@ public static class RuntimeCallableDispatcher
                     t, ManagedEmittedShape.Function, "Invoke", [typeof(object[])]));
             if (invoke != null)
             {
-                return invoke.Invoke(callable, new object?[] { args });
+                return InvokeReflected(invoke, callable, [args]);
             }
         }
 
         if (callable is Delegate del)
         {
-            return del.DynamicInvoke(new object[] { args });
+            try
+            {
+                return del.DynamicInvoke(new object[] { args });
+            }
+            catch (TargetInvocationException exception)
+                when (exception.InnerException != null)
+            {
+                ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+            }
         }
 
         return null;
+    }
+
+    private static object? InvokeReflected(
+        MethodInfo method, object target, object?[] arguments)
+    {
+        try
+        {
+            return method.Invoke(target, arguments);
+        }
+        catch (TargetInvocationException exception)
+            when (exception.InnerException != null)
+        {
+            ExceptionDispatchInfo.Capture(exception.InnerException).Throw();
+            throw;
+        }
     }
 
     /// <summary>

--- a/src/SharpTS/Runtime/Types/SharpTSObject.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSObject.cs
@@ -880,10 +880,14 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
         if (isAccessor)
         {
             // Accessor property
+            var getter = GetGetter(name);
+            var setter = GetSetter(name);
             return new SharpTSPropertyDescriptor
             {
-                Get = GetGetter(name),
-                Set = GetSetter(name),
+                Get = getter,
+                RawGet = getter,
+                Set = setter,
+                RawSet = setter,
                 HasGet = true,
                 HasSet = true,
                 Enumerable = flags.Enumerable,
@@ -923,7 +927,9 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
             return new SharpTSPropertyDescriptor
             {
                 Get = getter,
+                RawGet = getter,
                 Set = setter,
+                RawSet = setter,
                 HasGet = true,
                 HasSet = true,
                 Enumerable = flags.Enumerable,

--- a/src/SharpTS/Runtime/Types/SharpTSPropertyDescriptor.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSPropertyDescriptor.cs
@@ -12,8 +12,14 @@ public class SharpTSPropertyDescriptor
     /// <summary>Getter function for accessor properties</summary>
     public ISharpTSCallable? Get { get; set; }
 
+    /// <summary>The original getter value, including compiler-emitted callables.</summary>
+    public object? RawGet { get; set; }
+
     /// <summary>Setter function for accessor properties</summary>
     public ISharpTSCallable? Set { get; set; }
+
+    /// <summary>The original setter value, including compiler-emitted callables.</summary>
+    public object? RawSet { get; set; }
 
     /// <summary>Whether the property value can be changed.</summary>
     /// <remarks>
@@ -58,7 +64,9 @@ public class SharpTSPropertyDescriptor
     {
         Value = value;
         Get = getter;
+        RawGet = getter;
         Set = setter;
+        RawSet = setter;
         Writable = writable;
         Enumerable = enumerable;
         Configurable = configurable;
@@ -87,8 +95,8 @@ public class SharpTSPropertyDescriptor
         {
             // FromPropertyDescriptor returns a COMPLETE accessor descriptor:
             // both get and set are present, using undefined for an absent half.
-            obj.SetProperty("get", Get is null ? SharpTSUndefined.Instance : Get);
-            obj.SetProperty("set", Set is null ? SharpTSUndefined.Instance : Set);
+            obj.SetProperty("get", RawGet ?? SharpTSUndefined.Instance);
+            obj.SetProperty("set", RawSet ?? SharpTSUndefined.Instance);
         }
         else
         {
@@ -137,13 +145,15 @@ public class SharpTSPropertyDescriptor
         if (has("get"))
         {
             descriptor.HasGet = true;
-            if (read("get") is ISharpTSCallable getterFn) descriptor.Get = getterFn;
+            descriptor.RawGet = read("get");
+            if (descriptor.RawGet is ISharpTSCallable getterFn) descriptor.Get = getterFn;
         }
 
         if (has("set"))
         {
             descriptor.HasSet = true;
-            if (read("set") is ISharpTSCallable setterFn) descriptor.Set = setterFn;
+            descriptor.RawSet = read("set");
+            if (descriptor.RawSet is ISharpTSCallable setterFn) descriptor.Set = setterFn;
         }
 
         if (has("writable"))

--- a/src/SharpTS/Runtime/Types/SharpTSProxy.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSProxy.cs
@@ -110,7 +110,11 @@ public class SharpTSProxy : ISharpTSCallable
     {
         EnsureNotRevoked();
         object? value = _handler is SharpTSProxy proxy
-            ? proxy.TrapGetCompiled(trapName, ordinaryGet)
+            ? proxy.TrapGetCompiled(
+                trapName, proxy,
+                (target, key, _) => ordinaryGet(target, key),
+                ordinaryGet, ordinaryGet,
+                (_, _) => SharpTSUndefined.Instance)
             : ordinaryGet(_handler!, trapName);
 
         if (value == null || IsUndefinedLike(value)) return null;
@@ -133,7 +137,8 @@ public class SharpTSProxy : ISharpTSCallable
                 interp, callable, _handler, args);
 
         if (RuntimeCallableDispatcher.IsCallable(trap))
-            return RuntimeCallableDispatcher.Invoke(interp, trap, args.ToArray());
+            return RuntimeCallableDispatcher.InvokeWithThis(
+                interp, trap, _handler, args.ToArray());
 
         // Managed .NET interop fallback for arbitrary Invoke-shaped objects.
         // The emitted function path above no longer needs to inspect its
@@ -159,19 +164,60 @@ public class SharpTSProxy : ISharpTSCallable
     /// </summary>
     public object? TrapGetCompiled(
         string prop,
-        Func<object, string, object?> ordinaryGet)
+        object? receiver,
+        Func<object, string, object, object?> ordinaryGet,
+        Func<object, string, object?> ordinaryHandlerGet,
+        Func<object, string, object?> ordinaryFunctionGet,
+        Func<object, object, object?> ordinaryGetOwnPropertyDescriptor)
     {
-        var trap = GetTrapCallable("get", null);
+        var trap = GetTrapCallableCompiled("get", ordinaryHandlerGet);
         if (trap == null)
         {
             return _target is SharpTSProxy targetProxy
-                ? targetProxy.TrapGetCompiled(prop, ordinaryGet)
-                : ordinaryGet(_target, prop);
+                ? targetProxy.TrapGetCompiled(
+                    prop, receiver, ordinaryGet, ordinaryHandlerGet,
+                    ordinaryFunctionGet,
+                    ordinaryGetOwnPropertyDescriptor)
+                : prop is "call" or "apply" or "bind"
+                    && IsCallable
+                    ? ordinaryFunctionGet(this, prop)
+                    : ordinaryGet(_target, prop, receiver!);
         }
 
-        object? result = InvokeTrap(trap, null, [_target, prop, this]);
-        ValidateGetTrapResult(prop, result, null);
+        object? result = InvokeTrap(
+            trap, null, [_target, prop, receiver]);
+        ValidateGetTrapResultCompiled(
+            prop, result, ordinaryGetOwnPropertyDescriptor);
         return result;
+    }
+
+    private void ValidateGetTrapResultCompiled(
+        object propertyKey,
+        object? result,
+        Func<object, object, object?> ordinaryGetOwnPropertyDescriptor)
+    {
+        object? targetDescriptor = _target is SharpTSProxy targetProxy
+            ? targetProxy.TrapGetOwnPropertyDescriptorCompiled(
+                propertyKey, ordinaryGetOwnPropertyDescriptor,
+                _ => true, (_, _) => SharpTSUndefined.Instance)
+            : ordinaryGetOwnPropertyDescriptor(_target, propertyKey);
+        if (targetDescriptor == null || IsUndefinedLike(targetDescriptor)) return;
+
+        var descriptor = SharpTSPropertyDescriptor.FromAnyObject(targetDescriptor);
+        if (descriptor.Configurable) return;
+        if (descriptor.HasValue && !descriptor.Writable
+            && !SharpTSObject.SameValue(result, descriptor.Value))
+        {
+            throw new ThrowException(new SharpTSTypeError(
+                "Proxy get trap must return the value of a fixed data property"));
+        }
+        if ((descriptor.HasGet || descriptor.HasSet)
+            && IsUndefinedLike(descriptor.RawGet)
+            && !IsUndefinedLike(result))
+        {
+            throw new ThrowException(new SharpTSTypeError(
+                "Proxy get trap must return undefined for a fixed accessor without a getter"));
+        }
     }
 
     /// <summary>
@@ -181,23 +227,28 @@ public class SharpTSProxy : ISharpTSCallable
     /// </summary>
     public object? TrapGetIndexCompiled(
         object? prop,
-        Func<object, object, object?> ordinaryGet)
+        Func<object, object, object?> ordinaryGet,
+        Func<object, string, object?> ordinaryHandlerGet,
+        Func<object, object, object?> ordinaryGetOwnPropertyDescriptor)
     {
         object propertyKey = prop is SharpTSSymbol
             || prop?.GetType().Name == "$TSSymbol"
                 ? prop
                 : prop?.ToString() ?? "";
 
-        var trap = GetTrapCallable("get", null);
+        var trap = GetTrapCallableCompiled("get", ordinaryHandlerGet);
         if (trap == null)
         {
             return _target is SharpTSProxy targetProxy
-                ? targetProxy.TrapGetIndexCompiled(propertyKey, ordinaryGet)
+                ? targetProxy.TrapGetIndexCompiled(
+                    propertyKey, ordinaryGet, ordinaryHandlerGet,
+                    ordinaryGetOwnPropertyDescriptor)
                 : ordinaryGet(_target, propertyKey);
         }
 
         object? result = InvokeTrap(trap, null, [_target, propertyKey, this]);
-        ValidateGetTrapResult(propertyKey, result, null);
+        ValidateGetTrapResultCompiled(
+            propertyKey, result, ordinaryGetOwnPropertyDescriptor);
         return result;
     }
 
@@ -251,7 +302,8 @@ public class SharpTSProxy : ISharpTSCallable
             throw new ThrowException(new SharpTSTypeError(
                 "Proxy get trap must return the value of a fixed data property"));
         }
-        if ((descriptor.HasGet || descriptor.HasSet) && descriptor.Get == null
+        if ((descriptor.HasGet || descriptor.HasSet)
+            && (descriptor.RawGet == null || IsUndefinedLike(descriptor.RawGet))
             && result is not SharpTSUndefined)
         {
             throw new ThrowException(new SharpTSTypeError(
@@ -308,14 +360,15 @@ public class SharpTSProxy : ISharpTSCallable
     /// </summary>
     public object? TrapGetPrototypeOfCompiled(
         Func<object, object?> ordinaryGetPrototypeOf,
-        Func<object, bool> ordinaryIsExtensible)
+        Func<object, bool> ordinaryIsExtensible,
+        Func<object, string, object?> ordinaryGet)
     {
-        var trap = GetTrapCallable("getPrototypeOf", null);
+        var trap = GetTrapCallableCompiled("getPrototypeOf", ordinaryGet);
         if (trap == null)
         {
             return _target is SharpTSProxy proxy
                 ? proxy.TrapGetPrototypeOfCompiled(
-                    ordinaryGetPrototypeOf, ordinaryIsExtensible)
+                    ordinaryGetPrototypeOf, ordinaryIsExtensible, ordinaryGet)
                 : ordinaryGetPrototypeOf(_target);
         }
 
@@ -334,7 +387,7 @@ public class SharpTSProxy : ISharpTSCallable
 
         object? targetPrototype = _target is SharpTSProxy targetProxy
             ? targetProxy.TrapGetPrototypeOfCompiled(
-                ordinaryGetPrototypeOf, ordinaryIsExtensible)
+                ordinaryGetPrototypeOf, ordinaryIsExtensible, ordinaryGet)
             : ordinaryGetPrototypeOf(_target);
         if (!ReferenceEquals(result, targetPrototype))
         {
@@ -391,6 +444,32 @@ public class SharpTSProxy : ISharpTSCallable
         return result;
     }
 
+    public bool TrapIsExtensibleCompiled(
+        Func<object, bool> ordinaryIsExtensible,
+        Func<object, string, object?> ordinaryGet)
+    {
+        var trap = GetTrapCallableCompiled("isExtensible", ordinaryGet);
+        if (trap == null)
+        {
+            return _target is SharpTSProxy proxy
+                ? proxy.TrapIsExtensibleCompiled(
+                    ordinaryIsExtensible, ordinaryGet)
+                : ordinaryIsExtensible(_target);
+        }
+
+        bool result = ToBoolean(InvokeTrap(trap, null, [_target]));
+        bool targetResult = _target is SharpTSProxy targetProxy
+            ? targetProxy.TrapIsExtensibleCompiled(
+                ordinaryIsExtensible, ordinaryGet)
+            : ordinaryIsExtensible(_target);
+        if (result != targetResult)
+        {
+            throw new ThrowException(new SharpTSTypeError(
+                "Proxy isExtensible trap result does not match the target"));
+        }
+        return result;
+    }
+
     /// <summary>ECMA-262 §10.5.4 [[PreventExtensions]].</summary>
     internal bool TrapPreventExtensions(Interpreter interpreter)
     {
@@ -417,14 +496,15 @@ public class SharpTSProxy : ISharpTSCallable
     /// </summary>
     public bool TrapPreventExtensionsCompiled(
         Func<object, object?> ordinaryPreventExtensions,
-        Func<object, bool> ordinaryIsExtensible)
+        Func<object, bool> ordinaryIsExtensible,
+        Func<object, string, object?> ordinaryGet)
     {
-        var trap = GetTrapCallable("preventExtensions", null);
+        var trap = GetTrapCallableCompiled("preventExtensions", ordinaryGet);
         if (trap == null)
         {
             if (_target is SharpTSProxy proxy)
                 return proxy.TrapPreventExtensionsCompiled(
-                    ordinaryPreventExtensions, ordinaryIsExtensible);
+                    ordinaryPreventExtensions, ordinaryIsExtensible, ordinaryGet);
             _ = ordinaryPreventExtensions(_target);
             return true;
         }
@@ -488,7 +568,8 @@ public class SharpTSProxy : ISharpTSCallable
             throw new ThrowException(new SharpTSTypeError(
                 "Proxy set trap cannot change a fixed data property"));
         }
-        if ((descriptor.HasGet || descriptor.HasSet) && descriptor.Set == null)
+        if ((descriptor.HasGet || descriptor.HasSet)
+            && (descriptor.RawSet == null || IsUndefinedLike(descriptor.RawSet)))
         {
             throw new ThrowException(new SharpTSTypeError(
                 "Proxy set trap cannot assign to a fixed accessor without a setter"));
@@ -639,7 +720,8 @@ public class SharpTSProxy : ISharpTSCallable
         => value is not (null or SharpTSUndefined or string or bool or byte
             or sbyte or short or ushort or int or uint or long or ulong or float
             or double or decimal or System.Numerics.BigInteger or SharpTSBigInt
-            or SharpTSSymbol);
+            or SharpTSSymbol)
+            && value.GetType().Name is not ("$Undefined" or "$TSSymbol" or "$TSBigInt");
 
     public bool TrapHas(string prop, Interpreter? interp)
         => TrapHasCore(prop, interp);
@@ -650,29 +732,39 @@ public class SharpTSProxy : ISharpTSCallable
     /// carriers such as <c>List&lt;object?&gt;</c> retain their indexed semantics.
     /// </summary>
     public bool TrapHasCompiled(
-        string prop,
-        Func<object, string, bool> ordinaryHas)
+        object prop,
+        Func<object, object, bool> ordinaryHas,
+        Func<object, object, object?> ordinaryGetOwnPropertyDescriptor,
+        Func<object, bool> ordinaryIsExtensible,
+        Func<object, string, object?> ordinaryGet)
     {
-        var trap = GetTrapCallable("has", null);
+        var trap = GetTrapCallableCompiled("has", ordinaryGet);
         if (trap == null)
         {
             return _target is SharpTSProxy targetProxy
-                ? targetProxy.TrapHasCompiled(prop, ordinaryHas)
+                ? targetProxy.TrapHasCompiled(
+                    prop, ordinaryHas, ordinaryGetOwnPropertyDescriptor,
+                    ordinaryIsExtensible, ordinaryGet)
                 : ordinaryHas(_target, prop);
         }
 
         bool result = ToBoolean(InvokeTrap(trap, null, [_target, prop]));
         if (result) return true;
 
-        object? targetDescriptor = GetTargetOwnPropertyDescriptor(prop, null);
-        if (targetDescriptor is null or SharpTSUndefined) return false;
+        object? targetDescriptor = _target is SharpTSProxy descriptorProxy
+            ? descriptorProxy.TrapGetOwnPropertyDescriptorCompiled(
+                prop, ordinaryGetOwnPropertyDescriptor,
+                ordinaryIsExtensible, ordinaryGet)
+            : ordinaryGetOwnPropertyDescriptor(_target, prop);
+        if (targetDescriptor == null || IsUndefinedLike(targetDescriptor))
+            return false;
 
         var descriptor = SharpTSPropertyDescriptor.FromAnyObject(targetDescriptor);
         if (!descriptor.Configurable)
             throw new ThrowException(new SharpTSTypeError(
                 "Proxy has trap cannot hide a non-configurable property"));
 
-        if (!TargetIsExtensible(_target))
+        if (!ordinaryIsExtensible(_target))
             throw new ThrowException(new SharpTSTypeError(
                 "Proxy has trap cannot hide a property on a non-extensible target"));
 
@@ -739,6 +831,44 @@ public class SharpTSProxy : ISharpTSCallable
             throw new ThrowException(new SharpTSTypeError(
                 "Proxy deleteProperty trap cannot hide a property on a non-extensible target"));
 
+        return true;
+    }
+
+    public bool TrapDeletePropertyCompiled(
+        string prop,
+        Func<object, string, bool> ordinaryDelete,
+        Func<object, object, object?> ordinaryGetOwnPropertyDescriptor,
+        Func<object, bool> ordinaryIsExtensible,
+        Func<object, string, object?> ordinaryGet)
+    {
+        var trap = GetTrapCallableCompiled("deleteProperty", ordinaryGet);
+        if (trap == null)
+        {
+            return _target is SharpTSProxy proxy
+                ? proxy.TrapDeletePropertyCompiled(
+                    prop, ordinaryDelete, ordinaryGetOwnPropertyDescriptor,
+                    ordinaryIsExtensible, ordinaryGet)
+                : ordinaryDelete(_target, prop);
+        }
+
+        bool result = ToBoolean(InvokeTrap(trap, null, [_target, prop]));
+        if (!result) return false;
+
+        object? targetDescriptor = _target is SharpTSProxy descriptorProxy
+            ? descriptorProxy.TrapGetOwnPropertyDescriptorCompiled(
+                prop, ordinaryGetOwnPropertyDescriptor,
+                ordinaryIsExtensible, ordinaryGet)
+            : ordinaryGetOwnPropertyDescriptor(_target, prop);
+        if (targetDescriptor == null || IsUndefinedLike(targetDescriptor))
+            return true;
+
+        var descriptor = SharpTSPropertyDescriptor.FromAnyObject(targetDescriptor);
+        if (!descriptor.Configurable)
+            throw new ThrowException(new SharpTSTypeError(
+                "Proxy deleteProperty trap cannot delete a non-configurable property"));
+        if (!ordinaryIsExtensible(_target))
+            throw new ThrowException(new SharpTSTypeError(
+                "Proxy deleteProperty trap cannot hide a property on a non-extensible target"));
         return true;
     }
 
@@ -1015,16 +1145,17 @@ public class SharpTSProxy : ISharpTSCallable
         object? prototype,
         Func<object, object?, object?> ordinarySetPrototypeOf,
         Func<object, bool> ordinaryIsExtensible,
-        Func<object, object?> ordinaryGetPrototypeOf)
+        Func<object, object?> ordinaryGetPrototypeOf,
+        Func<object, string, object?> ordinaryGet)
     {
-        var trap = GetTrapCallable("setPrototypeOf", null);
+        var trap = GetTrapCallableCompiled("setPrototypeOf", ordinaryGet);
         if (trap == null)
         {
             if (_target is SharpTSProxy proxy)
             {
                 return proxy.TrapSetPrototypeOfCompiled(
                     prototype, ordinarySetPrototypeOf,
-                    ordinaryIsExtensible, ordinaryGetPrototypeOf);
+                    ordinaryIsExtensible, ordinaryGetPrototypeOf, ordinaryGet);
             }
             _ = ordinarySetPrototypeOf(_target, prototype);
             return true;
@@ -1036,7 +1167,7 @@ public class SharpTSProxy : ISharpTSCallable
 
         object? targetPrototype = _target is SharpTSProxy targetProxy
             ? targetProxy.TrapGetPrototypeOfCompiled(
-                ordinaryGetPrototypeOf, ordinaryIsExtensible)
+                ordinaryGetPrototypeOf, ordinaryIsExtensible, ordinaryGet)
             : ordinaryGetPrototypeOf(_target);
         if (!ReferenceEquals(prototype, targetPrototype))
         {
@@ -1055,13 +1186,20 @@ public class SharpTSProxy : ISharpTSCallable
     public bool TrapDefinePropertyCompiled(
         string prop,
         object descriptor,
-        Func<object, object, object, object?> ordinaryDefine)
+        Func<object, object, object, object?> ordinaryDefine,
+        Func<object, object, object?> ordinaryGetOwnPropertyDescriptor,
+        Func<object, bool> ordinaryIsExtensible,
+        Func<object, string, object?> ordinaryGet,
+        Func<object, string, bool> ordinaryHasOwn)
     {
-        var trap = GetTrapCallable("defineProperty", null);
+        var trap = GetTrapCallableCompiled("defineProperty", ordinaryGet);
         if (trap == null)
         {
             if (_target is SharpTSProxy proxy)
-                return proxy.TrapDefinePropertyCompiled(prop, descriptor, ordinaryDefine);
+                return proxy.TrapDefinePropertyCompiled(
+                    prop, descriptor, ordinaryDefine,
+                    ordinaryGetOwnPropertyDescriptor, ordinaryIsExtensible,
+                    ordinaryGet, ordinaryHasOwn);
             ordinaryDefine(_target, prop, descriptor);
             return true;
         }
@@ -1071,13 +1209,22 @@ public class SharpTSProxy : ISharpTSCallable
         if (!trapResult) return false;
 
         object? targetDescriptor = _target is SharpTSProxy targetProxy
-            ? targetProxy.TrapGetOwnPropertyDescriptor(prop, null)
-            : ObjectBuiltIns.RuntimeGetOwnPropertyDescriptor(_target, prop);
-        bool targetHasProperty = targetDescriptor is not (null or SharpTSUndefined);
+            ? targetProxy.TrapGetOwnPropertyDescriptorCompiled(
+                prop, ordinaryGetOwnPropertyDescriptor,
+                ordinaryIsExtensible, ordinaryGet)
+            : ordinaryGetOwnPropertyDescriptor(_target, prop);
+        bool targetHasProperty = targetDescriptor != null
+            && !IsUndefinedLike(targetDescriptor);
         var requested = SharpTSPropertyDescriptor.FromAnyObject(descriptor);
+        // Compiler-emitted descriptor carriers cross this late-bound boundary
+        // without sharing a CLR type identity with SharpTS.dll. Preserve field
+        // presence through emitted callbacks so an explicit false is not
+        // confused with an omitted boolean attribute.
+        HydrateRequestedDescriptor(
+            requested, descriptor, ordinaryGet, ordinaryHasOwn);
         if (!targetHasProperty)
         {
-            if (!TargetIsExtensible(_target))
+            if (!ordinaryIsExtensible(_target))
                 throw new ThrowException(new SharpTSTypeError(
                     "Proxy defineProperty trap cannot add a property to a non-extensible target"));
             if (requested.HasConfigurable && !requested.Configurable)
@@ -1086,11 +1233,52 @@ public class SharpTSProxy : ISharpTSCallable
         }
         else
         {
+            var targetRecord =
+                SharpTSPropertyDescriptor.FromAnyObject(targetDescriptor!);
+            HydrateRequestedDescriptor(
+                targetRecord, targetDescriptor!, ordinaryGet, ordinaryHasOwn);
             ValidateDefinePropertyInvariant(
-                requested,
-                SharpTSPropertyDescriptor.FromAnyObject(targetDescriptor!));
+                requested, targetRecord);
         }
         return true;
+    }
+
+    private static void HydrateRequestedDescriptor(
+        SharpTSPropertyDescriptor descriptor,
+        object source,
+        Func<object, string, object?> get,
+        Func<object, string, bool> hasOwn)
+    {
+        if (hasOwn(source, "value"))
+        {
+            descriptor.HasValue = true;
+            descriptor.Value = get(source, "value");
+        }
+        if (hasOwn(source, "get"))
+        {
+            descriptor.HasGet = true;
+            descriptor.RawGet = get(source, "get");
+        }
+        if (hasOwn(source, "set"))
+        {
+            descriptor.HasSet = true;
+            descriptor.RawSet = get(source, "set");
+        }
+        if (hasOwn(source, "writable"))
+        {
+            descriptor.HasWritable = true;
+            descriptor.Writable = ToBoolean(get(source, "writable"));
+        }
+        if (hasOwn(source, "enumerable"))
+        {
+            descriptor.HasEnumerable = true;
+            descriptor.Enumerable = ToBoolean(get(source, "enumerable"));
+        }
+        if (hasOwn(source, "configurable"))
+        {
+            descriptor.HasConfigurable = true;
+            descriptor.Configurable = ToBoolean(get(source, "configurable"));
+        }
     }
 
     private static void ValidateDefinePropertyInvariant(
@@ -1119,10 +1307,10 @@ public class SharpTSProxy : ISharpTSCallable
         if (targetAccessor)
         {
             if (requested.HasGet
-                && !SharpTSObject.SameValue(requested.Get, target.Get))
+                && !SharpTSObject.SameValue(requested.RawGet, target.RawGet))
                 ThrowInvariant();
             if (requested.HasSet
-                && !SharpTSObject.SameValue(requested.Set, target.Set))
+                && !SharpTSObject.SameValue(requested.RawSet, target.RawSet))
                 ThrowInvariant();
             return;
         }
@@ -1397,13 +1585,12 @@ public class SharpTSProxy : ISharpTSCallable
                 return FunctionBuiltIns.CallWithThis(
                     interp, callable, thisArg, args);
 
-            // Compiled mode: target is a TSFunction, not ISharpTSCallable
+            // Compiled mode: target is an emitted callable shape.
             if (interp == null)
             {
-                var invokeMethod = ManagedStructuralClrReflection.TryGetPublicMethodByName(
-                    _target.GetType(), "Invoke");
-                if (invokeMethod != null)
-                    return invokeMethod.Invoke(_target, [args.ToArray()]);
+                if (RuntimeCallableDispatcher.IsCallable(_target))
+                    return RuntimeCallableDispatcher.InvokeWithThis(
+                        null, _target, thisArg, args.ToArray());
             }
 
             throw new Exception("Runtime Error: Proxy target is not callable.");
@@ -1413,6 +1600,33 @@ public class SharpTSProxy : ISharpTSCallable
         object argsArg = interp != null ? new SharpTSArray(args) : (object)args;
         return InvokeTrap(trap, interp, [_target, thisArg, argsArg]);
     }
+
+    public object? TrapApplyCompiled(
+        object? thisArg,
+        object?[] args,
+        Func<object, object, object?[], object?> ordinaryCall,
+        Func<object, string, object?> ordinaryGet)
+    {
+        var trap = GetTrapCallableCompiled("apply", ordinaryGet);
+        if (trap == null)
+        {
+            if (_target is SharpTSProxy targetProxy)
+                return targetProxy.TrapApplyCompiled(
+                    thisArg, args, ordinaryCall, ordinaryGet);
+            return ordinaryCall(thisArg!, _target, args);
+        }
+
+        return InvokeTrap(
+            trap, null, [_target, thisArg, new List<object?>(args)]);
+    }
+
+    /// <summary>
+    /// Late-bound callable contract used by compiler-emitted Function.prototype
+    /// call/apply wrappers. Keeping this method on the proxy avoids a hard
+    /// SharpTS.dll reference in emitted programs while preserving [[Call]].
+    /// </summary>
+    public object? InvokeWithThis(object? thisArg, object?[] args)
+        => TrapApply(thisArg, args.ToList(), null);
 
     public object? TrapConstruct(
         List<object?> args, Interpreter? interp, object? newTarget = null)
@@ -1437,6 +1651,39 @@ public class SharpTSProxy : ISharpTSCallable
             throw new ThrowException(new SharpTSTypeError(
                 "Proxy construct trap must return an object"));
         return result;
+    }
+
+    public object? TrapConstructCompiled(
+        object?[] args,
+        object? newTarget,
+        Func<object, object?[], object?> ordinaryConstruct,
+        Func<object, string, object?> ordinaryGet)
+    {
+        object effectiveNewTarget = newTarget ?? this;
+        var trap = GetTrapCallableCompiled("construct", ordinaryGet);
+        if (trap == null)
+        {
+            if (_target is SharpTSProxy targetProxy)
+                return targetProxy.TrapConstructCompiled(
+                    args, effectiveNewTarget, ordinaryConstruct, ordinaryGet);
+            return ordinaryConstruct(_target, args);
+        }
+
+        object? result = InvokeTrap(
+            trap, null,
+            [_target, new List<object?>(args), effectiveNewTarget]);
+        if (!IsObjectValue(result))
+            throw new ThrowException(new SharpTSTypeError(
+                "Proxy construct trap must return an object"));
+        return result;
+    }
+
+    public bool HasConstructableTarget(Func<object, bool> isConstructor)
+    {
+        EnsureNotRevoked();
+        return _target is SharpTSProxy proxy
+            ? proxy.HasConstructableTarget(isConstructor)
+            : isConstructor(_target);
     }
 
     #endregion
@@ -1651,9 +1898,11 @@ public class SharpTSProxy : ISharpTSCallable
     /// <summary>
     /// Converts a trap result to boolean using JavaScript truthiness rules.
     /// </summary>
-    private static bool ToBoolean(object? value) => value switch
+    private static bool ToBoolean(object? value)
     {
-        null or SharpTSUndefined => false,
+        if (value == null || IsUndefinedLike(value)) return false;
+        return value switch
+        {
         bool b => b,
         double d => d != 0 && !double.IsNaN(d),
         float f => f != 0 && !float.IsNaN(f),
@@ -1664,5 +1913,6 @@ public class SharpTSProxy : ISharpTSCallable
         SharpTSBigInt bigInt => !bigInt.Value.IsZero,
         string s => s.Length > 0,
         _ => true
-    };
+        };
+    }
 }

--- a/tests/SharpTS.Tests/SharedTests/ProxyTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/ProxyTests.cs
@@ -10,6 +10,124 @@ namespace SharpTS.Tests.SharedTests;
 public class ProxyTests
 {
     [Theory, ModeData]
+    public void Proxy_MissingGetOwnPropertyDescriptorTrap_ForwardsCompleteDescriptor(ExecutionMode mode)
+    {
+        var source = """
+            const target: any = { attr: 1 };
+            const proxy: any = new Proxy(target, {});
+            const descriptor: any = Object.getOwnPropertyDescriptor(proxy, "attr");
+            console.log(descriptor.value);
+            console.log(descriptor.writable);
+            console.log(descriptor.enumerable);
+            console.log(descriptor.configurable);
+            console.log(proxy.hasOwnProperty("attr"));
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1\ntrue\ntrue\ntrue\ntrue\n", output);
+    }
+
+    [Theory, ModeData]
+    public void Proxy_MissingSetAndDeleteTraps_ForwardWithTheProxyAsReceiver(ExecutionMode mode)
+    {
+        var source = """
+            const target: any = { attr: 1 };
+            const proxy: any = new Proxy(target, {});
+            proxy.attr = "changed";
+            console.log(proxy.attr);
+            console.log(target.attr);
+            proxy.attr = 1;
+            console.log(delete proxy.attr);
+            console.log(proxy.hasOwnProperty("attr"));
+            console.log(target.hasOwnProperty("attr"));
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("changed\nchanged\ntrue\nfalse\nfalse\n", output);
+    }
+
+    [Theory, ModeData]
+    public void Proxy_MissingGetAndSetTraps_PreserveAccessorReceiver(ExecutionMode mode)
+    {
+        var source = """
+            let setterReceiver: any;
+            const target: any = {
+                get attr() { return this; },
+                set value(next: any) { setterReceiver = this; }
+            };
+            const proxy: any = new Proxy(target, {});
+            console.log(proxy.attr === proxy);
+            proxy.value = 1;
+            console.log(setterReceiver === proxy);
+            const child: any = Object.create(proxy);
+            console.log(child.attr === child);
+            child.value = 2;
+            console.log(setterReceiver === child);
+            """;
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\ntrue\ntrue\n", output);
+    }
+
+    [Theory, ModeData]
+    public void Proxy_MissingSetTrap_UsesIntrinsicTargetDescriptors(ExecutionMode mode)
+    {
+        var source = """
+            let setterValue: any;
+            const object: any = {
+                get getterOnly() {},
+                set setterOnly(value: any) { setterValue = value; }
+            };
+            const objectProxy: any = new Proxy(new Proxy(object, {}), {});
+            objectProxy.setterOnly = 1;
+            console.log(setterValue);
+            console.log(Reflect.set(objectProxy, "getterOnly", 2));
+
+            const regexp: any = /(?:)/g;
+            const regexpProxy: any = new Proxy(new Proxy(regexp, {}), {});
+            console.log(Reflect.set(regexpProxy, "global", true));
+            regexpProxy.lastIndex = 1;
+            console.log(regexp.lastIndex);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("1\nfalse\nfalse\n1\n", output);
+    }
+
+    [Theory, ModeData]
+    public void Proxy_DefinePropertyTrap_RejectsReportedWritableTransition(ExecutionMode mode)
+    {
+        var source = """
+            const target: any = {};
+            let sawWritableField = false;
+            let sawWritableValue: any;
+            const proxy: any = new Proxy(target, {
+                defineProperty(inner: any, key: string, descriptor: any) {
+                    sawWritableField = Object.prototype.hasOwnProperty.call(
+                        descriptor, "writable");
+                    sawWritableValue = descriptor.writable;
+                    Object.defineProperty(inner, key, {
+                        configurable: false,
+                        writable: true
+                    });
+                    return true;
+                }
+            });
+            try {
+                Reflect.defineProperty(proxy, "prop", { writable: false });
+                console.log(false);
+            } catch (error) {
+                console.log(error instanceof TypeError);
+            }
+            console.log(sawWritableField);
+            console.log(sawWritableValue);
+            const descriptor: any = Object.getOwnPropertyDescriptor(target, "prop");
+            console.log(descriptor.writable);
+            console.log(descriptor.configurable);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\nfalse\ntrue\nfalse\n", output);
+    }
+
+    [Theory, ModeData]
     public void Proxy_ArrayConcat_PreservesSymbolKeysAndArrayClassification(ExecutionMode mode)
     {
         var source = """


### PR DESCRIPTION
## Summary

- complete compiled Proxy internal-method trap lookup, nested fallback, receiver/new-target routing, apply/construct, revocation, and callable metadata
- enforce descriptor, extensibility, prototype, ownKeys, set/delete/has invariants with guest error identity
- align Reflect operations and ordinary property-key ordering, with shared interpreter/compiler regressions

## Validation

- compiled pinned Test262 Proxy/Reflect replay: 254 passed
- core suite: 16,751 passed, 3 skipped; the sole accessor-identity failure was fixed and its focused regression set passed 6/6
- Release solution build: 0 warnings, 0 errors
- git diff --check

Part of #1374.