### PR TITLE
Drain dynamic import and remaining Test262 tail

### DIFF
--- a/src/SharpTS/Compilation/AsyncArrowMoveNextEmitter.Variables.cs
+++ b/src/SharpTS/Compilation/AsyncArrowMoveNextEmitter.Variables.cs
@@ -429,9 +429,15 @@ public partial class AsyncArrowMoveNextEmitter
             return;
         }
 
-        // Fallback: null
-        _il.Emit(OpCodes.Ldnull);
-        SetStackType(StackType.Null);
+        // A closure created inside an async arrow may capture a top-level
+        // function, class, or variable. Use normal global resolution so a
+        // function capture receives its canonical wrapper (and expandos), not
+        // a null snapshot.
+        if (!TryEmitGlobalVariable(name))
+        {
+            _il.Emit(OpCodes.Ldnull);
+            SetStackType(StackType.Null);
+        }
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
+++ b/src/SharpTS/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
@@ -690,7 +690,7 @@ public partial class AsyncGeneratorMoveNextEmitter
             {
                 _il.Emit(OpCodes.Ldloc, local);
             }
-            else
+            else if (!TryEmitGlobalVariable(sourceVar))
             {
                 _il.Emit(OpCodes.Ldnull);
             }

--- a/src/SharpTS/Compilation/AsyncMoveNextEmitter.ArrowFunctions.cs
+++ b/src/SharpTS/Compilation/AsyncMoveNextEmitter.ArrowFunctions.cs
@@ -125,8 +125,11 @@ public partial class AsyncMoveNextEmitter
             {
                 _il.Emit(OpCodes.Ldloc, local);
             }
-            else
+            else if (!TryEmitGlobalVariable(sourceVar))
             {
+                // Preserve the historical unresolved-name fallback. Resolvable
+                // globals (notably function declarations with expando state)
+                // are loaded through the same canonical path as a normal read.
                 _il.Emit(OpCodes.Ldnull);
             }
 

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.Operators.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.Operators.cs
@@ -636,6 +636,8 @@ public abstract partial class ExpressionEmitterBase
         IL.Emit(OpCodes.Ldstr, Ctx.CurrentModulePath ?? "");
         IL.Emit(OpCodes.Call, Ctx.Runtime!.DynamicImportModule);
         IL.Emit(OpCodes.Call, Ctx.Runtime!.WrapTaskAsPromise);
+        IL.Emit(OpCodes.Dup);
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.MarkNonAutoAwaitPromiseMethod);
         SetStackUnknown();
     }
 

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.cs
@@ -1777,7 +1777,7 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
                 {
                     IL.Emit(OpCodes.Ldloc, local);
                 }
-                else
+                else if (!TryEmitGlobalVariable(sourceVar))
                 {
                     IL.Emit(OpCodes.Ldnull);
                 }

--- a/src/SharpTS/Compilation/ILEmitter.Modules.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Modules.cs
@@ -741,6 +741,12 @@ public partial class ILEmitter
 
         // Wrap Task<object?> in SharpTSPromise
         EmitCallUnknown(_ctx.Runtime!.WrapTaskAsPromise);
+
+        // A bare import() expression returns an ordinary Promise. Do not let
+        // the standalone entry point's top-level auto-await convenience turn
+        // an intentionally ignored rejection into an uncaught program error.
+        IL.Emit(OpCodes.Dup);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.MarkNonAutoAwaitPromiseMethod);
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Search.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Search.cs
@@ -2485,6 +2485,30 @@ public partial class RuntimeEmitter
             il.MarkLabel(notRegExpInstance);
         }
 
+        // Function objects have an intrinsic Function.prototype relationship
+        // that is not represented by a per-instance PDS prototype. Generic
+        // array algorithms call HasProperty before Get, so explicitly walk
+        // the function prototype to observe inherited indexed properties.
+        var notFunctionInstance = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, currentLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSFunctionType);
+        il.Emit(OpCodes.Brfalse, notFunctionInstance);
+        il.Emit(OpCodes.Call, runtime.FunctionPrototypePopulateMethod);
+        il.Emit(OpCodes.Ldsfld, runtime.FunctionPrototypeField);
+        il.Emit(OpCodes.Stloc, currentLocal);
+        il.Emit(OpCodes.Br, loopStart);
+        il.MarkLabel(notFunctionInstance);
+
+        var notBoundFunctionInstance = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, currentLocal);
+        il.Emit(OpCodes.Isinst, runtime.BoundTSFunctionType);
+        il.Emit(OpCodes.Brfalse, notBoundFunctionInstance);
+        il.Emit(OpCodes.Call, runtime.FunctionPrototypePopulateMethod);
+        il.Emit(OpCodes.Ldsfld, runtime.FunctionPrototypeField);
+        il.Emit(OpCodes.Stloc, currentLocal);
+        il.Emit(OpCodes.Br, loopStart);
+        il.MarkLabel(notBoundFunctionInstance);
+
         // Other object shapes can still carry an explicit PDS prototype.
         // Continue that chain before falling back to Object.prototype.
         il.Emit(OpCodes.Ldloc, currentLocal);

--- a/src/SharpTS/Compilation/RuntimeEmitter.DynamicImport.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.DynamicImport.cs
@@ -160,6 +160,7 @@ public partial class RuntimeEmitter
         var tcsLocal = il.DeclareLocal(tcsType);
         var exceptionLocal = il.DeclareLocal(_types.Exception);
         var lookupPathLocal = il.DeclareLocal(_types.String);
+        var importerDirectoryLocal = il.DeclareLocal(_types.String);
 
         // Labels
         var notFoundLabel = il.DefineLabel();
@@ -175,9 +176,18 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, typeof(string).GetMethod(
             nameof(string.StartsWith), [typeof(string)])!);
         il.Emit(OpCodes.Brfalse, lookupReadyLabel);
+
+        // Single-file compilation has no owning module path. Keep the raw
+        // relative specifier in that case: Path.GetDirectoryName("") returns
+        // null, and passing it to Path.Combine used to throw synchronously
+        // instead of returning import()'s required rejected Promise.
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Call, typeof(Path).GetMethod(
             nameof(Path.GetDirectoryName), [typeof(string)])!);
+        il.Emit(OpCodes.Stloc, importerDirectoryLocal);
+        il.Emit(OpCodes.Ldloc, importerDirectoryLocal);
+        il.Emit(OpCodes.Brfalse, lookupReadyLabel);
+        il.Emit(OpCodes.Ldloc, importerDirectoryLocal);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, typeof(Path).GetMethod(
             nameof(Path.Combine), [typeof(string), typeof(string)])!);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Index.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Index.cs
@@ -294,6 +294,11 @@ public partial class RuntimeEmitter
         // already passed it to il.Emit, which throws on null. A redundant != null guard here
         // would only poison nullable flow analysis for the unconditional casts further down.
         EmitProtoSymbolFallback(runtime.TSArrayType, runtime.ArrayPrototypeField, runtime.ArrayPrototypePopulateMethod);
+        // Functions inherit symbol-keyed properties from Function.prototype,
+        // including Symbol.isConcatSpreadable. The own symbol dictionary was
+        // already checked above; only a miss reaches this fallback.
+        EmitProtoSymbolFallback(runtime.TSFunctionType, runtime.FunctionPrototypeField, runtime.FunctionPrototypePopulateMethod);
+        EmitProtoSymbolFallback(runtime.BoundTSFunctionType, runtime.FunctionPrototypeField, runtime.FunctionPrototypePopulateMethod);
 
         // Ordinary symbol-keyed [[Get]] walks the receiver's explicit PDS
         // prototype chain just like string-keyed GetProperty. This is needed

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.SetProperty.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.SetProperty.cs
@@ -1362,6 +1362,25 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.PDSIsWritable);
         il.Emit(OpCodes.Brfalse, nullLabel);  // Not writable, silently return
 
+        // Dictionary-backed intrinsic prototypes may also carry an
+        // authoritative PDS data descriptor for the same key. Update it in
+        // place so descriptor-aware reads do not see the stale value (for
+        // example after Function.prototype.toString = custom).
+        var dictDescriptorLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
+        var dictRawStoreLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
+        il.Emit(OpCodes.Stloc, dictDescriptorLocal);
+        il.Emit(OpCodes.Ldloc, dictDescriptorLocal);
+        il.Emit(OpCodes.Brfalse, dictRawStoreLabel);
+        il.Emit(OpCodes.Ldloc, dictDescriptorLocal);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorValue.GetSetMethod()!);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(dictRawStoreLabel);
+
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Castclass, _types.DictionaryStringObject);
         il.Emit(OpCodes.Ldarg_1);
@@ -1818,6 +1837,16 @@ public partial class RuntimeEmitter
         EmitInvokePdsSetterWithValueAndReturn(il, runtime, sharpSetterLocal);
         il.MarkLabel(sharpNoSetterLabel);
 
+        // Object-literal accessors are stored in $Object's native _setters
+        // dictionary rather than PDS. They remain callable after freeze, so
+        // delegate before the receiver-wide PDSIsWritable integrity check.
+        var sharpDelegateToObjectLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSObjectType);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, runtime.TSObjectHasSetter);
+        il.Emit(OpCodes.Brtrue, sharpDelegateToObjectLabel);
+
         var sharpWritableLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
@@ -1827,6 +1856,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, nullLabel);
         EmitThrowTypeErrorWithName(il, runtime, "Cannot assign to read only property '", "' of object");
         il.MarkLabel(sharpWritableLabel);
+        il.MarkLabel(sharpDelegateToObjectLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Castclass, runtime.TSObjectType);
         il.Emit(OpCodes.Ldarg_1);
@@ -1851,6 +1881,15 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloca, valueLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ConditionalWeakTable, "TryGetValue", _types.Object, _types.Object.MakeByRefType()));
         il.Emit(OpCodes.Brfalse, sealedCheckLabel); // Not frozen, check sealed
+
+        // Frozen data properties reject writes, but accessor setters remain
+        // callable after Object.freeze.
+        var strictFrozenSetterLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloca, strictFrozenSetterLocal);
+        il.Emit(OpCodes.Call, runtime.PDSTryGetSetter);
+        il.Emit(OpCodes.Brtrue, doSetLabel);
 
         // Object is frozen - check strict mode
         il.Emit(OpCodes.Ldarg_3); // strictMode
@@ -1930,6 +1969,22 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, nullLabel); // sloppy → silent return
         EmitThrowTypeErrorWithName(il, runtime, "Cannot assign to read only property '", "' of object");
         il.MarkLabel(strictWritableLabel);
+
+        // Keep PDS-backed data descriptors in sync with dictionary assignment.
+        var strictDictDescriptorLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
+        var strictDictRawStoreLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
+        il.Emit(OpCodes.Stloc, strictDictDescriptorLocal);
+        il.Emit(OpCodes.Ldloc, strictDictDescriptorLocal);
+        il.Emit(OpCodes.Brfalse, strictDictRawStoreLabel);
+        il.Emit(OpCodes.Ldloc, strictDictDescriptorLocal);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorValue.GetSetMethod()!);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(strictDictRawStoreLabel);
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Castclass, _types.DictionaryStringObject);
@@ -2017,7 +2072,11 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, strictSymNoSetterLabel);
         il.Emit(OpCodes.Ldloc, strictSymSetterLocal);
         il.Emit(OpCodes.Isinst, runtime.UndefinedType);
-        il.Emit(OpCodes.Brfalse, symCheckObjectStateLabel); // callable setter
+        // A callable accessor setter remains writable after freeze. Route
+        // directly to invocation, bypassing the receiver integrity-level
+        // checks that apply only to data writes.
+        var strictSymInvokeSetterLabel = il.DefineLabel();
+        il.Emit(OpCodes.Brfalse, strictSymInvokeSetterLabel);
         il.MarkLabel(strictSymNoSetterLabel);
         il.Emit(OpCodes.Ldloc, strictSymDescriptorLocal);
         il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorGetter.GetGetMethod()!);
@@ -2027,6 +2086,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, strictSymDescriptorLocal);
         il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorWritable.GetGetMethod()!);
         il.Emit(OpCodes.Brfalse, symThrowLabel);
+        il.Emit(OpCodes.Br, symCheckObjectStateLabel);
+
+        il.MarkLabel(strictSymInvokeSetterLabel);
+        EmitInvokePdsSetterWithValueAndReturn(il, runtime, strictSymSetterLocal);
 
         il.MarkLabel(symCheckObjectStateLabel);
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.SetProperty.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.SetProperty.cs
@@ -1362,10 +1362,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.PDSIsWritable);
         il.Emit(OpCodes.Brfalse, nullLabel);  // Not writable, silently return
 
-        // Dictionary-backed intrinsic prototypes may also carry an
-        // authoritative PDS data descriptor for the same key. Update it in
-        // place so descriptor-aware reads do not see the stale value (for
-        // example after Function.prototype.toString = custom).
+        // Dictionary-backed objects may also carry a PDS data descriptor for
+        // the same key. Keep both stores synchronized: descriptor-aware reads
+        // observe the PDS value, while ordinary reads use the dictionary.
         var dictDescriptorLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
         var dictRawStoreLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
@@ -1377,7 +1376,6 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, dictDescriptorLocal);
         il.Emit(OpCodes.Ldarg_2);
         il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorValue.GetSetMethod()!);
-        il.Emit(OpCodes.Ret);
 
         il.MarkLabel(dictRawStoreLabel);
 
@@ -1970,7 +1968,7 @@ public partial class RuntimeEmitter
         EmitThrowTypeErrorWithName(il, runtime, "Cannot assign to read only property '", "' of object");
         il.MarkLabel(strictWritableLabel);
 
-        // Keep PDS-backed data descriptors in sync with dictionary assignment.
+        // Keep PDS-backed data descriptors and dictionary storage synchronized.
         var strictDictDescriptorLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
         var strictDictRawStoreLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
@@ -1982,7 +1980,6 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, strictDictDescriptorLocal);
         il.Emit(OpCodes.Ldarg_2);
         il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorValue.GetSetMethod()!);
-        il.Emit(OpCodes.Ret);
 
         il.MarkLabel(strictDictRawStoreLabel);
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.StringPrototypeStubs.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.StringPrototypeStubs.cs
@@ -573,6 +573,32 @@ public partial class RuntimeEmitter
         // so the toString tag must agree (#314).
         EmitFunctionBranch(_types.Type);
 
+        // A Proxy whose target is callable has its own [[Call]] internal
+        // method and therefore uses the Function builtin tag. The proxy
+        // carrier itself is not one of the concrete callable CLR wrappers
+        // above, so consult its runtime IsCallable slot explicitly. This also
+        // handles proxies whose targets are themselves callable proxies.
+        if (_features.UsesProxy)
+        {
+            var notProxyLabel = il.DefineLabel();
+            var proxyLabel = il.DefineLabel();
+            EmitProxyTypeCheck(
+                il, () => il.Emit(OpCodes.Ldarg_0),
+                proxyLabel, notProxyLabel);
+            il.MarkLabel(proxyLabel);
+            var proxyNotCallableLabel = il.DefineLabel();
+            EmitProxyMethodCall(il, () => il.Emit(OpCodes.Ldarg_0), "get_IsCallable", () =>
+            {
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Newarr, _types.Object);
+            });
+            il.Emit(OpCodes.Unbox_Any, _types.Boolean);
+            il.Emit(OpCodes.Brfalse, proxyNotCallableLabel);
+            EmitTag("[object Function]");
+            il.MarkLabel(proxyNotCallableLabel);
+            il.MarkLabel(notProxyLabel);
+        }
+
         // $Date — ECMA-262 §21.4.4.42 brand check via [[DateValue]] slot.
         if (runtime.TSDateType != null)
         {

--- a/tests/SharpTS.Tests/SharedTests/ArrayConcatSpreadTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/ArrayConcatSpreadTests.cs
@@ -19,6 +19,35 @@ namespace SharpTS.Tests.SharedTests;
 public class ArrayConcatSpreadTests
 {
     [Theory, ModeData]
+    public void Concat_SpreadableFunction_ObservesInheritedIndexes(ExecutionMode mode)
+    {
+        var source = @"
+            const first: any = function(a, b, c) {};
+            first[Symbol.isConcatSpreadable] = true;
+            first[0] = 1;
+            first[1] = 2;
+            first[2] = 3;
+            console.log(JSON.stringify([].concat(first)));
+
+            (Function.prototype as any)[Symbol.isConcatSpreadable] = true;
+            const second: any = function(a, b, c) {};
+            console.log(JSON.stringify([].concat(second)));
+
+            (Function.prototype as any)[0] = 4;
+            (Function.prototype as any)[1] = 5;
+            (Function.prototype as any)[2] = 6;
+            console.log(JSON.stringify([].concat(function(a, b, c) {})));
+
+            delete (Function.prototype as any)[Symbol.isConcatSpreadable];
+            delete (Function.prototype as any)[0];
+            delete (Function.prototype as any)[1];
+            delete (Function.prototype as any)[2];
+        ";
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("[1,2,3]\n[null,null,null]\n[4,5,6]\n", output);
+    }
+
+    [Theory, ModeData]
     public void Concat_SpreadOfArrayOfArrays_FlattensOneLevel(ExecutionMode mode)
     {
         // The issue repro: ...[[1, 2]] spreads into concat([1, 2]), which then

--- a/tests/SharpTS.Tests/SharedTests/AsyncArrowFunctionTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/AsyncArrowFunctionTests.cs
@@ -10,6 +10,24 @@ namespace SharpTS.Tests.SharedTests;
 public class AsyncArrowFunctionTests
 {
     [Theory, ModeData]
+    public void AsyncFunction_SyncArrowCapturesCanonicalTopLevelFunctionObject(ExecutionMode mode)
+    {
+        var source = """
+            function helper() {}
+            helper.extra = 42;
+
+            async function run() {
+                const callback = () => helper.extra;
+                return callback();
+            }
+
+            run().then(value => console.log(value));
+            """;
+
+        Assert.Equal("42\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
     public void AsyncArrow_BasicReturn(ExecutionMode mode)
     {
         var source = """

--- a/tests/SharpTS.Tests/SharedTests/ObjectFeatureTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/ObjectFeatureTests.cs
@@ -1734,6 +1734,31 @@ public class ObjectFeatureTests
     }
 
     [Theory, ModeData]
+    public void Object_DefineProperty_WritableProperty_SynchronizesDescriptorAndStorage(ExecutionMode mode)
+    {
+        var source = """
+            let sloppyObject: any = {};
+            Object.defineProperty(sloppyObject, "x", { value: 42, writable: true });
+            sloppyObject.x = 100;
+            console.log(sloppyObject.x);
+            console.log(Object.getOwnPropertyDescriptor(sloppyObject, "x").value);
+
+            let strictObject: any = {};
+            Object.defineProperty(strictObject, "x", { value: 42, writable: true });
+            function assignStrict() {
+                "use strict";
+                strictObject.x = 200;
+            }
+            assignStrict();
+            console.log(strictObject.x);
+            console.log(Object.getOwnPropertyDescriptor(strictObject, "x").value);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("100\n100\n200\n200\n", output);
+    }
+
+    [Theory, ModeData]
     public void Object_DefineProperty_MultipleProperties(ExecutionMode mode)
     {
         var source = """

--- a/tests/conformance/SharpTS.Test262/Issue1279ParityTests.cs
+++ b/tests/conformance/SharpTS.Test262/Issue1279ParityTests.cs
@@ -6551,6 +6551,37 @@ public void Promise_combinators_share_iterator_and_resolution_semantics(string r
     public void Function_environment_lowering_is_shared_by_function_and_class_paths(string relativePath)
         => AssertPass(relativePath, Test262ExecutionMode.Compiled);
 
+    public static TheoryData<string> DynamicImportCompilerCases => new()
+    {
+        "language/expressions/dynamic-import/always-create-new-promise.js",
+        "language/expressions/dynamic-import/assignment-expression/unary-expr.js",
+        "language/expressions/dynamic-import/catch/top-level-import-catch-file-does-not-exist.js",
+        "language/expressions/dynamic-import/catch/nested-async-function-await-file-does-not-exist.js",
+        "language/expressions/dynamic-import/catch/nested-async-function-file-does-not-exist.js",
+        "language/expressions/dynamic-import/catch/nested-async-function-return-await-file-does-not-exist.js",
+        "language/expressions/dynamic-import/syntax/valid/callexpression-arguments.js",
+        "language/expressions/dynamic-import/syntax/valid/nested-block-nested-imports.js",
+        "language/expressions/dynamic-import/syntax/valid/top-level-script-code-valid.js",
+    };
+
+    [Theory]
+    [MemberData(nameof(DynamicImportCompilerCases))]
+    public void Dynamic_import_call_shapes_and_rejections_match_in_compiled_mode(string relativePath)
+        => AssertPass(relativePath, Test262ExecutionMode.Compiled);
+
+    public static TheoryData<string> RemainingBuiltInTailCompilerCases => new()
+    {
+            "built-ins/Array/prototype/concat/Array.prototype.concat_spreadable-function.js",
+        "built-ins/Object/assign/target-is-frozen-accessor-property-set-succeeds.js",
+        "built-ins/Object/prototype/toString/symbol-tag-non-str-proxy-function.js",
+        "built-ins/String/S15.5.2.1_A1_T8.js",
+    };
+
+    [Theory]
+    [MemberData(nameof(RemainingBuiltInTailCompilerCases))]
+    public void Remaining_committed_built_in_tail_matches_in_compiled_mode(string relativePath)
+        => AssertPass(relativePath, Test262ExecutionMode.Compiled);
+
     private void AssertPass(
         string relativePath,
         Test262ExecutionMode mode,


### PR DESCRIPTION
## Summary

- make single-file relative dynamic imports reject asynchronously instead of throwing during path resolution
- preserve import() promises from top-level auto-await and retain canonical global captures in nested async closures
- finish the committed built-in tail covering frozen accessor assignment, function concat spreadability, callable Proxy branding, and Function.prototype string coercion
- add focused shared and Test262 regression coverage

Part of #1374.

## Validation

- dynamic-import focused Test262 sweep: 941/941 compiled files passed; compiler-only deficits reduced from 34 to 0
- focused Test262 parity regressions: 13/13 passed
- affected shared suites: 251/251 passed
- SharpTS.Tests and SharpTS.Test262 Release builds passed

Note: a full solution --no-restore build remains unavailable in the fresh worktree because unrelated GUI, benchmark, SDK, and sample projects do not have restored project.assets.json files.