### PR TITLE
Complete binary-data, collection, BigInt, and Symbol emitted helpers

### DIFF
--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -307,6 +307,8 @@ public class EmittedRuntime
     public MethodBuilder ArrayValues { get; set; } = null!;
     public TypeBuilder ArrayIteratorType { get; set; } = null!;
     public ConstructorBuilder ArrayIteratorCtor { get; set; } = null!;
+    public TypeBuilder MapCollectionIteratorType { get; set; } = null!;
+    public ConstructorBuilder MapCollectionIteratorCtor { get; set; } = null!;
     public MethodBuilder ArrayLikeMaterialize { get; set; } = null!;
     // ECMA-262 RequireObjectCoercible(this) — throws TypeError if `this` is
     // null or undefined. Called from $TSFunction.CoercePrimitiveArgs via
@@ -520,6 +522,7 @@ public class EmittedRuntime
     public FieldBuilder BigIntPrototypeField { get; set; } = null!;
     /// <summary>Symbol.prototype singleton used by value-position Symbol prototype access.</summary>
     public FieldBuilder SymbolPrototypeField { get; set; } = null!;
+    public MethodBuilder SymbolPrototypePopulateMethod { get; set; } = null!;
     /// <summary>JSON singleton — `typeof JSON === "object"` per ECMA-262.</summary>
     public FieldBuilder JsonSingletonField { get; set; } = null!;
     /// <summary>
@@ -912,6 +915,9 @@ public class EmittedRuntime
 
     // Symbol.description instance property getter
     public MethodBuilder SymbolDescriptionGetter { get; set; } = null!;
+    public MethodBuilder SymbolPrototypeDescription { get; set; } = null!;
+    public MethodBuilder SymbolPrototypeToString { get; set; } = null!;
+    public MethodBuilder SymbolPrototypeValueOf { get; set; } = null!;
 
     // Symbol storage for compiled objects (symbol as object key)
     public MethodBuilder GetSymbolDictMethod { get; set; } = null!;
@@ -919,6 +925,10 @@ public class EmittedRuntime
 
     // BigInt support
     public MethodBuilder CreateBigInt { get; set; } = null!;
+    public MethodBuilder BigIntAsIntN { get; set; } = null!;
+    public MethodBuilder BigIntAsUintN { get; set; } = null!;
+    /// <summary>$Runtime.ToBigInt(object) -> boxed BigInteger — strict ECMA-262 ToBigInt (unlike the callable BigInt conversion, Number primitives are rejected).</summary>
+    public MethodBuilder ToBigInt { get; set; } = null!;
     /// <summary>$Runtime.BigIntToNumber(BigInteger) -> double — ECMA-262 NumberFromBigInt with ties-to-even binary64 rounding.</summary>
     public MethodBuilder BigIntToNumber { get; set; } = null!;
     public MethodBuilder BigIntAdd { get; set; } = null!;
@@ -943,6 +953,7 @@ public class EmittedRuntime
     public MethodBuilder BigIntLessThanOrEqual { get; set; } = null!;
     public MethodBuilder BigIntGreaterThan { get; set; } = null!;
     public MethodBuilder BigIntGreaterThanOrEqual { get; set; } = null!;
+    public MethodBuilder UpdateNumeric { get; set; } = null!;
 
     // Promise support
     public MethodBuilder PromiseResolve { get; set; } = null!;
@@ -1636,6 +1647,7 @@ public class EmittedRuntime
     public MethodBuilder ArrayBufferByteLengthGetter { get; set; } = null!;
     public MethodBuilder ArrayBufferGetBuffer { get; set; } = null!;
     public MethodBuilder ArrayBufferSlice { get; set; } = null!;
+    public MethodBuilder ArrayBufferSliceDynamic { get; set; } = null!;
 
     // $SharedArrayBuffer type (pure-IL for standalone DLLs)
     public TypeBuilder SharedArrayBufferType { get; set; } = null!;

--- a/src/SharpTS/Compilation/Emitters/ArrayBufferStaticEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/ArrayBufferStaticEmitter.cs
@@ -27,8 +27,13 @@ public sealed class ArrayBufferStaticEmitter : IStaticTypeEmitterStrategy
     /// </summary>
     public bool TryEmitStaticPropertyGet(IEmitterContext emitter, string propertyName)
     {
-        // ArrayBuffer has no static properties
-        return false;
+        if (propertyName != "isView") return false;
+        var ctx = emitter.Context;
+        ctx.Types.EmitLoadMethodInfo(ctx.IL, ctx.Runtime!.TSArrayBufferIsView);
+        ctx.IL.Emit(OpCodes.Ldstr, "isView");
+        ctx.IL.Emit(OpCodes.Ldc_I4_1);
+        ctx.IL.Emit(OpCodes.Call, ctx.Runtime.TSFunctionGetOrCreate);
+        return true;
     }
 
     private static bool EmitIsView(IEmitterContext emitter, List<Expr> arguments)

--- a/src/SharpTS/Compilation/Emitters/DataViewEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/DataViewEmitter.cs
@@ -42,7 +42,6 @@ public sealed class DataViewEmitter : ITypeEmitterStrategy
                 EmitByteOffsetArg(emitter, arguments, 0);
                 EmitValueArg(emitter, arguments, 1);
                 il.Emit(OpCodes.Call, GetDataViewMethod(ctx, methodName));
-                il.Emit(OpCodes.Ldnull); // setters return undefined
                 return true;
 
             // 16-bit, 32-bit, float getters (with endianness)
@@ -79,7 +78,6 @@ public sealed class DataViewEmitter : ITypeEmitterStrategy
                 EmitValueArg(emitter, arguments, 1);
                 EmitLittleEndianArg(emitter, arguments, 2);
                 il.Emit(OpCodes.Call, GetDataViewMethod(ctx, methodName));
-                il.Emit(OpCodes.Ldnull); // setters return undefined
                 return true;
         }
 

--- a/src/SharpTS/Compilation/Emitters/FinalizationRegistryEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/FinalizationRegistryEmitter.cs
@@ -55,7 +55,6 @@ public sealed class FinalizationRegistryEmitter : ITypeEmitterStrategy
                 }
 
                 il.Emit(OpCodes.Call, ctx.Runtime!.FinalizationRegistryRegister);
-                il.Emit(OpCodes.Ldnull); // register returns undefined
                 return true;
 
             case "unregister":

--- a/src/SharpTS/Compilation/Emitters/MapEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/MapEmitter.cs
@@ -48,7 +48,7 @@ public sealed class MapEmitter : ITypeEmitterStrategy
 
             case "clear":
                 il.Emit(OpCodes.Call, ctx.Runtime!.MapClear);
-                il.Emit(OpCodes.Ldnull); // clear returns undefined
+                il.Emit(OpCodes.Ldsfld, ctx.Runtime.UndefinedInstance);
                 return true;
 
             case "keys":
@@ -65,6 +65,15 @@ public sealed class MapEmitter : ITypeEmitterStrategy
 
             case "forEach":
                 EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
+                if (arguments.Count > 1)
+                {
+                    emitter.EmitExpression(arguments[1]);
+                    emitter.EmitBoxIfNeeded(arguments[1]);
+                }
+                else
+                {
+                    il.Emit(OpCodes.Ldsfld, ctx.Runtime!.UndefinedInstance);
+                }
                 il.Emit(OpCodes.Call, ctx.Runtime!.MapForEach);
                 il.Emit(OpCodes.Ldsfld, ctx.Runtime!.UndefinedInstance);
                 return true;

--- a/src/SharpTS/Compilation/Emitters/MapStaticEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/MapStaticEmitter.cs
@@ -45,6 +45,12 @@ public sealed class MapStaticEmitter : IStaticTypeEmitterStrategy
 
     public bool TryEmitStaticPropertyGet(IEmitterContext emitter, string propertyName)
     {
-        return false;
+        if (propertyName != "groupBy") return false;
+        var ctx = emitter.Context;
+        ctx.Types.EmitLoadMethodInfo(ctx.IL, ctx.Runtime!.MapGroupBy);
+        ctx.IL.Emit(OpCodes.Ldstr, "groupBy");
+        ctx.IL.Emit(OpCodes.Ldc_I4_2);
+        ctx.IL.Emit(OpCodes.Call, ctx.Runtime.TSFunctionGetOrCreate);
+        return true;
     }
 }

--- a/src/SharpTS/Compilation/Emitters/SetEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/SetEmitter.cs
@@ -42,7 +42,7 @@ public sealed class SetEmitter : ITypeEmitterStrategy
 
             case "clear":
                 il.Emit(OpCodes.Call, ctx.Runtime!.SetClear);
-                il.Emit(OpCodes.Ldnull); // clear returns undefined
+                il.Emit(OpCodes.Ldsfld, ctx.Runtime.UndefinedInstance);
                 return true;
 
             case "keys":
@@ -59,6 +59,15 @@ public sealed class SetEmitter : ITypeEmitterStrategy
 
             case "forEach":
                 EmitterArgumentHelpers.EmitBoxedArgumentOrNull(emitter, arguments, 0);
+                if (arguments.Count > 1)
+                {
+                    emitter.EmitExpression(arguments[1]);
+                    emitter.EmitBoxIfNeeded(arguments[1]);
+                }
+                else
+                {
+                    il.Emit(OpCodes.Ldsfld, ctx.Runtime!.UndefinedInstance);
+                }
                 il.Emit(OpCodes.Call, ctx.Runtime!.SetForEach);
                 il.Emit(OpCodes.Ldsfld, ctx.Runtime!.UndefinedInstance);
                 return true;

--- a/src/SharpTS/Compilation/Emitters/SymbolStaticEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/SymbolStaticEmitter.cs
@@ -81,7 +81,8 @@ public sealed class SymbolStaticEmitter : IStaticTypeEmitterStrategy
         switch (propertyName)
         {
             case "prototype":
-                il.Emit(OpCodes.Ldsfld, ctx.Runtime!.SymbolPrototypeField);
+                il.Emit(OpCodes.Call, ctx.Runtime!.SymbolPrototypePopulateMethod);
+                il.Emit(OpCodes.Ldsfld, ctx.Runtime.SymbolPrototypeField);
                 return true;
             case "iterator":
                 il.Emit(OpCodes.Ldsfld, ctx.Runtime!.SymbolIterator);

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.cs
@@ -2000,6 +2000,12 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             "Set" => Types.HashSetOfObject,
             "WeakMap" => Types.ConditionalWeakTableObjectObject,
             "WeakSet" => Types.ConditionalWeakTableObjectObject,
+            // WeakRef and FinalizationRegistry are backed by BCL containers in
+            // standalone output.  Their Type tokens provide the constructor
+            // object in value position (typeof/isConstructor/prototype), while
+            // `new` remains routed through the dedicated emitted factories.
+            "WeakRef" => Types.WeakReferenceObject,
+            "FinalizationRegistry" => Types.ObjectArray,
             "Promise" => Types.TaskOfObject,
             "Function" => Ctx.Runtime!.TSFunctionType,
             // Symbol (#234): the value-form $TSSymbol token. ILEmitter handles
@@ -2388,7 +2394,8 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         // without this, `typeof Array` returns `"undefined"` in compiled mode even though
         // these names resolve fine everywhere else via TryEmitBuiltInClassType.
         if (name is "Array" or "Date" or "RegExp" or "Map" or "Set"
-            or "WeakMap" or "WeakSet" or "Promise" or "Buffer" or "Function"
+            or "WeakMap" or "WeakSet" or "WeakRef" or "FinalizationRegistry"
+            or "Promise" or "Buffer" or "Function"
             or "Object" or "String" or "Number" or "Boolean"
             or "TextEncoder" or "TextDecoder") return true;
         // Typed-array / buffer constructors as values (#331) — without this,

--- a/src/SharpTS/Compilation/ILEmitter.Calls.MapMethods.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.MapMethods.cs
@@ -109,7 +109,7 @@ public partial class ILEmitter
             case "clear":
                 IL.Emit(OpCodes.Ldloc, objLocal);
                 IL.Emit(OpCodes.Call, _ctx.Runtime!.MapClear);
-                IL.Emit(OpCodes.Ldnull); // clear returns undefined
+                IL.Emit(OpCodes.Ldsfld, _ctx.Runtime.UndefinedInstance);
                 break;
 
             case "keys":
@@ -138,8 +138,17 @@ public partial class ILEmitter
                 {
                     IL.Emit(OpCodes.Ldnull);
                 }
+                if (arguments.Count > 1)
+                {
+                    EmitExpression(arguments[1]);
+                    EmitBoxIfNeeded(arguments[1]);
+                }
+                else
+                {
+                    IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.UndefinedInstance);
+                }
                 IL.Emit(OpCodes.Call, _ctx.Runtime!.MapForEach);
-                IL.Emit(OpCodes.Ldnull); // forEach returns undefined
+                IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.UndefinedInstance);
                 break;
 
             default:

--- a/src/SharpTS/Compilation/ILEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Operators.cs
@@ -1322,9 +1322,40 @@ public partial class ILEmitter
                 return;
             }
 
+            // Update expressions use ToNumeric, so a BigInt operand remains
+            // BigInt and adds/subtracts 1n. The ordinary path below unboxes to
+            // double and therefore cannot consume boxed BigInteger values.
+            if (IsBigIntExpr(pi.Operand))
+            {
+                EmitVariable(v);
+                IL.Emit(OpCodes.Call, _ctx.Types.GetProperty(_ctx.Types.BigInteger, "One")!.GetGetMethod()!);
+                IL.Emit(OpCodes.Box, _ctx.Types.BigInteger);
+                IL.Emit(OpCodes.Call, pi.Operator.Type == TokenType.PLUS_PLUS
+                    ? _ctx.Runtime!.BigIntAdd
+                    : _ctx.Runtime!.BigIntSubtract);
+                IL.Emit(OpCodes.Dup);
+                EmitStoreIncrementedVariable(v.Name.Lexeme, isTypedDouble: false,
+                    resultIsUnboxedDouble: false);
+                return;
+            }
+
             // Check if this is a typed double local
             var localType = _ctx.Locals.GetLocalType(v.Name.Lexeme);
             bool isTypedDouble = localType != null && _ctx.Types.IsDouble(localType);
+
+            if (!isTypedDouble)
+            {
+                EmitVariable(v);
+                EmitBoxIfNeeded(v);
+                IL.Emit(pi.Operator.Type == TokenType.PLUS_PLUS
+                    ? OpCodes.Ldc_I4_1
+                    : OpCodes.Ldc_I4_0);
+                IL.Emit(OpCodes.Call, _ctx.Runtime!.UpdateNumeric);
+                IL.Emit(OpCodes.Dup);
+                EmitStoreIncrementedVariable(v.Name.Lexeme, isTypedDouble: false,
+                    resultIsUnboxedDouble: false);
+                return;
+            }
 
             EmitVariable(v);
 
@@ -1518,9 +1549,37 @@ public partial class ILEmitter
                 return;
             }
 
+            if (IsBigIntExpr(pi.Operand))
+            {
+                EmitVariable(v);
+                IL.Emit(OpCodes.Dup); // postfix expression keeps the old BigInt
+                IL.Emit(OpCodes.Call, _ctx.Types.GetProperty(_ctx.Types.BigInteger, "One")!.GetGetMethod()!);
+                IL.Emit(OpCodes.Box, _ctx.Types.BigInteger);
+                IL.Emit(OpCodes.Call, pi.Operator.Type == TokenType.PLUS_PLUS
+                    ? _ctx.Runtime!.BigIntAdd
+                    : _ctx.Runtime!.BigIntSubtract);
+                EmitStoreIncrementedVariable(v.Name.Lexeme, isTypedDouble: false,
+                    resultIsUnboxedDouble: false);
+                return;
+            }
+
             // Check if this is a typed double local
             var localType = _ctx.Locals.GetLocalType(v.Name.Lexeme);
             bool isTypedDouble = localType != null && _ctx.Types.IsDouble(localType);
+
+            if (!isTypedDouble)
+            {
+                EmitVariable(v);
+                EmitBoxIfNeeded(v);
+                IL.Emit(OpCodes.Dup);
+                IL.Emit(pi.Operator.Type == TokenType.PLUS_PLUS
+                    ? OpCodes.Ldc_I4_1
+                    : OpCodes.Ldc_I4_0);
+                IL.Emit(OpCodes.Call, _ctx.Runtime!.UpdateNumeric);
+                EmitStoreIncrementedVariable(v.Name.Lexeme, isTypedDouble: false,
+                    resultIsUnboxedDouble: false);
+                return;
+            }
 
             EmitVariable(v);
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.BigInt.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.BigInt.cs
@@ -6,6 +6,119 @@ namespace SharpTS.Compilation;
 
 public partial class RuntimeEmitter
 {
+    private void EmitBigIntStaticMethods(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        runtime.BigIntAsIntN = EmitBigIntTruncate(typeBuilder, runtime, "BigIntAsIntN", signed: true);
+        runtime.BigIntAsUintN = EmitBigIntTruncate(typeBuilder, runtime, "BigIntAsUintN", signed: false);
+    }
+
+    private MethodBuilder EmitBigIntTruncate(
+        TypeBuilder typeBuilder, EmittedRuntime runtime, string name, bool signed)
+    {
+        var method = typeBuilder.DefineMethod(
+            name,
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Object]);
+
+        var il = method.GetILGenerator();
+        var bitsNumber = il.DeclareLocal(_types.Double);
+        var bits = il.DeclareLocal(_types.Int32);
+        var value = il.DeclareLocal(_types.BigInteger);
+        var modulus = il.DeclareLocal(_types.BigInteger);
+        var truncated = il.DeclareLocal(_types.BigInteger);
+
+        // ToIndex(bits): NaN => +0; otherwise truncate and reject negative,
+        // infinite, or widths outside the emitted implementation's int range.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.ToNumber);
+        il.Emit(OpCodes.Stloc, bitsNumber);
+        var notNaN = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, bitsNumber);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsNaN", _types.Double));
+        il.Emit(OpCodes.Brfalse, notNaN);
+        il.Emit(OpCodes.Ldc_R8, 0.0);
+        il.Emit(OpCodes.Stloc, bitsNumber);
+        il.MarkLabel(notNaN);
+        il.Emit(OpCodes.Ldloc, bitsNumber);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Truncate", _types.Double));
+        il.Emit(OpCodes.Stloc, bitsNumber);
+
+        var invalidBits = il.DefineLabel();
+        var validBits = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, bitsNumber);
+        il.Emit(OpCodes.Ldc_R8, 0.0);
+        il.Emit(OpCodes.Blt, invalidBits);
+        il.Emit(OpCodes.Ldloc, bitsNumber);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsInfinity", _types.Double));
+        il.Emit(OpCodes.Brtrue, invalidBits);
+        il.Emit(OpCodes.Ldloc, bitsNumber);
+        il.Emit(OpCodes.Ldc_R8, (double)int.MaxValue);
+        il.Emit(OpCodes.Ble, validBits);
+        il.MarkLabel(invalidBits);
+        GuestErrorEmitter.ThrowError(il, runtime, runtime.TSRangeErrorCtor,
+            "BigInt bit width is outside the supported index range");
+        il.MarkLabel(validBits);
+        il.Emit(OpCodes.Ldloc, bitsNumber);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Stloc, bits);
+
+        // ToBigInt(value), including observable object-to-primitive coercion.
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.ToBigInt);
+        il.Emit(OpCodes.Unbox_Any, _types.BigInteger);
+        il.Emit(OpCodes.Stloc, value);
+
+        var nonZeroWidth = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, bits);
+        il.Emit(OpCodes.Brtrue, nonZeroWidth);
+        il.Emit(OpCodes.Call, _types.GetProperty(_types.BigInteger, "Zero")!.GetGetMethod()!);
+        il.Emit(OpCodes.Box, _types.BigInteger);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(nonZeroWidth);
+
+        // modulus = 1n << bits; truncated = ((value % modulus) + modulus) % modulus.
+        var shiftLeft = _types.GetMethod(_types.BigInteger, "op_LeftShift", _types.BigInteger, _types.Int32);
+        var remainder = _types.GetMethod(_types.BigInteger, "op_Modulus", _types.BigInteger, _types.BigInteger);
+        var add = _types.GetMethod(_types.BigInteger, "op_Addition", _types.BigInteger, _types.BigInteger);
+        var subtract = _types.GetMethod(_types.BigInteger, "op_Subtraction", _types.BigInteger, _types.BigInteger);
+        il.Emit(OpCodes.Call, _types.GetProperty(_types.BigInteger, "One")!.GetGetMethod()!);
+        il.Emit(OpCodes.Ldloc, bits);
+        il.Emit(OpCodes.Call, shiftLeft);
+        il.Emit(OpCodes.Stloc, modulus);
+        il.Emit(OpCodes.Ldloc, value);
+        il.Emit(OpCodes.Ldloc, modulus);
+        il.Emit(OpCodes.Call, remainder);
+        il.Emit(OpCodes.Ldloc, modulus);
+        il.Emit(OpCodes.Call, add);
+        il.Emit(OpCodes.Ldloc, modulus);
+        il.Emit(OpCodes.Call, remainder);
+        il.Emit(OpCodes.Stloc, truncated);
+
+        if (signed)
+        {
+            var returnValue = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, truncated);
+            il.Emit(OpCodes.Call, _types.GetProperty(_types.BigInteger, "One")!.GetGetMethod()!);
+            il.Emit(OpCodes.Ldloc, bits);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Call, shiftLeft);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.BigInteger, "op_LessThan", _types.BigInteger, _types.BigInteger));
+            il.Emit(OpCodes.Brtrue, returnValue);
+            il.Emit(OpCodes.Ldloc, truncated);
+            il.Emit(OpCodes.Ldloc, modulus);
+            il.Emit(OpCodes.Call, subtract);
+            il.Emit(OpCodes.Stloc, truncated);
+            il.MarkLabel(returnValue);
+        }
+
+        il.Emit(OpCodes.Ldloc, truncated);
+        il.Emit(OpCodes.Box, _types.BigInteger);
+        il.Emit(OpCodes.Ret);
+        return method;
+    }
+
     /// <summary>
     /// Emits ECMA-262 NumberFromBigInt. <see cref="BigInteger"/>'s direct
     /// conversion to <see cref="double"/> truncates some halfway-adjacent
@@ -168,6 +281,11 @@ public partial class RuntimeEmitter
         );
         runtime.CreateBigInt = method;
 
+        // Both BigInt(value) and ToBigInt(value) use ToPrimitive(value,
+        // number). Keep it separate because their Number handling differs:
+        // BigInt(1) accepts an integral Number while ToBigInt(1) rejects it.
+        var toPrimitive = EmitBigIntToPrimitive(typeBuilder, runtime);
+
         var il = method.GetILGenerator();
         var bigIntType = _types.BigInteger;
 
@@ -181,15 +299,52 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(notBigIntLabel);
 
+        // ToBigInt accepts booleans.
+        var notBooleanLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.Boolean);
+        il.Emit(OpCodes.Brfalse, notBooleanLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Unbox_Any, _types.Boolean);
+        var booleanFalse = il.DefineLabel();
+        il.Emit(OpCodes.Brfalse, booleanFalse);
+        il.Emit(OpCodes.Call, _types.GetProperty(bigIntType, "One")!.GetGetMethod()!);
+        il.Emit(OpCodes.Box, bigIntType);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(booleanFalse);
+        il.Emit(OpCodes.Call, _types.GetProperty(bigIntType, "Zero")!.GetGetMethod()!);
+        il.Emit(OpCodes.Box, bigIntType);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notBooleanLabel);
+
         // If double, convert to BigInteger
         var notDoubleLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, _types.Double);
         il.Emit(OpCodes.Brfalse, notDoubleLabel);
+        var numberLocal = il.DeclareLocal(_types.Double);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Unbox_Any, _types.Double);
-        il.Emit(OpCodes.Conv_I8);
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(bigIntType, _types.Int64));
+        il.Emit(OpCodes.Stloc, numberLocal);
+        var invalidNumber = il.DefineLabel();
+        var validNumber = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, numberLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsNaN", _types.Double));
+        il.Emit(OpCodes.Brtrue, invalidNumber);
+        il.Emit(OpCodes.Ldloc, numberLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsInfinity", _types.Double));
+        il.Emit(OpCodes.Brtrue, invalidNumber);
+        il.Emit(OpCodes.Ldloc, numberLocal);
+        il.Emit(OpCodes.Ldloc, numberLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Truncate", _types.Double));
+        il.Emit(OpCodes.Ceq);
+        il.Emit(OpCodes.Brtrue, validNumber);
+        il.MarkLabel(invalidNumber);
+        GuestErrorEmitter.ThrowError(il, runtime, runtime.TSRangeErrorCtor,
+            "The number cannot be converted to a BigInt because it is not an integer");
+        il.MarkLabel(validNumber);
+        il.Emit(OpCodes.Ldloc, numberLocal);
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(bigIntType, _types.Double));
         il.Emit(OpCodes.Box, bigIntType);
         il.Emit(OpCodes.Ret);
 
@@ -202,38 +357,310 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, notStringLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Castclass, _types.String);
-        // Handle hex prefix "0x" or "0X"
         var hexCheckLocal = il.DeclareLocal(_types.String);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.String, "Trim"));
         il.Emit(OpCodes.Stloc, hexCheckLocal);
+
+        // Empty/whitespace-only strings convert to 0n.
+        var nonEmptyString = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, hexCheckLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetPropertyGetter(_types.String, "Length"));
+        il.Emit(OpCodes.Brtrue, nonEmptyString);
+        il.Emit(OpCodes.Call, _types.GetProperty(bigIntType, "Zero")!.GetGetMethod()!);
+        il.Emit(OpCodes.Box, bigIntType);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(nonEmptyString);
+
+        var startsWithIgnoreCase = typeof(string).GetMethod(
+            nameof(string.StartsWith), [typeof(string), typeof(StringComparison)])!;
+
+        void EmitRadixParser(string prefix, int radix)
+        {
+            var nextPrefix = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, hexCheckLocal);
+            il.Emit(OpCodes.Ldstr, prefix);
+            il.Emit(OpCodes.Ldc_I4, (int)StringComparison.OrdinalIgnoreCase);
+            il.Emit(OpCodes.Callvirt, startsWithIgnoreCase);
+            il.Emit(OpCodes.Brfalse, nextPrefix);
+
+            var hasDigits = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, hexCheckLocal);
+            il.Emit(OpCodes.Callvirt, _types.GetPropertyGetter(_types.String, "Length"));
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Bgt, hasDigits);
+            GuestErrorEmitter.ThrowError(il, runtime, runtime.TSSyntaxErrorCtor,
+                "Cannot convert string to BigInt");
+            il.MarkLabel(hasDigits);
+
+            var resultLocal = il.DeclareLocal(bigIntType);
+            var indexLocal = il.DeclareLocal(_types.Int32);
+            var digitLocal = il.DeclareLocal(_types.Int32);
+            il.Emit(OpCodes.Call, _types.GetProperty(bigIntType, "Zero")!.GetGetMethod()!);
+            il.Emit(OpCodes.Stloc, resultLocal);
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Stloc, indexLocal);
+            var check = il.DefineLabel();
+            var body = il.DefineLabel();
+            il.Emit(OpCodes.Br, check);
+            il.MarkLabel(body);
+            il.Emit(OpCodes.Ldloc, hexCheckLocal);
+            il.Emit(OpCodes.Ldloc, indexLocal);
+            il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.String, "Chars")!.GetGetMethod()!);
+            il.Emit(OpCodes.Ldc_I4, (int)'0');
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Stloc, digitLocal);
+            var invalidDigit = il.DefineLabel();
+            var validDigit = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, digitLocal);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Blt, invalidDigit);
+            il.Emit(OpCodes.Ldloc, digitLocal);
+            il.Emit(OpCodes.Ldc_I4, radix);
+            il.Emit(OpCodes.Blt, validDigit);
+            il.MarkLabel(invalidDigit);
+            GuestErrorEmitter.ThrowError(il, runtime, runtime.TSSyntaxErrorCtor,
+                "Cannot convert string to BigInt");
+            il.MarkLabel(validDigit);
+            il.Emit(OpCodes.Ldloc, resultLocal);
+            il.Emit(OpCodes.Ldc_I4, radix);
+            il.Emit(OpCodes.Newobj, _types.GetConstructor(bigIntType, _types.Int32));
+            il.Emit(OpCodes.Call, _types.GetMethod(bigIntType, "op_Multiply", bigIntType, bigIntType));
+            il.Emit(OpCodes.Ldloc, digitLocal);
+            il.Emit(OpCodes.Newobj, _types.GetConstructor(bigIntType, _types.Int32));
+            il.Emit(OpCodes.Call, _types.GetMethod(bigIntType, "op_Addition", bigIntType, bigIntType));
+            il.Emit(OpCodes.Stloc, resultLocal);
+            il.Emit(OpCodes.Ldloc, indexLocal);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, indexLocal);
+            il.MarkLabel(check);
+            il.Emit(OpCodes.Ldloc, indexLocal);
+            il.Emit(OpCodes.Ldloc, hexCheckLocal);
+            il.Emit(OpCodes.Callvirt, _types.GetPropertyGetter(_types.String, "Length"));
+            il.Emit(OpCodes.Blt, body);
+            il.Emit(OpCodes.Ldloc, resultLocal);
+            il.Emit(OpCodes.Box, bigIntType);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(nextPrefix);
+        }
+
+        EmitRadixParser("0b", 2);
+        EmitRadixParser("0o", 8);
+
+        // Handle hex prefix "0x" or "0X".
         il.Emit(OpCodes.Ldloc, hexCheckLocal);
         il.Emit(OpCodes.Ldstr, "0x");
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "StartsWith", _types.String));
+        il.Emit(OpCodes.Ldc_I4, (int)StringComparison.OrdinalIgnoreCase);
+        il.Emit(OpCodes.Callvirt, startsWithIgnoreCase);
         var notHexLabel = il.DefineLabel();
         il.Emit(OpCodes.Brfalse, notHexLabel);
-        // Parse hex - prepend "0" to ensure positive interpretation
+        var numberStylesType = _types.Resolve("System.Globalization.NumberStyles");
+        var parsedStringLocal = il.DeclareLocal(bigIntType);
+        var parsedHex = il.DefineLabel();
+        il.BeginExceptionBlock();
+        // Parse hex - prepend "0" to ensure positive interpretation.
         il.Emit(OpCodes.Ldstr, "0");
         il.Emit(OpCodes.Ldloc, hexCheckLocal);
         il.Emit(OpCodes.Ldc_I4_2);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "Substring", _types.Int32));
         il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "Concat", _types.String, _types.String));
         il.Emit(OpCodes.Ldc_I4, (int)System.Globalization.NumberStyles.HexNumber);
-        var numberStylesType = _types.Resolve("System.Globalization.NumberStyles");
         il.Emit(OpCodes.Call, _types.GetMethod(bigIntType, "Parse", _types.String, numberStylesType));
+        il.Emit(OpCodes.Stloc, parsedStringLocal);
+        il.Emit(OpCodes.Leave, parsedHex);
+        il.BeginCatchBlock(_types.Resolve("System.FormatException"));
+        il.Emit(OpCodes.Pop);
+        GuestErrorEmitter.ThrowError(il, runtime, runtime.TSSyntaxErrorCtor,
+            "Cannot convert string to BigInt");
+        il.EndExceptionBlock();
+        il.MarkLabel(parsedHex);
+        il.Emit(OpCodes.Ldloc, parsedStringLocal);
         il.Emit(OpCodes.Box, bigIntType);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notHexLabel);
-        // Parse decimal
+        // Parse decimal, translating BCL FormatException into the guest
+        // SyntaxError required by StringToBigInt.
+        var parsedDecimal = il.DefineLabel();
+        il.BeginExceptionBlock();
         il.Emit(OpCodes.Ldloc, hexCheckLocal);
         il.Emit(OpCodes.Call, _types.GetMethod(bigIntType, "Parse", _types.String));
+        il.Emit(OpCodes.Stloc, parsedStringLocal);
+        il.Emit(OpCodes.Leave, parsedDecimal);
+        il.BeginCatchBlock(_types.Resolve("System.FormatException"));
+        il.Emit(OpCodes.Pop);
+        GuestErrorEmitter.ThrowError(il, runtime, runtime.TSSyntaxErrorCtor,
+            "Cannot convert string to BigInt");
+        il.EndExceptionBlock();
+        il.MarkLabel(parsedDecimal);
+        il.Emit(OpCodes.Ldloc, parsedStringLocal);
         il.Emit(OpCodes.Box, bigIntType);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(notStringLabel);
-        // Default: throw or return 0n
-        il.Emit(OpCodes.Ldstr, "Cannot convert to BigInt");
-        var invalidOpException = _types.Resolve("System.InvalidOperationException");
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(invalidOpException, _types.String));
-        il.Emit(OpCodes.Throw);
+
+        // Arrays use their ordinary primitive string conversion ([], [1],
+        // [10n], ...), then re-enter the string parser above.
+        var notArrayLikeLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.IListOfObject);
+        il.Emit(OpCodes.Brfalse, notArrayLikeLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
+        il.Emit(OpCodes.Call, method);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notArrayLikeLabel);
+
+        // Ordinary objects undergo ToPrimitive(number) once, then re-enter
+        // the callable BigInt conversion with the resulting primitive.
+        var primitiveLocal = il.DeclareLocal(_types.Object);
+        var objectLike = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSObjectType);
+        il.Emit(OpCodes.Brtrue, objectLike);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Brtrue, objectLike);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert value to BigInt");
+        il.MarkLabel(objectLike);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, toPrimitive);
+        il.Emit(OpCodes.Stloc, primitiveLocal);
+        il.Emit(OpCodes.Ldloc, primitiveLocal);
+        il.Emit(OpCodes.Call, method);
+        il.Emit(OpCodes.Ret);
+
+        EmitStrictToBigInt(typeBuilder, runtime, toPrimitive);
+    }
+
+    private MethodBuilder EmitBigIntToPrimitive(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "BigIntToPrimitive",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object]);
+        var il = method.GetILGenerator();
+        var emptyArgs = il.DeclareLocal(_types.ObjectArray);
+        var hintArgs = il.DeclareLocal(_types.ObjectArray);
+        var candidate = il.DeclareLocal(_types.Object);
+        var result = il.DeclareLocal(_types.Object);
+
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Stloc, emptyArgs);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldstr, "number");
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Stloc, hintArgs);
+
+        bool EmitReturnIfPrimitive(LocalBuilder value)
+        {
+            var next = il.DefineLabel();
+            var returnValue = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, value);
+            il.Emit(OpCodes.Brfalse, returnValue);
+            foreach (var primitiveType in new[]
+                     {
+                         runtime.UndefinedType, _types.String, _types.Double,
+                         _types.Boolean, _types.BigInteger, runtime.TSSymbolType
+                     })
+            {
+                il.Emit(OpCodes.Ldloc, value);
+                il.Emit(OpCodes.Isinst, primitiveType);
+                il.Emit(OpCodes.Brtrue, returnValue);
+            }
+            il.Emit(OpCodes.Br, next);
+            il.MarkLabel(returnValue);
+            il.Emit(OpCodes.Ldloc, value);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(next);
+            return true;
+        }
+
+        // ExoticToPrim: GetMethod(input, @@toPrimitive).
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldsfld, runtime.SymbolToPrimitive);
+        il.Emit(OpCodes.Call, runtime.GetIndex);
+        il.Emit(OpCodes.Stloc, candidate);
+        var ordinary = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, candidate);
+        il.Emit(OpCodes.Brfalse, ordinary);
+        il.Emit(OpCodes.Ldloc, candidate);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, ordinary);
+        il.Emit(OpCodes.Ldloc, candidate);
+        il.Emit(OpCodes.Call, runtime.TypeOf);
+        il.Emit(OpCodes.Ldstr, "function");
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+        var exoticCallable = il.DefineLabel();
+        il.Emit(OpCodes.Brtrue, exoticCallable);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Symbol.toPrimitive is not callable");
+        il.MarkLabel(exoticCallable);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, candidate);
+        il.Emit(OpCodes.Ldloc, hintArgs);
+        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
+        il.Emit(OpCodes.Stloc, result);
+        EmitReturnIfPrimitive(result);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Symbol.toPrimitive must return a primitive value");
+
+        il.MarkLabel(ordinary);
+        foreach (var name in new[] { "valueOf", "toString" })
+        {
+            var nextMethod = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldstr, name);
+            il.Emit(OpCodes.Call, runtime.GetProperty);
+            il.Emit(OpCodes.Stloc, candidate);
+            il.Emit(OpCodes.Ldloc, candidate);
+            il.Emit(OpCodes.Call, runtime.TypeOf);
+            il.Emit(OpCodes.Ldstr, "function");
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+            il.Emit(OpCodes.Brfalse, nextMethod);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, candidate);
+            il.Emit(OpCodes.Ldloc, emptyArgs);
+            il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
+            il.Emit(OpCodes.Stloc, result);
+            EmitReturnIfPrimitive(result);
+            il.MarkLabel(nextMethod);
+        }
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot convert object to primitive value");
+        return method;
+    }
+
+    private void EmitStrictToBigInt(
+        TypeBuilder typeBuilder, EmittedRuntime runtime, MethodBuilder toPrimitive)
+    {
+        var method = runtime.ToBigInt;
+        var il = method.GetILGenerator();
+        var notNumber = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.Double);
+        il.Emit(OpCodes.Brfalse, notNumber);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "BigInt value is required");
+        il.MarkLabel(notNumber);
+
+        var convertPrimitive = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSObjectType);
+        il.Emit(OpCodes.Brtrue, convertPrimitive);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        var direct = il.DefineLabel();
+        il.Emit(OpCodes.Brfalse, direct);
+        il.MarkLabel(convertPrimitive);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, toPrimitive);
+        il.Emit(OpCodes.Call, method);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(direct);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.CreateBigInt);
+        il.Emit(OpCodes.Ret);
     }
 
     private void EmitBigIntArithmetic(TypeBuilder typeBuilder, EmittedRuntime runtime)
@@ -480,9 +907,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(throwRange);
-        il.Emit(OpCodes.Ldstr, "toString() radix must be between 2 and 36");
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Resolve("System.Exception"), _types.String));
-        il.Emit(OpCodes.Throw);
+        GuestErrorEmitter.ThrowError(il, runtime, runtime.TSRangeErrorCtor,
+            "toString() radix must be between 2 and 36");
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/RuntimeEmitter.BigIntPrototypePopulate.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.BigIntPrototypePopulate.cs
@@ -34,7 +34,7 @@ public partial class RuntimeEmitter
         });
 
         EmitWirePrototypeMethod(il, runtime, runtime.BigIntPrototypeField, descLocal,
-            setItem, "toString", toStringHelper, 1);
+            setItem, "toString", toStringHelper, 0);
         EmitWirePrototypeMethod(il, runtime, runtime.BigIntPrototypeField, descLocal,
             setItem, "valueOf", valueOfHelper, 0);
 
@@ -118,18 +118,25 @@ public partial class RuntimeEmitter
             "BigIntPrototypeToString",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.String,
-            [_types.Object, _types.Object]);
+            [_types.Object, _types.ObjectArray]);
+        method.DefineParameter(2, ParameterAttributes.None, "args");
         var il = method.GetILGenerator();
         var radixLocal = il.DeclareLocal(_types.Double);
         var useDefault = il.DefineLabel();
         var radixReady = il.DefineLabel();
 
         il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
         il.Emit(OpCodes.Brfalse, useDefault);
         il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
         il.Emit(OpCodes.Isinst, runtime.UndefinedType);
         il.Emit(OpCodes.Brtrue, useDefault);
         il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
         il.Emit(OpCodes.Call, runtime.ToNumber);
         il.Emit(OpCodes.Stloc, radixLocal);
         il.Emit(OpCodes.Br, radixReady);

--- a/src/SharpTS/Compilation/RuntimeEmitter.BoxedPrimitives.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.BoxedPrimitives.cs
@@ -198,7 +198,8 @@ public partial class RuntimeEmitter
         il.MarkLabel(descriptorLoopEnd);
         il.MarkLabel(skipStringDescriptors);
 
-        // Set prototype based on typeTag (Boolean/Number/String/BigInt → matching singleton).
+        // Set prototype based on typeTag (Boolean/Number/String/BigInt/Symbol
+        // → matching singleton).
         // Populate is called to ensure the prototype singleton has the right
         // methods (e.g. toString stub) before we link.
         void LinkProto(string tag, FieldBuilder protoField, MethodBuilder populate)
@@ -219,6 +220,7 @@ public partial class RuntimeEmitter
         LinkProto("String",  runtime.StringPrototypeField,  runtime.StringPrototypePopulateMethod);
         if (_features.UsesBigInt)
             LinkProto("BigInt", runtime.BigIntPrototypeField, runtime.BigIntPrototypePopulateMethod);
+        LinkProto("Symbol", runtime.SymbolPrototypeField, runtime.SymbolPrototypePopulateMethod);
 
         il.Emit(OpCodes.Ldloc, objLocal);
         il.Emit(OpCodes.Ret);

--- a/src/SharpTS/Compilation/RuntimeEmitter.BuiltInStaticDispatch.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.BuiltInStaticDispatch.cs
@@ -174,6 +174,14 @@ public partial class RuntimeEmitter
         EmitLookup(runtime.TSSymbolType, "for", runtime.SymbolFor, 1);
         EmitLookup(runtime.TSSymbolType, "keyFor", runtime.SymbolKeyFor, 1);
 
+        // BigInt.asIntN/asUintN — BigInt resolves to System.Numerics.BigInteger
+        // in emitted value form; the BCL type has no JavaScript truncation APIs.
+        if (runtime.BigIntAsIntN != null)
+        {
+            EmitLookup(_types.BigInteger, "asIntN", runtime.BigIntAsIntN, 2);
+            EmitLookup(_types.BigInteger, "asUintN", runtime.BigIntAsUintN, 2);
+        }
+
         // Promise.* and Error.isError are emitted on $Runtime rather than as
         // CLR statics on their constructor Type tokens. Route value-form and
         // descriptor reads through the same identity-cached wrappers used by

--- a/src/SharpTS/Compilation/RuntimeEmitter.FinalizationRegistry.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.FinalizationRegistry.cs
@@ -203,7 +203,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "FinalizationRegistryRegister",
             MethodAttributes.Public | MethodAttributes.Static,
-            _types.Void,
+            _types.Object,
             [_types.Object, _types.Object, _types.Object, _types.Object]
         );
         runtime.FinalizationRegistryRegister = method;
@@ -337,6 +337,7 @@ public partial class RuntimeEmitter
         il.EndExceptionBlock();
 
         il.MarkLabel(returnLabel);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Functions.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Functions.cs
@@ -1244,11 +1244,15 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, callArgsLocal);
         il.MarkLabel(afterCallArgsLabel);
 
-        // Check target type and invoke. TSFunction/BoundTSFunction honor the thisArg
-        // via InvokeWithThis; bound methods already capture their receiver so thisArg
-        // is ignored for them (per JS spec for bound callables).
+        // Check target type and invoke. TSFunction/BoundTSFunction honor the
+        // thisArg via InvokeWithThis. Collection/array method wrappers capture
+        // the receiver only as an implementation detail; Function.prototype.call
+        // must rebind them to its explicit thisArg just like native methods.
         var isTSFunctionLabel = il.DefineLabel();
         var isBoundTSFunctionLabel = il.DefineLabel();
+        var isBoundArrayMethodLabel = il.DefineLabel();
+        var isBoundMapMethodLabel = il.DefineLabel();
+        var isBoundSetMethodLabel = il.DefineLabel();
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, targetField);
@@ -1260,7 +1264,44 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.BoundTSFunctionType);
         il.Emit(OpCodes.Brtrue, isBoundTSFunctionLabel);
 
-        // Non-TSFunction callables, including proxies, retain thisArg.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, targetField);
+        il.Emit(OpCodes.Isinst, runtime.BoundArrayMethodType);
+        var notBoundArrayMethodLabel = il.DefineLabel();
+        il.Emit(OpCodes.Brfalse, notBoundArrayMethodLabel);
+        il.Emit(OpCodes.Ldloc, thisArgLocal);
+        il.Emit(OpCodes.Isinst, _types.ListOfObject);
+        il.Emit(OpCodes.Brtrue, isBoundArrayMethodLabel);
+        il.MarkLabel(notBoundArrayMethodLabel);
+
+        if (_features.UsesMap)
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, targetField);
+            il.Emit(OpCodes.Isinst, runtime.BoundMapMethodType);
+            var notBoundMapMethodLabel = il.DefineLabel();
+            il.Emit(OpCodes.Brfalse, notBoundMapMethodLabel);
+            il.Emit(OpCodes.Ldloc, thisArgLocal);
+            il.Emit(OpCodes.Isinst, _types.DictionaryObjectObject);
+            il.Emit(OpCodes.Brtrue, isBoundMapMethodLabel);
+            il.MarkLabel(notBoundMapMethodLabel);
+        }
+
+        if (_features.UsesSet)
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, targetField);
+            il.Emit(OpCodes.Isinst, runtime.BoundSetMethodType);
+            var notBoundSetMethodLabel = il.DefineLabel();
+            il.Emit(OpCodes.Brfalse, notBoundSetMethodLabel);
+            il.Emit(OpCodes.Ldloc, thisArgLocal);
+            il.Emit(OpCodes.Isinst, _types.HashSetOfObject);
+            il.Emit(OpCodes.Brtrue, isBoundSetMethodLabel);
+            il.MarkLabel(notBoundSetMethodLabel);
+        }
+
+        // Remaining non-TSFunction callables, including proxies, retain the
+        // explicit thisArg through the shared dispatch fallback.
         EmitDispatchToTarget(
             il, runtime, targetField, callArgsLocal, thisArgLocal);
 
@@ -1287,6 +1328,50 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, callArgsLocal);
         il.Emit(OpCodes.Callvirt, runtime.BoundTSFunctionInvokeWithThis);
         il.Emit(OpCodes.Ret);
+
+        // Recreate the lightweight method wrapper with call's explicit
+        // receiver, preserving the captured JavaScript method name.
+        il.MarkLabel(isBoundArrayMethodLabel);
+        il.Emit(OpCodes.Ldloc, thisArgLocal);
+        il.Emit(OpCodes.Castclass, _types.ListOfObject);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, targetField);
+        il.Emit(OpCodes.Castclass, runtime.BoundArrayMethodType);
+        il.Emit(OpCodes.Ldfld, runtime.BoundArrayMethodNameField);
+        il.Emit(OpCodes.Newobj, runtime.BoundArrayMethodCtor);
+        il.Emit(OpCodes.Ldloc, callArgsLocal);
+        il.Emit(OpCodes.Callvirt, runtime.BoundArrayMethodInvoke);
+        il.Emit(OpCodes.Ret);
+
+        if (_features.UsesMap)
+        {
+            il.MarkLabel(isBoundMapMethodLabel);
+            il.Emit(OpCodes.Ldloc, thisArgLocal);
+            il.Emit(OpCodes.Castclass, _types.DictionaryObjectObject);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, targetField);
+            il.Emit(OpCodes.Castclass, runtime.BoundMapMethodType);
+            il.Emit(OpCodes.Ldfld, runtime.BoundMapMethodNameField);
+            il.Emit(OpCodes.Newobj, runtime.BoundMapMethodCtor);
+            il.Emit(OpCodes.Ldloc, callArgsLocal);
+            il.Emit(OpCodes.Callvirt, runtime.BoundMapMethodInvoke);
+            il.Emit(OpCodes.Ret);
+        }
+
+        if (_features.UsesSet)
+        {
+            il.MarkLabel(isBoundSetMethodLabel);
+            il.Emit(OpCodes.Ldloc, thisArgLocal);
+            il.Emit(OpCodes.Castclass, _types.HashSetOfObject);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, targetField);
+            il.Emit(OpCodes.Castclass, runtime.BoundSetMethodType);
+            il.Emit(OpCodes.Ldfld, runtime.BoundSetMethodNameField);
+            il.Emit(OpCodes.Newobj, runtime.BoundSetMethodCtor);
+            il.Emit(OpCodes.Ldloc, callArgsLocal);
+            il.Emit(OpCodes.Callvirt, runtime.BoundSetMethodInvoke);
+            il.Emit(OpCodes.Ret);
+        }
 
         // InvokeWithThis
         var iwtBuilder = typeBuilder.DefineMethod(

--- a/src/SharpTS/Compilation/RuntimeEmitter.GroupBy.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.GroupBy.cs
@@ -203,6 +203,15 @@ public partial class RuntimeEmitter
 
         var il = method.GetILGenerator();
 
+        var callbackCallable = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.TypeOf);
+        il.Emit(OpCodes.Ldstr, "function");
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+        il.Emit(OpCodes.Brtrue, callbackCallable);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Map.groupBy: callback is not callable");
+        il.MarkLabel(callbackCallable);
+
         // Locals
         var mapLocal = il.DeclareLocal(_types.Object);                      // result map
         var listLocal = il.DeclareLocal(_types.ListOfObject);               // array elements
@@ -217,30 +226,43 @@ public partial class RuntimeEmitter
         var hasExistingLabel = il.DefineLabel();
         var addElementLabel = il.DefineLabel();
 
-        var isTSArrayLabel = il.DefineLabel();
-        var afterUnwrapLabel = il.DefineLabel();
-
         // map = CreateMap() — creates Dictionary<object, object?> with ReferenceEqualityComparer
         il.Emit(OpCodes.Call, runtime.CreateMap);
         il.Emit(OpCodes.Stloc, mapLocal);
 
-        // list = unwrap iterable (handle both List<object?> and $Array)
+        // GroupBy consumes the iterator protocol, not only array storage.
+        // Validate a nullish/absent @@iterator before the shared materializer's
+        // host-IEnumerable compatibility fallback can accept the value.
+        var materialize = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.TSArrayType);
-        il.Emit(OpCodes.Brtrue, isTSArrayLabel);
-
+        il.Emit(OpCodes.Brtrue, materialize);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, _types.ListOfObject);
-        il.Emit(OpCodes.Stloc, listLocal);
-        il.Emit(OpCodes.Br, afterUnwrapLabel);
-
-        il.MarkLabel(isTSArrayLabel);
+        il.Emit(OpCodes.Isinst, _types.ListOfObject);
+        il.Emit(OpCodes.Brtrue, materialize);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayElementsGetter);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Brtrue, materialize);
+        var iteratorFn = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldsfld, runtime.SymbolIterator);
+        il.Emit(OpCodes.Call, runtime.GetIteratorFunction);
+        il.Emit(OpCodes.Stloc, iteratorFn);
+        var invalidIterable = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, iteratorFn);
+        il.Emit(OpCodes.Brfalse, invalidIterable);
+        il.Emit(OpCodes.Ldloc, iteratorFn);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brfalse, materialize);
+        il.MarkLabel(invalidIterable);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Map.groupBy: items is not iterable");
+        il.MarkLabel(materialize);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldsfld, runtime.SymbolIterator);
+        il.Emit(OpCodes.Ldtoken, runtime.RuntimeType);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle")!);
+        il.Emit(OpCodes.Call, runtime.IterateToList);
         il.Emit(OpCodes.Stloc, listLocal);
-
-        il.MarkLabel(afterUnwrapLabel);
 
         // i = 0
         il.Emit(OpCodes.Ldc_I4_0);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Iterator.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Iterator.cs
@@ -20,7 +20,8 @@ public partial class RuntimeEmitter
             "$ArrayIterator",
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
             _types.Object,
-            [_types.IEnumeratorOfObject, _types.IEnumerator, _types.IDisposable]);
+            [_types.IEnumeratorOfObject, _types.IEnumerator, _types.IDisposable,
+             _types.IEnumerableOfObject, _types.IEnumerable]);
         runtime.ArrayIteratorType = typeBuilder;
 
         var arrayField = typeBuilder.DefineField(
@@ -198,6 +199,212 @@ public partial class RuntimeEmitter
             _types.Void,
             Type.EmptyTypes);
         dispose.GetILGenerator().Emit(OpCodes.Ret);
+
+        // JavaScript iterator objects are iterable themselves. The CLR
+        // interfaces keep yield* and generic for-of delegation compatible.
+        EmitGetEnumeratorReturnsSelf(typeBuilder);
+
+        typeBuilder.CreateType();
+    }
+
+    /// <summary>
+    /// Emits a Map iterator backed by the original dictionary plus its initial
+    /// ordered key list. Each MoveNext re-reads the key from the live map, so
+    /// entries deleted or cleared after iterator creation are skipped instead
+    /// of leaking snapshot values. Kind: 0=keys, 1=values, 2=entries.
+    /// </summary>
+    private void EmitMapCollectionIteratorType(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        var typeBuilder = EmitTypeDefinitions.DefineType(
+            moduleBuilder,
+            "$MapCollectionIterator",
+            TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
+            _types.Object,
+            [_types.IEnumeratorOfObject, _types.IEnumerator, _types.IDisposable,
+             _types.IEnumerableOfObject, _types.IEnumerable]);
+        runtime.MapCollectionIteratorType = typeBuilder;
+
+        var mapField = typeBuilder.DefineField("_map", _types.DictionaryObjectObject,
+            FieldAttributes.Private | FieldAttributes.InitOnly);
+        var keysField = typeBuilder.DefineField("_keys", _types.ListOfObject,
+            FieldAttributes.Private | FieldAttributes.InitOnly);
+        var kindField = typeBuilder.DefineField("_kind", _types.Int32,
+            FieldAttributes.Private | FieldAttributes.InitOnly);
+        var indexField = typeBuilder.DefineField("_index", _types.Int32, FieldAttributes.Private);
+        var currentField = typeBuilder.DefineField("_current", _types.Object, FieldAttributes.Private);
+        var completedField = typeBuilder.DefineField("_completed", _types.Boolean, FieldAttributes.Private);
+
+        var ctor = typeBuilder.DefineConstructor(MethodAttributes.Public,
+            CallingConventions.Standard,
+            [_types.DictionaryObjectObject, _types.ListOfObject, _types.Int32]);
+        runtime.MapCollectionIteratorCtor = ctor;
+        var ctorIl = ctor.GetILGenerator();
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Call, _types.GetConstructor(_types.Object, Type.EmptyTypes)!);
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Ldarg_1);
+        ctorIl.Emit(OpCodes.Stfld, mapField);
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Ldarg_2);
+        ctorIl.Emit(OpCodes.Stfld, keysField);
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Ldarg_3);
+        ctorIl.Emit(OpCodes.Stfld, kindField);
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Ldc_I4_M1);
+        ctorIl.Emit(OpCodes.Stfld, indexField);
+        ctorIl.Emit(OpCodes.Ret);
+
+        var currentProperty = typeBuilder.DefineProperty(
+            "Current", PropertyAttributes.None, _types.Object, Type.EmptyTypes);
+        var currentGetter = typeBuilder.DefineMethod("get_Current",
+            MethodAttributes.Public | MethodAttributes.Virtual |
+            MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+            _types.Object, Type.EmptyTypes);
+        var currentIl = currentGetter.GetILGenerator();
+        currentIl.Emit(OpCodes.Ldarg_0);
+        currentIl.Emit(OpCodes.Ldfld, currentField);
+        currentIl.Emit(OpCodes.Ret);
+        currentProperty.SetGetMethod(currentGetter);
+
+        var nongenericCurrent = typeBuilder.DefineMethod(
+            "System.Collections.IEnumerator.get_Current",
+            MethodAttributes.Private | MethodAttributes.Virtual |
+            MethodAttributes.SpecialName | MethodAttributes.HideBySig |
+            MethodAttributes.NewSlot | MethodAttributes.Final,
+            _types.Object, Type.EmptyTypes);
+        var nongenericIl = nongenericCurrent.GetILGenerator();
+        nongenericIl.Emit(OpCodes.Ldarg_0);
+        nongenericIl.Emit(OpCodes.Ldfld, currentField);
+        nongenericIl.Emit(OpCodes.Ret);
+        typeBuilder.DefineMethodOverride(nongenericCurrent,
+            _types.GetProperty(_types.IEnumerator, "Current")!.GetGetMethod()!);
+
+        var moveNext = typeBuilder.DefineMethod("MoveNext",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+            _types.Boolean, Type.EmptyTypes);
+        var il = moveNext.GetILGenerator();
+        var nextIndex = il.DeclareLocal(_types.Int32);
+        var key = il.DeclareLocal(_types.Object);
+        var value = il.DeclareLocal(_types.Object);
+        var output = il.DeclareLocal(_types.Object);
+        var pair = il.DeclareLocal(_types.ListOfObject);
+        var loop = il.DefineLabel();
+        var inRange = il.DefineLabel();
+        var emitValue = il.DefineLabel();
+        var emitEntry = il.DefineLabel();
+        var denormalized = il.DefineLabel();
+        var storeCurrent = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, completedField);
+        il.Emit(OpCodes.Brfalse, loop);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, indexField);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, nextIndex);
+        il.Emit(OpCodes.Ldloc, nextIndex);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, keysField);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.ListOfObject, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Blt, inRange);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stfld, completedField);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(inRange);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, nextIndex);
+        il.Emit(OpCodes.Stfld, indexField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, keysField);
+        il.Emit(OpCodes.Ldloc, nextIndex);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.ListOfObject, "Item").GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, key);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, mapField);
+        il.Emit(OpCodes.Ldloc, key);
+        il.Emit(OpCodes.Ldloca, value);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryObjectObject, "TryGetValue")!);
+        il.Emit(OpCodes.Brfalse, loop);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, kindField);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Beq, emitValue);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, kindField);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Beq, emitEntry);
+
+        // keys(): denormalize the internal null sentinel.
+        il.Emit(OpCodes.Ldloc, key);
+        il.Emit(OpCodes.Ldsfld, runtime.MapNullSentinel);
+        var keyNotNullSentinel = il.DefineLabel();
+        il.Emit(OpCodes.Bne_Un, keyNotNullSentinel);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Br, denormalized);
+        il.MarkLabel(keyNotNullSentinel);
+        il.Emit(OpCodes.Ldloc, key);
+        il.MarkLabel(denormalized);
+        il.Emit(OpCodes.Stloc, output);
+        il.Emit(OpCodes.Br, storeCurrent);
+
+        il.MarkLabel(emitValue);
+        il.Emit(OpCodes.Ldloc, value);
+        il.Emit(OpCodes.Stloc, output);
+        il.Emit(OpCodes.Br, storeCurrent);
+
+        il.MarkLabel(emitEntry);
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, Type.EmptyTypes)!);
+        il.Emit(OpCodes.Stloc, pair);
+        il.Emit(OpCodes.Ldloc, pair);
+        il.Emit(OpCodes.Ldloc, key);
+        il.Emit(OpCodes.Ldsfld, runtime.MapNullSentinel);
+        var entryKeyNotNull = il.DefineLabel();
+        var entryKeyReady = il.DefineLabel();
+        il.Emit(OpCodes.Bne_Un, entryKeyNotNull);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Br, entryKeyReady);
+        il.MarkLabel(entryKeyNotNull);
+        il.Emit(OpCodes.Ldloc, key);
+        il.MarkLabel(entryKeyReady);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", [_types.Object])!);
+        il.Emit(OpCodes.Ldloc, pair);
+        il.Emit(OpCodes.Ldloc, value);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", [_types.Object])!);
+        il.Emit(OpCodes.Ldloc, pair);
+        il.Emit(OpCodes.Stloc, output);
+
+        il.MarkLabel(storeCurrent);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, output);
+        il.Emit(OpCodes.Stfld, currentField);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+
+        var reset = typeBuilder.DefineMethod("Reset",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+            _types.Void, Type.EmptyTypes);
+        var resetIl = reset.GetILGenerator();
+        resetIl.Emit(OpCodes.Ldstr, "Reset is not supported for map iterators");
+        resetIl.Emit(OpCodes.Newobj,
+            typeof(NotSupportedException).GetConstructor([typeof(string)])!);
+        resetIl.Emit(OpCodes.Throw);
+
+        var dispose = typeBuilder.DefineMethod("Dispose",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+            _types.Void, Type.EmptyTypes);
+        dispose.GetILGenerator().Emit(OpCodes.Ret);
+
+        EmitGetEnumeratorReturnsSelf(typeBuilder);
 
         typeBuilder.CreateType();
     }
@@ -993,13 +1200,43 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.String, "Length")!.GetGetMethod()!);
             il.Emit(OpCodes.Bge, strLoopEnd);
 
-            // result.Add(str[idx].ToString())
+            // String iteration advances by Unicode code point, so a surrogate
+            // pair is yielded as one string rather than two lone UTF-16 chars.
             var charLocal = il.DeclareLocal(_types.Char);
-            il.Emit(OpCodes.Ldloc, resultLocal);
             il.Emit(OpCodes.Ldloc, strLocal);
             il.Emit(OpCodes.Ldloc, idxLocal);
             il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "get_Chars", [_types.Int32])!);
             il.Emit(OpCodes.Stloc, charLocal);
+            var singleChar = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, charLocal);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.Char, "IsHighSurrogate", _types.Char));
+            il.Emit(OpCodes.Brfalse, singleChar);
+            il.Emit(OpCodes.Ldloc, idxLocal);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Ldloc, strLocal);
+            il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.String, "Length")!.GetGetMethod()!);
+            il.Emit(OpCodes.Bge, singleChar);
+            il.Emit(OpCodes.Ldloc, strLocal);
+            il.Emit(OpCodes.Ldloc, idxLocal);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "get_Chars", [_types.Int32])!);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.Char, "IsLowSurrogate", _types.Char));
+            il.Emit(OpCodes.Brfalse, singleChar);
+            il.Emit(OpCodes.Ldloc, resultLocal);
+            il.Emit(OpCodes.Ldloc, strLocal);
+            il.Emit(OpCodes.Ldloc, idxLocal);
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "Substring", _types.Int32, _types.Int32));
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", _types.Object));
+            il.Emit(OpCodes.Ldloc, idxLocal);
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, idxLocal);
+            il.Emit(OpCodes.Br, strLoopStart);
+            il.MarkLabel(singleChar);
+            il.Emit(OpCodes.Ldloc, resultLocal);
             il.Emit(OpCodes.Ldloca, charLocal);
             il.Emit(OpCodes.Call, _types.GetMethodNoParams(_types.Char, "ToString"));
             il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", _types.Object));

--- a/src/SharpTS/Compilation/RuntimeEmitter.Maps.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Maps.cs
@@ -420,7 +420,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "MapKeys",
             MethodAttributes.Public | MethodAttributes.Static,
-            _types.ListOfObject,
+            _types.Object,
             [_types.Object]
         );
         runtime.MapKeys = method;
@@ -466,11 +466,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, _types.GetProperty(enumeratorType, "Current")!.GetGetMethod()!);
         il.Emit(OpCodes.Stloc, currentLocal);
 
-        // result.Add(DenormalizeMapKey(current.Key));
+        // Keep normalized keys so the live iterator can re-check membership.
         il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ldloca, currentLocal);
         il.Emit(OpCodes.Call, _types.GetProperty(kvpType, "Key")!.GetGetMethod()!);
-        il.Emit(OpCodes.Call, runtime.DenormalizeMapKey);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add")!);
 
         il.Emit(OpCodes.Br, loopStartLabel);
@@ -480,13 +479,19 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloca, enumeratorLocal);
         il.Emit(OpCodes.Call, _types.GetMethod(enumeratorType, "Dispose")!);
 
-        // return result;
+        // return new $MapIterator(dict, initialKeys, keysKind);
+        il.Emit(OpCodes.Ldloc, dictLocal);
         il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Newobj, runtime.MapCollectionIteratorCtor);
         il.Emit(OpCodes.Ret);
 
         // return new List<object?>();
         il.MarkLabel(returnEmptyLabel);
+        il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, Type.EmptyTypes)!);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Newobj, runtime.MapCollectionIteratorCtor);
         il.Emit(OpCodes.Ret);
     }
 
@@ -495,7 +500,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "MapValues",
             MethodAttributes.Public | MethodAttributes.Static,
-            _types.ListOfObject,
+            _types.Object,
             [_types.Object]
         );
         runtime.MapValues = method;
@@ -541,10 +546,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, _types.GetProperty(enumeratorType, "Current")!.GetGetMethod()!);
         il.Emit(OpCodes.Stloc, currentLocal);
 
-        // result.Add(current.Value);
+        // Keep the key snapshot; values are read from the live map by MoveNext.
         il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ldloca, currentLocal);
-        il.Emit(OpCodes.Call, _types.GetProperty(kvpType, "Value")!.GetGetMethod()!);
+        il.Emit(OpCodes.Call, _types.GetProperty(kvpType, "Key")!.GetGetMethod()!);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add")!);
 
         il.Emit(OpCodes.Br, loopStartLabel);
@@ -554,13 +559,18 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloca, enumeratorLocal);
         il.Emit(OpCodes.Call, _types.GetMethod(enumeratorType, "Dispose")!);
 
-        // return result;
+        il.Emit(OpCodes.Ldloc, dictLocal);
         il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Newobj, runtime.MapCollectionIteratorCtor);
         il.Emit(OpCodes.Ret);
 
         // return new List<object?>();
         il.MarkLabel(returnEmptyLabel);
+        il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, Type.EmptyTypes)!);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Newobj, runtime.MapCollectionIteratorCtor);
         il.Emit(OpCodes.Ret);
     }
 
@@ -569,7 +579,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "MapEntries",
             MethodAttributes.Public | MethodAttributes.Static,
-            _types.ListOfObject,
+            _types.Object,
             [_types.Object]
         );
         runtime.MapEntries = method;
@@ -616,25 +626,11 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, _types.GetProperty(enumeratorType, "Current")!.GetGetMethod()!);
         il.Emit(OpCodes.Stloc, currentLocal);
 
-        // var pair = new List<object?> { current.Key, current.Value };
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, Type.EmptyTypes)!);
-        il.Emit(OpCodes.Stloc, pairLocal);
-
-        // pair.Add(DenormalizeMapKey(current.Key))
-        il.Emit(OpCodes.Ldloc, pairLocal);
+        // Keep the normalized key. The live iterator constructs [key, value]
+        // when it advances, after confirming the entry still exists.
+        il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ldloca, currentLocal);
         il.Emit(OpCodes.Call, _types.GetProperty(kvpType, "Key")!.GetGetMethod()!);
-        il.Emit(OpCodes.Call, runtime.DenormalizeMapKey);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add")!);
-
-        il.Emit(OpCodes.Ldloc, pairLocal);
-        il.Emit(OpCodes.Ldloca, currentLocal);
-        il.Emit(OpCodes.Call, _types.GetProperty(kvpType, "Value")!.GetGetMethod()!);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add")!);
-
-        // result.Add(pair);
-        il.Emit(OpCodes.Ldloc, resultLocal);
-        il.Emit(OpCodes.Ldloc, pairLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add")!);
 
         il.Emit(OpCodes.Br, loopStartLabel);
@@ -644,14 +640,27 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloca, enumeratorLocal);
         il.Emit(OpCodes.Call, _types.GetMethod(enumeratorType, "Dispose")!);
 
-        // return result;
+        il.Emit(OpCodes.Ldloc, dictLocal);
         il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Newobj, runtime.MapCollectionIteratorCtor);
         il.Emit(OpCodes.Ret);
 
         // return new List<object?>();
         il.MarkLabel(returnEmptyLabel);
+        il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, Type.EmptyTypes)!);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Newobj, runtime.MapCollectionIteratorCtor);
         il.Emit(OpCodes.Ret);
+    }
+
+    // Shared by Set iterator factories, whose materialized values use the
+    // ArrayIterator value mode.
+    private static void EmitArrayIteratorWrapper(ILGenerator il, EmittedRuntime runtime)
+    {
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Newobj, runtime.ArrayIteratorCtor);
     }
 
     private void EmitMapForEach(TypeBuilder typeBuilder, EmittedRuntime runtime)
@@ -660,7 +669,7 @@ public partial class RuntimeEmitter
             "MapForEach",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Void,
-            [_types.Object, _types.Object]
+            [_types.Object, _types.Object, _types.Object]
         );
         runtime.MapForEach = method;
 
@@ -731,10 +740,11 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Stelem_Ref);
 
-        // InvokeValue(callback, args)
+        // Call(callback, thisArg, args)
+        il.Emit(OpCodes.Ldarg_2);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldloc, argsLocal);
-        il.Emit(OpCodes.Call, runtime.InvokeValue);
+        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
         il.Emit(OpCodes.Pop);  // Discard return value
 
         il.Emit(OpCodes.Br, loopStartLabel);
@@ -847,6 +857,24 @@ public partial class RuntimeEmitter
             il.MarkLabel(doneLabel);
         }
 
+        void EmitArgOrUndefined(int index)
+        {
+            var missing = il.DefineLabel();
+            var done = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldlen);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Ldc_I4, index);
+            il.Emit(OpCodes.Ble, missing);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldc_I4, index);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Br, done);
+            il.MarkLabel(missing);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            il.MarkLabel(done);
+        }
+
         // Each case loads _map then arg(s), calls the helper, and leaves one value on stack.
 
         // get(key) -> value
@@ -894,7 +922,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, mapField);
             il.Emit(OpCodes.Call, runtime.MapClear);
-            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         });
 
         // keys() -> iterator
@@ -927,8 +955,9 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, mapField);
             EmitArgOrNull(0);
+            EmitArgOrUndefined(1);
             il.Emit(OpCodes.Call, runtime.MapForEach);
-            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         });
 
         // Fallthrough: return null

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.DeleteProperty.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.DeleteProperty.cs
@@ -318,7 +318,9 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldc_I4_1);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(typeNoPdsDescLabel);
-            // "prototype"/"name"/"length" are non-configurable on every built-in.
+            // Constructor `prototype` is non-configurable. Function `name`
+            // and `length` are configurable per ECMA-262 §17 and therefore
+            // use the synthetic built-in deletion ledger below.
             var typeBuiltinNameTrueLabel = il.DefineLabel();
             void EmitTypeBuiltinNameCheck(string n)
             {
@@ -328,8 +330,20 @@ public partial class RuntimeEmitter
                 il.Emit(OpCodes.Brtrue, typeBuiltinNameTrueLabel);
             }
             EmitTypeBuiltinNameCheck("prototype");
-            EmitTypeBuiltinNameCheck("name");
-            EmitTypeBuiltinNameCheck("length");
+            foreach (var configurableFunctionKey in new[] { "name", "length" })
+            {
+                var nextKey = il.DefineLabel();
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldstr, configurableFunctionKey);
+                il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+                il.Emit(OpCodes.Brfalse, nextKey);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Call, runtime.MarkBuiltinDeletedMethod);
+                il.Emit(OpCodes.Ldc_I4_1);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(nextKey);
+            }
 
             // Number Type-specific non-configurable constants. Reflection
             // probe below would miss these because JS names (UPPER_SNAKE_CASE)

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.GetPropertyBranches.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.GetPropertyBranches.cs
@@ -800,6 +800,22 @@ public partial class RuntimeEmitter
         // behavior delegates to the wrapped Symbol rather than Object.prototype.
         // Resolve this after own properties/descriptors so an own override still
         // wins, while hasOwnProperty continues to report false for the method.
+        var notBoxedSymbolDescription = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldstr, "description");
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+        il.Emit(OpCodes.Brfalse, notBoxedSymbolDescription);
+        il.Emit(OpCodes.Ldloc, tsObjectInstanceLocal);
+        il.Emit(OpCodes.Ldstr, "__primitiveType");
+        il.Emit(OpCodes.Callvirt, runtime.TSObjectGetProperty);
+        il.Emit(OpCodes.Ldstr, "Symbol");
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Object, "Equals", _types.Object, _types.Object));
+        il.Emit(OpCodes.Brfalse, notBoxedSymbolDescription);
+        il.Emit(OpCodes.Ldloc, tsObjectInstanceLocal);
+        il.Emit(OpCodes.Call, runtime.SymbolPrototypeDescription);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notBoxedSymbolDescription);
+
         var notBoxedSymbolToString = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldstr, "toString");

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -212,6 +212,7 @@ public partial class RuntimeEmitter
 
         var il = method.GetILGenerator();
         var nullLabel = il.DefineLabel();
+
         var tryMethodLabel = il.DefineLabel();
         var errorPrototypeLookupLabel = il.DefineLabel();
 
@@ -1067,6 +1068,16 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         var nullLabel = il.DefineLabel();
 
+        void EmitBoundRuntimeMethod(MethodBuilder helper, string jsName, int jsLength)
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            _types.EmitLoadMethodInfo(il, helper);
+            il.Emit(OpCodes.Ldstr, jsName);
+            il.Emit(OpCodes.Ldc_I4, jsLength);
+            il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);
+            il.Emit(OpCodes.Ret);
+        }
+
         // null check
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brfalse, nullLabel);
@@ -1193,6 +1204,90 @@ public partial class RuntimeEmitter
         var notListLabel = il.DefineLabel();
         EmitListGetBranch(il, runtime, notListLabel);
         il.MarkLabel(notListLabel);
+
+        // WeakMap and WeakSet share ConditionalWeakTable<object,object> as
+        // their emitted representation. Their distinct method names resolve
+        // the ambiguous receiver brand; has/delete have identical semantics.
+        if (_features.UsesWeakMap || _features.UsesWeakSet)
+        {
+            var notWeakCollectionLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, _types.ConditionalWeakTableObjectObject);
+            il.Emit(OpCodes.Brfalse, notWeakCollectionLabel);
+
+            void EmitWeakMethod(string name, MethodBuilder helper, int length)
+            {
+                var next = il.DefineLabel();
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldstr, name);
+                il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+                il.Emit(OpCodes.Brfalse, next);
+                EmitBoundRuntimeMethod(helper, name, length);
+                il.MarkLabel(next);
+            }
+
+            if (_features.UsesWeakMap)
+            {
+                EmitWeakMethod("get", runtime.WeakMapGet, 1);
+                EmitWeakMethod("set", runtime.WeakMapSet, 2);
+            }
+            if (_features.UsesWeakSet)
+                EmitWeakMethod("add", runtime.WeakSetAdd, 1);
+
+            var sharedHas = _features.UsesWeakMap ? runtime.WeakMapHas : runtime.WeakSetHas;
+            var sharedDelete = _features.UsesWeakMap ? runtime.WeakMapDelete : runtime.WeakSetDelete;
+            EmitWeakMethod("has", sharedHas, 1);
+            EmitWeakMethod("delete", sharedDelete, 1);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notWeakCollectionLabel);
+        }
+
+        if (_features.UsesWeakRef)
+        {
+            var notWeakRefLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, _types.WeakReferenceObject);
+            il.Emit(OpCodes.Brfalse, notWeakRefLabel);
+            var notDerefLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldstr, "deref");
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+            il.Emit(OpCodes.Brfalse, notDerefLabel);
+            EmitBoundRuntimeMethod(runtime.WeakRefDeref, "deref", 0);
+            il.MarkLabel(notDerefLabel);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notWeakRefLabel);
+        }
+
+        // FinalizationRegistry is an internal four-slot object[]. Intercept its
+        // unique method names before the generic arguments-array branch.
+        if (_features.UsesFinalizationRegistry)
+        {
+            var notFinalizationRegistryLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, _types.ObjectArray);
+            il.Emit(OpCodes.Brfalse, notFinalizationRegistryLabel);
+
+            var notRegisterLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldstr, "register");
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+            il.Emit(OpCodes.Brfalse, notRegisterLabel);
+            EmitBoundRuntimeMethod(runtime.FinalizationRegistryRegister, "register", 2);
+            il.MarkLabel(notRegisterLabel);
+
+            var notUnregisterLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldstr, "unregister");
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+            il.Emit(OpCodes.Brfalse, notUnregisterLabel);
+            EmitBoundRuntimeMethod(runtime.FinalizationRegistryUnregister, "unregister", 1);
+            il.MarkLabel(notUnregisterLabel);
+            il.Emit(OpCodes.Br, notFinalizationRegistryLabel);
+            il.MarkLabel(notFinalizationRegistryLabel);
+        }
 
         // object[] (compiled `arguments` representation) - "length"/index.
         var notObjectArrayLabel = il.DefineLabel();
@@ -1353,6 +1448,30 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Call, runtime.IsTypedArrayMethod);
             il.Emit(OpCodes.Brtrue, typedArrayLabel);
         }
+
+        // Symbol primitives walk Symbol.prototype. Handle description with
+        // the primitive as the accessor receiver; ordinary methods recurse
+        // through the populated prototype dictionary so their $Runtime-backed
+        // wrappers retain non-constructor semantics.
+        var notSymbolPrimitiveLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSSymbolType);
+        il.Emit(OpCodes.Brfalse, notSymbolPrimitiveLabel);
+        var notSymbolDescriptionLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldstr, "description");
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+        il.Emit(OpCodes.Brfalse, notSymbolDescriptionLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.SymbolPrototypeDescription);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notSymbolDescriptionLabel);
+        il.Emit(OpCodes.Call, runtime.SymbolPrototypePopulateMethod);
+        il.Emit(OpCodes.Ldsfld, runtime.SymbolPrototypeField);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, method);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notSymbolPrimitiveLabel);
 
         // Primitive bool/double receivers — look up the named property in the
         // matching prototype singleton (Boolean.prototype / Number.prototype).
@@ -1604,6 +1723,15 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldsfld, runtime.BigIntPrototypeField);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(notBigIntLabel);
+            var notSymbolLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldtoken, runtime.TSSymbolType);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+            il.Emit(OpCodes.Bne_Un, notSymbolLabel);
+            il.Emit(OpCodes.Call, runtime.SymbolPrototypePopulateMethod);
+            il.Emit(OpCodes.Ldsfld, runtime.SymbolPrototypeField);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notSymbolLabel);
             var notStringLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldtoken, _types.String);
@@ -1820,6 +1948,15 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Box, _types.Double);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(notObjectLengthLabel);
+            var notBigIntLengthLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldtoken, _types.BigInteger);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+            il.Emit(OpCodes.Bne_Un, notBigIntLengthLabel);
+            il.Emit(OpCodes.Ldc_R8, 1.0);
+            il.Emit(OpCodes.Box, _types.Double);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notBigIntLengthLabel);
             il.MarkLabel(notTypeLengthLabel);
 
             // hasOwnProperty — return a $TSFunction wrapping HasOwnPropertyHelper,
@@ -1898,6 +2035,14 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldstr, "name");
             il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
             il.Emit(OpCodes.Brfalse, notClassNameLabel);
+            var genericTypeNameLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, typeLocal);
+            il.Emit(OpCodes.Ldtoken, _types.BigInteger);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+            il.Emit(OpCodes.Bne_Un, genericTypeNameLabel);
+            il.Emit(OpCodes.Ldstr, "BigInt");
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(genericTypeNameLabel);
             il.Emit(OpCodes.Ldloc, typeLocal);
             il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Type, "Name").GetGetMethod()!);
             il.Emit(OpCodes.Ret);
@@ -2125,8 +2270,21 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Box, _types.Double);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(notArrayBufferByteLengthLabel);
-            // Return null for other properties
-            il.Emit(OpCodes.Ldnull);
+            // ArrayBuffer.prototype.slice — bind the emitted instance helper so
+            // generic/any-typed receivers remain callable.
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldstr, "slice");
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+            var notArrayBufferSliceLabel = il.DefineLabel();
+            il.Emit(OpCodes.Brfalse, notArrayBufferSliceLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            _types.EmitLoadMethodInfo(il, runtime.ArrayBufferSliceDynamic);
+            il.Emit(OpCodes.Ldstr, "slice");
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notArrayBufferSliceLabel);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
             il.Emit(OpCodes.Ret);
 
             // $SharedArrayBuffer handler - check for "byteLength"
@@ -2144,8 +2302,19 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Box, _types.Double);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(notSharedArrayBufferByteLengthLabel);
-            // Return null for other properties
-            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldstr, "slice");
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+            var notSharedArrayBufferSliceLabel = il.DefineLabel();
+            il.Emit(OpCodes.Brfalse, notSharedArrayBufferSliceLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            _types.EmitLoadMethodInfo(il, runtime.SharedArrayBufferSlice);
+            il.Emit(OpCodes.Ldstr, "slice");
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notSharedArrayBufferSliceLabel);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
             il.Emit(OpCodes.Ret);
 
             EmitDataViewHandler();
@@ -2197,8 +2366,51 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, runtime.DataViewBufferGetter);
         il.Emit(OpCodes.Ret);
             il.MarkLabel(notDataViewBufferLabel);
-            // Return null for other properties
-            il.Emit(OpCodes.Ldnull);
+            // DataView's methods live on the emitted concrete type. Expose
+            // them as receiver-bound $TSFunctions for value-form calls.
+            void EmitDataViewMethod(string jsName, MethodBuilder helper, int length)
+            {
+                var next = il.DefineLabel();
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldstr, jsName);
+                il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
+                il.Emit(OpCodes.Brfalse, next);
+                il.Emit(OpCodes.Ldarg_0);
+                _types.EmitLoadMethodInfo(il, helper);
+                il.Emit(OpCodes.Ldstr, jsName);
+                il.Emit(OpCodes.Ldc_I4, length);
+                il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(next);
+            }
+
+            // Bind the public adapters rather than the concrete $DataView
+            // instance methods.  The adapters implement the ECMAScript
+            // argument coercions (ToNumber/ToBigInt) and normalize setter
+            // results to the emitted undefined singleton.  $TSFunction
+            // prepends its bound target when invoking a static helper.
+            EmitDataViewMethod("getInt8", runtime.TSDataViewGetInt8, 1);
+            EmitDataViewMethod("getUint8", runtime.TSDataViewGetUint8, 1);
+            EmitDataViewMethod("getInt16", runtime.TSDataViewGetInt16, 1);
+            EmitDataViewMethod("getUint16", runtime.TSDataViewGetUint16, 1);
+            EmitDataViewMethod("getInt32", runtime.TSDataViewGetInt32, 1);
+            EmitDataViewMethod("getUint32", runtime.TSDataViewGetUint32, 1);
+            EmitDataViewMethod("getFloat32", runtime.TSDataViewGetFloat32, 1);
+            EmitDataViewMethod("getFloat64", runtime.TSDataViewGetFloat64, 1);
+            EmitDataViewMethod("getBigInt64", runtime.TSDataViewGetBigInt64, 1);
+            EmitDataViewMethod("getBigUint64", runtime.TSDataViewGetBigUint64, 1);
+            EmitDataViewMethod("setInt8", runtime.TSDataViewSetInt8, 2);
+            EmitDataViewMethod("setUint8", runtime.TSDataViewSetUint8, 2);
+            EmitDataViewMethod("setInt16", runtime.TSDataViewSetInt16, 2);
+            EmitDataViewMethod("setUint16", runtime.TSDataViewSetUint16, 2);
+            EmitDataViewMethod("setInt32", runtime.TSDataViewSetInt32, 2);
+            EmitDataViewMethod("setUint32", runtime.TSDataViewSetUint32, 2);
+            EmitDataViewMethod("setFloat32", runtime.TSDataViewSetFloat32, 2);
+            EmitDataViewMethod("setFloat64", runtime.TSDataViewSetFloat64, 2);
+            EmitDataViewMethod("setBigInt64", runtime.TSDataViewSetBigInt64, 2);
+            EmitDataViewMethod("setBigUint64", runtime.TSDataViewSetBigUint64, 2);
+
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
             il.Emit(OpCodes.Ret);
         }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Operators.cs
@@ -9,6 +9,56 @@ namespace SharpTS.Compilation;
 public partial class RuntimeEmitter
 {
     /// <summary>
+    /// ToNumeric update helper used by ++/-- on object-typed storage. BigInt
+    /// remains BigInt; all other values follow ToNumber and return a Number.
+    /// </summary>
+    private void EmitUpdateNumeric(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "UpdateNumeric",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Boolean]);
+        runtime.UpdateNumeric = method;
+        var il = method.GetILGenerator();
+        var numberPath = il.DefineLabel();
+        var subtractBigInt = il.DefineLabel();
+        var subtractNumber = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.BigInteger);
+        il.Emit(OpCodes.Brfalse, numberPath);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Unbox_Any, _types.BigInteger);
+        il.Emit(OpCodes.Call, _types.GetProperty(_types.BigInteger, "One")!.GetGetMethod()!);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Brfalse, subtractBigInt);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.BigInteger, "op_Addition",
+            _types.BigInteger, _types.BigInteger));
+        il.Emit(OpCodes.Box, _types.BigInteger);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(subtractBigInt);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.BigInteger, "op_Subtraction",
+            _types.BigInteger, _types.BigInteger));
+        il.Emit(OpCodes.Box, _types.BigInteger);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(numberPath);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.ToNumber);
+        il.Emit(OpCodes.Ldc_R8, 1.0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Brfalse, subtractNumber);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Box, _types.Double);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(subtractNumber);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Box, _types.Double);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
     /// Emits <c>$Runtime.JsLessThan(object x, object y) -&gt; bool</c>:
     /// ECMA-262 7.2.13 IsLessThan abstract algorithm (LeftFirst=true).
     /// If both operands are strings, lexicographic comparison.
@@ -25,6 +75,152 @@ public partial class RuntimeEmitter
         runtime.JsLessThan = method;
 
         var il = method.GetILGenerator();
+
+        // Native integer loop counters are an internal optimization, but they
+        // are still JavaScript Numbers. Normalize them before the runtime type
+        // dispatch so mixed BigInt/Number comparisons take the same path as a
+        // boxed double instead of falling through to ToNumber(BigInt).
+        var leftCounterNormalized = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.Int64);
+        il.Emit(OpCodes.Brfalse, leftCounterNormalized);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Unbox_Any, _types.Int64);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Box, _types.Double);
+        il.Emit(OpCodes.Starg_S, 0);
+        il.MarkLabel(leftCounterNormalized);
+
+        var rightCounterNormalized = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, _types.Int64);
+        il.Emit(OpCodes.Brfalse, rightCounterNormalized);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Unbox_Any, _types.Int64);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Box, _types.Double);
+        il.Emit(OpCodes.Starg_S, 1);
+        il.MarkLabel(rightCounterNormalized);
+
+        // Mixed BigInt/Number relational comparison is permitted by
+        // IsLessThan (unlike arithmetic mixing). Handle the boxed CLR shapes
+        // before the ordinary ToNumber path, which correctly rejects BigInt.
+        // Comparing against the truncated integer first preserves the result
+        // around negative fractional Numbers without converting the BigInt to
+        // an imprecise double.
+        var normalComparison = il.DefineLabel();
+        var leftBigIntNumber = il.DefineLabel();
+        var rightBigIntNumber = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.BigInteger);
+        var leftNotBigInt = il.DefineLabel();
+        il.Emit(OpCodes.Brfalse, leftNotBigInt);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, _types.Double);
+        il.Emit(OpCodes.Brtrue, leftBigIntNumber);
+        il.Emit(OpCodes.Br, normalComparison);
+        il.MarkLabel(leftNotBigInt);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, _types.BigInteger);
+        il.Emit(OpCodes.Brfalse, normalComparison);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.Double);
+        il.Emit(OpCodes.Brtrue, rightBigIntNumber);
+        il.Emit(OpCodes.Br, normalComparison);
+
+        var bigIntegerCtorDouble = _types.GetConstructor(_types.BigInteger, _types.Double);
+        var bigIntegerLess = _types.GetMethod(_types.BigInteger, "op_LessThan",
+            _types.BigInteger, _types.BigInteger);
+        var bigIntegerGreater = _types.GetMethod(_types.BigInteger, "op_GreaterThan",
+            _types.BigInteger, _types.BigInteger);
+        var mixedBigInt = il.DeclareLocal(_types.BigInteger);
+        var mixedNumber = il.DeclareLocal(_types.Double);
+        var truncatedBigInt = il.DeclareLocal(_types.BigInteger);
+
+        // BigInt < Number
+        il.MarkLabel(leftBigIntNumber);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Unbox_Any, _types.BigInteger);
+        il.Emit(OpCodes.Stloc, mixedBigInt);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Unbox_Any, _types.Double);
+        il.Emit(OpCodes.Stloc, mixedNumber);
+        var leftFinite = il.DefineLabel();
+        var mixedReturnFalse = il.DefineLabel();
+        var mixedReturnTrue = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, mixedNumber);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsNaN", _types.Double));
+        il.Emit(OpCodes.Brtrue, mixedReturnFalse);
+        il.Emit(OpCodes.Ldloc, mixedNumber);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsPositiveInfinity", _types.Double));
+        il.Emit(OpCodes.Brtrue, mixedReturnTrue);
+        il.Emit(OpCodes.Ldloc, mixedNumber);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsNegativeInfinity", _types.Double));
+        il.Emit(OpCodes.Brfalse, leftFinite);
+        il.Emit(OpCodes.Br, mixedReturnFalse);
+        il.MarkLabel(leftFinite);
+        il.Emit(OpCodes.Ldloc, mixedNumber);
+        il.Emit(OpCodes.Newobj, bigIntegerCtorDouble);
+        il.Emit(OpCodes.Stloc, truncatedBigInt);
+        il.Emit(OpCodes.Ldloc, mixedBigInt);
+        il.Emit(OpCodes.Ldloc, truncatedBigInt);
+        il.Emit(OpCodes.Call, bigIntegerLess);
+        il.Emit(OpCodes.Brtrue, mixedReturnTrue);
+        il.Emit(OpCodes.Ldloc, mixedBigInt);
+        il.Emit(OpCodes.Ldloc, truncatedBigInt);
+        il.Emit(OpCodes.Call, bigIntegerGreater);
+        il.Emit(OpCodes.Brtrue, mixedReturnFalse);
+        il.Emit(OpCodes.Ldloc, mixedNumber);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Truncate", _types.Double));
+        il.Emit(OpCodes.Ldloc, mixedNumber);
+        il.Emit(OpCodes.Clt);
+        il.Emit(OpCodes.Ret);
+
+        // Number < BigInt
+        il.MarkLabel(rightBigIntNumber);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Unbox_Any, _types.BigInteger);
+        il.Emit(OpCodes.Stloc, mixedBigInt);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Unbox_Any, _types.Double);
+        il.Emit(OpCodes.Stloc, mixedNumber);
+        var rightFinite = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, mixedNumber);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsNaN", _types.Double));
+        il.Emit(OpCodes.Brtrue, mixedReturnFalse);
+        il.Emit(OpCodes.Ldloc, mixedNumber);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsNegativeInfinity", _types.Double));
+        il.Emit(OpCodes.Brtrue, mixedReturnTrue);
+        il.Emit(OpCodes.Ldloc, mixedNumber);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsPositiveInfinity", _types.Double));
+        il.Emit(OpCodes.Brfalse, rightFinite);
+        il.Emit(OpCodes.Br, mixedReturnFalse);
+        il.MarkLabel(rightFinite);
+        il.Emit(OpCodes.Ldloc, mixedNumber);
+        il.Emit(OpCodes.Newobj, bigIntegerCtorDouble);
+        il.Emit(OpCodes.Stloc, truncatedBigInt);
+        il.Emit(OpCodes.Ldloc, truncatedBigInt);
+        il.Emit(OpCodes.Ldloc, mixedBigInt);
+        il.Emit(OpCodes.Call, bigIntegerLess);
+        il.Emit(OpCodes.Brtrue, mixedReturnTrue);
+        il.Emit(OpCodes.Ldloc, truncatedBigInt);
+        il.Emit(OpCodes.Ldloc, mixedBigInt);
+        il.Emit(OpCodes.Call, bigIntegerGreater);
+        il.Emit(OpCodes.Brtrue, mixedReturnFalse);
+        il.Emit(OpCodes.Ldloc, mixedNumber);
+        il.Emit(OpCodes.Ldloc, mixedNumber);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Truncate", _types.Double));
+        il.Emit(OpCodes.Clt);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(mixedReturnTrue);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(mixedReturnFalse);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(normalComparison);
 
         // If both args are strings, do lexicographic comparison (CompareOrdinal < 0).
         var notBothStrings = il.DefineLabel();
@@ -951,6 +1147,39 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, rightLocal);
         il.Emit(OpCodes.Isinst, _types.String);
         il.Emit(OpCodes.Brtrue, stringConcatLabel);
+
+        // ToNumeric preserves BigInt. Runtime-typed BigInt expressions (for
+        // example a loop variable plus a BigInt literal in Test262) do not
+        // reach the statically specialized emitter, so handle them here too.
+        // Mixing BigInt and Number is a TypeError; two BigInts add exactly.
+        var leftNotBigInt = il.DefineLabel();
+        var addBigInts = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, leftLocal);
+        il.Emit(OpCodes.Isinst, _types.BigInteger);
+        il.Emit(OpCodes.Brfalse, leftNotBigInt);
+        il.Emit(OpCodes.Ldloc, rightLocal);
+        il.Emit(OpCodes.Isinst, _types.BigInteger);
+        il.Emit(OpCodes.Brtrue, addBigInts);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot mix BigInt and other types");
+
+        il.MarkLabel(leftNotBigInt);
+        var neitherBigInt = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, rightLocal);
+        il.Emit(OpCodes.Isinst, _types.BigInteger);
+        il.Emit(OpCodes.Brfalse, neitherBigInt);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot mix BigInt and other types");
+
+        il.MarkLabel(addBigInts);
+        il.Emit(OpCodes.Ldloc, leftLocal);
+        il.Emit(OpCodes.Unbox_Any, _types.BigInteger);
+        il.Emit(OpCodes.Ldloc, rightLocal);
+        il.Emit(OpCodes.Unbox_Any, _types.BigInteger);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.BigInteger, "op_Addition",
+            _types.BigInteger, _types.BigInteger));
+        il.Emit(OpCodes.Box, _types.BigInteger);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(neitherBigInt);
 
         // Either operand $Undefined → NaN (ECMA-262 12.8.3: ToNumber(undefined) = NaN,
         // and any arithmetic with NaN yields NaN). Convert.ToDouble($Undefined) throws

--- a/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -486,6 +486,7 @@ public partial class RuntimeEmitter
         DefineStringPrototypePopulateShell(typeBuilder, runtime);
         DefineNumberPrototypePopulateShell(typeBuilder, runtime);
         DefineBigIntPrototypePopulateShell(typeBuilder, runtime);
+        DefineSymbolPrototypePopulateShell(typeBuilder, runtime);
         DefineBooleanPrototypePopulateShell(typeBuilder, runtime);
         DefineDatePrototypePopulateShell(typeBuilder, runtime);
         DefineErrorPrototypePopulateShell(typeBuilder, runtime);
@@ -666,6 +667,7 @@ public partial class RuntimeEmitter
         cctorIL.Emit(OpCodes.Call, runtime.NumberPrototypePopulateMethod);
         if (_features.UsesBigInt)
             cctorIL.Emit(OpCodes.Call, runtime.BigIntPrototypePopulateMethod);
+        cctorIL.Emit(OpCodes.Call, runtime.SymbolPrototypePopulateMethod);
         cctorIL.Emit(OpCodes.Call, runtime.BooleanPrototypePopulateMethod);
         cctorIL.Emit(OpCodes.Call, runtime.DatePrototypePopulateMethod);
         cctorIL.Emit(OpCodes.Call, runtime.StringPrototypePopulateMethod);
@@ -730,6 +732,7 @@ public partial class RuntimeEmitter
         EmitJsToInt32(typeBuilder, runtime);
         EmitJsLessThan(typeBuilder, runtime);
         EmitJsLessOrEqual(typeBuilder, runtime);
+        EmitUpdateNumeric(typeBuilder, runtime);
         EmitIsTruthy(typeBuilder, runtime);
         // Promise resolving callbacks need the adoption helper token before
         // EmitPromiseMethods fills in its body later in this method.
@@ -885,6 +888,25 @@ public partial class RuntimeEmitter
             if (_features.UsesNodeStreams)
                 EmitStreamAddAbortSignalMethod(typeBuilder, runtime);
         }
+        // DataView method values are bound by GetProperty below. Emit the
+        // constructor/property/method adapters now so those wrappers can use
+        // their MethodInfo tokens; the remaining Worker helpers stay in their
+        // usual late block.
+        if (_features.HasAnyTypedArray)
+            EmitDataViewHelper(typeBuilder, runtime);
+        // Weak collections/references and FinalizationRegistry are represented
+        // by BCL types, so generic property access cannot discover their
+        // JavaScript method names. Emit their helpers before GetProperty so its
+        // receiver branches can bind them into $TSFunction wrappers.
+        if (_features.UsesWeakMap)
+            EmitWeakMapMethods(typeBuilder, runtime);
+        if (_features.UsesWeakSet)
+            EmitWeakSetMethods(typeBuilder, runtime);
+        if (_features.UsesWeakRef)
+            EmitWeakRefMethods(typeBuilder, runtime);
+        EmitFinalizationRegistryMethods(typeBuilder, runtime);
+        // Boxed Symbol property access binds these helpers directly.
+        EmitSymbolPrototypePopulate(typeBuilder, runtime);
         // String/Number/Boolean populate shells already defined above
         // (before cctor) so the cctor can call them eagerly.
         EmitGetProperty(typeBuilder, runtime);
@@ -949,6 +971,8 @@ public partial class RuntimeEmitter
         // but BEFORE IterateToList (which needs IteratorWrapperCtor)
         EmitIteratorWrapperType(moduleBuilder, runtime);
         EmitArrayIteratorType(moduleBuilder, runtime);
+        if (_features.UsesMap)
+            EmitMapCollectionIteratorType(moduleBuilder, runtime);
         EmitPromiseResolveValue(moduleBuilder, runtime);
         // Promise combinators reserve their normalization method token early,
         // but its incremental custom-iterator body needs both the basic
@@ -1241,6 +1265,7 @@ public partial class RuntimeEmitter
         if (_features.UsesBigInt)
         {
             EmitCreateBigInt(typeBuilder, runtime);
+            EmitBigIntStaticMethods(typeBuilder, runtime);
             EmitBigIntArithmetic(typeBuilder, runtime);
             EmitBigIntComparison(typeBuilder, runtime);
             EmitBigIntBitwise(typeBuilder, runtime);
@@ -1310,17 +1335,8 @@ public partial class RuntimeEmitter
         // Set methods — gated on UsesSet.
         if (_features.UsesSet)
             EmitSetMethods(typeBuilder, runtime);
-        // WeakMap methods — gated on UsesWeakMap (`new WeakMap()` / bare `WeakMap`).
-        if (_features.UsesWeakMap)
-            EmitWeakMapMethods(typeBuilder, runtime);
-        // WeakSet methods — gated on UsesWeakSet.
-        if (_features.UsesWeakSet)
-            EmitWeakSetMethods(typeBuilder, runtime);
-        // WeakRef methods — gated on UsesWeakRef.
-        if (_features.UsesWeakRef)
-            EmitWeakRefMethods(typeBuilder, runtime);
-        // FinalizationRegistry methods
-        EmitFinalizationRegistryMethods(typeBuilder, runtime);
+        // WeakMap/WeakSet/WeakRef/FinalizationRegistry helpers are emitted
+        // before GetProperty, which binds their BCL-backed receiver methods.
         // Proxy methods — gated on UsesProxy (`new Proxy()` / bare `Proxy`).
         // Proxy trap dispatch late-binds to SharpTSProxy on its normal path, so the
         // compiled output needs SharpTS.dll present at runtime when Proxy is used.

--- a/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClassPhase1.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClassPhase1.cs
@@ -137,6 +137,19 @@ public partial class RuntimeEmitter
             _types.Double,
             [_types.Object]);
 
+        // Reserve strict ToBigInt for DataView's BigInt setter adapters. The
+        // adapters must be emitted before GetProperty can bind method values;
+        // EmitStrictToBigInt fills this body later after observable
+        // object-to-primitive helpers are available.
+        if (_features.UsesBigInt)
+        {
+            runtime.ToBigInt = typeBuilder.DefineMethod(
+                "ToBigInt",
+                MethodAttributes.Public | MethodAttributes.Static,
+                _types.Object,
+                [_types.Object]);
+        }
+
         // Reserve ToJsString(object) → string. Stringify (which $RegExp's
         // Symbol.* helpers currently call) doesn't run @@toPrimitive on
         // objects; ToJsString does (ECMA-262 §7.1.1). Forward-declared so

--- a/src/SharpTS/Compilation/RuntimeEmitter.Sets.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Sets.cs
@@ -312,7 +312,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "SetKeys",
             MethodAttributes.Public | MethodAttributes.Static,
-            _types.ListOfObject,
+            _types.Object,
             [_types.Object]
         );
         runtime.SetKeys = method;
@@ -326,7 +326,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "SetValues",
             MethodAttributes.Public | MethodAttributes.Static,
-            _types.ListOfObject,
+            _types.Object,
             [_types.Object]
         );
         runtime.SetValues = method;
@@ -393,11 +393,13 @@ public partial class RuntimeEmitter
 
         // return result;
         il.Emit(OpCodes.Ldloc, resultLocal);
+        EmitArrayIteratorWrapper(il, runtime);
         il.Emit(OpCodes.Ret);
 
         // return new List<object?>();
         il.MarkLabel(returnEmptyLabel);
         il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, Type.EmptyTypes)!);
+        EmitArrayIteratorWrapper(il, runtime);
         il.Emit(OpCodes.Ret);
     }
 
@@ -406,7 +408,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "SetEntries",
             MethodAttributes.Public | MethodAttributes.Static,
-            _types.ListOfObject,
+            _types.Object,
             [_types.Object]
         );
         runtime.SetEntries = method;
@@ -478,11 +480,13 @@ public partial class RuntimeEmitter
 
         // return result;
         il.Emit(OpCodes.Ldloc, resultLocal);
+        EmitArrayIteratorWrapper(il, runtime);
         il.Emit(OpCodes.Ret);
 
         // return new List<object?>();
         il.MarkLabel(returnEmptyLabel);
         il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, Type.EmptyTypes)!);
+        EmitArrayIteratorWrapper(il, runtime);
         il.Emit(OpCodes.Ret);
     }
 
@@ -492,7 +496,7 @@ public partial class RuntimeEmitter
             "SetForEach",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Void,
-            [_types.Object, _types.Object]
+            [_types.Object, _types.Object, _types.Object]
         );
         runtime.SetForEach = method;
 
@@ -559,10 +563,11 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Stelem_Ref);
 
-        // InvokeValue(callback, args)
+        // Call(callback, thisArg, args)
+        il.Emit(OpCodes.Ldarg_2);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldloc, argsLocal);
-        il.Emit(OpCodes.Call, runtime.InvokeValue);
+        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
         il.Emit(OpCodes.Pop); // Discard return value
 
         il.Emit(OpCodes.Br, loopStartLabel);
@@ -578,6 +583,17 @@ public partial class RuntimeEmitter
 
     #region ES2025 Set Operations
 
+    private void EmitRequireSetReceiver(ILGenerator il, EmittedRuntime runtime)
+    {
+        var valid = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.HashSetOfObject);
+        il.Emit(OpCodes.Brtrue, valid);
+        GuestErrorEmitter.ThrowTypeError(il, runtime,
+            "Set operation called on an incompatible receiver");
+        il.MarkLabel(valid);
+    }
+
     private void EmitSetUnion(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         var method = typeBuilder.DefineMethod(
@@ -589,6 +605,7 @@ public partial class RuntimeEmitter
         runtime.SetUnion = method;
 
         var il = method.GetILGenerator();
+        EmitRequireSetReceiver(il, runtime);
         var setType = _types.HashSetOfObject;
         var ctorWithComparer = _types.GetConstructor(setType, [_types.IEqualityComparerOfObject])!;
         var enumeratorType = _types.MakeGenericType(typeof(HashSet<>.Enumerator).GetGenericTypeDefinition(), _types.Object);
@@ -679,6 +696,7 @@ public partial class RuntimeEmitter
         runtime.SetIntersection = method;
 
         var il = method.GetILGenerator();
+        EmitRequireSetReceiver(il, runtime);
         var setType = _types.HashSetOfObject;
         var ctorWithComparer = _types.GetConstructor(setType, [_types.IEqualityComparerOfObject])!;
         var enumeratorType = _types.MakeGenericType(typeof(HashSet<>.Enumerator).GetGenericTypeDefinition(), _types.Object);
@@ -761,6 +779,7 @@ public partial class RuntimeEmitter
         runtime.SetDifference = method;
 
         var il = method.GetILGenerator();
+        EmitRequireSetReceiver(il, runtime);
         var setType = _types.HashSetOfObject;
         var ctorWithComparer = _types.GetConstructor(setType, [_types.IEqualityComparerOfObject])!;
         var enumeratorType = _types.MakeGenericType(typeof(HashSet<>.Enumerator).GetGenericTypeDefinition(), _types.Object);
@@ -846,6 +865,7 @@ public partial class RuntimeEmitter
         runtime.SetSymmetricDifference = method;
 
         var il = method.GetILGenerator();
+        EmitRequireSetReceiver(il, runtime);
         var setType = _types.HashSetOfObject;
         var ctorWithComparer = _types.GetConstructor(setType, [_types.IEqualityComparerOfObject])!;
         var enumeratorType = _types.MakeGenericType(typeof(HashSet<>.Enumerator).GetGenericTypeDefinition(), _types.Object);
@@ -978,6 +998,7 @@ public partial class RuntimeEmitter
         runtime.SetIsSubsetOf = method;
 
         var il = method.GetILGenerator();
+        EmitRequireSetReceiver(il, runtime);
         var setType = _types.HashSetOfObject;
         var enumeratorType = _types.MakeGenericType(typeof(HashSet<>.Enumerator).GetGenericTypeDefinition(), _types.Object);
 
@@ -1064,6 +1085,7 @@ public partial class RuntimeEmitter
         runtime.SetIsSupersetOf = method;
 
         var il = method.GetILGenerator();
+        EmitRequireSetReceiver(il, runtime);
         var setType = _types.HashSetOfObject;
         var enumeratorType = _types.MakeGenericType(typeof(HashSet<>.Enumerator).GetGenericTypeDefinition(), _types.Object);
 
@@ -1150,6 +1172,7 @@ public partial class RuntimeEmitter
         runtime.SetIsDisjointFrom = method;
 
         var il = method.GetILGenerator();
+        EmitRequireSetReceiver(il, runtime);
         var setType = _types.HashSetOfObject;
         var enumeratorType = _types.MakeGenericType(typeof(HashSet<>.Enumerator).GetGenericTypeDefinition(), _types.Object);
 
@@ -1343,6 +1366,24 @@ public partial class RuntimeEmitter
             il.MarkLabel(doneLabel);
         }
 
+        void EmitArgOrUndefined(int index)
+        {
+            var missing = il.DefineLabel();
+            var done = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldlen);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Ldc_I4, index);
+            il.Emit(OpCodes.Ble, missing);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldc_I4, index);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Br, done);
+            il.MarkLabel(missing);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            il.MarkLabel(done);
+        }
+
         // add(value) -> set (chainable)
         EmitCase("add", () =>
         {
@@ -1378,7 +1419,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, setField);
             il.Emit(OpCodes.Call, runtime.SetClear);
-            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         });
 
         // keys() -> iterator
@@ -1411,8 +1452,9 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, setField);
             EmitArgOrNull(0);
+            EmitArgOrUndefined(1);
             il.Emit(OpCodes.Call, runtime.SetForEach);
-            il.Emit(OpCodes.Ldnull);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         });
 
         // ES2025 set operations: union, intersection, difference, symmetricDifference

--- a/src/SharpTS/Compilation/RuntimeEmitter.SymbolPrototypePopulate.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.SymbolPrototypePopulate.cs
@@ -1,0 +1,147 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    private void DefineSymbolPrototypePopulateShell(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        runtime.SymbolPrototypePopulateMethod = typeBuilder.DefineMethod(
+            "_SymbolPrototypePopulate",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            Type.EmptyTypes);
+    }
+
+    private void EmitSymbolPrototypePopulate(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var valueOf = EmitSymbolPrototypeValueOf(typeBuilder, runtime);
+        var toString = EmitSymbolPrototypeToString(typeBuilder, runtime, valueOf);
+        var description = EmitSymbolPrototypeDescription(typeBuilder, runtime, valueOf);
+        runtime.SymbolPrototypeValueOf = valueOf;
+        runtime.SymbolPrototypeToString = toString;
+        runtime.SymbolPrototypeDescription = description;
+
+        var method = runtime.SymbolPrototypePopulateMethod;
+        var il = method.GetILGenerator();
+        var setItem = _types.GetMethod(_types.DictionaryStringObject, "set_Item",
+            _types.String, _types.Object);
+        EmitPrototypePopulateGuard(il, runtime.SymbolPrototypeField);
+        var descLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
+
+        EmitInstallConstructor(il, runtime, runtime.SymbolPrototypeField, descLocal, setItem, () =>
+        {
+            il.Emit(OpCodes.Ldtoken, runtime.TSSymbolType);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+        });
+        EmitWirePrototypeMethod(il, runtime, runtime.SymbolPrototypeField, descLocal,
+            setItem, "toString", toString, 0);
+        EmitWirePrototypeMethod(il, runtime, runtime.SymbolPrototypeField, descLocal,
+            setItem, "valueOf", valueOf, 0);
+
+        // description is a configurable, non-enumerable accessor property.
+        description.DefineParameter(1, ParameterAttributes.None, "__this");
+        var getterLocal = il.DeclareLocal(_types.Object);
+        _types.EmitLoadMethodInfo(il, description);
+        il.Emit(OpCodes.Ldstr, "get description");
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Call, runtime.TSFunctionGetOrCreate);
+        il.Emit(OpCodes.Stloc, getterLocal);
+        il.Emit(OpCodes.Newobj, runtime.CompiledPropertyDescriptorCtor);
+        il.Emit(OpCodes.Stloc, descLocal);
+        il.Emit(OpCodes.Ldloc, descLocal);
+        il.Emit(OpCodes.Ldloc, getterLocal);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorGetter.GetSetMethod()!);
+        il.Emit(OpCodes.Ldloc, descLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorEnumerable.GetSetMethod()!);
+        il.Emit(OpCodes.Ldloc, descLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorConfigurable.GetSetMethod()!);
+        il.Emit(OpCodes.Ldsfld, runtime.SymbolPrototypeField);
+        il.Emit(OpCodes.Ldstr, "description");
+        il.Emit(OpCodes.Ldloc, descLocal);
+        il.Emit(OpCodes.Call, runtime.PDSDefineProperty);
+        il.Emit(OpCodes.Pop);
+
+        il.Emit(OpCodes.Ldsfld, runtime.SymbolPrototypeField);
+        il.Emit(OpCodes.Ldsfld, runtime.ObjectPrototypeField);
+        il.Emit(OpCodes.Call, runtime.PDSSetPrototype);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private MethodBuilder EmitSymbolPrototypeValueOf(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "SymbolPrototypeValueOf",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object]);
+        var il = method.GetILGenerator();
+        var notPrimitive = il.DefineLabel();
+        var throwTypeError = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSSymbolType);
+        il.Emit(OpCodes.Brfalse, notPrimitive);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notPrimitive);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSObjectType);
+        il.Emit(OpCodes.Brfalse, throwTypeError);
+        var primitiveLocal = il.DeclareLocal(_types.Object);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSObjectType);
+        il.Emit(OpCodes.Callvirt, runtime.TSObjectFieldsGetter);
+        il.Emit(OpCodes.Ldstr, "__primitiveValue");
+        il.Emit(OpCodes.Ldloca, primitiveLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "TryGetValue",
+            [_types.String, _types.Object.MakeByRefType()])!);
+        il.Emit(OpCodes.Brfalse, throwTypeError);
+        il.Emit(OpCodes.Ldloc, primitiveLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSSymbolType);
+        il.Emit(OpCodes.Brfalse, throwTypeError);
+        il.Emit(OpCodes.Ldloc, primitiveLocal);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(throwTypeError);
+        GuestErrorEmitter.ThrowTypeError(il, runtime,
+            "Symbol.prototype.valueOf requires that 'this' be a Symbol");
+        return method;
+    }
+
+    private MethodBuilder EmitSymbolPrototypeToString(
+        TypeBuilder typeBuilder, EmittedRuntime runtime, MethodBuilder valueOf)
+    {
+        var method = typeBuilder.DefineMethod(
+            "SymbolPrototypeToString",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.String,
+            [_types.Object]);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, valueOf);
+        il.Emit(OpCodes.Castclass, runtime.TSSymbolType);
+        il.Emit(OpCodes.Callvirt, runtime.SymbolToStringMethod);
+        il.Emit(OpCodes.Ret);
+        return method;
+    }
+
+    private MethodBuilder EmitSymbolPrototypeDescription(
+        TypeBuilder typeBuilder, EmittedRuntime runtime, MethodBuilder valueOf)
+    {
+        var method = typeBuilder.DefineMethod(
+            "SymbolPrototypeDescription",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object]);
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, valueOf);
+        il.Emit(OpCodes.Castclass, runtime.TSSymbolType);
+        il.Emit(OpCodes.Callvirt, runtime.SymbolDescriptionGetter);
+        il.Emit(OpCodes.Ret);
+        return method;
+    }
+}

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSArrayBuffer.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSArrayBuffer.cs
@@ -48,6 +48,13 @@ public partial class RuntimeEmitter
         ctorIl.Emit(OpCodes.Call, _types.GetDefaultConstructor(_types.Object));
 
         // _buffer = new byte[byteLength]
+        var validLength = ctorIl.DefineLabel();
+        ctorIl.Emit(OpCodes.Ldarg_1);
+        ctorIl.Emit(OpCodes.Ldc_I4_0);
+        ctorIl.Emit(OpCodes.Bge, validLength);
+        GuestErrorEmitter.ThrowError(ctorIl, runtime, runtime.TSRangeErrorCtor,
+            "Invalid ArrayBuffer length");
+        ctorIl.MarkLabel(validLength);
         ctorIl.Emit(OpCodes.Ldarg_0);
         ctorIl.Emit(OpCodes.Ldarg_1);
         ctorIl.Emit(OpCodes.Newarr, typeof(byte));
@@ -66,6 +73,7 @@ public partial class RuntimeEmitter
 
         // Method: public $ArrayBuffer Slice(int begin, int end)
         EmitArrayBufferSlice(typeBuilder, runtime, bufferField, ctor);
+        EmitArrayBufferSliceDynamic(typeBuilder, runtime);
 
         // Finalize the type
         typeBuilder.CreateType();
@@ -187,12 +195,16 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, bufLenLocal);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Max", _types.Int32, _types.Int32));
         il.Emit(OpCodes.Stloc, beginLocal);
         var afterBeginLabel = il.DefineLabel();
         il.Emit(OpCodes.Br, afterBeginLabel);
 
         il.MarkLabel(beginPositiveLabel);
         il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, bufLenLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Min", _types.Int32, _types.Int32));
         il.Emit(OpCodes.Stloc, beginLocal);
 
         il.MarkLabel(afterBeginLabel);
@@ -210,6 +222,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, bufLenLocal);
         il.Emit(OpCodes.Ldarg_2);
         il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Max", _types.Int32, _types.Int32));
         il.Emit(OpCodes.Stloc, endLocal);
         il.Emit(OpCodes.Br, afterEndLabel);
 
@@ -232,6 +246,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, endLocal);
         il.Emit(OpCodes.Ldloc, beginLocal);
         il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Max", _types.Int32, _types.Int32));
         il.Emit(OpCodes.Stloc, lengthLocal);
 
         // var result = new $ArrayBuffer(length)
@@ -253,6 +269,49 @@ public partial class RuntimeEmitter
 
         // return result
         il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitArrayBufferSliceDynamic(
+        TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "SliceDynamic",
+            MethodAttributes.Public,
+            typeBuilder,
+            [_types.Object, _types.Object]);
+        runtime.ArrayBufferSliceDynamic = method;
+        var il = method.GetILGenerator();
+        var begin = il.DeclareLocal(_types.Int32);
+        var end = il.DeclareLocal(_types.Int32);
+
+        void EmitIndexOrDefault(int arg, LocalBuilder target, int defaultValue)
+        {
+            var useDefault = il.DefineLabel();
+            var ready = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg, arg);
+            il.Emit(OpCodes.Brfalse, useDefault);
+            il.Emit(OpCodes.Ldarg, arg);
+            il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+            il.Emit(OpCodes.Brtrue, useDefault);
+            il.Emit(OpCodes.Ldarg, arg);
+            il.Emit(OpCodes.Call, runtime.ToNumber);
+            il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Truncate", _types.Double));
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Stloc, target);
+            il.Emit(OpCodes.Br, ready);
+            il.MarkLabel(useDefault);
+            il.Emit(OpCodes.Ldc_I4, defaultValue);
+            il.Emit(OpCodes.Stloc, target);
+            il.MarkLabel(ready);
+        }
+
+        EmitIndexOrDefault(1, begin, 0);
+        EmitIndexOrDefault(2, end, int.MaxValue);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, begin);
+        il.Emit(OpCodes.Ldloc, end);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayBufferSlice);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSDataView.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSDataView.cs
@@ -833,7 +833,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             methodName,
             MethodAttributes.Public,
-            _types.Void,
+            _types.Object,
             [_types.Int32, _types.Object]
         );
 
@@ -856,6 +856,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Conv_U1);
 
         il.Emit(OpCodes.Stelem_I1);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il.Emit(OpCodes.Ret);
 
         if (methodName == "SetInt8") runtime.DataViewSetInt8 = method;
@@ -870,7 +871,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             methodName,
             MethodAttributes.Public,
-            _types.Void,
+            _types.Object,
             [_types.Int32, _types.Object, _types.Boolean]
         );
 
@@ -911,6 +912,7 @@ public partial class RuntimeEmitter
         EmitStoreByte(il, bufferField, offsetLocal, 1, valueLocal, 8); // high byte
 
         il.MarkLabel(endLabel);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il.Emit(OpCodes.Ret);
 
         if (methodName == "SetInt16") runtime.DataViewSetInt16 = method;
@@ -959,7 +961,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             methodName,
             MethodAttributes.Public,
-            _types.Void,
+            _types.Object,
             [_types.Int32, _types.Object, _types.Boolean]
         );
 
@@ -987,10 +989,13 @@ public partial class RuntimeEmitter
         }
         else
         {
-            // For unsigned, must go through uint64 first to handle values > Int32.MaxValue
-            // Conv_I4 on doubles > Int32.MaxValue has undefined behavior per ECMA-335
-            il.Emit(OpCodes.Conv_U8);  // double -> uint64 (handles values up to 2^64)
-            il.Emit(OpCodes.Conv_I4);  // uint64 -> int32 (truncates to low 32 bits)
+            // ToUint32 keeps the low 32 bits for both negative inputs and
+            // positive inputs above Int32.MaxValue.  Convert through signed
+            // 64-bit first (all finite Uint32 source values fit) and then
+            // truncate to the low word. Conv_U8 turns negative values into
+            // zero/unspecified overflow on the CLR and corrupted their bytes.
+            il.Emit(OpCodes.Conv_I8);
+            il.Emit(OpCodes.Conv_I4);
         }
         il.Emit(OpCodes.Stloc, valueLocal);
 
@@ -1015,6 +1020,7 @@ public partial class RuntimeEmitter
         EmitStoreByte(il, bufferField, offsetLocal, 3, valueLocal, 24);
 
         il.MarkLabel(endLabel);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il.Emit(OpCodes.Ret);
 
         if (methodName == "SetInt32") runtime.DataViewSetInt32 = method;
@@ -1028,7 +1034,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "SetFloat32",
             MethodAttributes.Public,
-            _types.Void,
+            _types.Object,
             [_types.Int32, _types.Object, _types.Boolean]
         );
 
@@ -1073,6 +1079,7 @@ public partial class RuntimeEmitter
         EmitStoreByte(il, bufferField, offsetLocal, 3, valueLocal, 24);
 
         il.MarkLabel(endLabel);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il.Emit(OpCodes.Ret);
 
         runtime.DataViewSetFloat32 = method;
@@ -1085,7 +1092,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "SetFloat64",
             MethodAttributes.Public,
-            _types.Void,
+            _types.Object,
             [_types.Int32, _types.Object, _types.Boolean]
         );
 
@@ -1138,6 +1145,7 @@ public partial class RuntimeEmitter
         EmitStoreByte64(il, bufferField, offsetLocal, 7, valueLocal, 56);
 
         il.MarkLabel(endLabel);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il.Emit(OpCodes.Ret);
 
         runtime.DataViewSetFloat64 = method;
@@ -1152,7 +1160,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             methodName,
             MethodAttributes.Public,
-            _types.Void,
+            _types.Object,
             [_types.Int32, _types.Object, _types.Boolean]
         );
 
@@ -1215,6 +1223,7 @@ public partial class RuntimeEmitter
         EmitStoreByte64(il, bufferField, offsetLocal, 7, valueLocal, 56);
 
         il.MarkLabel(endLabel);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il.Emit(OpCodes.Ret);
 
         if (signed)

--- a/src/SharpTS/Compilation/RuntimeEmitter.Worker.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Worker.cs
@@ -23,7 +23,8 @@ public partial class RuntimeEmitter
         {
             EmitSharedArrayBufferHelper(runtimeType, runtime);
             EmitArrayBufferHelper(runtimeType, runtime);
-            EmitDataViewHelper(runtimeType, runtime);
+            // DataView adapters are emitted before GetProperty in
+            // EmitRuntimeClass because dynamic method values bind them.
             EmitTypedArrayHelpers(runtimeType, runtime);
             // Atomics static methods (pure-IL with reflection fallback for SharpTS types)
             EmitAtomicsHelpersPure(runtimeType, runtime);
@@ -555,7 +556,7 @@ public partial class RuntimeEmitter
         var method = runtimeType.DefineMethod(
             $"DataView{runtimeMethodName}",
             MethodAttributes.Public | MethodAttributes.Static,
-            _types.Void,
+            _types.Object,
             paramTypes
         );
 
@@ -579,6 +580,22 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Castclass, runtime.DataViewType);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldarg_2);
+        if (runtimeMethodName is "SetBigInt64" or "SetBigUint64")
+        {
+            // BigInt helpers are feature-gated. A DataView-only program still
+            // emits these adapters, so preserve the raw value when the BigInt
+            // conversion helper is absent (the methods are unreachable there).
+            if (runtime.ToBigInt is not null)
+                il.Emit(OpCodes.Call, runtime.ToBigInt);
+        }
+        else
+        {
+            // DataView numeric setters perform ToNumber before converting to
+            // their element representation. This supplies NaN for undefined
+            // and raises the guest TypeError for Symbol values.
+            il.Emit(OpCodes.Call, runtime.ToNumber);
+            il.Emit(OpCodes.Box, _types.Double);
+        }
         if (hasEndianness)
             il.Emit(OpCodes.Ldarg_3);
         il.Emit(OpCodes.Callvirt, target);

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -140,12 +140,13 @@ public sealed class RuntimeFeatureDetector
             _set.TypedArrays |= RuntimeFeatureSet.TypedArrayKinds.ArrayBuffer
                               | RuntimeFeatureSet.TypedArrayKinds.TypedArrayBase;
         }
-        // BigInt64Array / BigUint64Array store BigInteger values. Even without
-        // a `123n` literal in the source, arithmetic on their elements lowers
-        // to BigInt helpers in the type-checker. Imply UsesBigInt to keep them
-        // emitted.
+        // BigInt64Array / BigUint64Array store BigInteger values, and DataView
+        // exposes get/setBigInt64 plus get/setBigUint64. Even without a `123n`
+        // literal in the source, those surfaces require strict ToBigInt and
+        // the BigInt helpers. Imply UsesBigInt to keep them emitted.
         if ((_set.TypedArrays & (RuntimeFeatureSet.TypedArrayKinds.BigInt64
-                              | RuntimeFeatureSet.TypedArrayKinds.BigUint64)) != 0)
+                              | RuntimeFeatureSet.TypedArrayKinds.BigUint64
+                              | RuntimeFeatureSet.TypedArrayKinds.DataView)) != 0)
         {
             _set.UsesBigInt = true;
         }

--- a/tests/SharpTS.Tests/CompilerTests/Issue1374EmittedHelperTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/Issue1374EmittedHelperTests.cs
@@ -1,0 +1,107 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public class Issue1374EmittedHelperTests
+{
+    [Fact]
+    public void Binary_data_helpers_coerce_values_return_undefined_and_preserve_endianness()
+    {
+        const string source = """
+            const buffer: any = new ArrayBuffer(8);
+            const view = new DataView(buffer);
+            console.log(view.setFloat64(0, undefined) === undefined);
+            console.log(Number.isNaN(view.getFloat64(0)));
+            view.setUint32(0, 0x01020304, true);
+            console.log(view.getUint8(0), view.getUint8(1), view.getUint8(2), view.getUint8(3));
+            try {
+              view.setBigInt64(0, Symbol("1"));
+              console.log(false);
+            } catch (error) {
+              console.log(error instanceof TypeError);
+            }
+            console.log(buffer.slice(1, 4).byteLength);
+            """;
+
+        Assert.Equal("true\ntrue\n4 3 2 1\ntrue\n3\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void Collection_helpers_keep_map_iterators_live_and_return_js_values()
+    {
+        const string source = """
+            const map: any = new Map([[1, "a"], [2, "b"], [3, "c"]]);
+            const keys: any = map.keys();
+            console.log(keys.next().value);
+            map.delete(2);
+            console.log(keys.next().value);
+            console.log(keys.next().done);
+
+            const clearKeys: any = map.keys();
+            console.log(clearKeys.next().value);
+            console.log(map.clear() === undefined);
+            console.log(clearKeys.next().done);
+
+            const setMethod: any = map.set;
+            console.log(setMethod.call(map, 4, "d") === map);
+            const set: any = new Set([1]);
+            console.log(set.clear() === undefined);
+            """;
+
+        Assert.Equal("1\n3\ntrue\n1\ntrue\ntrue\ntrue\ntrue\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void BigInt_helpers_cover_dynamic_arithmetic_updates_radices_and_width_coercion()
+    {
+        const string source = """
+            let letters = "";
+            for (let radix: any = 11; radix <= 36; radix++) {
+              for (let value: any = 10n; value < radix; value++) {
+                letters += value.toString(radix);
+                Number(value + 87n);
+              }
+            }
+            console.log(letters.length, letters[0], letters[letters.length - 1]);
+            console.log(BigInt.asIntN("8" as any, 255n));
+            console.log(BigInt.asUintN(8, -1n));
+            """;
+
+        Assert.Equal("351 a z\n-1n\n255n\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void Symbol_prototype_helpers_use_symbol_receivers_and_metadata()
+    {
+        const string source = """
+            const symbol: any = Symbol("desc");
+            const proto: any = Symbol.prototype;
+            console.log(proto.valueOf.call(symbol) === symbol);
+            console.log(proto.toString.call(symbol));
+            console.log(symbol.description);
+            console.log(Symbol.prototype.constructor === Symbol);
+            """;
+
+        Assert.Equal("true\nSymbol(desc)\ndesc\ntrue\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void Weak_collection_and_reference_helpers_have_js_constructor_shapes()
+    {
+        const string source = """
+            const key: any = {};
+            const weakMap: any = new WeakMap();
+            weakMap.set(key, 42);
+            console.log(weakMap.get(key), weakMap.has(key));
+            const weakSet: any = new WeakSet();
+            weakSet.add(key);
+            console.log(weakSet.has(key));
+            console.log(typeof WeakRef, typeof FinalizationRegistry);
+            console.log(Object.getPrototypeOf(WeakRef) === Function.prototype);
+            console.log(Object.getPrototypeOf(FinalizationRegistry) === Function.prototype);
+            """;
+
+        Assert.Equal("42 true\ntrue\nfunction function\ntrue\ntrue\n", TestHarness.RunCompiled(source));
+    }
+}


### PR DESCRIPTION
## Summary

- complete emitted ArrayBuffer and DataView coercion, slicing, endian, and BigInt setter behavior
- complete Map, Set, weak collection/reference, and FinalizationRegistry dispatch, return values, groupBy, and iterator behavior
- add BigInt conversion, width, parsing, mixed comparison/update, arithmetic, and prototype helpers
- add Symbol prototype methods, metadata, boxing, and description behavior
- add focused compiled regression coverage for all four helper clusters

Contributes to #1374.

## Verification

- `dotnet test tests\SharpTS.Tests\SharpTS.Tests.csproj -c Release --no-restore` — 16,771 passed, 3 skipped, 0 failed
- focused issue #1374, bound-method, and proxy suites — 98 passed, 0 failed
- `dotnet build SharpTS.sln -c Release --nologo -p:NuGetAudit=false --no-restore` — 0 warnings, 0 errors; IL verification passed
- focused Test262 differential compiler deficits reduced from 200 to 8
  - 7 remaining Set cases require unsupported generator `yield` lowering
  - 1 remaining DataView case is `Reflect.construct` validation ordering rather than a binary-data helper