### PR TITLE
Support captured generators in class generator methods

### DIFF
--- a/src/SharpTS/Compilation/GeneratorMoveNextEmitter.ArrowFunctions.cs
+++ b/src/SharpTS/Compilation/GeneratorMoveNextEmitter.ArrowFunctions.cs
@@ -18,8 +18,7 @@ public partial class GeneratorMoveNextEmitter
         // routed through `$functionDC` and so is intentionally absent from the arrow's own by-value
         // snapshot fields — its write reaches shared storage and this guard does not fire. What
         // remains is the still-unsupported subset: a write to a captured variable that is only ever
-        // snapshotted by value (e.g. inside an instance generator method, whose state machine has no
-        // function DC wired). Fail fast there rather than miscompiling `arr.forEach(n => sum += n)`.
+        // snapshotted by value. Fail fast there rather than silently losing the write.
         CapturedWriteAnalysis.ThrowIfCapturedWriteWouldBeLost(af, _ctx?.DisplayClassFields);
 
         base.EmitArrowFunction(af);

--- a/src/SharpTS/Compilation/ILCompiler.AsyncGenerators.cs
+++ b/src/SharpTS/Compilation/ILCompiler.AsyncGenerators.cs
@@ -175,7 +175,7 @@ public partial class ILCompiler
     }
 
     /// <summary>
-    /// Emits the body of an instance async generator method using a state machine.
+    /// Emits the body of an instance or static async generator method using a state machine.
     /// Called for class methods marked with both IsAsync and IsGenerator = true.
     /// </summary>
     private void EmitAsyncGeneratorMethodBody(MethodBuilder methodBuilder, Stmt.Function method, FieldInfo? fieldsField,
@@ -215,16 +215,14 @@ public partial class ILCompiler
         if (methodDCKey != null && _closures.FunctionDisplayClasses.TryGetValue(methodDCKey, out var methodFuncDC))
             smBuilder.DefineFunctionDisplayClassField(methodFuncDC);
 
-        // Emit stub method body (creates state machine and returns it). A static async generator method
-        // (#778) has no `this` and no function-DC write-capture support (it is not registered in
-        // RegisterGeneratorMethodFunctionDisplayClasses, so methodDCKey is null), mirroring the sync
-        // static generator (#692).
+        // Emit the creation stub and seed the method's function display class for both instance and
+        // static async generators. Static parameters begin at argument zero.
         EmitIteratorMethodStub(
             methodBuilder,
             smBuilder,
             method,
             isInstanceMethod,
-            isInstanceMethod ? methodDCKey : null,
+            methodDCKey,
             fieldsField,
             currentClassName);
 

--- a/src/SharpTS/Compilation/ILCompiler.Classes.Methods.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.Methods.cs
@@ -704,14 +704,9 @@ public partial class ILCompiler
         // themselves). The qualified class name is threaded so nested private member access resolves.
         if (method.IsAsync && method.IsGenerator)
         {
-            // Static async generators are not yet supported (the async-generator state machine is
-            // instance-only; the public static form fails the same way, #761): fall through to the
-            // linear path, which reports the existing "Yield not supported" error rather than invalid IL.
-            if (!isStatic)
-            {
-                EmitAsyncGeneratorMethodBody(methodBuilder, method, fieldsField, currentClassName: qualifiedClassName);
-                return;
-            }
+            EmitAsyncGeneratorMethodBody(methodBuilder, method, isStatic ? null : fieldsField,
+                isInstanceMethod: !isStatic, currentClassName: qualifiedClassName);
+            return;
         }
         else if (method.IsAsync)
         {
@@ -727,9 +722,6 @@ public partial class ILCompiler
                 isInstanceMethod: !isStatic, currentClassName: qualifiedClassName);
             return;
         }
-        // A static async generator falls through to the linear emission below, which reports
-        // "Yield not supported" (the public static async-generator gap, #761), not invalid IL.
-
         var il = methodBuilder.GetILGenerator();
         var ctx = CreateModuleMemberContext(il, methodBuilder);
         ctx.IsStrictMode = true;

--- a/src/SharpTS/Compilation/ILCompiler.Classes.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.cs
@@ -82,9 +82,9 @@ public partial class ILCompiler
         // closure captures a method-local binding.
         RegisterSyncMethodFunctionDisplayClasses(classStmt.Methods, qualifiedClassName);
 
-        // #724: register function display classes for instance generator methods whose arrows write a
-        // captured method local, before Phase 5's PropagateFunctionDCRequirements runs. Skipped for
-        // external (@DotNetType) classes, which return above without an emitted body.
+        // Register live function storage for captured locals in sync/async, instance/static generator
+        // methods before Phase 5's PropagateFunctionDCRequirements runs. Skipped for external
+        // (@DotNetType) classes, which return above without an emitted body.
         RegisterGeneratorMethodFunctionDisplayClasses(classStmt, qualifiedClassName);
 
         // Same, for async (non-generator) methods whose nested sync arrow writes a captured method local,

--- a/src/SharpTS/Compilation/ILCompiler.Generators.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Generators.cs
@@ -11,7 +11,7 @@ namespace SharpTS.Compilation;
 /// </summary>
 public partial class ILCompiler
 {
-    // Maps an instance generator method's AST node to the function-display-class key registered for
+    // Maps a generator method's AST node to the function-display-class key registered for
     // it during DefineClass (#724). EmitGeneratorMethodBody reads this to wire the state machine's
     // function DC at emit time. Keyed by AST identity so the Phase-4 registration and the later
     // Phase-7 emission agree without reconstructing a string from the emitted type name.
@@ -145,10 +145,9 @@ public partial class ILCompiler
 
         // #945: a read-only capture forwarded by a HOISTED lambda-lifted nested generator (the sync
         // forwarding arrow NestedFunctionLifter marks IsLiftedForwarder) must also live in the DC, so the
-        // hoisted forwarder reads it live at call time. Marked forwarders only appear in free/module/
-        // nested-in-function generator bodies (class-method enclosers decline → unmarked), so generator
-        // METHODS are unaffected. Unioned BEFORE the empty-set short-circuit and the per-iteration
-        // exclusion below, which still strips any per-iteration loop binding a forwarder happens to read.
+        // hoisted forwarder reads it live at call time. This applies uniformly to free generators and
+        // generator methods. Unioned BEFORE the empty-set short-circuit and the per-iteration exclusion
+        // below, which still strips any per-iteration loop binding a forwarder happens to read.
         var forwardedReads = CollectLiftedForwarderCapturedReads(funcStmt);
         forwardedReads.IntersectWith(capturedLocals);
         result.UnionWith(forwardedReads);
@@ -261,16 +260,11 @@ public partial class ILCompiler
     }
 
     /// <summary>
-    /// Phase-4 registration (called from <see cref="DefineClass"/>): for each SYNC instance generator
-    /// method whose body contains an arrow that WRITES a variable captured from the method scope,
-    /// registers a function-level display class — the instance-method analogue of the free-function
-    /// wiring <see cref="DefineGeneratorFunctionDisplayClass"/> does for <c>function*</c> declarations
-    /// (#724/#674). This must run before Phase 5 so <see cref="PropagateFunctionDCRequirements"/> can
-    /// resolve the nested arrow back to the method (via <c>FunctionAstNodes</c>) and route its write
-    /// through <c>$functionDC</c> instead of a by-value snapshot. <see cref="EmitGeneratorMethodBody"/>
-    /// later consumes the recorded key to wire the state machine's function DC. No-op for methods with
-    /// no such write-capture, leaving their state machines fully standalone. Covers both sync (#724)
-    /// and async (#725) instance generator methods; static and plain methods use other paths.
+    /// Phase-4 registration (called from <see cref="DefineClass"/>): registers shared function display
+    /// classes for sync/async and instance/static generator methods whose locals are captured by nested
+    /// closures. This must run before Phase 5 so <see cref="PropagateFunctionDCRequirements"/> can route
+    /// those closures to the correct live storage. Class expressions reuse the same registration later
+    /// in Phase 5, once their generated class names are known.
     /// </summary>
     private void RegisterGeneratorMethodFunctionDisplayClasses(Stmt.Class classStmt, string qualifiedClassName) =>
         RegisterGeneratorMethodFunctionDisplayClasses(classStmt.Methods, qualifiedClassName);
@@ -297,10 +291,10 @@ public partial class ILCompiler
             if (capturedLocals.Count == 0)
                 continue;
 
-            // Method names with bodies are unique within a class (overload signatures have no body),
-            // and the qualified class name disambiguates across modules/namespaces — so the "::" key is
-            // unique and disjoint from free-function registry keys (which never contain "::").
-            string key = $"{qualifiedClassName}::{method.Name.Lexeme}";
+            // A class may legally contain same-named static and instance methods. Include the dispatch
+            // kind so their independent per-invocation storage can never alias in the registries.
+            string dispatchKind = method.IsStatic ? "static" : "instance";
+            string key = $"{qualifiedClassName}::{dispatchKind}::{method.Name.Lexeme}";
             _closures.FunctionAstNodes[key] = method;
             RegisterFunctionDisplayClass(key, capturedLocals);
             (method.IsAsync ? _asyncGeneratorMethodFunctionDCKeys : _generatorMethodFunctionDCKeys)[method] = key;
@@ -428,7 +422,7 @@ public partial class ILCompiler
     }
 
     /// <summary>
-    /// Emits the body of an instance generator method using a state machine.
+    /// Emits the body of an instance or static generator method using a state machine.
     /// Called for class methods marked with IsGenerator = true.
     /// </summary>
     private void EmitGeneratorMethodBody(MethodBuilder methodBuilder, Stmt.Function method, FieldInfo? fieldsField,
@@ -470,10 +464,8 @@ public partial class ILCompiler
         if (methodDCKey != null && _closures.FunctionDisplayClasses.TryGetValue(methodDCKey, out var methodFuncDC))
             smBuilder.DefineFunctionDisplayClassField(methodFuncDC);
 
-        // Emit stub method body (creates state machine and returns it). A static generator method
-        // (#692) has no function-DC write-capture support (it is not registered in
-        // RegisterGeneratorMethodFunctionDisplayClasses, so methodDCKey is null) and a write-capture
-        // inside one still fail-fasts safely via the CapturedWriteAnalysis guard.
+        // Emit the creation stub and seed the method's function display class for both instance and
+        // static generators (the latter uses parameter argument offset zero).
         EmitIteratorMethodStub(
             methodBuilder,
             smBuilder,

--- a/src/SharpTS/Compilation/ILCompiler.IteratorStubs.cs
+++ b/src/SharpTS/Compilation/ILCompiler.IteratorStubs.cs
@@ -67,8 +67,8 @@ public partial class ILCompiler
             }
         }
 
-        // Instantiate the function display class (#674/#725) and seed any captured-and-mutated parameter
-        // into it so an arrow that writes it shares the iterator's storage. Captured outer-scope variables
+        // Instantiate the function display class (#674/#725) and seed every captured parameter it owns
+        // so nested closures share the iterator's live storage. Captured outer-scope variables
         // are NOT copied here — snapshotting them at creation hid later mutations (#541); MoveNext reads
         // them live from their enclosing storage instead.
         EmitGeneratorFunctionDCInit(il, smBuilder.FunctionDCField, funcStmt, qualifiedName, paramOffset: 0);
@@ -83,7 +83,7 @@ public partial class ILCompiler
     /// (<see cref="MethodBuilder.GetParameters"/>): a private method's parameters are all <c>object</c>
     /// slots, so boxing the AST-resolved value type would mismatch the loaded <c>object</c>
     /// (StackUnexpected). The function DC is seeded only when <paramref name="funcDCKey"/> is non-null;
-    /// static iterator methods pass null (they have no write-capture support — #692/#778).
+    /// static iterator methods use the same path with parameter argument offset zero.
     /// </summary>
     private void EmitIteratorMethodStub(
         MethodBuilder methodBuilder,
@@ -129,8 +129,8 @@ public partial class ILCompiler
             }
         }
 
-        // Seed captured-and-mutated parameters into the function DC (typed stub params → value types are
-        // boxed before the store). No-op when the method has no function DC. Static methods pass null.
+        // Seed captured parameters into the function DC (typed stub params → value types are boxed
+        // before the store). No-op when the method has no function DC.
         if (funcDCKey != null)
             EmitGeneratorFunctionDCInit(il, smBuilder.FunctionDCField, method, funcDCKey, paramOffset, paramTypes);
 

--- a/src/SharpTS/Compilation/NestedFunctionLifter.cs
+++ b/src/SharpTS/Compilation/NestedFunctionLifter.cs
@@ -381,6 +381,45 @@ internal sealed class NestedFunctionLifter
     {
         switch (stmt)
         {
+            case Stmt.Expression e:
+                CollectShapeCandidatesExpr(e.Expr, enclosingBlockBindings, scan);
+                break;
+            case Stmt.Return { Value: not null } r:
+                CollectShapeCandidatesExpr(r.Value, enclosingBlockBindings, scan);
+                break;
+            case Stmt.Var { Initializer: not null } v:
+                CollectShapeCandidatesExpr(v.Initializer, enclosingBlockBindings, scan);
+                break;
+            case Stmt.Const c:
+                CollectShapeCandidatesExpr(c.Initializer, enclosingBlockBindings, scan);
+                break;
+            case Stmt.Throw t:
+                CollectShapeCandidatesExpr(t.Value, enclosingBlockBindings, scan);
+                break;
+            case Stmt.Field field:
+                if (field.ComputedKey != null) CollectShapeCandidatesExpr(field.ComputedKey, enclosingBlockBindings, scan);
+                if (field.Initializer != null) CollectShapeCandidatesExpr(field.Initializer, enclosingBlockBindings, scan);
+                break;
+            case Stmt.Accessor accessor:
+                if (accessor.ComputedKey != null) CollectShapeCandidatesExpr(accessor.ComputedKey, enclosingBlockBindings, scan);
+                if (accessor.SetterParam?.DefaultValue != null) CollectShapeCandidatesExpr(accessor.SetterParam.DefaultValue, enclosingBlockBindings, scan);
+                foreach (var bodyStmt in accessor.Body)
+                    new ClassExpressionShapeScanner(enclosingBlockBindings, scan).Visit(bodyStmt);
+                break;
+            case Stmt.AutoAccessor accessor:
+                if (accessor.Initializer != null) CollectShapeCandidatesExpr(accessor.Initializer, enclosingBlockBindings, scan);
+                break;
+            case Stmt.StaticBlock block:
+                foreach (var bodyStmt in block.Body)
+                    new ClassExpressionShapeScanner(enclosingBlockBindings, scan).Visit(bodyStmt);
+                break;
+            case Stmt.Using u:
+                foreach (var binding in u.Bindings)
+                {
+                    if (binding.DestructuringPattern != null) CollectShapeCandidatesExpr(binding.DestructuringPattern, enclosingBlockBindings, scan);
+                    CollectShapeCandidatesExpr(binding.Initializer, enclosingBlockBindings, scan);
+                }
+                break;
             case Stmt.Function f when f.Body != null:
                 // (1) A declaration nested INSIDE a function-like whose shape needs the top-level
                 // state-machine pipeline (gen/async, or a plain fn inside a state machine). Captures
@@ -399,6 +438,9 @@ internal sealed class NestedFunctionLifter
                     scan.ModuleBlockEnclosingBindings[f] = enclosingBlockBindings;
                 }
                 // A nested function's own body establishes a fresh enclosing kind for its children.
+                foreach (var parameter in f.Parameters)
+                    if (parameter.DefaultValue != null)
+                        CollectShapeCandidatesExpr(parameter.DefaultValue, enclosingBlockBindings, scan);
                 CollectShapeCandidates(f.Body, f.IsGenerator || f.IsAsync, insideFunction: true, insideModuleBlock: false, enclosingBlockBindings, scan);
                 break;
             case Stmt.Block b:
@@ -408,14 +450,17 @@ internal sealed class NestedFunctionLifter
                 CollectShapeCandidates(s.Statements, enclosingIsStateMachine, insideFunction, insideModuleBlock, enclosingBlockBindings, scan);
                 break;
             case Stmt.If i:
+                CollectShapeCandidatesExpr(i.Condition, enclosingBlockBindings, scan);
                 CollectShapeCandidatesStmt(i.ThenBranch, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, enclosingBlockBindings, scan);
                 if (i.ElseBranch != null) CollectShapeCandidatesStmt(i.ElseBranch, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, enclosingBlockBindings, scan);
                 break;
             case Stmt.While w:
+                CollectShapeCandidatesExpr(w.Condition, enclosingBlockBindings, scan);
                 CollectShapeCandidatesStmt(w.Body, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, enclosingBlockBindings, scan);
                 break;
             case Stmt.DoWhile d:
                 CollectShapeCandidatesStmt(d.Body, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, enclosingBlockBindings, scan);
+                CollectShapeCandidatesExpr(d.Condition, enclosingBlockBindings, scan);
                 break;
             case Stmt.For fo:
                 // The loop variable is scoped to the loop body — add it to the bindings so a body
@@ -423,14 +468,18 @@ internal sealed class NestedFunctionLifter
                 // case) is recognized as capturing and left nested.
                 var forBindings = !insideFunction ? WithDeclaration(enclosingBlockBindings, fo.Initializer) : enclosingBlockBindings;
                 if (fo.Initializer != null) CollectShapeCandidatesStmt(fo.Initializer, enclosingIsStateMachine, insideFunction, insideModuleBlock, enclosingBlockBindings, scan);
+                if (fo.Condition != null) CollectShapeCandidatesExpr(fo.Condition, forBindings, scan);
+                if (fo.Increment != null) CollectShapeCandidatesExpr(fo.Increment, forBindings, scan);
                 CollectShapeCandidatesStmt(fo.Body, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, forBindings, scan);
                 break;
             case Stmt.ForOf fof:
                 var forOfBindings = !insideFunction ? WithName(enclosingBlockBindings, fof.Variable.Lexeme) : enclosingBlockBindings;
+                CollectShapeCandidatesExpr(fof.Iterable, enclosingBlockBindings, scan);
                 CollectShapeCandidatesStmt(fof.Body, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, forOfBindings, scan);
                 break;
             case Stmt.ForIn fin:
                 var forInBindings = !insideFunction ? WithName(enclosingBlockBindings, fin.Variable.Lexeme) : enclosingBlockBindings;
+                CollectShapeCandidatesExpr(fin.Object, enclosingBlockBindings, scan);
                 CollectShapeCandidatesStmt(fin.Body, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, forInBindings, scan);
                 break;
             case Stmt.LabeledStatement l:
@@ -446,18 +495,99 @@ internal sealed class NestedFunctionLifter
                 if (t.FinallyBlock != null) CollectShapeCandidates(t.FinallyBlock, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, enclosingBlockBindings, scan);
                 break;
             case Stmt.Switch sw:
+                CollectShapeCandidatesExpr(sw.Subject, enclosingBlockBindings, scan);
+                foreach (var c in sw.Cases) CollectShapeCandidatesExpr(c.Value, enclosingBlockBindings, scan);
                 foreach (var c in sw.Cases) CollectShapeCandidates(c.Body, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, enclosingBlockBindings, scan);
                 if (sw.DefaultBody != null) CollectShapeCandidates(sw.DefaultBody, enclosingIsStateMachine, insideFunction, insideModuleBlock: !insideFunction, enclosingBlockBindings, scan);
                 break;
             case Stmt.Class cls:
                 // Method bodies are function-likes regardless of where the class sits.
+                if (cls.SuperclassExpr != null)
+                    CollectShapeCandidatesExpr(cls.SuperclassExpr, enclosingBlockBindings, scan);
                 foreach (var m in cls.Methods)
+                {
+                    if (m.ComputedKey != null) CollectShapeCandidatesExpr(m.ComputedKey, enclosingBlockBindings, scan);
+                    foreach (var p in m.Parameters)
+                        if (p.DefaultValue != null) CollectShapeCandidatesExpr(p.DefaultValue, enclosingBlockBindings, scan);
                     if (m.Body != null) CollectShapeCandidates(m.Body, m.IsGenerator || m.IsAsync, insideFunction: true, insideModuleBlock: false, enclosingBlockBindings, scan);
+                }
+                foreach (var field in cls.Fields)
+                {
+                    if (field.ComputedKey != null) CollectShapeCandidatesExpr(field.ComputedKey, enclosingBlockBindings, scan);
+                    if (field.Initializer != null) CollectShapeCandidatesExpr(field.Initializer, enclosingBlockBindings, scan);
+                }
+                if (cls.Accessors != null)
+                    foreach (var accessor in cls.Accessors)
+                    {
+                        if (accessor.ComputedKey != null) CollectShapeCandidatesExpr(accessor.ComputedKey, enclosingBlockBindings, scan);
+                        if (accessor.SetterParam?.DefaultValue != null) CollectShapeCandidatesExpr(accessor.SetterParam.DefaultValue, enclosingBlockBindings, scan);
+                        foreach (var bodyStmt in accessor.Body)
+                            new ClassExpressionShapeScanner(enclosingBlockBindings, scan).Visit(bodyStmt);
+                    }
+                if (cls.AutoAccessors != null)
+                    foreach (var accessor in cls.AutoAccessors)
+                        if (accessor.Initializer != null) CollectShapeCandidatesExpr(accessor.Initializer, enclosingBlockBindings, scan);
+                if (cls.StaticInitializers != null)
+                    foreach (var initializer in cls.StaticInitializers)
+                        if (initializer is Stmt.StaticBlock block)
+                            foreach (var bodyStmt in block.Body)
+                                new ClassExpressionShapeScanner(enclosingBlockBindings, scan).Visit(bodyStmt);
                 break;
-            case Stmt.Export ex when ex.Declaration != null:
-                CollectShapeCandidatesStmt(ex.Declaration, enclosingIsStateMachine, insideFunction, insideModuleBlock, enclosingBlockBindings, scan);
+            case Stmt.Export ex:
+                if (ex.Declaration != null)
+                    CollectShapeCandidatesStmt(ex.Declaration, enclosingIsStateMachine, insideFunction, insideModuleBlock, enclosingBlockBindings, scan);
+                if (ex.DefaultExpr != null) CollectShapeCandidatesExpr(ex.DefaultExpr, enclosingBlockBindings, scan);
+                if (ex.ExportAssignment != null) CollectShapeCandidatesExpr(ex.ExportAssignment, enclosingBlockBindings, scan);
                 break;
             // Stmt.Namespace is intentionally NOT traversed (#583 §3 lift barrier).
+        }
+    }
+
+    private static void CollectShapeCandidatesExpr(Expr expr, HashSet<string> enclosingBlockBindings, ShapeScan scan) =>
+        new ClassExpressionShapeScanner(enclosingBlockBindings, scan).Visit(expr);
+
+    /// <summary>Finds class expressions anywhere under an expression and scans each method body using
+    /// function-like candidate semantics. The ordinary visitor supplies exhaustive expression traversal;
+    /// the override supplements class-definition children not covered by its generic class visitor.</summary>
+    private sealed class ClassExpressionShapeScanner(HashSet<string> enclosingBlockBindings, ShapeScan scan)
+        : Parsing.Visitors.AstVisitorBase
+    {
+        protected override void VisitClassExpr(Expr.ClassExpr expr)
+        {
+            if (expr.SuperclassExpr != null) Visit(expr.SuperclassExpr);
+
+            foreach (var method in expr.Methods)
+            {
+                if (method.ComputedKey != null) Visit(method.ComputedKey);
+                foreach (var parameter in method.Parameters)
+                    if (parameter.DefaultValue != null) Visit(parameter.DefaultValue);
+                if (method.Body != null)
+                    CollectShapeCandidates(method.Body, method.IsGenerator || method.IsAsync,
+                        insideFunction: true, insideModuleBlock: false, enclosingBlockBindings, scan);
+            }
+
+            foreach (var field in expr.Fields)
+            {
+                if (field.ComputedKey != null) Visit(field.ComputedKey);
+                if (field.Initializer != null) Visit(field.Initializer);
+            }
+
+            if (expr.Accessors != null)
+                foreach (var accessor in expr.Accessors)
+                {
+                    if (accessor.ComputedKey != null) Visit(accessor.ComputedKey);
+                    if (accessor.SetterParam?.DefaultValue != null) Visit(accessor.SetterParam.DefaultValue);
+                    foreach (var bodyStmt in accessor.Body) Visit(bodyStmt);
+                }
+
+            if (expr.AutoAccessors != null)
+                foreach (var accessor in expr.AutoAccessors)
+                    if (accessor.Initializer != null) Visit(accessor.Initializer);
+
+            if (expr.StaticInitializers != null)
+                foreach (var initializer in expr.StaticInitializers)
+                    if (initializer is Stmt.StaticBlock block)
+                        foreach (var bodyStmt in block.Body) Visit(bodyStmt);
         }
     }
 
@@ -560,15 +690,13 @@ internal sealed class NestedFunctionLifter
                     // call time and the earlier hoisted creation position is harmless. The generator-
                     // encloser case (#945) is the generator analog of the async-function #924 fix.
                     //
-                    // When the enclosing function is a class GENERATOR METHOD (sync or async, static or
-                    // instance), keep the binding in place: a static generator method has no function
-                    // display class at all and an instance one wires it only for write-captures, so a
-                    // hoisted forwarding arrow would snapshot the captured local by value at creation and
-                    // read a stale value. Those decline cleanly (a clean failure, never a miscompile).
+                    // Class generator methods use the same shared function display class for lifted
+                    // forwarder captures, including static and async methods, so they follow the same
+                    // hoisting rule as free generator functions.
                     // Module-block/loop captures (#622) likewise stay in place so each loop iteration
                     // rebuilds a fresh arrow over that iteration's binding.
                     result ??= new List<Stmt>(body.GetRange(0, i));
-                    bool hoist = _hoistedForwards.Contains(f) && !enclosingIsGeneratorClassMethod;
+                    bool hoist = _hoistedForwards.Contains(f);
                     var binding = LambdaLiftCandidate(f, forwarded, hoisted: hoist);
                     if (hoist)
                         (aliases ??= new List<Stmt>()).Add(binding);
@@ -685,10 +813,9 @@ internal sealed class NestedFunctionLifter
             IsAsync: false,
             IsGenerator: false)
         {
-            // #945: when this forwarder is HOISTED into a generator encloser's body, mark it so the
-            // generator function-DC pass routes its read-only forwarded captures through the shared
-            // display class (live read), not a stale by-value snapshot. Only hoisted forwarders are
-            // marked — class-method (declined) and module-block/loop (#622) forwarders stay unmarked.
+            // When this forwarder is HOISTED into a generator encloser's body, mark it so the generator
+            // function-DC pass routes its read-only forwarded captures through shared live storage.
+            // Module-block/loop (#622) forwarders remain unmarked because they stay in place.
             IsLiftedForwarder = hoisted,
         };
 
@@ -696,6 +823,279 @@ internal sealed class NestedFunctionLifter
         // function-declaration hoisting. Module-block/loop capture (#622): a block-scoped `let` left
         // in place, re-bound per loop iteration.
         return new Stmt.Var(f.Name, TypeAnnotation: null, Initializer: arrow, IsVar: hoisted);
+    }
+
+    /// <summary>Rewrites only expression paths that contain a changed descendant. In particular this
+    /// reaches class expressions in every ordinary expression position without replacing unrelated AST
+    /// identities used by closure and type maps.</summary>
+    private Expr ProcessExpr(Expr expr)
+    {
+        switch (expr)
+        {
+            case Expr.ClassExpr cls:
+                return ProcessClassExpression(cls);
+            case Expr.ArrowFunction arrow:
+            {
+                var parameters = ProcessParameters(arrow.Parameters);
+                var expressionBody = arrow.ExpressionBody == null ? null : ProcessExpr(arrow.ExpressionBody);
+                var blockBody = arrow.BlockBody == null ? null : ProcessBody(
+                    arrow.BlockBody, arrow.IsGenerator || arrow.IsAsync, arrow.IsAsync && !arrow.IsGenerator,
+                    enclosingIsGeneratorClassMethod: false);
+                return ReferenceEquals(parameters, arrow.Parameters)
+                    && (arrow.ExpressionBody == null || ReferenceEquals(expressionBody, arrow.ExpressionBody))
+                    && (arrow.BlockBody == null || ReferenceEquals(blockBody, arrow.BlockBody))
+                        ? arrow
+                        : arrow with { Parameters = parameters, ExpressionBody = expressionBody, BlockBody = blockBody };
+            }
+            case Expr.DestructuringAssign d:
+            {
+                var assignments = RewriteListIfChanged(d.Assignments,
+                    s => ProcessStmt(s, enclosingIsStateMachine: false, enclosingIsAsyncFunction: false, enclosingIsGeneratorClassMethod: false));
+                var result = ProcessExpr(d.ResultValue);
+                var rawTarget = d.RawTarget == null ? null : ProcessExpr(d.RawTarget);
+                var rawDefault = d.RawDefault == null ? null : ProcessExpr(d.RawDefault);
+                return ReferenceEquals(assignments, d.Assignments) && ReferenceEquals(result, d.ResultValue)
+                    && (d.RawTarget == null || ReferenceEquals(rawTarget, d.RawTarget))
+                    && (d.RawDefault == null || ReferenceEquals(rawDefault, d.RawDefault))
+                        ? d : d with { Assignments = assignments, ResultValue = result, RawTarget = rawTarget, RawDefault = rawDefault };
+            }
+            case Expr.Comma e:
+            {
+                var left = ProcessExpr(e.Left); var right = ProcessExpr(e.Right);
+                return ReferenceEquals(left, e.Left) && ReferenceEquals(right, e.Right) ? e : e with { Left = left, Right = right };
+            }
+            case Expr.Binary e:
+            {
+                var left = ProcessExpr(e.Left); var right = ProcessExpr(e.Right);
+                return ReferenceEquals(left, e.Left) && ReferenceEquals(right, e.Right) ? e : e with { Left = left, Right = right };
+            }
+            case Expr.Logical e:
+            {
+                var left = ProcessExpr(e.Left); var right = ProcessExpr(e.Right);
+                return ReferenceEquals(left, e.Left) && ReferenceEquals(right, e.Right) ? e : e with { Left = left, Right = right };
+            }
+            case Expr.NullishCoalescing e:
+            {
+                var left = ProcessExpr(e.Left); var right = ProcessExpr(e.Right);
+                return ReferenceEquals(left, e.Left) && ReferenceEquals(right, e.Right) ? e : e with { Left = left, Right = right };
+            }
+            case Expr.Ternary e:
+            {
+                var condition = ProcessExpr(e.Condition); var thenBranch = ProcessExpr(e.ThenBranch); var elseBranch = ProcessExpr(e.ElseBranch);
+                return ReferenceEquals(condition, e.Condition) && ReferenceEquals(thenBranch, e.ThenBranch) && ReferenceEquals(elseBranch, e.ElseBranch)
+                    ? e : e with { Condition = condition, ThenBranch = thenBranch, ElseBranch = elseBranch };
+            }
+            case Expr.Grouping e:
+            {
+                var child = ProcessExpr(e.Expression);
+                return ReferenceEquals(child, e.Expression) ? e : e with { Expression = child };
+            }
+            case Expr.Unary e:
+            {
+                var child = ProcessExpr(e.Right);
+                return ReferenceEquals(child, e.Right) ? e : e with { Right = child };
+            }
+            case Expr.Delete e:
+            {
+                var child = ProcessExpr(e.Operand);
+                return ReferenceEquals(child, e.Operand) ? e : e with { Operand = child };
+            }
+            case Expr.Assign e:
+            {
+                var value = ProcessExpr(e.Value);
+                return ReferenceEquals(value, e.Value) ? e : e with { Value = value };
+            }
+            case Expr.Call e:
+            {
+                var callee = ProcessExpr(e.Callee);
+                var arguments = RewriteListIfChanged(e.Arguments, ProcessExpr);
+                return ReferenceEquals(callee, e.Callee) && ReferenceEquals(arguments, e.Arguments)
+                    ? e : e with { Callee = callee, Arguments = arguments };
+            }
+            case Expr.Get e:
+            {
+                var obj = ProcessExpr(e.Object);
+                return ReferenceEquals(obj, e.Object) ? e : e with { Object = obj };
+            }
+            case Expr.Set e:
+            {
+                var obj = ProcessExpr(e.Object); var value = ProcessExpr(e.Value);
+                return ReferenceEquals(obj, e.Object) && ReferenceEquals(value, e.Value) ? e : e with { Object = obj, Value = value };
+            }
+            case Expr.GetPrivate e:
+            {
+                var obj = ProcessExpr(e.Object);
+                return ReferenceEquals(obj, e.Object) ? e : e with { Object = obj };
+            }
+            case Expr.SetPrivate e:
+            {
+                var obj = ProcessExpr(e.Object); var value = ProcessExpr(e.Value);
+                return ReferenceEquals(obj, e.Object) && ReferenceEquals(value, e.Value) ? e : e with { Object = obj, Value = value };
+            }
+            case Expr.CallPrivate e:
+            {
+                var obj = ProcessExpr(e.Object); var arguments = RewriteListIfChanged(e.Arguments, ProcessExpr);
+                return ReferenceEquals(obj, e.Object) && ReferenceEquals(arguments, e.Arguments) ? e : e with { Object = obj, Arguments = arguments };
+            }
+            case Expr.New e:
+            {
+                var callee = ProcessExpr(e.Callee); var arguments = RewriteListIfChanged(e.Arguments, ProcessExpr);
+                return ReferenceEquals(callee, e.Callee) && ReferenceEquals(arguments, e.Arguments) ? e : e with { Callee = callee, Arguments = arguments };
+            }
+            case Expr.ArrayLiteral e:
+            {
+                var elements = RewriteListIfChanged(e.Elements, ProcessExpr);
+                return ReferenceEquals(elements, e.Elements) ? e : e with { Elements = elements };
+            }
+            case Expr.ObjectLiteral e:
+            {
+                List<Expr.Property>? properties = null;
+                for (int i = 0; i < e.Properties.Count; i++)
+                {
+                    var property = e.Properties[i];
+                    Expr.PropertyKey? key = property.Key;
+                    if (property.Key is Expr.ComputedKey computed)
+                    {
+                        var keyExpr = ProcessExpr(computed.Expression);
+                        if (!ReferenceEquals(keyExpr, computed.Expression)) key = new Expr.ComputedKey(keyExpr);
+                    }
+                    var value = ProcessExpr(property.Value);
+                    var setterParam = property.SetterParam == null ? null : ProcessParameter(property.SetterParam);
+                    if (!ReferenceEquals(key, property.Key) || !ReferenceEquals(value, property.Value)
+                        || !ReferenceEquals(setterParam, property.SetterParam))
+                    {
+                        properties ??= new List<Expr.Property>(e.Properties);
+                        properties[i] = property with { Key = key, Value = value, SetterParam = setterParam };
+                    }
+                }
+                return properties == null ? e : e with { Properties = properties };
+            }
+            case Expr.GetIndex e:
+            {
+                var obj = ProcessExpr(e.Object); var index = ProcessExpr(e.Index);
+                return ReferenceEquals(obj, e.Object) && ReferenceEquals(index, e.Index) ? e : e with { Object = obj, Index = index };
+            }
+            case Expr.SetIndex e:
+            {
+                var obj = ProcessExpr(e.Object); var index = ProcessExpr(e.Index); var value = ProcessExpr(e.Value);
+                return ReferenceEquals(obj, e.Object) && ReferenceEquals(index, e.Index) && ReferenceEquals(value, e.Value)
+                    ? e : e with { Object = obj, Index = index, Value = value };
+            }
+            case Expr.CompoundAssign e:
+            {
+                var value = ProcessExpr(e.Value);
+                return ReferenceEquals(value, e.Value) ? e : e with { Value = value };
+            }
+            case Expr.CompoundSet e:
+            {
+                var obj = ProcessExpr(e.Object); var value = ProcessExpr(e.Value);
+                return ReferenceEquals(obj, e.Object) && ReferenceEquals(value, e.Value) ? e : e with { Object = obj, Value = value };
+            }
+            case Expr.CompoundSetIndex e:
+            {
+                var obj = ProcessExpr(e.Object); var index = ProcessExpr(e.Index); var value = ProcessExpr(e.Value);
+                return ReferenceEquals(obj, e.Object) && ReferenceEquals(index, e.Index) && ReferenceEquals(value, e.Value)
+                    ? e : e with { Object = obj, Index = index, Value = value };
+            }
+            case Expr.LogicalAssign e:
+            {
+                var value = ProcessExpr(e.Value);
+                return ReferenceEquals(value, e.Value) ? e : e with { Value = value };
+            }
+            case Expr.LogicalSet e:
+            {
+                var obj = ProcessExpr(e.Object); var value = ProcessExpr(e.Value);
+                return ReferenceEquals(obj, e.Object) && ReferenceEquals(value, e.Value) ? e : e with { Object = obj, Value = value };
+            }
+            case Expr.LogicalSetIndex e:
+            {
+                var obj = ProcessExpr(e.Object); var index = ProcessExpr(e.Index); var value = ProcessExpr(e.Value);
+                return ReferenceEquals(obj, e.Object) && ReferenceEquals(index, e.Index) && ReferenceEquals(value, e.Value)
+                    ? e : e with { Object = obj, Index = index, Value = value };
+            }
+            case Expr.PrefixIncrement e:
+            {
+                var operand = ProcessExpr(e.Operand);
+                return ReferenceEquals(operand, e.Operand) ? e : e with { Operand = operand };
+            }
+            case Expr.PostfixIncrement e:
+            {
+                var operand = ProcessExpr(e.Operand);
+                return ReferenceEquals(operand, e.Operand) ? e : e with { Operand = operand };
+            }
+            case Expr.TemplateLiteral e:
+            {
+                var expressions = RewriteListIfChanged(e.Expressions, ProcessExpr);
+                return ReferenceEquals(expressions, e.Expressions) ? e : e with { Expressions = expressions };
+            }
+            case Expr.TaggedTemplateLiteral e:
+            {
+                var tag = ProcessExpr(e.Tag); var expressions = RewriteListIfChanged(e.Expressions, ProcessExpr);
+                return ReferenceEquals(tag, e.Tag) && ReferenceEquals(expressions, e.Expressions) ? e : e with { Tag = tag, Expressions = expressions };
+            }
+            case Expr.Spread e:
+            {
+                var child = ProcessExpr(e.Expression);
+                return ReferenceEquals(child, e.Expression) ? e : e with { Expression = child };
+            }
+            case Expr.TypeAssertion e:
+            {
+                var child = ProcessExpr(e.Expression);
+                return ReferenceEquals(child, e.Expression) ? e : e with { Expression = child };
+            }
+            case Expr.Satisfies e:
+            {
+                var child = ProcessExpr(e.Expression);
+                return ReferenceEquals(child, e.Expression) ? e : e with { Expression = child };
+            }
+            case Expr.NonNullAssertion e:
+            {
+                var child = ProcessExpr(e.Expression);
+                return ReferenceEquals(child, e.Expression) ? e : e with { Expression = child };
+            }
+            case Expr.Await e:
+            {
+                var child = ProcessExpr(e.Expression);
+                return ReferenceEquals(child, e.Expression) ? e : e with { Expression = child };
+            }
+            case Expr.DynamicImport e:
+            {
+                var child = ProcessExpr(e.PathExpression);
+                return ReferenceEquals(child, e.PathExpression) ? e : e with { PathExpression = child };
+            }
+            case Expr.Yield { Value: not null } e:
+            {
+                var child = ProcessExpr(e.Value);
+                return ReferenceEquals(child, e.Value) ? e : e with { Value = child };
+            }
+            default:
+                return expr;
+        }
+    }
+
+    private List<Stmt.Parameter> ProcessParameters(List<Stmt.Parameter> parameters) =>
+        RewriteListIfChanged(parameters, ProcessParameter);
+
+    private Stmt.Parameter ProcessParameter(Stmt.Parameter parameter)
+    {
+        if (parameter.DefaultValue == null) return parameter;
+        var value = ProcessExpr(parameter.DefaultValue);
+        return ReferenceEquals(value, parameter.DefaultValue) ? parameter : parameter with { DefaultValue = value };
+    }
+
+    private static List<T> RewriteListIfChanged<T>(List<T> source, Func<T, T> rewrite)
+    {
+        List<T>? result = null;
+        for (int i = 0; i < source.Count; i++)
+        {
+            var next = rewrite(source[i]);
+            if (!ReferenceEquals(next, source[i]))
+            {
+                result ??= new List<T>(source);
+                result[i] = next;
+            }
+        }
+        return result ?? source;
     }
 
     /// <summary>
@@ -717,12 +1117,67 @@ internal sealed class NestedFunctionLifter
     {
         switch (stmt)
         {
+            case Stmt.Expression e:
+            {
+                var expression = ProcessExpr(e.Expr);
+                return ReferenceEquals(expression, e.Expr) ? e : new Stmt.Expression(expression);
+            }
+            case Stmt.Return { Value: not null } r:
+            {
+                var value = ProcessExpr(r.Value);
+                return ReferenceEquals(value, r.Value) ? r : new Stmt.Return(r.Keyword, value);
+            }
+            case Stmt.Var { Initializer: not null } v:
+            {
+                var initializer = ProcessExpr(v.Initializer);
+                return ReferenceEquals(initializer, v.Initializer) ? v : v with { Initializer = initializer };
+            }
+            case Stmt.Const c:
+            {
+                var initializer = ProcessExpr(c.Initializer);
+                return ReferenceEquals(initializer, c.Initializer) ? c : c with { Initializer = initializer };
+            }
+            case Stmt.Throw t:
+            {
+                var value = ProcessExpr(t.Value);
+                return ReferenceEquals(value, t.Value) ? t : new Stmt.Throw(t.Keyword, value);
+            }
+            case Stmt.Field field:
+                return ProcessClassField(field);
+            case Stmt.Accessor accessor:
+                return ProcessClassAccessor(accessor);
+            case Stmt.AutoAccessor accessor:
+                return ProcessClassAutoAccessor(accessor);
+            case Stmt.StaticBlock block:
+            {
+                var body = ProcessBody(block.Body, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
+                return ReferenceEquals(body, block.Body) ? block : block with { Body = body };
+            }
+            case Stmt.Using u:
+            {
+                List<Stmt.UsingBinding>? bindings = null;
+                for (int i = 0; i < u.Bindings.Count; i++)
+                {
+                    var binding = u.Bindings[i];
+                    var pattern = binding.DestructuringPattern == null ? null : ProcessExpr(binding.DestructuringPattern);
+                    var initializer = ProcessExpr(binding.Initializer);
+                    if ((binding.DestructuringPattern != null && !ReferenceEquals(pattern, binding.DestructuringPattern))
+                        || !ReferenceEquals(initializer, binding.Initializer))
+                    {
+                        bindings ??= new List<Stmt.UsingBinding>(u.Bindings);
+                        bindings[i] = binding with { DestructuringPattern = pattern, Initializer = initializer };
+                    }
+                }
+                return bindings == null ? u : u with { Bindings = bindings };
+            }
             case Stmt.Function f when f.Body != null:
             {
                 // Not lifted (not a safe candidate), but its body may contain nested candidates.
                 // A nested function declaration is never a class method, so the flag resets to false.
+                var parameters = ProcessParameters(f.Parameters);
                 var nb = ProcessBody(f.Body, f.IsGenerator || f.IsAsync, f.IsAsync && !f.IsGenerator, enclosingIsGeneratorClassMethod: false);
-                return ReferenceEquals(nb, f.Body) ? f : f with { Body = nb };
+                return ReferenceEquals(parameters, f.Parameters) && ReferenceEquals(nb, f.Body)
+                    ? f : f with { Parameters = parameters, Body = nb };
             }
             case Stmt.Block b:
             {
@@ -736,39 +1191,52 @@ internal sealed class NestedFunctionLifter
             }
             case Stmt.If i:
             {
+                var condition = ProcessExpr(i.Condition);
                 var nt = ProcessStmt(i.ThenBranch, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
                 var ne = i.ElseBranch != null ? ProcessStmt(i.ElseBranch, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod) : null;
-                if (ReferenceEquals(nt, i.ThenBranch) && (i.ElseBranch == null || ReferenceEquals(ne, i.ElseBranch)))
+                if (ReferenceEquals(condition, i.Condition) && ReferenceEquals(nt, i.ThenBranch)
+                    && (i.ElseBranch == null || ReferenceEquals(ne, i.ElseBranch)))
                     return i;
-                return new Stmt.If(i.Condition, nt, ne);
+                return new Stmt.If(condition, nt, ne);
             }
             case Stmt.While w:
             {
+                var condition = ProcessExpr(w.Condition);
                 var nb = ProcessStmt(w.Body, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
-                return ReferenceEquals(nb, w.Body) ? w : new Stmt.While(w.Condition, nb);
+                return ReferenceEquals(condition, w.Condition) && ReferenceEquals(nb, w.Body) ? w : new Stmt.While(condition, nb);
             }
             case Stmt.DoWhile d:
             {
                 var nb = ProcessStmt(d.Body, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
-                return ReferenceEquals(nb, d.Body) ? d : new Stmt.DoWhile(nb, d.Condition);
+                var condition = ProcessExpr(d.Condition);
+                return ReferenceEquals(nb, d.Body) && ReferenceEquals(condition, d.Condition) ? d : new Stmt.DoWhile(nb, condition);
             }
             case Stmt.For fo:
             {
                 var ni = fo.Initializer != null ? ProcessStmt(fo.Initializer, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod) : null;
+                var condition = fo.Condition == null ? null : ProcessExpr(fo.Condition);
+                var increment = fo.Increment == null ? null : ProcessExpr(fo.Increment);
                 var nb = ProcessStmt(fo.Body, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
-                if ((fo.Initializer == null || ReferenceEquals(ni, fo.Initializer)) && ReferenceEquals(nb, fo.Body))
+                if ((fo.Initializer == null || ReferenceEquals(ni, fo.Initializer))
+                    && (fo.Condition == null || ReferenceEquals(condition, fo.Condition))
+                    && (fo.Increment == null || ReferenceEquals(increment, fo.Increment))
+                    && ReferenceEquals(nb, fo.Body))
                     return fo;
-                return new Stmt.For(ni, fo.Condition, fo.Increment, nb);
+                return new Stmt.For(ni, condition, increment, nb);
             }
             case Stmt.ForOf fof:
             {
+                var iterable = ProcessExpr(fof.Iterable);
                 var nb = ProcessStmt(fof.Body, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
-                return ReferenceEquals(nb, fof.Body) ? fof : fof with { Body = nb };
+                return ReferenceEquals(iterable, fof.Iterable) && ReferenceEquals(nb, fof.Body)
+                    ? fof : fof with { Iterable = iterable, Body = nb };
             }
             case Stmt.ForIn fin:
             {
+                var obj = ProcessExpr(fin.Object);
                 var nb = ProcessStmt(fin.Body, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
-                return ReferenceEquals(nb, fin.Body) ? fin : fin with { Body = nb };
+                return ReferenceEquals(obj, fin.Object) && ReferenceEquals(nb, fin.Body)
+                    ? fin : fin with { Object = obj, Body = nb };
             }
             case Stmt.LabeledStatement l:
             {
@@ -788,28 +1256,35 @@ internal sealed class NestedFunctionLifter
             }
             case Stmt.Switch sw:
             {
+                var subject = ProcessExpr(sw.Subject);
                 List<Stmt.SwitchCase>? newCases = null;
                 for (int i = 0; i < sw.Cases.Count; i++)
                 {
                     var c = sw.Cases[i];
+                    var value = ProcessExpr(c.Value);
                     var nb = ProcessBody(c.Body, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
-                    if (!ReferenceEquals(nb, c.Body))
+                    if (!ReferenceEquals(value, c.Value) || !ReferenceEquals(nb, c.Body))
                     {
                         newCases ??= new List<Stmt.SwitchCase>(sw.Cases);
-                        newCases[i] = new Stmt.SwitchCase(c.Value, nb);
+                        newCases[i] = new Stmt.SwitchCase(value, nb);
                     }
                 }
                 var newDefault = sw.DefaultBody != null ? ProcessBody(sw.DefaultBody, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod) : null;
                 bool defaultChanged = sw.DefaultBody != null && !ReferenceEquals(newDefault, sw.DefaultBody);
-                if (newCases == null && !defaultChanged) return sw;
-                return new Stmt.Switch(sw.Subject, newCases ?? sw.Cases, defaultChanged ? newDefault : sw.DefaultBody);
+                if (ReferenceEquals(subject, sw.Subject) && newCases == null && !defaultChanged) return sw;
+                return new Stmt.Switch(subject, newCases ?? sw.Cases, defaultChanged ? newDefault : sw.DefaultBody);
             }
             case Stmt.Class cls:
                 return ProcessClass(cls);
-            case Stmt.Export ex when ex.Declaration != null:
+            case Stmt.Export ex:
             {
-                var nd = ProcessStmt(ex.Declaration, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
-                return ReferenceEquals(nd, ex.Declaration) ? ex : ex with { Declaration = nd };
+                var declaration = ex.Declaration == null ? null : ProcessStmt(ex.Declaration, enclosingIsStateMachine, enclosingIsAsyncFunction, enclosingIsGeneratorClassMethod);
+                var defaultExpr = ex.DefaultExpr == null ? null : ProcessExpr(ex.DefaultExpr);
+                var exportAssignment = ex.ExportAssignment == null ? null : ProcessExpr(ex.ExportAssignment);
+                return (ex.Declaration == null || ReferenceEquals(declaration, ex.Declaration))
+                    && (ex.DefaultExpr == null || ReferenceEquals(defaultExpr, ex.DefaultExpr))
+                    && (ex.ExportAssignment == null || ReferenceEquals(exportAssignment, ex.ExportAssignment))
+                        ? ex : ex with { Declaration = declaration, DefaultExpr = defaultExpr, ExportAssignment = exportAssignment };
             }
             // Stmt.Namespace is intentionally NOT traversed (#583 §3 lift barrier).
             default:
@@ -819,22 +1294,121 @@ internal sealed class NestedFunctionLifter
 
     private Stmt ProcessClass(Stmt.Class cls)
     {
-        List<Stmt.Function>? newMethods = null;
-        for (int i = 0; i < cls.Methods.Count; i++)
+        var superclass = cls.SuperclassExpr == null ? null : ProcessExpr(cls.SuperclassExpr);
+        var methods = RewriteListIfChanged(cls.Methods, ProcessClassMethod);
+        var fields = RewriteListIfChanged(cls.Fields, ProcessClassField);
+        var accessors = cls.Accessors == null ? null : RewriteListIfChanged(cls.Accessors, ProcessClassAccessor);
+        var autoAccessors = cls.AutoAccessors == null ? null : RewriteListIfChanged(cls.AutoAccessors, ProcessClassAutoAccessor);
+        var staticInitializers = ProcessStaticInitializers(cls.Fields, fields, cls.StaticInitializers);
+
+        return (cls.SuperclassExpr == null || ReferenceEquals(superclass, cls.SuperclassExpr))
+            && ReferenceEquals(methods, cls.Methods)
+            && ReferenceEquals(fields, cls.Fields)
+            && (cls.Accessors == null || ReferenceEquals(accessors, cls.Accessors))
+            && (cls.AutoAccessors == null || ReferenceEquals(autoAccessors, cls.AutoAccessors))
+            && (cls.StaticInitializers == null || ReferenceEquals(staticInitializers, cls.StaticInitializers))
+                ? cls
+                : cls with
+                {
+                    SuperclassExpr = superclass,
+                    Methods = methods,
+                    Fields = fields,
+                    Accessors = accessors,
+                    AutoAccessors = autoAccessors,
+                    StaticInitializers = staticInitializers,
+                };
+    }
+
+    private Expr ProcessClassExpression(Expr.ClassExpr cls)
+    {
+        var superclass = cls.SuperclassExpr == null ? null : ProcessExpr(cls.SuperclassExpr);
+        var methods = RewriteListIfChanged(cls.Methods, ProcessClassMethod);
+        var fields = RewriteListIfChanged(cls.Fields, ProcessClassField);
+        var accessors = cls.Accessors == null ? null : RewriteListIfChanged(cls.Accessors, ProcessClassAccessor);
+        var autoAccessors = cls.AutoAccessors == null ? null : RewriteListIfChanged(cls.AutoAccessors, ProcessClassAutoAccessor);
+        var staticInitializers = ProcessStaticInitializers(cls.Fields, fields, cls.StaticInitializers);
+
+        return (cls.SuperclassExpr == null || ReferenceEquals(superclass, cls.SuperclassExpr))
+            && ReferenceEquals(methods, cls.Methods)
+            && ReferenceEquals(fields, cls.Fields)
+            && (cls.Accessors == null || ReferenceEquals(accessors, cls.Accessors))
+            && (cls.AutoAccessors == null || ReferenceEquals(autoAccessors, cls.AutoAccessors))
+            && (cls.StaticInitializers == null || ReferenceEquals(staticInitializers, cls.StaticInitializers))
+                ? cls
+                : cls with
+                {
+                    SuperclassExpr = superclass,
+                    Methods = methods,
+                    Fields = fields,
+                    Accessors = accessors,
+                    AutoAccessors = autoAccessors,
+                    StaticInitializers = staticInitializers,
+                };
+    }
+
+    private Stmt.Function ProcessClassMethod(Stmt.Function method)
+    {
+        var computedKey = method.ComputedKey == null ? null : ProcessExpr(method.ComputedKey);
+        var parameters = ProcessParameters(method.Parameters);
+        var body = method.Body == null ? null : ProcessBody(
+            method.Body, method.IsGenerator || method.IsAsync, method.IsAsync && !method.IsGenerator,
+            enclosingIsGeneratorClassMethod: method.IsGenerator);
+        return (method.ComputedKey == null || ReferenceEquals(computedKey, method.ComputedKey))
+            && ReferenceEquals(parameters, method.Parameters)
+            && (method.Body == null || ReferenceEquals(body, method.Body))
+                ? method
+                : method with { ComputedKey = computedKey, Parameters = parameters, Body = body };
+    }
+
+    private Stmt.Field ProcessClassField(Stmt.Field field)
+    {
+        var computedKey = field.ComputedKey == null ? null : ProcessExpr(field.ComputedKey);
+        var initializer = field.Initializer == null ? null : ProcessExpr(field.Initializer);
+        return (field.ComputedKey == null || ReferenceEquals(computedKey, field.ComputedKey))
+            && (field.Initializer == null || ReferenceEquals(initializer, field.Initializer))
+                ? field : field with { ComputedKey = computedKey, Initializer = initializer };
+    }
+
+    private Stmt.Accessor ProcessClassAccessor(Stmt.Accessor accessor)
+    {
+        var computedKey = accessor.ComputedKey == null ? null : ProcessExpr(accessor.ComputedKey);
+        var setterParam = accessor.SetterParam == null ? null : ProcessParameter(accessor.SetterParam);
+        var body = ProcessBody(accessor.Body, enclosingIsStateMachine: false, enclosingIsAsyncFunction: false,
+            enclosingIsGeneratorClassMethod: false);
+        return (accessor.ComputedKey == null || ReferenceEquals(computedKey, accessor.ComputedKey))
+            && ReferenceEquals(setterParam, accessor.SetterParam) && ReferenceEquals(body, accessor.Body)
+                ? accessor : accessor with { ComputedKey = computedKey, SetterParam = setterParam, Body = body };
+    }
+
+    private Stmt.AutoAccessor ProcessClassAutoAccessor(Stmt.AutoAccessor accessor)
+    {
+        var initializer = accessor.Initializer == null ? null : ProcessExpr(accessor.Initializer);
+        return accessor.Initializer == null || ReferenceEquals(initializer, accessor.Initializer)
+            ? accessor : accessor with { Initializer = initializer };
+    }
+
+    private List<Stmt>? ProcessStaticInitializers(
+        List<Stmt.Field> originalFields,
+        List<Stmt.Field> rewrittenFields,
+        List<Stmt>? staticInitializers)
+    {
+        if (staticInitializers == null) return null;
+
+        var fieldMap = new Dictionary<Stmt.Field, Stmt.Field>(ReferenceEqualityComparer.Instance);
+        for (int i = 0; i < originalFields.Count; i++) fieldMap[originalFields[i]] = rewrittenFields[i];
+        return RewriteListIfChanged(staticInitializers, initializer =>
         {
-            var m = cls.Methods[i];
-            if (m.Body == null) continue;
-            // #945: a class generator method (sync or async, static or instance) does NOT reliably wire
-            // a function display class for read-only captures, so a forwarding binding hoisted into its
-            // body would read a stale by-value snapshot. Flag it so the gate declines to hoist there.
-            var nb = ProcessBody(m.Body, m.IsGenerator || m.IsAsync, m.IsAsync && !m.IsGenerator, enclosingIsGeneratorClassMethod: m.IsGenerator);
-            if (!ReferenceEquals(nb, m.Body))
+            if (initializer is Stmt.Field field && fieldMap.TryGetValue(field, out var rewrittenField))
+                return rewrittenField;
+            if (initializer is Stmt.StaticBlock block)
             {
-                newMethods ??= new List<Stmt.Function>(cls.Methods);
-                newMethods[i] = m with { Body = nb };
+                var body = ProcessBody(block.Body, enclosingIsStateMachine: false, enclosingIsAsyncFunction: false,
+                    enclosingIsGeneratorClassMethod: false);
+                return ReferenceEquals(body, block.Body) ? block : block with { Body = body };
             }
-        }
-        return newMethods == null ? cls : cls with { Methods = newMethods };
+            return ProcessStmt(initializer, enclosingIsStateMachine: false, enclosingIsAsyncFunction: false,
+                enclosingIsGeneratorClassMethod: false);
+        });
     }
 
     #endregion

--- a/src/SharpTS/Parsing/GeneratorArrowLifter.cs
+++ b/src/SharpTS/Parsing/GeneratorArrowLifter.cs
@@ -573,6 +573,8 @@ internal sealed class GeneratorArrowLifter
                 return LiftGeneratorArrow(af);
             case Expr.ArrowFunction af:
                 return RewriteNonGeneratorArrow(af);
+            case Expr.ClassExpr cls:
+                return RewriteClassExpression(cls);
 
             case Expr.Comma c:
             {
@@ -773,10 +775,63 @@ internal sealed class GeneratorArrowLifter
 
             default:
                 // Leaf / type-only / declaration-only nodes carry no nested generator expression:
-                // Literal, Variable, This, Super, RegexLiteral, ImportMeta, ClassExpr (handled
-                // structurally elsewhere). Returned unchanged.
+                // Literal, Variable, This, Super, RegexLiteral, ImportMeta. Returned unchanged.
                 return expr;
         }
+    }
+
+    /// <summary>
+    /// Rewrites a class expression with the same class-definition and function-scope rules as a class
+    /// declaration. Class expressions may occur on any expression path, so handling them here is what
+    /// lets generator expressions inside their methods, fields, accessors, computed keys, and static
+    /// initializers reach the declaration-based generator pipeline.
+    /// </summary>
+    private Expr RewriteClassExpression(Expr.ClassExpr cls)
+    {
+        var newSuperclass = cls.SuperclassExpr is null ? null : RewriteExpr(cls.SuperclassExpr);
+        var newMethods = RewriteListIfChanged(cls.Methods, RewriteClassMethod);
+        var newFields = RewriteListIfChanged(cls.Fields, RewriteClassField);
+        var newAccessors = cls.Accessors is null
+            ? null
+            : RewriteListIfChanged(cls.Accessors, RewriteClassAccessor);
+        var newAutoAccessors = cls.AutoAccessors is null
+            ? null
+            : RewriteListIfChanged(cls.AutoAccessors, RewriteAutoAccessor);
+
+        // StaticInitializers repeats the static Field nodes held in Fields. Reuse the corresponding
+        // rewritten node so a generator in a static field initializer is lifted exactly once.
+        List<Stmt>? newStaticInitializers = cls.StaticInitializers;
+        if (cls.StaticInitializers is not null)
+        {
+            var rewrittenFields = new Dictionary<Stmt.Field, Stmt.Field>(ReferenceEqualityComparer.Instance);
+            for (int i = 0; i < cls.Fields.Count; i++)
+                rewrittenFields[cls.Fields[i]] = newFields[i];
+
+            newStaticInitializers = RewriteListIfChanged(cls.StaticInitializers, initializer =>
+                initializer is Stmt.Field field && rewrittenFields.TryGetValue(field, out var rewrittenField)
+                    ? rewrittenField
+                    : initializer is Stmt.StaticBlock block
+                        ? RewriteStaticBlock(block)
+                        : RewriteStmt(initializer));
+        }
+
+        if ((cls.SuperclassExpr is null || ReferenceEquals(newSuperclass, cls.SuperclassExpr))
+            && ReferenceEquals(newMethods, cls.Methods)
+            && ReferenceEquals(newFields, cls.Fields)
+            && (cls.Accessors is null || ReferenceEquals(newAccessors, cls.Accessors))
+            && (cls.AutoAccessors is null || ReferenceEquals(newAutoAccessors, cls.AutoAccessors))
+            && (cls.StaticInitializers is null || ReferenceEquals(newStaticInitializers, cls.StaticInitializers)))
+            return cls;
+
+        return cls with
+        {
+            SuperclassExpr = newSuperclass,
+            Methods = newMethods,
+            Fields = newFields,
+            Accessors = newAccessors,
+            AutoAccessors = newAutoAccessors,
+            StaticInitializers = newStaticInitializers,
+        };
     }
 
     private Expr RewriteObjectLiteral(Expr.ObjectLiteral obj)

--- a/src/SharpTS/TypeSystem/TypeChecker.Expressions.cs
+++ b/src/SharpTS/TypeSystem/TypeChecker.Expressions.cs
@@ -2312,8 +2312,13 @@ public partial class TypeChecker
                 {
                     if (method.Body != null)
                     {
-                        foreach (var bodyStmt in method.Body)
-                            CheckStmt(bodyStmt);
+                        // Match ordinary function-body checking (and class declarations): generator
+                        // expression lifting appends __genArrow_N at the body end while its binding is
+                        // referenced earlier, so declarations and lexical bindings must be visible
+                        // before the sequential pass.
+                        HoistFunctionDeclarations(method.Body);
+                        HoistLexicalDeclarations(method.Body);
+                        CheckStmtList(method.Body);
 
                         // #367/#372: object-slot number/boolean-typed locals, parameters, and returns
                         // that may hold the undefined sentinel.

--- a/src/SharpTS/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/src/SharpTS/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -939,6 +939,12 @@ public partial class TypeChecker
                     // Abstract methods have no body to check
                     if (method.Body != null)
                     {
+                        // Method bodies have ordinary function-declaration and lexical hoisting
+                        // semantics. GeneratorArrowLifter appends a synthesized __genArrow_N
+                        // declaration after the earlier forwarding reference, so predeclare both
+                        // declaration kinds before the source-order body pass.
+                        HoistFunctionDeclarations(method.Body);
+                        HoistLexicalDeclarations(method.Body);
                         CheckStmtList(method.Body);
 
                         // #367/#372: object-slot number/boolean-typed locals, parameters, and returns

--- a/tests/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/AsyncGeneratorTests.cs
@@ -1779,18 +1779,15 @@ public class AsyncGeneratorTests
         Assert.Equal("3,4\n", TestHarness.RunCompiled(source));
     }
 
-    // #945 decline: a class GENERATOR METHOD encloser (here an async-generator instance method) stays
-    // unsupported in compiled mode — its state machine wires no function DC for read-only captures, so
-    // hoisting the forwarding binding would read a stale by-value snapshot. It must fail CLEANLY (compile
-    // error), never miscompile to a wrong value. The interpreter runs the nested declaration natively.
-    [Fact]
-    public void AsyncGeneratorExpression_CapturesAsyncGeneratorMethodLocal_CompiledDeclinesCleanly()
+    [Theory, ModeData]
+    public void AsyncGeneratorExpression_CapturesAsyncGeneratorMethodLocal(ExecutionMode mode)
     {
         var source = """
             class C {
                 async *m() {
                     let y = 3;
                     const g = async function* () { yield y; yield y + 1; };
+                    y = 8;
                     for await (const v of g()) yield v;
                 }
             }
@@ -1801,12 +1798,27 @@ public class AsyncGeneratorTests
             }
             main();
             """;
-        Assert.Equal("3,4\n", TestHarness.Run(source, ExecutionMode.Interpreted));
-        string compiled;
-        try { compiled = TestHarness.RunCompiled(source); }
-        catch { compiled = "<compile-or-runtime-error>"; }
-        // A clean failure is acceptable; the correct "3,4\n" is acceptable; a wrong value is not.
-        Assert.True(compiled == "<compile-or-runtime-error>" || compiled == "3,4\n", $"unexpected: {compiled}");
+        Assert.Equal("8,9\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void AsyncGeneratorExpression_CapturesStaticAsyncGeneratorMethodParameter(ExecutionMode mode)
+    {
+        var source = """
+            class C {
+                static async *m(y: number) {
+                    const g = async function* () { yield y; };
+                    y += 5;
+                    for await (const v of g()) yield v;
+                }
+            }
+            async function main() {
+                for await (const v of C.m(4)) console.log(v);
+            }
+            main();
+            """;
+
+        Assert.Equal("9\n", TestHarness.Run(source, mode));
     }
 
     #endregion

--- a/tests/SharpTS.Tests/SharedTests/GeneratorTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/GeneratorTests.cs
@@ -1649,6 +1649,41 @@ public class GeneratorTests
         Assert.Contains("Yield not supported", ex.Message);
     }
 
+    [Fact]
+    public void GeneratorExpression_ClosesOverLocal_WithDefaultParam_CompiledFailsCleanly()
+    {
+        var source = """
+            function outer() {
+              let y = 5;
+              const g = function*(x: number = 2) { yield y + x; };
+              return [...g()];
+            }
+            console.log(outer());
+            """;
+
+        Assert.Equal("[7]\n", TestHarness.Run(source, ExecutionMode.Interpreted));
+        var ex = Assert.Throws<CompileException>(() => TestHarness.RunCompiled(source));
+        Assert.Contains("Yield not supported", ex.Message);
+    }
+
+    [Fact]
+    public void GeneratorExpression_ClosesOverLocal_UsingArguments_CompiledFailsCleanly()
+    {
+        var source = """
+            function outer() {
+              let y = 5;
+              const g = function*() { yield y; yield arguments.length; };
+              return [...g(1, 2)];
+            }
+            console.log(outer());
+            """;
+
+        // The interpreter's generator-expression `arguments` binding is a separate existing gap; this
+        // test pins the compiler's conservative decline only.
+        var ex = Assert.Throws<CompileException>(() => TestHarness.RunCompiled(source));
+        Assert.Contains("Yield not supported", ex.Message);
+    }
+
     [Theory, ModeData]
     public void GeneratorExpression_ClosesOverLocal_UsingThis_ThreadsDynamicThis(ExecutionMode mode)
     {
@@ -1691,9 +1726,8 @@ public class GeneratorTests
     // #945 (generator-encloser analog of #534/#924): a generator expression closing over a local of an
     // enclosing top-level/module-level (or nested-in-plain-function) `function*` now runs in BOTH modes.
     // The lifted forwarding binding is hoisted to the generator body top and its read-only forwarded
-    // capture is routed through the generator's #674 function display class, so the hoisted forwarder
-    // reads it LIVE. Class generator-method enclosers (sync/async, static/instance) instead decline
-    // cleanly (a compile error, never a stale-value miscompile) — pinned below.
+    // capture is routed through the generator's function display class, so the hoisted forwarder reads
+    // it LIVE. The same storage path now covers class generator methods, including static and async.
 
     [Theory, ModeData]
     public void GeneratorExpression_ClosesOverGeneratorLocal(ExecutionMode mode)
@@ -1787,50 +1821,91 @@ public class GeneratorTests
         Assert.Equal("[7]\n", TestHarness.Run(source, mode));
     }
 
-    [Fact]
-    public void GeneratorExpression_ClosesOverInstanceGeneratorMethodLocal_CompiledDeclinesCleanly()
+    [Theory, ModeData]
+    public void GeneratorExpression_ClosesOverInstanceGeneratorMethodLocal(ExecutionMode mode)
     {
-        // A class instance generator method encloser has no function DC wired for read-only captures, so
-        // the compiler keeps the binding in place and the body's `yield` fails cleanly ("Yield not
-        // supported in this context") — never a stale-value miscompile. Interpreter runs it natively.
+        // The forwarding closure is created at method entry, then reads y after its mutation through the
+        // shared generator-method display class.
         var source = """
             class C {
               *m() {
                 let y = 5;
                 const g = function*() { yield y; };
+                y = 9;
                 yield* g();
               }
             }
             console.log([...new C().m()]);
             """;
 
-        Assert.Equal("[5]\n", TestHarness.Run(source, ExecutionMode.Interpreted));
-        var ex = Assert.Throws<CompileException>(() => TestHarness.RunCompiled(source));
-        Assert.Contains("Yield not supported", ex.Message);
+        Assert.Equal("[9]\n", TestHarness.Run(source, mode));
     }
 
-    [Fact]
-    public void GeneratorExpression_ClosesOverStaticGeneratorMethodLocal_CompiledDeclinesCleanly()
+    [Theory, ModeData]
+    public void GeneratorExpression_ClosesOverStaticGeneratorMethodParameter(ExecutionMode mode)
     {
-        // A static generator method has no function DC at all; same clean decline as the instance case.
+        // Static method parameters start at IL argument zero; seed the captured parameter into the live
+        // display-class cell before MoveNext and observe a later mutation.
         var source = """
             class C {
-              static *m() {
-                let y = 7;
+              static *m(y: number) {
                 const g = function*() { yield y; };
+                y += 4;
                 yield* g();
               }
             }
-            console.log([...C.m()]);
+            console.log([...C.m(7)]);
             """;
 
-        Assert.Equal("[7]\n", TestHarness.Run(source, ExecutionMode.Interpreted));
-        var ex = Assert.Throws<CompileException>(() => TestHarness.RunCompiled(source));
-        Assert.Contains("Yield not supported", ex.Message);
+        Assert.Equal("[11]\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void GeneratorExpressions_ClassExpressionMethods_AllKindsUseIndependentLiveStorage(ExecutionMode mode)
+    {
+        // A ternary forces NestedFunctionLifter to reach the class expression through a non-trivial
+        // expression path. Same-named static/instance methods must receive distinct DC keys. The static
+        // parameter cases also pin argument offset zero for both iterator families.
+        var source = """
+            const C = true ? class {
+              *m(seed: number) {
+                const g = function*() { yield seed; };
+                seed += 1;
+                yield* g();
+              }
+              static *m(seed: number) {
+                const g = function*() { yield seed; };
+                seed += 2;
+                yield* g();
+              }
+              async *am(seed: number) {
+                const g = async function*() { yield seed; };
+                seed += 3;
+                for await (const value of g()) yield value;
+              }
+              static async *am(seed: number) {
+                const g = async function*() { yield seed; };
+                seed += 4;
+                for await (const value of g()) yield value;
+              }
+            } : class {};
+
+            async function main() {
+              const values: number[] = [];
+              values.push(new C().m(10).next().value);
+              values.push(C.m(10).next().value);
+              for await (const value of new C().am(10)) values.push(value);
+              for await (const value of C.am(10)) values.push(value);
+              console.log(values.join(","));
+            }
+            main();
+            """;
+
+        Assert.Equal("11,12,13,14\n", TestHarness.Run(source, mode));
     }
 
     [Fact]
-    public void GeneratorExpression_NamedSelfRecursive_ClosesOverGeneratorLocal_CompiledNeverWrong()
+    public void GeneratorExpression_NamedSelfRecursive_ClosesOverGeneratorLocal_CompiledFailsCleanly()
     {
         // A NAMED self-recursive generator expression that also captures an enclosing local is declined by
         // the lambda-lift (self-recursion can't be forwarded). The compiled path must be a clean error or
@@ -1845,10 +1920,8 @@ public class GeneratorTests
             console.log([...outer()]);
             """;
 
-        string compiled;
-        try { compiled = TestHarness.RunCompiled(source); }
-        catch { compiled = "<compile-or-runtime-error>"; }
-        Assert.True(compiled == "<compile-or-runtime-error>" || compiled == "[2, 2]\n", $"unexpected: {compiled}");
+        var ex = Assert.Throws<CompileException>(() => TestHarness.RunCompiled(source));
+        Assert.Contains("Yield not supported", ex.Message);
     }
 
     #endregion

--- a/tests/SharpTS.Tests/SharedTests/PrivateAsyncGeneratorMethodTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/PrivateAsyncGeneratorMethodTests.cs
@@ -1,5 +1,3 @@
-using SharpTS.Diagnostics.Exceptions;
-using SharpTS.Parsing;
 using SharpTS.Tests.Infrastructure;
 using Xunit;
 
@@ -137,13 +135,11 @@ public class PrivateAsyncGeneratorMethodTests
         Assert.Equal("11\n", TestHarness.Run(source, mode));
     }
 
-    [Fact]
-    public void StaticAsyncGeneratorPrivate_ReportsCleanError_NotInvalidIL()
+    [Theory, ModeData]
+    public void StaticAsyncGeneratorPrivateMethod(ExecutionMode mode)
     {
-        // Static async generators are not yet supported (the async-generator state machine is
-        // instance-only; the public static form fails the same way, #761). The static private form must
-        // report that clean compile error rather than emitting invalid IL — i.e. the fix routes only the
-        // supported cases.
+        // Static private async generators share the public static iterator path: no instance field and
+        // parameters beginning at argument zero.
         var source = """
             class A {
               static async *#p(x: number) { yield x; yield x + 1; }
@@ -152,6 +148,6 @@ public class PrivateAsyncGeneratorMethodTests
             A.go().then(v => console.log(v));
             """;
 
-        Assert.Throws<CompileException>(() => TestHarness.CompileAndVerifyOnly(source, DecoratorMode.None));
+        Assert.Equal("11\n", TestHarness.Run(source, mode));
     }
 }


### PR DESCRIPTION
## Summary

- rewrite generator expressions inside class expressions and hoist synthesized declarations before class method body checking
- route lifted forwarders through live generator-method display-class storage for sync/async and static/instance methods
- seed static async-generator parameters correctly and isolate same-named static and instance method storage
- retain conservative compile declines for recursive, arguments, rest, and default-parameter forwarding shapes

## Tests

- `dotnet build SharpTS.sln -c Release --nologo -p:NuGetAudit=false --no-restore`
- focused generator-method matrix: 14 passed
- generator, async-generator, and generator-arrow suites: 483 passed
- full core suite: 16,789 passed, 3 skipped
- Issue 1374 Test262 class residual parity: 96 passed
- `git diff --check`

No Test262 baseline changes.