### PR TITLE
Optimize JSON round-trip performance

### DIFF
--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/StarterWorkloadBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/StarterWorkloadBenchmarks.cs
@@ -2,6 +2,7 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
 using SharpTS.Execution;
 using SharpTS.Microbenchmarks.Baselines;
+using SharpTS.Microbenchmarks.Infrastructure;
 using SharpTS.Parsing;
 using SharpTS.TypeSystem;
 
@@ -95,7 +96,7 @@ public class JsonImportedModulePhaseBenchmarks : ComputationalBenchmarkBase
     private Func<double, double> _parse = null!;
     private Func<double, double> _roundTrip = null!;
 
-    [Params(1000)]
+    [Params(1000, 10000)]
     public int N { get; set; }
 
     [GlobalSetup]
@@ -205,6 +206,41 @@ public class JsonInterpreterPhaseBenchmarks
         var tokens = new Lexer(source).ScanTokens();
         return new Parser(tokens).ParseOrThrow();
     }
+}
+
+/// <summary>
+/// Interpreter counterpart to <see cref="JsonImportedModulePhaseBenchmarks"/>.
+/// Module resolution, type checking, realm creation, and module execution occur
+/// in setup; measured calls retain the imported live binding and capturing arrow
+/// callback used by the exact cross-runtime workload.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class JsonImportedModuleInterpreterPhaseBenchmarks : IDisposable
+{
+    private InterpretedJsonModuleBenchmark _benchmark = null!;
+
+    [Params(1000, 10000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup() => _benchmark = InterpretedJsonModuleBenchmark.Create();
+
+    [Benchmark(Baseline = true)]
+    public double Build() => _benchmark.Build(N);
+
+    [Benchmark]
+    public double BuildAndStringify() => _benchmark.Stringify(N);
+
+    [Benchmark]
+    public double BuildStringifyAndParse() => _benchmark.Parse(N);
+
+    [Benchmark]
+    public double FullRoundTrip() => _benchmark.RoundTrip(N);
+
+    [GlobalCleanup]
+    public void Dispose() => _benchmark?.Dispose();
 }
 
 [MemoryDiagnoser]

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Infrastructure/InterpretedJsonModuleBenchmark.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Infrastructure/InterpretedJsonModuleBenchmark.cs
@@ -1,0 +1,110 @@
+using System.Reflection;
+using SharpTS.Diagnostics;
+using SharpTS.Execution;
+using SharpTS.Modules;
+using SharpTS.Runtime;
+using SharpTS.Runtime.Types;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Microbenchmarks.Infrastructure;
+
+/// <summary>
+/// Loads the JSON phase probes through the interpreter's real module resolver,
+/// live import cells, and capturing callback boundary. The bridge publishes the
+/// already-imported functions on this interpreter realm's global object only so
+/// BenchmarkDotNet can invoke them repeatedly after module setup.
+/// </summary>
+internal sealed class InterpretedJsonModuleBenchmark : IDisposable
+{
+    private const string BuildName = "__sharpTSJsonImportedBuild";
+    private const string StringifyName = "__sharpTSJsonImportedStringify";
+    private const string ParseName = "__sharpTSJsonImportedParse";
+    private const string RoundTripName = "__sharpTSJsonImportedRoundTrip";
+
+    private readonly Interpreter _interpreter;
+    private readonly RuntimeValue[] _arguments = new RuntimeValue[1];
+    private readonly ISharpTSCallable _build;
+    private readonly ISharpTSCallable _stringify;
+    private readonly ISharpTSCallable _parse;
+    private readonly ISharpTSCallable _roundTrip;
+
+    private InterpretedJsonModuleBenchmark(
+        Interpreter interpreter,
+        SharpTSGlobalThis globalThis)
+    {
+        _interpreter = interpreter;
+        _build = GetCallable(globalThis, BuildName);
+        _stringify = GetCallable(globalThis, StringifyName);
+        _parse = GetCallable(globalThis, ParseName);
+        _roundTrip = GetCallable(globalThis, RoundTripName);
+    }
+
+    internal static InterpretedJsonModuleBenchmark Create()
+    {
+        const string assemblyName = "JsonImportedInterpreterModules";
+        string virtualRoot = Path.Combine(
+            Path.GetTempPath(), $"sharpts_benchmark_{assemblyName}");
+        var virtualFiles = new Dictionary<string, string>(
+            StringComparer.OrdinalIgnoreCase);
+        foreach (var (path, source) in JsonModuleBenchmark.LoadSources(
+                     includeInterpreterBridge: true))
+        {
+            string fullPath = Path.GetFullPath(Path.Combine(
+                virtualRoot, path.TrimStart('.', '/', '\\')));
+            virtualFiles[fullPath] = source;
+        }
+
+        string entryPath = Path.GetFullPath(Path.Combine(
+            virtualRoot, "json-interpreter-bridge.ts"));
+        var resolver = new ModuleResolver(entryPath, virtualFiles);
+        ParsedModule entryModule = resolver.LoadModule(entryPath);
+        List<ParsedModule> modules = resolver.GetModulesInOrder(entryModule);
+
+        var checker = new TypeChecker();
+        TypeMap typeMap = checker.CheckModules(modules, resolver);
+        List<Diagnostic> errors = checker.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .ToList();
+        if (errors.Count != 0)
+        {
+            throw new InvalidOperationException(
+                "Interpreter module benchmark type-check failed:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, errors));
+        }
+
+        var interpreter = new Interpreter(
+            stdout: TextWriter.Null,
+            stderr: TextWriter.Null);
+        interpreter.InterpretModules(modules, resolver, typeMap);
+
+        PropertyInfo globalThisProperty = typeof(Interpreter).GetProperty(
+            "GlobalThis", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                "Could not access the interpreter realm's global object");
+        var globalThis = (SharpTSGlobalThis?)globalThisProperty.GetValue(interpreter)
+            ?? throw new InvalidOperationException(
+                "The interpreter realm did not create a global object");
+        return new InterpretedJsonModuleBenchmark(interpreter, globalThis);
+    }
+
+    internal double Build(int n) => Invoke(_build, n);
+    internal double Stringify(int n) => Invoke(_stringify, n);
+    internal double Parse(int n) => Invoke(_parse, n);
+    internal double RoundTrip(int n) => Invoke(_roundTrip, n);
+
+    private double Invoke(ISharpTSCallable callable, int n)
+    {
+        _arguments[0] = RuntimeValue.FromNumber(n);
+        return callable.CallV2(_interpreter, _arguments).AsNumber();
+    }
+
+    private static ISharpTSCallable GetCallable(
+        SharpTSGlobalThis globalThis,
+        string name)
+        => globalThis.GetProperty(name) as ISharpTSCallable
+            ?? throw new InvalidOperationException(
+                $"Interpreter JSON bridge did not publish '{name}'");
+
+    public void Dispose() => _interpreter.Dispose();
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Infrastructure/JsonModuleBenchmark.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Infrastructure/JsonModuleBenchmark.cs
@@ -15,20 +15,32 @@ internal static class JsonModuleBenchmark
         "SharpTS.Microbenchmarks.TypeScriptSources.BenchmarkCallback.ts";
     private const string DriverResource =
         "SharpTS.Microbenchmarks.TypeScriptSources.JsonBenchmarkDriver.ts";
+    private const string InterpreterBridgeResource =
+        "SharpTS.Microbenchmarks.TypeScriptSources.JsonInterpreterBridge.ts";
 
     internal static readonly HashSet<string> ModuleOnlyResources =
-        [CallbackResource, DriverResource];
+        [CallbackResource, DriverResource, InterpreterBridgeResource];
 
     internal static string Compile(string assemblyName)
         => CompilationCache.GetOrCompileModules(
             LoadSources(), "json-driver.ts", assemblyName);
 
-    private static Dictionary<string, string> LoadSources() => new()
+    internal static Dictionary<string, string> LoadSources(
+        bool includeInterpreterBridge = false)
     {
-        ["algorithms.ts"] = ReadResource(AlgorithmsResource),
-        ["benchmark-callback.ts"] = ReadResource(CallbackResource),
-        ["json-driver.ts"] = ReadResource(DriverResource),
-    };
+        var sources = new Dictionary<string, string>
+        {
+            ["algorithms.ts"] = ReadResource(AlgorithmsResource),
+            ["benchmark-callback.ts"] = ReadResource(CallbackResource),
+            ["json-driver.ts"] = ReadResource(DriverResource),
+        };
+        if (includeInterpreterBridge)
+        {
+            sources["json-interpreter-bridge.ts"] =
+                ReadResource(InterpreterBridgeResource);
+        }
+        return sources;
+    }
 
     private static string ReadResource(string name)
     {

--- a/benchmarks/micro/SharpTS.Microbenchmarks/README.md
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/README.md
@@ -44,8 +44,10 @@ The `JsonImportedModule*` benchmarks compile a virtual three-module graph via
 driver whose closures capture `n`. This reproduces the imported `json.ts` call
 shape while leaving BenchmarkDotNet in control of the timing loop. The phase
 class measures cumulative build/stringify/parse/traversal work at `n=1,000`;
-the round-trip class records allocations and GC counts at `n=1,000` and
-`n=10,000`. The original direct-delegate JSON benchmarks remain as a comparison.
+the imported interpreter counterpart measures the same module/callback path.
+Both faithful phase classes cover `n=1,000` and `n=10,000`, while the compiled
+round-trip class provides a shorter hard-gate allocation/GC run at both sizes.
+The original direct-delegate JSON benchmarks remain as a comparison.
 
 ## Running
 

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/JsonInterpreterBridge.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/JsonInterpreterBridge.ts
@@ -1,0 +1,15 @@
+import {
+    importedJsonBuildPhase,
+    importedJsonStringifyPhase,
+    importedJsonParsePhase,
+    importedJsonRoundTrip
+} from "./json-driver.ts";
+
+// BenchmarkDotNet needs stable handles after module initialization. Publishing
+// the already-imported functions on this realm's global object does not alter
+// the measured call shape: each function still crosses the live import and
+// capturing-callback boundary in JsonBenchmarkDriver.ts.
+(globalThis as any).__sharpTSJsonImportedBuild = importedJsonBuildPhase;
+(globalThis as any).__sharpTSJsonImportedStringify = importedJsonStringifyPhase;
+(globalThis as any).__sharpTSJsonImportedParse = importedJsonParsePhase;
+(globalThis as any).__sharpTSJsonImportedRoundTrip = importedJsonRoundTrip;

--- a/src/SharpTS/Compilation/CountedPushLoopAnalyzer.cs
+++ b/src/SharpTS/Compilation/CountedPushLoopAnalyzer.cs
@@ -1,0 +1,84 @@
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Recognizes the deliberately narrow, side-effect-free counted append loop:
+/// <code>for (let i = 0; i &lt; n; i++) items.push(pureValue);</code>
+/// The emitter can reserve <c>items</c> once without changing observable
+/// evaluation order. Broader loops intentionally fall back to normal growth.
+/// </summary>
+internal static class CountedPushLoopAnalyzer
+{
+    internal readonly record struct Reservation(
+        Expr.Variable Array,
+        Expr.Variable Bound);
+
+    internal static bool TryAnalyze(Stmt.For loop, out Reservation reservation)
+    {
+        reservation = default;
+        if (loop.Initializer is not Stmt.Var
+            {
+                Name.Lexeme: var counter,
+                Initializer: Expr.Literal { Value: double initial }
+            }
+            || initial != 0)
+            return false;
+
+        if (loop.Condition is not Expr.Binary
+            {
+                Left: Expr.Variable { Name.Lexeme: var conditionCounter },
+                Operator.Type: TokenType.LESS,
+                Right: Expr.Variable bound
+            }
+            || conditionCounter != counter)
+            return false;
+
+        if (loop.Increment is not Expr.PostfixIncrement
+            {
+                Operand: Expr.Variable { Name.Lexeme: var incrementCounter },
+                Operator.Type: TokenType.PLUS_PLUS
+            }
+            || incrementCounter != counter)
+            return false;
+
+        Stmt body = loop.Body is Stmt.Block { Statements.Count: 1 } block
+            ? block.Statements[0]
+            : loop.Body;
+        if (body is not Stmt.Expression
+            {
+                Expr: Expr.Call
+                {
+                    Optional: false,
+                    Callee: Expr.Get
+                    {
+                        Optional: false,
+                        Object: Expr.Variable array,
+                        Name.Lexeme: "push"
+                    },
+                    Arguments: { Count: 1 } arguments
+                }
+            }
+            || !IsPure(arguments[0]))
+            return false;
+
+        reservation = new Reservation(array, bound);
+        return true;
+    }
+
+    private static bool IsPure(Expr expression) => expression switch
+    {
+        Expr.Literal => true,
+        Expr.Variable => true,
+        Expr.Grouping grouping => IsPure(grouping.Expression),
+        Expr.Unary unary => IsPure(unary.Right),
+        Expr.Binary binary => IsPure(binary.Left) && IsPure(binary.Right),
+        Expr.ObjectLiteral literal => literal.Properties.All(property =>
+            !property.IsSpread
+            && property.Kind == Expr.ObjectPropertyKind.Value
+            && property.Key is not Expr.ComputedKey
+            && IsPure(property.Value)),
+        Expr.ArrayLiteral literal => literal.Elements.All(IsPure),
+        _ => false
+    };
+}

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -906,7 +906,21 @@ public class EmittedRuntime
     public MethodBuilder JsonParse { get; set; } = null!;
     public MethodBuilder JsonParseWithReviver { get; set; } = null!;
     public MethodBuilder JsonStringify { get; set; } = null!;
+    public MethodBuilder JsonStringifyShaped { get; set; } = null!;
     public MethodBuilder JsonStringifyFull { get; set; } = null!;
+    /// <summary>
+    /// Lazily initialized immutable shape descriptors used by statically typed
+    /// no-replacer JSON.stringify call sites. They live on $Program so every
+    /// emitted function shares one descriptor without a SharpTS dependency.
+    /// </summary>
+    public Dictionary<string, FieldBuilder> JsonShapeFields { get; } = [];
+    public TypeBuilder JsonScalarRecordType { get; set; } = null!;
+    public ConstructorBuilder JsonScalarRecordCtor { get; set; } = null!;
+    public Dictionary<int, ConstructorBuilder> JsonScalarRecordInlineCtors { get; } = [];
+    public MethodBuilder JsonScalarRecordShapeGetter { get; set; } = null!;
+    public MethodBuilder JsonScalarRecordValuesGetter { get; set; } = null!;
+    public MethodBuilder JsonScalarRecordGetValue { get; set; } = null!;
+    public MethodBuilder JsonScalarRecordIsMaterializedGetter { get; set; } = null!;
     public TypeBuilder TSRawJsonType { get; set; } = null!;
     public ConstructorBuilder TSRawJsonCtor { get; set; } = null!;
     public MethodBuilder TSRawJsonTextGetter { get; set; } = null!;

--- a/src/SharpTS/Compilation/Emitters/JSONStaticEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/JSONStaticEmitter.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Reflection.Emit;
 using SharpTS.Parsing;
+using SharpTS.TypeSystem;
 
 namespace SharpTS.Compilation.Emitters;
 
@@ -64,6 +65,16 @@ public sealed class JSONStaticEmitter : IStaticTypeEmitterStrategy
                 return true;
 
             case "stringify":
+                JsonSerializationShape? staticShape = null;
+                FieldBuilder? shapeField = null;
+                if (arguments.Count == 1 && ctx.ProgramType is not null &&
+                    JsonSerializationShapeAnalyzer.TryAnalyze(
+                        ctx.TypeMap?.Get(arguments[0]), out var analyzedShape))
+                {
+                    staticShape = analyzedShape;
+                    shapeField = GetOrDefineShapeField(ctx, analyzedShape);
+                }
+
                 // Arg 0: value (required)
                 if (arguments.Count > 0)
                 {
@@ -94,7 +105,17 @@ public sealed class JSONStaticEmitter : IStaticTypeEmitterStrategy
                 }
                 else
                 {
-                    il.Emit(OpCodes.Call, ctx.Runtime!.JsonStringify);
+                    if (staticShape is not null && shapeField is not null)
+                    {
+                        bool closedShape = JsonSerializationShapeAnalyzer.IsClosed(staticShape);
+                        EmitLazyShapeDescriptor(ctx, staticShape, shapeField, closedShape);
+                        il.Emit(closedShape ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
+                        il.Emit(OpCodes.Call, ctx.Runtime!.JsonStringifyShaped);
+                    }
+                    else
+                    {
+                        il.Emit(OpCodes.Call, ctx.Runtime!.JsonStringify);
+                    }
                 }
                 return true;
 
@@ -170,4 +191,103 @@ public sealed class JSONStaticEmitter : IStaticTypeEmitterStrategy
 
     public bool HasStaticProperty(string memberName) =>
         memberName is "parse" or "stringify" or "rawJSON" or "isRawJSON";
+
+    internal static FieldBuilder GetOrDefineShapeField(
+        CompilationContext ctx,
+        JsonSerializationShape shape)
+    {
+        string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(shape);
+        if (ctx.Runtime!.JsonShapeFields.TryGetValue(fingerprint, out var field))
+            return field;
+
+        field = ctx.ProgramType!.DefineField(
+            $"$jsonShape_{ctx.Runtime.JsonShapeFields.Count}",
+            ctx.Types.Object,
+            FieldAttributes.Assembly | FieldAttributes.Static);
+        ctx.Runtime.JsonShapeFields.Add(fingerprint, field);
+        return field;
+    }
+
+    internal static void EmitLazyShapeDescriptor(
+        CompilationContext ctx,
+        JsonSerializationShape shape,
+        FieldBuilder field,
+        bool closed)
+    {
+        var il = ctx.IL;
+        var ready = il.DefineLabel();
+        il.Emit(OpCodes.Ldsfld, field);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brtrue, ready);
+        il.Emit(OpCodes.Pop);
+        EmitShapeDescriptor(il, ctx, shape, closed);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Stsfld, field);
+        il.MarkLabel(ready);
+    }
+
+    private static void EmitShapeDescriptor(
+        ILGenerator il,
+        CompilationContext ctx,
+        JsonSerializationShape shape,
+        bool closed)
+    {
+        switch (shape)
+        {
+            case JsonSerializationShape.Generic:
+                il.Emit(OpCodes.Ldstr, "$g");
+                return;
+            case JsonSerializationShape.Number:
+                il.Emit(OpCodes.Ldstr, closed ? "$N" : "$n");
+                return;
+            case JsonSerializationShape.String:
+                il.Emit(OpCodes.Ldstr, closed ? "$S" : "$s");
+                return;
+            case JsonSerializationShape.Boolean:
+                il.Emit(OpCodes.Ldstr, closed ? "$B" : "$b");
+                return;
+            case JsonSerializationShape.Array array:
+                il.Emit(OpCodes.Ldc_I4_2);
+                il.Emit(OpCodes.Newarr, ctx.Types.Object);
+                EmitArraySlot(il, 0, () => il.Emit(OpCodes.Ldstr, closed ? "$A" : "$a"));
+                EmitArraySlot(il, 1, () => EmitShapeReference(il, ctx, array.Element, closed));
+                return;
+            case JsonSerializationShape.Record record:
+                il.Emit(OpCodes.Ldc_I4, 1 + record.Fields.Count * 2);
+                il.Emit(OpCodes.Newarr, ctx.Types.Object);
+                EmitArraySlot(il, 0, () => il.Emit(OpCodes.Ldstr, closed ? "$O" : "$o"));
+                for (int i = 0; i < record.Fields.Count; i++)
+                {
+                    var field = record.Fields[i];
+                    EmitArraySlot(il, 1 + i * 2, () => il.Emit(OpCodes.Ldstr, field.Key));
+                    EmitArraySlot(il, 2 + i * 2,
+                        () => EmitShapeReference(il, ctx, field.Value, closed));
+                }
+                return;
+        }
+
+        void EmitArraySlot(ILGenerator generator, int index, Action emitValue)
+        {
+            generator.Emit(OpCodes.Dup);
+            generator.Emit(OpCodes.Ldc_I4, index);
+            emitValue();
+            generator.Emit(OpCodes.Stelem_Ref);
+        }
+    }
+
+    private static void EmitShapeReference(
+        ILGenerator il,
+        CompilationContext ctx,
+        JsonSerializationShape shape,
+        bool closed)
+    {
+        if (shape is JsonSerializationShape.Record or JsonSerializationShape.Array)
+        {
+            var field = GetOrDefineShapeField(ctx, shape);
+            EmitLazyShapeDescriptor(ctx, shape, field, closed);
+            return;
+        }
+
+        EmitShapeDescriptor(il, ctx, shape, closed);
+    }
 }

--- a/src/SharpTS/Compilation/ILCompiler.ContextFactories.cs
+++ b/src/SharpTS/Compilation/ILCompiler.ContextFactories.cs
@@ -63,6 +63,7 @@ public partial class ILCompiler
             EnumKinds = _enums.Kinds,
             // Compilation-wide services
             Runtime = _runtime,
+            ProgramType = _programType,
             RuntimeFeatures = _features,
             LexicalTdzNames = _lexicalBindingNames,
             StaticDirectEvalStatements = _staticDirectEvalStatements,

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -639,7 +639,7 @@ public partial class ILCompiler
         _isStrictMode = Parsing.DirectivePrologue.HasUseStrict(statements);
         statements = NestedFunctionLifter.Lift(statements, _entryPointDebugScope?.Spans);
         _lexicalBindingNames = LexicalBindingNameCollector.Collect(statements);
-        _features ??= new RuntimeFeatureDetector().Detect(statements);
+        _features ??= new RuntimeFeatureDetector().Detect(statements, _typeMap);
         return statements;
     }
 
@@ -1294,7 +1294,7 @@ public partial class ILCompiler
         if (_features is null)
         {
             var detector = new RuntimeFeatureDetector();
-            _features = detector.Detect(allStatements);
+            _features = detector.Detect(allStatements, _typeMap);
             if (modules.Any(module => module.IsCommonJs))
                 _features.UsesCjsRequire = true;
         }

--- a/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
@@ -116,6 +116,12 @@ public partial class ILEmitter
         }
         else if (!hasSpreads && !hasComputedKeys)
         {
+            if (TryEmitJsonScalarRecordLiteral(o))
+            {
+                SetStackUnknown();
+                return;
+            }
+
             // Simple case: no spreads, no computed keys. Drop the legacy
             // `Call CreateObject` no-op identity helper. Pre-size the
             // dictionary only when property count > 3: .NET's
@@ -202,6 +208,63 @@ public partial class ILEmitter
         // emit `Box Double` on the fresh Dictionary pointer, producing a
         // double whose bits were the reinterpreted heap address.
         SetStackUnknown();
+    }
+
+    private bool TryEmitJsonScalarRecordLiteral(Expr.ObjectLiteral literal)
+    {
+        if (_ctx.RuntimeFeatures?.UsesJSON != true || _ctx.ProgramType is null)
+            return false;
+
+        JsonSerializationShape.Record? record = null;
+        if (JsonSerializationShapeAnalyzer.TryAnalyze(
+                _ctx.TypeMap?.Get(literal), out var analyzed) &&
+            analyzed is JsonSerializationShape.Record typedRecord)
+            record = typedRecord;
+        else if (JsonSerializationShapeAnalyzer.TryAnalyzeObjectLiteral(
+            literal, _ctx.TypeMap, out var literalRecord))
+            record = literalRecord;
+
+        if (record is null || !JsonSerializationShapeAnalyzer.IsClosed(record) ||
+            record.Fields.Count != literal.Properties.Count)
+            return false;
+
+        for (int i = 0; i < literal.Properties.Count; i++)
+        {
+            var property = literal.Properties[i];
+            if (property.IsSpread || property.Key is Expr.ComputedKey ||
+                property.Kind is not Expr.ObjectPropertyKind.Value ||
+                GetPropertyKeyString(property.Key!) != record.Fields[i].Key)
+                return false;
+        }
+
+        var shapeField = Emitters.JSONStaticEmitter.GetOrDefineShapeField(_ctx, record);
+        Emitters.JSONStaticEmitter.EmitLazyShapeDescriptor(
+            _ctx, record, shapeField, closed: true);
+        if (_ctx.Runtime!.JsonScalarRecordInlineCtors.TryGetValue(
+            literal.Properties.Count, out var inlineCtor))
+        {
+            foreach (var property in literal.Properties)
+            {
+                EmitExpression(property.Value);
+                EmitBoxIfNeeded(property.Value);
+            }
+            IL.Emit(OpCodes.Newobj, inlineCtor);
+        }
+        else
+        {
+            IL.Emit(OpCodes.Ldc_I4, literal.Properties.Count);
+            IL.Emit(OpCodes.Newarr, _ctx.Types.Object);
+            for (int i = 0; i < literal.Properties.Count; i++)
+            {
+                IL.Emit(OpCodes.Dup);
+                IL.Emit(OpCodes.Ldc_I4, i);
+                EmitExpression(literal.Properties[i].Value);
+                EmitBoxIfNeeded(literal.Properties[i].Value);
+                IL.Emit(OpCodes.Stelem_Ref);
+            }
+            IL.Emit(OpCodes.Newobj, _ctx.Runtime.JsonScalarRecordCtor);
+        }
+        return true;
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
@@ -228,6 +228,10 @@ public partial class ILEmitter
             record.Fields.Count != literal.Properties.Count)
             return false;
 
+        if (!_ctx.RuntimeFeatures.JsonScalarRecordShapeFingerprints.Contains(
+            JsonSerializationShapeAnalyzer.Fingerprint(record)))
+            return false;
+
         for (int i = 0; i < literal.Properties.Count; i++)
         {
             var property = literal.Properties[i];

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -328,10 +328,10 @@ public partial class ILEmitter
         // Skipped when optional chaining is in play — null-check semantics
         // there are non-trivial and hot-path optionals are rare.
         if (!g.Optional
-            && objType is TypeInfo.Record
+            && objType is TypeInfo.Record recordType
             && _ctx.Runtime?.UndefinedInstance != null)
         {
-            EmitTypedRecordPropertyGet(g);
+            EmitTypedRecordPropertyGet(g, recordType);
             return;
         }
 
@@ -389,12 +389,15 @@ public partial class ILEmitter
     /// instances downcast to record shape, etc.) we fall through to the
     /// existing dispatch.
     /// </summary>
-    private void EmitTypedRecordPropertyGet(Expr.Get g)
+    private void EmitTypedRecordPropertyGet(Expr.Get g, TypeInfo.Record recordType)
     {
         EmitExpression(g.Object);
         EmitBoxIfNeeded(g.Object);
 
         var receiverLocal = IL.DeclareLocal(_ctx.Types.Object);
+        LocalBuilder? scalarLocal = _ctx.RuntimeFeatures?.UsesJSON == true
+            ? IL.DeclareLocal(_ctx.Runtime!.JsonScalarRecordType)
+            : null;
         var dictLocal = IL.DeclareLocal(_ctx.Types.DictionaryStringObject);
         var outLocal = IL.DeclareLocal(_ctx.Types.Object);
         IL.Emit(OpCodes.Stloc, receiverLocal);
@@ -402,6 +405,53 @@ public partial class ILEmitter
         var fallbackLabel = IL.DefineLabel();
         var endLabel = IL.DefineLabel();
         var notFoundLabel = IL.DefineLabel();
+
+        if (scalarLocal is not null && _ctx.ProgramType is not null &&
+            JsonSerializationShapeAnalyzer.TryAnalyze(recordType, out var analyzedShape) &&
+            analyzedShape is JsonSerializationShape.Record recordShape &&
+            JsonSerializationShapeAnalyzer.IsClosed(recordShape))
+        {
+            int scalarIndex = -1;
+            for (int index = 0; index < recordShape.Fields.Count; index++)
+            {
+                if (recordShape.Fields[index].Key == g.Name.Lexeme)
+                {
+                    scalarIndex = index;
+                    break;
+                }
+            }
+
+            if (scalarIndex >= 0)
+            {
+                var dictionaryLabel = IL.DefineLabel();
+                var shapeField = Emitters.JSONStaticEmitter.GetOrDefineShapeField(
+                    _ctx, recordShape);
+                IL.Emit(OpCodes.Ldloc, receiverLocal);
+                IL.Emit(OpCodes.Isinst, _ctx.Runtime!.JsonScalarRecordType);
+                IL.Emit(OpCodes.Stloc, scalarLocal);
+                IL.Emit(OpCodes.Ldloc, scalarLocal);
+                IL.Emit(OpCodes.Brfalse, dictionaryLabel);
+                IL.Emit(OpCodes.Ldloc, scalarLocal);
+                IL.Emit(OpCodes.Callvirt, _ctx.Runtime.JsonScalarRecordIsMaterializedGetter);
+                IL.Emit(OpCodes.Brtrue, fallbackLabel);
+                IL.Emit(OpCodes.Ldloc, scalarLocal);
+                IL.Emit(OpCodes.Call, _ctx.Runtime.PDSHasPropertyDescriptors);
+                IL.Emit(OpCodes.Brtrue, fallbackLabel);
+                IL.Emit(OpCodes.Ldloc, scalarLocal);
+                IL.Emit(OpCodes.Call, _ctx.Runtime.PDSHasPrototypeEntry);
+                IL.Emit(OpCodes.Brtrue, fallbackLabel);
+                IL.Emit(OpCodes.Ldloc, scalarLocal);
+                IL.Emit(OpCodes.Callvirt, _ctx.Runtime.JsonScalarRecordShapeGetter);
+                Emitters.JSONStaticEmitter.EmitLazyShapeDescriptor(
+                    _ctx, recordShape, shapeField, closed: true);
+                IL.Emit(OpCodes.Bne_Un, fallbackLabel);
+                IL.Emit(OpCodes.Ldloc, scalarLocal);
+                IL.Emit(OpCodes.Ldc_I4, scalarIndex);
+                IL.Emit(OpCodes.Callvirt, _ctx.Runtime.JsonScalarRecordGetValue);
+                IL.Emit(OpCodes.Br, endLabel);
+                IL.MarkLabel(dictionaryLabel);
+            }
+        }
 
         // dictLocal = receiver as Dictionary<string, object>
         IL.Emit(OpCodes.Ldloc, receiverLocal);

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -651,6 +651,13 @@ public partial class ILEmitter
             if (f.Initializer != null)
                 EmitStatement(f.Initializer);
 
+            // A tightly-proven `for (let i = 0; i < n; i++) a.push(pureValue)`
+            // can reserve its boxed-array storage once. This removes geometric
+            // growth (and the 16,384-slot LOH allocation at n=10,000) without
+            // evaluating any user expression early; unsupported runtime shapes
+            // and unbounded/NaN counts simply retain normal List<T> growth.
+            EmitCountedPushReservation(f);
+
             // Per-iteration reference cells (#650): for a loop binding that the body
             // both mutates and a closure captures, wrap its initial value in a fresh
             // StrongBox and route all body/condition/increment access through the cell
@@ -728,6 +735,55 @@ public partial class ILEmitter
                 _ctx.IntegerCounterLocals.Remove(activeIntCounter);
             _integerLoopCounterName = savedIntCounterName;
         }
+    }
+
+    private void EmitCountedPushReservation(Stmt.For loop)
+    {
+        if (!CountedPushLoopAnalyzer.TryAnalyze(loop, out var reservation))
+            return;
+
+        var arrayLocal = _ctx.Locals.GetLocal(reservation.Array.Name.Lexeme);
+        if (arrayLocal is null)
+            return;
+
+        var listType = _ctx.Types.ListOfObject;
+        var listLocal = IL.DeclareLocal(listType);
+        var countLocal = IL.DeclareLocal(_ctx.Types.Double);
+        var skipLabel = _ctx.ILBuilder.DefineLabel("counted_push_reserve_skip");
+
+        IL.Emit(OpCodes.Ldloc, arrayLocal);
+        if (arrayLocal.LocalType != listType)
+            IL.Emit(OpCodes.Isinst, listType);
+        IL.Emit(OpCodes.Stloc, listLocal);
+        IL.Emit(OpCodes.Ldloc, listLocal);
+        _ctx.ILBuilder.Emit_Brfalse(skipLabel);
+
+        SetStackUnknown();
+        EmitExpression(reservation.Bound);
+        EnsureDouble();
+        IL.Emit(OpCodes.Stloc, countLocal);
+
+        // Bound eager allocation to one million elements. The unordered branch
+        // form also rejects NaN; ceiling covers finite fractional upper bounds.
+        IL.Emit(OpCodes.Ldloc, countLocal);
+        IL.Emit(OpCodes.Ldc_R8, 0.0);
+        IL.Emit(OpCodes.Blt_Un, skipLabel);
+        IL.Emit(OpCodes.Ldloc, countLocal);
+        IL.Emit(OpCodes.Ldc_R8, 1_000_000.0);
+        IL.Emit(OpCodes.Bgt_Un, skipLabel);
+
+        IL.Emit(OpCodes.Ldloc, listLocal);
+        IL.Emit(OpCodes.Ldloc, countLocal);
+        IL.Emit(OpCodes.Call, typeof(Math).GetMethod("Ceiling", [_ctx.Types.Double])!);
+        IL.Emit(OpCodes.Conv_I4);
+        IL.Emit(OpCodes.Callvirt, _ctx.Types.GetMethod(
+            listType,
+            "EnsureCapacity",
+            [_ctx.Types.Int32])!);
+        IL.Emit(OpCodes.Pop);
+
+        _ctx.ILBuilder.MarkLabel(skipLabel);
+        SetStackUnknown();
     }
 
     protected override void EmitIf(Stmt.If i)

--- a/src/SharpTS/Compilation/JsonSerializationShape.cs
+++ b/src/SharpTS/Compilation/JsonSerializationShape.cs
@@ -1,0 +1,199 @@
+using System.Globalization;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Closed, immutable description of the statically known JSON portion of a
+/// value. Unknown leaves remain generic; record keys and array element shapes
+/// let the emitted runtime bypass dynamic object traversal after a complete
+/// side-effect-free guard succeeds.
+/// </summary>
+internal abstract record JsonSerializationShape
+{
+    internal sealed record Generic : JsonSerializationShape;
+    internal sealed record Number : JsonSerializationShape;
+    internal sealed record String : JsonSerializationShape;
+    internal sealed record Boolean : JsonSerializationShape;
+    internal sealed record Array(JsonSerializationShape Element) : JsonSerializationShape;
+    internal sealed record Record(IReadOnlyList<(string Key, JsonSerializationShape Value)> Fields)
+        : JsonSerializationShape;
+}
+
+internal static class JsonSerializationShapeAnalyzer
+{
+    private const int MaxStaticDepth = 32;
+
+    public static bool TryAnalyze(TypeInfo? type, out JsonSerializationShape shape)
+    {
+        var active = new HashSet<TypeInfo>(ReferenceEqualityComparer.Instance);
+        shape = Analyze(type, active, 0);
+        return shape is JsonSerializationShape.Record or JsonSerializationShape.Array;
+    }
+
+    public static bool TryAnalyzeObjectLiteral(
+        Expr.ObjectLiteral literal,
+        TypeMap? typeMap,
+        out JsonSerializationShape.Record shape)
+    {
+        var fields = new List<(string Key, JsonSerializationShape Value)>(literal.Properties.Count);
+        var active = new HashSet<TypeInfo>(ReferenceEqualityComparer.Instance);
+        foreach (var property in literal.Properties)
+        {
+            if (property.IsSpread || property.Kind is not Expr.ObjectPropertyKind.Value ||
+                property.Key is Expr.ComputedKey)
+            {
+                shape = null!;
+                return false;
+            }
+
+            string key = property.Key switch
+            {
+                Expr.IdentifierKey identifier => identifier.Name.Lexeme,
+                Expr.LiteralKey literalKey when literalKey.Literal.Type == TokenType.STRING
+                    => (string)literalKey.Literal.Literal!,
+                Expr.LiteralKey literalKey when literalKey.Literal.Type == TokenType.NUMBER
+                    => Convert.ToString(literalKey.Literal.Literal, CultureInfo.InvariantCulture)!,
+                _ => ""
+            };
+            if (key.Length == 0 || key == "toJSON" || IsArrayIndex(key))
+            {
+                shape = null!;
+                return false;
+            }
+
+            fields.Add((key, Analyze(typeMap?.Get(property.Value), active, 1)));
+        }
+
+        shape = new JsonSerializationShape.Record(fields);
+        return true;
+    }
+
+    public static string Fingerprint(JsonSerializationShape shape)
+    {
+        var builder = new System.Text.StringBuilder();
+        AppendFingerprint(builder, shape);
+        return builder.ToString();
+    }
+
+    public static bool IsClosed(JsonSerializationShape shape) => shape switch
+    {
+        JsonSerializationShape.Generic => false,
+        JsonSerializationShape.Array array => IsClosed(array.Element),
+        JsonSerializationShape.Record record => record.Fields.All(field => IsClosed(field.Value)),
+        _ => true
+    };
+
+    private static JsonSerializationShape Analyze(
+        TypeInfo? type,
+        HashSet<TypeInfo> active,
+        int depth)
+    {
+        if (type is null || depth >= MaxStaticDepth)
+            return new JsonSerializationShape.Generic();
+
+        return type switch
+        {
+            TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral
+                => new JsonSerializationShape.Number(),
+            TypeInfo.String or TypeInfo.StringLiteral
+                => new JsonSerializationShape.String(),
+            TypeInfo.Primitive { Type: TokenType.TYPE_BOOLEAN } or TypeInfo.BooleanLiteral
+                => new JsonSerializationShape.Boolean(),
+            TypeInfo.Array array => AnalyzeArray(array, active, depth),
+            TypeInfo.Record record => AnalyzeRecord(record, active, depth),
+            _ => new JsonSerializationShape.Generic()
+        };
+    }
+
+    private static JsonSerializationShape AnalyzeArray(
+        TypeInfo.Array array,
+        HashSet<TypeInfo> active,
+        int depth)
+    {
+        if (!active.Add(array)) return new JsonSerializationShape.Generic();
+        try
+        {
+            return new JsonSerializationShape.Array(
+                Analyze(array.ElementType, active, depth + 1));
+        }
+        finally
+        {
+            active.Remove(array);
+        }
+    }
+
+    private static JsonSerializationShape AnalyzeRecord(
+        TypeInfo.Record record,
+        HashSet<TypeInfo> active,
+        int depth)
+    {
+        if (record.HasIndexSignature || record.IsCallable || record.IsConstructable ||
+            !active.Add(record))
+            return new JsonSerializationShape.Generic();
+
+        try
+        {
+            var fields = new List<(string Key, JsonSerializationShape Value)>(record.Fields.Count);
+            foreach (var field in record.Fields)
+            {
+                // An own hook must run through the generic serializer. Canonical
+                // array-index keys have spec-defined numeric ordering rather than
+                // declaration/insertion ordering, so they are conservatively left
+                // out of the constant-order path as well.
+                if (field.Key == "toJSON" || IsArrayIndex(field.Key))
+                    return new JsonSerializationShape.Generic();
+
+                fields.Add((field.Key, Analyze(field.Value, active, depth + 1)));
+            }
+
+            return new JsonSerializationShape.Record(fields);
+        }
+        finally
+        {
+            active.Remove(record);
+        }
+    }
+
+    private static bool IsArrayIndex(string key) =>
+        uint.TryParse(key, NumberStyles.None, CultureInfo.InvariantCulture, out uint value) &&
+        value != uint.MaxValue &&
+        value.ToString(CultureInfo.InvariantCulture) == key;
+
+    private static void AppendFingerprint(
+        System.Text.StringBuilder builder,
+        JsonSerializationShape shape)
+    {
+        switch (shape)
+        {
+            case JsonSerializationShape.Generic:
+                builder.Append('g');
+                break;
+            case JsonSerializationShape.Number:
+                builder.Append('n');
+                break;
+            case JsonSerializationShape.String:
+                builder.Append('s');
+                break;
+            case JsonSerializationShape.Boolean:
+                builder.Append('b');
+                break;
+            case JsonSerializationShape.Array array:
+                builder.Append('[');
+                AppendFingerprint(builder, array.Element);
+                builder.Append(']');
+                break;
+            case JsonSerializationShape.Record record:
+                builder.Append('{');
+                foreach (var (key, value) in record.Fields)
+                {
+                    builder.Append(key.Length).Append(':').Append(key).Append('=');
+                    AppendFingerprint(builder, value);
+                    builder.Append(';');
+                }
+                builder.Append('}');
+                break;
+        }
+    }
+}

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.Parse.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.Parse.cs
@@ -26,7 +26,7 @@ public partial class RuntimeEmitter
         // }
         il.BeginExceptionBlock();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, EmitJsonParseHelper(typeBuilder));
+        il.Emit(OpCodes.Call, EmitJsonParseHelper(typeBuilder, runtime));
         il.Emit(OpCodes.Stloc, resultLocal);
         il.Emit(OpCodes.Leave, endLabel);
 
@@ -53,7 +53,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
-    private MethodBuilder EmitJsonParseHelper(TypeBuilder typeBuilder)
+    private MethodBuilder EmitJsonParseHelper(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         // Parse JSON using RuntimeTypes helper
         var method = typeBuilder.DefineMethod(
@@ -64,26 +64,35 @@ public partial class RuntimeEmitter
         );
 
         var il = method.GetILGenerator();
+        var shapeLocal = il.DeclareLocal(_types.Object);
+        var (_, tryGetShape) = EmitJsonShapeAssociationHelpers(typeBuilder);
 
-        // Call RuntimeTypes.JsonParse directly - this method exists in the emitted assembly
+        // Carry a weakly associated closed shape only when the exact string
+        // instance came from the guarded shaped serializer.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, EmitJsonParseStaticHelper(typeBuilder));
+        il.Emit(OpCodes.Ldloca, shapeLocal);
+        il.Emit(OpCodes.Call, tryGetShape);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Call, EmitJsonParseStaticHelper(typeBuilder, runtime));
         il.Emit(OpCodes.Ret);
 
         return method;
     }
 
-    private MethodBuilder EmitJsonParseStaticHelper(TypeBuilder typeBuilder)
+    private MethodBuilder EmitJsonParseStaticHelper(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         var validateControlChars = EmitJsonValidateControlChars(typeBuilder);
-        var parseValue = EmitParseValueFromReaderHelper(typeBuilder);
+        var parseValue = EmitParseValueFromReaderHelper(typeBuilder, runtime);
 
         var method = typeBuilder.DefineMethod(
             "ParseJsonValue",
             MethodAttributes.Private | MethodAttributes.Static,
             _types.Object,
-            [_types.Object]
+            [_types.Object, _types.Object]
         );
+        method.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
 
         var il = method.GetILGenerator();
 
@@ -97,18 +106,25 @@ public partial class RuntimeEmitter
         // — standalone DLLs stay standalone. The token decoders (GetString/GetDouble)
         // are the SAME engine JsonDocument used, so the produced values are identical.
         var readerType = typeof(System.Text.Json.Utf8JsonReader);
+        var encodingType = typeof(System.Text.Encoding);
+        var bytePoolType = typeof(System.Buffers.ArrayPool<byte>);
+        var propertyNamesType = typeof(List<string>);
         var strLocal = il.DeclareLocal(_types.String);
         var bytesLocal = il.DeclareLocal(typeof(byte[]));
+        var byteCountLocal = il.DeclareLocal(_types.Int32);
+        var encodingLocal = il.DeclareLocal(encodingType);
         var optionsLocal = il.DeclareLocal(typeof(System.Text.Json.JsonReaderOptions));
         var readerLocal = il.DeclareLocal(readerType);
+        var propertyNamesLocal = il.DeclareLocal(propertyNamesType);
         var resultLocal = il.DeclareLocal(_types.Object);
         var notNullLabel = il.DefineLabel();
         var gotTokenLabel = il.DefineLabel();
+        var parsedLabel = il.DefineLabel();
         var okEndLabel = il.DefineLabel();
 
         // if (arg == null) return null;
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Brfalse_S, notNullLabel);
+        il.Emit(OpCodes.Brfalse, notNullLabel);
 
         // str = arg.ToString();
         il.Emit(OpCodes.Ldarg_0);
@@ -121,21 +137,56 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, strLocal);
         il.Emit(OpCodes.Call, validateControlChars);
 
-        // bytes = Encoding.UTF8.GetBytes(str)
-        il.Emit(OpCodes.Call, typeof(System.Text.Encoding).GetProperty("UTF8")!.GetGetMethod()!);
+        // encoding = Encoding.UTF8;
+        // byteCount = encoding.GetByteCount(str);
+        // bytes = ArrayPool<byte>.Shared.Rent(Math.Max(byteCount, 1));
+        il.Emit(OpCodes.Call, encodingType.GetProperty("UTF8")!.GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, encodingLocal);
+        il.Emit(OpCodes.Ldloc, encodingLocal);
         il.Emit(OpCodes.Ldloc, strLocal);
-        il.Emit(OpCodes.Callvirt, typeof(System.Text.Encoding).GetMethod("GetBytes", [typeof(string)])!);
+        il.Emit(OpCodes.Callvirt, encodingType.GetMethod("GetByteCount", [typeof(string)])!);
+        il.Emit(OpCodes.Stloc, byteCountLocal);
+        il.Emit(OpCodes.Call, bytePoolType.GetProperty("Shared")!.GetGetMethod()!);
+        il.Emit(OpCodes.Ldloc, byteCountLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Call, typeof(Math).GetMethod("Max", [typeof(int), typeof(int)])!);
+        il.Emit(OpCodes.Callvirt, bytePoolType.GetMethod("Rent", [typeof(int)])!);
         il.Emit(OpCodes.Stloc, bytesLocal);
 
-        // reader = new Utf8JsonReader((ReadOnlySpan<byte>)bytes, default)
+        // Return the bounded shared buffer even when transcoding or parsing throws.
+        il.BeginExceptionBlock();
+
+        // encoding.GetBytes(str, 0, str.Length, bytes, 0)
+        il.Emit(OpCodes.Ldloc, encodingLocal);
+        il.Emit(OpCodes.Ldloc, strLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldloc, strLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.String, "Length").GetGetMethod()!);
+        il.Emit(OpCodes.Ldloc, bytesLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Callvirt, encodingType.GetMethod(
+            "GetBytes",
+            [typeof(string), typeof(int), typeof(int), typeof(byte[]), typeof(int)])!);
+        il.Emit(OpCodes.Pop);
+
+        // reader = new Utf8JsonReader(new ReadOnlySpan<byte>(bytes, 0, byteCount), default)
         il.Emit(OpCodes.Ldloca, optionsLocal);
         il.Emit(OpCodes.Initobj, typeof(System.Text.Json.JsonReaderOptions));
         il.Emit(OpCodes.Ldloca, readerLocal);
         il.Emit(OpCodes.Ldloc, bytesLocal);
-        il.Emit(OpCodes.Call, typeof(ReadOnlySpan<byte>).GetMethod("op_Implicit", [typeof(byte[])])!);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldloc, byteCountLocal);
+        il.Emit(OpCodes.Newobj, typeof(ReadOnlySpan<byte>).GetConstructor(
+            [typeof(byte[]), typeof(int), typeof(int)])!);
         il.Emit(OpCodes.Ldloc, optionsLocal);
         il.Emit(OpCodes.Call, readerType.GetConstructor(
             [typeof(ReadOnlySpan<byte>), typeof(System.Text.Json.JsonReaderOptions)])!);
+
+        // Reuse repeated property-name strings within this document. The cache is
+        // deliberately small and parse-scoped so it cannot retain user data.
+        il.Emit(OpCodes.Ldc_I4_8);
+        il.Emit(OpCodes.Newobj, propertyNamesType.GetConstructor([typeof(int)])!);
+        il.Emit(OpCodes.Stloc, propertyNamesLocal);
 
         // if (!reader.Read()) throw  — empty input is not a valid JSON document.
         il.Emit(OpCodes.Ldloca, readerLocal);
@@ -146,8 +197,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Throw);
 
         il.MarkLabel(gotTokenLabel);
-        // result = ParseValueFromReader(ref reader)
+        // result = ParseValueFromReader(ref reader, propertyNames)
         il.Emit(OpCodes.Ldloca, readerLocal);
+        il.Emit(OpCodes.Ldloc, propertyNamesLocal);
+        il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Call, parseValue);
         il.Emit(OpCodes.Stloc, resultLocal);
 
@@ -155,10 +208,22 @@ public partial class RuntimeEmitter
         // trailing token is a SyntaxError (matches JsonDocument.Parse).
         il.Emit(OpCodes.Ldloca, readerLocal);
         il.Emit(OpCodes.Call, readerType.GetMethod("Read", Type.EmptyTypes)!);
-        il.Emit(OpCodes.Brfalse, okEndLabel);
+        il.Emit(OpCodes.Brfalse, parsedLabel);
         il.Emit(OpCodes.Ldstr, "Unexpected non-whitespace character after JSON");
         il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
         il.Emit(OpCodes.Throw);
+
+        il.MarkLabel(parsedLabel);
+        il.Emit(OpCodes.Leave, okEndLabel);
+
+        il.BeginFinallyBlock();
+        il.Emit(OpCodes.Call, bytePoolType.GetProperty("Shared")!.GetGetMethod()!);
+        il.Emit(OpCodes.Ldloc, bytesLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Callvirt, bytePoolType.GetMethod(
+            "Return",
+            [typeof(byte[]), typeof(bool)])!);
+        il.EndExceptionBlock();
 
         il.MarkLabel(okEndLabel);
         il.Emit(OpCodes.Ldloc, resultLocal);
@@ -319,7 +384,8 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
-    /// Emits <c>object? ParseValueFromReader(ref Utf8JsonReader reader)</c>: a recursive
+    /// Emits <c>object? ParseValueFromReader(ref Utf8JsonReader reader,
+    /// List&lt;string&gt; propertyNames)</c>: a recursive
     /// descent that consumes the value at the reader's current position and returns the
     /// runtime graph node for it — <c>Dictionary&lt;string,object?&gt;</c> for objects,
     /// <c>List&lt;object?&gt;</c> for arrays, a boxed double / bool, a string, or null.
@@ -329,26 +395,41 @@ public partial class RuntimeEmitter
     /// JsonDocument walker produced, so the resulting graph (consumed by the reviver and
     /// everything downstream) is byte-for-byte the same.
     /// </summary>
-    private MethodBuilder EmitParseValueFromReaderHelper(TypeBuilder typeBuilder)
+    private MethodBuilder EmitParseValueFromReaderHelper(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime)
     {
         var readerType = typeof(System.Text.Json.Utf8JsonReader);
+        var propertyNamesType = typeof(List<string>);
         var readMethod = readerType.GetMethod("Read", Type.EmptyTypes)!;
         var tokenTypeGetter = readerType.GetProperty("TokenType")!.GetGetMethod()!;
         var getStringMethod = readerType.GetMethod("GetString", Type.EmptyTypes)!;
         var getDoubleMethod = readerType.GetMethod("GetDouble", Type.EmptyTypes)!;
+        var getPropertyName = EmitJsonPropertyNameHelper(typeBuilder);
 
         var method = typeBuilder.DefineMethod(
             "ParseValueFromReader",
             MethodAttributes.Private | MethodAttributes.Static,
             _types.Object,
-            [readerType.MakeByRefType()]
+            [readerType.MakeByRefType(), propertyNamesType, _types.Object]
         );
+        method.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
 
         var il = method.GetILGenerator();
 
         var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
         var listLocal = il.DeclareLocal(_types.ListOfObject);
         var nameLocal = il.DeclareLocal(_types.String);
+        var shapeLocal = il.DeclareLocal(_types.ObjectArray);
+        var childShapeLocal = il.DeclareLocal(_types.Object);
+        var parsedValueLocal = il.DeclareLocal(_types.Object);
+        var shapeIndexLocal = il.DeclareLocal(_types.Int32);
+        var valueIndexLocal = il.DeclareLocal(_types.Int32);
+        var valueCountLocal = il.DeclareLocal(_types.Int32);
+        var overflowValuesLocal = il.DeclareLocal(_types.ObjectArray);
+        var valueLocals = Enumerable.Range(0, 4)
+            .Select(_ => il.DeclareLocal(_types.Object))
+            .ToArray();
 
         var objectLabel = il.DefineLabel();
         var arrayLabel = il.DefineLabel();
@@ -357,6 +438,7 @@ public partial class RuntimeEmitter
         var trueLabel = il.DefineLabel();
         var falseLabel = il.DefineLabel();
         var nullLabel = il.DefineLabel();
+        var shapedObjectLabel = il.DefineLabel();
 
         // switch (reader.TokenType) — same dup/Beq ladder shape as the old DOM walker.
         il.Emit(OpCodes.Ldarg_0);
@@ -392,6 +474,23 @@ public partial class RuntimeEmitter
         // --- Object: { (PropertyName value)* } ---
         il.MarkLabel(objectLabel);
         il.Emit(OpCodes.Pop); // pop tokenType
+        var genericObjectLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Isinst, _types.ObjectArray);
+        il.Emit(OpCodes.Stloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Brfalse, genericObjectLabel);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Ldstr, "$O");
+        // Shape tags are emitted ldstr literals in this module. Reference
+        // identity is therefore exact, verifier-safe, and avoids a checked
+        // cast plus string equality for every parsed record.
+        il.Emit(OpCodes.Ceq);
+        il.Emit(OpCodes.Brtrue, shapedObjectLabel);
+
+        il.MarkLabel(genericObjectLabel);
         il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.DictionaryStringObject));
         il.Emit(OpCodes.Stloc, dictLocal);
 
@@ -406,9 +505,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, tokenTypeGetter);
         il.Emit(OpCodes.Ldc_I4, (int)System.Text.Json.JsonTokenType.EndObject);
         il.Emit(OpCodes.Beq, objEnd);
-        // name = reader.GetString() (current token is the property name)
+        // name = GetJsonPropertyName(ref reader, propertyNames)
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, getStringMethod);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, getPropertyName);
         il.Emit(OpCodes.Stloc, nameLocal);
         // reader.Read() → the value's first token
         il.Emit(OpCodes.Ldarg_0);
@@ -418,6 +518,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, dictLocal);
         il.Emit(OpCodes.Ldloc, nameLocal);
         il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Call, method); // recursive
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item", [_types.String, _types.Object]));
         il.Emit(OpCodes.Br, objLoop);
@@ -426,9 +528,147 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, dictLocal);
         il.Emit(OpCodes.Ret);
 
+        // --- Closed shaped object: parse directly into fixed scalar slots. ---
+        il.MarkLabel(shapedObjectLabel);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Div);
+        il.Emit(OpCodes.Stloc, valueCountLocal);
+        var fixedValues = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, valueCountLocal);
+        il.Emit(OpCodes.Ldc_I4_4);
+        il.Emit(OpCodes.Ble, fixedValues);
+        il.Emit(OpCodes.Ldloc, valueCountLocal);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Stloc, overflowValuesLocal);
+        il.MarkLabel(fixedValues);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, shapeIndexLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, valueIndexLocal);
+
+        var shapedLoop = il.DefineLabel();
+        var shapedEnd = il.DefineLabel();
+        var shapedMismatch = il.DefineLabel();
+        il.MarkLabel(shapedLoop);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, readMethod);
+        il.Emit(OpCodes.Brfalse, shapedEnd);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, tokenTypeGetter);
+        il.Emit(OpCodes.Ldc_I4, (int)System.Text.Json.JsonTokenType.EndObject);
+        il.Emit(OpCodes.Beq, shapedEnd);
+        // The shape association is identity-based on the immutable string, but
+        // retain an allocation-free key check as a corruption guard.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, shapeIndexLocal);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Call, readerType.GetMethod("ValueTextEquals", [typeof(string)])!);
+        il.Emit(OpCodes.Brfalse, shapedMismatch);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, readMethod);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, shapeIndexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Call, method);
+        il.Emit(OpCodes.Stloc, parsedValueLocal);
+
+        var overflowStore = il.DefineLabel();
+        var storedValue = il.DefineLabel();
+        var storeLabels = valueLocals.Select(_ => il.DefineLabel()).ToArray();
+        il.Emit(OpCodes.Ldloc, overflowValuesLocal);
+        il.Emit(OpCodes.Brtrue, overflowStore);
+        il.Emit(OpCodes.Ldloc, valueIndexLocal);
+        il.Emit(OpCodes.Switch, storeLabels);
+        il.Emit(OpCodes.Br, shapedMismatch);
+        for (int index = 0; index < valueLocals.Length; index++)
+        {
+            il.MarkLabel(storeLabels[index]);
+            il.Emit(OpCodes.Ldloc, parsedValueLocal);
+            il.Emit(OpCodes.Stloc, valueLocals[index]);
+            il.Emit(OpCodes.Br, storedValue);
+        }
+        il.MarkLabel(overflowStore);
+        il.Emit(OpCodes.Ldloc, overflowValuesLocal);
+        il.Emit(OpCodes.Ldloc, valueIndexLocal);
+        il.Emit(OpCodes.Ldloc, parsedValueLocal);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.MarkLabel(storedValue);
+        il.Emit(OpCodes.Ldloc, shapeIndexLocal);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, shapeIndexLocal);
+        il.Emit(OpCodes.Ldloc, valueIndexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, valueIndexLocal);
+        il.Emit(OpCodes.Br, shapedLoop);
+
+        il.MarkLabel(shapedEnd);
+        il.Emit(OpCodes.Ldloc, valueIndexLocal);
+        il.Emit(OpCodes.Ldloc, valueCountLocal);
+        il.Emit(OpCodes.Bne_Un, shapedMismatch);
+        var overflowConstruct = il.DefineLabel();
+        var constructLabels = Enumerable.Range(0, 4)
+            .Select(_ => il.DefineLabel()).ToArray();
+        il.Emit(OpCodes.Ldloc, overflowValuesLocal);
+        il.Emit(OpCodes.Brtrue, overflowConstruct);
+        il.Emit(OpCodes.Ldloc, valueCountLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Switch, constructLabels);
+        il.Emit(OpCodes.Br, shapedMismatch);
+        for (int arity = 1; arity <= 4; arity++)
+        {
+            il.MarkLabel(constructLabels[arity - 1]);
+            il.Emit(OpCodes.Ldloc, shapeLocal);
+            for (int index = 0; index < arity; index++)
+                il.Emit(OpCodes.Ldloc, valueLocals[index]);
+            il.Emit(OpCodes.Newobj, runtime.JsonScalarRecordInlineCtors[arity]);
+            il.Emit(OpCodes.Ret);
+        }
+        il.MarkLabel(overflowConstruct);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, overflowValuesLocal);
+        il.Emit(OpCodes.Newobj, runtime.JsonScalarRecordCtor);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(shapedMismatch);
+        il.Emit(OpCodes.Ldstr, "JSON shape association mismatch");
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
+        il.Emit(OpCodes.Throw);
+
         // --- Array: [ value* ] ---
         il.MarkLabel(arrayLabel);
         il.Emit(OpCodes.Pop); // pop tokenType
+        var arrayShapeReady = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Isinst, _types.ObjectArray);
+        il.Emit(OpCodes.Stloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Brfalse, arrayShapeReady);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Ldstr, "$A");
+        il.Emit(OpCodes.Ceq);
+        il.Emit(OpCodes.Brfalse, arrayShapeReady);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Stloc, childShapeLocal);
+        il.MarkLabel(arrayShapeReady);
         il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.ListOfObject));
         il.Emit(OpCodes.Stloc, listLocal);
 
@@ -446,6 +686,8 @@ public partial class RuntimeEmitter
         // list.Add(ParseValueFromReader(ref reader))
         il.Emit(OpCodes.Ldloc, listLocal);
         il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, childShapeLocal);
         il.Emit(OpCodes.Call, method); // recursive
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", [_types.Object]));
         il.Emit(OpCodes.Br, arrLoop);
@@ -485,6 +727,83 @@ public partial class RuntimeEmitter
         // --- Null / None / unhandled ---
         il.MarkLabel(nullLabel);
         il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ret);
+
+        return method;
+    }
+
+    /// <summary>
+    /// Emits a bounded, per-parse property-name cache. <c>ValueTextEquals</c>
+    /// compares the reader's UTF-8 token without allocating a candidate string,
+    /// so record arrays reuse the first materialized "id" / "label" instances.
+    /// </summary>
+    private MethodBuilder EmitJsonPropertyNameHelper(TypeBuilder typeBuilder)
+    {
+        var readerType = typeof(System.Text.Json.Utf8JsonReader);
+        var propertyNamesType = typeof(List<string>);
+        var method = typeBuilder.DefineMethod(
+            "GetJsonPropertyName",
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.String,
+            [readerType.MakeByRefType(), propertyNamesType]
+        );
+
+        var il = method.GetILGenerator();
+        var indexLocal = il.DeclareLocal(_types.Int32);
+        var candidateLocal = il.DeclareLocal(_types.String);
+        var nameLocal = il.DeclareLocal(_types.String);
+        var loopLabel = il.DefineLabel();
+        var missLabel = il.DefineLabel();
+        var returnCandidateLabel = il.DefineLabel();
+        var returnNameLabel = il.DefineLabel();
+        var countGetter = propertyNamesType.GetProperty("Count")!.GetGetMethod()!;
+
+        // for (int i = 0; i < propertyNames.Count; i++)
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        il.MarkLabel(loopLabel);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, countGetter);
+        il.Emit(OpCodes.Bge, missLabel);
+
+        // candidate = propertyNames[i];
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Callvirt, propertyNamesType.GetMethod("get_Item", [typeof(int)])!);
+        il.Emit(OpCodes.Stloc, candidateLocal);
+
+        // if (reader.ValueTextEquals(candidate)) return candidate;
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, candidateLocal);
+        il.Emit(OpCodes.Call, readerType.GetMethod("ValueTextEquals", [typeof(string)])!);
+        il.Emit(OpCodes.Brtrue, returnCandidateLabel);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        il.Emit(OpCodes.Br, loopLabel);
+
+        // string name = reader.GetString()!;
+        // if (propertyNames.Count < 64) propertyNames.Add(name);
+        il.MarkLabel(missLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, readerType.GetMethod("GetString", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Stloc, nameLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, countGetter);
+        il.Emit(OpCodes.Ldc_I4, 64);
+        il.Emit(OpCodes.Bge, returnNameLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, nameLocal);
+        il.Emit(OpCodes.Callvirt, propertyNamesType.GetMethod("Add", [typeof(string)])!);
+
+        il.MarkLabel(returnNameLabel);
+        il.Emit(OpCodes.Ldloc, nameLocal);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(returnCandidateLabel);
+        il.Emit(OpCodes.Ldloc, candidateLocal);
         il.Emit(OpCodes.Ret);
 
         return method;

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.ScalarRecord.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.ScalarRecord.cs
@@ -1,0 +1,398 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    /// <summary>
+    /// Emits a compact ordinary-record carrier for closed scalar object
+    /// literals. Reads stay slot-backed; any consumer asking for Fields or any
+    /// write lazily creates the canonical Dictionary representation. This keeps
+    /// general object semantics on the existing paths while JSON can consume an
+    /// untouched exact-shape record without per-record dictionary storage.
+    /// </summary>
+    private void EmitJsonScalarRecordClass(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        var typeBuilder = EmitTypeDefinitions.DefineType(
+            moduleBuilder,
+            "$JsonScalarRecord",
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed |
+            TypeAttributes.BeforeFieldInit,
+            _types.Object);
+        runtime.JsonScalarRecordType = typeBuilder;
+        EmitTypeDefinitions.AddInterfaceImplementation(typeBuilder, runtime.IHasFieldsInterface);
+
+        var shapeField = typeBuilder.DefineField("_shape", _types.Object, FieldAttributes.Private);
+        var valuesField = typeBuilder.DefineField("_values", _types.ObjectArray, FieldAttributes.Private);
+        var inlineValueFields = Enumerable.Range(0, 4)
+            .Select(index => typeBuilder.DefineField(
+                $"_v{index}", _types.Object, FieldAttributes.Private))
+            .ToArray();
+        var materializedField = typeBuilder.DefineField(
+            "_materialized", _types.DictionaryStringObject, FieldAttributes.Private);
+
+        var ctor = typeBuilder.DefineConstructor(
+            MethodAttributes.Public,
+            CallingConventions.Standard,
+            [_types.Object, _types.ObjectArray]);
+        runtime.JsonScalarRecordCtor = ctor;
+        var ctorIl = ctor.GetILGenerator();
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Call, _types.GetConstructor(_types.Object, Type.EmptyTypes)!);
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Ldarg_1);
+        ctorIl.Emit(OpCodes.Stfld, shapeField);
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Ldarg_2);
+        ctorIl.Emit(OpCodes.Stfld, valuesField);
+        ctorIl.Emit(OpCodes.Ret);
+
+        for (int arity = 1; arity <= inlineValueFields.Length; arity++)
+        {
+            var parameterTypes = new Type[arity + 1];
+            parameterTypes[0] = _types.Object;
+            Array.Fill(parameterTypes, _types.Object, 1, arity);
+            var inlineCtor = typeBuilder.DefineConstructor(
+                MethodAttributes.Public,
+                CallingConventions.Standard,
+                parameterTypes);
+            runtime.JsonScalarRecordInlineCtors.Add(arity, inlineCtor);
+            var inlineIl = inlineCtor.GetILGenerator();
+            inlineIl.Emit(OpCodes.Ldarg_0);
+            inlineIl.Emit(OpCodes.Call, _types.GetConstructor(_types.Object, Type.EmptyTypes)!);
+            inlineIl.Emit(OpCodes.Ldarg_0);
+            inlineIl.Emit(OpCodes.Ldarg_1);
+            inlineIl.Emit(OpCodes.Stfld, shapeField);
+            for (int index = 0; index < arity; index++)
+            {
+                inlineIl.Emit(OpCodes.Ldarg_0);
+                inlineIl.Emit(OpCodes.Ldarg, index + 2);
+                inlineIl.Emit(OpCodes.Stfld, inlineValueFields[index]);
+            }
+            inlineIl.Emit(OpCodes.Ret);
+        }
+
+        runtime.JsonScalarRecordShapeGetter = EmitSimpleGetter(
+            "get_Shape", _types.Object, shapeField);
+        runtime.JsonScalarRecordValuesGetter = EmitSimpleGetter(
+            "get_Values", _types.ObjectArray, valuesField);
+
+        var getValue = typeBuilder.DefineMethod(
+            "GetValue",
+            MethodAttributes.Public | MethodAttributes.HideBySig,
+            _types.Object,
+            [_types.Int32]);
+        getValue.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
+        runtime.JsonScalarRecordGetValue = getValue;
+        var getValueIl = getValue.GetILGenerator();
+        var inline = getValueIl.DefineLabel();
+        getValueIl.Emit(OpCodes.Ldarg_0);
+        getValueIl.Emit(OpCodes.Ldfld, valuesField);
+        getValueIl.Emit(OpCodes.Dup);
+        getValueIl.Emit(OpCodes.Brfalse, inline);
+        getValueIl.Emit(OpCodes.Ldarg_1);
+        getValueIl.Emit(OpCodes.Ldelem_Ref);
+        getValueIl.Emit(OpCodes.Ret);
+        getValueIl.MarkLabel(inline);
+        getValueIl.Emit(OpCodes.Pop);
+        var valueLabels = inlineValueFields.Select(_ => getValueIl.DefineLabel()).ToArray();
+        getValueIl.Emit(OpCodes.Ldarg_1);
+        getValueIl.Emit(OpCodes.Switch, valueLabels);
+        getValueIl.Emit(OpCodes.Ldnull);
+        getValueIl.Emit(OpCodes.Ret);
+        for (int index = 0; index < inlineValueFields.Length; index++)
+        {
+            getValueIl.MarkLabel(valueLabels[index]);
+            getValueIl.Emit(OpCodes.Ldarg_0);
+            getValueIl.Emit(OpCodes.Ldfld, inlineValueFields[index]);
+            getValueIl.Emit(OpCodes.Ret);
+        }
+
+        var isMaterialized = typeBuilder.DefineMethod(
+            "get_IsMaterialized",
+            MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+            _types.Boolean,
+            Type.EmptyTypes);
+        runtime.JsonScalarRecordIsMaterializedGetter = isMaterialized;
+        var materializedIl = isMaterialized.GetILGenerator();
+        materializedIl.Emit(OpCodes.Ldarg_0);
+        materializedIl.Emit(OpCodes.Ldfld, materializedField);
+        materializedIl.Emit(OpCodes.Ldnull);
+        materializedIl.Emit(OpCodes.Cgt_Un);
+        materializedIl.Emit(OpCodes.Ret);
+
+        var ensure = typeBuilder.DefineMethod(
+            "EnsureMaterialized",
+            MethodAttributes.Private,
+            _types.DictionaryStringObject,
+            Type.EmptyTypes);
+        EmitEnsureMaterialized(ensure.GetILGenerator(), shapeField, getValue, materializedField);
+
+        var fieldsGetter = typeBuilder.DefineMethod(
+            "get_Fields",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.SpecialName |
+            MethodAttributes.HideBySig,
+            _types.DictionaryStringObject,
+            Type.EmptyTypes);
+        var fieldsIl = fieldsGetter.GetILGenerator();
+        fieldsIl.Emit(OpCodes.Ldarg_0);
+        fieldsIl.Emit(OpCodes.Call, ensure);
+        fieldsIl.Emit(OpCodes.Ret);
+        typeBuilder.DefineMethodOverride(fieldsGetter, runtime.IHasFieldsFieldsGetter);
+
+        var getProperty = typeBuilder.DefineMethod(
+            "GetProperty",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+            _types.Object,
+            [_types.String]);
+        getProperty.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
+        EmitScalarGetProperty(
+            getProperty.GetILGenerator(), shapeField, getValue, materializedField);
+        typeBuilder.DefineMethodOverride(getProperty, runtime.IHasFieldsGetProperty);
+
+        var setProperty = typeBuilder.DefineMethod(
+            "SetProperty",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+            _types.Void,
+            [_types.String, _types.Object]);
+        var setIl = setProperty.GetILGenerator();
+        setIl.Emit(OpCodes.Ldarg_0);
+        setIl.Emit(OpCodes.Call, ensure);
+        setIl.Emit(OpCodes.Ldarg_1);
+        setIl.Emit(OpCodes.Ldarg_2);
+        setIl.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.DictionaryStringObject, "set_Item", [_types.String, _types.Object])!);
+        setIl.Emit(OpCodes.Ret);
+        typeBuilder.DefineMethodOverride(setProperty, runtime.IHasFieldsSetProperty);
+
+        var hasProperty = typeBuilder.DefineMethod(
+            "HasProperty",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+            _types.Boolean,
+            [_types.String]);
+        EmitScalarHasProperty(
+            hasProperty.GetILGenerator(), shapeField, materializedField);
+        typeBuilder.DefineMethodOverride(hasProperty, runtime.IHasFieldsHasProperty);
+
+        typeBuilder.CreateType();
+
+        MethodBuilder EmitSimpleGetter(string name, Type returnType, FieldBuilder field)
+        {
+            var getter = typeBuilder.DefineMethod(
+                name,
+                MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+                returnType,
+                Type.EmptyTypes);
+            var il = getter.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, field);
+            il.Emit(OpCodes.Ret);
+            return getter;
+        }
+    }
+
+    private void EmitEnsureMaterialized(
+        ILGenerator il,
+        FieldBuilder shapeField,
+        MethodBuilder getValue,
+        FieldBuilder materializedField)
+    {
+        var shapeLocal = il.DeclareLocal(_types.ObjectArray);
+        var resultLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var indexLocal = il.DeclareLocal(_types.Int32);
+        var valueIndexLocal = il.DeclareLocal(_types.Int32);
+        var build = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, materializedField);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brfalse, build);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(build);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, shapeField);
+        il.Emit(OpCodes.Castclass, _types.ObjectArray);
+        il.Emit(OpCodes.Stloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Div);
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(
+            _types.DictionaryStringObject, [_types.Int32])!);
+        il.Emit(OpCodes.Stloc, resultLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, valueIndexLocal);
+
+        var loop = il.DefineLabel();
+        var done = il.DefineLabel();
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Bge, done);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, valueIndexLocal);
+        il.Emit(OpCodes.Call, getValue);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.DictionaryStringObject, "set_Item", [_types.String, _types.Object])!);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        il.Emit(OpCodes.Ldloc, valueIndexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, valueIndexLocal);
+        il.Emit(OpCodes.Br, loop);
+
+        il.MarkLabel(done);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Stfld, materializedField);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitScalarGetProperty(
+        ILGenerator il,
+        FieldBuilder shapeField,
+        MethodBuilder getValue,
+        FieldBuilder materializedField)
+    {
+        var shapeLocal = il.DeclareLocal(_types.ObjectArray);
+        var indexLocal = il.DeclareLocal(_types.Int32);
+        var valueIndexLocal = il.DeclareLocal(_types.Int32);
+        var valueLocal = il.DeclareLocal(_types.Object);
+        var compact = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, materializedField);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brfalse, compact);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloca, valueLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.DictionaryStringObject,
+            "TryGetValue",
+            [_types.String, _types.Object.MakeByRefType()])!);
+        var materializedMiss = il.DefineLabel();
+        il.Emit(OpCodes.Brfalse, materializedMiss);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(materializedMiss);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(compact);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, shapeField);
+        il.Emit(OpCodes.Castclass, _types.ObjectArray);
+        il.Emit(OpCodes.Stloc, shapeLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, valueIndexLocal);
+        var loop = il.DefineLabel();
+        var miss = il.DefineLabel();
+        var next = il.DefineLabel();
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Bge, miss);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.String, "op_Equality", [_types.String, _types.String])!);
+        il.Emit(OpCodes.Brfalse, next);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, valueIndexLocal);
+        il.Emit(OpCodes.Call, getValue);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(next);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        il.Emit(OpCodes.Ldloc, valueIndexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, valueIndexLocal);
+        il.Emit(OpCodes.Br, loop);
+        il.MarkLabel(miss);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitScalarHasProperty(
+        ILGenerator il,
+        FieldBuilder shapeField,
+        FieldBuilder materializedField)
+    {
+        var shapeLocal = il.DeclareLocal(_types.ObjectArray);
+        var indexLocal = il.DeclareLocal(_types.Int32);
+        var compact = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, materializedField);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brfalse, compact);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.DictionaryStringObject, "ContainsKey", [_types.String])!);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(compact);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, shapeField);
+        il.Emit(OpCodes.Castclass, _types.ObjectArray);
+        il.Emit(OpCodes.Stloc, shapeLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        var loop = il.DefineLabel();
+        var miss = il.DefineLabel();
+        var next = il.DefineLabel();
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Bge, miss);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.String, "op_Equality", [_types.String, _types.String])!);
+        il.Emit(OpCodes.Brfalse, next);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(next);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        il.Emit(OpCodes.Br, loop);
+        il.MarkLabel(miss);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+    }
+}

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.Append.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.Append.cs
@@ -1,0 +1,604 @@
+using System.Globalization;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    private MethodBuilder? _appendJsonValueMethod;
+    private MethodBuilder? _appendJsonNumberMethod;
+
+    /// <summary>
+    /// Emits integer-valued finite doubles directly into a StringBuilder-owned
+    /// span. Other numbers retain the shared ECMAScript formatter.
+    /// </summary>
+    private MethodBuilder EmitAppendJsonNumberHelper(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime)
+    {
+        if (_appendJsonNumberMethod is not null)
+            return _appendJsonNumberMethod;
+
+        var method = typeBuilder.DefineMethod(
+            "AppendJsonNumber",
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.Void,
+            [_types.StringBuilder, _types.Double]);
+        method.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
+        _appendJsonNumberMethod = method;
+
+        var numberBufferField = typeBuilder.DefineField(
+            "_jsonNumberBuffer",
+            typeof(char[]),
+            FieldAttributes.Private | FieldAttributes.Static);
+        numberBufferField.SetCustomAttribute(
+            typeof(ThreadStaticAttribute).GetConstructor(Type.EmptyTypes)!,
+            CustomAttributeEncoder.EmptyBlob);
+
+        var il = method.GetILGenerator();
+        var spanLocal = il.DeclareLocal(typeof(Span<char>));
+        var bufferLocal = il.DeclareLocal(typeof(char[]));
+        var formatLocal = il.DeclareLocal(typeof(ReadOnlySpan<char>));
+        var charsWrittenLocal = il.DeclareLocal(_types.Int32);
+        var integerLocal = il.DeclareLocal(typeof(long));
+        var appendNull = il.DefineLabel();
+        var fallback = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsNaN", [_types.Double]));
+        il.Emit(OpCodes.Brtrue, appendNull);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsInfinity", [_types.Double]));
+        il.Emit(OpCodes.Brtrue, appendNull);
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, typeof(Math).GetMethod("Truncate", [typeof(double)])!);
+        il.Emit(OpCodes.Bne_Un, fallback);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, typeof(Math).GetMethod("Abs", [typeof(double)])!);
+        il.Emit(OpCodes.Ldc_R8, 9_007_199_254_740_992.0);
+        il.Emit(OpCodes.Bge_Un, fallback);
+
+        // Reuse a bounded per-thread maximum-width buffer. Formatting and
+        // StringBuilder.Append(char[], start, count) create no child string.
+        var bufferReady = il.DefineLabel();
+        il.Emit(OpCodes.Ldsfld, numberBufferField);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brtrue, bufferReady);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldc_I4, 20);
+        il.Emit(OpCodes.Newarr, _types.Char);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Stsfld, numberBufferField);
+        il.MarkLabel(bufferReady);
+        il.Emit(OpCodes.Stloc, bufferLocal);
+        il.Emit(OpCodes.Ldloc, bufferLocal);
+        il.Emit(OpCodes.Call, typeof(Span<char>).GetMethod(
+            "op_Implicit",
+            [typeof(char[])])!);
+        il.Emit(OpCodes.Stloc, spanLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Conv_I8);
+        il.Emit(OpCodes.Stloc, integerLocal);
+        il.Emit(OpCodes.Ldloca, formatLocal);
+        il.Emit(OpCodes.Initobj, typeof(ReadOnlySpan<char>));
+        il.Emit(OpCodes.Ldloca, integerLocal);
+        il.Emit(OpCodes.Ldloc, spanLocal);
+        il.Emit(OpCodes.Ldloca, charsWrittenLocal);
+        il.Emit(OpCodes.Ldloc, formatLocal);
+        il.Emit(OpCodes.Call, typeof(CultureInfo).GetProperty("InvariantCulture")!.GetGetMethod()!);
+        il.Emit(OpCodes.Call, typeof(long).GetMethod(
+            "TryFormat",
+            [
+                typeof(Span<char>),
+                typeof(int).MakeByRefType(),
+                typeof(ReadOnlySpan<char>),
+                typeof(IFormatProvider)
+            ])!);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, bufferLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldloc, charsWrittenLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.StringBuilder,
+            "Append",
+            [typeof(char[]), _types.Int32, _types.Int32])!);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(appendNull);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "null");
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.StringBuilder, "Append", [_types.String]));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(fallback);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.FormatNumber);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.StringBuilder, "Append", [_types.String]));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+        return method;
+    }
+
+    /// <summary>
+    /// Emits the no-replacer/no-space single-destination serializer. One root
+    /// builder owns the complete result; recursive calls append into it and
+    /// return false only for JSON-undefined values.
+    /// </summary>
+    private MethodBuilder EmitAppendJsonValueHelper(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime)
+    {
+        if (_appendJsonValueMethod is not null)
+            return _appendJsonValueMethod;
+
+        var appendNumber = EmitAppendJsonNumberHelper(typeBuilder, runtime);
+        var method = typeBuilder.DefineMethod(
+            "AppendJsonValue",
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.Boolean,
+            [
+                _types.StringBuilder, // destination
+                _types.Object,        // value
+                _types.Int32,         // depth
+                _types.String,        // string/root key (null for array indices)
+                _types.Int32,         // array index
+                _types.Boolean,       // key is array index
+                _types.Boolean,       // emit object-property prefix
+                _types.Boolean        // prefix needs comma
+            ]);
+        _appendJsonValueMethod = method;
+
+        var il = method.GetILGenerator();
+        var valueLocal = il.DeclareLocal(_types.Object);
+        var allowPooledKeysLocal = il.DeclareLocal(_types.Boolean);
+        var rawJsonLabel = il.DefineLabel();
+        var nullLabel = il.DefineLabel();
+        var boolLabel = il.DefineLabel();
+        var numberLabel = il.DefineLabel();
+        var stringLabel = il.DefineLabel();
+        var arrayLabel = il.DefineLabel();
+        var objectLabel = il.DefineLabel();
+        var classLabel = il.DefineLabel();
+        var regexpLabel = il.DefineLabel();
+        var falseLabel = il.DefineLabel();
+        var dispatchLabel = il.DefineLabel();
+
+        var depthOk = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldc_I4, 512);
+        il.Emit(OpCodes.Blt, depthOk);
+        GuestErrorEmitter.ThrowTypeError(il, runtime, "Converting circular structure to JSON");
+        il.MarkLabel(depthOk);
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Stloc, valueLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, allowPooledKeysLocal);
+
+        // Undefined is the only ordinary false result: roots map it to the
+        // singleton, arrays substitute null, and objects omit the property.
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, falseLabel);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Brfalse, dispatchLabel);
+
+        EmitToJsonCheck(
+            il,
+            valueLocal,
+            runtime,
+            keyArgIndex: 3,
+            keyIndexArgIndex: 4,
+            keyIsIndexArgIndex: 5);
+
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, falseLabel);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Brfalse, dispatchLabel);
+
+        // Callable and symbol values serialize as undefined.
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSSymbolType);
+        il.Emit(OpCodes.Brtrue, falseLabel);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSFunctionType);
+        il.Emit(OpCodes.Brtrue, falseLabel);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, runtime.BoundTSFunctionType);
+        il.Emit(OpCodes.Brtrue, falseLabel);
+
+        EmitBoxedPrimitiveJsonCoerce(il, valueLocal, runtime);
+        EmitBigIntCheck(il, valueLocal, runtime);
+
+        var notProxy = il.DefineLabel();
+        EmitProxyMaterializeForJson(il, valueLocal, notProxy, runtime);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, allowPooledKeysLocal);
+        il.Emit(OpCodes.Br, dispatchLabel);
+        il.MarkLabel(notProxy);
+
+        // Nothing below can produce JSON-undefined, so the object-property
+        // prefix is safe to append exactly once now.
+        il.MarkLabel(dispatchLabel);
+        EmitAppendJsonPropertyPrefix(il);
+
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Brfalse, nullLabel);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSRawJsonType);
+        il.Emit(OpCodes.Brtrue, rawJsonLabel);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, _types.Boolean);
+        il.Emit(OpCodes.Brtrue, boolLabel);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, _types.Double);
+        il.Emit(OpCodes.Brtrue, numberLabel);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Brtrue, stringLabel);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, _types.ListOfObject);
+        il.Emit(OpCodes.Brtrue, arrayLabel);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Brtrue, objectLabel);
+        if (_features.UsesRegExp)
+        {
+            il.Emit(OpCodes.Ldloc, valueLocal);
+            il.Emit(OpCodes.Isinst, runtime.TSRegExpType);
+            il.Emit(OpCodes.Brtrue, regexpLabel);
+        }
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, runtime.IHasFieldsInterface);
+        il.Emit(OpCodes.Brtrue, classLabel);
+        il.Emit(OpCodes.Br, nullLabel);
+
+        il.MarkLabel(rawJsonLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Castclass, runtime.TSRawJsonType);
+        il.Emit(OpCodes.Callvirt, runtime.TSRawJsonTextGetter);
+        EmitStringBuilderAppendString(il);
+        EmitTrueReturn(il);
+
+        il.MarkLabel(nullLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "null");
+        EmitStringBuilderAppendString(il);
+        EmitTrueReturn(il);
+
+        il.MarkLabel(boolLabel);
+        var appendFalse = il.DefineLabel();
+        var boolDone = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Unbox_Any, _types.Boolean);
+        il.Emit(OpCodes.Brfalse, appendFalse);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "true");
+        EmitStringBuilderAppendString(il);
+        il.Emit(OpCodes.Br, boolDone);
+        il.MarkLabel(appendFalse);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "false");
+        EmitStringBuilderAppendString(il);
+        il.MarkLabel(boolDone);
+        EmitTrueReturn(il);
+
+        il.MarkLabel(numberLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Unbox_Any, _types.Double);
+        il.Emit(OpCodes.Call, appendNumber);
+        EmitTrueReturn(il);
+
+        il.MarkLabel(stringLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Call, _appendEscapedJsonStringMethod!);
+        EmitTrueReturn(il);
+
+        il.MarkLabel(arrayLabel);
+        EmitAppendJsonArray(il, method, valueLocal, runtime);
+
+        il.MarkLabel(objectLabel);
+        EmitAppendJsonObject(
+            il,
+            method,
+            valueLocal,
+            allowPooledKeysLocal,
+            runtime);
+
+        il.MarkLabel(classLabel);
+        var fieldsLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Call, runtime.TSObjectMergeEnumerable);
+        il.Emit(OpCodes.Stloc, fieldsLocal);
+        il.Emit(OpCodes.Ldloc, fieldsLocal);
+        il.Emit(OpCodes.Brfalse, regexpLabel);
+        il.Emit(OpCodes.Ldloc, fieldsLocal);
+        il.Emit(OpCodes.Stloc, valueLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, allowPooledKeysLocal);
+        il.Emit(OpCodes.Br, objectLabel);
+
+        il.MarkLabel(regexpLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "{}");
+        EmitStringBuilderAppendString(il);
+        EmitTrueReturn(il);
+
+        il.MarkLabel(falseLabel);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+        return method;
+    }
+
+    private void EmitAppendJsonPropertyPrefix(ILGenerator il)
+    {
+        var noPrefix = il.DefineLabel();
+        var noComma = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg, 6);
+        il.Emit(OpCodes.Brfalse, noPrefix);
+        il.Emit(OpCodes.Ldarg, 7);
+        il.Emit(OpCodes.Brfalse, noComma);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4, (int)',');
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.StringBuilder, "Append", [_types.Char]));
+        il.Emit(OpCodes.Pop);
+        il.MarkLabel(noComma);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_3);
+        il.Emit(OpCodes.Call, _appendEscapedJsonStringMethod!);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4, (int)':');
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.StringBuilder, "Append", [_types.Char]));
+        il.Emit(OpCodes.Pop);
+        il.MarkLabel(noPrefix);
+    }
+
+    private void EmitAppendJsonArray(
+        ILGenerator il,
+        MethodBuilder appendValue,
+        LocalBuilder valueLocal,
+        EmittedRuntime runtime)
+    {
+        var arrayLocal = il.DeclareLocal(_types.ListOfObject);
+        var indexLocal = il.DeclareLocal(_types.Int32);
+        var loop = il.DefineLabel();
+        var end = il.DefineLabel();
+        var noComma = il.DefineLabel();
+        var notHole = il.DefineLabel();
+        var appended = il.DefineLabel();
+
+        EmitDeoptIfNumericArray(il, runtime, () => il.Emit(OpCodes.Ldloc, valueLocal));
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Castclass, _types.ListOfObject);
+        il.Emit(OpCodes.Stloc, arrayLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4, (int)'[');
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.StringBuilder, "Append", [_types.Char]));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, indexLocal);
+
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldloc, arrayLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.ListOfObject, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Bge, end);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Brfalse, noComma);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4, (int)',');
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.StringBuilder, "Append", [_types.Char]));
+        il.Emit(OpCodes.Pop);
+        il.MarkLabel(noComma);
+
+        il.Emit(OpCodes.Ldloc, arrayLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.ListOfObject, "get_Item", [_types.Int32]));
+        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Brfalse, notHole);
+        EmitAppendNullLiteral(il);
+        il.Emit(OpCodes.Br, appended);
+
+        il.MarkLabel(notHole);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, arrayLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.ListOfObject, "get_Item", [_types.Int32]));
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Call, appendValue);
+        il.Emit(OpCodes.Brtrue, appended);
+        EmitAppendNullLiteral(il);
+
+        il.MarkLabel(appended);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        il.Emit(OpCodes.Br, loop);
+
+        il.MarkLabel(end);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4, (int)']');
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.StringBuilder, "Append", [_types.Char]));
+        il.Emit(OpCodes.Pop);
+        EmitTrueReturn(il);
+    }
+
+    private void EmitAppendJsonObject(
+        ILGenerator il,
+        MethodBuilder appendValue,
+        LocalBuilder valueLocal,
+        LocalBuilder allowPooledKeysLocal,
+        EmittedRuntime runtime)
+    {
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var keysLocal = il.DeclareLocal(_types.ListOfObject);
+        var keyLocal = il.DeclareLocal(_types.String);
+        var dictValueLocal = il.DeclareLocal(_types.Object);
+        var indexLocal = il.DeclareLocal(_types.Int32);
+        var firstLocal = il.DeclareLocal(_types.Boolean);
+        var rentedLocal = il.DeclareLocal(_types.Boolean);
+        var fallbackSnapshot = il.DefineLabel();
+        var snapshotReady = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Castclass, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Stloc, dictLocal);
+        il.Emit(OpCodes.Ldloc, allowPooledKeysLocal);
+        il.Emit(OpCodes.Brfalse, fallbackSnapshot);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Call, runtime.PDSHasPropertyDescriptors);
+        il.Emit(OpCodes.Brtrue, fallbackSnapshot);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Call, _jsonTryRentDictionaryKeysMethod!);
+        il.Emit(OpCodes.Stloc, keysLocal);
+        il.Emit(OpCodes.Ldloc, keysLocal);
+        il.Emit(OpCodes.Brfalse, fallbackSnapshot);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, rentedLocal);
+        il.Emit(OpCodes.Br, snapshotReady);
+
+        il.MarkLabel(fallbackSnapshot);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Call, runtime.GetKeys);
+        il.Emit(OpCodes.Stloc, keysLocal);
+        il.MarkLabel(snapshotReady);
+
+        var cleanupDone = il.DefineLabel();
+        il.BeginExceptionBlock();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4, (int)'{');
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.StringBuilder, "Append", [_types.Char]));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, firstLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, indexLocal);
+
+        var loop = il.DefineLabel();
+        var end = il.DefineLabel();
+        var generalRead = il.DefineLabel();
+        var valueReady = il.DefineLabel();
+        var omitted = il.DefineLabel();
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldloc, keysLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.ListOfObject, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Bge, end);
+        il.Emit(OpCodes.Ldloc, keysLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.ListOfObject, "get_Item", [_types.Int32]));
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Stloc, keyLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, indexLocal);
+
+        il.Emit(OpCodes.Ldloc, rentedLocal);
+        il.Emit(OpCodes.Brfalse, generalRead);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Ldloca, dictValueLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.DictionaryStringObject,
+            "TryGetValue",
+            [_types.String, _types.Object.MakeByRefType()])!);
+        il.Emit(OpCodes.Brtrue, valueReady);
+        il.MarkLabel(generalRead);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Call, _jsonGetDictionaryPropertyMethod!);
+        il.Emit(OpCodes.Stloc, dictValueLocal);
+        il.MarkLabel(valueReady);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, dictValueLocal);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldloc, firstLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ceq);
+        il.Emit(OpCodes.Call, appendValue);
+        il.Emit(OpCodes.Brfalse, omitted);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, firstLocal);
+        il.MarkLabel(omitted);
+        il.Emit(OpCodes.Br, loop);
+
+        il.MarkLabel(end);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4, (int)'}');
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.StringBuilder, "Append", [_types.Char]));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Leave, cleanupDone);
+
+        il.BeginFinallyBlock();
+        var notRented = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, rentedLocal);
+        il.Emit(OpCodes.Brfalse, notRented);
+        il.Emit(OpCodes.Ldloc, keysLocal);
+        il.Emit(OpCodes.Call, _jsonReturnDictionaryKeysMethod!);
+        il.MarkLabel(notRented);
+        il.EndExceptionBlock();
+
+        il.MarkLabel(cleanupDone);
+        EmitTrueReturn(il);
+    }
+
+    private void EmitAppendNullLiteral(ILGenerator il)
+    {
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "null");
+        EmitStringBuilderAppendString(il);
+    }
+
+    private void EmitStringBuilderAppendString(ILGenerator il)
+    {
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.StringBuilder, "Append", [_types.String]));
+        il.Emit(OpCodes.Pop);
+    }
+
+    private static void EmitTrueReturn(ILGenerator il)
+    {
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+    }
+}

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.Shape.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.Shape.cs
@@ -1,0 +1,1139 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    private MethodBuilder? _canUseJsonShapeMethod;
+    private MethodBuilder? _canUseJsonShapeNodeMethod;
+    private MethodBuilder? _jsonShapePrototypesSafeMethod;
+    private MethodBuilder? _appendJsonShapedValueMethod;
+    private FieldBuilder? _jsonShapeTableField;
+    private MethodBuilder? _getJsonShapeTableMethod;
+    private MethodBuilder? _registerJsonShapeMethod;
+    private MethodBuilder? _tryGetJsonShapeMethod;
+
+    private (MethodBuilder Register, MethodBuilder TryGet) EmitJsonShapeAssociationHelpers(
+        TypeBuilder typeBuilder)
+    {
+        if (_registerJsonShapeMethod is not null && _tryGetJsonShapeMethod is not null)
+            return (_registerJsonShapeMethod, _tryGetJsonShapeMethod);
+
+        var tableType = typeof(System.Runtime.CompilerServices.ConditionalWeakTable<,>)
+            .MakeGenericType(_types.String, _types.Object);
+        _jsonShapeTableField = typeBuilder.DefineField(
+            "_jsonShapes", tableType, FieldAttributes.Private | FieldAttributes.Static);
+
+        var getTable = typeBuilder.DefineMethod(
+            "GetJsonShapeTable",
+            MethodAttributes.Private | MethodAttributes.Static,
+            tableType,
+            Type.EmptyTypes);
+        _getJsonShapeTableMethod = getTable;
+        var getIl = getTable.GetILGenerator();
+        var ready = getIl.DefineLabel();
+        getIl.Emit(OpCodes.Ldsfld, _jsonShapeTableField);
+        getIl.Emit(OpCodes.Dup);
+        getIl.Emit(OpCodes.Brtrue, ready);
+        getIl.Emit(OpCodes.Pop);
+        getIl.Emit(OpCodes.Ldsflda, _jsonShapeTableField);
+        getIl.Emit(OpCodes.Newobj, tableType.GetConstructor(Type.EmptyTypes)!);
+        getIl.Emit(OpCodes.Ldnull);
+        var compareExchange = typeof(System.Threading.Interlocked).GetMethods()
+            .Single(candidate => candidate.Name == "CompareExchange" &&
+                candidate.IsGenericMethodDefinition &&
+                candidate.GetParameters().Length == 3)
+            .MakeGenericMethod(tableType);
+        getIl.Emit(OpCodes.Call, compareExchange);
+        getIl.Emit(OpCodes.Pop);
+        getIl.Emit(OpCodes.Ldsfld, _jsonShapeTableField);
+        getIl.MarkLabel(ready);
+        getIl.Emit(OpCodes.Ret);
+
+        var register = typeBuilder.DefineMethod(
+            "RegisterJsonShape",
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.Void,
+            [_types.String, _types.Object]);
+        _registerJsonShapeMethod = register;
+        var registerIl = register.GetILGenerator();
+        var tableLocal = registerIl.DeclareLocal(tableType);
+        registerIl.Emit(OpCodes.Call, getTable);
+        registerIl.Emit(OpCodes.Stloc, tableLocal);
+        registerIl.Emit(OpCodes.Ldloc, tableLocal);
+        registerIl.Emit(OpCodes.Ldarg_0);
+        registerIl.Emit(OpCodes.Callvirt, tableType.GetMethod("Remove", [_types.String])!);
+        registerIl.Emit(OpCodes.Pop);
+        registerIl.Emit(OpCodes.Ldloc, tableLocal);
+        registerIl.Emit(OpCodes.Ldarg_0);
+        registerIl.Emit(OpCodes.Ldarg_1);
+        registerIl.Emit(OpCodes.Callvirt, tableType.GetMethod("Add", [_types.String, _types.Object])!);
+        registerIl.Emit(OpCodes.Ret);
+
+        var tryGet = typeBuilder.DefineMethod(
+            "TryGetJsonShape",
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.Boolean,
+            [_types.Object, _types.Object.MakeByRefType()]);
+        _tryGetJsonShapeMethod = tryGet;
+        var tryIl = tryGet.GetILGenerator();
+        var stringLocal = tryIl.DeclareLocal(_types.String);
+        var miss = tryIl.DefineLabel();
+        var missWithResidual = tryIl.DefineLabel();
+        tryIl.Emit(OpCodes.Ldarg_0);
+        tryIl.Emit(OpCodes.Isinst, _types.String);
+        tryIl.Emit(OpCodes.Stloc, stringLocal);
+        tryIl.Emit(OpCodes.Ldloc, stringLocal);
+        tryIl.Emit(OpCodes.Brfalse, miss);
+        tryIl.Emit(OpCodes.Ldsfld, _jsonShapeTableField);
+        tryIl.Emit(OpCodes.Dup);
+        tryIl.Emit(OpCodes.Brfalse, missWithResidual);
+        tryIl.Emit(OpCodes.Ldloc, stringLocal);
+        tryIl.Emit(OpCodes.Ldarg_1);
+        tryIl.Emit(OpCodes.Callvirt, tableType.GetMethod(
+            "TryGetValue", [_types.String, _types.Object.MakeByRefType()])!);
+        tryIl.Emit(OpCodes.Ret);
+        tryIl.MarkLabel(missWithResidual);
+        tryIl.Emit(OpCodes.Pop);
+        tryIl.MarkLabel(miss);
+        tryIl.Emit(OpCodes.Ldarg_1);
+        tryIl.Emit(OpCodes.Ldnull);
+        tryIl.Emit(OpCodes.Stind_Ref);
+        tryIl.Emit(OpCodes.Ldc_I4_0);
+        tryIl.Emit(OpCodes.Ret);
+        return (register, tryGet);
+    }
+
+    /// <summary>
+    /// Ensures the implicit Array/Object prototype chain cannot introduce a
+    /// toJSON hook. The check reads only dictionaries and descriptor metadata;
+    /// it never invokes a getter, so a failed guard can fall back exactly once.
+    /// </summary>
+    private MethodBuilder EmitJsonShapePrototypesSafeHelper(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime)
+    {
+        if (_jsonShapePrototypesSafeMethod is not null)
+            return _jsonShapePrototypesSafeMethod;
+
+        var method = typeBuilder.DefineMethod(
+            "JsonShapePrototypesSafe",
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.Boolean,
+            Type.EmptyTypes);
+        _jsonShapePrototypesSafeMethod = method;
+
+        var il = method.GetILGenerator();
+        var scratch = il.DeclareLocal(_types.Object);
+        var unsafeLabel = il.DefineLabel();
+
+        il.Emit(OpCodes.Call, runtime.ObjectPrototypePopulateMethod);
+        EmitPrototypeHasNoJsonHook(
+            il, runtime.ObjectPrototypeField, scratch, unsafeLabel, runtime,
+            expectsObjectPrototype: false);
+        il.Emit(OpCodes.Call, runtime.ArrayPrototypePopulateMethod);
+        EmitPrototypeHasNoJsonHook(
+            il, runtime.ArrayPrototypeField, scratch, unsafeLabel, runtime,
+            expectsObjectPrototype: true);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(unsafeLabel);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+        return method;
+    }
+
+    private void EmitPrototypeHasNoJsonHook(
+        ILGenerator il,
+        FieldBuilder prototypeField,
+        LocalBuilder scratch,
+        Label unsafeLabel,
+        EmittedRuntime runtime,
+        bool expectsObjectPrototype)
+    {
+        il.Emit(OpCodes.Ldsfld, prototypeField);
+        il.Emit(OpCodes.Call, runtime.PDSGetPrototype);
+        if (expectsObjectPrototype)
+        {
+            il.Emit(OpCodes.Ldsfld, runtime.ObjectPrototypeField);
+            il.Emit(OpCodes.Bne_Un, unsafeLabel);
+        }
+        else
+        {
+            il.Emit(OpCodes.Brtrue, unsafeLabel);
+        }
+
+        il.Emit(OpCodes.Ldsfld, prototypeField);
+        il.Emit(OpCodes.Ldstr, "toJSON");
+        il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
+        il.Emit(OpCodes.Brtrue, unsafeLabel);
+
+        il.Emit(OpCodes.Ldsfld, prototypeField);
+        il.Emit(OpCodes.Ldstr, "toJSON");
+        il.Emit(OpCodes.Ldloca, scratch);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.DictionaryStringObject,
+            "TryGetValue",
+            [_types.String, _types.Object.MakeByRefType()])!);
+        il.Emit(OpCodes.Brtrue, unsafeLabel);
+    }
+
+    /// <summary>
+    /// Side-effect-free whole-graph preflight for the typed JSON path. A true
+    /// result proves every shaped node still has the exact ordinary runtime
+    /// representation, descriptor/prototype state, key set and key order the
+    /// compiler observed. Generic leaves impose no assumption.
+    /// </summary>
+    private MethodBuilder EmitCanUseJsonShapeHelper(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime)
+    {
+        if (_canUseJsonShapeMethod is not null)
+            return _canUseJsonShapeMethod;
+
+        var method = typeBuilder.DefineMethod(
+            "CanUseJsonShape",
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.Boolean,
+            [_types.Object, _types.Object, _types.Int32]);
+        _canUseJsonShapeMethod = method;
+
+        var il = method.GetILGenerator();
+        var tagLocal = il.DeclareLocal(_types.String);
+        var shapeLocal = il.DeclareLocal(_types.ObjectArray);
+        var listLocal = il.DeclareLocal(_types.ListOfObject);
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var indexLocal = il.DeclareLocal(_types.Int32);
+        var valueLocal = il.DeclareLocal(_types.Object);
+        var keyLocal = il.DeclareLocal(_types.String);
+
+        var getEnumerator = _types.GetMethod(
+            _types.DictionaryStringObject, "GetEnumerator", Type.EmptyTypes)!;
+        var enumeratorType = getEnumerator.ReturnType;
+        var enumeratorLocal = il.DeclareLocal(enumeratorType);
+        var currentGetter = _types.GetProperty(enumeratorType, "Current").GetGetMethod()!;
+        var pairType = currentGetter.ReturnType;
+        var pairLocal = il.DeclareLocal(pairType);
+        var pairKeyGetter = _types.GetProperty(pairType, "Key").GetGetMethod()!;
+        var moveNext = _types.GetMethod(enumeratorType, "MoveNext", Type.EmptyTypes)!;
+
+        var falseLabel = il.DefineLabel();
+        var shapeNode = il.DefineLabel();
+        var genericTag = il.DefineLabel();
+        var numberTag = il.DefineLabel();
+        var stringTag = il.DefineLabel();
+        var boolTag = il.DefineLabel();
+        var arrayNode = il.DefineLabel();
+        var objectNode = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldc_I4, 512);
+        il.Emit(OpCodes.Bge, falseLabel);
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brfalse, shapeNode);
+        il.Emit(OpCodes.Stloc, tagLocal);
+        EmitStringTagBranch(il, tagLocal, "$g", genericTag);
+        EmitStringTagBranch(il, tagLocal, "$n", numberTag);
+        EmitStringTagBranch(il, tagLocal, "$N", numberTag);
+        EmitStringTagBranch(il, tagLocal, "$s", stringTag);
+        EmitStringTagBranch(il, tagLocal, "$S", stringTag);
+        EmitStringTagBranch(il, tagLocal, "$b", boolTag);
+        EmitStringTagBranch(il, tagLocal, "$B", boolTag);
+        il.Emit(OpCodes.Br, falseLabel);
+
+        il.MarkLabel(genericTag);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(numberTag);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.Double);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Cgt_Un);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(stringTag);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Cgt_Un);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(boolTag);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.Boolean);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Cgt_Un);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(shapeNode);
+        il.Emit(OpCodes.Pop); // null left by isinst string
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, _types.ObjectArray);
+        il.Emit(OpCodes.Stloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Brfalse, falseLabel);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Stloc, tagLocal);
+        EmitStringTagBranch(il, tagLocal, "$a", arrayNode);
+        EmitStringTagBranch(il, tagLocal, "$A", arrayNode);
+        EmitStringTagBranch(il, tagLocal, "$o", objectNode);
+        EmitStringTagBranch(il, tagLocal, "$O", objectNode);
+        il.Emit(OpCodes.Br, falseLabel);
+
+        il.MarkLabel(arrayNode);
+        EmitExactRuntimeTypeCheck(il, 0, _types.ListOfObject, falseLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.PDSHasPropertyDescriptors);
+        il.Emit(OpCodes.Brtrue, falseLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.PDSHasPrototypeEntry);
+        il.Emit(OpCodes.Brtrue, falseLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, _types.ListOfObject);
+        il.Emit(OpCodes.Stloc, listLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, indexLocal);
+
+        var arrayLoop = il.DefineLabel();
+        var arrayDone = il.DefineLabel();
+        il.MarkLabel(arrayLoop);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.ListOfObject, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Bge, arrayDone);
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "get_Item", [_types.Int32])!);
+        il.Emit(OpCodes.Stloc, valueLocal);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Brtrue, falseLabel);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Call, method);
+        il.Emit(OpCodes.Brfalse, falseLabel);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        il.Emit(OpCodes.Br, arrayLoop);
+        il.MarkLabel(arrayDone);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(objectNode);
+        EmitExactRuntimeTypeCheck(il, 0, _types.DictionaryStringObject, falseLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.PDSHasPropertyDescriptors);
+        il.Emit(OpCodes.Brtrue, falseLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.PDSHasPrototypeEntry);
+        il.Emit(OpCodes.Brtrue, falseLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Stloc, dictLocal);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.DictionaryStringObject, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Bne_Un, falseLabel);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Callvirt, getEnumerator);
+        il.Emit(OpCodes.Stloc, enumeratorLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, indexLocal);
+
+        var objectLoop = il.DefineLabel();
+        var objectDone = il.DefineLabel();
+        il.MarkLabel(objectLoop);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Bge, objectDone);
+        il.Emit(OpCodes.Ldloca, enumeratorLocal);
+        il.Emit(OpCodes.Call, moveNext);
+        il.Emit(OpCodes.Brfalse, falseLabel);
+        il.Emit(OpCodes.Ldloca, enumeratorLocal);
+        il.Emit(OpCodes.Call, currentGetter);
+        il.Emit(OpCodes.Stloc, pairLocal);
+        il.Emit(OpCodes.Ldloca, pairLocal);
+        il.Emit(OpCodes.Call, pairKeyGetter);
+        il.Emit(OpCodes.Stloc, keyLocal);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.String, "op_Equality", [_types.String, _types.String])!);
+        il.Emit(OpCodes.Brfalse, falseLabel);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Ldloca, valueLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.DictionaryStringObject,
+            "TryGetValue",
+            [_types.String, _types.Object.MakeByRefType()])!);
+        il.Emit(OpCodes.Brfalse, falseLabel);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Call, method);
+        il.Emit(OpCodes.Brfalse, falseLabel);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        il.Emit(OpCodes.Br, objectLoop);
+
+        il.MarkLabel(objectDone);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(falseLabel);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+        return method;
+    }
+
+    private void EmitStringTagBranch(
+        ILGenerator il,
+        LocalBuilder tag,
+        string expected,
+        Label target)
+    {
+        il.Emit(OpCodes.Ldloc, tag);
+        il.Emit(OpCodes.Ldstr, expected);
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.String, "op_Equality", [_types.String, _types.String])!);
+        il.Emit(OpCodes.Brtrue, target);
+    }
+
+    private void EmitExactRuntimeTypeCheck(
+        ILGenerator il,
+        int argument,
+        Type exactType,
+        Label failure)
+    {
+        il.Emit(OpCodes.Ldarg, argument);
+        il.Emit(OpCodes.Brfalse, failure);
+        il.Emit(OpCodes.Ldarg, argument);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Object, "GetType", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Ldtoken, exactType);
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.Type, "GetTypeFromHandle", [_types.RuntimeTypeHandle])!);
+        il.Emit(OpCodes.Bne_Un, failure);
+    }
+
+    /// <summary>
+    /// Checks only the current shaped node. Closed scalar graphs use this from
+    /// the append walk, avoiding a second whole-graph traversal. Because these
+    /// checks never invoke user code, a later failure may safely discard the
+    /// private builder and enter the generic serializer once.
+    /// </summary>
+    private MethodBuilder EmitCanUseJsonShapeNodeHelper(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime)
+    {
+        if (_canUseJsonShapeNodeMethod is not null)
+            return _canUseJsonShapeNodeMethod;
+
+        var method = typeBuilder.DefineMethod(
+            "CanUseJsonShapeNode",
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.Boolean,
+            [_types.Object, _types.Object]);
+        _canUseJsonShapeNodeMethod = method;
+
+        var il = method.GetILGenerator();
+        var tagLocal = il.DeclareLocal(_types.String);
+        var shapeLocal = il.DeclareLocal(_types.ObjectArray);
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var indexLocal = il.DeclareLocal(_types.Int32);
+
+        var getEnumerator = _types.GetMethod(
+            _types.DictionaryStringObject, "GetEnumerator", Type.EmptyTypes)!;
+        var enumeratorType = getEnumerator.ReturnType;
+        var enumeratorLocal = il.DeclareLocal(enumeratorType);
+        var currentGetter = _types.GetProperty(enumeratorType, "Current").GetGetMethod()!;
+        var pairType = currentGetter.ReturnType;
+        var pairLocal = il.DeclareLocal(pairType);
+        var pairKeyGetter = _types.GetProperty(pairType, "Key").GetGetMethod()!;
+        var moveNext = _types.GetMethod(enumeratorType, "MoveNext", Type.EmptyTypes)!;
+
+        var falseLabel = il.DefineLabel();
+        var trueLabel = il.DefineLabel();
+        var shapeNode = il.DefineLabel();
+        var numberTag = il.DefineLabel();
+        var stringTag = il.DefineLabel();
+        var boolTag = il.DefineLabel();
+        var arrayNode = il.DefineLabel();
+        var objectNode = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brfalse, shapeNode);
+        il.Emit(OpCodes.Stloc, tagLocal);
+        EmitStringTagBranch(il, tagLocal, "$g", trueLabel);
+        EmitStringTagBranch(il, tagLocal, "$n", numberTag);
+        EmitStringTagBranch(il, tagLocal, "$s", stringTag);
+        EmitStringTagBranch(il, tagLocal, "$b", boolTag);
+        il.Emit(OpCodes.Br, falseLabel);
+
+        il.MarkLabel(numberTag);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.Double);
+        il.Emit(OpCodes.Brtrue, trueLabel);
+        il.Emit(OpCodes.Br, falseLabel);
+
+        il.MarkLabel(stringTag);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Brtrue, trueLabel);
+        il.Emit(OpCodes.Br, falseLabel);
+
+        il.MarkLabel(boolTag);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, _types.Boolean);
+        il.Emit(OpCodes.Brtrue, trueLabel);
+        il.Emit(OpCodes.Br, falseLabel);
+
+        il.MarkLabel(shapeNode);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, _types.ObjectArray);
+        il.Emit(OpCodes.Stloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Brfalse, falseLabel);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Stloc, tagLocal);
+        EmitStringTagBranch(il, tagLocal, "$a", arrayNode);
+        EmitStringTagBranch(il, tagLocal, "$A", arrayNode);
+        EmitStringTagBranch(il, tagLocal, "$o", objectNode);
+        EmitStringTagBranch(il, tagLocal, "$O", objectNode);
+        il.Emit(OpCodes.Br, falseLabel);
+
+        il.MarkLabel(arrayNode);
+        EmitExactRuntimeTypeCheck(il, 0, _types.ListOfObject, falseLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.PDSHasPropertyDescriptors);
+        il.Emit(OpCodes.Brtrue, falseLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.PDSHasPrototypeEntry);
+        il.Emit(OpCodes.Brtrue, falseLabel);
+        il.Emit(OpCodes.Br, trueLabel);
+
+        il.MarkLabel(objectNode);
+        EmitExactRuntimeTypeCheck(il, 0, _types.DictionaryStringObject, falseLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.PDSHasPropertyDescriptors);
+        il.Emit(OpCodes.Brtrue, falseLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.PDSHasPrototypeEntry);
+        il.Emit(OpCodes.Brtrue, falseLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Stloc, dictLocal);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.DictionaryStringObject, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Bne_Un, falseLabel);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Callvirt, getEnumerator);
+        il.Emit(OpCodes.Stloc, enumeratorLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, indexLocal);
+
+        var objectLoop = il.DefineLabel();
+        var objectDone = il.DefineLabel();
+        il.MarkLabel(objectLoop);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Bge, objectDone);
+        il.Emit(OpCodes.Ldloca, enumeratorLocal);
+        il.Emit(OpCodes.Call, moveNext);
+        il.Emit(OpCodes.Brfalse, falseLabel);
+        il.Emit(OpCodes.Ldloca, enumeratorLocal);
+        il.Emit(OpCodes.Call, currentGetter);
+        il.Emit(OpCodes.Stloc, pairLocal);
+        il.Emit(OpCodes.Ldloca, pairLocal);
+        il.Emit(OpCodes.Call, pairKeyGetter);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.String, "op_Equality", [_types.String, _types.String])!);
+        il.Emit(OpCodes.Brfalse, falseLabel);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        il.Emit(OpCodes.Br, objectLoop);
+
+        il.MarkLabel(objectDone);
+        il.Emit(OpCodes.Br, trueLabel);
+        il.MarkLabel(falseLabel);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(trueLabel);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+        return method;
+    }
+
+    private MethodBuilder EmitAppendJsonShapedValueHelper(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime,
+        MethodBuilder appendValue)
+    {
+        if (_appendJsonShapedValueMethod is not null)
+            return _appendJsonShapedValueMethod;
+
+        var appendNumber = EmitAppendJsonNumberHelper(typeBuilder, runtime);
+        var method = typeBuilder.DefineMethod(
+            "AppendJsonShapedValue",
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.Boolean,
+            [
+                _types.StringBuilder,
+                _types.Object,
+                _types.Object,
+                _types.Int32,
+                _types.String,
+                _types.Int32,
+                _types.Boolean,
+                _types.Boolean,
+                _types.Boolean
+            ]);
+        method.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
+        _appendJsonShapedValueMethod = method;
+
+        var il = method.GetILGenerator();
+        var tagLocal = il.DeclareLocal(_types.String);
+        var shapeLocal = il.DeclareLocal(_types.ObjectArray);
+        var listLocal = il.DeclareLocal(_types.ListOfObject);
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var scalarLocal = il.DeclareLocal(runtime.JsonScalarRecordType);
+        var valueLocal = il.DeclareLocal(_types.Object);
+        var keyLocal = il.DeclareLocal(_types.String);
+        var indexLocal = il.DeclareLocal(_types.Int32);
+        var firstLocal = il.DeclareLocal(_types.Boolean);
+        var closedLocal = il.DeclareLocal(_types.Boolean);
+        var getEnumerator = _types.GetMethod(
+            _types.DictionaryStringObject, "GetEnumerator", Type.EmptyTypes)!;
+        var enumeratorType = getEnumerator.ReturnType;
+        var enumeratorLocal = il.DeclareLocal(enumeratorType);
+        var currentGetter = _types.GetProperty(enumeratorType, "Current").GetGetMethod()!;
+        var pairType = currentGetter.ReturnType;
+        var pairLocal = il.DeclareLocal(pairType);
+        var pairKeyGetter = _types.GetProperty(pairType, "Key").GetGetMethod()!;
+        var pairValueGetter = _types.GetProperty(pairType, "Value").GetGetMethod()!;
+        var moveNext = _types.GetMethod(enumeratorType, "MoveNext", Type.EmptyTypes)!;
+
+        var genericTag = il.DefineLabel();
+        var numberTag = il.DefineLabel();
+        var stringTag = il.DefineLabel();
+        var boolTag = il.DefineLabel();
+        var shapeNode = il.DefineLabel();
+        var arrayNode = il.DefineLabel();
+        var objectNode = il.DefineLabel();
+        var invalidShape = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brfalse, shapeNode);
+        il.Emit(OpCodes.Stloc, tagLocal);
+        EmitStringTagBranch(il, tagLocal, "$g", genericTag);
+        EmitStringTagBranch(il, tagLocal, "$n", numberTag);
+        EmitStringTagBranch(il, tagLocal, "$N", numberTag);
+        EmitStringTagBranch(il, tagLocal, "$s", stringTag);
+        EmitStringTagBranch(il, tagLocal, "$S", stringTag);
+        EmitStringTagBranch(il, tagLocal, "$b", boolTag);
+        EmitStringTagBranch(il, tagLocal, "$B", boolTag);
+        il.Emit(OpCodes.Br, invalidShape);
+
+        il.MarkLabel(genericTag);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldarg_3);
+        il.Emit(OpCodes.Ldarg, 4);
+        il.Emit(OpCodes.Ldarg, 5);
+        il.Emit(OpCodes.Ldarg, 6);
+        il.Emit(OpCodes.Ldarg, 7);
+        il.Emit(OpCodes.Ldarg, 8);
+        il.Emit(OpCodes.Call, appendValue);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(numberTag);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, _types.Double);
+        il.Emit(OpCodes.Brfalse, invalidShape);
+        EmitAppendShapedPropertyPrefix(il);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Unbox_Any, _types.Double);
+        il.Emit(OpCodes.Call, appendNumber);
+        EmitTrueReturn(il);
+
+        il.MarkLabel(stringTag);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Brfalse, invalidShape);
+        EmitAppendShapedPropertyPrefix(il);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Call, _appendEscapedJsonStringMethod!);
+        EmitTrueReturn(il);
+
+        il.MarkLabel(boolTag);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, _types.Boolean);
+        il.Emit(OpCodes.Brfalse, invalidShape);
+        EmitAppendShapedPropertyPrefix(il);
+        var appendFalse = il.DefineLabel();
+        var boolDone = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Unbox_Any, _types.Boolean);
+        il.Emit(OpCodes.Brfalse, appendFalse);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "true");
+        EmitStringBuilderAppendString(il);
+        il.Emit(OpCodes.Br, boolDone);
+        il.MarkLabel(appendFalse);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldstr, "false");
+        EmitStringBuilderAppendString(il);
+        il.MarkLabel(boolDone);
+        EmitTrueReturn(il);
+
+        il.MarkLabel(shapeNode);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Castclass, _types.ObjectArray);
+        il.Emit(OpCodes.Stloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Stloc, tagLocal);
+        EmitStringTagBranch(il, tagLocal, "$a", arrayNode);
+        EmitStringTagBranch(il, tagLocal, "$A", arrayNode);
+        EmitStringTagBranch(il, tagLocal, "$o", objectNode);
+        EmitStringTagBranch(il, tagLocal, "$O", objectNode);
+        il.Emit(OpCodes.Br, invalidShape);
+
+        il.MarkLabel(arrayNode);
+        il.Emit(OpCodes.Ldloc, tagLocal);
+        il.Emit(OpCodes.Ldstr, "$A");
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.String, "op_Equality", [_types.String, _types.String])!);
+        il.Emit(OpCodes.Stloc, closedLocal);
+        var arrayGuarded = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, closedLocal);
+        il.Emit(OpCodes.Brfalse, arrayGuarded);
+        var arrayTypeAccepted = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Brtrue, arrayTypeAccepted);
+        EmitExactRuntimeTypeCheck(il, 1, _types.ListOfObject, invalidShape);
+        il.MarkLabel(arrayTypeAccepted);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.PDSHasPropertyDescriptors);
+        il.Emit(OpCodes.Brtrue, invalidShape);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.PDSHasPrototypeEntry);
+        il.Emit(OpCodes.Brtrue, invalidShape);
+        il.MarkLabel(arrayGuarded);
+        var arrayNotTsArray = il.DefineLabel();
+        var arrayBoxed = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brfalse, arrayNotTsArray);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayEnsureBoxed);
+        il.Emit(OpCodes.Br, arrayBoxed);
+        il.MarkLabel(arrayNotTsArray);
+        il.Emit(OpCodes.Pop);
+        il.MarkLabel(arrayBoxed);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Castclass, _types.ListOfObject);
+        il.Emit(OpCodes.Stloc, listLocal);
+        EmitAppendShapedPropertyPrefix(il);
+        EmitAppendChar(il, '[');
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, indexLocal);
+
+        var arrayLoop = il.DefineLabel();
+        var arrayDone = il.DefineLabel();
+        var arrayNoComma = il.DefineLabel();
+        var arrayAppended = il.DefineLabel();
+        il.MarkLabel(arrayLoop);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.ListOfObject, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Bge, arrayDone);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Brfalse, arrayNoComma);
+        EmitAppendChar(il, ',');
+        il.MarkLabel(arrayNoComma);
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "get_Item", [_types.Int32])!);
+        il.Emit(OpCodes.Stloc, valueLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Ldarg_3);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Call, method);
+        il.Emit(OpCodes.Brtrue, arrayAppended);
+        il.Emit(OpCodes.Ldloc, closedLocal);
+        il.Emit(OpCodes.Brtrue, invalidShape);
+        EmitAppendNullLiteral(il);
+        il.MarkLabel(arrayAppended);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        il.Emit(OpCodes.Br, arrayLoop);
+        il.MarkLabel(arrayDone);
+        EmitAppendChar(il, ']');
+        EmitTrueReturn(il);
+
+        il.MarkLabel(objectNode);
+        il.Emit(OpCodes.Ldloc, tagLocal);
+        il.Emit(OpCodes.Ldstr, "$O");
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.String, "op_Equality", [_types.String, _types.String])!);
+        il.Emit(OpCodes.Stloc, closedLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, runtime.JsonScalarRecordType);
+        il.Emit(OpCodes.Stloc, scalarLocal);
+        var dictionaryObject = il.DefineLabel();
+        var objectStorageReady = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, scalarLocal);
+        il.Emit(OpCodes.Brfalse, dictionaryObject);
+        il.Emit(OpCodes.Ldloc, closedLocal);
+        il.Emit(OpCodes.Brfalse, invalidShape);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.PDSHasPropertyDescriptors);
+        il.Emit(OpCodes.Brtrue, invalidShape);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.PDSHasPrototypeEntry);
+        il.Emit(OpCodes.Brtrue, invalidShape);
+        il.Emit(OpCodes.Ldloc, scalarLocal);
+        il.Emit(OpCodes.Callvirt, runtime.JsonScalarRecordIsMaterializedGetter);
+        il.Emit(OpCodes.Brtrue, invalidShape);
+        il.Emit(OpCodes.Ldloc, scalarLocal);
+        il.Emit(OpCodes.Callvirt, runtime.JsonScalarRecordShapeGetter);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Bne_Un, invalidShape);
+        il.Emit(OpCodes.Br, objectStorageReady);
+
+        il.MarkLabel(dictionaryObject);
+        var objectGuarded = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, closedLocal);
+        il.Emit(OpCodes.Brfalse, objectGuarded);
+        EmitExactRuntimeTypeCheck(il, 1, _types.DictionaryStringObject, invalidShape);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.PDSHasPropertyDescriptors);
+        il.Emit(OpCodes.Brtrue, invalidShape);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.PDSHasPrototypeEntry);
+        il.Emit(OpCodes.Brtrue, invalidShape);
+        il.MarkLabel(objectGuarded);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Castclass, _types.DictionaryStringObject);
+        il.Emit(OpCodes.Stloc, dictLocal);
+        var objectCountReady = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, closedLocal);
+        il.Emit(OpCodes.Brfalse, objectCountReady);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(
+            _types.DictionaryStringObject, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Bne_Un, invalidShape);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Callvirt, getEnumerator);
+        il.Emit(OpCodes.Stloc, enumeratorLocal);
+        il.MarkLabel(objectCountReady);
+        il.MarkLabel(objectStorageReady);
+        EmitAppendShapedPropertyPrefix(il);
+        EmitAppendChar(il, '{');
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, firstLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, indexLocal);
+
+        var objectLoop = il.DefineLabel();
+        var objectDone = il.DefineLabel();
+        var objectOmitted = il.DefineLabel();
+        il.MarkLabel(objectLoop);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Bge, objectDone);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Stloc, keyLocal);
+        var openObjectRead = il.DefineLabel();
+        var objectValueReady = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, scalarLocal);
+        il.Emit(OpCodes.Brfalse, openObjectRead);
+        il.Emit(OpCodes.Ldloc, scalarLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Div);
+        il.Emit(OpCodes.Callvirt, runtime.JsonScalarRecordGetValue);
+        il.Emit(OpCodes.Stloc, valueLocal);
+        il.Emit(OpCodes.Br, objectValueReady);
+        il.MarkLabel(openObjectRead);
+        var openDictionaryRead = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, closedLocal);
+        il.Emit(OpCodes.Brfalse, openDictionaryRead);
+        il.Emit(OpCodes.Ldloca, enumeratorLocal);
+        il.Emit(OpCodes.Call, moveNext);
+        il.Emit(OpCodes.Brfalse, invalidShape);
+        il.Emit(OpCodes.Ldloca, enumeratorLocal);
+        il.Emit(OpCodes.Call, currentGetter);
+        il.Emit(OpCodes.Stloc, pairLocal);
+        il.Emit(OpCodes.Ldloca, pairLocal);
+        il.Emit(OpCodes.Call, pairKeyGetter);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.String, "op_Equality", [_types.String, _types.String])!);
+        il.Emit(OpCodes.Brfalse, invalidShape);
+        il.Emit(OpCodes.Ldloca, pairLocal);
+        il.Emit(OpCodes.Call, pairValueGetter);
+        il.Emit(OpCodes.Stloc, valueLocal);
+        il.Emit(OpCodes.Br, objectValueReady);
+        il.MarkLabel(openDictionaryRead);
+        il.Emit(OpCodes.Ldloc, dictLocal);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Ldloca, valueLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.DictionaryStringObject,
+            "TryGetValue",
+            [_types.String, _types.Object.MakeByRefType()])!);
+        il.Emit(OpCodes.Pop);
+        il.MarkLabel(objectValueReady);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Ldarg_3);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldloc, firstLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ceq);
+        il.Emit(OpCodes.Call, method);
+        il.Emit(OpCodes.Brfalse, objectOmitted);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, firstLocal);
+        var objectContinue = il.DefineLabel();
+        il.Emit(OpCodes.Br, objectContinue);
+        il.MarkLabel(objectOmitted);
+        il.Emit(OpCodes.Ldloc, closedLocal);
+        il.Emit(OpCodes.Brtrue, invalidShape);
+        il.MarkLabel(objectContinue);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        il.Emit(OpCodes.Br, objectLoop);
+        il.MarkLabel(objectDone);
+        EmitAppendChar(il, '}');
+        EmitTrueReturn(il);
+
+        il.MarkLabel(invalidShape);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+        return method;
+    }
+
+    private void EmitAppendShapedPropertyPrefix(ILGenerator il)
+    {
+        var noPrefix = il.DefineLabel();
+        var noComma = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg, 7);
+        il.Emit(OpCodes.Brfalse, noPrefix);
+        il.Emit(OpCodes.Ldarg, 8);
+        il.Emit(OpCodes.Brfalse, noComma);
+        EmitAppendChar(il, ',');
+        il.MarkLabel(noComma);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg, 4);
+        il.Emit(OpCodes.Call, _appendEscapedJsonStringMethod!);
+        EmitAppendChar(il, ':');
+        il.MarkLabel(noPrefix);
+    }
+
+    private void EmitAppendChar(ILGenerator il, char value)
+    {
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4, (int)value);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.StringBuilder, "Append", [_types.Char]));
+        il.Emit(OpCodes.Pop);
+    }
+
+    private void EmitJsonStringifyShapedMethod(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime,
+        MethodBuilder appendValue)
+    {
+        var (registerShape, _) = EmitJsonShapeAssociationHelpers(typeBuilder);
+        var prototypesSafe = EmitJsonShapePrototypesSafeHelper(typeBuilder, runtime);
+        var canUseShape = EmitCanUseJsonShapeHelper(typeBuilder, runtime);
+        var appendShaped = EmitAppendJsonShapedValueHelper(typeBuilder, runtime, appendValue);
+        var method = typeBuilder.DefineMethod(
+            "JsonStringifyShaped",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Object, _types.Boolean]);
+        method.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
+        runtime.JsonStringifyShaped = method;
+
+        var il = method.GetILGenerator();
+        var fallback = il.DefineLabel();
+        var undefinedRoot = il.DefineLabel();
+        var cleanupDone = il.DefineLabel();
+        var builderLocal = il.DeclareLocal(_types.StringBuilder);
+        var resultLocal = il.DeclareLocal(_types.Object);
+        var fallbackLocal = il.DeclareLocal(_types.Boolean);
+
+        il.Emit(OpCodes.Call, prototypesSafe);
+        il.Emit(OpCodes.Brfalse, fallback);
+        var shapeReady = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Brtrue, shapeReady);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Call, canUseShape);
+        il.Emit(OpCodes.Brfalse, fallback);
+        il.MarkLabel(shapeReady);
+
+        il.Emit(OpCodes.Call, _jsonRentStringBuilderMethod!);
+        il.Emit(OpCodes.Stloc, builderLocal);
+        il.BeginExceptionBlock();
+        il.Emit(OpCodes.Ldloc, builderLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldstr, "");
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Call, appendShaped);
+        il.Emit(OpCodes.Brfalse, undefinedRoot);
+        il.Emit(OpCodes.Ldloc, builderLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "ToString"));
+        il.Emit(OpCodes.Stloc, resultLocal);
+        var resultRegistered = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Brfalse, resultRegistered);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, registerShape);
+        il.MarkLabel(resultRegistered);
+        il.Emit(OpCodes.Leave, cleanupDone);
+
+        il.MarkLabel(undefinedRoot);
+        var storeUndefined = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Brfalse, storeUndefined);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, fallbackLocal);
+        il.Emit(OpCodes.Leave, cleanupDone);
+        il.MarkLabel(storeUndefined);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Stloc, resultLocal);
+        il.Emit(OpCodes.Leave, cleanupDone);
+
+        il.BeginFinallyBlock();
+        il.Emit(OpCodes.Ldloc, builderLocal);
+        il.Emit(OpCodes.Call, _jsonReturnStringBuilderMethod!);
+        il.EndExceptionBlock();
+        il.MarkLabel(cleanupDone);
+        il.Emit(OpCodes.Ldloc, fallbackLocal);
+        il.Emit(OpCodes.Brtrue, fallback);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(fallback);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.JsonStringify);
+        il.Emit(OpCodes.Ret);
+    }
+}

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.Shape.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.Shape.cs
@@ -20,10 +20,26 @@ public partial class RuntimeEmitter
         if (_registerJsonShapeMethod is not null && _tryGetJsonShapeMethod is not null)
             return (_registerJsonShapeMethod, _tryGetJsonShapeMethod);
 
+        var tableOpenType = typeof(System.Runtime.CompilerServices.ConditionalWeakTable<,>);
+        var tableOpenArguments = tableOpenType.GetGenericArguments();
         var tableType = EmitGenerics.MakeGenericType(
-            typeof(System.Runtime.CompilerServices.ConditionalWeakTable<,>),
+            tableOpenType,
             _types.String,
             _types.Object);
+        var tableConstructor = EmitterTypeHelpers.ResolveConstructor(
+            tableType,
+            tableOpenType.GetConstructor(Type.EmptyTypes)!);
+        var tableRemove = EmitterTypeHelpers.ResolveMethod(
+            tableType,
+            tableOpenType.GetMethod("Remove", [tableOpenArguments[0]])!);
+        var tableAdd = EmitterTypeHelpers.ResolveMethod(
+            tableType,
+            tableOpenType.GetMethod("Add", [tableOpenArguments[0], tableOpenArguments[1]])!);
+        var tableTryGetValue = EmitterTypeHelpers.ResolveMethod(
+            tableType,
+            tableOpenType.GetMethod(
+                "TryGetValue",
+                [tableOpenArguments[0], tableOpenArguments[1].MakeByRefType()])!);
         _jsonShapeTableField = typeBuilder.DefineField(
             "_jsonShapes", tableType, FieldAttributes.Private | FieldAttributes.Static);
 
@@ -40,7 +56,7 @@ public partial class RuntimeEmitter
         getIl.Emit(OpCodes.Brtrue, ready);
         getIl.Emit(OpCodes.Pop);
         getIl.Emit(OpCodes.Ldsflda, _jsonShapeTableField);
-        getIl.Emit(OpCodes.Newobj, tableType.GetConstructor(Type.EmptyTypes)!);
+        getIl.Emit(OpCodes.Newobj, tableConstructor);
         getIl.Emit(OpCodes.Ldnull);
         var compareExchangeDefinition = typeof(System.Threading.Interlocked).GetMethods()
             .Single(candidate => candidate.Name == "CompareExchange" &&
@@ -66,12 +82,12 @@ public partial class RuntimeEmitter
         registerIl.Emit(OpCodes.Stloc, tableLocal);
         registerIl.Emit(OpCodes.Ldloc, tableLocal);
         registerIl.Emit(OpCodes.Ldarg_0);
-        registerIl.Emit(OpCodes.Callvirt, tableType.GetMethod("Remove", [_types.String])!);
+        registerIl.Emit(OpCodes.Callvirt, tableRemove);
         registerIl.Emit(OpCodes.Pop);
         registerIl.Emit(OpCodes.Ldloc, tableLocal);
         registerIl.Emit(OpCodes.Ldarg_0);
         registerIl.Emit(OpCodes.Ldarg_1);
-        registerIl.Emit(OpCodes.Callvirt, tableType.GetMethod("Add", [_types.String, _types.Object])!);
+        registerIl.Emit(OpCodes.Callvirt, tableAdd);
         registerIl.Emit(OpCodes.Ret);
 
         var tryGet = typeBuilder.DefineMethod(
@@ -94,8 +110,7 @@ public partial class RuntimeEmitter
         tryIl.Emit(OpCodes.Brfalse, missWithResidual);
         tryIl.Emit(OpCodes.Ldloc, stringLocal);
         tryIl.Emit(OpCodes.Ldarg_1);
-        tryIl.Emit(OpCodes.Callvirt, tableType.GetMethod(
-            "TryGetValue", [_types.String, _types.Object.MakeByRefType()])!);
+        tryIl.Emit(OpCodes.Callvirt, tableTryGetValue);
         tryIl.Emit(OpCodes.Ret);
         tryIl.MarkLabel(missWithResidual);
         tryIl.Emit(OpCodes.Pop);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.Shape.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.Shape.cs
@@ -20,8 +20,10 @@ public partial class RuntimeEmitter
         if (_registerJsonShapeMethod is not null && _tryGetJsonShapeMethod is not null)
             return (_registerJsonShapeMethod, _tryGetJsonShapeMethod);
 
-        var tableType = typeof(System.Runtime.CompilerServices.ConditionalWeakTable<,>)
-            .MakeGenericType(_types.String, _types.Object);
+        var tableType = EmitGenerics.MakeGenericType(
+            typeof(System.Runtime.CompilerServices.ConditionalWeakTable<,>),
+            _types.String,
+            _types.Object);
         _jsonShapeTableField = typeBuilder.DefineField(
             "_jsonShapes", tableType, FieldAttributes.Private | FieldAttributes.Static);
 
@@ -40,11 +42,12 @@ public partial class RuntimeEmitter
         getIl.Emit(OpCodes.Ldsflda, _jsonShapeTableField);
         getIl.Emit(OpCodes.Newobj, tableType.GetConstructor(Type.EmptyTypes)!);
         getIl.Emit(OpCodes.Ldnull);
-        var compareExchange = typeof(System.Threading.Interlocked).GetMethods()
+        var compareExchangeDefinition = typeof(System.Threading.Interlocked).GetMethods()
             .Single(candidate => candidate.Name == "CompareExchange" &&
                 candidate.IsGenericMethodDefinition &&
-                candidate.GetParameters().Length == 3)
-            .MakeGenericMethod(tableType);
+                candidate.GetParameters().Length == 3);
+        var compareExchange = EmitGenerics.MakeGenericMethod(
+            compareExchangeDefinition, tableType);
         getIl.Emit(OpCodes.Call, compareExchange);
         getIl.Emit(OpCodes.Pop);
         getIl.Emit(OpCodes.Ldsfld, _jsonShapeTableField);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.cs
@@ -821,7 +821,8 @@ public partial class RuntimeEmitter
         EmitJsonStringBuilderPool(typeBuilder);
 
         // Then emit the main stringify helper
-        var stringifyHelper = EmitJsonStringifyHelper(typeBuilder, runtime);
+        _ = EmitJsonStringifyHelper(typeBuilder, runtime);
+        var appendValue = EmitAppendJsonValueHelper(typeBuilder, runtime);
 
         var method = typeBuilder.DefineMethod(
             "JsonStringify",
@@ -833,41 +834,46 @@ public partial class RuntimeEmitter
 
         var il = method.GetILGenerator();
 
-        // ECMA-262 25.5.2.1 step 12: SerializeJSONProperty("", { "": value }).
-        // StringifyValue performs the single toJSON lookup using the root key.
-        var rootValueLocalSimple = il.DeclareLocal(_types.Object);
+        // One root-owned builder spans the complete recursive walk. It remains
+        // rented through toJSON/reentrant calls and is returned on every abrupt
+        // completion; the bounded pool discards unusually large buffers.
+        var builderLocal = il.DeclareLocal(_types.StringBuilder);
+        var resultRootLocal = il.DeclareLocal(_types.Object);
+        var undefinedRoot = il.DefineLabel();
+        var cleanupDone = il.DefineLabel();
+        il.Emit(OpCodes.Call, _jsonRentStringBuilderMethod!);
+        il.Emit(OpCodes.Stloc, builderLocal);
+        il.BeginExceptionBlock();
+        il.Emit(OpCodes.Ldloc, builderLocal);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Stloc, rootValueLocalSimple);
-
-        // Map $Undefined → JS undefined directly here, since StringifyValue
-        // returns C# null for $Undefined and we'd map back to $Undefined below.
-        // Skip the helper for that case to short-circuit cleanly.
-        var notUndefRootLabel = il.DefineLabel();
-        il.Emit(OpCodes.Ldloc, rootValueLocalSimple);
-        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
-        il.Emit(OpCodes.Brfalse, notUndefRootLabel);
-        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
-        il.Emit(OpCodes.Ret);
-        il.MarkLabel(notUndefRootLabel);
-
-        // Call our emitted StringifyValue helper. Map null → $Undefined.Instance
-        // because StringifyValue returns null for undefined inputs and the
-        // spec wants `JSON.stringify(undefined) === undefined`.
-        var resultRootLocal = il.DeclareLocal(_types.String);
-        il.Emit(OpCodes.Ldloc, rootValueLocalSimple);
-        il.Emit(OpCodes.Ldc_I4_0); // indent = 0
-        il.Emit(OpCodes.Ldc_I4_0); // depth = 0
-        il.Emit(OpCodes.Ldstr, ""); // key = "" (root per ECMA-262 25.5.2.1 step 12)
-        il.Emit(OpCodes.Call, stringifyHelper);
+        il.Emit(OpCodes.Ldc_I4_0); // depth
+        il.Emit(OpCodes.Ldstr, ""); // root key
+        il.Emit(OpCodes.Ldc_I4_0); // unused array index
+        il.Emit(OpCodes.Ldc_I4_0); // key is not an index
+        il.Emit(OpCodes.Ldc_I4_0); // no object-property prefix
+        il.Emit(OpCodes.Ldc_I4_0); // no comma
+        il.Emit(OpCodes.Call, appendValue);
+        il.Emit(OpCodes.Brfalse, undefinedRoot);
+        il.Emit(OpCodes.Ldloc, builderLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "ToString"));
         il.Emit(OpCodes.Stloc, resultRootLocal);
-        il.Emit(OpCodes.Ldloc, resultRootLocal);
-        var nonNullJsonLabel = il.DefineLabel();
-        il.Emit(OpCodes.Brtrue, nonNullJsonLabel);
+        il.Emit(OpCodes.Leave, cleanupDone);
+
+        il.MarkLabel(undefinedRoot);
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
-        il.Emit(OpCodes.Ret);
-        il.MarkLabel(nonNullJsonLabel);
+        il.Emit(OpCodes.Stloc, resultRootLocal);
+        il.Emit(OpCodes.Leave, cleanupDone);
+
+        il.BeginFinallyBlock();
+        il.Emit(OpCodes.Ldloc, builderLocal);
+        il.Emit(OpCodes.Call, _jsonReturnStringBuilderMethod!);
+        il.EndExceptionBlock();
+
+        il.MarkLabel(cleanupDone);
         il.Emit(OpCodes.Ldloc, resultRootLocal);
         il.Emit(OpCodes.Ret);
+
+        EmitJsonStringifyShapedMethod(typeBuilder, runtime, appendValue);
     }
 
     private MethodBuilder EmitJsonStringifyHelper(TypeBuilder typeBuilder, EmittedRuntime runtime)
@@ -1159,7 +1165,8 @@ public partial class RuntimeEmitter
     }
 
     private void EmitToJsonCheck(ILGenerator il, LocalBuilder valueLocal, EmittedRuntime runtime,
-        string? key = null, int? keyArgIndex = null, LocalBuilder? keyLocal = null)
+        string? key = null, int? keyArgIndex = null, LocalBuilder? keyLocal = null,
+        int? keyIndexArgIndex = null, int? keyIsIndexArgIndex = null)
     {
         var doneLabel = il.DefineLabel();
 
@@ -1212,7 +1219,20 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Newarr, _types.Object);
         il.Emit(OpCodes.Dup);
         il.Emit(OpCodes.Ldc_I4_0);
-        if (keyLocal != null)
+        if (keyIndexArgIndex.HasValue && keyIsIndexArgIndex.HasValue)
+        {
+            var stringKeyLabel = il.DefineLabel();
+            var keyReadyLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg, keyIsIndexArgIndex.Value);
+            il.Emit(OpCodes.Brfalse, stringKeyLabel);
+            il.Emit(OpCodes.Ldarga, keyIndexArgIndex.Value);
+            il.Emit(OpCodes.Call, _types.GetMethodNoParams(_types.Int32, "ToString"));
+            il.Emit(OpCodes.Br, keyReadyLabel);
+            il.MarkLabel(stringKeyLabel);
+            il.Emit(OpCodes.Ldarg, keyArgIndex!.Value);
+            il.MarkLabel(keyReadyLabel);
+        }
+        else if (keyLocal != null)
             il.Emit(OpCodes.Ldloc, keyLocal);
         else if (keyArgIndex.HasValue)
             il.Emit(OpCodes.Ldarg, keyArgIndex.Value);
@@ -1379,11 +1399,12 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.IHasFieldsInterface);
         il.Emit(OpCodes.Brfalse, notTsObjectLabel);
 
-        // toJsonField = (($IHasFields)value).GetProperty("toJSON");
+        // Use ordinary Get so compact JSON records observe a mutable
+        // prototype's inherited toJSON hook. Class instances retain their
+        // existing IHasFields behavior inside the shared GetProperty helper.
         il.Emit(OpCodes.Ldloc, valueLocal);
-        il.Emit(OpCodes.Castclass, runtime.IHasFieldsInterface);
         il.Emit(OpCodes.Ldstr, "toJSON");
-        il.Emit(OpCodes.Callvirt, runtime.IHasFieldsGetProperty);
+        il.Emit(OpCodes.Call, runtime.GetProperty);
         il.Emit(OpCodes.Stloc, toJsonFieldLocal);
         il.Emit(OpCodes.Ldloc, toJsonFieldLocal);
         il.Emit(OpCodes.Brfalse, noToJsonLabel);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.DeleteProperty.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.DeleteProperty.cs
@@ -118,6 +118,7 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         var nullLabel = il.DefineLabel();
         var dictLabel = il.DefineLabel();
+        var scalarRecordDelLabel = il.DefineLabel();
         var trueLabel = il.DefineLabel();
 
         // Emits the failed-delete path: strict mode (arg 2 set) throws
@@ -271,6 +272,13 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.TSArrayType);
         il.Emit(OpCodes.Brtrue, tsArrayDelLabel);
+
+        if (runtime.JsonScalarRecordType is not null)
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.JsonScalarRecordType);
+            il.Emit(OpCodes.Brtrue, scalarRecordDelLabel);
+        }
 
         // Dictionary
         il.Emit(OpCodes.Ldarg_0);
@@ -455,6 +463,35 @@ public partial class RuntimeEmitter
             EmitDeleteFail("' of object");
             il.MarkLabel(notTypeForDelLabel);
         }
+
+        var afterScalarRecordDelLabel = il.DefineLabel();
+        il.Emit(OpCodes.Br, afterScalarRecordDelLabel);
+
+        // Compact JSON records use their materialized Fields dictionary as
+        // ordinary backing storage. Descriptor configurability was already
+        // checked by the common guard above; remove both representations and
+        // compact insertion order so delete/re-add appends the key.
+        il.MarkLabel(scalarRecordDelLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.PDSDeleteProperty);
+        il.Emit(OpCodes.Pop);
+        var scalarDeleteFields =
+            il.DeclareLocal(_types.DictionaryStringObject);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.IHasFieldsInterface);
+        il.Emit(OpCodes.Callvirt, runtime.IHasFieldsFieldsGetter);
+        il.Emit(OpCodes.Stloc, scalarDeleteFields);
+        il.Emit(OpCodes.Ldloc, scalarDeleteFields);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.DictionaryStringObject, "Remove", _types.String));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldloc, scalarDeleteFields);
+        il.Emit(OpCodes.Call, runtime.CompactDictionaryOrder);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(afterScalarRecordDelLabel);
 
         // Remaining runtime-backed objects (notably Error instances) can own
         // properties represented solely in the descriptor store. Honor the

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.cs
@@ -1405,6 +1405,24 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
         il.MarkLabel(accessorCleanupNotTSObject);
 
+        if (runtime.JsonScalarRecordType is not null)
+        {
+            var accessorCleanupNotScalar = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.JsonScalarRecordType);
+            il.Emit(OpCodes.Brfalse, accessorCleanupNotScalar);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, runtime.IHasFieldsInterface);
+            il.Emit(OpCodes.Callvirt, runtime.IHasFieldsFieldsGetter);
+            il.Emit(OpCodes.Ldloc, propNameLocal);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(
+                _types.DictionaryStringObject, "set_Item"));
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(accessorCleanupNotScalar);
+        }
+
         var accessorCleanupNotArrayIndex = il.DefineLabel();
         var accessorArrayIndexLocal = il.DeclareLocal(_types.UInt32);
         il.Emit(OpCodes.Ldarg_0);
@@ -1654,6 +1672,39 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "set_Item", _types.Int32, _types.Object));
         il.Emit(OpCodes.Br, endLabel);
         il.MarkLabel(notListIdxLabel);
+
+        // The compact scalar carrier is an ordinary object whose canonical
+        // mutable representation is its lazily materialized Fields dictionary.
+        // Apply data descriptors there just as for $Object/dictionary targets.
+        if (runtime.JsonScalarRecordType is not null)
+        {
+            var notScalarForValueLabel = il.DefineLabel();
+            var scalarFieldsLocal =
+                il.DeclareLocal(_types.DictionaryStringObject);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.JsonScalarRecordType);
+            il.Emit(OpCodes.Brfalse, notScalarForValueLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, runtime.IHasFieldsInterface);
+            il.Emit(OpCodes.Callvirt, runtime.IHasFieldsFieldsGetter);
+            il.Emit(OpCodes.Stloc, scalarFieldsLocal);
+            var scalarDoWriteLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, wasGenericLocal);
+            il.Emit(OpCodes.Brfalse, scalarDoWriteLabel);
+            il.Emit(OpCodes.Ldloc, scalarFieldsLocal);
+            il.Emit(OpCodes.Ldloc, propNameLocal);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(
+                _types.DictionaryStringObject, "ContainsKey", _types.String));
+            il.Emit(OpCodes.Brtrue, endLabel);
+            il.MarkLabel(scalarDoWriteLabel);
+            il.Emit(OpCodes.Ldloc, scalarFieldsLocal);
+            il.Emit(OpCodes.Ldloc, propNameLocal);
+            il.Emit(OpCodes.Ldloc, valueToWriteLocal);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(
+                _types.DictionaryStringObject, "set_Item"));
+            il.Emit(OpCodes.Br, endLabel);
+            il.MarkLabel(notScalarForValueLabel);
+        }
 
         // Also write the value to $Object._fields when target is $Object.
         // Same generic-skip semantics as the dict path.

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -428,6 +428,29 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Beq, errorPrototypeLookupLabel);
         il.MarkLabel(notPlainTSObjectLabel);
 
+        // A compact JSON record is an ordinary object, not a class instance:
+        // own slots win, but an own miss must continue through its mutable
+        // [[Prototype]] chain. General IHasFields instances return immediately
+        // because their class lookup is handled by the generated carrier.
+        if (runtime.JsonScalarRecordType is not null)
+        {
+            var notScalarRecordLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.JsonScalarRecordType);
+            il.Emit(OpCodes.Brfalse, notScalarRecordLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, runtime.IHasFieldsInterface);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Callvirt, runtime.IHasFieldsHasProperty);
+            il.Emit(OpCodes.Brfalse, errorPrototypeLookupLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, runtime.IHasFieldsInterface);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Callvirt, runtime.IHasFieldsGetProperty);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notScalarRecordLabel);
+        }
+
         // Check $IHasFields interface (covers user-defined classes and $Object subclasses with typed properties)
         var notHasFieldsLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Prototype.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Prototype.cs
@@ -588,6 +588,20 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, tryGetValue!);
         il.Emit(OpCodes.Brtrue, foundInLocalLabel);
 
+        // The compact JSON scalar carrier implements IHasFields for ordinary
+        // object operations, but it is not a user class instance. Its default
+        // [[Prototype]] is %Object.prototype% just like a dictionary literal.
+        if (runtime.JsonScalarRecordType is not null)
+        {
+            var notScalarRecord = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.JsonScalarRecordType);
+            il.Emit(OpCodes.Brfalse, notScalarRecord);
+            il.Emit(OpCodes.Ldsfld, runtime.ObjectPrototypeField);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(notScalarRecord);
+        }
+
         // An emitted class instance inherits from the stable object surfaced
         // as Constructor.prototype. Prototype objects themselves have an
         // explicit PDS entry installed by GetClassPrototype, so they return
@@ -1068,6 +1082,12 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.IHasFieldsInterface);
         il.Emit(OpCodes.Brfalse, notClassInstanceLabel);
+        if (runtime.JsonScalarRecordType is not null)
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.JsonScalarRecordType);
+            il.Emit(OpCodes.Brtrue, notClassInstanceLabel);
+        }
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.TSObjectType);
         il.Emit(OpCodes.Brtrue, notClassInstanceLabel);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Utilities.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Utilities.cs
@@ -226,7 +226,9 @@ public partial class RuntimeEmitter
     /// _fields PLUS getter-resolved entries from _getters (accessor properties
     /// invoked via InvokeMethodValue with obj as \`this\`). For non-\$Object
     /// receivers (including null and \$IHasFields user classes), returns the
-    /// receiver's Fields dict directly. Used by JSON.stringify to honor the
+    /// receiver's Fields dict directly when it has no property descriptors;
+    /// descriptor-bearing receivers are projected through GetKeys/GetProperty.
+    /// Used by JSON.stringify to honor the
     /// ECMA-262 25.5.2.4 spec rule that EnumerableOwnPropertyNames covers both
     /// data and accessor properties.
     /// </summary>
@@ -343,6 +345,59 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.IHasFieldsInterface);
         var nullReturnLabel = il.DefineLabel();
         il.Emit(OpCodes.Brfalse, nullReturnLabel);
+
+        // Compact JSON records retain ordinary-object descriptor semantics.
+        // Once a descriptor is installed, create an enumerable snapshot so
+        // hidden properties are filtered and accessors are invoked.
+        var directFieldsLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.PDSHasPropertyDescriptors);
+        il.Emit(OpCodes.Brfalse, directFieldsLabel);
+
+        var descriptorResultLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var descriptorKeysLocal = il.DeclareLocal(_types.ListOfObject);
+        var descriptorIndexLocal = il.DeclareLocal(_types.Int32);
+        var descriptorKeyLocal = il.DeclareLocal(_types.String);
+        il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.DictionaryStringObject));
+        il.Emit(OpCodes.Stloc, descriptorResultLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.GetKeys);
+        il.Emit(OpCodes.Stloc, descriptorKeysLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, descriptorIndexLocal);
+
+        var descriptorLoopLabel = il.DefineLabel();
+        var descriptorDoneLabel = il.DefineLabel();
+        il.MarkLabel(descriptorLoopLabel);
+        il.Emit(OpCodes.Ldloc, descriptorIndexLocal);
+        il.Emit(OpCodes.Ldloc, descriptorKeysLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(
+            _types.ListOfObject, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Bge, descriptorDoneLabel);
+        il.Emit(OpCodes.Ldloc, descriptorKeysLocal);
+        il.Emit(OpCodes.Ldloc, descriptorIndexLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.ListOfObject, "get_Item", _types.Int32));
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Stloc, descriptorKeyLocal);
+        il.Emit(OpCodes.Ldloc, descriptorResultLocal);
+        il.Emit(OpCodes.Ldloc, descriptorKeyLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, descriptorKeyLocal);
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.DictionaryStringObject, "set_Item", _types.String, _types.Object));
+        il.Emit(OpCodes.Ldloc, descriptorIndexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, descriptorIndexLocal);
+        il.Emit(OpCodes.Br, descriptorLoopLabel);
+
+        il.MarkLabel(descriptorDoneLabel);
+        il.Emit(OpCodes.Ldloc, descriptorResultLocal);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(directFieldsLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Castclass, runtime.IHasFieldsInterface);
         il.Emit(OpCodes.Callvirt, runtime.IHasFieldsFieldsGetter);

--- a/src/SharpTS/Compilation/RuntimeEmitter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.cs
@@ -156,7 +156,10 @@ public partial class RuntimeEmitter
         EmitTSObjectClass(moduleBuilder, runtime);
 
         if (features.UsesJSON)
+        {
+            EmitJsonScalarRecordClass(moduleBuilder, runtime);
             EmitTSRawJsonClass(moduleBuilder, runtime);
+        }
 
         // Emit $RegExp class for standalone regex support — gated on UsesRegExp.
         // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSRegExp

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -1,4 +1,5 @@
 using SharpTS.Parsing;
+using SharpTS.TypeSystem;
 
 namespace SharpTS.Compilation;
 
@@ -28,6 +29,7 @@ namespace SharpTS.Compilation;
 public sealed class RuntimeFeatureDetector
 {
     private readonly RuntimeFeatureSet _set;
+    private TypeMap? _typeMap;
 
     public RuntimeFeatureDetector()
     {
@@ -84,8 +86,9 @@ public sealed class RuntimeFeatureDetector
         };
     }
 
-    public RuntimeFeatureSet Detect(List<Stmt> statements)
+    public RuntimeFeatureSet Detect(List<Stmt> statements, TypeMap? typeMap = null)
     {
+        _typeMap = typeMap;
         foreach (var stmt in statements)
             VisitStmt(stmt);
 
@@ -793,6 +796,20 @@ public sealed class RuntimeFeatureDetector
                 break;
 
             case Expr.Call c:
+                if (_typeMap is not null
+                    && c.Arguments.Count == 1
+                    && c.Callee is Expr.Get
+                    {
+                        Object: Expr.Variable { Name.Lexeme: "JSON" },
+                        Name.Lexeme: "stringify",
+                        Optional: false
+                    }
+                    && JsonSerializationShapeAnalyzer.TryAnalyze(
+                        _typeMap.Get(c.Arguments[0]), out var jsonShape)
+                    && JsonSerializationShapeAnalyzer.IsClosed(jsonShape))
+                {
+                    CollectClosedJsonRecordShapes(jsonShape);
+                }
                 if (c.Arguments.Count > 0
                     && c.Callee is Expr.Get
                     {
@@ -1001,6 +1018,22 @@ public sealed class RuntimeFeatureDetector
 
             // Leaves with no nested expressions worth walking.
             default:
+                break;
+        }
+    }
+
+    private void CollectClosedJsonRecordShapes(JsonSerializationShape shape)
+    {
+        switch (shape)
+        {
+            case JsonSerializationShape.Record record:
+                _set.JsonScalarRecordShapeFingerprints.Add(
+                    JsonSerializationShapeAnalyzer.Fingerprint(record));
+                foreach (var (_, value) in record.Fields)
+                    CollectClosedJsonRecordShapes(value);
+                break;
+            case JsonSerializationShape.Array array:
+                CollectClosedJsonRecordShapes(array.Element);
                 break;
         }
     }

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -16,6 +16,13 @@ namespace SharpTS.Compilation;
 /// </summary>
 public sealed class RuntimeFeatureSet
 {
+    /// <summary>
+    /// Closed record shapes reachable from a direct, one-argument
+    /// <c>JSON.stringify</c> call. Object-literal emission uses this allow-list
+    /// to keep the compact JSON carrier out of unrelated object graphs.
+    /// </summary>
+    internal HashSet<string> JsonScalarRecordShapeFingerprints { get; } = [];
+
     // ── Network family ────────────────────────────────────────────────────
     public bool UsesNet { get; set; } = true;       // 'net' module / NetServer / NetSocket
     public bool UsesHttp { get; set; } = true;      // 'http'/'https' module / HttpServer

--- a/src/SharpTS/Execution/Interpreter.Calls.cs
+++ b/src/SharpTS/Execution/Interpreter.Calls.cs
@@ -744,6 +744,25 @@ public partial class Interpreter
             }
         }
 
+        // The JSON construction workload creates labels such as "item-" + i.
+        // For safe integer-valued doubles, append the number span directly into
+        // the one result string instead of allocating an intermediate numeric
+        // string. Both operands are already primitives, so no ToPrimitive hook
+        // or Symbol error can be skipped by this specialization.
+        if (op.Type == TokenType.PLUS)
+        {
+            if (leftRV.IsString && rightRV.IsNumber)
+            {
+                return RuntimeValue.FromString(ConcatStringAndNumber(
+                    leftRV.AsString(), rightRV.AsNumber(), numberFirst: false));
+            }
+            if (leftRV.IsNumber && rightRV.IsString)
+            {
+                return RuntimeValue.FromString(ConcatStringAndNumber(
+                    rightRV.AsString(), leftRV.AsNumber(), numberFirst: true));
+            }
+        }
+
         object? left = leftRV.ToObject();
         object? right = rightRV.ToObject();
 
@@ -774,6 +793,30 @@ public partial class Interpreter
             OperatorDescriptor.InstanceOf => RuntimeValue.FromBoxed(EvaluateInstanceof(left, right)),
             _ => RuntimeValue.Undefined
         };
+    }
+
+    private static string ConcatStringAndNumber(
+        string text,
+        double number,
+        bool numberFirst)
+    {
+        if (number == Math.Floor(number)
+            && Math.Abs(number) < 9007199254740992.0)
+        {
+            Span<char> buffer = stackalloc char[20];
+            ((long)number).TryFormat(
+                buffer,
+                out int charsWritten,
+                provider: System.Globalization.CultureInfo.InvariantCulture);
+            return numberFirst
+                ? string.Concat(buffer[..charsWritten], text.AsSpan())
+                : string.Concat(text.AsSpan(), buffer[..charsWritten]);
+        }
+
+        string formatted = Compilation.RuntimeTypes.FormatNumber(number);
+        return numberFirst
+            ? string.Concat(formatted, text)
+            : string.Concat(text, formatted);
     }
 
     private bool TryEvaluateDotNetBinary(

--- a/src/SharpTS/Execution/Interpreter.Calls.cs
+++ b/src/SharpTS/Execution/Interpreter.Calls.cs
@@ -1441,9 +1441,12 @@ public partial class Interpreter
     /// <returns>A new SharpTSObject with all properties set.</returns>
     private static SharpTSObject BuildObjectFromFields(
         Dictionary<string, object?> stringFields,
-        Dictionary<SharpTSSymbol, object?> symbolFields)
+        Dictionary<SharpTSSymbol, object?>? symbolFields)
     {
         var result = new SharpTSObject(stringFields);
+        if (symbolFields is null)
+            return result;
+
         foreach (var (sym, val) in symbolFields)
         {
             result.SetBySymbol(sym, val);

--- a/src/SharpTS/Execution/Interpreter.Expressions.cs
+++ b/src/SharpTS/Execution/Interpreter.Expressions.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using SharpTS.Modules;
 using SharpTS.Parsing;
 using SharpTS.Parsing.Visitors;
@@ -895,6 +896,7 @@ public partial class Interpreter
     /// <param name="obj">The object being indexed.</param>
     /// <param name="index">The index value.</param>
     /// <returns>An IndexTarget discriminated union representing the resolved target.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private IndexTarget ResolveIndexTarget(object? obj, object? index)
     {
         if (obj is SharpTSArray array)
@@ -955,8 +957,23 @@ public partial class Interpreter
     /// Supports array element access and enum reverse mapping (numeric value to name).
     /// </remarks>
     /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation">MDN Bracket Notation</seealso>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private RuntimeValue EvaluateGetIndex(Expr.GetIndex getIndex)
-        => EvaluateGetIndexCore(_syncContext, getIndex).GetAwaiter().GetResult();
+    {
+        // Avoid an async state machine for synchronous indexed reads. This is
+        // the inner path for record-array traversal such as back[i].value.
+        object? obj = Evaluate(getIndex.Object);
+        if (getIndex.Optional
+            && obj is null or Runtime.Types.SharpTSUndefined)
+        {
+            return RuntimeValue.Undefined;
+        }
+
+        return PerformIndexGet(
+            getIndex.Object,
+            obj,
+            Evaluate(getIndex.Index));
+    }
 
     /// <summary>
     /// Core indexed-read logic shared by the sync and async evaluators.
@@ -982,6 +999,7 @@ public partial class Interpreter
     /// receiver expression, needed only to synthesize a Get for the dot-notation
     /// fallback path.
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private RuntimeValue PerformIndexGet(Expr objectExpr, object? obj, object? index)
     {
         // ECMA-262 §13.3.3 RequireObjectCoercible: a bracket read on a nullish base
@@ -1016,6 +1034,25 @@ public partial class Interpreter
                 return RuntimeValue.FromBoxed(proxy.TrapGet(symbol, this));
             string key = index?.ToString() ?? "";
             return proxy.TrapGetRV(key, this);
+        }
+
+        // A present ordinary array element shadows every prototype property.
+        // Take that exact case before the generic symbol/property-key target
+        // resolver (which otherwise allocates and walks multiple dispatch
+        // layers). Holes and indexed accessors deliberately fall through.
+        if (obj is SharpTSArray directArray
+            && index is double directNumber
+            && double.IsFinite(directNumber)
+            && directNumber >= 0
+            && directNumber <= SharpTSArray.MaxWriteIndex
+            && Math.Truncate(directNumber) == directNumber)
+        {
+            long directIndex = (long)directNumber;
+            if (directArray.TryGetPresentDataIndex(
+                    directIndex, out object? directValue))
+            {
+                return RuntimeValue.FromBoxed(directValue);
+            }
         }
 
         if (obj is ISharpTSSymbolPropertyBag symbolBag
@@ -1277,6 +1314,7 @@ public partial class Interpreter
         return EvaluateGetOnFallback(prototype, key);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private RuntimeValue GetArrayIndexValue(SharpTSArray array, long index)
     {
         // Arguments objects are array-like, not Array exotic objects. Adding an

--- a/src/SharpTS/Execution/Interpreter.Expressions.cs
+++ b/src/SharpTS/Execution/Interpreter.Expressions.cs
@@ -537,11 +537,11 @@ public partial class Interpreter
     /// <summary>
     /// Applies a property key-value pair to the target fields dictionaries (sync version).
     /// </summary>
-    private void ApplyPropertyToFields(
+    private Dictionary<SharpTSSymbol, object?>? ApplyPropertyToFields(
         Expr.PropertyKey key,
         object? value,
         Dictionary<string, object?> stringFields,
-        Dictionary<SharpTSSymbol, object?> symbolFields)
+        Dictionary<SharpTSSymbol, object?>? symbolFields)
     {
         switch (key)
         {
@@ -557,25 +557,27 @@ public partial class Interpreter
             case Expr.ComputedKey ck:
                 object? keyValue = Evaluate(ck.Expression);
                 if (keyValue is SharpTSSymbol sym)
-                    symbolFields[sym] = value;
+                    (symbolFields ??= [])[sym] = value;
                 else if (keyValue is double numKey)
                     stringFields[numKey.ToString()] = value;
                 else
                     stringFields[keyValue?.ToString() ?? "undefined"] = value;
                 break;
         }
+        return symbolFields;
     }
 
     /// <summary>
     /// Applies a property key-value pair to the target fields dictionaries using an evaluation context.
     /// Shared between sync and async paths via IEvaluationContext.
     /// </summary>
-    private async ValueTask ApplyPropertyToFieldsCore(
+    private async ValueTask<Dictionary<SharpTSSymbol, object?>?>
+        ApplyPropertyToFieldsCore(
         IEvaluationContext ctx,
         Expr.PropertyKey key,
         object? value,
         Dictionary<string, object?> stringFields,
-        Dictionary<SharpTSSymbol, object?> symbolFields)
+        Dictionary<SharpTSSymbol, object?>? symbolFields)
     {
         switch (key)
         {
@@ -591,13 +593,14 @@ public partial class Interpreter
             case Expr.ComputedKey ck:
                 object? keyValue = (await ctx.EvaluateExprAsync(ck.Expression)).ToObject();
                 if (keyValue is SharpTSSymbol sym)
-                    symbolFields[sym] = value;
+                    (symbolFields ??= [])[sym] = value;
                 else if (keyValue is double numKey)
                     stringFields[numKey.ToString()] = value;
                 else
                     stringFields[keyValue?.ToString() ?? "undefined"] = value;
                 break;
         }
+        return symbolFields;
     }
 
     /// <summary>
@@ -609,7 +612,7 @@ public partial class Interpreter
     private async ValueTask<object?> EvaluateObjectCore(IEvaluationContext ctx, Expr.ObjectLiteral obj)
     {
         Dictionary<string, object?> stringFields = [];
-        Dictionary<SharpTSSymbol, object?> symbolFields = [];
+        Dictionary<SharpTSSymbol, object?>? symbolFields = null;
         List<(object key, ISharpTSCallable getter)>? getters = null;
         List<(object key, ISharpTSCallable setter)>? setters = null;
 
@@ -637,7 +640,8 @@ public partial class Interpreter
             else
             {
                 object? value = (await ctx.EvaluateExprAsync(prop.Value)).ToObject();
-                await ApplyPropertyToFieldsCore(ctx, prop.Key!, value, stringFields, symbolFields);
+                symbolFields = await ApplyPropertyToFieldsCore(
+                    ctx, prop.Key!, value, stringFields, symbolFields);
             }
         }
 
@@ -687,7 +691,7 @@ public partial class Interpreter
     private RuntimeValue EvaluateObject(Expr.ObjectLiteral obj)
     {
         Dictionary<string, object?> stringFields = [];
-        Dictionary<SharpTSSymbol, object?> symbolFields = [];
+        Dictionary<SharpTSSymbol, object?>? symbolFields = null;
         List<(object key, ISharpTSCallable getter)>? getters = null;
         List<(object key, ISharpTSCallable setter)>? setters = null;
 
@@ -715,7 +719,8 @@ public partial class Interpreter
             else
             {
                 object? value = Evaluate(prop.Value);
-                ApplyPropertyToFields(prop.Key!, value, stringFields, symbolFields);
+                symbolFields = ApplyPropertyToFields(
+                    prop.Key!, value, stringFields, symbolFields);
             }
         }
 

--- a/src/SharpTS/Execution/Interpreter.Properties.cs
+++ b/src/SharpTS/Execution/Interpreter.Properties.cs
@@ -1751,6 +1751,20 @@ public partial class Interpreter
     /// </summary>
     private RuntimeValue EvaluateGetOnRecordRV(SharpTSObject simpleObj, string memberName)
     {
+        // Parsed records and ordinary object literals have no accessor overlay.
+        // Read their data property once instead of probing getter storage,
+        // ContainsKey, and then the dictionary indexer. Callable values still
+        // retain member-access binding semantics.
+        if (simpleObj.TryGetOrdinaryDataProperty(memberName, out var ownValue))
+        {
+            if (!simpleObj.ShouldPreserveCallableValueIdentity(memberName)
+                && TryBindReceiverForMethodAccess(ownValue, simpleObj) is { } boundMethod)
+            {
+                return RuntimeValue.FromObject(boundMethod);
+            }
+            return RuntimeValue.FromBoxed(ownValue);
+        }
+
         // Check for getter first on the own object
         var getter = simpleObj.GetGetter(memberName);
         if (getter != null)

--- a/src/SharpTS/Execution/Interpreter.Properties.cs
+++ b/src/SharpTS/Execution/Interpreter.Properties.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using SharpTS.Parsing;
 using SharpTS.Runtime;
 using SharpTS.Runtime.BuiltIns;
@@ -490,8 +491,28 @@ public partial class Interpreter
     /// </remarks>
     /// <seealso href="https://www.typescriptlang.org/docs/handbook/2/objects.html">TypeScript Object Types</seealso>
     /// <seealso href="https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining">TypeScript Optional Chaining</seealso>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private RuntimeValue EvaluateGet(Expr.Get get)
-        => EvaluateGetCore(_syncContext, get).GetAwaiter().GetResult();
+    {
+        // Keep ordinary synchronous member reads out of the shared async state
+        // machine. SyncEvaluationContext only returns completed ValueTasks, but
+        // resuming that state machine still dominates tight traversal loops.
+        if (get.Object is Expr.Variable nsVar
+            && !IsRealmIntrinsicName(nsVar.Name.Lexeme)
+            && nsVar.Name.Lexeme != BuiltInNames.Promise)
+        {
+            object? member = BuiltInRegistry.Instance.GetStaticMethod(
+                nsVar.Name.Lexeme, get.Name.Lexeme);
+            if (member is not null)
+            {
+                return member is BuiltInMethod bm && bm.IsConstant
+                    ? RuntimeValue.FromBoxed(bm.CallBoxed(this, []))
+                    : RuntimeValue.FromObject(member);
+            }
+        }
+
+        return EvaluateGetOnObject(get, Evaluate(get.Object));
+    }
 
     /// <summary>
     /// Core property-access logic shared by the sync and async evaluators; the evaluation
@@ -951,6 +972,7 @@ public partial class Interpreter
     /// Core property access logic, shared between sync and async evaluation.
     /// Uses TypeCategoryResolver for unified type dispatch.
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private RuntimeValue EvaluateGetOnObject(Expr.Get get, object? obj)
     {
         // Handle optional chaining - return undefined if object is null or undefined
@@ -973,6 +995,21 @@ public partial class Interpreter
         if (obj is SharpTSProxy proxy)
         {
             return proxy.TrapGetRV(get.Name.Lexeme, this);
+        }
+
+        // These two exact ordinary shapes dominate data traversal. Resolve
+        // them before namespace/category/built-in dispatch while retaining the
+        // existing record helper's accessor, prototype, and callable rules.
+        string directMemberName = get.Name.Lexeme;
+        if (obj is SharpTSArray directArray
+            && directMemberName == "length")
+        {
+            return RuntimeValue.FromNumber(directArray.LongLength);
+        }
+        if (obj?.GetType() == typeof(SharpTSObject))
+        {
+            return EvaluateGetOnRecordRV(
+                (SharpTSObject)obj, directMemberName);
         }
 
         // String.prototype / Number.prototype / Boolean.prototype resolve to
@@ -1749,6 +1786,7 @@ public partial class Interpreter
     /// (lodash.js ~2177) does `this.clear()` in its ctor where `clear` lives on
     /// `MapCache.prototype`; without the walk it resolves to undefined.
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private RuntimeValue EvaluateGetOnRecordRV(SharpTSObject simpleObj, string memberName)
     {
         // Parsed records and ordinary object literals have no accessor overlay.
@@ -1757,6 +1795,9 @@ public partial class Interpreter
         // retain member-access binding semantics.
         if (simpleObj.TryGetOrdinaryDataProperty(memberName, out var ownValue))
         {
+            if (ownValue is not ISharpTSCallable)
+                return RuntimeValue.FromBoxed(ownValue);
+
             if (!simpleObj.ShouldPreserveCallableValueIdentity(memberName)
                 && TryBindReceiverForMethodAccess(ownValue, simpleObj) is { } boundMethod)
             {

--- a/src/SharpTS/Execution/Interpreter.Statements.cs
+++ b/src/SharpTS/Execution/Interpreter.Statements.cs
@@ -11,6 +11,7 @@ using SharpTS.Runtime.Exceptions;
 using SharpTS.Runtime.Types;
 using SharpTS.TypeSystem;
 using System.Collections.Frozen;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace SharpTS.Execution;
@@ -1770,7 +1771,57 @@ public partial class Interpreter
         // Drain labels parked by an enclosing labeled statement before running the initializer,
         // so `continue <label>`/`break <label>` resolve to this loop (#558).
         var labels = TakePendingLoopLabels();
-        return ExecuteForCore(_syncContext, forStmt, labels).GetAwaiter().GetResult();
+        return ExecuteForSync(forStmt, labels);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private ExecutionResult ExecuteForSync(
+        Stmt.For forStmt,
+        IReadOnlyList<string>? labels)
+    {
+        RuntimeEnvironment loopEnv = new(_environment);
+        using (PushScope(loopEnv))
+        {
+            if (forStmt.Initializer is not null)
+                Execute(forStmt.Initializer);
+
+            List<string>? perIterationNames =
+                CollectPerIterationBindings(forStmt.Initializer);
+            if (perIterationNames is not null)
+                CreatePerIterationEnvironment(loopEnv, perIterationNames);
+
+            while (forStmt.Condition is null
+                || EvaluateRV(forStmt.Condition).IsTruthy())
+            {
+                ExecutionResult result = Execute(forStmt.Body);
+                var (shouldBreak, shouldContinue, abruptResult) =
+                    HandleLoopResult(result, labels);
+                if (shouldBreak)
+                    break;
+
+                if (shouldContinue)
+                {
+                    if (perIterationNames is not null)
+                        CreatePerIterationEnvironment(
+                            loopEnv, perIterationNames);
+                    if (forStmt.Increment is not null)
+                        EvaluateRV(forStmt.Increment);
+                    Thread.Sleep(0);
+                    continue;
+                }
+
+                if (abruptResult.HasValue)
+                    return abruptResult.Value;
+
+                if (perIterationNames is not null)
+                    CreatePerIterationEnvironment(loopEnv, perIterationNames);
+                if (forStmt.Increment is not null)
+                    EvaluateRV(forStmt.Increment);
+                ProcessPendingCallbacks();
+            }
+
+            return ExecutionResult.Success();
+        }
     }
 
     /// <summary>

--- a/src/SharpTS/Runtime/BuiltIns/JSONBuiltIns.cs
+++ b/src/SharpTS/Runtime/BuiltIns/JSONBuiltIns.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using SharpTS.Execution;
@@ -70,6 +71,7 @@ public static class JSONBuiltIns
         => RuntimeValue.FromBoolean(
             args.Length > 0 && args[0].ToObject() is SharpTSRawJson);
 
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private static RuntimeValue ParseJson(Interpreter interp, RuntimeValue _, ReadOnlySpan<RuntimeValue> args)
     {
         object? input = args.Length > 0
@@ -281,6 +283,7 @@ public static class JSONBuiltIns
         return reviver.Call(interp, [key, val]);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private static RuntimeValue StringifyJson(Interpreter interp, RuntimeValue _, ReadOnlySpan<RuntimeValue> args)
     {
         var value = args[0].ToObject();
@@ -379,6 +382,7 @@ public static class JSONBuiltIns
             (_stringBuilders ??= []).Push(builder);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private static bool StringifyValue(Interpreter interp, object holder, object? value, string? key,
         ISharpTSCallable? replacer, IReadOnlyList<string>? allowedKeys, string indentStr, int depth, StringBuilder sb, List<object> seen,
         int arrayIndex = -1)
@@ -622,6 +626,7 @@ public static class JSONBuiltIns
         StringifyJsonObject(interp, regex, regex.OwnEnumerableKeys(),
             replacer, allowedKeys, indentStr, depth, sb, seen);
 
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private static void StringifyObject(Interpreter interp, SharpTSObject obj,
         ISharpTSCallable? replacer, IReadOnlyList<string>? allowedKeys, string indentStr, int depth, StringBuilder sb, List<object> seen)
     {
@@ -657,6 +662,7 @@ public static class JSONBuiltIns
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private static bool TryStringifyOrdinaryScalarRecord(
         SharpTSObject obj,
         StringBuilder builder)
@@ -750,6 +756,7 @@ public static class JSONBuiltIns
     /// OwnPropertyKeys-then-Get order — so the allowedKeys filter never
     /// allocates a filtered dictionary.
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private static void StringifyJsonObject(Interpreter interp, object node,
         IEnumerable<string> keys,
         ISharpTSCallable? replacer, IReadOnlyList<string>? allowedKeys, string indentStr, int depth,

--- a/src/SharpTS/Runtime/RuntimeJson.cs
+++ b/src/SharpTS/Runtime/RuntimeJson.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using SharpTS.Runtime.Types;
@@ -18,6 +19,7 @@ internal static class RuntimeJson
     /// Parses JSON text into SharpTS runtime values. Throws
     /// <see cref="JsonException"/> on invalid input.
     /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     public static object? Parse(string text)
     {
         int byteCount = Encoding.UTF8.GetByteCount(text);
@@ -47,6 +49,7 @@ internal static class RuntimeJson
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private static object? ParseValue(
         ref Utf8JsonReader reader,
         List<string> propertyNames)
@@ -65,6 +68,7 @@ internal static class RuntimeJson
         };
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private static SharpTSObject ParseObject(
         ref Utf8JsonReader reader,
         List<string> propertyNames)
@@ -91,6 +95,7 @@ internal static class RuntimeJson
         return new SharpTSObject(fields);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private static SharpTSArray ParseArray(
         ref Utf8JsonReader reader,
         List<string> propertyNames)

--- a/src/SharpTS/Runtime/RuntimeJson.cs
+++ b/src/SharpTS/Runtime/RuntimeJson.cs
@@ -1,54 +1,123 @@
+using System.Buffers;
+using System.Text;
 using System.Text.Json;
 using SharpTS.Runtime.Types;
 
 namespace SharpTS.Runtime;
 
 /// <summary>
-/// Single authoritative conversion from <see cref="JsonElement"/> trees to SharpTS runtime
-/// values (<see cref="SharpTSArray"/> / <see cref="SharpTSObject"/>, doubles, strings, bools,
-/// null). Shared by JSON.parse, fetch Request/Response bodies, and IPC deserialization.
-/// Exception translation stays at each caller (JSON.parse throws its syntax error; body
-/// readers reject their promise) — callers wrap <see cref="Parse"/> in their own try/catch.
-/// The compiled-standalone converter in Compilation/RuntimeTypes.Json.cs is intentionally
-/// separate: it produces List/Dictionary shapes and must not depend on SharpTS runtime types.
+/// One-pass JSON parser for interpreter runtime values. The parser writes
+/// directly into <see cref="SharpTSArray"/> and <see cref="SharpTSObject"/>
+/// nodes instead of materializing a <see cref="JsonDocument"/> DOM first.
 /// </summary>
 internal static class RuntimeJson
 {
-    /// <summary>Parses JSON text into SharpTS runtime values. Throws <see cref="JsonException"/> on invalid input.</summary>
+    private const int MaxCachedPropertyNames = 64;
+
+    /// <summary>
+    /// Parses JSON text into SharpTS runtime values. Throws
+    /// <see cref="JsonException"/> on invalid input.
+    /// </summary>
     public static object? Parse(string text)
     {
-        using var doc = JsonDocument.Parse(text);
-        return FromElement(doc.RootElement);
+        int byteCount = Encoding.UTF8.GetByteCount(text);
+        byte[] rented = ArrayPool<byte>.Shared.Rent(Math.Max(byteCount, 1));
+        try
+        {
+            int written = Encoding.UTF8.GetBytes(
+                text.AsSpan(), rented.AsSpan(0, byteCount));
+            var reader = new Utf8JsonReader(
+                rented.AsSpan(0, written),
+                isFinalBlock: true,
+                state: default);
+            if (!reader.Read())
+                throw new JsonException("Expected a JSON value.");
+
+            var propertyNames = new List<string>(8);
+            object? result = ParseValue(ref reader, propertyNames);
+            if (reader.Read())
+                throw new JsonException("Additional text follows the JSON value.");
+            return result;
+        }
+        finally
+        {
+            // ArrayPool.Shared has bounded buckets and rejects oversized arrays;
+            // the parse never retains workload-sized buffers itself.
+            ArrayPool<byte>.Shared.Return(rented, clearArray: false);
+        }
     }
 
-    /// <summary>Recursively converts a <see cref="JsonElement"/> to SharpTS runtime values.</summary>
-    public static object? FromElement(JsonElement element)
+    private static object? ParseValue(
+        ref Utf8JsonReader reader,
+        List<string> propertyNames)
     {
-        return element.ValueKind switch
+        return reader.TokenType switch
         {
-            JsonValueKind.Null => null,
-            JsonValueKind.True => true,
-            JsonValueKind.False => false,
-            JsonValueKind.Number => element.GetDouble(),
-            JsonValueKind.String => element.GetString(),
-            JsonValueKind.Array => new SharpTSArray(
-                element.EnumerateArray().Select(FromElement).ToList()),
-            JsonValueKind.Object => FromObject(element),
-            _ => null
+            JsonTokenType.StartObject => ParseObject(ref reader, propertyNames),
+            JsonTokenType.StartArray => ParseArray(ref reader, propertyNames),
+            JsonTokenType.String => reader.GetString(),
+            JsonTokenType.Number => reader.GetDouble(),
+            JsonTokenType.True => true,
+            JsonTokenType.False => false,
+            JsonTokenType.Null => null,
+            _ => throw new JsonException(
+                $"Unexpected JSON token {reader.TokenType}.")
         };
     }
 
-    private static SharpTSObject FromObject(JsonElement element)
+    private static SharpTSObject ParseObject(
+        ref Utf8JsonReader reader,
+        List<string> propertyNames)
     {
         var fields = new Dictionary<string, object?>();
-        foreach (var property in element.EnumerateObject())
+        while (reader.Read() && reader.TokenType != JsonTokenType.EndObject)
         {
-            // JSON permits duplicate names. JSON.parse keeps the last value,
-            // including for "__proto__", which is an ordinary data property
-            // here rather than object-literal prototype syntax.
-            fields[property.Name] = FromElement(property.Value);
+            if (reader.TokenType != JsonTokenType.PropertyName)
+                throw new JsonException("Expected a JSON property name.");
+
+            string propertyName = GetCachedPropertyName(
+                ref reader, propertyNames);
+            if (!reader.Read())
+                throw new JsonException("Expected a JSON property value.");
+
+            // Duplicate names overwrite the value but retain the first
+            // insertion position, matching JSON.parse and the previous DOM
+            // conversion path. "__proto__" remains an ordinary data property.
+            fields[propertyName] = ParseValue(ref reader, propertyNames);
         }
 
+        if (reader.TokenType != JsonTokenType.EndObject)
+            throw new JsonException("Unexpected end of JSON object.");
         return new SharpTSObject(fields);
+    }
+
+    private static SharpTSArray ParseArray(
+        ref Utf8JsonReader reader,
+        List<string> propertyNames)
+    {
+        var result = new SharpTSArray();
+        while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
+            result.Add(ParseValue(ref reader, propertyNames));
+
+        if (reader.TokenType != JsonTokenType.EndArray)
+            throw new JsonException("Unexpected end of JSON array.");
+        return result;
+    }
+
+    private static string GetCachedPropertyName(
+        ref Utf8JsonReader reader,
+        List<string> propertyNames)
+    {
+        foreach (string candidate in propertyNames)
+        {
+            if (reader.ValueTextEquals(candidate))
+                return candidate;
+        }
+
+        string propertyName = reader.GetString()
+            ?? throw new JsonException("A JSON property name was null.");
+        if (propertyNames.Count < MaxCachedPropertyNames)
+            propertyNames.Add(propertyName);
+        return propertyName;
     }
 }

--- a/src/SharpTS/Runtime/Types/SharpTSArray.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSArray.cs
@@ -213,6 +213,29 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     public bool HasIndex(int index) => HasIndex((long)index);
 
     /// <summary>
+    /// Reads a present indexed data property in one storage probe. Returns
+    /// false for holes, out-of-range indices, and indexed accessors so callers
+    /// can preserve the full prototype/accessor path for those cases.
+    /// </summary>
+    internal bool TryGetPresentDataIndex(long index, out object? value)
+    {
+        value = null;
+        if ((ulong)index >= (ulong)_length
+            || index <= uint.MaxValue
+                && (_indexAccessors?.ContainsKey((uint)index) ?? false))
+        {
+            return false;
+        }
+
+        object? candidate = GetCore(index);
+        if (candidate is ArrayHole)
+            return false;
+
+        value = candidate;
+        return true;
+    }
+
+    /// <summary>
     /// Makes <paramref name="index"/> a hole (ECMA-262 <c>delete arr[i]</c>).
     /// Length is unchanged. No-op for out-of-range indices or frozen arrays.
     /// </summary>

--- a/src/SharpTS/Runtime/Types/SharpTSObject.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSObject.cs
@@ -241,6 +241,23 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
     public RuntimeValue GetPropertyRV(string name) => RuntimeValue.FromBoxed(GetProperty(name));
 
     /// <summary>
+    /// Performs the common ordinary data-property read with one dictionary
+    /// lookup. Accessor metadata is disjoint from the data dictionary in the
+    /// normal representation; if any accessor overlay exists, callers retain
+    /// the full getter/prototype dispatch path.
+    /// </summary>
+    internal bool TryGetOrdinaryDataProperty(
+        string name,
+        out object? value)
+    {
+        if (_accessorProperties is null)
+            return _fields.TryGetValue(name, out value);
+
+        value = null;
+        return false;
+    }
+
+    /// <summary>
     /// Reflection-friendly field accessor used by the compiled-mode
     /// <c>GetFieldsProperty</c> helper. Its <c>GetMember(string)</c> reflection
     /// fallback (<c>Compilation/RuntimeEmitter.Objects.Properties.cs</c>) calls

--- a/src/SharpTS/Runtime/Types/SharpTSObject.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSObject.cs
@@ -22,7 +22,10 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
     // JSON record never pays for a second collection per object. Mutations that
     // can detach property existence from _fields materialize it first.
     private List<string>? _stringPropertyOrder;
-    private readonly Dictionary<SharpTSSymbol, object?> _symbolFields = new();
+    // Ordinary objects overwhelmingly contain string keys only. Allocate
+    // permanent symbol storage only when the first symbol data property is
+    // created; accessor and order metadata are independently lazy as well.
+    private Dictionary<SharpTSSymbol, object?>? _symbolFields;
     private List<SharpTSSymbol>? _symbolPropertyOrder;
     private Dictionary<SharpTSSymbol, (ISharpTSCallable? Get, ISharpTSCallable? Set)>?
         _symbolAccessors;
@@ -165,7 +168,10 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
     public IEnumerable<SharpTSSymbol> GetSymbolPropertyNames()
         => _symbolPropertyOrder is not null
             ? _symbolPropertyOrder
-            : _symbolFields.Keys;
+            : _symbolFields?.Keys ?? Enumerable.Empty<SharpTSSymbol>();
+
+    private Dictionary<SharpTSSymbol, object?> EnsureSymbolFields()
+        => _symbolFields ??= [];
 
     private List<string> EnsureStringPropertyOrder()
         => _stringPropertyOrder ??= [.. _fields.Keys];
@@ -183,11 +189,13 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
         if (_symbolPropertyOrder is not null)
             return _symbolPropertyOrder;
 
-        _symbolPropertyOrder = [.. _symbolFields.Keys];
+        _symbolPropertyOrder = _symbolFields is null
+            ? []
+            : [.. _symbolFields.Keys];
         if (_symbolAccessors is not null)
         {
             foreach (SharpTSSymbol symbol in _symbolAccessors.Keys)
-                if (!_symbolFields.ContainsKey(symbol))
+                if (!(_symbolFields?.ContainsKey(symbol) ?? false))
                     _symbolPropertyOrder.Add(symbol);
         }
         return _symbolPropertyOrder;
@@ -486,7 +494,9 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
     /// </summary>
     public object? GetBySymbol(SharpTSSymbol symbol)
     {
-        return _symbolFields.TryGetValue(symbol, out var value) ? value : null;
+        return _symbolFields?.TryGetValue(symbol, out var value) == true
+            ? value
+            : null;
     }
 
     /// <summary>Installs a symbol-keyed accessor property.</summary>
@@ -496,7 +506,7 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
         bool exists = HasSymbolProperty(symbol);
         _symbolAccessors ??= [];
         _symbolAccessors[symbol] = (getter, setter);
-        _symbolFields.Remove(symbol);
+        _symbolFields?.Remove(symbol);
         _symbolDescriptors ??= [];
         _symbolDescriptors[symbol] = PropertyDescriptorFlags.Default;
         if (!exists) EnsureSymbolPropertyOrder().Add(symbol);
@@ -545,7 +555,7 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
             _symbolDescriptors ??= [];
             _symbolDescriptors[symbol] = PropertyDescriptorFlags.Default;
         }
-        _symbolFields[symbol] = value;
+        EnsureSymbolFields()[symbol] = value;
     }
 
     /// <summary>
@@ -585,7 +595,7 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
             _symbolDescriptors ??= [];
             _symbolDescriptors[symbol] = PropertyDescriptorFlags.Default;
         }
-        _symbolFields[symbol] = value;
+        EnsureSymbolFields()[symbol] = value;
     }
 
     /// <summary>
@@ -593,7 +603,7 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
     /// </summary>
     public bool HasSymbolProperty(SharpTSSymbol symbol)
     {
-        return _symbolFields.ContainsKey(symbol)
+        return (_symbolFields?.ContainsKey(symbol) ?? false)
             || (_symbolAccessors?.ContainsKey(symbol) ?? false);
     }
 
@@ -612,7 +622,7 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
         List<SharpTSSymbol>? propertyOrder = HasSymbolProperty(symbol)
             ? EnsureSymbolPropertyOrder()
             : null;
-        bool removed = _symbolFields.Remove(symbol);
+        bool removed = _symbolFields?.Remove(symbol) ?? false;
         removed = (_symbolAccessors?.Remove(symbol) ?? false) || removed;
         if (removed)
         {
@@ -645,7 +655,7 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
         List<SharpTSSymbol>? propertyOrder = HasSymbolProperty(symbol)
             ? EnsureSymbolPropertyOrder()
             : null;
-        bool removed = _symbolFields.Remove(symbol);
+        bool removed = _symbolFields?.Remove(symbol) ?? false;
         removed = (_symbolAccessors?.Remove(symbol) ?? false) || removed;
         if (removed)
         {
@@ -724,15 +734,15 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
             if (descriptor.HasSet) setter = descriptor.Set;
             _symbolAccessors ??= [];
             _symbolAccessors[symbol] = (getter, setter);
-            _symbolFields.Remove(symbol);
+            _symbolFields?.Remove(symbol);
         }
         else
         {
             _symbolAccessors?.Remove(symbol);
             if (descriptor.HasValue)
-                _symbolFields[symbol] = descriptor.Value;
+                EnsureSymbolFields()[symbol] = descriptor.Value;
             else if (!hasExisting)
-                _symbolFields[symbol] = SharpTSUndefined.Instance;
+                EnsureSymbolFields()[symbol] = SharpTSUndefined.Instance;
         }
 
         if (!hasExisting) propertyOrder.Add(symbol);
@@ -963,7 +973,9 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
     /// <summary>Gets the complete descriptor for an own symbol-keyed property.</summary>
     internal SharpTSPropertyDescriptor? GetOwnPropertyDescriptor(SharpTSSymbol symbol)
     {
-        bool hasDataProperty = _symbolFields.TryGetValue(symbol, out var value);
+        object? value = null;
+        bool hasDataProperty = _symbolFields?.TryGetValue(symbol, out value)
+            == true;
         bool isAccessor = _symbolAccessors?.ContainsKey(symbol) ?? false;
         if (!hasDataProperty && !isAccessor) return null;
 

--- a/tests/SharpTS.Tests/Compilation/CountedPushLoopAnalyzerTests.cs
+++ b/tests/SharpTS.Tests/Compilation/CountedPushLoopAnalyzerTests.cs
@@ -1,0 +1,40 @@
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using Xunit;
+
+namespace SharpTS.Tests.Compilation;
+
+public class CountedPushLoopAnalyzerTests
+{
+    [Fact]
+    public void PureCountedRecordPush_IsRecognized()
+    {
+        var loop = ParseLoop("""
+            for (let i: number = 0; i < n; i++) {
+                items.push({ id: i, name: "item-" + i, value: i * 3 - 1 });
+            }
+            """);
+
+        Assert.True(CountedPushLoopAnalyzer.TryAnalyze(loop, out var reservation));
+        Assert.Equal("items", reservation.Array.Name.Lexeme);
+        Assert.Equal("n", reservation.Bound.Name.Lexeme);
+    }
+
+    [Theory]
+    [InlineData("for (let i = 1; i < n; i++) items.push({ value: i });")]
+    [InlineData("for (let i = 0; i <= n; i++) items.push({ value: i });")]
+    [InlineData("for (let i = 0; i < n; i++) { items.push({ value: i }); log(i); }")]
+    [InlineData("for (let i = 0; i < n; i++) items.push(makeItem(i));")]
+    [InlineData("for (let i = 0; i < getCount(); i++) items.push({ value: i });")]
+    public void NonProvenShapes_AreRejected(string source)
+    {
+        Assert.False(CountedPushLoopAnalyzer.TryAnalyze(
+            ParseLoop(source),
+            out _));
+    }
+
+    private static Stmt.For ParseLoop(string source) =>
+        Assert.IsType<Stmt.For>(new Parser(new Lexer(source).ScanTokens())
+            .ParseOrThrow()
+            .Single());
+}

--- a/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
@@ -1,11 +1,43 @@
 using SharpTS.Compilation;
 using SharpTS.Parsing;
+using SharpTS.TypeSystem;
 using Xunit;
 
 namespace SharpTS.Tests.CompilerTests;
 
 public class RuntimeFeatureDetectorTests
 {
+    [Theory]
+    [InlineData("const value = { x: 1 }; JSON.stringify(value);", 1)]
+    [InlineData("const value = { x: 1 }; JSON.stringify(value, null, 2);", 0)]
+    [InlineData("const value = { x: 1 }; const stringify = JSON.stringify; stringify(value);", 0)]
+    public void CollectsJsonScalarRecordsOnlyForDirectOneArgumentCalls(
+        string source,
+        int expectedShapeCount)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var features = new RuntimeFeatureDetector().Detect(statements, typeMap);
+
+        Assert.Equal(expectedShapeCount, features.JsonScalarRecordShapeFingerprints.Count);
+    }
+
+    [Fact]
+    public void CollectsNestedClosedJsonScalarRecords()
+    {
+        const string source = """
+            const items: { i: number; s: string; v: boolean }[] = [];
+            items.push({ i: 1, s: "x", v: true });
+            const root = { items };
+            JSON.stringify(root);
+            """;
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var features = new RuntimeFeatureDetector().Detect(statements, typeMap);
+
+        Assert.Equal(2, features.JsonScalarRecordShapeFingerprints.Count);
+    }
+
     [Theory]
     [InlineData("async function f() { for await (const x of [1]) {} }", true)]
     [InlineData("function f() { for (const x of [1]) {} }", false)]

--- a/tests/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
@@ -174,6 +174,59 @@ public class StandaloneDllTests
         }
     }
 
+    [Fact]
+    public void Isolated_JsonParse_ShouldExecuteWithoutSharpTsDll()
+    {
+        var source = """
+            const parsed: any[] = JSON.parse(
+                '[{"id":1,"label":"a"},{"\\u0069d":2,"label":"b"}]');
+            console.log(parsed[0].id, parsed[1].id, parsed[1].label);
+            """;
+
+        var (tempDir, dllPath) = CompileStandalone(source);
+        try
+        {
+            Assert.DoesNotContain(GetAssemblyReferences(dllPath), r => r == "SharpTS");
+            Assert.Equal("1 2 b\n", ExecuteCompiledDllIsolated(dllPath, timeoutMs: 15000));
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
+    [Fact]
+    public void Isolated_ShapedJsonRoundTrip_ShouldExecuteWithoutSharpTsDll()
+    {
+        var source = """
+            const payload: {
+                items: { id: number; label: string; note: null }[]
+            } = {
+                items: [{ id: 1, label: "a", note: null }]
+            };
+            const json: string = JSON.stringify(payload);
+            const parsed: any = JSON.parse(json);
+            console.log(json);
+            console.log(parsed.items[0].id, parsed.items[0].label,
+                parsed.items[0].note === null);
+            """;
+
+        var (tempDir, dllPath) = CompileStandalone(source);
+        try
+        {
+            Assert.DoesNotContain(
+                GetAssemblyReferences(dllPath), r => r == "SharpTS");
+            Assert.Equal(
+                "{\"items\":[{\"id\":1,\"label\":\"a\",\"note\":null}]}\n" +
+                "1 a true\n",
+                ExecuteCompiledDllIsolated(dllPath, timeoutMs: 15000));
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
     /// <summary>
     /// Broader sibling of <see cref="CompiledDll_ShouldNotReferenceSharpTsAssembly"/>: the trivial
     /// program there only exercises one code path. This compiles a battery of diverse language

--- a/tests/SharpTS.Tests/SharedTests/CountedPushLoopTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/CountedPushLoopTests.cs
@@ -1,0 +1,37 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+public class CountedPushLoopTests
+{
+    [Theory, ModeData]
+    public void CountedPushReservation_RetainsBoundsAndRuntimeFallbacks(
+        ExecutionMode mode)
+    {
+        var source = """
+            function fill(n: number): number {
+                const items: { value: number }[] = [];
+                for (let i: number = 0; i < n; i++) {
+                    items.push({ value: i });
+                }
+                return items.length + items[items.length - 1].value;
+            }
+            console.log(fill(3.2));
+
+            const receiver: any = {
+                total: 0,
+                push: function (value: number): number {
+                    this.total = this.total + value;
+                    return 0;
+                }
+            };
+            for (let i: number = 0; i < 3; i++) {
+                receiver.push(i);
+            }
+            console.log(receiver.total);
+            """;
+
+        Assert.Equal("7\n3\n", TestHarness.Run(source, mode));
+    }
+}

--- a/tests/SharpTS.Tests/SharedTests/JSONTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/JSONTests.cs
@@ -587,7 +587,7 @@ public class JSONTests
         Assert.Equal("1 2 4\nid,label\nid\n", TestHarness.Run(source, mode));
     }
 
-    [Theory, CompiledOnlyData]
+    [Theory, ModeData]
     public void JSON_ShapedRecord_FallsBackForObservableMutations(
         ExecutionMode mode)
     {
@@ -630,7 +630,7 @@ public class JSONTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory, CompiledOnlyData]
+    [Theory, ModeData]
     public void JSON_CompactRecord_RetainsOrdinaryObjectSemantics(
         ExecutionMode mode)
     {
@@ -656,7 +656,7 @@ public class JSONTests
             TestHarness.Run(source, mode));
     }
 
-    [Theory, CompiledOnlyData]
+    [Theory, ModeData]
     public void JSON_ShapedRoundTrip_HandlesNestedAndNullSlots(
         ExecutionMode mode)
     {

--- a/tests/SharpTS.Tests/SharedTests/JSONTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/JSONTests.cs
@@ -547,6 +547,32 @@ public class JSONTests
     }
 
     [Theory, ModeData]
+    public void JSON_Parse_OrdinaryTraversalRetainsAccessorAndPrototypeFallbacks(
+        ExecutionMode mode)
+    {
+        var source = """
+            const parsed: any = JSON.parse('{"value":7}');
+            console.log(parsed.value);
+
+            Object.defineProperty(parsed, "other", {
+                get: function (): number { return 9; },
+                enumerable: true,
+                configurable: true
+            });
+            console.log(parsed.value, parsed.other);
+
+            const inherited: any = Object.create(parsed);
+            console.log(inherited.value);
+
+            const callable: any = JSON.parse('{"value":11}');
+            callable.read = function (): number { return this.value; };
+            console.log(callable.read());
+            """;
+
+        Assert.Equal("7\n7 9\n7\n11\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
     public void JSON_Stringify_KeySnapshotSurvivesGetterMutation(
         ExecutionMode mode)
     {

--- a/tests/SharpTS.Tests/SharedTests/JSONTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/JSONTests.cs
@@ -573,6 +573,126 @@ public class JSONTests
     }
 
     [Theory, ModeData]
+    public void JSON_Parse_RepeatedAndEscapedPropertyNamesRetainSemantics(
+        ExecutionMode mode)
+    {
+        var source = """
+            const parsed: any[] = JSON.parse(
+                '[{"id":1,"label":"a"},{"\\u0069d":2,"label":"b"},{"id":3,"id":4}]');
+            console.log(parsed[0].id, parsed[1].id, parsed[2].id);
+            console.log(Object.keys(parsed[1]).join(","));
+            console.log(Object.keys(parsed[2]).join(","));
+            """;
+
+        Assert.Equal("1 2 4\nid,label\nid\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, CompiledOnlyData]
+    public void JSON_ShapedRecord_FallsBackForObservableMutations(
+        ExecutionMode mode)
+    {
+        var source = """
+            const hidden: { a: number; b: number } = { a: 1, b: 2 };
+            Object.defineProperty(hidden, "a", {
+                value: 9, enumerable: false, configurable: true
+            });
+            console.log(JSON.stringify(hidden));
+
+            const inherited: { a: number } = { a: 4 };
+            Object.setPrototypeOf(inherited, {
+                toJSON: function (): any { return { hooked: this.a + 1 }; }
+            });
+            console.log(JSON.stringify(inherited));
+
+            const extended: { a: number } = { a: 1 };
+            (extended as any).z = 3;
+            console.log(JSON.stringify(extended));
+
+            const reordered: { a: number; b: number } = { a: 1, b: 2 };
+            const dynamic: any = reordered;
+            delete dynamic.a;
+            dynamic.a = 7;
+            console.log(JSON.stringify(reordered));
+
+            const ownHook: { a: number } = { a: 6 };
+            (ownHook as any).toJSON = function (): any {
+                return { custom: this.a };
+            };
+            console.log(JSON.stringify(ownHook));
+            """;
+
+        Assert.Equal(
+            "{\"b\":2}\n" +
+            "{\"hooked\":5}\n" +
+            "{\"a\":1,\"z\":3}\n" +
+            "{\"b\":2,\"a\":7}\n" +
+            "{\"custom\":6}\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, CompiledOnlyData]
+    public void JSON_CompactRecord_RetainsOrdinaryObjectSemantics(
+        ExecutionMode mode)
+    {
+        var source = """
+            const record: { a: number; b: string; c: boolean; d: null } = {
+                a: 1, b: "x", c: true, d: null
+            };
+            console.log(record.a, record.b, record.c, record.d === null);
+            record.a = 8;
+            const dynamic: any = record;
+            delete dynamic.b;
+            Object.defineProperty(dynamic, "e", {
+                value: 5, enumerable: true, configurable: true
+            });
+            console.log(Object.keys(record).join(","));
+            console.log(JSON.stringify(record));
+            """;
+
+        Assert.Equal(
+            "1 x true true\n" +
+            "a,c,d,e\n" +
+            "{\"a\":8,\"c\":true,\"d\":null,\"e\":5}\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, CompiledOnlyData]
+    public void JSON_ShapedRoundTrip_HandlesNestedAndNullSlots(
+        ExecutionMode mode)
+    {
+        var source = """
+            const payload: {
+                items: { id: number; label: string; active: boolean; note: null }[]
+            } = {
+                items: [
+                    { id: 1, label: "a", active: true, note: null },
+                    { id: 2, label: "b", active: false, note: null }
+                ]
+            };
+            const json: string = JSON.stringify(payload);
+            const shaped: any = JSON.parse(json);
+            const copied: string = (" " + json).slice(1);
+            const generic: any = JSON.parse(copied);
+            console.log(shaped.items[0].id, shaped.items[1].label,
+                shaped.items[0].note === null);
+            console.log(generic.items[0].id, generic.items[1].label,
+                generic.items[1].note === null);
+            shaped.items[0].id = 9;
+            Object.defineProperty(shaped.items[1], "extra", {
+                value: 3, enumerable: true, configurable: true
+            });
+            console.log(JSON.stringify(shaped));
+            """;
+
+        Assert.Equal(
+            "1 b true\n" +
+            "1 b true\n" +
+            "{\"items\":[{\"id\":9,\"label\":\"a\",\"active\":true,\"note\":null}," +
+            "{\"id\":2,\"label\":\"b\",\"active\":false,\"note\":null,\"extra\":3}]}\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
     public void JSON_Stringify_KeySnapshotSurvivesGetterMutation(
         ExecutionMode mode)
     {

--- a/tests/SharpTS.Tests/SharedTests/NumberFormattingParityTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/NumberFormattingParityTests.cs
@@ -62,6 +62,20 @@ public class NumberFormattingParityTests
     }
 
     [Theory, ModeData]
+    public void IntegerConcat_PreservesOrderSignAndNegativeZero(ExecutionMode mode)
+    {
+        var source = """
+            console.log("item-" + 42);
+            console.log("item-" + -42);
+            console.log(42 + "-item");
+            console.log("zero-" + -0);
+            """;
+        Assert.Equal(
+            "item-42\nitem--42\n42-item\nzero-0\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
     public void JsonStringify_PrecisionAndSpecials(ExecutionMode mode)
     {
         // NaN/Infinity serialize as null; everything else uses Number::toString.


### PR DESCRIPTION
Closes #1407.

## Summary

- Add faithful cumulative JSON phase benchmarks for both compiled and interpreted imported-module execution.
- Stream interpreter JSON parsing directly into runtime values with bounded UTF-8 pooling, property-name reuse, lazy symbols, and synchronous traversal fast paths.
- Emit compiled JSON stringify into one destination, specialize guarded closed scalar-record graphs, reuse parse shapes/property names, and reserve capacity for proven counted-push loops.
- Preserve observable JSON/object semantics through exact runtime guards and generic fallbacks for getters, proxies, descriptors, custom prototypes, `toJSON`, replacers, formatting, cycles, key-order changes, and shape mismatches.
- Keep emitted output standalone and route new generic metadata construction through the Native-AOT seam.

## Acceptance gates

Three independent executions of the exact cross-runtime workload from the final tree:

| Mode | N | Independent means (ms) | Median | Required | Result |
|---|---:|---:|---:|---:|---|
| compiled | 1,000 | 3.2296, 2.6083, 3.9552 | **3.2296** | <= 3.443 | pass |
| compiled | 10,000 | 29.1410, 23.7335, 35.5834 | **29.1410** | <= 33.44 | pass |
| interpreter | 1,000 | 15.5904, 12.6192, 11.8890 | **12.6192** | <= 17.05 | pass |

Measured starting medians were 5.4884 / 49.2683 / 20.9658 ms, so the corresponding improvements are approximately 41.2%, 40.9%, and 39.8%.

## Allocation and profiling evidence

Faithful imported-module BenchmarkDotNet 0.14.0 `ShortRun` results:

| Mode | N | Build | + stringify | + parse | Full | Full allocation | Full Gen0 / Gen1 / Gen2 per 1k ops |
|---|---:|---:|---:|---:|---:|---:|---:|
| compiled | 1,000 | 0.371 ms | 0.466 ms | 0.731 ms | 0.761 ms | 633.17 KB | 68.36 / 19.53 / 0 |
| compiled | 10,000 | 4.130 ms | 6.698 ms | 11.690 ms | 11.578 ms | 6,723.83 KB | 843.75 / 531.25 / 234.38 |
| interpreter | 1,000 | 1.359 ms | 1.606 ms | 1.932 ms | 2.683 ms | 2.98 MB | 328.13 / 187.50 / 0 |
| interpreter | 10,000 | 19.553 ms | 26.325 ms | 36.863 ms | 38.002 ms | 30.10 MB | 3,230.77 / 2,076.92 / 1,000 |

- Compiled 1k full-round-trip allocation fell from 1,380.8 KB to 633.17 KB (about 54.1%).
- Isolated compiled parser allocation fell from 447.57 KB to 313.56 KB (about 29.9%).
- Counted-push reservation removed the build phase's 16,384-slot growth allocation and Gen2 event at 10k.
- A rejected reader pre-count experiment saved about 0.48 MB at 10k but regressed time by 7.7% at 1k and 10.4% at 10k, so it was reverted.

An exact-runner `gc-verbose` EventPipe trace recorded 12 / 5 / 4 Gen0 / Gen1 / Gen2 collections, 23 suspension intervals totaling 34.619 ms (6.191 ms maximum), 185.638 MB of sampled allocations, and 13.112 MB of sampled LOH allocations. The principal LOH sources were the unavoidable final JSON string, parse-list growth, the round-trip builder buffer, and the bounded pooled UTF-8 parse buffer.

FullOpts JIT disassembly was captured from the exact runner for `jsonRoundTrip` (2,560 bytes), `JsonStringifyShaped` (312 bytes), `AppendJsonShapedValue` (4,113 bytes), and `ParseValueFromReader` (1,508 bytes).

## Verification

- Release solution build: 0 warnings / 0 errors; emitted IL verification passed.
- CI-equivalent core suite: 16,968 passed, 3 expected environment skips, 0 failed (16,971 total).
- Spread, Fetch/HTTP headers, Request/Response, Proxy JSON, and AOT regression families: 249/249 passed.
- JSON + counted-push focused suite: 127/127 passed.
- Array/property/loop regression set: 130/130 passed.
- Verifier-enabled shaped/parse/standalone set: 6/6 passed.
- Standalone JSON DLL tests: 2/2 passed without a SharpTS runtime dependency.
- Test262 JSON parity/conformance: 85/85 passed.
- TypeScript conformance project: 65/65 harness tests passed; the selected 534-case corpus matches the committed baseline with no baseline changes.
- GUI conformance: 83/83 passed.

Environment: Windows 11 `10.0.29639.1000`, .NET SDK `10.0.400`, .NET runtime `10.0.11` x64 RyuJIT AVX2 with workstation concurrent GC.

## Workstream commits

- `3fc012f7` faithful imported JSON phase benchmarks
- `a93645b2` streaming interpreter parse
- `8b87f311` interpreter construction/traversal tuning
- `b2c4a433` counted-push capacity reservation
- `bb4514a9` synchronous interpreter JSON traversal
- `bce72719` compiled stringify/parse/shape specialization
- `df1cac69` dual-mode guard/fallback verification
- `9307b22f` compact-record eligibility scoping
- `e291466c` Native-AOT generic seam compliance
- `61d0f6b9` trim-safe JSON shape generic-member resolution
