### PR TITLE
Avoid duplicate RegExp match buffers (#1387)

### DIFF
--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/RegexGlobalMatchAllocationBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/RegexGlobalMatchAllocationBenchmarks.cs
@@ -1,7 +1,10 @@
 using System.Reflection;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
+using SharpTS.Execution;
 using SharpTS.Microbenchmarks.Infrastructure;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
 
 namespace SharpTS.Microbenchmarks.Benchmarks;
 
@@ -45,4 +48,62 @@ public class RegexGlobalMatchAllocationBenchmarks
     [Benchmark]
     public object? DetailedStringMatchAll()
         => BenchmarkHarness.InvokeCompiled(_detailedMatchAll, Input, (double)N);
+}
+
+/// <summary>
+/// Interpreter counterpart to <see cref="RegexGlobalMatchAllocationBenchmarks"/>.
+/// Parsing, checking, declaration setup, and regex-template compilation happen
+/// outside the measured operation; each benchmark executes the same hot loops
+/// as the compiled allocation comparison.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class RegexGlobalMatchInterpreterAllocationBenchmarks : IDisposable
+{
+    private Interpreter _interpreter = null!;
+    private TypeMap _typeMap = null!;
+    private List<Stmt> _globalMatch = null!;
+    private List<Stmt> _detailedMatchAll = null!;
+
+    [Params(100, 10_000)]
+    public int N { get; set; }
+
+    private const string Input = "alpha beta gamma delta epsilon";
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var assembly = typeof(RegexGlobalMatchInterpreterAllocationBenchmarks).Assembly;
+        using var stream = assembly.GetManifestResourceStream(
+            "SharpTS.Microbenchmarks.TypeScriptSources.Regex.ts")
+            ?? throw new InvalidOperationException("Could not find embedded resource Regex.ts");
+        using var reader = new StreamReader(stream);
+        List<Stmt> declarations = Parse(reader.ReadToEnd());
+        _typeMap = new TypeChecker().Check(declarations);
+        _interpreter = new Interpreter(
+            stdout: TextWriter.Null,
+            stderr: TextWriter.Null);
+        _interpreter.Interpret(declarations, _typeMap);
+
+        _globalMatch = Parse($"regexGlobalMatchLoop({Quote(Input)}, {N});");
+        _detailedMatchAll = Parse($"regexDetailedMatchAllLoop({Quote(Input)}, {N});");
+    }
+
+    [Benchmark(Baseline = true)]
+    public object? IntrinsicGlobalStringMatch()
+        => _interpreter.InterpretRepl(_globalMatch, _typeMap);
+
+    [Benchmark]
+    public object? DetailedStringMatchAll()
+        => _interpreter.InterpretRepl(_detailedMatchAll, _typeMap);
+
+    [GlobalCleanup]
+    public void Dispose() => _interpreter?.Dispose();
+
+    private static List<Stmt> Parse(string source)
+        => new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+
+    private static string Quote(string value)
+        => $"\"{value.Replace("\\", "\\\\", StringComparison.Ordinal).Replace("\"", "\\\"", StringComparison.Ordinal)}\"";
 }

--- a/src/SharpTS/Runtime/Types/SharpTSRegExp.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSRegExp.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Text;
 using System.Text.RegularExpressions;
+using SharpTS.Runtime;
 using SharpTS.TypeSystem;
 
 namespace SharpTS.Runtime.Types;
@@ -853,7 +854,7 @@ public class SharpTSRegExp : ITypeCategorized
     /// <summary>
     /// Match all occurrences in the string (used by String.match with global flag).
     /// </summary>
-    internal List<object?> MatchAll(string input)
+    internal Deque<object?> MatchAll(string input)
     {
         // String.prototype.match(/g) only needs the full-match substrings, not
         // capture groups — so use EnumerateMatches (ValueMatch structs, span-
@@ -861,15 +862,14 @@ public class SharpTSRegExp : ITypeCategorized
         // object allocation that dominates this path (~2.3x faster here), and
         // matches Matches(input)'s whole-string scan semantics exactly.
         //
-        // Returns List<object?> (not List<string>) so callers hand it straight
-        // to the SharpTSArray ctor with no element-by-element re-box into an
-        // object list. The substrings are reference types, so storing them as
-        // object? is free (no boxing). Mirrored by the emitted MatchAll
-        // (RuntimeEmitter.TSRegExp.cs) — keep both in lockstep.
-        List<object?> result = [];
+        // Build the array's Deque backing directly. Returning List<object?>
+        // forced SharpTSArray(IEnumerable<object?>) to allocate a second buffer
+        // and copy every matched string. The substrings are reference types, so
+        // storing them as object? is free (no boxing).
+        Deque<object?> result = [];
         foreach (ValueMatch m in _regex.EnumerateMatches(input))
         {
-            result.Add(input.Substring(m.Index, m.Length));
+            result.AddLast(input.Substring(m.Index, m.Length));
         }
         return result;
     }

--- a/tests/SharpTS.Tests/SharedTests/RegExpExecSemanticsTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/RegExpExecSemanticsTests.cs
@@ -1,3 +1,4 @@
+using SharpTS.Runtime.Types;
 using SharpTS.Tests.Infrastructure;
 using Xunit;
 
@@ -9,6 +10,17 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class RegExpExecSemanticsTests
 {
+    [Fact]
+    public void IntrinsicGlobalMatchBuffer_BecomesArrayBackingWithoutCopy()
+    {
+        var regexp = new SharpTSRegExp("[a-z]+", "g");
+        var matches = regexp.MatchAll("alpha beta gamma");
+        var result = new SharpTSArray(matches);
+
+        Assert.Same(matches, result.Elements);
+        Assert.Equal(new object?[] { "alpha", "beta", "gamma" }, result);
+    }
+
     [Theory, ModeData]
     public void Exec_ReturnsUndefinedForUnmatchedCaptures(
         ExecutionMode mode)


### PR DESCRIPTION
Closes #1387

## Summary

- build the interpreter intrinsic global-match result directly in the Deque used by SharpTSArray, removing a redundant List allocation and element copy
- assert that the native match buffer is transferred into the array without copying
- add a faithful interpreter allocation benchmark beside the existing compiled benchmark

The observable symbol lookup, override, custom exec, and fallback behavior restored on main remains unchanged.

## Performance

Exact three-run n=10,000 medians on the issue host:

| Mode | Before this change | After | Acceptance ceiling |
|---|---:|---:|---:|
| compiled | 3.6097 ms | 3.6257 ms | 4.225 ms |
| interpreter | 4.5026 ms | 4.3124 ms | 4.375 ms |

BenchmarkDotNet ShortRun allocation comparison at n=10,000:

- intrinsic global match: 43,880.22 KB/op before, 42,926.69 KB/op after
- detailed matchAll fallback: 161,370.68 KB/op after
- detailed fallback allocates 3.76x as much as the intrinsic path

## Validation

- focused RegExp tests: 93 passed
- core suite: 16,973 passed, 3 expected skips, 0 failed
- TypeScript conformance: 65 passed
- Test262 compiled baseline: passed in 2m58s
- Test262 interpreted baseline: passed in 6m12s
- Release solution build: passed with IL verification, 0 warnings, 0 errors