### PR TITLE
Restore dense array sort performance

### DIFF
--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ArraySortBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ArraySortBenchmarks.cs
@@ -1,54 +1,198 @@
 using System.Reflection;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Order;
+using SharpTS.Execution;
 using SharpTS.Microbenchmarks.Infrastructure;
+using SharpTS.Parsing;
+using SharpTS.Runtime;
+using SharpTS.Runtime.Types;
+using SharpTS.TypeSystem;
 
 namespace SharpTS.Microbenchmarks.Benchmarks;
 
 /// <summary>
-/// Dense <c>Array.prototype.sort</c> benchmark. The TypeScript function copies
-/// a reusable input before sorting so every invocation sees identical unsorted
-/// data, while <see cref="MemoryDiagnoserAttribute"/> captures the sort path's
-/// managed allocation cost.
+/// Faithful compiled counterpart to the cross-runtime sort workload. Numeric
+/// and record arrays use the same seeded inputs and callback shapes; cumulative
+/// slice-only probes isolate copying from comparator/sort/write-back costs.
 /// </summary>
 [MemoryDiagnoser]
 [RankColumn]
 [Orderer(SummaryOrderPolicy.FastestToSlowest)]
 public class ArraySortBenchmarks
 {
-    private MethodInfo _sortNumbers = null!;
+    private Func<List<object>, double> _copyNumbers = null!;
+    private Func<List<object>, double> _copyRecords = null!;
+    private Func<List<object>, double> _sortNumbers = null!;
+    private Func<List<object>, double> _sortRecords = null!;
+    private Func<List<object>, List<object>, double> _sortCombined = null!;
     private List<object> _numbers = null!;
+    private List<object> _records = null!;
 
-    [Params(100, 1_000, 10_000)]
+    [Params(1_000, 10_000)]
     public int N { get; set; }
 
     [GlobalSetup]
     public void Setup()
     {
-        var assembly = typeof(ArraySortBenchmarks).Assembly;
-        using var stream = assembly.GetManifestResourceStream(
+        Assembly assembly = typeof(ArraySortBenchmarks).Assembly;
+        using Stream stream = assembly.GetManifestResourceStream(
             "SharpTS.Microbenchmarks.TypeScriptSources.ArraySort.ts")
             ?? throw new InvalidOperationException(
                 "Could not find embedded resource ArraySort.ts");
         using var reader = new StreamReader(stream);
-        string source = reader.ReadToEnd();
 
-        string dllPath = CompilationCache.GetOrCompile(source, "ArraySort");
+        string dllPath = CompilationCache.GetOrCompile(
+            reader.ReadToEnd(), "ArraySort");
         Assembly compiled = BenchmarkHarness.LoadCompiledAssembly(
             dllPath, "arraysort");
-        _sortNumbers = BenchmarkHarness.GetCompiledMethod(
-            compiled, "sortNumbers");
+        _copyNumbers = GetUnary(compiled, "copyNumbers");
+        _copyRecords = GetUnary(compiled, "copyRecords");
+        _sortNumbers = GetUnary(compiled, "sortNumbers");
+        _sortRecords = GetUnary(compiled, "sortRecords");
+        _sortCombined = BenchmarkHarness.GetCompiledMethod(compiled, "sortCombined")
+            .CreateDelegate<Func<List<object>, List<object>, double>>();
 
-        _numbers = new List<object>(N);
-        long state = 123456789;
-        for (int index = 0; index < N; index++)
-        {
-            state = state * 48271 % 2147483647;
-            _numbers.Add((double)state);
-        }
+        MethodInfo makeNumbers = BenchmarkHarness.GetCompiledMethod(
+            compiled, "makeNumbers");
+        MethodInfo makeRecords = BenchmarkHarness.GetCompiledMethod(
+            compiled, "makeRecords");
+        _numbers = (List<object>?)BenchmarkHarness.InvokeCompiled(
+            makeNumbers, (double)N)
+            ?? throw new InvalidOperationException(
+                "makeNumbers did not return an array backing list");
+        _records = (List<object>?)BenchmarkHarness.InvokeCompiled(
+            makeRecords, (double)N)
+            ?? throw new InvalidOperationException(
+                "makeRecords did not return an array backing list");
     }
 
+    [Benchmark(Baseline = true)]
+    public double SliceNumbers() => _copyNumbers(_numbers);
+
     [Benchmark]
-    public object? SharpTS_DenseNumericSort()
-        => BenchmarkHarness.InvokeCompiled(_sortNumbers, _numbers);
+    public double SliceRecords() => _copyRecords(_records);
+
+    [Benchmark]
+    public double SortNumbers() => _sortNumbers(_numbers);
+
+    [Benchmark]
+    public double SortRecords() => _sortRecords(_records);
+
+    [Benchmark]
+    public double CombinedAcceptanceShape() => _sortCombined(_numbers, _records);
+
+    private static Func<List<object>, double> GetUnary(
+        Assembly assembly, string name)
+        => BenchmarkHarness.GetCompiledMethod(assembly, name)
+            .CreateDelegate<Func<List<object>, double>>();
+}
+
+/// <summary>
+/// Interpreter counterpart to <see cref="ArraySortBenchmarks"/>. Parsing,
+/// checking, declaration setup, and seeded input generation are outside the
+/// measured operations; callbacks enter through the interpreter's callable
+/// interface without REPL parsing overhead.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class ArraySortInterpreterBenchmarks : IDisposable
+{
+    private Interpreter _interpreter = null!;
+    private ISharpTSCallable _copyNumbers = null!;
+    private ISharpTSCallable _copyRecords = null!;
+    private ISharpTSCallable _sortNumbers = null!;
+    private ISharpTSCallable _sortRecords = null!;
+    private ISharpTSCallable _sortCombined = null!;
+    private RuntimeValue _numbers;
+    private RuntimeValue _records;
+    private readonly RuntimeValue[] _unaryArgs = new RuntimeValue[1];
+    private readonly RuntimeValue[] _binaryArgs = new RuntimeValue[2];
+
+    [Params(1_000, 10_000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        string source = LoadSource();
+        List<Stmt> declarations = Parse(source);
+        TypeMap typeMap = new TypeChecker().Check(declarations);
+        _interpreter = new Interpreter(
+            stdout: TextWriter.Null,
+            stderr: TextWriter.Null);
+        _interpreter.Interpret(declarations, typeMap);
+
+        RuntimeEnvironment environment = GetEnvironment(_interpreter);
+        _copyNumbers = GetCallable(environment, "copyNumbers");
+        _copyRecords = GetCallable(environment, "copyRecords");
+        _sortNumbers = GetCallable(environment, "sortNumbers");
+        _sortRecords = GetCallable(environment, "sortRecords");
+        _sortCombined = GetCallable(environment, "sortCombined");
+
+        RuntimeValue[] size = [RuntimeValue.FromNumber(N)];
+        _numbers = GetCallable(environment, "makeNumbers")
+            .CallV2(_interpreter, size);
+        _records = GetCallable(environment, "makeRecords")
+            .CallV2(_interpreter, size);
+    }
+
+    [Benchmark(Baseline = true)]
+    public double SliceNumbers() => InvokeUnary(_copyNumbers, _numbers);
+
+    [Benchmark]
+    public double SliceRecords() => InvokeUnary(_copyRecords, _records);
+
+    [Benchmark]
+    public double SortNumbers() => InvokeUnary(_sortNumbers, _numbers);
+
+    [Benchmark]
+    public double SortRecords() => InvokeUnary(_sortRecords, _records);
+
+    [Benchmark]
+    public double CombinedAcceptanceShape()
+    {
+        _binaryArgs[0] = _numbers;
+        _binaryArgs[1] = _records;
+        return _sortCombined.CallV2(_interpreter, _binaryArgs).AsNumber();
+    }
+
+    [GlobalCleanup]
+    public void Dispose() => _interpreter?.Dispose();
+
+    private double InvokeUnary(ISharpTSCallable callable, RuntimeValue argument)
+    {
+        _unaryArgs[0] = argument;
+        return callable.CallV2(_interpreter, _unaryArgs).AsNumber();
+    }
+
+    private static string LoadSource()
+    {
+        Assembly assembly = typeof(ArraySortInterpreterBenchmarks).Assembly;
+        using Stream stream = assembly.GetManifestResourceStream(
+            "SharpTS.Microbenchmarks.TypeScriptSources.ArraySort.ts")
+            ?? throw new InvalidOperationException(
+                "Could not find embedded resource ArraySort.ts");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    private static List<Stmt> Parse(string source)
+        => new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+
+    private static RuntimeEnvironment GetEnvironment(Interpreter interpreter)
+        => (RuntimeEnvironment?)(typeof(Interpreter).GetProperty(
+                "Environment", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?.GetValue(interpreter))
+            ?? throw new InvalidOperationException(
+                "The interpreter did not create a runtime environment");
+
+    private static ISharpTSCallable GetCallable(
+        RuntimeEnvironment environment, string name)
+        => environment.TryGet(name, out RuntimeValue value)
+            ? value.ToObject() as ISharpTSCallable
+                ?? throw new InvalidOperationException(
+                    $"Interpreter binding '{name}' is not callable")
+            : throw new InvalidOperationException(
+                $"Interpreter benchmark function '{name}' was not found");
 }

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ArraySort.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ArraySort.ts
@@ -1,5 +1,50 @@
+interface SortRecord {
+    key: number;
+    tag: string;
+}
+
+function makeNumbers(n: number): number[] {
+    const out: number[] = [];
+    let state: number = 123456789;
+    for (let i: number = 0; i < n; i++) {
+        state = (state * 48271) % 2147483647;
+        out.push(state);
+    }
+    return out;
+}
+
+function makeRecords(n: number): SortRecord[] {
+    const out: SortRecord[] = [];
+    let state: number = 987654321;
+    for (let i: number = 0; i < n; i++) {
+        state = (state * 48271) % 2147483647;
+        out.push({ key: state, tag: "t" + (state % 1000) });
+    }
+    return out;
+}
+
+function copyNumbers(source: number[]): number {
+    const copy: number[] = source.slice();
+    return copy[0] + copy[copy.length - 1];
+}
+
+function copyRecords(source: SortRecord[]): number {
+    const copy: SortRecord[] = source.slice();
+    return copy[0].key + copy[copy.length - 1].key;
+}
+
 function sortNumbers(source: number[]): number {
     const copy: number[] = source.slice();
     copy.sort((left: number, right: number): number => left - right);
     return copy[0] + copy[copy.length - 1];
+}
+
+function sortRecords(source: SortRecord[]): number {
+    const copy: SortRecord[] = source.slice();
+    copy.sort((left: SortRecord, right: SortRecord): number => left.key - right.key);
+    return copy[0].key;
+}
+
+function sortCombined(numbers: number[], records: SortRecord[]): number {
+    return sortNumbers(numbers) + sortRecords(records);
 }

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -288,6 +288,7 @@ public class EmittedRuntime
     public MethodBuilder ArrayFlatMap { get; set; } = null!;
     public MethodBuilder ArrayFlatHelper { get; set; } = null!;
     public MethodBuilder ArraySort { get; set; } = null!;
+    public MethodBuilder ArraySortDirect { get; set; } = null!;
     public MethodBuilder ArraySortProto { get; set; } = null!;
     public MethodBuilder ArraySortCanUseDenseFastPath { get; set; } = null!;
     public MethodBuilder ArrayToSorted { get; set; } = null!;

--- a/src/SharpTS/Compilation/Emitters/ArrayEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/ArrayEmitter.cs
@@ -328,6 +328,10 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
                 break;
 
             case "sort":
+                // The direct path re-emits the comparator from its AST, so an
+                // await-safe pre-spill must continue through the general path.
+                if (argLocals == null && TryEmitSortDirectCall(emitter, arguments))
+                    break;
                 if (arguments.Count == 0)
                     il.Emit(OpCodes.Ldsfld, ctx.Runtime!.UndefinedInstance);
                 else
@@ -1077,6 +1081,59 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         emitter.EmitExpression(arguments[1]);
         emitter.EmitBoxIfNeeded(arguments[1]);
         ctx.IL.Emit(OpCodes.Call, ctx.Runtime!.ArrayReduceDirect);
+        return true;
+    }
+
+    /// <summary>
+    /// Sort-specific fast path for a statically resolved two-parameter arrow.
+    /// The runtime helper still snapshots the dense backing store and validates
+    /// it after every comparator call, preserving observable mutation semantics;
+    /// only the boxed callable-dispatch boundary is removed.
+    /// </summary>
+    private static bool TryEmitSortDirectCall(IEmitterContext emitter, List<Expr> arguments)
+    {
+        var ctx = emitter.Context;
+        if (arguments.Count != 1) return false;
+        var af = ResolveCallbackArrow(emitter, arguments[0]);
+        if (af is null) return false;
+        if (af.HasOwnThis || af.IsAsync || af.IsGenerator) return false;
+        if (af.Parameters.Count != 2) return false;
+        foreach (var p in af.Parameters)
+        {
+            if (p.IsRest || p.IsOptional) return false;
+            if (p.DefaultValue != null) return false;
+        }
+        if (!ctx.ArrowMethods.TryGetValue(af, out var staticMethod)) return false;
+
+        bool allObject = staticMethod.ReturnType == ctx.Types.Object;
+        if (allObject)
+        {
+            foreach (var sp in staticMethod.GetParameters())
+            {
+                if (sp.ParameterType != ctx.Types.Object)
+                {
+                    allObject = false;
+                    break;
+                }
+            }
+        }
+
+        if (allObject)
+        {
+            if (!emitter.TryEmitArrowAsDelegate(af, typeof(Func<object, object, object>)))
+                return false;
+        }
+        else if (!TryBindTypedArrowAdapter(
+                     emitter,
+                     af,
+                     staticMethod,
+                     funcArity: 2,
+                     boolReturn: false))
+        {
+            return false;
+        }
+
+        ctx.IL.Emit(OpCodes.Call, ctx.Runtime!.ArraySortDirect);
         return true;
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Mutators.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Mutators.cs
@@ -1654,6 +1654,39 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
+    /// Dense-array sort entry point for a comparator arrow whose identity and
+    /// body are statically known at the call site. The delegate invokes the
+    /// emitted arrow directly, avoiding the per-comparison $TSFunction and
+    /// MethodInvoker boundary. Snapshot and write-back still use sort's normal
+    /// shape guards, including the post-comparator revalidation.
+    /// </summary>
+    private void EmitArraySortDirect(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var comparatorType = typeof(Func<object, object, object>);
+        var method = typeBuilder.DefineMethod(
+            "ArraySortDirect",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.ListOfObject,
+            [_types.ListOfObject, comparatorType]);
+        runtime.ArraySortDirect = method;
+
+        var il = method.GetILGenerator();
+        var frozenLabel = il.DefineLabel();
+        EmitArrayFrozenSealedCheck(
+            il, runtime, frozenLabel,
+            checkSealed: false, checkExtensible: false);
+
+        EmitSortBody(
+            il, runtime,
+            mutateInPlace: true,
+            directComparator: true);
+
+        il.MarkLabel(frozenLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
     /// Emits the shape guard shared by sort's snapshot and write-back phases.
     /// It performs no indexed Get/Set/Delete operations and invokes no guest
     /// code, so a failed check can safely fall through to the observable path.
@@ -1860,7 +1893,10 @@ public partial class RuntimeEmitter
 
         // Now sort the copy using the same logic as EmitArraySort
         // We need to emit sort body but use copyLocal instead of arg0
-        EmitSortBodyOnLocal(il, runtime, copyLocal, observeProperties: false);
+        EmitSortBodyOnLocal(
+            il, runtime, copyLocal,
+            observeProperties: false,
+            directComparator: false);
     }
 
     /// <summary>
@@ -1910,13 +1946,20 @@ public partial class RuntimeEmitter
     /// Emits the body of the sort algorithm (stable bottom-up merge sort, Θ(n log n)).
     /// When mutateInPlace is true, sorts arg0 and returns arg0.
     /// </summary>
-    private void EmitSortBody(ILGenerator il, EmittedRuntime runtime, bool mutateInPlace)
+    private void EmitSortBody(
+        ILGenerator il,
+        EmittedRuntime runtime,
+        bool mutateInPlace,
+        bool directComparator = false)
     {
         var listLocal = il.DeclareLocal(_types.ListOfObject);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Stloc, listLocal);
 
-        EmitSortBodyOnLocal(il, runtime, listLocal, observeProperties: mutateInPlace);
+        EmitSortBodyOnLocal(
+            il, runtime, listLocal,
+            observeProperties: mutateInPlace,
+            directComparator: directComparator);
     }
 
     /// <summary>
@@ -1927,7 +1970,8 @@ public partial class RuntimeEmitter
         ILGenerator il,
         EmittedRuntime runtime,
         LocalBuilder listLocal,
-        bool observeProperties)
+        bool observeProperties,
+        bool directComparator)
     {
         // JavaScript sort algorithm:
         // 1. Partition: separate defined values from undefined values
@@ -2118,9 +2162,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, dstLocal);
 
         // argsBuf = new object[2] — allocated once here; reused for every comparator call.
-        il.Emit(OpCodes.Ldc_I4_2);
-        il.Emit(OpCodes.Newarr, _types.Object);
-        il.Emit(OpCodes.Stloc, argsLocal);
+        if (!directComparator)
+        {
+            // The general callable path reuses one argument buffer. A proven
+            // arrow delegate receives both elements directly and needs none.
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Newarr, _types.Object);
+            il.Emit(OpCodes.Stloc, argsLocal);
+        }
 
         var widthCond = il.DefineLabel();
         var widthBody = il.DefineLabel();
@@ -2203,57 +2252,75 @@ public partial class RuntimeEmitter
         // --- merge body: compare src[i] vs src[j] -> compareResultLocal ---
         il.MarkLabel(mergeBody);
 
-        var hasCompareFn = il.DefineLabel();
-        var noCompareFn = il.DefineLabel();
         var checkCompareResult = il.DefineLabel();
 
-        // compareFn is "absent" when null OR $Undefined.Instance (ECMA-262):
-        // `arr.sort(undefined)` must use the default comparator, not invoke undefined.
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Brfalse, noCompareFn);
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
-        il.Emit(OpCodes.Brtrue, noCompareFn);
-        il.Emit(OpCodes.Br, hasCompareFn);
+        if (directComparator)
+        {
+            // A statically resolved arrow comparator is already represented as a
+            // Func<object, object, object>. Call it directly so every comparison
+            // avoids the boxed callable-dispatch boundary and argument buffer.
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldloc, srcLocal);
+            il.Emit(OpCodes.Ldloc, iLocal);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Ldloc, srcLocal);
+            il.Emit(OpCodes.Ldloc, jLocal);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Callvirt, typeof(Func<object, object, object>).GetMethod("Invoke")!);
+        }
+        else
+        {
+            var hasCompareFn = il.DefineLabel();
+            var noCompareFn = il.DefineLabel();
 
-        il.MarkLabel(noCompareFn);
-        // Default: CompareOrdinal(ToJsString(src[i]), ToJsString(src[j])). ToJsString
-        // runs the ToPrimitive protocol so `{toString:()=>"-2"}` sorts as "-2".
-        il.Emit(OpCodes.Ldloc, srcLocal);
-        il.Emit(OpCodes.Ldloc, iLocal);
-        il.Emit(OpCodes.Ldelem_Ref);
-        il.Emit(OpCodes.Call, runtime.ToJsString);
-        il.Emit(OpCodes.Stloc, str1Local);
-        il.Emit(OpCodes.Ldloc, srcLocal);
-        il.Emit(OpCodes.Ldloc, jLocal);
-        il.Emit(OpCodes.Ldelem_Ref);
-        il.Emit(OpCodes.Call, runtime.ToJsString);
-        il.Emit(OpCodes.Stloc, str2Local);
-        il.Emit(OpCodes.Ldloc, str1Local);
-        il.Emit(OpCodes.Ldloc, str2Local);
-        il.Emit(OpCodes.Call, typeof(string).GetMethod("CompareOrdinal", [typeof(string), typeof(string)])!);
-        il.Emit(OpCodes.Stloc, compareResultLocal);
-        il.Emit(OpCodes.Br, checkCompareResult);
+            // compareFn is "absent" when null OR $Undefined.Instance (ECMA-262):
+            // `arr.sort(undefined)` must use the default comparator, not invoke undefined.
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Brfalse, noCompareFn);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+            il.Emit(OpCodes.Brtrue, noCompareFn);
+            il.Emit(OpCodes.Br, hasCompareFn);
 
-        il.MarkLabel(hasCompareFn);
-        // result = InvokeValue(compareFn, argsBuf) with argsBuf[0]=src[i], argsBuf[1]=src[j].
-        // argsBuf is the single hoisted object[2] declared above — no per-comparison allocation.
-        il.Emit(OpCodes.Ldloc, argsLocal);
-        il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Ldloc, srcLocal);
-        il.Emit(OpCodes.Ldloc, iLocal);
-        il.Emit(OpCodes.Ldelem_Ref);
-        il.Emit(OpCodes.Stelem_Ref);
-        il.Emit(OpCodes.Ldloc, argsLocal);
-        il.Emit(OpCodes.Ldc_I4_1);
-        il.Emit(OpCodes.Ldloc, srcLocal);
-        il.Emit(OpCodes.Ldloc, jLocal);
-        il.Emit(OpCodes.Ldelem_Ref);
-        il.Emit(OpCodes.Stelem_Ref);
-        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Ldloc, argsLocal);
-        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
+            il.MarkLabel(noCompareFn);
+            // Default: CompareOrdinal(ToJsString(src[i]), ToJsString(src[j])). ToJsString
+            // runs the ToPrimitive protocol so `{toString:()=>"-2"}` sorts as "-2".
+            il.Emit(OpCodes.Ldloc, srcLocal);
+            il.Emit(OpCodes.Ldloc, iLocal);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Call, runtime.ToJsString);
+            il.Emit(OpCodes.Stloc, str1Local);
+            il.Emit(OpCodes.Ldloc, srcLocal);
+            il.Emit(OpCodes.Ldloc, jLocal);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Call, runtime.ToJsString);
+            il.Emit(OpCodes.Stloc, str2Local);
+            il.Emit(OpCodes.Ldloc, str1Local);
+            il.Emit(OpCodes.Ldloc, str2Local);
+            il.Emit(OpCodes.Call, typeof(string).GetMethod("CompareOrdinal", [typeof(string), typeof(string)])!);
+            il.Emit(OpCodes.Stloc, compareResultLocal);
+            il.Emit(OpCodes.Br, checkCompareResult);
+
+            il.MarkLabel(hasCompareFn);
+            // result = InvokeValue(compareFn, argsBuf) with argsBuf[0]=src[i], argsBuf[1]=src[j].
+            // argsBuf is the single hoisted object[2] declared above — no per-comparison allocation.
+            il.Emit(OpCodes.Ldloc, argsLocal);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ldloc, srcLocal);
+            il.Emit(OpCodes.Ldloc, iLocal);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Stelem_Ref);
+            il.Emit(OpCodes.Ldloc, argsLocal);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Ldloc, srcLocal);
+            il.Emit(OpCodes.Ldloc, jLocal);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Stelem_Ref);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldloc, argsLocal);
+            il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
+        }
 
         // Convert compare result to a sign in compareResultLocal:
         // double -> sign (<0 / 0 / >0); NaN or non-double -> 0 (equal -> take left -> stable).

--- a/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -1160,6 +1160,7 @@ public partial class RuntimeEmitter
         // EmitArrayConstructor is emitted earlier (before InvokeValue) so its
         // MethodBuilder is available to InvokeValue's Type-callee dispatch.
         EmitArraySort(typeBuilder, runtime);
+        EmitArraySortDirect(typeBuilder, runtime);
         EmitArraySortProto(typeBuilder, runtime);
         EmitArrayToSorted(typeBuilder, runtime);
         EmitArrayToSortedGeneric(typeBuilder, runtime);

--- a/src/SharpTS/Runtime/BuiltIns/ArrayBuiltIns.cs
+++ b/src/SharpTS/Runtime/BuiltIns/ArrayBuiltIns.cs
@@ -207,21 +207,34 @@ public static class ArrayBuiltIns
         private readonly ISharpTSCallable _fn;
         private readonly Interpreter _interp;
         private readonly List<object?> _compareArgs = new(2) { null, null };
+        private readonly SharpTSArrowFunction? _simpleNumericArrow;
 
         public CompareFnComparer(ISharpTSCallable fn, Interpreter interp)
-            => (_fn, _interp) = (fn, interp);
+        {
+            (_fn, _interp) = (fn, interp);
+            // Keep ordinary invocation while debugging so comparator frames and
+            // expression breakpoints remain visible.
+            if (interp.DebugController is null
+                && fn is SharpTSArrowFunction { HasSimpleSortComparator: true } arrow)
+                _simpleNumericArrow = arrow;
+        }
 
         public int Compare((object? Element, long Index) x, (object? Element, long Index) y)
         {
-            _compareArgs[0] = x.Element;
-            _compareArgs[1] = y.Element;
-            // NOTE: deliberately stays on the legacy boxed Call rather than CallV2. For the
-            // common trivial comparator (`(a,b)=>a-b`), eagerly converting both boxed args to
-            // RuntimeValue here (FromBoxed) costs more than this near-free reference copy and
-            // measured ~13% SLOWER on a 100k interpreter sort — the boxed Call lets the
-            // comparator body unbox lazily. Revisit only with a non-boxing comparator path.
-            var result = _fn.Call(_interp, _compareArgs);
-            double numericResult = _interp.ToNumberWithPrimitive(result);
+            double numericResult;
+            if (_simpleNumericArrow?.TryEvaluateSimpleSortComparator(
+                    _interp, x.Element, y.Element, out numericResult) != true)
+            {
+                _compareArgs[0] = x.Element;
+                _compareArgs[1] = y.Element;
+                // NOTE: deliberately stays on the legacy boxed Call rather than CallV2. For the
+                // common trivial comparator (`(a,b)=>a-b`), eagerly converting both boxed args to
+                // RuntimeValue here (FromBoxed) costs more than this near-free reference copy and
+                // measured ~13% SLOWER on a 100k interpreter sort — the boxed Call lets the
+                // comparator body unbox lazily. Revisit only with a non-boxing comparator path.
+                var result = _fn.Call(_interp, _compareArgs);
+                numericResult = _interp.ToNumberWithPrimitive(result);
+            }
             if (!double.IsNaN(numericResult) && numericResult != 0)
                 return numericResult < 0 ? -1 : 1;
             // Stability tie-breaker: preserve original order

--- a/src/SharpTS/Runtime/Types/SharpTSFunction.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSFunction.cs
@@ -410,6 +410,9 @@ public class SharpTSArrowFunction : ISharpTSCallable, ITypeCategorized
     private readonly Expr.ArrowFunction _declaration;
     private readonly RuntimeEnvironment _closure;
     private readonly int _arity;
+    // null = no specialization; empty = `a - b`; otherwise `a.<property> - b.<property>`.
+    // One reference keeps the footprint of every other arrow function small.
+    private readonly string? _simpleSortProperty;
     // Receiver bound via Bind(). Stored on the function itself rather than
     // wrapping _closure with an extra scope — otherwise runtime scope depth
     // wouldn't match the resolver's static distances and outer captures break.
@@ -438,6 +441,7 @@ public class SharpTSArrowFunction : ISharpTSCallable, ITypeCategorized
         _boundThis = boundThis;
         _hasBoundThis = hasBoundThis;
         _arity = declaration.Parameters.Count(p => p.DefaultValue == null && !p.IsRest && !p.IsOptional);
+        _simpleSortProperty = DescribeSimpleSortComparator(declaration);
         InitializeIntrinsicProperties(declaration.Name?.Lexeme ?? "");
     }
 
@@ -564,6 +568,92 @@ public class SharpTSArrowFunction : ISharpTSCallable, ITypeCategorized
     }
 
     public int Arity() => _arity;
+
+    internal bool HasSimpleSortComparator => _simpleSortProperty is not null;
+
+    /// <summary>
+    /// Evaluates the common pure sort-comparator forms <c>a - b</c> and
+    /// <c>a.key - b.key</c> without allocating a call environment. Property
+    /// reads still use the interpreter's ordinary observable Get operation.
+    /// </summary>
+    internal bool TryEvaluateSimpleSortComparator(
+        Interpreter interpreter,
+        object? first,
+        object? second,
+        out double result)
+    {
+        if (_simpleSortProperty is null)
+        {
+            result = 0;
+            return false;
+        }
+
+        object? left = first;
+        object? right = second;
+        if (_simpleSortProperty.Length != 0)
+        {
+            left = interpreter.GetPropertyValue(left, _simpleSortProperty);
+            right = interpreter.GetPropertyValue(right, _simpleSortProperty);
+        }
+
+        result = interpreter.ToNumberWithPrimitive(left)
+            - interpreter.ToNumberWithPrimitive(right);
+        return true;
+    }
+
+    private static string? DescribeSimpleSortComparator(
+        Expr.ArrowFunction declaration)
+    {
+        if (declaration.Parameters.Count != 2
+            || declaration.ExpressionBody is not Expr.Binary
+            {
+                Operator.Type: TokenType.MINUS
+            } binary)
+        {
+            return null;
+        }
+
+        foreach (Stmt.Parameter parameter in declaration.Parameters)
+        {
+            if (parameter.DefaultValue is not null
+                || parameter.IsRest
+                || parameter.IsOptional)
+            {
+                return null;
+            }
+        }
+
+        string firstName = declaration.Parameters[0].Name.Lexeme;
+        string secondName = declaration.Parameters[1].Name.Lexeme;
+        if (binary.Left is Expr.Variable left
+            && left.Name.Lexeme == firstName
+            && binary.Right is Expr.Variable right
+            && right.Name.Lexeme == secondName)
+        {
+            return string.Empty;
+        }
+
+        if (binary.Left is Expr.Get
+            {
+                Object: Expr.Variable leftReceiver,
+                Optional: false,
+                Defaulted: false
+            } leftGet
+            && leftReceiver.Name.Lexeme == firstName
+            && binary.Right is Expr.Get
+            {
+                Object: Expr.Variable rightReceiver,
+                Optional: false,
+                Defaulted: false
+            } rightGet
+            && rightReceiver.Name.Lexeme == secondName
+            && leftGet.Name.Lexeme == rightGet.Name.Lexeme)
+        {
+            return leftGet.Name.Lexeme;
+        }
+
+        return null;
+    }
 
     internal bool IsStrict
         => _closure.IsStrictMode

--- a/tests/SharpTS.Tests/CompilerTests/ArraySortDirectComparatorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/ArraySortDirectComparatorTests.cs
@@ -1,0 +1,110 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>
+/// Structural coverage for #1388: only comparators whose arrow identity is
+/// statically proven lower through the direct sort helper. Dynamic comparator
+/// values retain the general callable path.
+/// </summary>
+public sealed class ArraySortDirectComparatorTests
+{
+    [Fact]
+    public void StableAnnotatedArrow_UsesDirectHelper_WhileDynamicComparatorDoesNot()
+    {
+        Assembly assembly = Compile("""
+            function sortStable(values: number[]): number[] {
+                values.sort((a: number, b: number): number => a - b);
+                return values;
+            }
+
+            function sortDynamic(
+                values: number[],
+                compare: (a: number, b: number) => number
+            ): number[] {
+                values.sort(compare);
+                return values;
+            }
+            """);
+
+        MethodInfo stable = FindFunction(assembly, "sortStable");
+        MethodInfo dynamic = FindFunction(assembly, "sortDynamic");
+
+        Assert.Contains(CalledMethods(stable), method => method.Name == "ArraySortDirect");
+        Assert.DoesNotContain(CalledMethods(stable), method => method.Name == "ArraySort");
+        Assert.Contains(CalledMethods(dynamic), method => method.Name == "ArraySort");
+        Assert.DoesNotContain(CalledMethods(dynamic), method => method.Name == "ArraySortDirect");
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"issue_1388_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name)
+        => assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<MethodBase> CalledMethods(MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException(
+                $"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+
+            if (opCode.OperandType == OperandType.InlineMethod)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                yield return module.ResolveMethod(token)
+                    ?? throw new InvalidOperationException(
+                        $"Could not resolve method token {token}.");
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+
+            offset += operandSize;
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}

--- a/tests/SharpTS.Tests/SharedTests/ArraySortTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/ArraySortTests.cs
@@ -116,6 +116,33 @@ public class ArraySortTests
     }
 
     [Theory, ModeData]
+    public void Array_Sort_SimplePropertyComparator_PreservesObservableGets(
+        ExecutionMode mode)
+    {
+        var source = """
+            let reads: string[] = [];
+            let high: any = { name: "high" };
+            let low: any = { name: "low" };
+            Object.defineProperty(high, "key", {
+                get(): number { reads.push("high"); return 2; },
+                configurable: true
+            });
+            Object.defineProperty(low, "key", {
+                get(): number { reads.push("low"); return 1; },
+                configurable: true
+            });
+
+            let items: any[] = [high, low];
+            items.sort((a: any, b: any): number => a.key - b.key);
+            console.log(items[0].name + "," + items[1].name);
+            console.log(reads.length > 0);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("low,high\ntrue\n", output);
+    }
+
+    [Theory, ModeData]
     public void Array_Sort_ComparatorReceivesUndefinedThis(ExecutionMode mode)
     {
         var source = """


### PR DESCRIPTION
Fixes #1388.

## Summary

- lower stable inline and `const`-bound two-argument arrow comparators to a typed compiled `ArraySortDirect` helper
- recognize only exact numeric `a - b` and `a.key - b.key` comparator shapes in the interpreter, while retaining normal calls when debugging
- preserve the existing dense/frozen-array guards, comparator side-effect ordering, and post-comparator shape validation
- keep dynamic, mutable, optional/default/rest, async/generator, and otherwise unsupported comparator bindings on the general ECMAScript call path
- add the faithful seeded numeric-and-record benchmark plus structural IL and observable-side-effect regression coverage

## Exact acceptance benchmark

Five independent runs of `benchmarks/cross-runtime/scripts/sort.ts` after a Release build:

| Engine | Previous median meanMs | Current median meanMs | Gate |
| --- | ---: | ---: | ---: |
| compiled | 8.1151 ms | 1.5465 ms | <= 5.456 ms |
| interpreter | 11.7548 ms | 3.0102 ms | < 6.27 ms |

The exact emitted program also passes IL verification.

## BenchmarkDotNet allocation evidence

Faithful combined numeric-plus-record workload at N=1000:

| Engine | Before time | After time | Before allocated | After allocated |
| --- | ---: | ---: | ---: | ---: |
| compiled | 2.2787 ms | 1.08033 ms | 1297.78 KB | 612.44 KB |
| interpreter | 6.4799 ms | 2.05807 ms | 9228.56 KB | 298.84 KB |

At N=10000, combined compiled time is 15.52045 ms with 8366.76 KB allocated; combined interpreter time is 31.43443 ms with 10362.15 KB allocated.

## Verification

- targeted array-sort and structural IL tests: 64 passed
- full core suite: 17,000 passed, 0 failed, 3 skipped
- compiled Test262 baseline: passed with zero drift
- TypeScript conformance baseline: 65 passed with zero drift (534 selected programs)
- full `SharpTS.sln` Release build: 0 warnings, 0 errors; IL verification passed
- `git diff --check`: clean
- hosted CI: all required Ubuntu, Windows, AOT, native, GUI packaging, and policy checks passed
