### PR TITLE
perf: lower stable recursive records to CLR shapes

### DIFF
--- a/src/SharpTS/Compilation/CompilationContext.cs
+++ b/src/SharpTS/Compilation/CompilationContext.cs
@@ -37,6 +37,9 @@ public record struct HoistedArrayEntry(LocalBuilder TypedLocal, ArrayElementsDes
 /// </summary>
 public record struct HoistedTypedArrayEntry(LocalBuilder TypedLocal, Type XArrayType, string ElementType);
 
+public record struct HoistedCompactRecordEntry(
+    LocalBuilder TypedLocal, string Fingerprint);
+
 /// <summary>
 /// Holds compilation state passed between ILCompiler and ILEmitter.
 /// </summary>
@@ -77,6 +80,13 @@ public partial class CompilationContext
     // counters. Reads convert to double on load; the increment and recognized index sites consume
     // the int directly. Populated/cleared per loop scope by EmitFor/EmitVarStatement.
     public HashSet<string> IntegerCounterLocals { get; } = new();
+
+    /// <summary>
+    /// Function parameters whose exact compact-record type test was hoisted to
+    /// the prologue. Entries are limited to parameters never reassigned in the
+    /// body, so property reads may reuse the typed local safely.
+    /// </summary>
+    public Dictionary<string, HoistedCompactRecordEntry> HoistedCompactRecordParameters { get; } = [];
 
     // Emitted runtime types and methods (for standalone DLLs)
     public EmittedRuntime? Runtime { get; set; }

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -916,8 +916,15 @@ public class EmittedRuntime
     /// </summary>
     public Dictionary<string, FieldBuilder> JsonShapeFields { get; } = [];
     public TypeBuilder JsonScalarRecordType { get; set; } = null!;
+    public Type CompactObjectRecordInterface { get; set; } = null!;
     public ConstructorBuilder JsonScalarRecordCtor { get; set; } = null!;
     public Dictionary<int, ConstructorBuilder> JsonScalarRecordInlineCtors { get; } = [];
+    public Dictionary<int, TypeBuilder> JsonScalarRecordInlineTypes { get; } = [];
+    public Dictionary<(int Arity, int Index), MethodBuilder> JsonScalarRecordInlineGetters { get; } = [];
+    public Dictionary<string, TypeBuilder> CompactObjectRecordTypes { get; } = [];
+    public Dictionary<string, ConstructorBuilder> CompactObjectRecordCtors { get; } = [];
+    public Dictionary<(string Fingerprint, int Index), FieldBuilder> CompactObjectRecordValueFields { get; } = [];
+    public Dictionary<string, FieldBuilder> CompactObjectRecordAnyMaterializedFields { get; } = [];
     public MethodBuilder JsonScalarRecordShapeGetter { get; set; } = null!;
     public MethodBuilder JsonScalarRecordValuesGetter { get; set; } = null!;
     public MethodBuilder JsonScalarRecordGetValue { get; set; } = null!;

--- a/src/SharpTS/Compilation/ILCompiler.Functions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Functions.cs
@@ -504,6 +504,36 @@ public partial class ILCompiler
             resolvedParamTypes,
             argumentOffset: 0);
 
+        // Hoist exact compact-record type tests for parameters that retain their
+        // binding throughout the function. Recursive record walkers otherwise
+        // repeat the same isinst at every field read and every tree node.
+        var currentFuncType = _typeMap?.GetFunctionType(qualifiedFunctionName)
+            ?? _typeMap?.GetFunctionType(funcStmt.Name.Lexeme);
+        if (currentFuncType is not null && _runtime is not null)
+        {
+            var assignedParameters = ParameterAssignmentAnalyzer.FindAssigned(funcStmt.Body);
+            for (int i = 0; i < funcStmt.Parameters.Count && i < currentFuncType.ParamTypes.Count; i++)
+            {
+                string parameterName = funcStmt.Parameters[i].Name.Lexeme;
+                if (assignedParameters.Contains(parameterName) ||
+                    !TryGetCompactRecordShape(currentFuncType.ParamTypes[i], out var parameterShape))
+                    continue;
+
+                string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(parameterShape);
+                if (!_runtime.CompactObjectRecordTypes.TryGetValue(
+                        fingerprint, out var compactType))
+                    continue;
+
+                var typedLocal = il.DeclareLocal(compactType);
+                il.Emit(OpCodes.Ldarg, i);
+                il.Emit(OpCodes.Isinst, compactType);
+                il.Emit(OpCodes.Stloc, typedLocal);
+                ctx.HoistedCompactRecordParameters.Add(
+                    parameterName,
+                    new HoistedCompactRecordEntry(typedLocal, fingerprint));
+            }
+        }
+
         // Initialize captured parameters into the function display class. Runs
         // AFTER EmitDefaultParameters (which writes defaults back via Starg) so
         // closures see the defaulted value, not the missing-arg padding.
@@ -549,6 +579,45 @@ public partial class ILCompiler
             il.Emit(OpCodes.Ret);
         }
 
+    }
+
+    private static bool TryGetCompactRecordShape(
+        SharpTS.TypeSystem.TypeInfo type, out JsonSerializationShape.Record shape)
+    {
+        if (type is SharpTS.TypeSystem.TypeInfo.Record record &&
+            JsonSerializationShapeAnalyzer.TryAnalyze(record, out var analyzed) &&
+            analyzed is JsonSerializationShape.Record direct)
+        {
+            shape = direct;
+            return true;
+        }
+
+        if (type is SharpTS.TypeSystem.TypeInfo.Union union)
+        {
+            JsonSerializationShape.Record? found = null;
+            foreach (var member in union.Types)
+            {
+                if (member is SharpTS.TypeSystem.TypeInfo.Null or SharpTS.TypeSystem.TypeInfo.Undefined)
+                    continue;
+                if (member is not SharpTS.TypeSystem.TypeInfo.Record recordMember ||
+                    !JsonSerializationShapeAnalyzer.TryAnalyze(recordMember, out var memberShape) ||
+                    memberShape is not JsonSerializationShape.Record recordShape ||
+                    found is not null)
+                {
+                    shape = null!;
+                    return false;
+                }
+                found = recordShape;
+            }
+            if (found is not null)
+            {
+                shape = found;
+                return true;
+            }
+        }
+
+        shape = null!;
+        return false;
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
@@ -122,6 +122,12 @@ public partial class ILEmitter
                 return;
             }
 
+            if (TryEmitCompactObjectRecordLiteral(o))
+            {
+                SetStackUnknown();
+                return;
+            }
+
             // Simple case: no spreads, no computed keys. Drop the legacy
             // `Call CreateObject` no-op identity helper. Pre-size the
             // dictionary only when property count > 3: .NET's
@@ -268,6 +274,53 @@ public partial class ILEmitter
             }
             IL.Emit(OpCodes.Newobj, _ctx.Runtime.JsonScalarRecordCtor);
         }
+        return true;
+    }
+
+    /// <summary>
+    /// Emits a provably stable small plain object literal as an exact slot-backed CLR
+    /// carrier. Open and recursive record fields are supported, but mutation, export,
+    /// and escape through an unknown call retain the ordinary dictionary path.
+    /// </summary>
+    private bool TryEmitCompactObjectRecordLiteral(Expr.ObjectLiteral literal)
+    {
+        if (_ctx.RuntimeFeatures?.UsesCompactObjectRecords != true ||
+            _ctx.ProgramType is null || literal.Properties.Count is < 1 or > 4)
+            return false;
+
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var property in literal.Properties)
+        {
+            if (property.IsSpread || property.Kind is not Expr.ObjectPropertyKind.Value ||
+                property.Key is Expr.ComputedKey)
+                return false;
+
+            string key = GetPropertyKeyString(property.Key!);
+            if (key is "toJSON" or "valueOf" or "toString" || !names.Add(key) ||
+                uint.TryParse(key, System.Globalization.NumberStyles.None,
+                    System.Globalization.CultureInfo.InvariantCulture, out _))
+                return false;
+        }
+
+        if (!JsonSerializationShapeAnalyzer.TryAnalyzeObjectLiteral(
+                literal, _ctx.TypeMap, out var record))
+            return false;
+
+        string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(record);
+        if (!_ctx.RuntimeFeatures.CanAssumeCompactObjectRecordIsUnmaterialized(
+                fingerprint))
+            return false;
+
+        if (!_ctx.Runtime!.CompactObjectRecordCtors.TryGetValue(
+                fingerprint, out var exactCtor))
+            return false;
+
+        foreach (var property in literal.Properties)
+        {
+            EmitExpression(property.Value);
+            EmitBoxIfNeeded(property.Value);
+        }
+        IL.Emit(OpCodes.Newobj, exactCtor);
         return true;
     }
 

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -395,9 +395,9 @@ public partial class ILEmitter
         EmitBoxIfNeeded(g.Object);
 
         var receiverLocal = IL.DeclareLocal(_ctx.Types.Object);
-        LocalBuilder? scalarLocal = _ctx.RuntimeFeatures?.UsesJSON == true
-            ? IL.DeclareLocal(_ctx.Runtime!.JsonScalarRecordType)
-            : null;
+        bool hasCompactCarrier =
+            (_ctx.RuntimeFeatures?.UsesJSON == true ||
+             _ctx.RuntimeFeatures?.UsesCompactObjectRecords == true);
         var dictLocal = IL.DeclareLocal(_ctx.Types.DictionaryStringObject);
         var outLocal = IL.DeclareLocal(_ctx.Types.Object);
         IL.Emit(OpCodes.Stloc, receiverLocal);
@@ -405,11 +405,11 @@ public partial class ILEmitter
         var fallbackLabel = IL.DefineLabel();
         var endLabel = IL.DefineLabel();
         var notFoundLabel = IL.DefineLabel();
+        bool exactCarrierSpecialized = false;
 
-        if (scalarLocal is not null && _ctx.ProgramType is not null &&
+        if (hasCompactCarrier && _ctx.ProgramType is not null &&
             JsonSerializationShapeAnalyzer.TryAnalyze(recordType, out var analyzedShape) &&
-            analyzedShape is JsonSerializationShape.Record recordShape &&
-            JsonSerializationShapeAnalyzer.IsClosed(recordShape))
+            analyzedShape is JsonSerializationShape.Record recordShape)
         {
             int scalarIndex = -1;
             for (int index = 0; index < recordShape.Fields.Count; index++)
@@ -421,63 +421,129 @@ public partial class ILEmitter
                 }
             }
 
-            if (scalarIndex >= 0)
+            string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(recordShape);
+            if (scalarIndex >= 0 &&
+                _ctx.Runtime!.CompactObjectRecordTypes.TryGetValue(
+                    fingerprint, out var exactType) &&
+                _ctx.Runtime.CompactObjectRecordValueFields.TryGetValue(
+                    (fingerprint, scalarIndex), out var exactValueField) &&
+                _ctx.Runtime.CompactObjectRecordAnyMaterializedFields.TryGetValue(
+                    fingerprint, out var anyMaterializedField))
             {
+                exactCarrierSpecialized = true;
+                LocalBuilder exactLocal;
+                if (g.Object is Expr.Variable receiverVariable &&
+                    _ctx.HoistedCompactRecordParameters.TryGetValue(
+                        receiverVariable.Name.Lexeme, out var hoisted) &&
+                    hoisted.Fingerprint == fingerprint)
+                {
+                    exactLocal = hoisted.TypedLocal;
+                }
+                else
+                {
+                    exactLocal = IL.DeclareLocal(exactType);
+                    IL.Emit(OpCodes.Ldloc, receiverLocal);
+                    IL.Emit(OpCodes.Isinst, exactType);
+                    IL.Emit(OpCodes.Stloc, exactLocal);
+                }
+                IL.Emit(OpCodes.Ldloc, exactLocal);
+                IL.Emit(OpCodes.Brfalse, fallbackLabel);
+                if (!_ctx.RuntimeFeatures!.CanAssumeCompactObjectRecordIsUnmaterialized(
+                        fingerprint))
+                {
+                    IL.Emit(OpCodes.Ldsfld, anyMaterializedField);
+                    IL.Emit(OpCodes.Brtrue, fallbackLabel);
+                }
+                if (_ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == true)
+                {
+                    IL.Emit(OpCodes.Ldloc, exactLocal);
+                    IL.Emit(OpCodes.Call, _ctx.Runtime.PDSHasPropertyDescriptors);
+                    IL.Emit(OpCodes.Brtrue, fallbackLabel);
+                }
+                IL.Emit(OpCodes.Ldloc, exactLocal);
+                IL.Emit(OpCodes.Ldfld, exactValueField);
+                IL.Emit(OpCodes.Br, endLabel);
+            }
+            else if (scalarIndex >= 0 &&
+                _ctx.Runtime!.JsonScalarRecordInlineTypes.TryGetValue(
+                    recordShape.Fields.Count, out var inlineType) &&
+                _ctx.Runtime.JsonScalarRecordInlineGetters.TryGetValue(
+                    (recordShape.Fields.Count, scalarIndex), out var directGetter))
+            {
+                var inlineLocal = IL.DeclareLocal(inlineType);
                 var dictionaryLabel = IL.DefineLabel();
                 var shapeField = Emitters.JSONStaticEmitter.GetOrDefineShapeField(
                     _ctx, recordShape);
+                bool closed = JsonSerializationShapeAnalyzer.IsClosed(recordShape);
+                bool carrierTypeIdentifiesShape =
+                    _ctx.RuntimeFeatures!.HasUniqueCompactObjectRecordShape(
+                        recordShape.Fields.Count,
+                        JsonSerializationShapeAnalyzer.Fingerprint(recordShape));
                 IL.Emit(OpCodes.Ldloc, receiverLocal);
-                IL.Emit(OpCodes.Isinst, _ctx.Runtime!.JsonScalarRecordType);
-                IL.Emit(OpCodes.Stloc, scalarLocal);
-                IL.Emit(OpCodes.Ldloc, scalarLocal);
+                IL.Emit(OpCodes.Isinst, inlineType);
+                IL.Emit(OpCodes.Stloc, inlineLocal);
+                IL.Emit(OpCodes.Ldloc, inlineLocal);
                 IL.Emit(OpCodes.Brfalse, dictionaryLabel);
-                IL.Emit(OpCodes.Ldloc, scalarLocal);
+                IL.Emit(OpCodes.Ldloc, inlineLocal);
                 IL.Emit(OpCodes.Callvirt, _ctx.Runtime.JsonScalarRecordIsMaterializedGetter);
                 IL.Emit(OpCodes.Brtrue, fallbackLabel);
-                IL.Emit(OpCodes.Ldloc, scalarLocal);
-                IL.Emit(OpCodes.Call, _ctx.Runtime.PDSHasPropertyDescriptors);
-                IL.Emit(OpCodes.Brtrue, fallbackLabel);
-                IL.Emit(OpCodes.Ldloc, scalarLocal);
-                IL.Emit(OpCodes.Call, _ctx.Runtime.PDSHasPrototypeEntry);
-                IL.Emit(OpCodes.Brtrue, fallbackLabel);
-                IL.Emit(OpCodes.Ldloc, scalarLocal);
-                IL.Emit(OpCodes.Callvirt, _ctx.Runtime.JsonScalarRecordShapeGetter);
-                Emitters.JSONStaticEmitter.EmitLazyShapeDescriptor(
-                    _ctx, recordShape, shapeField, closed: true);
-                IL.Emit(OpCodes.Bne_Un, fallbackLabel);
-                IL.Emit(OpCodes.Ldloc, scalarLocal);
-                IL.Emit(OpCodes.Ldc_I4, scalarIndex);
-                IL.Emit(OpCodes.Callvirt, _ctx.Runtime.JsonScalarRecordGetValue);
+                // A descriptor can replace an own slot with an accessor, so programs
+                // that mention descriptor APIs retain the per-read PDS guard. When
+                // the whole-program detector proves those APIs absent, no descriptor
+                // entry can exist and the ConditionalWeakTable probe is dead weight.
+                if (_ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == true)
+                {
+                    IL.Emit(OpCodes.Ldloc, inlineLocal);
+                    IL.Emit(OpCodes.Call, _ctx.Runtime.PDSHasPropertyDescriptors);
+                    IL.Emit(OpCodes.Brtrue, fallbackLabel);
+                }
+                // Prototype mutation cannot shadow this carrier's known own slot.
+                // Deletion or any write materializes the record first and is caught
+                // by IsMaterialized above, so a separate prototype-table lookup is
+                // unnecessary for this exact-shape read.
+                if (!carrierTypeIdentifiesShape)
+                {
+                    IL.Emit(OpCodes.Ldloc, inlineLocal);
+                    IL.Emit(OpCodes.Callvirt, _ctx.Runtime.JsonScalarRecordShapeGetter);
+                    Emitters.JSONStaticEmitter.EmitLazyShapeDescriptor(
+                        _ctx, recordShape, shapeField, closed);
+                    IL.Emit(OpCodes.Bne_Un, fallbackLabel);
+                }
+                IL.Emit(OpCodes.Ldloc, inlineLocal);
+                IL.Emit(OpCodes.Call, directGetter);
                 IL.Emit(OpCodes.Br, endLabel);
                 IL.MarkLabel(dictionaryLabel);
             }
         }
 
-        // dictLocal = receiver as Dictionary<string, object>
-        IL.Emit(OpCodes.Ldloc, receiverLocal);
-        IL.Emit(OpCodes.Isinst, _ctx.Types.DictionaryStringObject);
-        IL.Emit(OpCodes.Stloc, dictLocal);
-        IL.Emit(OpCodes.Ldloc, dictLocal);
-        IL.Emit(OpCodes.Brfalse, fallbackLabel);
+        if (!exactCarrierSpecialized)
+        {
+            // dictLocal = receiver as Dictionary<string, object>
+            IL.Emit(OpCodes.Ldloc, receiverLocal);
+            IL.Emit(OpCodes.Isinst, _ctx.Types.DictionaryStringObject);
+            IL.Emit(OpCodes.Stloc, dictLocal);
+            IL.Emit(OpCodes.Ldloc, dictLocal);
+            IL.Emit(OpCodes.Brfalse, fallbackLabel);
 
-        // dict.TryGetValue(name, out value) ? value : $Undefined
-        IL.Emit(OpCodes.Ldloc, dictLocal);
-        IL.Emit(OpCodes.Ldstr, g.Name.Lexeme);
-        IL.Emit(OpCodes.Ldloca, outLocal);
-        var tryGetValue = _ctx.Types.GetMethod(
-            _ctx.Types.DictionaryStringObject,
-            "TryGetValue",
-            _ctx.Types.String,
-            _ctx.Types.Object.MakeByRefType());
-        IL.Emit(OpCodes.Callvirt, tryGetValue);
-        IL.Emit(OpCodes.Brfalse, notFoundLabel);
-        IL.Emit(OpCodes.Ldloc, outLocal);
-        IL.Emit(OpCodes.Br, endLabel);
+            // dict.TryGetValue(name, out value) ? value : $Undefined
+            IL.Emit(OpCodes.Ldloc, dictLocal);
+            IL.Emit(OpCodes.Ldstr, g.Name.Lexeme);
+            IL.Emit(OpCodes.Ldloca, outLocal);
+            var tryGetValue = _ctx.Types.GetMethod(
+                _ctx.Types.DictionaryStringObject,
+                "TryGetValue",
+                _ctx.Types.String,
+                _ctx.Types.Object.MakeByRefType());
+            IL.Emit(OpCodes.Callvirt, tryGetValue);
+            IL.Emit(OpCodes.Brfalse, notFoundLabel);
+            IL.Emit(OpCodes.Ldloc, outLocal);
+            IL.Emit(OpCodes.Br, endLabel);
 
-        IL.MarkLabel(notFoundLabel);
-        // ECMA-262: missing property reads as undefined.
-        IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.UndefinedInstance);
-        IL.Emit(OpCodes.Br, endLabel);
+            IL.MarkLabel(notFoundLabel);
+            // ECMA-262: missing property reads as undefined.
+            IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.UndefinedInstance);
+            IL.Emit(OpCodes.Br, endLabel);
+        }
 
         IL.MarkLabel(fallbackLabel);
         IL.Emit(OpCodes.Ldloc, receiverLocal);

--- a/src/SharpTS/Compilation/ParameterAssignmentAnalyzer.cs
+++ b/src/SharpTS/Compilation/ParameterAssignmentAnalyzer.cs
@@ -1,0 +1,52 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+
+namespace SharpTS.Compilation;
+
+internal static class ParameterAssignmentAnalyzer
+{
+    public static HashSet<string> FindAssigned(IEnumerable<Stmt> body)
+    {
+        var visitor = new AssignmentVisitor();
+        foreach (var statement in body)
+            visitor.Visit(statement);
+        return visitor.Assigned;
+    }
+
+    private sealed class AssignmentVisitor : AstVisitorBase
+    {
+        public HashSet<string> Assigned { get; } = new(StringComparer.Ordinal);
+
+        protected override void VisitAssign(Expr.Assign expr)
+        {
+            Assigned.Add(expr.Name.Lexeme);
+            base.VisitAssign(expr);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expr)
+        {
+            Assigned.Add(expr.Name.Lexeme);
+            base.VisitCompoundAssign(expr);
+        }
+
+        protected override void VisitLogicalAssign(Expr.LogicalAssign expr)
+        {
+            Assigned.Add(expr.Name.Lexeme);
+            base.VisitLogicalAssign(expr);
+        }
+
+        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expr)
+        {
+            if (expr.Operand is Expr.Variable variable)
+                Assigned.Add(variable.Name.Lexeme);
+            base.VisitPrefixIncrement(expr);
+        }
+
+        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expr)
+        {
+            if (expr.Operand is Expr.Variable variable)
+                Assigned.Add(variable.Name.Lexeme);
+            base.VisitPostfixIncrement(expr);
+        }
+    }
+}

--- a/src/SharpTS/Compilation/RuntimeEmitter.CompactObjectRecord.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.CompactObjectRecord.cs
@@ -1,0 +1,246 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    private void EmitCompactObjectRecordInterface(
+        ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        var interfaceBuilder = EmitTypeDefinitions.DefineType(
+            moduleBuilder,
+            "$ICompactObjectRecord",
+            TypeAttributes.Public | TypeAttributes.Interface | TypeAttributes.Abstract,
+            null);
+        runtime.CompactObjectRecordInterface = interfaceBuilder.CreateType()!;
+    }
+
+    /// <summary>
+    /// Emits one exact CLR reference type per small plain-record shape.  The
+    /// object contains only its value slots; a shared weak table holds the
+    /// canonical dictionary only after a dynamic write or observation asks for
+    /// it.  A type-wide bit makes the untouched typed-read path a single branch
+    /// followed by ldfld while retaining full IHasFields mutation semantics.
+    /// </summary>
+    private void EmitCompactObjectRecordClasses(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        int ordinal = 0;
+        foreach (var pair in _features.CompactObjectRecordShapes.OrderBy(pair => pair.Key, StringComparer.Ordinal))
+        {
+            string fingerprint = pair.Key;
+            JsonSerializationShape.Record shape = pair.Value;
+            if (shape.Fields.Count is < 1 or > 4)
+                continue;
+
+            var typeBuilder = EmitTypeDefinitions.DefineType(
+                moduleBuilder,
+                $"$CompactObjectRecord{ordinal++}",
+                TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed |
+                TypeAttributes.BeforeFieldInit,
+                _types.Object);
+            EmitTypeDefinitions.AddInterfaceImplementation(typeBuilder, runtime.IHasFieldsInterface);
+            EmitTypeDefinitions.AddInterfaceImplementation(
+                typeBuilder, runtime.CompactObjectRecordInterface);
+            runtime.CompactObjectRecordTypes.Add(fingerprint, typeBuilder);
+
+            var valueFields = shape.Fields.Select((_, index) =>
+                typeBuilder.DefineField($"_v{index}", _types.Object, FieldAttributes.Assembly)).ToArray();
+            Type weakTableType = _types.MakeGenericType(
+                _types.ConditionalWeakTableOpen, _types.Object, _types.DictionaryStringObject);
+            var materializedTable = typeBuilder.DefineField(
+                "_materialized", weakTableType, FieldAttributes.Private | FieldAttributes.Static);
+            var anyMaterialized = typeBuilder.DefineField(
+                "_anyMaterialized", _types.Boolean, FieldAttributes.Assembly | FieldAttributes.Static);
+            runtime.CompactObjectRecordAnyMaterializedFields.Add(fingerprint, anyMaterialized);
+            for (int index = 0; index < valueFields.Length; index++)
+                runtime.CompactObjectRecordValueFields.Add((fingerprint, index), valueFields[index]);
+
+            var ctor = typeBuilder.DefineConstructor(
+                MethodAttributes.Public,
+                CallingConventions.Standard,
+                Enumerable.Repeat(_types.Object, valueFields.Length).ToArray());
+            runtime.CompactObjectRecordCtors.Add(fingerprint, ctor);
+            var ctorIl = ctor.GetILGenerator();
+            ctorIl.Emit(OpCodes.Ldarg_0);
+            ctorIl.Emit(OpCodes.Call, _types.GetConstructor(_types.Object, Type.EmptyTypes)!);
+            for (int index = 0; index < valueFields.Length; index++)
+            {
+                ctorIl.Emit(OpCodes.Ldarg_0);
+                ctorIl.Emit(OpCodes.Ldarg, index + 1);
+                ctorIl.Emit(OpCodes.Stfld, valueFields[index]);
+            }
+            ctorIl.Emit(OpCodes.Ret);
+
+            MethodInfo tableTryGet = _types.GetMethod(
+                weakTableType, "TryGetValue", _types.Object,
+                _types.DictionaryStringObject.MakeByRefType());
+            MethodInfo tableAdd = _types.GetMethod(
+                weakTableType, "Add", _types.Object, _types.DictionaryStringObject);
+            MethodInfo dictSet = _types.GetMethod(
+                _types.DictionaryStringObject, "set_Item", _types.String, _types.Object);
+            MethodInfo dictTryGet = _types.GetMethod(
+                _types.DictionaryStringObject, "TryGetValue", _types.String,
+                _types.Object.MakeByRefType());
+            MethodInfo dictContains = _types.GetMethod(
+                _types.DictionaryStringObject, "ContainsKey", _types.String);
+            MethodInfo stringEquals = _types.GetMethod(
+                _types.String, "op_Equality", _types.String, _types.String);
+
+            var ensure = typeBuilder.DefineMethod(
+                "EnsureMaterialized", MethodAttributes.Private | MethodAttributes.HideBySig,
+                _types.DictionaryStringObject, Type.EmptyTypes);
+            EmitEnsure(ensure.GetILGenerator());
+
+            var fieldsGetter = typeBuilder.DefineMethod(
+                "get_Fields",
+                MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.SpecialName |
+                MethodAttributes.HideBySig,
+                _types.DictionaryStringObject, Type.EmptyTypes);
+            var fieldsIl = fieldsGetter.GetILGenerator();
+            fieldsIl.Emit(OpCodes.Ldarg_0);
+            fieldsIl.Emit(OpCodes.Call, ensure);
+            fieldsIl.Emit(OpCodes.Ret);
+            typeBuilder.DefineMethodOverride(fieldsGetter, runtime.IHasFieldsFieldsGetter);
+
+            var getProperty = typeBuilder.DefineMethod(
+                "GetProperty", MethodAttributes.Public | MethodAttributes.Virtual |
+                MethodAttributes.HideBySig, _types.Object, [_types.String]);
+            EmitGetProperty(getProperty.GetILGenerator());
+            typeBuilder.DefineMethodOverride(getProperty, runtime.IHasFieldsGetProperty);
+
+            var setProperty = typeBuilder.DefineMethod(
+                "SetProperty", MethodAttributes.Public | MethodAttributes.Virtual |
+                MethodAttributes.HideBySig, _types.Void, [_types.String, _types.Object]);
+            var setIl = setProperty.GetILGenerator();
+            setIl.Emit(OpCodes.Ldarg_0);
+            setIl.Emit(OpCodes.Call, ensure);
+            setIl.Emit(OpCodes.Ldarg_1);
+            setIl.Emit(OpCodes.Ldarg_2);
+            setIl.Emit(OpCodes.Callvirt, dictSet);
+            setIl.Emit(OpCodes.Ret);
+            typeBuilder.DefineMethodOverride(setProperty, runtime.IHasFieldsSetProperty);
+
+            var hasProperty = typeBuilder.DefineMethod(
+                "HasProperty", MethodAttributes.Public | MethodAttributes.Virtual |
+                MethodAttributes.HideBySig, _types.Boolean, [_types.String]);
+            EmitHasProperty(hasProperty.GetILGenerator());
+            typeBuilder.DefineMethodOverride(hasProperty, runtime.IHasFieldsHasProperty);
+
+            typeBuilder.CreateType();
+
+            void EmitEnsure(ILGenerator il)
+            {
+                var result = il.DeclareLocal(_types.DictionaryStringObject);
+                var tableReady = il.DefineLabel();
+                var create = il.DefineLabel();
+                il.Emit(OpCodes.Ldsfld, materializedTable);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Brtrue_S, tableReady);
+                il.Emit(OpCodes.Pop);
+                il.Emit(OpCodes.Newobj, _types.GetConstructor(weakTableType, Type.EmptyTypes)!);
+                il.Emit(OpCodes.Dup);
+                il.Emit(OpCodes.Stsfld, materializedTable);
+                il.MarkLabel(tableReady);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldloca, result);
+                il.Emit(OpCodes.Callvirt, tableTryGet);
+                il.Emit(OpCodes.Brfalse_S, create);
+                il.Emit(OpCodes.Ldloc, result);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(create);
+                il.Emit(OpCodes.Ldc_I4, valueFields.Length);
+                il.Emit(OpCodes.Newobj, _types.GetConstructor(
+                    _types.DictionaryStringObject, [_types.Int32])!);
+                il.Emit(OpCodes.Stloc, result);
+                for (int index = 0; index < valueFields.Length; index++)
+                {
+                    il.Emit(OpCodes.Ldloc, result);
+                    il.Emit(OpCodes.Ldstr, shape.Fields[index].Key);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldfld, valueFields[index]);
+                    il.Emit(OpCodes.Callvirt, dictSet);
+                }
+                il.Emit(OpCodes.Ldsfld, materializedTable);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldloc, result);
+                il.Emit(OpCodes.Callvirt, tableAdd);
+                il.Emit(OpCodes.Ldc_I4_1);
+                il.Emit(OpCodes.Stsfld, anyMaterialized);
+                il.Emit(OpCodes.Ldloc, result);
+                il.Emit(OpCodes.Ret);
+            }
+
+            void EmitGetProperty(ILGenerator il)
+            {
+                var dictionary = il.DeclareLocal(_types.DictionaryStringObject);
+                var value = il.DeclareLocal(_types.Object);
+                var compact = il.DefineLabel();
+                il.Emit(OpCodes.Ldsfld, anyMaterialized);
+                il.Emit(OpCodes.Brfalse_S, compact);
+                il.Emit(OpCodes.Ldsfld, materializedTable);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldloca, dictionary);
+                il.Emit(OpCodes.Callvirt, tableTryGet);
+                il.Emit(OpCodes.Brfalse_S, compact);
+                il.Emit(OpCodes.Ldloc, dictionary);
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Ldloca, value);
+                il.Emit(OpCodes.Callvirt, dictTryGet);
+                var missing = il.DefineLabel();
+                il.Emit(OpCodes.Brfalse_S, missing);
+                il.Emit(OpCodes.Ldloc, value);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(missing);
+                il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(compact);
+                for (int index = 0; index < valueFields.Length; index++)
+                {
+                    var next = il.DefineLabel();
+                    il.Emit(OpCodes.Ldarg_1);
+                    il.Emit(OpCodes.Ldstr, shape.Fields[index].Key);
+                    il.Emit(OpCodes.Call, stringEquals);
+                    il.Emit(OpCodes.Brfalse_S, next);
+                    il.Emit(OpCodes.Ldarg_0);
+                    il.Emit(OpCodes.Ldfld, valueFields[index]);
+                    il.Emit(OpCodes.Ret);
+                    il.MarkLabel(next);
+                }
+                il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+                il.Emit(OpCodes.Ret);
+            }
+
+            void EmitHasProperty(ILGenerator il)
+            {
+                var dictionary = il.DeclareLocal(_types.DictionaryStringObject);
+                var compact = il.DefineLabel();
+                il.Emit(OpCodes.Ldsfld, anyMaterialized);
+                il.Emit(OpCodes.Brfalse_S, compact);
+                il.Emit(OpCodes.Ldsfld, materializedTable);
+                il.Emit(OpCodes.Ldarg_0);
+                il.Emit(OpCodes.Ldloca, dictionary);
+                il.Emit(OpCodes.Callvirt, tableTryGet);
+                il.Emit(OpCodes.Brfalse_S, compact);
+                il.Emit(OpCodes.Ldloc, dictionary);
+                il.Emit(OpCodes.Ldarg_1);
+                il.Emit(OpCodes.Callvirt, dictContains);
+                il.Emit(OpCodes.Ret);
+                il.MarkLabel(compact);
+                foreach (var field in shape.Fields)
+                {
+                    var next = il.DefineLabel();
+                    il.Emit(OpCodes.Ldarg_1);
+                    il.Emit(OpCodes.Ldstr, field.Key);
+                    il.Emit(OpCodes.Call, stringEquals);
+                    il.Emit(OpCodes.Brfalse_S, next);
+                    il.Emit(OpCodes.Ldc_I4_1);
+                    il.Emit(OpCodes.Ret);
+                    il.MarkLabel(next);
+                }
+                il.Emit(OpCodes.Ldc_I4_0);
+                il.Emit(OpCodes.Ret);
+            }
+        }
+    }
+}

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.ScalarRecord.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.ScalarRecord.cs
@@ -17,53 +17,125 @@ public partial class RuntimeEmitter
         var typeBuilder = EmitTypeDefinitions.DefineType(
             moduleBuilder,
             "$JsonScalarRecord",
-            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed |
+            TypeAttributes.Public | TypeAttributes.Class |
             TypeAttributes.BeforeFieldInit,
             _types.Object);
         runtime.JsonScalarRecordType = typeBuilder;
         EmitTypeDefinitions.AddInterfaceImplementation(typeBuilder, runtime.IHasFieldsInterface);
+        EmitTypeDefinitions.AddInterfaceImplementation(
+            typeBuilder, runtime.CompactObjectRecordInterface);
 
         var shapeField = typeBuilder.DefineField("_shape", _types.Object, FieldAttributes.Private);
-        var valuesField = typeBuilder.DefineField("_values", _types.ObjectArray, FieldAttributes.Private);
-        var inlineValueFields = Enumerable.Range(0, 4)
-            .Select(index => typeBuilder.DefineField(
-                $"_v{index}", _types.Object, FieldAttributes.Private))
-            .ToArray();
         var materializedField = typeBuilder.DefineField(
             "_materialized", _types.DictionaryStringObject, FieldAttributes.Private);
 
-        var ctor = typeBuilder.DefineConstructor(
-            MethodAttributes.Public,
+        var baseCtor = typeBuilder.DefineConstructor(
+            MethodAttributes.Family,
             CallingConventions.Standard,
-            [_types.Object, _types.ObjectArray]);
-        runtime.JsonScalarRecordCtor = ctor;
-        var ctorIl = ctor.GetILGenerator();
+            [_types.Object]);
+        var ctorIl = baseCtor.GetILGenerator();
         ctorIl.Emit(OpCodes.Ldarg_0);
         ctorIl.Emit(OpCodes.Call, _types.GetConstructor(_types.Object, Type.EmptyTypes)!);
         ctorIl.Emit(OpCodes.Ldarg_0);
         ctorIl.Emit(OpCodes.Ldarg_1);
         ctorIl.Emit(OpCodes.Stfld, shapeField);
-        ctorIl.Emit(OpCodes.Ldarg_0);
-        ctorIl.Emit(OpCodes.Ldarg_2);
-        ctorIl.Emit(OpCodes.Stfld, valuesField);
         ctorIl.Emit(OpCodes.Ret);
 
-        for (int arity = 1; arity <= inlineValueFields.Length; arity++)
+        var getValue = typeBuilder.DefineMethod(
+            "GetValue",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+            _types.Object,
+            [_types.Int32]);
+        getValue.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
+        runtime.JsonScalarRecordGetValue = getValue;
+        var baseGetValueIl = getValue.GetILGenerator();
+        baseGetValueIl.Emit(OpCodes.Ldnull);
+        baseGetValueIl.Emit(OpCodes.Ret);
+
+        var valuesGetter = typeBuilder.DefineMethod(
+            "get_Values",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.SpecialName |
+            MethodAttributes.HideBySig,
+            _types.ObjectArray,
+            Type.EmptyTypes);
+        runtime.JsonScalarRecordValuesGetter = valuesGetter;
+        var baseValuesIl = valuesGetter.GetILGenerator();
+        baseValuesIl.Emit(OpCodes.Ldnull);
+        baseValuesIl.Emit(OpCodes.Ret);
+
+        var derivedTypes = new List<TypeBuilder>();
+
+        var arrayType = EmitTypeDefinitions.DefineType(
+            moduleBuilder,
+            "$JsonScalarRecordArray",
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed |
+            TypeAttributes.BeforeFieldInit,
+            typeBuilder);
+        derivedTypes.Add(arrayType);
+        var valuesField = arrayType.DefineField("_values", _types.ObjectArray, FieldAttributes.Private);
+        var arrayCtor = arrayType.DefineConstructor(
+            MethodAttributes.Public,
+            CallingConventions.Standard,
+            [_types.Object, _types.ObjectArray]);
+        runtime.JsonScalarRecordCtor = arrayCtor;
+        var arrayCtorIl = arrayCtor.GetILGenerator();
+        arrayCtorIl.Emit(OpCodes.Ldarg_0);
+        arrayCtorIl.Emit(OpCodes.Ldarg_1);
+        arrayCtorIl.Emit(OpCodes.Call, baseCtor);
+        arrayCtorIl.Emit(OpCodes.Ldarg_0);
+        arrayCtorIl.Emit(OpCodes.Ldarg_2);
+        arrayCtorIl.Emit(OpCodes.Stfld, valuesField);
+        arrayCtorIl.Emit(OpCodes.Ret);
+        var arrayGetValue = arrayType.DefineMethod(
+            "GetValue",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+            _types.Object,
+            [_types.Int32]);
+        var arrayGetIl = arrayGetValue.GetILGenerator();
+        arrayGetIl.Emit(OpCodes.Ldarg_0);
+        arrayGetIl.Emit(OpCodes.Ldfld, valuesField);
+        arrayGetIl.Emit(OpCodes.Ldarg_1);
+        arrayGetIl.Emit(OpCodes.Ldelem_Ref);
+        arrayGetIl.Emit(OpCodes.Ret);
+        arrayType.DefineMethodOverride(arrayGetValue, getValue);
+        var arrayValuesGetter = arrayType.DefineMethod(
+            "get_Values",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.SpecialName |
+            MethodAttributes.HideBySig,
+            _types.ObjectArray,
+            Type.EmptyTypes);
+        var arrayValuesIl = arrayValuesGetter.GetILGenerator();
+        arrayValuesIl.Emit(OpCodes.Ldarg_0);
+        arrayValuesIl.Emit(OpCodes.Ldfld, valuesField);
+        arrayValuesIl.Emit(OpCodes.Ret);
+        arrayType.DefineMethodOverride(arrayValuesGetter, valuesGetter);
+
+        for (int arity = 1; arity <= 4; arity++)
         {
+            var inlineType = EmitTypeDefinitions.DefineType(
+                moduleBuilder,
+                $"$JsonScalarRecord{arity}",
+                TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed |
+                TypeAttributes.BeforeFieldInit,
+                typeBuilder);
+            derivedTypes.Add(inlineType);
+            runtime.JsonScalarRecordInlineTypes.Add(arity, inlineType);
+            var inlineValueFields = Enumerable.Range(0, arity)
+                .Select(index => inlineType.DefineField(
+                    $"_v{index}", _types.Object, FieldAttributes.Private))
+                .ToArray();
             var parameterTypes = new Type[arity + 1];
             parameterTypes[0] = _types.Object;
             Array.Fill(parameterTypes, _types.Object, 1, arity);
-            var inlineCtor = typeBuilder.DefineConstructor(
+            var inlineCtor = inlineType.DefineConstructor(
                 MethodAttributes.Public,
                 CallingConventions.Standard,
                 parameterTypes);
             runtime.JsonScalarRecordInlineCtors.Add(arity, inlineCtor);
             var inlineIl = inlineCtor.GetILGenerator();
             inlineIl.Emit(OpCodes.Ldarg_0);
-            inlineIl.Emit(OpCodes.Call, _types.GetConstructor(_types.Object, Type.EmptyTypes)!);
-            inlineIl.Emit(OpCodes.Ldarg_0);
             inlineIl.Emit(OpCodes.Ldarg_1);
-            inlineIl.Emit(OpCodes.Stfld, shapeField);
+            inlineIl.Emit(OpCodes.Call, baseCtor);
             for (int index = 0; index < arity; index++)
             {
                 inlineIl.Emit(OpCodes.Ldarg_0);
@@ -71,43 +143,43 @@ public partial class RuntimeEmitter
                 inlineIl.Emit(OpCodes.Stfld, inlineValueFields[index]);
             }
             inlineIl.Emit(OpCodes.Ret);
+
+            var inlineGetValue = inlineType.DefineMethod(
+                "GetValue",
+                MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+                _types.Object,
+                [_types.Int32]);
+            inlineGetValue.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
+            var inlineGetIl = inlineGetValue.GetILGenerator();
+            var valueLabels = inlineValueFields.Select(_ => inlineGetIl.DefineLabel()).ToArray();
+            inlineGetIl.Emit(OpCodes.Ldarg_1);
+            inlineGetIl.Emit(OpCodes.Switch, valueLabels);
+            inlineGetIl.Emit(OpCodes.Ldnull);
+            inlineGetIl.Emit(OpCodes.Ret);
+            for (int index = 0; index < inlineValueFields.Length; index++)
+            {
+                inlineGetIl.MarkLabel(valueLabels[index]);
+                inlineGetIl.Emit(OpCodes.Ldarg_0);
+                inlineGetIl.Emit(OpCodes.Ldfld, inlineValueFields[index]);
+                inlineGetIl.Emit(OpCodes.Ret);
+
+                var directGetter = inlineType.DefineMethod(
+                    $"GetValue{index}",
+                    MethodAttributes.Public | MethodAttributes.HideBySig,
+                    _types.Object,
+                    Type.EmptyTypes);
+                directGetter.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
+                runtime.JsonScalarRecordInlineGetters.Add((arity, index), directGetter);
+                var directIl = directGetter.GetILGenerator();
+                directIl.Emit(OpCodes.Ldarg_0);
+                directIl.Emit(OpCodes.Ldfld, inlineValueFields[index]);
+                directIl.Emit(OpCodes.Ret);
+            }
+            inlineType.DefineMethodOverride(inlineGetValue, getValue);
         }
 
         runtime.JsonScalarRecordShapeGetter = EmitSimpleGetter(
             "get_Shape", _types.Object, shapeField);
-        runtime.JsonScalarRecordValuesGetter = EmitSimpleGetter(
-            "get_Values", _types.ObjectArray, valuesField);
-
-        var getValue = typeBuilder.DefineMethod(
-            "GetValue",
-            MethodAttributes.Public | MethodAttributes.HideBySig,
-            _types.Object,
-            [_types.Int32]);
-        getValue.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
-        runtime.JsonScalarRecordGetValue = getValue;
-        var getValueIl = getValue.GetILGenerator();
-        var inline = getValueIl.DefineLabel();
-        getValueIl.Emit(OpCodes.Ldarg_0);
-        getValueIl.Emit(OpCodes.Ldfld, valuesField);
-        getValueIl.Emit(OpCodes.Dup);
-        getValueIl.Emit(OpCodes.Brfalse, inline);
-        getValueIl.Emit(OpCodes.Ldarg_1);
-        getValueIl.Emit(OpCodes.Ldelem_Ref);
-        getValueIl.Emit(OpCodes.Ret);
-        getValueIl.MarkLabel(inline);
-        getValueIl.Emit(OpCodes.Pop);
-        var valueLabels = inlineValueFields.Select(_ => getValueIl.DefineLabel()).ToArray();
-        getValueIl.Emit(OpCodes.Ldarg_1);
-        getValueIl.Emit(OpCodes.Switch, valueLabels);
-        getValueIl.Emit(OpCodes.Ldnull);
-        getValueIl.Emit(OpCodes.Ret);
-        for (int index = 0; index < inlineValueFields.Length; index++)
-        {
-            getValueIl.MarkLabel(valueLabels[index]);
-            getValueIl.Emit(OpCodes.Ldarg_0);
-            getValueIl.Emit(OpCodes.Ldfld, inlineValueFields[index]);
-            getValueIl.Emit(OpCodes.Ret);
-        }
 
         var isMaterialized = typeBuilder.DefineMethod(
             "get_IsMaterialized",
@@ -176,6 +248,8 @@ public partial class RuntimeEmitter
         typeBuilder.DefineMethodOverride(hasProperty, runtime.IHasFieldsHasProperty);
 
         typeBuilder.CreateType();
+        foreach (var derivedType in derivedTypes)
+            derivedType.CreateType();
 
         MethodBuilder EmitSimpleGetter(string name, Type returnType, FieldBuilder field)
         {
@@ -245,7 +319,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Castclass, _types.String);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldloc, valueIndexLocal);
-        il.Emit(OpCodes.Call, getValue);
+        il.Emit(OpCodes.Callvirt, getValue);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(
             _types.DictionaryStringObject, "set_Item", [_types.String, _types.Object])!);
         il.Emit(OpCodes.Ldloc, indexLocal);
@@ -325,7 +399,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, next);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldloc, valueIndexLocal);
-        il.Emit(OpCodes.Call, getValue);
+        il.Emit(OpCodes.Callvirt, getValue);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(next);
         il.Emit(OpCodes.Ldloc, indexLocal);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.DeleteProperty.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.DeleteProperty.cs
@@ -276,7 +276,7 @@ public partial class RuntimeEmitter
         if (runtime.JsonScalarRecordType is not null)
         {
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.JsonScalarRecordType);
+            il.Emit(OpCodes.Isinst, runtime.CompactObjectRecordInterface);
             il.Emit(OpCodes.Brtrue, scalarRecordDelLabel);
         }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.cs
@@ -1409,7 +1409,7 @@ public partial class RuntimeEmitter
         {
             var accessorCleanupNotScalar = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.JsonScalarRecordType);
+            il.Emit(OpCodes.Isinst, runtime.CompactObjectRecordInterface);
             il.Emit(OpCodes.Brfalse, accessorCleanupNotScalar);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Castclass, runtime.IHasFieldsInterface);
@@ -1682,7 +1682,7 @@ public partial class RuntimeEmitter
             var scalarFieldsLocal =
                 il.DeclareLocal(_types.DictionaryStringObject);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.JsonScalarRecordType);
+            il.Emit(OpCodes.Isinst, runtime.CompactObjectRecordInterface);
             il.Emit(OpCodes.Brfalse, notScalarForValueLabel);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Castclass, runtime.IHasFieldsInterface);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -436,7 +436,7 @@ public partial class RuntimeEmitter
         {
             var notScalarRecordLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.JsonScalarRecordType);
+            il.Emit(OpCodes.Isinst, runtime.CompactObjectRecordInterface);
             il.Emit(OpCodes.Brfalse, notScalarRecordLabel);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Castclass, runtime.IHasFieldsInterface);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Prototype.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Prototype.cs
@@ -595,7 +595,7 @@ public partial class RuntimeEmitter
         {
             var notScalarRecord = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.JsonScalarRecordType);
+            il.Emit(OpCodes.Isinst, runtime.CompactObjectRecordInterface);
             il.Emit(OpCodes.Brfalse, notScalarRecord);
             il.Emit(OpCodes.Ldsfld, runtime.ObjectPrototypeField);
             il.Emit(OpCodes.Ret);
@@ -1085,7 +1085,7 @@ public partial class RuntimeEmitter
         if (runtime.JsonScalarRecordType is not null)
         {
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.JsonScalarRecordType);
+            il.Emit(OpCodes.Isinst, runtime.CompactObjectRecordInterface);
             il.Emit(OpCodes.Brtrue, notClassInstanceLabel);
         }
         il.Emit(OpCodes.Ldarg_0);

--- a/src/SharpTS/Compilation/RuntimeEmitter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.cs
@@ -150,14 +150,20 @@ public partial class RuntimeEmitter
         // Emit $IHasFields interface for unified property access
         // Must come before $Object which implements it
         EmitHasFieldsInterface(moduleBuilder, runtime);
+        EmitCompactObjectRecordInterface(moduleBuilder, runtime);
 
         // Emit $Object class for standalone object support
         // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSObject
         EmitTSObjectClass(moduleBuilder, runtime);
 
-        if (features.UsesJSON)
+        if (features.UsesJSON || features.UsesCompactObjectRecords)
         {
             EmitJsonScalarRecordClass(moduleBuilder, runtime);
+            EmitCompactObjectRecordClasses(moduleBuilder, runtime);
+        }
+
+        if (features.UsesJSON)
+        {
             EmitTSRawJsonClass(moduleBuilder, runtime);
         }
 

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -1332,6 +1332,20 @@ public sealed class RuntimeFeatureDetector
 
     private void MarkObjectLiteralShape(Expr expression)
     {
+        Expr unwrapped = expression switch
+        {
+            Expr.Grouping grouping => grouping.Expression,
+            Expr.TypeAssertion assertion => assertion.Expression,
+            Expr.Satisfies satisfies => satisfies.Expression,
+            Expr.NonNullAssertion assertion => assertion.Expression,
+            _ => expression
+        };
+        if (!ReferenceEquals(unwrapped, expression))
+        {
+            MarkObjectLiteralShape(unwrapped);
+            return;
+        }
+
         if (expression is Expr.ObjectLiteral literal &&
             JsonSerializationShapeAnalyzer.TryAnalyzeObjectLiteral(
                 literal, _typeMap, out var shape))

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -1,4 +1,5 @@
 using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
 using SharpTS.TypeSystem;
 
 namespace SharpTS.Compilation;
@@ -29,6 +30,8 @@ namespace SharpTS.Compilation;
 public sealed class RuntimeFeatureDetector
 {
     private readonly RuntimeFeatureSet _set;
+    private readonly HashSet<string> _sourceFunctions = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _opaqueValueBindings = new(StringComparer.Ordinal);
     private TypeMap? _typeMap;
 
     public RuntimeFeatureDetector()
@@ -56,6 +59,7 @@ public sealed class RuntimeFeatureDetector
             UsesReflectMetadata = false,
             UsesCjsRequire = false,
             UsesJSON = false,
+            UsesCompactObjectRecords = false,
             UsesIntl = false,
             UsesReflect = false,
             UsesIteratorHelpers = false,
@@ -82,6 +86,7 @@ public sealed class RuntimeFeatureDetector
             UsesSet = false,
             UsesDynamicPropertyDescriptors = false,
             UsesDatePrototypeMutation = false,
+            PotentiallyMaterializesUnknownCompactObjectRecordShape = false,
             TypedArrays = RuntimeFeatureSet.TypedArrayKinds.None,
         };
     }
@@ -89,6 +94,7 @@ public sealed class RuntimeFeatureDetector
     public RuntimeFeatureSet Detect(List<Stmt> statements, TypeMap? typeMap = null)
     {
         _typeMap = typeMap;
+        CollectStableSourceFunctionNames(statements);
         foreach (var stmt in statements)
             VisitStmt(stmt);
 
@@ -167,6 +173,11 @@ public sealed class RuntimeFeatureDetector
         if (_set.UsesAbortSignalAny)
         {
             _set.UsesAbortController = true;
+        }
+        if (_set.UsesDynamicImport || _set.UsesSourceExecution || _set.UsesVm ||
+            _set.UsesCjsRequire)
+        {
+            _set.PotentiallyMaterializesUnknownCompactObjectRecordShape = true;
         }
 
         return _set;
@@ -540,9 +551,35 @@ public sealed class RuntimeFeatureDetector
                 _set.UsesCjsRequire = true;
                 break;
             case Stmt.Export exp:
+                if (exp.Declaration is Stmt.Function exportedFunction && _typeMap is not null)
+                {
+                    var functionType = _typeMap.GetFunctionType(exportedFunction.Name.Lexeme);
+                    if (functionType is not null)
+                    {
+                        MarkPotentiallyMaterialized(functionType.ReturnType);
+                        foreach (var parameterType in functionType.ParamTypes)
+                            MarkPotentiallyMaterialized(parameterType);
+                    }
+                }
+                else if (exp.Declaration is Stmt.Var exportedVar && exportedVar.Initializer is not null)
+                {
+                    MarkPotentiallyMaterialized(exportedVar.Initializer);
+                }
+                else if (exp.Declaration is Stmt.Const exportedConst)
+                {
+                    MarkPotentiallyMaterialized(exportedConst.Initializer);
+                }
                 if (exp.Declaration is not null) VisitStmt(exp.Declaration);
-                if (exp.DefaultExpr is not null) VisitExpr(exp.DefaultExpr);
-                if (exp.ExportAssignment is not null) VisitExpr(exp.ExportAssignment);
+                if (exp.DefaultExpr is not null)
+                {
+                    MarkPotentiallyMaterialized(exp.DefaultExpr);
+                    VisitExpr(exp.DefaultExpr);
+                }
+                if (exp.ExportAssignment is not null)
+                {
+                    MarkPotentiallyMaterialized(exp.ExportAssignment);
+                    VisitExpr(exp.ExportAssignment);
+                }
                 break;
 
             case Stmt.Block block:
@@ -554,10 +591,17 @@ public sealed class RuntimeFeatureDetector
                 break;
 
             case Stmt.Var var:
-                if (var.Initializer is not null) VisitExpr(var.Initializer);
+                if (var.Initializer is not null)
+                {
+                    if (_opaqueValueBindings.Contains(var.Name.Lexeme))
+                        MarkPotentiallyMaterialized(var.Initializer);
+                    VisitExpr(var.Initializer);
+                }
                 break;
 
             case Stmt.Const cst:
+                if (_opaqueValueBindings.Contains(cst.Name.Lexeme))
+                    MarkPotentiallyMaterialized(cst.Initializer);
                 VisitExpr(cst.Initializer);
                 break;
 
@@ -762,6 +806,7 @@ public sealed class RuntimeFeatureDetector
                 break;
 
             case Expr.Set s:
+                MarkMutationTarget(s.Object);
                 if (IsDatePrototype(s.Object))
                     _set.UsesDatePrototypeMutation = true;
                 if (s.Object is Expr.Variable osv)
@@ -788,6 +833,7 @@ public sealed class RuntimeFeatureDetector
                 VisitExpr(gi.Index);
                 break;
             case Expr.SetIndex si:
+                MarkMutationTarget(si.Object);
                 if (IsDatePrototype(si.Object))
                     _set.UsesDatePrototypeMutation = true;
                 VisitExpr(si.Object);
@@ -796,6 +842,24 @@ public sealed class RuntimeFeatureDetector
                 break;
 
             case Expr.Call c:
+                if (c.Callee is not Expr.Variable directSourceCall ||
+                    !_sourceFunctions.Contains(directSourceCall.Name.Lexeme))
+                {
+                    foreach (var argument in c.Arguments)
+                        MarkPotentiallyMaterialized(argument);
+                }
+                if (c.Arguments.Count > 0 && c.Callee is Expr.Get
+                    {
+                        Object: Expr.Variable { Name.Lexeme: "Object" },
+                        Name.Lexeme: "assign" or "defineProperty" or "defineProperties"
+                    })
+                    MarkMutationTarget(c.Arguments[0]);
+                if (c.Arguments.Count > 0 && c.Callee is Expr.Get
+                    {
+                        Object: Expr.Variable { Name.Lexeme: "Reflect" },
+                        Name.Lexeme: "set" or "deleteProperty" or "defineProperty"
+                    })
+                    MarkMutationTarget(c.Arguments[0]);
                 if (_typeMap is not null
                     && c.Arguments.Count == 1
                     && c.Callee is Expr.Get
@@ -853,21 +917,27 @@ public sealed class RuntimeFeatureDetector
                 break;
 
             case Expr.New n:
+                foreach (var argument in n.Arguments)
+                    MarkPotentiallyMaterialized(argument);
                 VisitExpr(n.Callee);
                 foreach (var a in n.Arguments) VisitExpr(a);
                 break;
 
             case Expr.Assign asg:
+                if (_opaqueValueBindings.Contains(asg.Name.Lexeme))
+                    MarkPotentiallyMaterialized(asg.Value);
                 VisitExpr(asg.Value);
                 break;
             case Expr.CompoundAssign ca:
                 VisitExpr(ca.Value);
                 break;
             case Expr.CompoundSet cs:
+                MarkMutationTarget(cs.Object);
                 VisitExpr(cs.Object);
                 VisitExpr(cs.Value);
                 break;
             case Expr.CompoundSetIndex csi:
+                MarkMutationTarget(csi.Object);
                 VisitExpr(csi.Object);
                 VisitExpr(csi.Index);
                 VisitExpr(csi.Value);
@@ -876,10 +946,12 @@ public sealed class RuntimeFeatureDetector
                 VisitExpr(la.Value);
                 break;
             case Expr.LogicalSet ls:
+                MarkMutationTarget(ls.Object);
                 VisitExpr(ls.Object);
                 VisitExpr(ls.Value);
                 break;
             case Expr.LogicalSetIndex lsi:
+                MarkMutationTarget(lsi.Object);
                 VisitExpr(lsi.Object);
                 VisitExpr(lsi.Index);
                 VisitExpr(lsi.Value);
@@ -920,12 +992,20 @@ public sealed class RuntimeFeatureDetector
                 VisitExpr(u.Right);
                 break;
             case Expr.Delete d:
+                if (d.Operand is Expr.Get deletedProperty)
+                    MarkMutationTarget(deletedProperty.Object);
+                else if (d.Operand is Expr.GetIndex deletedIndex)
+                    MarkMutationTarget(deletedIndex.Object);
+                else
+                    _set.PotentiallyMaterializesUnknownCompactObjectRecordShape = true;
                 VisitExpr(d.Operand);
                 break;
             case Expr.PrefixIncrement pi:
+                MarkMutationOperand(pi.Operand);
                 VisitExpr(pi.Operand);
                 break;
             case Expr.PostfixIncrement po:
+                MarkMutationOperand(po.Operand);
                 VisitExpr(po.Operand);
                 break;
             case Expr.GetPrivate gp:
@@ -944,8 +1024,35 @@ public sealed class RuntimeFeatureDetector
                 foreach (var e in al.Elements) VisitExpr(e);
                 break;
             case Expr.ObjectLiteral ol:
+                // Small plain records can use the emitted slot-backed ordinary-object
+                // carrier. This is deliberately only an emission gate; the literal
+                // emitter repeats the full key/duplicate validation before selecting it.
+                if (ol.Properties.Count is >= 1 and <= 4 && ol.Properties.All(prop =>
+                        !prop.IsSpread &&
+                        prop.Key is not Expr.ComputedKey &&
+                        prop.Kind == Expr.ObjectPropertyKind.Value))
+                {
+                    _set.UsesCompactObjectRecords = true;
+                    if (_typeMap is not null &&
+                        JsonSerializationShapeAnalyzer.TryAnalyzeObjectLiteral(
+                            ol, _typeMap, out var compactShape))
+                    {
+                        if (!_set.CompactObjectRecordShapeFingerprints.TryGetValue(
+                                compactShape.Fields.Count, out var shapes))
+                        {
+                            shapes = [];
+                            _set.CompactObjectRecordShapeFingerprints.Add(
+                                compactShape.Fields.Count, shapes);
+                        }
+                        string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(compactShape);
+                        shapes.Add(fingerprint);
+                        _set.CompactObjectRecordShapes.TryAdd(fingerprint, compactShape);
+                    }
+                }
                 foreach (var prop in ol.Properties)
                 {
+                    if (prop.IsSpread)
+                        MarkPotentiallyMaterialized(prop.Value);
                     if (prop.Key is Expr.ComputedKey computed)
                         VisitExpr(computed.Expression);
                     VisitExpr(prop.Value);
@@ -970,6 +1077,7 @@ public sealed class RuntimeFeatureDetector
                 foreach (var e in ttl.Expressions) VisitExpr(e);
                 break;
             case Expr.Spread sp2:
+                MarkPotentiallyMaterialized(sp2.Expression);
                 VisitExpr(sp2.Expression);
                 break;
             case Expr.TypeAssertion ta:
@@ -983,6 +1091,7 @@ public sealed class RuntimeFeatureDetector
                 break;
             case Expr.DynamicImport dimp:
                 _set.UsesDynamicImport = true;
+                _set.PotentiallyMaterializesUnknownCompactObjectRecordShape = true;
                 VisitExpr(dimp.PathExpression);
                 if (dimp.PathExpression is Expr.Literal lit2 && lit2.Value is string p)
                     HandleModulePath(p);
@@ -1043,4 +1152,238 @@ public sealed class RuntimeFeatureDetector
         Object: Expr.Variable { Name.Lexeme: "Date" },
         Name.Lexeme: "prototype"
     };
+
+    private void MarkMutationOperand(Expr operand)
+    {
+        if (operand is Expr.Get property)
+            MarkMutationTarget(property.Object);
+        else if (operand is Expr.GetIndex index)
+            MarkMutationTarget(index.Object);
+    }
+
+    private void CollectStableSourceFunctionNames(IReadOnlyList<Stmt> statements)
+    {
+        var stableFunctions = new HashSet<Stmt.Function>();
+        StableFunctionBindingAnalyzer.Analyze(statements, stableFunctions);
+
+        // A simple-name call is safe to treat as a call into scanned source only when
+        // the declaration is the sole binding with that name anywhere in the tree.
+        // This deliberately rejects otherwise harmless shadows; accepting one could
+        // let a record escape through a parameter/import/local that happens to share a
+        // source function's spelling.
+        var declarations = new DeclaredNameCounter();
+        foreach (var statement in statements)
+            declarations.Visit(statement);
+        _opaqueValueBindings.UnionWith(declarations.OpaqueValueBindings);
+
+        foreach (var function in stableFunctions)
+        {
+            TypeInfo.Function? functionType = _typeMap?.GetFunctionType(function.Name.Lexeme);
+            bool hasOpaqueBoundary = functionType is not null &&
+                (ContainsOpaqueType(functionType.ReturnType) ||
+                 functionType.ParamTypes.Any(ContainsOpaqueType));
+            if (!hasOpaqueBoundary &&
+                declarations.Counts.GetValueOrDefault(function.Name.Lexeme) == 1)
+                _sourceFunctions.Add(function.Name.Lexeme);
+        }
+    }
+
+    private static bool ContainsOpaqueType(TypeInfo type) => type switch
+    {
+        TypeInfo.Any or TypeInfo.Unknown => true,
+        TypeInfo.Union union => union.Types.Any(ContainsOpaqueType),
+        _ => false
+    };
+
+    private sealed class DeclaredNameCounter : AstVisitorBase
+    {
+        public Dictionary<string, int> Counts { get; } = [];
+        public HashSet<string> OpaqueValueBindings { get; } = new(StringComparer.Ordinal);
+
+        private void Add(string name) =>
+            Counts[name] = Counts.GetValueOrDefault(name) + 1;
+
+        private void AddParameters(IEnumerable<Stmt.Parameter> parameters)
+        {
+            foreach (var parameter in parameters)
+            {
+                Add(parameter.Name.Lexeme);
+                if (IsOpaqueAnnotation(parameter.Type))
+                    OpaqueValueBindings.Add(parameter.Name.Lexeme);
+            }
+        }
+
+        private static bool IsOpaqueAnnotation(string? annotation) =>
+            annotation?.Trim() is "any" or "unknown";
+
+        protected override void VisitVar(Stmt.Var stmt)
+        {
+            Add(stmt.Name.Lexeme);
+            if (IsOpaqueAnnotation(stmt.TypeAnnotation))
+                OpaqueValueBindings.Add(stmt.Name.Lexeme);
+            base.VisitVar(stmt);
+        }
+
+        protected override void VisitConst(Stmt.Const stmt)
+        {
+            Add(stmt.Name.Lexeme);
+            if (IsOpaqueAnnotation(stmt.TypeAnnotation))
+                OpaqueValueBindings.Add(stmt.Name.Lexeme);
+            base.VisitConst(stmt);
+        }
+
+        protected override void VisitFunction(Stmt.Function stmt)
+        {
+            Add(stmt.Name.Lexeme);
+            AddParameters(stmt.Parameters);
+            base.VisitFunction(stmt);
+        }
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expr)
+        {
+            if (expr.Name is not null)
+                Add(expr.Name.Lexeme);
+            AddParameters(expr.Parameters);
+            base.VisitArrowFunction(expr);
+        }
+
+        protected override void VisitClass(Stmt.Class stmt)
+        {
+            Add(stmt.Name.Lexeme);
+            base.VisitClass(stmt);
+        }
+
+        protected override void VisitEnum(Stmt.Enum stmt)
+        {
+            Add(stmt.Name.Lexeme);
+            base.VisitEnum(stmt);
+        }
+
+        protected override void VisitNamespace(Stmt.Namespace stmt)
+        {
+            Add(stmt.Name.Lexeme);
+            base.VisitNamespace(stmt);
+        }
+
+        protected override void VisitForOf(Stmt.ForOf stmt)
+        {
+            Add(stmt.Variable.Lexeme);
+            base.VisitForOf(stmt);
+        }
+
+        protected override void VisitForIn(Stmt.ForIn stmt)
+        {
+            Add(stmt.Variable.Lexeme);
+            base.VisitForIn(stmt);
+        }
+
+        protected override void VisitTryCatch(Stmt.TryCatch stmt)
+        {
+            if (stmt.CatchParam is not null)
+                Add(stmt.CatchParam.Lexeme);
+            base.VisitTryCatch(stmt);
+        }
+
+        protected override void VisitImport(Stmt.Import stmt)
+        {
+            if (stmt.DefaultImport is not null)
+                Add(stmt.DefaultImport.Lexeme);
+            if (stmt.NamespaceImport is not null)
+                Add(stmt.NamespaceImport.Lexeme);
+            if (stmt.NamedImports is not null)
+            {
+                foreach (var specifier in stmt.NamedImports)
+                {
+                    if (!specifier.IsTypeOnly)
+                        Add((specifier.LocalName ?? specifier.Imported).Lexeme);
+                }
+            }
+            base.VisitImport(stmt);
+        }
+
+        protected override void VisitImportAlias(Stmt.ImportAlias stmt)
+        {
+            Add(stmt.AliasName.Lexeme);
+            base.VisitImportAlias(stmt);
+        }
+
+        protected override void VisitImportRequire(Stmt.ImportRequire stmt)
+        {
+            Add(stmt.AliasName.Lexeme);
+            base.VisitImportRequire(stmt);
+        }
+    }
+
+    private void MarkMutationTarget(Expr target)
+    {
+        MarkObjectLiteralShape(target);
+        TypeInfo? type = _typeMap?.Get(target);
+        if (type is TypeInfo.Any or TypeInfo.Unknown)
+            _set.PotentiallyMaterializesUnknownCompactObjectRecordShape = true;
+        else
+            MarkPotentiallyMaterialized(type);
+    }
+
+    private void MarkPotentiallyMaterialized(Expr expression)
+    {
+        MarkObjectLiteralShape(expression);
+        MarkPotentiallyMaterialized(_typeMap?.Get(expression));
+    }
+
+    private void MarkObjectLiteralShape(Expr expression)
+    {
+        if (expression is Expr.ObjectLiteral literal &&
+            JsonSerializationShapeAnalyzer.TryAnalyzeObjectLiteral(
+                literal, _typeMap, out var shape))
+        {
+            _set.PotentiallyMaterializedCompactObjectRecordShapes.Add(
+                JsonSerializationShapeAnalyzer.Fingerprint(shape));
+        }
+    }
+
+    private void MarkPotentiallyMaterialized(TypeInfo? type)
+    {
+        var visited = new HashSet<TypeInfo>(ReferenceEqualityComparer.Instance);
+        MarkPotentiallyMaterialized(type, visited);
+    }
+
+    private void MarkPotentiallyMaterialized(TypeInfo? type, HashSet<TypeInfo> visited)
+    {
+        if (type is null || !visited.Add(type))
+            return;
+
+        switch (type)
+        {
+            case TypeInfo.Record record:
+                if (JsonSerializationShapeAnalyzer.TryAnalyze(record, out var analyzed) &&
+                    analyzed is JsonSerializationShape.Record shape &&
+                    shape.Fields.Count is >= 1 and <= 4)
+                {
+                    _set.PotentiallyMaterializedCompactObjectRecordShapes.Add(
+                        JsonSerializationShapeAnalyzer.Fingerprint(shape));
+                }
+                foreach (var fieldType in record.Fields.Values)
+                    MarkPotentiallyMaterialized(fieldType, visited);
+                if (record.StringIndexType is not null)
+                    MarkPotentiallyMaterialized(record.StringIndexType, visited);
+                if (record.NumberIndexType is not null)
+                    MarkPotentiallyMaterialized(record.NumberIndexType, visited);
+                if (record.SymbolIndexType is not null)
+                    MarkPotentiallyMaterialized(record.SymbolIndexType, visited);
+                break;
+            case TypeInfo.Union union:
+                foreach (var member in union.Types)
+                    MarkPotentiallyMaterialized(member, visited);
+                break;
+            case TypeInfo.Array array:
+                MarkPotentiallyMaterialized(array.ElementType, visited);
+                break;
+            case TypeInfo.Tuple tuple:
+                foreach (var element in tuple.Elements)
+                    MarkPotentiallyMaterialized(element.Type, visited);
+                if (tuple.RestElementType is not null)
+                    MarkPotentiallyMaterialized(tuple.RestElementType, visited);
+                break;
+        }
+    }
 }

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -23,6 +23,27 @@ public sealed class RuntimeFeatureSet
     /// </summary>
     internal HashSet<string> JsonScalarRecordShapeFingerprints { get; } = [];
 
+    /// <summary>
+    /// Shapes of small plain-object literals, grouped by slot count. When an
+    /// arity has a single shape, the JSON scalar carrier's CLR type is itself
+    /// an exact shape guard and typed reads need not compare the lazy descriptor.
+    /// Ordinary stable records use the per-fingerprint types below.
+    /// </summary>
+    internal Dictionary<int, HashSet<string>> CompactObjectRecordShapeFingerprints { get; } = [];
+
+    internal Dictionary<string, JsonSerializationShape.Record> CompactObjectRecordShapes { get; } = [];
+
+    internal HashSet<string> PotentiallyMaterializedCompactObjectRecordShapes { get; } = [];
+    internal bool PotentiallyMaterializesUnknownCompactObjectRecordShape { get; set; } = true;
+
+    internal bool HasUniqueCompactObjectRecordShape(int arity, string fingerprint) =>
+        CompactObjectRecordShapeFingerprints.TryGetValue(arity, out var shapes) &&
+        shapes.Count == 1 && shapes.Contains(fingerprint);
+
+    internal bool CanAssumeCompactObjectRecordIsUnmaterialized(string fingerprint) =>
+        !PotentiallyMaterializesUnknownCompactObjectRecordShape &&
+        !PotentiallyMaterializedCompactObjectRecordShapes.Contains(fingerprint);
+
     // ── Network family ────────────────────────────────────────────────────
     public bool UsesNet { get; set; } = true;       // 'net' module / NetServer / NetSocket
     public bool UsesHttp { get; set; } = true;      // 'http'/'https' module / HttpServer
@@ -52,6 +73,7 @@ public sealed class RuntimeFeatureSet
     public bool UsesReflectMetadata { get; set; } = true;   // Reflect.metadata / Reflect.defineMetadata
     public bool UsesCjsRequire { get; set; } = true;        // require() / module.exports
     public bool UsesJSON { get; set; } = true;              // JSON.parse / JSON.stringify
+    public bool UsesCompactObjectRecords { get; set; } = true; // compact slot-backed ordinary object literals
     public bool UsesIntl { get; set; } = true;              // Intl.NumberFormat, DateTimeFormat, Collator
     public bool UsesReflect { get; set; } = true;           // Reflect.set/get/deleteProperty/has/etc.
     public bool UsesIteratorHelpers { get; set; } = true;   // Iterator.prototype.map/filter/flatMap/take/drop

--- a/tests/SharpTS.Tests/CompilerTests/CompactObjectRecordTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/CompactObjectRecordTests.cs
@@ -1,0 +1,173 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>
+/// Regression coverage for #1412: exact small record shapes use slot-backed CLR
+/// reference types, while dynamic observation and mutation retain ordinary JS
+/// object behavior through lazy dictionary materialization.
+/// </summary>
+public sealed class CompactObjectRecordTests
+{
+    private const string TreeSource = """
+        type TreeNode = { left: TreeNode | null; right: TreeNode | null };
+
+        function buildTree(depth: number): TreeNode {
+            if (depth <= 0) return { left: null, right: null };
+            return { left: buildTree(depth - 1), right: buildTree(depth - 1) };
+        }
+
+        function itemCheck(node: TreeNode | null): number {
+            if (node === null) return 1;
+            return 1 + itemCheck(node.left) + itemCheck(node.right);
+        }
+
+        function binaryTrees(depth: number): number {
+            return itemCheck(buildTree(depth));
+        }
+        """;
+
+    [Fact]
+    public void TypedRecursiveRecord_ReadsAndAllocationsUseExactSlotCarrier()
+    {
+        Assembly assembly = Compile(TreeSource);
+        MethodInfo buildTree = FindFunction(assembly, "buildTree");
+        MethodInfo itemCheck = FindFunction(assembly, "itemCheck");
+
+        Assert.Contains(ReadMembers(buildTree), member =>
+            member.OpCode == OpCodes.Newobj &&
+            member.Member?.DeclaringType?.Name.StartsWith(
+                "$CompactObjectRecord", StringComparison.Ordinal) == true);
+        Assert.Contains(ReadMembers(itemCheck), member =>
+            member.OpCode == OpCodes.Ldfld &&
+            member.Member?.DeclaringType?.Name.StartsWith(
+                "$CompactObjectRecord", StringComparison.Ordinal) == true);
+        Assert.DoesNotContain(ReadMembers(itemCheck), member =>
+            member.Member?.DeclaringType?.IsGenericType == true &&
+            member.Member.DeclaringType.GetGenericTypeDefinition() == typeof(Dictionary<,>));
+
+        var binaryTrees = FindFunction(assembly, "binaryTrees")
+            .CreateDelegate<Func<double, double>>();
+        Assert.Equal(16383, binaryTrees(12));
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        Assert.Equal(16383, binaryTrees(12));
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.InRange(allocated, 250_000, 300_000);
+    }
+
+    [Fact]
+    public void DynamicMutationDeletionAndDescriptorsRetainGeneralObjectPath()
+    {
+        const string source = """
+            type Node = { left: Node | null; right: Node | null };
+            const node: Node = { left: null, right: null };
+            console.log(node.left, node.right, Object.keys(node).join(","));
+            node.left = { left: null, right: null };
+            console.log(node.left === null, node.left!.right);
+            console.log(delete node.right, node.right);
+            Object.defineProperty(node, "left", {
+                get: () => "getter",
+                configurable: true
+            });
+            console.log(node.left, Object.keys(node).join(","));
+            """;
+
+        Assembly assembly = Compile(source);
+        Assert.DoesNotContain(
+            assembly.GetType("$Program")!
+                .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                .SelectMany(ReadMembers),
+            member => member.OpCode == OpCodes.Newobj &&
+                member.Member?.DeclaringType?.Name.StartsWith(
+                    "$CompactObjectRecord", StringComparison.Ordinal) == true);
+
+        Assert.Equal(
+            "null null left,right\nfalse null\ntrue undefined\ngetter left\n",
+            TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void SameArityDifferentShapesRemainDistinct()
+    {
+        const string source = """
+            const first: { x: number; y: number } = { x: 1, y: 2 };
+            const second: { left: string; right: string } = { left: "a", right: "b" };
+            console.log(first.x, first.y, second.left, second.right);
+            """;
+
+        Assert.Equal("1 2 a b\n", TestHarness.RunCompiled(source));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"issue_1412_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Member)> ReadMembers(MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? member = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineField or
+                OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                member = opCode.OperandType switch
+                {
+                    OperandType.InlineMethod => module.ResolveMethod(token),
+                    OperandType.InlineField => module.ResolveField(token),
+                    _ => module.ResolveType(token)
+                };
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or OperandType.InlineField or
+                    OperandType.InlineMethod or OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch => 4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, member);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}

--- a/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
@@ -77,4 +77,111 @@ public class RuntimeFeatureDetectorTests
 
         Assert.Equal(expected, features.UsesDatePrototypeMutation);
     }
+
+    [Theory]
+    [InlineData("const node: { left: object | null; right: object | null } = { left: null, right: null }; const isLeaf = node.left === null; console.log(isLeaf);", true)]
+    [InlineData("const node: { left: object | null; right: object | null } = { left: null, right: null }; node.left = null;", false)]
+    [InlineData("export const node: { left: object | null; right: object | null } = { left: null, right: null };", false)]
+    [InlineData("const options: { month: string; day: string } = { month: 'long', day: 'numeric' }; new Intl.DateTimeFormat('en-US', options);", false)]
+    [InlineData("const node: { left: object | null; right: object | null } = { left: null, right: null }; const clone = { ...node };", false)]
+    public void ProvesCompactRecordShapeStableOnlyWithoutMutationOrEscape(
+        string source, bool expectedStable)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var features = new RuntimeFeatureDetector().Detect(statements, typeMap);
+        var shape = Assert.Single(features.CompactObjectRecordShapes);
+
+        bool actualStable = features.CanAssumeCompactObjectRecordIsUnmaterialized(shape.Key);
+        Assert.True(actualStable == expectedStable,
+            $"expectedStable={expectedStable}; actualStable={actualStable}; " +
+            $"unknown={features.PotentiallyMaterializesUnknownCompactObjectRecordShape}; " +
+            $"mutable=[{string.Join(",", features.PotentiallyMaterializedCompactObjectRecordShapes)}]; " +
+            $"shape={shape.Key}");
+    }
+
+    [Theory]
+    [InlineData("""
+        type Node = { left: Node | null; right: Node | null };
+        function consume(node: Node): void { const isLeaf = node.left === null; }
+        const node: Node = { left: null, right: null };
+        consume(node);
+        """, true)]
+    [InlineData("""
+        type Node = { left: Node | null; right: Node | null };
+        function consume(node: Node): void { const isLeaf = node.left === null; }
+        function invoke(consume: (node: Node) => void): void {
+            const node: Node = { left: null, right: null };
+            consume(node);
+        }
+        """, false)]
+    [InlineData("""
+        type Node = { left: Node | null; right: Node | null };
+        function consume(node: any): void { console.log(node); }
+        const node: Node = { left: null, right: null };
+        consume(node);
+        """, false)]
+    public void SourceCallProofRejectsShadowedFunctionBindings(
+        string source, bool expectedStable)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var features = new RuntimeFeatureDetector().Detect(statements, typeMap);
+        var shape = Assert.Single(features.CompactObjectRecordShapes);
+
+        Assert.Equal(
+            expectedStable,
+            features.CanAssumeCompactObjectRecordIsUnmaterialized(shape.Key));
+    }
+
+    [Fact]
+    public void EscapeProofRejectsWideningThroughAnyBinding()
+    {
+        const string source = """
+            type Node = { left: Node | null; right: Node | null };
+            const node: Node = { left: null, right: null };
+            const escaped: any = node;
+            console.log(escaped);
+            """;
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var features = new RuntimeFeatureDetector().Detect(statements, typeMap);
+        var shape = Assert.Single(features.CompactObjectRecordShapes);
+
+        Assert.False(features.CanAssumeCompactObjectRecordIsUnmaterialized(shape.Key));
+    }
+
+    [Fact]
+    public void EscapeProofRejectsContextuallyAnyObjectLiteral()
+    {
+        const string source = """
+            const escaped: any = { left: null, right: null };
+            console.log(escaped);
+            """;
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var features = new RuntimeFeatureDetector().Detect(statements, typeMap);
+        var shape = Assert.Single(features.CompactObjectRecordShapes);
+
+        Assert.False(features.CanAssumeCompactObjectRecordIsUnmaterialized(shape.Key));
+    }
+
+    [Fact]
+    public void EscapeProofTraversesNestedRecordFields()
+    {
+        const string source = """
+            type Node = { left: Node | null; right: Node | null };
+            type Wrapper = { node: Node };
+            const node: Node = { left: null, right: null };
+            const wrapper: Wrapper = { node };
+            console.log(wrapper);
+            """;
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var features = new RuntimeFeatureDetector().Detect(statements, typeMap);
+
+        Assert.Equal(2, features.CompactObjectRecordShapes.Count);
+        Assert.All(features.CompactObjectRecordShapes.Keys, fingerprint =>
+            Assert.False(features.CanAssumeCompactObjectRecordIsUnmaterialized(fingerprint)));
+    }
 }

--- a/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
@@ -84,6 +84,7 @@ public class RuntimeFeatureDetectorTests
     [InlineData("export const node: { left: object | null; right: object | null } = { left: null, right: null };", false)]
     [InlineData("const options: { month: string; day: string } = { month: 'long', day: 'numeric' }; new Intl.DateTimeFormat('en-US', options);", false)]
     [InlineData("const node: { left: object | null; right: object | null } = { left: null, right: null }; const clone = { ...node };", false)]
+    [InlineData("console.log(({ left: null, right: null } as any));", false)]
     public void ProvesCompactRecordShapeStableOnlyWithoutMutationOrEscape(
         string source, bool expectedStable)
     {


### PR DESCRIPTION
## Summary

- emit one exact slot-backed CLR reference type per provably stable 1-4 field record shape
- lower qualifying literals to exact constructors and typed property reads to direct `ldfld`
- hoist exact record guards for non-reassigned function parameters
- preserve general JS object behavior through conservative mutation/export/unknown-call/constructor/spread/`any`/shadowing bailouts and lazy materialization support
- specialize JSON scalar record storage by arity so small carriers no longer pay for four inline slots plus an array field

## Binary-trees results

Pinned pre-change baseline: `73dae04d`.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| cross-runtime depth-16 median | 36.7815 ms | 5.9341 ms | -83.9% |
| BenchmarkDotNet depth-16 mean | 51.049 ms | 11.429 ms | -77.6% |
| BenchmarkDotNet allocation | 27,653.64 KB/op | 4,096.14 KB/op | -85.2% |
| interpreter depth-16 median | 359.5105 ms | 361.9458 ms | +0.7% |

The compiled allocation now matches the idiomatic C# baseline (4,095.98 KB/op). The exact cross-runtime workload retains its checksum guard and emitted IL verification passes.

This intentionally **does not close #1412** yet: the three-process compiled median is 5.9341 ms, narrowly above the issue's 5.0 ms stretch gate. The remaining traversal overhead is the object-typed recursive call boundary; typed recursive fields/core signatures are the next optimization layer.

## Correctness boundary

Exact carriers are selected only for unique stable source bindings and are rejected for:

- property/index writes, compound/logical writes, increment, delete, descriptors, and reflective mutation
- exports, dynamic import/eval/source execution/CJS/vm exposure
- unknown calls and constructors
- object/array spread and dynamic observation
- `any`/`unknown` widening at source function and local-binding boundaries
- shadowed, duplicate, or reassigned function bindings
- computed/spread/accessor/method/duplicate/numeric-key object literals

Concrete nested record shapes are followed transitively when an outer record escapes.

## Verification

- `dotnet build SharpTS.sln -c Release --nologo -p:NuGetAudit=false --no-restore -m:1` — pass, including IL verification
- focused compact-record/runtime-feature tests — 31/31 pass
- spread/proxy/crypto-options/array-index/object/parity regression matrix — 807/807 pass
- TypeScript conformance baseline — 65/65 pass
- compiler suite — 491/494 pass; only host failures remain (local TLS authentication plus two standalone child probes that print the expected exception but hit the harness exit timeout)
- default Test262 run produced no failures but did not complete within an 8-minute bound because subprocess workers did not terminate reliably on this host
- broad non-network core run produced no failures before being stopped after 6+ minutes for the same host degradation

Refs #1412