### PR TITLE
Lower closed JSON record slots to native CLR fields

### DIFF
--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -921,6 +921,10 @@ public class EmittedRuntime
     public Dictionary<int, ConstructorBuilder> JsonScalarRecordInlineCtors { get; } = [];
     public Dictionary<int, TypeBuilder> JsonScalarRecordInlineTypes { get; } = [];
     public Dictionary<(int Arity, int Index), MethodBuilder> JsonScalarRecordInlineGetters { get; } = [];
+    public Dictionary<string, TypeBuilder> JsonTypedScalarRecordTypes { get; } = [];
+    public Dictionary<string, ConstructorBuilder> JsonTypedScalarRecordCtors { get; } = [];
+    public Dictionary<(string Fingerprint, int Index), FieldBuilder> JsonTypedScalarRecordValueFields { get; } = [];
+    public Dictionary<string, FieldBuilder> JsonTypedScalarRecordShapeFields { get; } = [];
     public Dictionary<string, TypeBuilder> CompactObjectRecordTypes { get; } = [];
     public Dictionary<string, ConstructorBuilder> CompactObjectRecordCtors { get; } = [];
     public Dictionary<(string Fingerprint, int Index), FieldBuilder> CompactObjectRecordValueFields { get; } = [];

--- a/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
@@ -234,8 +234,8 @@ public partial class ILEmitter
             record.Fields.Count != literal.Properties.Count)
             return false;
 
-        if (!_ctx.RuntimeFeatures.JsonScalarRecordShapeFingerprints.Contains(
-            JsonSerializationShapeAnalyzer.Fingerprint(record)))
+        string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(record);
+        if (!_ctx.RuntimeFeatures.JsonScalarRecordShapeFingerprints.Contains(fingerprint))
             return false;
 
         for (int i = 0; i < literal.Properties.Count; i++)
@@ -250,7 +250,32 @@ public partial class ILEmitter
         var shapeField = Emitters.JSONStaticEmitter.GetOrDefineShapeField(_ctx, record);
         Emitters.JSONStaticEmitter.EmitLazyShapeDescriptor(
             _ctx, record, shapeField, closed: true);
-        if (_ctx.Runtime!.JsonScalarRecordInlineCtors.TryGetValue(
+        if (_ctx.Runtime!.JsonTypedScalarRecordCtors.TryGetValue(
+                fingerprint, out var typedCtor))
+        {
+            for (int index = 0; index < literal.Properties.Count; index++)
+            {
+                var property = literal.Properties[index];
+                EmitExpression(property.Value);
+                switch (record.Fields[index].Value)
+                {
+                    case JsonSerializationShape.Number:
+                        EnsureDouble();
+                        break;
+                    case JsonSerializationShape.Boolean:
+                        EnsureBoolean();
+                        break;
+                    case JsonSerializationShape.String:
+                        EnsureString();
+                        break;
+                    default:
+                        EmitBoxIfNeeded(property.Value);
+                        break;
+                }
+            }
+            IL.Emit(OpCodes.Newobj, typedCtor);
+        }
+        else if (_ctx.Runtime.JsonScalarRecordInlineCtors.TryGetValue(
             literal.Properties.Count, out var inlineCtor))
         {
             foreach (var property in literal.Properties)

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -423,6 +423,50 @@ public partial class ILEmitter
 
             string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(recordShape);
             if (scalarIndex >= 0 &&
+                _ctx.Runtime!.JsonTypedScalarRecordTypes.TryGetValue(
+                    fingerprint, out var jsonExactType) &&
+                _ctx.Runtime.JsonTypedScalarRecordValueFields.TryGetValue(
+                    (fingerprint, scalarIndex), out var jsonExactValueField) &&
+                jsonExactValueField.FieldType == _ctx.Types.Double)
+            {
+                // A statically-numbered slot can stay as a native double through
+                // the consumer.  The non-carrier fallback applies ToNumber just
+                // as the old boxed path's numeric consumer did.
+                var jsonExactLocal = IL.DeclareLocal(jsonExactType);
+                var numberResult = IL.DeclareLocal(_ctx.Types.Double);
+                var jsonFallback = IL.DefineLabel();
+                var jsonEnd = IL.DefineLabel();
+                IL.Emit(OpCodes.Ldloc, receiverLocal);
+                IL.Emit(OpCodes.Isinst, jsonExactType);
+                IL.Emit(OpCodes.Stloc, jsonExactLocal);
+                IL.Emit(OpCodes.Ldloc, jsonExactLocal);
+                IL.Emit(OpCodes.Brfalse, jsonFallback);
+                IL.Emit(OpCodes.Ldloc, jsonExactLocal);
+                IL.Emit(OpCodes.Callvirt,
+                    _ctx.Runtime.JsonScalarRecordIsMaterializedGetter);
+                IL.Emit(OpCodes.Brtrue, jsonFallback);
+                if (_ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == true)
+                {
+                    IL.Emit(OpCodes.Ldloc, jsonExactLocal);
+                    IL.Emit(OpCodes.Call, _ctx.Runtime.PDSHasPropertyDescriptors);
+                    IL.Emit(OpCodes.Brtrue, jsonFallback);
+                }
+                IL.Emit(OpCodes.Ldloc, jsonExactLocal);
+                IL.Emit(OpCodes.Ldfld, jsonExactValueField);
+                IL.Emit(OpCodes.Stloc, numberResult);
+                IL.Emit(OpCodes.Br, jsonEnd);
+                IL.MarkLabel(jsonFallback);
+                IL.Emit(OpCodes.Ldloc, receiverLocal);
+                IL.Emit(OpCodes.Ldstr, g.Name.Lexeme);
+                IL.Emit(OpCodes.Call, _ctx.Runtime.GetProperty);
+                IL.Emit(OpCodes.Call, _ctx.Runtime.ConvertToNumber);
+                IL.Emit(OpCodes.Stloc, numberResult);
+                IL.MarkLabel(jsonEnd);
+                IL.Emit(OpCodes.Ldloc, numberResult);
+                SetStackType(StackType.Double);
+                return;
+            }
+            else if (scalarIndex >= 0 &&
                 _ctx.Runtime!.CompactObjectRecordTypes.TryGetValue(
                     fingerprint, out var exactType) &&
                 _ctx.Runtime.CompactObjectRecordValueFields.TryGetValue(

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.Parse.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.Parse.cs
@@ -415,6 +415,21 @@ public partial class RuntimeEmitter
         );
         method.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
 
+        var typedRecordParsers = _features.JsonScalarRecordShapes
+            .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+            .Where(pair => runtime.JsonTypedScalarRecordCtors.ContainsKey(pair.Key))
+            .Select((pair, ordinal) => (
+                Fingerprint: pair.Key,
+                Shape: pair.Value,
+                Method: typeBuilder.DefineMethod(
+                    $"ParseJsonTypedScalarRecord{ordinal}",
+                    MethodAttributes.Private | MethodAttributes.Static,
+                    _types.Object,
+                    [readerType.MakeByRefType(), propertyNamesType, _types.Object])))
+            .ToArray();
+        foreach (var parser in typedRecordParsers)
+            parser.Method.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
+
         var il = method.GetILGenerator();
 
         var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
@@ -530,6 +545,20 @@ public partial class RuntimeEmitter
 
         // --- Closed shaped object: parse directly into fixed scalar slots. ---
         il.MarkLabel(shapedObjectLabel);
+        foreach (var parser in typedRecordParsers)
+        {
+            var nextParser = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Ldsfld,
+                runtime.JsonTypedScalarRecordShapeFields[parser.Fingerprint]);
+            il.Emit(OpCodes.Bne_Un, nextParser);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Call, parser.Method);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(nextParser);
+        }
         il.Emit(OpCodes.Ldloc, shapeLocal);
         il.Emit(OpCodes.Ldlen);
         il.Emit(OpCodes.Conv_I4);
@@ -729,7 +758,197 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ret);
 
+        foreach (var parser in typedRecordParsers)
+            EmitTypedRecordParser(parser.Fingerprint, parser.Shape, parser.Method);
+
         return method;
+
+        void EmitTypedRecordParser(
+            string fingerprint,
+            JsonSerializationShape.Record shape,
+            MethodBuilder parserMethod)
+        {
+            var parserIl = parserMethod.GetILGenerator();
+            var descriptorLocal = parserIl.DeclareLocal(_types.ObjectArray);
+            Type[] fieldTypes = shape.Fields
+                .Select(field => GetJsonScalarRecordFieldType(field.Value))
+                .ToArray();
+            LocalBuilder[] fieldLocals = fieldTypes
+                .Select(parserIl.DeclareLocal)
+                .ToArray();
+            var mismatch = parserIl.DefineLabel();
+            var valueTextEquals = readerType.GetMethod(
+                "ValueTextEquals", [typeof(string)])!;
+
+            parserIl.Emit(OpCodes.Ldarg_2);
+            parserIl.Emit(OpCodes.Castclass, _types.ObjectArray);
+            parserIl.Emit(OpCodes.Stloc, descriptorLocal);
+
+            for (int index = 0; index < shape.Fields.Count; index++)
+            {
+                var field = shape.Fields[index];
+                parserIl.Emit(OpCodes.Ldarg_0);
+                parserIl.Emit(OpCodes.Call, readMethod);
+                parserIl.Emit(OpCodes.Brfalse, mismatch);
+                parserIl.Emit(OpCodes.Ldarg_0);
+                parserIl.Emit(OpCodes.Call, tokenTypeGetter);
+                parserIl.Emit(OpCodes.Ldc_I4,
+                    (int)System.Text.Json.JsonTokenType.PropertyName);
+                parserIl.Emit(OpCodes.Bne_Un, mismatch);
+                parserIl.Emit(OpCodes.Ldarg_0);
+                parserIl.Emit(OpCodes.Ldstr, field.Key);
+                parserIl.Emit(OpCodes.Call, valueTextEquals);
+                parserIl.Emit(OpCodes.Brfalse, mismatch);
+                parserIl.Emit(OpCodes.Ldarg_0);
+                parserIl.Emit(OpCodes.Call, readMethod);
+                parserIl.Emit(OpCodes.Brfalse, mismatch);
+
+                switch (field.Value)
+                {
+                    case JsonSerializationShape.Number:
+                        EmitRequiredToken(
+                            parserIl, tokenTypeGetter,
+                            System.Text.Json.JsonTokenType.Number, mismatch);
+                        parserIl.Emit(OpCodes.Ldarg_0);
+                        parserIl.Emit(OpCodes.Call, getDoubleMethod);
+                        parserIl.Emit(OpCodes.Stloc, fieldLocals[index]);
+                        break;
+                    case JsonSerializationShape.String:
+                        EmitRequiredToken(
+                            parserIl, tokenTypeGetter,
+                            System.Text.Json.JsonTokenType.String, mismatch);
+                        parserIl.Emit(OpCodes.Ldarg_0);
+                        parserIl.Emit(OpCodes.Call, getStringMethod);
+                        parserIl.Emit(OpCodes.Stloc, fieldLocals[index]);
+                        break;
+                    case JsonSerializationShape.Boolean:
+                    {
+                        var isFalse = parserIl.DefineLabel();
+                        var boolReady = parserIl.DefineLabel();
+                        parserIl.Emit(OpCodes.Ldarg_0);
+                        parserIl.Emit(OpCodes.Call, tokenTypeGetter);
+                        parserIl.Emit(OpCodes.Dup);
+                        parserIl.Emit(OpCodes.Ldc_I4,
+                            (int)System.Text.Json.JsonTokenType.True);
+                        parserIl.Emit(OpCodes.Beq, boolReady);
+                        parserIl.Emit(OpCodes.Ldc_I4,
+                            (int)System.Text.Json.JsonTokenType.False);
+                        parserIl.Emit(OpCodes.Bne_Un, mismatch);
+                        parserIl.Emit(OpCodes.Ldc_I4_0);
+                        parserIl.Emit(OpCodes.Stloc, fieldLocals[index]);
+                        parserIl.Emit(OpCodes.Br, isFalse);
+                        parserIl.MarkLabel(boolReady);
+                        parserIl.Emit(OpCodes.Pop);
+                        parserIl.Emit(OpCodes.Ldc_I4_1);
+                        parserIl.Emit(OpCodes.Stloc, fieldLocals[index]);
+                        parserIl.MarkLabel(isFalse);
+                        break;
+                    }
+                    case JsonSerializationShape.Array
+                    {
+                        Element: JsonSerializationShape.Record elementRecord
+                    }:
+                    {
+                        string elementFingerprint =
+                            JsonSerializationShapeAnalyzer.Fingerprint(elementRecord);
+                        MethodBuilder elementParser = typedRecordParsers
+                            .Single(candidate =>
+                                candidate.Fingerprint == elementFingerprint)
+                            .Method;
+                        var arrayDescriptorLocal =
+                            parserIl.DeclareLocal(_types.ObjectArray);
+                        var elementDescriptorLocal =
+                            parserIl.DeclareLocal(_types.Object);
+                        var elementsLocal =
+                            parserIl.DeclareLocal(_types.ListOfObject);
+                        var arrayLoop = parserIl.DefineLabel();
+                        var arrayEnd = parserIl.DefineLabel();
+
+                        EmitRequiredToken(
+                            parserIl, tokenTypeGetter,
+                            System.Text.Json.JsonTokenType.StartArray, mismatch);
+                        parserIl.Emit(OpCodes.Ldloc, descriptorLocal);
+                        parserIl.Emit(OpCodes.Ldc_I4, 2 + index * 2);
+                        parserIl.Emit(OpCodes.Ldelem_Ref);
+                        parserIl.Emit(OpCodes.Castclass, _types.ObjectArray);
+                        parserIl.Emit(OpCodes.Stloc, arrayDescriptorLocal);
+                        parserIl.Emit(OpCodes.Ldloc, arrayDescriptorLocal);
+                        parserIl.Emit(OpCodes.Ldc_I4_1);
+                        parserIl.Emit(OpCodes.Ldelem_Ref);
+                        parserIl.Emit(OpCodes.Stloc, elementDescriptorLocal);
+                        parserIl.Emit(OpCodes.Newobj,
+                            _types.GetDefaultConstructor(_types.ListOfObject));
+                        parserIl.Emit(OpCodes.Stloc, elementsLocal);
+
+                        parserIl.MarkLabel(arrayLoop);
+                        parserIl.Emit(OpCodes.Ldarg_0);
+                        parserIl.Emit(OpCodes.Call, readMethod);
+                        parserIl.Emit(OpCodes.Brfalse, mismatch);
+                        parserIl.Emit(OpCodes.Ldarg_0);
+                        parserIl.Emit(OpCodes.Call, tokenTypeGetter);
+                        parserIl.Emit(OpCodes.Ldc_I4,
+                            (int)System.Text.Json.JsonTokenType.EndArray);
+                        parserIl.Emit(OpCodes.Beq, arrayEnd);
+                        EmitRequiredToken(
+                            parserIl, tokenTypeGetter,
+                            System.Text.Json.JsonTokenType.StartObject, mismatch);
+                        parserIl.Emit(OpCodes.Ldloc, elementsLocal);
+                        parserIl.Emit(OpCodes.Ldarg_0);
+                        parserIl.Emit(OpCodes.Ldarg_1);
+                        parserIl.Emit(OpCodes.Ldloc, elementDescriptorLocal);
+                        parserIl.Emit(OpCodes.Call, elementParser);
+                        parserIl.Emit(OpCodes.Callvirt, _types.GetMethod(
+                            _types.ListOfObject, "Add", [_types.Object]));
+                        parserIl.Emit(OpCodes.Br, arrayLoop);
+
+                        parserIl.MarkLabel(arrayEnd);
+                        parserIl.Emit(OpCodes.Ldloc, elementsLocal);
+                        parserIl.Emit(OpCodes.Stloc, fieldLocals[index]);
+                        break;
+                    }
+                    default:
+                        parserIl.Emit(OpCodes.Ldarg_0);
+                        parserIl.Emit(OpCodes.Ldarg_1);
+                        parserIl.Emit(OpCodes.Ldloc, descriptorLocal);
+                        parserIl.Emit(OpCodes.Ldc_I4, 2 + index * 2);
+                        parserIl.Emit(OpCodes.Ldelem_Ref);
+                        parserIl.Emit(OpCodes.Call, method);
+                        parserIl.Emit(OpCodes.Stloc, fieldLocals[index]);
+                        break;
+                }
+            }
+
+            parserIl.Emit(OpCodes.Ldarg_0);
+            parserIl.Emit(OpCodes.Call, readMethod);
+            parserIl.Emit(OpCodes.Brfalse, mismatch);
+            EmitRequiredToken(
+                parserIl, tokenTypeGetter,
+                System.Text.Json.JsonTokenType.EndObject, mismatch);
+            parserIl.Emit(OpCodes.Ldarg_2);
+            foreach (var fieldLocal in fieldLocals)
+                parserIl.Emit(OpCodes.Ldloc, fieldLocal);
+            parserIl.Emit(OpCodes.Newobj,
+                runtime.JsonTypedScalarRecordCtors[fingerprint]);
+            parserIl.Emit(OpCodes.Ret);
+
+            parserIl.MarkLabel(mismatch);
+            parserIl.Emit(OpCodes.Ldstr, "JSON shape association mismatch");
+            parserIl.Emit(OpCodes.Newobj,
+                _types.GetConstructor(_types.Exception, _types.String));
+            parserIl.Emit(OpCodes.Throw);
+        }
+
+        void EmitRequiredToken(
+            ILGenerator targetIl,
+            MethodInfo getter,
+            System.Text.Json.JsonTokenType token,
+            Label mismatch)
+        {
+            targetIl.Emit(OpCodes.Ldarg_0);
+            targetIl.Emit(OpCodes.Call, getter);
+            targetIl.Emit(OpCodes.Ldc_I4, (int)token);
+            targetIl.Emit(OpCodes.Bne_Un, mismatch);
+        }
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.ScalarRecord.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.ScalarRecord.cs
@@ -178,6 +178,85 @@ public partial class RuntimeEmitter
             inlineType.DefineMethodOverride(inlineGetValue, getValue);
         }
 
+        int typedOrdinal = 0;
+        foreach (var pair in _features.JsonScalarRecordShapes.OrderBy(
+                     pair => pair.Key, StringComparer.Ordinal))
+        {
+            string fingerprint = pair.Key;
+            JsonSerializationShape.Record shape = pair.Value;
+            if (shape.Fields.Count == 0)
+                continue;
+
+            var exactType = EmitTypeDefinitions.DefineType(
+                moduleBuilder,
+                $"$JsonTypedScalarRecord{typedOrdinal++}",
+                TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed |
+                TypeAttributes.BeforeFieldInit,
+                typeBuilder);
+            derivedTypes.Add(exactType);
+            runtime.JsonTypedScalarRecordTypes.Add(fingerprint, exactType);
+
+            var exactShapeField = exactType.DefineField(
+                "Shape", _types.Object,
+                FieldAttributes.Assembly | FieldAttributes.Static);
+            runtime.JsonTypedScalarRecordShapeFields.Add(fingerprint, exactShapeField);
+
+            Type[] valueTypes = shape.Fields
+                .Select(field => GetJsonScalarRecordFieldType(field.Value))
+                .ToArray();
+            var valueFields = valueTypes.Select((fieldType, index) =>
+                exactType.DefineField(
+                    $"_v{index}", fieldType, FieldAttributes.Assembly)).ToArray();
+            for (int index = 0; index < valueFields.Length; index++)
+                runtime.JsonTypedScalarRecordValueFields.Add(
+                    (fingerprint, index), valueFields[index]);
+
+            var parameterTypes = new Type[valueTypes.Length + 1];
+            parameterTypes[0] = _types.Object;
+            Array.Copy(valueTypes, 0, parameterTypes, 1, valueTypes.Length);
+            var exactCtor = exactType.DefineConstructor(
+                MethodAttributes.Public,
+                CallingConventions.Standard,
+                parameterTypes);
+            runtime.JsonTypedScalarRecordCtors.Add(fingerprint, exactCtor);
+            var exactCtorIl = exactCtor.GetILGenerator();
+            exactCtorIl.Emit(OpCodes.Ldarg_0);
+            exactCtorIl.Emit(OpCodes.Ldarg_1);
+            exactCtorIl.Emit(OpCodes.Call, baseCtor);
+            exactCtorIl.Emit(OpCodes.Ldarg_1);
+            exactCtorIl.Emit(OpCodes.Stsfld, exactShapeField);
+            for (int index = 0; index < valueFields.Length; index++)
+            {
+                exactCtorIl.Emit(OpCodes.Ldarg_0);
+                exactCtorIl.Emit(OpCodes.Ldarg, index + 2);
+                exactCtorIl.Emit(OpCodes.Stfld, valueFields[index]);
+            }
+            exactCtorIl.Emit(OpCodes.Ret);
+
+            var exactGetValue = exactType.DefineMethod(
+                "GetValue",
+                MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig,
+                _types.Object,
+                [_types.Int32]);
+            exactGetValue.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
+            var exactGetIl = exactGetValue.GetILGenerator();
+            var exactLabels = valueFields.Select(_ => exactGetIl.DefineLabel()).ToArray();
+            exactGetIl.Emit(OpCodes.Ldarg_1);
+            exactGetIl.Emit(OpCodes.Switch, exactLabels);
+            exactGetIl.Emit(OpCodes.Ldnull);
+            exactGetIl.Emit(OpCodes.Ret);
+            for (int index = 0; index < valueFields.Length; index++)
+            {
+                exactGetIl.MarkLabel(exactLabels[index]);
+                exactGetIl.Emit(OpCodes.Ldarg_0);
+                exactGetIl.Emit(OpCodes.Ldfld, valueFields[index]);
+                if (valueTypes[index].IsValueType)
+                    exactGetIl.Emit(OpCodes.Box, valueTypes[index]);
+                exactGetIl.Emit(OpCodes.Ret);
+            }
+            exactType.DefineMethodOverride(exactGetValue, getValue);
+        }
+
         runtime.JsonScalarRecordShapeGetter = EmitSimpleGetter(
             "get_Shape", _types.Object, shapeField);
 
@@ -265,6 +344,14 @@ public partial class RuntimeEmitter
             return getter;
         }
     }
+
+    private Type GetJsonScalarRecordFieldType(JsonSerializationShape shape) => shape switch
+    {
+        JsonSerializationShape.Number => _types.Double,
+        JsonSerializationShape.Boolean => _types.Boolean,
+        JsonSerializationShape.String => _types.String,
+        _ => _types.Object
+    };
 
     private void EmitEnsureMaterialized(
         ILGenerator il,

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.Shape.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.Shape.cs
@@ -665,6 +665,26 @@ public partial class RuntimeEmitter
         method.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
         _appendJsonShapedValueMethod = method;
 
+        var typedRecordAppenders = _features.JsonScalarRecordShapes
+            .OrderBy(pair => pair.Key, StringComparer.Ordinal)
+            .Where(pair => runtime.JsonTypedScalarRecordTypes.ContainsKey(pair.Key))
+            .Select((pair, ordinal) => (
+                Fingerprint: pair.Key,
+                Shape: pair.Value,
+                Method: typeBuilder.DefineMethod(
+                    $"AppendJsonTypedScalarRecord{ordinal}",
+                    MethodAttributes.Private | MethodAttributes.Static,
+                    _types.Boolean,
+                    [
+                        _types.StringBuilder,
+                        runtime.JsonTypedScalarRecordTypes[pair.Key],
+                        _types.ObjectArray,
+                        _types.Int32
+                    ])))
+            .ToArray();
+        foreach (var appender in typedRecordAppenders)
+            appender.Method.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
+
         var il = method.GetILGenerator();
         var tagLocal = il.DeclareLocal(_types.String);
         var shapeLocal = il.DeclareLocal(_types.ObjectArray);
@@ -895,6 +915,25 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, runtime.JsonScalarRecordShapeGetter);
         il.Emit(OpCodes.Ldloc, shapeLocal);
         il.Emit(OpCodes.Bne_Un, invalidShape);
+        foreach (var appender in typedRecordAppenders)
+        {
+            var exactType = runtime.JsonTypedScalarRecordTypes[appender.Fingerprint];
+            var exactLocal = il.DeclareLocal(exactType);
+            var nextAppender = il.DefineLabel();
+            il.Emit(OpCodes.Ldloc, scalarLocal);
+            il.Emit(OpCodes.Isinst, exactType);
+            il.Emit(OpCodes.Stloc, exactLocal);
+            il.Emit(OpCodes.Ldloc, exactLocal);
+            il.Emit(OpCodes.Brfalse, nextAppender);
+            EmitAppendShapedPropertyPrefix(il);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, exactLocal);
+            il.Emit(OpCodes.Ldloc, shapeLocal);
+            il.Emit(OpCodes.Ldarg_3);
+            il.Emit(OpCodes.Call, appender.Method);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(nextAppender);
+        }
         il.Emit(OpCodes.Br, objectStorageReady);
 
         il.MarkLabel(dictionaryObject);
@@ -1034,7 +1073,94 @@ public partial class RuntimeEmitter
         il.MarkLabel(invalidShape);
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Ret);
+
+        foreach (var appender in typedRecordAppenders)
+            EmitTypedRecordAppender(
+                appender.Fingerprint, appender.Shape, appender.Method);
         return method;
+
+        void EmitTypedRecordAppender(
+            string fingerprint,
+            JsonSerializationShape.Record shape,
+            MethodBuilder appenderMethod)
+        {
+            var appenderIl = appenderMethod.GetILGenerator();
+            EmitAppendChar(appenderIl, '{');
+            for (int index = 0; index < shape.Fields.Count; index++)
+            {
+                if (index != 0)
+                    EmitAppendChar(appenderIl, ',');
+                appenderIl.Emit(OpCodes.Ldarg_0);
+                appenderIl.Emit(OpCodes.Ldstr,
+                    Runtime.BuiltIns.JsonStringEscaper.Quote(
+                        shape.Fields[index].Key));
+                EmitStringBuilderAppendString(appenderIl);
+                EmitAppendChar(appenderIl, ':');
+
+                FieldBuilder valueField =
+                    runtime.JsonTypedScalarRecordValueFields[(fingerprint, index)];
+                switch (shape.Fields[index].Value)
+                {
+                    case JsonSerializationShape.Number:
+                        appenderIl.Emit(OpCodes.Ldarg_0);
+                        appenderIl.Emit(OpCodes.Ldarg_1);
+                        appenderIl.Emit(OpCodes.Ldfld, valueField);
+                        appenderIl.Emit(OpCodes.Call, appendNumber);
+                        break;
+                    case JsonSerializationShape.String:
+                        appenderIl.Emit(OpCodes.Ldarg_0);
+                        appenderIl.Emit(OpCodes.Ldarg_1);
+                        appenderIl.Emit(OpCodes.Ldfld, valueField);
+                        appenderIl.Emit(OpCodes.Call, _appendEscapedJsonStringMethod!);
+                        break;
+                    case JsonSerializationShape.Boolean:
+                    {
+                        var appendFalse = appenderIl.DefineLabel();
+                        var boolDone = appenderIl.DefineLabel();
+                        appenderIl.Emit(OpCodes.Ldarg_1);
+                        appenderIl.Emit(OpCodes.Ldfld, valueField);
+                        appenderIl.Emit(OpCodes.Brfalse, appendFalse);
+                        appenderIl.Emit(OpCodes.Ldarg_0);
+                        appenderIl.Emit(OpCodes.Ldstr, "true");
+                        EmitStringBuilderAppendString(appenderIl);
+                        appenderIl.Emit(OpCodes.Br, boolDone);
+                        appenderIl.MarkLabel(appendFalse);
+                        appenderIl.Emit(OpCodes.Ldarg_0);
+                        appenderIl.Emit(OpCodes.Ldstr, "false");
+                        EmitStringBuilderAppendString(appenderIl);
+                        appenderIl.MarkLabel(boolDone);
+                        break;
+                    }
+                    default:
+                    {
+                        var appended = appenderIl.DefineLabel();
+                        appenderIl.Emit(OpCodes.Ldarg_0);
+                        appenderIl.Emit(OpCodes.Ldarg_1);
+                        appenderIl.Emit(OpCodes.Ldfld, valueField);
+                        appenderIl.Emit(OpCodes.Ldarg_2);
+                        appenderIl.Emit(OpCodes.Ldc_I4, 2 + index * 2);
+                        appenderIl.Emit(OpCodes.Ldelem_Ref);
+                        appenderIl.Emit(OpCodes.Ldarg_3);
+                        appenderIl.Emit(OpCodes.Ldc_I4_1);
+                        appenderIl.Emit(OpCodes.Add);
+                        appenderIl.Emit(OpCodes.Ldnull);
+                        appenderIl.Emit(OpCodes.Ldc_I4_0);
+                        appenderIl.Emit(OpCodes.Ldc_I4_0);
+                        appenderIl.Emit(OpCodes.Ldc_I4_0);
+                        appenderIl.Emit(OpCodes.Ldc_I4_0);
+                        appenderIl.Emit(OpCodes.Call, method);
+                        appenderIl.Emit(OpCodes.Brtrue, appended);
+                        appenderIl.Emit(OpCodes.Ldc_I4_0);
+                        appenderIl.Emit(OpCodes.Ret);
+                        appenderIl.MarkLabel(appended);
+                        break;
+                    }
+                }
+            }
+            EmitAppendChar(appenderIl, '}');
+            appenderIl.Emit(OpCodes.Ldc_I4_1);
+            appenderIl.Emit(OpCodes.Ret);
+        }
     }
 
     private void EmitAppendShapedPropertyPrefix(ILGenerator il)

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -1136,8 +1136,9 @@ public sealed class RuntimeFeatureDetector
         switch (shape)
         {
             case JsonSerializationShape.Record record:
-                _set.JsonScalarRecordShapeFingerprints.Add(
-                    JsonSerializationShapeAnalyzer.Fingerprint(record));
+                string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(record);
+                _set.JsonScalarRecordShapeFingerprints.Add(fingerprint);
+                _set.JsonScalarRecordShapes.TryAdd(fingerprint, record);
                 foreach (var (_, value) in record.Fields)
                     CollectClosedJsonRecordShapes(value);
                 break;

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -24,6 +24,13 @@ public sealed class RuntimeFeatureSet
     internal HashSet<string> JsonScalarRecordShapeFingerprints { get; } = [];
 
     /// <summary>
+    /// Closed JSON record shapes keyed by their structural fingerprint.  The
+    /// runtime emitter uses these to give primitive slots their native CLR
+    /// types while retaining the scalar-record materialization fallback.
+    /// </summary>
+    internal Dictionary<string, JsonSerializationShape.Record> JsonScalarRecordShapes { get; } = [];
+
+    /// <summary>
     /// Shapes of small plain-object literals, grouped by slot count. When an
     /// arity has a single shape, the JSON scalar carrier's CLR type is itself
     /// an exact shape guard and typed reads need not compare the lazy descriptor.

--- a/tests/SharpTS.Tests/CompilerTests/JsonTypedScalarRecordTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/JsonTypedScalarRecordTests.cs
@@ -1,0 +1,215 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>Regression coverage for #1414 closed JSON scalar records.</summary>
+public sealed class JsonTypedScalarRecordTests
+{
+    private const string Source = """
+        type Item = { id: number; name: string; value: number };
+        type Payload = { items: Item[] };
+
+        function roundTrip(n: number): number {
+            const items: Item[] = [];
+            for (let i: number = 0; i < n; i++) {
+                items.push({ id: i, name: "item-" + i, value: i * 3 - 1 });
+            }
+            const payload: Payload = { items: items };
+            const json: string = JSON.stringify(payload);
+            const parsed: any = JSON.parse(json);
+            const back: Item[] = parsed.items;
+            let sum: number = 0;
+            for (let i: number = 0; i < back.length; i++) {
+                sum = sum + back[i].value;
+            }
+            return sum;
+        }
+
+        console.log(roundTrip(4));
+        """;
+
+    [Fact]
+    public void ClosedRecordUsesNativeFieldsAcrossLiteralStringifyAndParse()
+    {
+        Assembly assembly = Compile(Source);
+        Type itemCarrier = assembly.GetTypes().Single(type =>
+            type.Name.StartsWith("$JsonTypedScalarRecord", StringComparison.Ordinal) &&
+            type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+                .Count(field => field.Name.StartsWith("_v", StringComparison.Ordinal)) == 3);
+        Type[] fieldTypes = itemCarrier
+            .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(field => field.Name.StartsWith("_v", StringComparison.Ordinal))
+            .OrderBy(field => field.Name, StringComparer.Ordinal)
+            .Select(field => field.FieldType)
+            .ToArray();
+        Assert.Equal([typeof(double), typeof(string), typeof(double)], fieldTypes);
+
+        MethodInfo parser = assembly.GetType("$Runtime")!
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method =>
+                method.Name.StartsWith("ParseJsonTypedScalarRecord", StringComparison.Ordinal) &&
+                ReadMembers(method).Any(member =>
+                    member.OpCode == OpCodes.Newobj &&
+                    member.Member?.DeclaringType == itemCarrier));
+        Assert.DoesNotContain(ReadMembers(parser), member => member.OpCode == OpCodes.Box);
+
+        MethodInfo appender = assembly.GetType("$Runtime")!
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method =>
+                method.Name.StartsWith("AppendJsonTypedScalarRecord", StringComparison.Ordinal) &&
+                method.GetParameters()[1].ParameterType == itemCarrier);
+        Assert.DoesNotContain(ReadMembers(appender), member => member.OpCode == OpCodes.Box);
+
+        MethodInfo roundTrip = FindFunction(assembly, "roundTrip");
+        var roundTripMembers = ReadMembers(roundTrip).ToArray();
+        int typedRead = Array.FindIndex(roundTripMembers, member =>
+            member.OpCode == OpCodes.Ldfld &&
+            member.Member?.DeclaringType == itemCarrier &&
+            member.Member is FieldInfo { FieldType: var type } && type == typeof(double));
+        Assert.True(typedRead >= 0);
+        Assert.NotEqual(OpCodes.Box, roundTripMembers[typedRead + 1].OpCode);
+        Assert.Equal("14\n", TestHarness.RunCompiled(Source));
+    }
+
+    [Fact]
+    public void DynamicMutationMaterializesAndPreservesJsonObjectSemantics()
+    {
+        const string source = """
+            type Item = { id: number; name: string; value: number };
+            const item: Item = { id: 1, name: "a", value: 2 };
+            const json: string = JSON.stringify(item);
+            const parsed: any = JSON.parse(json);
+            parsed.value = "changed";
+            delete parsed.name;
+            Object.defineProperty(parsed, "extra", {
+                value: true, enumerable: true, configurable: true
+            });
+            console.log(parsed.value, parsed.name, JSON.stringify(parsed));
+            """;
+
+        Assert.Equal(
+            "changed undefined {\"id\":1,\"value\":\"changed\",\"extra\":true}\n",
+            TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void OnlyTheAssociatedStringUsesTheTypedParser()
+    {
+        const string source = """
+            type Item = { id: number; name: string; value: number };
+            function associated(): any {
+                const item: Item = { id: 1, name: "a", value: 2 };
+                const json: string = JSON.stringify(item);
+                return JSON.parse(json);
+            }
+            function copied(): any {
+                const item: Item = { id: 1, name: "a", value: 2 };
+                const json: string = JSON.stringify(item);
+                const copy: string = (" " + json).slice(1);
+                return JSON.parse(copy);
+            }
+            function associatedArray(): any {
+                const value: { items: Item[] } = {
+                    items: [{ id: 1, name: "a", value: 2 }]
+                };
+                const json: string = JSON.stringify(value);
+                return JSON.parse(json).items;
+            }
+            """;
+
+        Assembly assembly = Compile(source);
+        object associated = FindFunction(assembly, "associated").Invoke(null, null)!;
+        object copied = FindFunction(assembly, "copied").Invoke(null, null)!;
+        object associatedArray =
+            FindFunction(assembly, "associatedArray").Invoke(null, null)!;
+        Assert.StartsWith("$JsonTypedScalarRecord", associated.GetType().Name);
+        Assert.IsType<Dictionary<string, object>>(copied);
+        Assert.IsType<List<object>>(associatedArray);
+    }
+
+    [Fact]
+    public void ClosedRecordWithNumericArrayPassesIlVerification()
+    {
+        const string source = """
+            const value: { a: number; values: number[] } = {
+                a: 0.1 + 0.2,
+                values: [NaN, Infinity]
+            };
+            console.log(JSON.stringify(value));
+            """;
+
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+        Assert.True(errors.Count == 0, string.Join(Environment.NewLine, errors));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"issue_1414_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Member)> ReadMembers(MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? member = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineField or
+                OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                member = opCode.OperandType switch
+                {
+                    OperandType.InlineMethod => module.ResolveMethod(token),
+                    OperandType.InlineField => module.ResolveField(token),
+                    _ => module.ResolveType(token)
+                };
+            }
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or OperandType.InlineField or
+                    OperandType.InlineMethod or OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch => 4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, member);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}

--- a/tests/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
@@ -200,15 +200,15 @@ public class StandaloneDllTests
     {
         var source = """
             const payload: {
-                items: { id: number; label: string; note: null }[]
+                items: { id: number; label: string; active: boolean }[]
             } = {
-                items: [{ id: 1, label: "a", note: null }]
+                items: [{ id: 1, label: "a", active: true }]
             };
             const json: string = JSON.stringify(payload);
             const parsed: any = JSON.parse(json);
             console.log(json);
             console.log(parsed.items[0].id, parsed.items[0].label,
-                parsed.items[0].note === null);
+                parsed.items[0].active);
             """;
 
         var (tempDir, dllPath) = CompileStandalone(source);
@@ -217,7 +217,7 @@ public class StandaloneDllTests
             Assert.DoesNotContain(
                 GetAssemblyReferences(dllPath), r => r == "SharpTS");
             Assert.Equal(
-                "{\"items\":[{\"id\":1,\"label\":\"a\",\"note\":null}]}\n" +
+                "{\"items\":[{\"id\":1,\"label\":\"a\",\"active\":true}]}\n" +
                 "1 a true\n",
                 ExecuteCompiledDllIsolated(dllPath, timeoutMs: 15000));
         }


### PR DESCRIPTION
## Summary

- emit one exact scalar-record carrier per closed JSON shape, with `double`, `bool`, and `string` fields instead of boxed object slots
- construct, stringify, and parse those carriers through shape-specific IL, including direct record-array parsing
- read statically numeric properties as native doubles while retaining materialization, descriptor, prototype, and generic fallbacks
- add IL-shape, dynamic-mutation, association-identity, verifier, and standalone-DLL regression coverage

## Performance

Exact faithful imported-module BDN ShortRun on Windows/.NET 10:

| N | main baseline | this branch | #1414 target |
|---:|---:|---:|---:|
| 10,000 time | 12.320 ms | 10.717 ms | <= 8.5 ms |
| 10,000 allocation | 6,411 KB | 5,474 KB | <= 4,500 KB |

The typed carrier removes approximately 0.94 MB per 10k round trip and improves elapsed time by approximately 13%, but it does not yet meet the issue hard gate. Three independent exact cross-runtime executions produced median means of 3.3585 ms at 1k (passes 3.5 ms) and 23.6269 ms at 10k (above 22 ms; a preceding run measured 20.6985 ms, showing notable host variance).

This PR therefore progresses #1414 but intentionally does not close it.

## Verification

- Release solution rebuild: pass; emitted IL verification passed twice
- focused JSON, compact-record, IL-verification, parity, overload, standalone, and new regression slice: 319/319 pass
- JSON Test262: 84/85 pass; `replacer-function-arguments.js` fails consistently on the separate replacer/full-serializer path and needs follow-up
- the local full core run could not provide a reliable result because this sandbox rejects HttpListener handles and then produces IPC/TLS timeouts

The generated standalone DLL remains free of a SharpTS assembly reference.