### PR TITLE
Elide discarded stable array push results

### DIFF
--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -257,6 +257,7 @@ public class EmittedRuntime
     public MethodBuilder ArrayForEach { get; set; } = null!;
     public MethodBuilder ArrayForEachDirect { get; set; } = null!;
     public MethodBuilder ArrayPush { get; set; } = null!;
+    public MethodBuilder ArrayPushOneDiscarded { get; set; } = null!;
     public MethodBuilder ArrayPushDouble { get; set; } = null!;
     public MethodBuilder ArrayPushBool { get; set; } = null!;
     public MethodBuilder ArrayPushProto { get; set; } = null!;

--- a/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -10,6 +10,51 @@ namespace SharpTS.Compilation;
 /// </summary>
 public partial class ILEmitter
 {
+    protected override bool TryEmitDiscardedExpression(Expr expression)
+    {
+        if (expression is not Expr.Call
+            {
+                Optional: false,
+                Callee: Expr.Get
+                {
+                    Optional: false,
+                    Name.Lexeme: "push"
+                } methodGet,
+                Arguments: { Count: 1 } arguments
+            })
+            return false;
+
+        // Only a statically known Array gets the guarded intrinsic. `any`,
+        // unions, tuples, imported live values, and method aliases keep normal
+        // property/call dispatch. Descriptor and prototype-chain APIs globally
+        // disable this path; the emitted helper repeats receiver-local guards
+        // for sparse and subclassed arrays before appending directly.
+        TypeSystem.TypeInfo? receiverType = _ctx.TypeMap?.Get(methodGet.Object);
+        if (receiverType is not TypeSystem.TypeInfo.Array
+            || arguments[0] is Expr.Spread
+            || _ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors != false
+            || _ctx.RuntimeFeatures.UsesArrayPrototypeMutation)
+            return false;
+
+        // Preserve the still-cheaper typed-array paths: promoted locals append
+        // directly to List<T>, while escaping number[] receivers call
+        // $Array.PushDouble without boxing or representation deoptimization.
+        if (methodGet.Object is Expr.Variable pushVariable
+            && _ctx.TryGetPromotedArrayLocal(pushVariable.Name.Lexeme) is not null)
+            return false;
+        if (ArrayElements.Resolve(receiverType) is { Kind: ArrayElementsKind.Double }
+            && IsNumericType(_ctx.TypeMap?.Get(arguments[0])))
+            return false;
+
+        EmitExpression(methodGet.Object);
+        EmitBoxIfNeeded(methodGet.Object);
+        EmitExpression(arguments[0]);
+        EmitBoxIfNeeded(arguments[0]);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.ArrayPushOneDiscarded);
+        SetStackUnknown();
+        return true;
+    }
+
     private void EmitMethodCall(
         Expr.Get methodGet,
         List<Expr> arguments,

--- a/src/SharpTS/Compilation/ILEmitter.cs
+++ b/src/SharpTS/Compilation/ILEmitter.cs
@@ -188,9 +188,14 @@ public partial class ILEmitter : StatementEmitterBase, IEmitterContext
         switch (stmt)
         {
             case Stmt.Expression e:
-                EmitExpression(e.Expr);
-                // All expressions leave a value on the stack, so pop when used as a statement
-                IL.Emit(OpCodes.Pop);
+                if (!TryEmitDiscardedExpression(e.Expr))
+                {
+                    EmitExpression(e.Expr);
+                    // Ordinary expressions leave a value on the stack. A
+                    // discarded-expression intrinsic reports success only
+                    // after emitting a stack-neutral replacement.
+                    IL.Emit(OpCodes.Pop);
+                }
                 break;
 
             case Stmt.Var v:

--- a/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Mutators.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Mutators.cs
@@ -819,6 +819,74 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
+    /// <summary>
+    /// Appends one value when a syntactic <c>array.push(value)</c> result is
+    /// discarded. Exact, dense, ordinary <c>$Array</c> instances take the
+    /// allocation-free <see cref="EmitArrayPush"/> path. Every unusual runtime
+    /// shape rebuilds the ordinary one-element argument vector and delegates to
+    /// <see cref="EmitArrayPushProto"/>, retaining its complete Set/length order.
+    /// </summary>
+    private void EmitArrayPushOneDiscarded(
+        TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "ArrayPushOneDiscarded",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            [_types.Object, _types.Object]);
+        runtime.ArrayPushOneDiscarded = method;
+
+        var il = method.GetILGenerator();
+        var fallback = il.DefineLabel();
+
+        // Subclasses can override observable array behavior. Require the exact
+        // emitted $Array carrier, not merely an `isinst` match.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Brfalse, fallback);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
+        il.Emit(OpCodes.Ldtoken, runtime.TSArrayType);
+        il.Emit(OpCodes.Call, _types.TypeGetTypeFromHandle);
+        il.Emit(OpCodes.Ceq);
+        il.Emit(OpCodes.Brfalse, fallback);
+
+        // A numeric-mode array has no boxed base-list elements yet. Deopt before
+        // looking at Count or calling the boxed append helper.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayEnsureBoxed);
+
+        // Sparse arrays need ArrayPushProto's full long-length/index machinery.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayLongLengthGetter);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, _types.ListOfObject);
+        il.Emit(OpCodes.Callvirt,
+            _types.GetProperty(_types.ListOfObject, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Conv_I8);
+        il.Emit(OpCodes.Bne_Un, fallback);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, _types.ListOfObject);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.ArrayPush);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(fallback);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Call, runtime.ArrayPushProto);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+    }
+
     // Variadic ArrayUnshift wired into Array.prototype. Per ECMA-262 unshift
     // takes ...items and inserts them at the start preserving order: for items
     // [a, b, c], result has [a, b, c, ...rest]. We achieve this by inserting

--- a/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -1110,6 +1110,7 @@ public partial class RuntimeEmitter
         EmitArrayPushTyped(typeBuilder, runtime, ArrayElements.Double);
         EmitArrayPushTyped(typeBuilder, runtime, ArrayElements.Bool);
         EmitArrayPushProto(typeBuilder, runtime);
+        EmitArrayPushOneDiscarded(typeBuilder, runtime);
         EmitArrayFind(typeBuilder, runtime);
         EmitArrayFindDirect(typeBuilder, runtime);
         EmitArrayFindDirectBool(typeBuilder, runtime);

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -86,6 +86,7 @@ public sealed class RuntimeFeatureDetector
             UsesSet = false,
             UsesDynamicPropertyDescriptors = false,
             UsesDatePrototypeMutation = false,
+            UsesArrayPrototypeMutation = false,
             PotentiallyMaterializesUnknownCompactObjectRecordShape = false,
             TypedArrays = RuntimeFeatureSet.TypedArrayKinds.None,
         };
@@ -746,9 +747,18 @@ public sealed class RuntimeFeatureDetector
                 break;
 
             case Expr.Get g:
+                if (IsArrayPrototype(g) || g.Name.Lexeme == "__proto__")
+                    _set.UsesArrayPrototypeMutation = true;
                 if (g.Object is Expr.Variable ov)
                 {
                     HandleMemberAccess(ov.Name.Lexeme, g.Name.Lexeme);
+                    if (ov.Name.Lexeme is "Object" or "Reflect"
+                        && g.Name.Lexeme == "setPrototypeOf")
+                        _set.UsesArrayPrototypeMutation = true;
+                    if ((ov.Name.Lexeme == "Object" && g.Name.Lexeme == "assign")
+                        || (ov.Name.Lexeme == "Reflect"
+                            && g.Name.Lexeme is "set" or "deleteProperty"))
+                        _set.UsesArrayPrototypeMutation = true;
                     if ((ov.Name.Lexeme == "Object"
                             && g.Name.Lexeme is "defineProperty" or "defineProperties" or "create")
                         || (ov.Name.Lexeme == "Reflect" && g.Name.Lexeme == "defineProperty"))
@@ -809,6 +819,10 @@ public sealed class RuntimeFeatureDetector
                 MarkMutationTarget(s.Object);
                 if (IsDatePrototype(s.Object))
                     _set.UsesDatePrototypeMutation = true;
+                if (IsArrayPrototype(s.Object)
+                    || s.Name.Lexeme == "__proto__"
+                    || (s.Name.Lexeme == "push" && CouldTargetArray(s.Object)))
+                    _set.UsesArrayPrototypeMutation = true;
                 if (s.Object is Expr.Variable osv)
                     HandleMemberAccess(osv.Name.Lexeme, s.Name.Lexeme);
                 VisitExpr(s.Object);
@@ -829,6 +843,12 @@ public sealed class RuntimeFeatureDetector
                     // Computed access may resolve to defineProperty at runtime.
                     _set.UsesDynamicPropertyDescriptors = true;
                 }
+                if (gi.Object is Expr.Variable indexedPrototypeOwner
+                    && indexedPrototypeOwner.Name.Lexeme is "Object" or "Reflect"
+                    && gi.Index is Expr.Literal { Value: "setPrototypeOf" })
+                {
+                    _set.UsesArrayPrototypeMutation = true;
+                }
                 VisitExpr(gi.Object);
                 VisitExpr(gi.Index);
                 break;
@@ -836,12 +856,28 @@ public sealed class RuntimeFeatureDetector
                 MarkMutationTarget(si.Object);
                 if (IsDatePrototype(si.Object))
                     _set.UsesDatePrototypeMutation = true;
+                if (IsArrayPrototype(si.Object)
+                    || si.Index is Expr.Literal { Value: "__proto__" }
+                    || (si.Index is Expr.Literal { Value: "push" }
+                        && CouldTargetArray(si.Object)))
+                    _set.UsesArrayPrototypeMutation = true;
                 VisitExpr(si.Object);
                 VisitExpr(si.Index);
                 VisitExpr(si.Value);
                 break;
 
             case Expr.Call c:
+                if (c.Callee is Expr.Get
+                    {
+                        Object: Expr.Variable { Name.Lexeme: "Object" or "Reflect" },
+                        Name.Lexeme: "setPrototypeOf"
+                    })
+                {
+                    // Alias tracking for prototype objects is deliberately not
+                    // attempted here. Any explicit prototype-chain mutation API
+                    // disables the direct append path for the whole program.
+                    _set.UsesArrayPrototypeMutation = true;
+                }
                 if (c.Callee is not Expr.Variable directSourceCall ||
                     !_sourceFunctions.Contains(directSourceCall.Name.Lexeme))
                 {
@@ -933,11 +969,16 @@ public sealed class RuntimeFeatureDetector
                 break;
             case Expr.CompoundSet cs:
                 MarkMutationTarget(cs.Object);
+                if (cs.Name.Lexeme == "push" && CouldTargetArray(cs.Object))
+                    _set.UsesArrayPrototypeMutation = true;
                 VisitExpr(cs.Object);
                 VisitExpr(cs.Value);
                 break;
             case Expr.CompoundSetIndex csi:
                 MarkMutationTarget(csi.Object);
+                if (csi.Index is Expr.Literal { Value: "push" }
+                    && CouldTargetArray(csi.Object))
+                    _set.UsesArrayPrototypeMutation = true;
                 VisitExpr(csi.Object);
                 VisitExpr(csi.Index);
                 VisitExpr(csi.Value);
@@ -947,11 +988,16 @@ public sealed class RuntimeFeatureDetector
                 break;
             case Expr.LogicalSet ls:
                 MarkMutationTarget(ls.Object);
+                if (ls.Name.Lexeme == "push" && CouldTargetArray(ls.Object))
+                    _set.UsesArrayPrototypeMutation = true;
                 VisitExpr(ls.Object);
                 VisitExpr(ls.Value);
                 break;
             case Expr.LogicalSetIndex lsi:
                 MarkMutationTarget(lsi.Object);
+                if (lsi.Index is Expr.Literal { Value: "push" }
+                    && CouldTargetArray(lsi.Object))
+                    _set.UsesArrayPrototypeMutation = true;
                 VisitExpr(lsi.Object);
                 VisitExpr(lsi.Index);
                 VisitExpr(lsi.Value);
@@ -993,9 +1039,19 @@ public sealed class RuntimeFeatureDetector
                 break;
             case Expr.Delete d:
                 if (d.Operand is Expr.Get deletedProperty)
+                {
                     MarkMutationTarget(deletedProperty.Object);
+                    if (deletedProperty.Name.Lexeme == "push"
+                        && CouldTargetArray(deletedProperty.Object))
+                        _set.UsesArrayPrototypeMutation = true;
+                }
                 else if (d.Operand is Expr.GetIndex deletedIndex)
+                {
                     MarkMutationTarget(deletedIndex.Object);
+                    if (deletedIndex.Index is Expr.Literal { Value: "push" }
+                        && CouldTargetArray(deletedIndex.Object))
+                        _set.UsesArrayPrototypeMutation = true;
+                }
                 else
                     _set.PotentiallyMaterializesUnknownCompactObjectRecordShape = true;
                 VisitExpr(d.Operand);
@@ -1153,6 +1209,42 @@ public sealed class RuntimeFeatureDetector
         Object: Expr.Variable { Name.Lexeme: "Date" },
         Name.Lexeme: "prototype"
     };
+
+    private static bool IsArrayPrototype(Expr expr) => expr is Expr.Get
+    {
+        Object: Expr.Variable { Name.Lexeme: "Array" },
+        Name.Lexeme: "prototype"
+    };
+
+    private bool CouldTargetArray(Expr expr)
+    {
+        // Preserve the useful static type through casts commonly used to mutate a
+        // builtin method (`(items as any).push = ...`).  If type information is not
+        // available, be conservative: the feature set is also used by callers that
+        // construct a detector without a TypeMap.
+        while (true)
+        {
+            switch (expr)
+            {
+                case Expr.Grouping grouping:
+                    expr = grouping.Expression;
+                    continue;
+                case Expr.TypeAssertion assertion:
+                    expr = assertion.Expression;
+                    continue;
+                case Expr.Satisfies satisfies:
+                    expr = satisfies.Expression;
+                    continue;
+                case Expr.NonNullAssertion nonNull:
+                    expr = nonNull.Expression;
+                    continue;
+            }
+
+            break;
+        }
+
+        return _typeMap is null || _typeMap.Get(expr) is TypeInfo.Array;
+    }
 
     private void MarkMutationOperand(Expr operand)
     {

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -113,6 +113,10 @@ public sealed class RuntimeFeatureSet
     // A Date.prototype write makes statically typed Date method calls observable
     // through the prototype object, so the direct DateEmitter fast path is unsafe.
     public bool UsesDatePrototypeMutation { get; set; } = true;
+    // Any observable access to Array.prototype, push-binding mutation,
+    // prototype-chain mutation API, or __proto__ access makes a backing-list-only
+    // array append unsafe. The discarded-result push fast path requires this false.
+    public bool UsesArrayPrototypeMutation { get; set; } = true;
 
     // ── Typed arrays ──────────────────────────────────────────────────────
     /// <summary>

--- a/src/SharpTS/Compilation/StatementEmitterBase.cs
+++ b/src/SharpTS/Compilation/StatementEmitterBase.cs
@@ -255,8 +255,11 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
         switch (stmt)
         {
             case Stmt.Expression e:
-                EmitExpression(e.Expr);
-                IL.Emit(OpCodes.Pop);
+                if (!TryEmitDiscardedExpression(e.Expr))
+                {
+                    EmitExpression(e.Expr);
+                    IL.Emit(OpCodes.Pop);
+                }
                 break;
 
             case Stmt.Var v:
@@ -359,6 +362,13 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
                 throw new CompileException($"Unhandled statement type in ILEmitter: {stmt.GetType().Name}");
         }
     }
+
+    /// <summary>
+    /// Gives an emitter a chance to lower an expression whose JavaScript value
+    /// is discarded without first manufacturing a stack result. The default
+    /// keeps the ordinary expression-plus-pop behavior.
+    /// </summary>
+    protected virtual bool TryEmitDiscardedExpression(Expr expression) => false;
 
     /// <summary>
     /// Emits a 'using' or 'await using' declaration.

--- a/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
@@ -79,6 +79,26 @@ public class RuntimeFeatureDetectorTests
     }
 
     [Theory]
+    [InlineData("const p = Array.prototype;", true)]
+    [InlineData("Object.setPrototypeOf({}, null);", true)]
+    [InlineData("Reflect.setPrototypeOf({}, null);", true)]
+    [InlineData("const setProto = Object.setPrototypeOf;", true)]
+    [InlineData("const setProto = Reflect['setPrototypeOf'];", true)]
+    [InlineData("const value = ([] as any).__proto__;", true)]
+    [InlineData("const values: object[] = []; (values as any).push = () => 0;", true)]
+    [InlineData("const values: object[] = []; delete (values as any)['push'];", true)]
+    [InlineData("Reflect.set([], 'push', () => 0);", true)]
+    [InlineData("Object.assign([], { push: () => 0 });", true)]
+    [InlineData("const values: number[] = []; values.push(1);", false)]
+    public void DetectsArrayPrototypeMutationRisk(string source, bool expected)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var features = new RuntimeFeatureDetector().Detect(statements);
+
+        Assert.Equal(expected, features.UsesArrayPrototypeMutation);
+    }
+
+    [Theory]
     [InlineData("const node: { left: object | null; right: object | null } = { left: null, right: null }; const isLeaf = node.left === null; console.log(isLeaf);", true)]
     [InlineData("const node: { left: object | null; right: object | null } = { left: null, right: null }; node.left = null;", false)]
     [InlineData("export const node: { left: object | null; right: object | null } = { left: null, right: null };", false)]

--- a/tests/SharpTS.Tests/CompilerTests/StableDiscardedArrayPushTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableDiscardedArrayPushTests.cs
@@ -1,0 +1,195 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>Regression coverage for the allocation-free #1414 push slice.</summary>
+public sealed class StableDiscardedArrayPushTests
+{
+    [Fact]
+    public void DiscardedStablePush_UsesVoidGuardedHelperWithoutArgumentArrayOrBox()
+    {
+        Assembly assembly = Compile("""
+            type Item = { value: number };
+            function append(items: Item[], item: Item): void {
+                items.push(item);
+            }
+            """);
+
+        MethodInfo append = FindFunction(assembly, "append");
+        var instructions = ReadInstructions(append).ToArray();
+
+        Assert.Contains(instructions, instruction =>
+            instruction.OpCode == OpCodes.Call &&
+            instruction.Operand is MethodBase { Name: "ArrayPushOneDiscarded" });
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "ArrayPushProto" });
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.OpCode == OpCodes.Newarr &&
+            instruction.Operand is Type type && type == typeof(object));
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.OpCode == OpCodes.Box);
+    }
+
+    [Fact]
+    public void ObservedPushResult_RetainsGeneralResultProducingPath()
+    {
+        Assembly assembly = Compile("""
+            type Item = { value: number };
+            function append(items: Item[], item: Item): number {
+                return items.push(item);
+            }
+            """);
+
+        var instructions = ReadInstructions(FindFunction(assembly, "append")).ToArray();
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "ArrayPushProto" });
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "ArrayPushOneDiscarded" });
+    }
+
+    [Fact]
+    public void NumericPush_RetainsUnboxedArrayPath()
+    {
+        Assembly assembly = Compile("""
+            function append(items: number[], value: number): void {
+                items.push(value);
+            }
+            """);
+
+        var instructions = ReadInstructions(FindFunction(assembly, "append")).ToArray();
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "PushDouble" });
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "ArrayPushOneDiscarded" });
+    }
+
+    [Theory]
+    [InlineData("Object.defineProperty([], '0', { value: 1 });")]
+    [InlineData("const p = Array.prototype;")]
+    [InlineData("Object.setPrototypeOf({}, null);")]
+    [InlineData("const altered: Item[] = []; (altered as any).push = () => 0;")]
+    [InlineData("Reflect.set([], 'push', () => 0);")]
+    [InlineData("Object.assign([], { push: () => 0 });")]
+    public void ObservableDescriptorOrPrototypeCode_DisablesDirectCall(string prelude)
+    {
+        Assembly assembly = Compile($$"""
+            type Item = { value: number };
+            {{prelude}}
+            function append(items: Item[], item: Item): void {
+                items.push(item);
+            }
+            """);
+
+        var instructions = ReadInstructions(FindFunction(assembly, "append")).ToArray();
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "ArrayPushProto" });
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "ArrayPushOneDiscarded" });
+    }
+
+    [Fact]
+    public void RuntimeGuard_PreservesGenericArrayLikeReceiverSemantics()
+    {
+        const string source = """
+            type Item = { value: number };
+            function append(items: Item[]): void {
+                items.push({ value: 7 });
+            }
+            const receiver: any = { length: 0 };
+            append(receiver as Item[]);
+            console.log(receiver.length, receiver[0].value);
+            """;
+
+        Assert.Equal("1 7\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void StableDiscardedPush_PassesIlVerification()
+    {
+        const string source = """
+            type Item = { value: number };
+            function append(items: Item[], item: Item): void {
+                items.push(item);
+            }
+            const items: Item[] = [];
+            append(items, { value: 7 });
+            console.log(items[0].value);
+            """;
+
+        var errors = TestHarness.CompileAndVerifyOnly(source);
+        Assert.Empty(errors);
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"issue_1414_push_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token)
+                    : module.ResolveType(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}


### PR DESCRIPTION
## Summary

- add a statement-level lowering hook for expression results that do not need to be materialized
- lower qualifying one-argument rray.push(value); statements to a void emitted helper, eliminating the per-call object[] and boxed length
- guard the fast path to exact dense $Array carriers and retain the full generic push path for sparse, subclassed, descriptor, prototype, reflection, and mutated-binding cases
- preserve the existing promoted and escaping 
umber[] paths
- add emitted-IL, runtime fallback, mutation bailout, and IL-verification coverage

Together with merged #1415, this clears #1414's hard performance gates.

## Performance

Exact imported-module BenchmarkDotNet ShortRun:

| N | Mean | Allocated | Gate |
|---:|---:|---:|---:|
| 1,000 | 455.2 us | 362.77 KB | — |
| 10,000 | 7.412 ms | 3,851.54 KB | <= 8.5 ms / <= 4.5 MB |

Three independent exact compiled cross-runtime runs produced medians of **1.5569 ms** at N=1,000 and **12.5729 ms** at N=10,000, below the **3.5 ms** and **22.0 ms** gates.

The N=10,000 cumulative phase means are 1.237 ms build, 3.280 ms build+stringify, 7.467 ms build+stringify+parse, and 7.514 ms full round trip.

## Verification

- Release solution build: pass, 0 errors; emitted IL verification passed twice
- focused feature/IL/runtime tests: 51/51 pass
- compiler test namespace excluding the sandbox-only isolated TLS case: 520/520 pass
- exact benchmark checksum/output guard: pass in all three independent processes
- local broad core execution was not actionable in this sandbox: HttpListener creation fails with invalid handles, certificate/PFX access is denied, and dependent IPC/TLS cases time out

Closes #1414