### PR TITLE
Optimize stable recursive compact-record signatures

### DIFF
--- a/src/SharpTS/Compilation/CompilationContext.cs
+++ b/src/SharpTS/Compilation/CompilationContext.cs
@@ -38,7 +38,7 @@ public record struct HoistedArrayEntry(LocalBuilder TypedLocal, ArrayElementsDes
 public record struct HoistedTypedArrayEntry(LocalBuilder TypedLocal, Type XArrayType, string ElementType);
 
 public record struct HoistedCompactRecordEntry(
-    LocalBuilder TypedLocal, string Fingerprint);
+    LocalBuilder TypedLocal, string Fingerprint, bool IsExact);
 
 /// <summary>
 /// Holds compilation state passed between ILCompiler and ILEmitter.

--- a/src/SharpTS/Compilation/ExactCompactRecordFunctionAnalyzer.cs
+++ b/src/SharpTS/Compilation/ExactCompactRecordFunctionAnalyzer.cs
@@ -1,0 +1,406 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Proves which module-private, call-only functions may expose generated compact-record
+/// carrier types in their CLR signatures. The proof is intentionally whole-module and
+/// conservative: any value use or export retains the ordinary JavaScript object ABI.
+/// </summary>
+internal static class ExactCompactRecordFunctionAnalyzer
+{
+    internal static void Analyze(
+        IReadOnlyList<Stmt> statements,
+        TypeMap? typeMap,
+        RuntimeFeatureSet? features,
+        IReadOnlySet<Stmt.Function> stableFunctions,
+        Dictionary<Stmt.Function, HashSet<int>> exactParameters,
+        Dictionary<Stmt.Function, string> exactReturns)
+    {
+        if (typeMap is null || features is null)
+            return;
+
+        var topLevelFunctions = new List<Stmt.Function>();
+        var exportedNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var statement in statements)
+            CollectTopLevel(statement, topLevelFunctions, exportedNames, exported: false);
+
+        foreach (var statement in statements)
+        {
+            if (statement is Stmt.Export { NamedExports: { } exports, FromModulePath: null })
+            {
+                foreach (var export in exports)
+                    if (!export.IsTypeOnly)
+                        exportedNames.Add(export.LocalName.Lexeme);
+            }
+        }
+
+        var declarationCounts = topLevelFunctions
+            .GroupBy(function => function.Name.Lexeme, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.Ordinal);
+        var byName = topLevelFunctions
+            .Where(function => declarationCounts[function.Name.Lexeme] == 1)
+            .ToDictionary(function => function.Name.Lexeme, StringComparer.Ordinal);
+
+        var usage = new UsageCollector(byName);
+        foreach (var statement in statements)
+            usage.Visit(statement);
+
+        var candidates = new HashSet<Stmt.Function>(topLevelFunctions.Where(function =>
+                function.Body is not null &&
+                !function.IsAsync && !function.IsGenerator &&
+                function.TypeParams is not { Count: > 0 } &&
+                function.Decorators is not { Count: > 0 } &&
+                function.Parameters.All(parameter =>
+                    !parameter.IsRest && !parameter.IsOptional && parameter.DefaultValue is null) &&
+                stableFunctions.Contains(function) &&
+                declarationCounts[function.Name.Lexeme] == 1 &&
+                !exportedNames.Contains(function.Name.Lexeme) &&
+                !usage.ValueUsedNames.Contains(function.Name.Lexeme) &&
+                usage.CallsByTarget.ContainsKey(function)),
+            ReferenceEqualityComparer.Instance);
+
+        foreach (var function in candidates)
+        {
+            TypeInfo.Function? functionType = typeMap.GetFunctionType(function.Name.Lexeme);
+            if (functionType is null)
+                continue;
+
+            var assigned = ParameterAssignmentAnalyzer.FindAssigned(function.Body!);
+            for (int index = 0;
+                 index < function.Parameters.Count && index < functionType.ParamTypes.Count;
+                 index++)
+            {
+                if (!assigned.Contains(function.Parameters[index].Name.Lexeme) &&
+                    JsonSerializationShapeAnalyzer.TryGetRecordShape(
+                        functionType.ParamTypes[index], out var shape) &&
+                    features.CompactObjectRecordShapes.ContainsKey(
+                        JsonSerializationShapeAnalyzer.Fingerprint(shape)) &&
+                    features.CanAssumeCompactObjectRecordIsUnmaterialized(
+                        JsonSerializationShapeAnalyzer.Fingerprint(shape)))
+                {
+                    if (!exactParameters.TryGetValue(function, out var indices))
+                    {
+                        indices = [];
+                        exactParameters.Add(function, indices);
+                    }
+                    indices.Add(index);
+                }
+            }
+
+            bool returnMayBeUndefined = ReturnSlotAnalysis.BlockReturnsMayBeUndefined(
+                function.Body, typeMap);
+            if (!returnMayBeUndefined &&
+                JsonSerializationShapeAnalyzer.TryGetRecordShape(
+                    functionType.ReturnType, out var returnShape))
+            {
+                string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(returnShape);
+                if (features.CompactObjectRecordShapes.ContainsKey(fingerprint) &&
+                    features.CanAssumeCompactObjectRecordIsUnmaterialized(fingerprint))
+                    exactReturns[function] = fingerprint;
+            }
+            else if (!returnMayBeUndefined &&
+                TryInferReturnFingerprint(function, typeMap, features, out string fingerprint))
+            {
+                exactReturns[function] = fingerprint;
+            }
+        }
+
+        // Start optimistic, then remove facts invalidated by any return or call edge.
+        // Recursive SCCs remain optimized only when every edge inside and entering the
+        // SCC carries the same exact shape.
+        bool changed;
+        do
+        {
+            changed = false;
+            foreach (var function in candidates)
+            {
+                if (exactReturns.ContainsKey(function) &&
+                    !ValidateReturns(function, byName, typeMap, features,
+                        exactParameters, exactReturns))
+                {
+                    exactReturns.Remove(function);
+                    changed = true;
+                }
+
+                if (!exactParameters.TryGetValue(function, out var indices))
+                    continue;
+
+                TypeInfo.Function functionType = typeMap.GetFunctionType(function.Name.Lexeme)!;
+                foreach (int index in indices.ToArray())
+                {
+                    var parameterShape = GetCompactRecordShape(functionType.ParamTypes[index]);
+                    string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(parameterShape);
+                    if (usage.CallsByTarget[function].Any(callSite =>
+                            index >= callSite.Call.Arguments.Count ||
+                            !IsExactExpression(callSite.Call.Arguments[index], fingerprint,
+                                callSite.Caller, byName, typeMap, features,
+                                exactParameters, exactReturns)))
+                    {
+                        indices.Remove(index);
+                        changed = true;
+                    }
+                }
+                if (indices.Count == 0)
+                    exactParameters.Remove(function);
+            }
+        } while (changed);
+    }
+
+    private static bool ValidateReturns(
+        Stmt.Function function,
+        IReadOnlyDictionary<string, Stmt.Function> byName,
+        TypeMap typeMap,
+        RuntimeFeatureSet features,
+        IReadOnlyDictionary<Stmt.Function, HashSet<int>> exactParameters,
+        IReadOnlyDictionary<Stmt.Function, string> exactReturns)
+    {
+        string fingerprint = exactReturns[function];
+        var collector = new ReturnCollector();
+        foreach (var statement in function.Body!)
+            collector.Visit(statement);
+        return collector.Values.Count > 0 && !collector.HasBareReturn &&
+            collector.Values.All(value => IsExactExpression(value, fingerprint, function,
+                byName, typeMap, features, exactParameters, exactReturns));
+    }
+
+    private static bool IsExactExpression(
+        Expr expression,
+        string fingerprint,
+        Stmt.Function? caller,
+        IReadOnlyDictionary<string, Stmt.Function> byName,
+        TypeMap typeMap,
+        RuntimeFeatureSet features,
+        IReadOnlyDictionary<Stmt.Function, HashSet<int>> exactParameters,
+        IReadOnlyDictionary<Stmt.Function, string> exactReturns)
+    {
+        switch (expression)
+        {
+            case Expr.Literal { Value: null }:
+                return true;
+            case Expr.Grouping grouping:
+                return IsExactExpression(grouping.Expression, fingerprint, caller, byName,
+                    typeMap, features, exactParameters, exactReturns);
+            case Expr.TypeAssertion assertion:
+                return IsExactExpression(assertion.Expression, fingerprint, caller, byName,
+                    typeMap, features, exactParameters, exactReturns);
+            case Expr.Satisfies satisfies:
+                return IsExactExpression(satisfies.Expression, fingerprint, caller, byName,
+                    typeMap, features, exactParameters, exactReturns);
+            case Expr.NonNullAssertion nonNull:
+                return IsExactExpression(nonNull.Expression, fingerprint, caller, byName,
+                    typeMap, features, exactParameters, exactReturns);
+            case Expr.Ternary ternary:
+                return IsExactExpression(ternary.ThenBranch, fingerprint, caller, byName,
+                           typeMap, features, exactParameters, exactReturns) &&
+                       IsExactExpression(ternary.ElseBranch, fingerprint, caller, byName,
+                           typeMap, features, exactParameters, exactReturns);
+            case Expr.Call { Callee: Expr.Variable variable, Optional: false }
+                when byName.TryGetValue(variable.Name.Lexeme, out var target) &&
+                     exactReturns.TryGetValue(target, out string? targetFingerprint):
+                return targetFingerprint == fingerprint;
+            case Expr.Variable variable when caller is not null:
+                return TryGetExactParameterFingerprint(caller, variable.Name.Lexeme,
+                    typeMap, exactParameters, out string variableFingerprint) &&
+                    variableFingerprint == fingerprint;
+            case Expr.Get { Object: Expr.Variable receiver, Optional: false } get
+                when caller is not null &&
+                     TryGetExactParameterFingerprint(caller, receiver.Name.Lexeme,
+                         typeMap, exactParameters, out string receiverFingerprint) &&
+                     receiverFingerprint == fingerprint &&
+                     features.CompactObjectRecordShapes.TryGetValue(
+                         receiverFingerprint, out var receiverShape):
+            {
+                int fieldIndex = FindField(receiverShape, get.Name.Lexeme);
+                return fieldIndex >= 0 &&
+                    features.CompactObjectRecordSelfFields.Contains(
+                        (receiverFingerprint, fieldIndex));
+            }
+            case Expr.ObjectLiteral literal:
+                if (!JsonSerializationShapeAnalyzer.TryAnalyzeCompactObjectLiteral(
+                        literal, typeMap, features.CompactObjectRecordShapes.Values,
+                        out var literalShape) ||
+                    JsonSerializationShapeAnalyzer.Fingerprint(literalShape) != fingerprint)
+                    return false;
+                for (int index = 0; index < literal.Properties.Count; index++)
+                {
+                    if (features.CompactObjectRecordSelfFields.Contains((fingerprint, index)) &&
+                        !IsExactExpression(literal.Properties[index].Value, fingerprint, caller,
+                            byName, typeMap, features, exactParameters, exactReturns))
+                        return false;
+                }
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryGetExactParameterFingerprint(
+        Stmt.Function function,
+        string parameterName,
+        TypeMap typeMap,
+        IReadOnlyDictionary<Stmt.Function, HashSet<int>> exactParameters,
+        out string fingerprint)
+    {
+        int index = function.Parameters.FindIndex(parameter =>
+            parameter.Name.Lexeme == parameterName);
+        if (index >= 0 && exactParameters.TryGetValue(function, out var indices) &&
+            indices.Contains(index))
+        {
+            var functionType = typeMap.GetFunctionType(function.Name.Lexeme);
+            if (functionType is not null && index < functionType.ParamTypes.Count &&
+                JsonSerializationShapeAnalyzer.TryGetRecordShape(
+                    functionType.ParamTypes[index], out var shape))
+            {
+                fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(shape);
+                return true;
+            }
+        }
+        fingerprint = "";
+        return false;
+    }
+
+    private static bool TryInferReturnFingerprint(
+        Stmt.Function function,
+        TypeMap typeMap,
+        RuntimeFeatureSet features,
+        out string fingerprint)
+    {
+        var collector = new ReturnCollector();
+        foreach (var statement in function.Body!)
+            collector.Visit(statement);
+        string? inferred = null;
+        foreach (var value in collector.Values)
+        {
+            Expr unwrapped = Unwrap(value);
+            if (unwrapped is not Expr.ObjectLiteral literal ||
+                !JsonSerializationShapeAnalyzer.TryAnalyzeCompactObjectLiteral(
+                    literal, typeMap, features.CompactObjectRecordShapes.Values,
+                    out var shape))
+            {
+                fingerprint = "";
+                return false;
+            }
+            string current = JsonSerializationShapeAnalyzer.Fingerprint(shape);
+            if (!features.CompactObjectRecordShapes.ContainsKey(current) ||
+                !features.CanAssumeCompactObjectRecordIsUnmaterialized(current) ||
+                inferred is not null && inferred != current)
+            {
+                fingerprint = "";
+                return false;
+            }
+            inferred = current;
+        }
+        fingerprint = inferred ?? "";
+        return !collector.HasBareReturn && inferred is not null;
+    }
+
+    private static Expr Unwrap(Expr expression) => expression switch
+    {
+        Expr.Grouping grouping => Unwrap(grouping.Expression),
+        Expr.TypeAssertion assertion => Unwrap(assertion.Expression),
+        Expr.Satisfies satisfies => Unwrap(satisfies.Expression),
+        Expr.NonNullAssertion nonNull => Unwrap(nonNull.Expression),
+        _ => expression
+    };
+
+    private static int FindField(JsonSerializationShape.Record shape, string name)
+    {
+        for (int index = 0; index < shape.Fields.Count; index++)
+            if (shape.Fields[index].Key == name)
+                return index;
+        return -1;
+    }
+
+    private static JsonSerializationShape.Record GetCompactRecordShape(TypeInfo type)
+    {
+        JsonSerializationShapeAnalyzer.TryGetRecordShape(type, out var shape);
+        return shape;
+    }
+
+    private static void CollectTopLevel(
+        Stmt statement,
+        ICollection<Stmt.Function> functions,
+        ISet<string> exportedNames,
+        bool exported)
+    {
+        switch (statement)
+        {
+            case Stmt.Function function:
+                functions.Add(function);
+                if (exported)
+                    exportedNames.Add(function.Name.Lexeme);
+                break;
+            case Stmt.Export { Declaration: { } declaration }:
+                CollectTopLevel(declaration, functions, exportedNames, exported: true);
+                break;
+            case Stmt.Sequence sequence:
+                foreach (var inner in sequence.Statements)
+                    CollectTopLevel(inner, functions, exportedNames, exported);
+                break;
+        }
+    }
+
+    private sealed record CallSite(Stmt.Function? Caller, Expr.Call Call);
+
+    private sealed class UsageCollector(
+        IReadOnlyDictionary<string, Stmt.Function> functions) : AstVisitorBase
+    {
+        private Stmt.Function? _currentFunction;
+        public HashSet<string> ValueUsedNames { get; } = new(StringComparer.Ordinal);
+        public Dictionary<Stmt.Function, List<CallSite>> CallsByTarget { get; } =
+            new(ReferenceEqualityComparer.Instance);
+
+        protected override void VisitFunction(Stmt.Function stmt)
+        {
+            var previous = _currentFunction;
+            _currentFunction = stmt;
+            base.VisitFunction(stmt);
+            _currentFunction = previous;
+        }
+
+        protected override void VisitCall(Expr.Call expr)
+        {
+            if (expr.Callee is Expr.Variable variable &&
+                functions.TryGetValue(variable.Name.Lexeme, out var target) &&
+                !expr.Optional && expr.Arguments.All(argument => argument is not Expr.Spread))
+            {
+                if (!CallsByTarget.TryGetValue(target, out var calls))
+                {
+                    calls = [];
+                    CallsByTarget.Add(target, calls);
+                }
+                calls.Add(new CallSite(_currentFunction, expr));
+                foreach (var argument in expr.Arguments)
+                    Visit(argument);
+                return;
+            }
+            base.VisitCall(expr);
+        }
+
+        protected override void VisitVariable(Expr.Variable expr)
+        {
+            if (functions.ContainsKey(expr.Name.Lexeme))
+                ValueUsedNames.Add(expr.Name.Lexeme);
+        }
+    }
+
+    private sealed class ReturnCollector : AstVisitorBase
+    {
+        public List<Expr> Values { get; } = [];
+        public bool HasBareReturn { get; private set; }
+
+        protected override void VisitReturn(Stmt.Return stmt)
+        {
+            if (stmt.Value is null)
+                HasBareReturn = true;
+            else
+                Values.Add(stmt.Value);
+        }
+
+        protected override void VisitFunction(Stmt.Function stmt) { }
+        protected override void VisitArrowFunction(Expr.ArrowFunction expr) { }
+    }
+}

--- a/src/SharpTS/Compilation/ILCompiler.Functions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Functions.cs
@@ -136,12 +136,32 @@ public partial class ILCompiler
         var paramTypes = ParameterTypeResolver.ResolveParameters(
             funcStmt.Parameters, _typeMapper, funcType, _typeMap);
 
+        if (funcType is not null && _runtime is not null &&
+            _exactCompactRecordParameters.TryGetValue(funcStmt, out var exactParameterIndices))
+        {
+            foreach (int index in exactParameterIndices)
+            {
+                if (index < paramTypes.Length && index < funcType.ParamTypes.Count &&
+                    TryGetCompactRecordShape(funcType.ParamTypes[index], out var parameterShape) &&
+                    _runtime.CompactObjectRecordTypes.TryGetValue(
+                        JsonSerializationShapeAnalyzer.Fingerprint(parameterShape),
+                        out var compactType))
+                    paramTypes[index] = compactType;
+            }
+        }
+
         // Resolve typed return type (optimization: avoid boxing for : number returns).
         // Widen a number/boolean slot to object if the checker flagged an undefined-reachable
         // return (e.g. `return undefined as any`) — the unboxed slot would coerce it (#344).
         bool returnMayBeUndefined = ReturnSlotAnalysis.BlockReturnsMayBeUndefined(funcStmt.Body, _typeMap);
         Type returnType = ParameterTypeResolver.ResolveReturnType(
             funcType?.ReturnType, isAsync: false, _typeMapper, returnMayBeUndefined);
+        if (_runtime is not null &&
+            _exactCompactRecordReturns.TryGetValue(funcStmt, out string? returnFingerprint) &&
+            _runtime.CompactObjectRecordTypes.TryGetValue(
+                returnFingerprint,
+                out var compactReturnType))
+            returnType = compactReturnType;
 
         var methodBuilder = _programType.DefineMethod(
             qualifiedFunctionName,
@@ -526,11 +546,13 @@ public partial class ILCompiler
 
                 var typedLocal = il.DeclareLocal(compactType);
                 il.Emit(OpCodes.Ldarg, i);
-                il.Emit(OpCodes.Isinst, compactType);
+                bool isExact = methodParams[i].ParameterType == compactType;
+                if (!isExact)
+                    il.Emit(OpCodes.Isinst, compactType);
                 il.Emit(OpCodes.Stloc, typedLocal);
                 ctx.HoistedCompactRecordParameters.Add(
                     parameterName,
-                    new HoistedCompactRecordEntry(typedLocal, fingerprint));
+                    new HoistedCompactRecordEntry(typedLocal, fingerprint, isExact));
             }
         }
 

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -66,6 +66,10 @@ public partial class ILCompiler
     // MethodBuilder, preserving value dispatch for imported and otherwise replaceable bindings.
     private readonly HashSet<Stmt.Function> _stableSelfCallFunctions =
         new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<Stmt.Function, HashSet<int>> _exactCompactRecordParameters =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<Stmt.Function, string> _exactCompactRecordReturns =
+        new(ReferenceEqualityComparer.Instance);
     private TypeBuilder _programType = null!;
 
     // Organized state containers (see ILCompiler.State.cs for definitions)
@@ -664,6 +668,9 @@ public partial class ILCompiler
     {
         PreScanBuiltInModuleImports(statements);
         StableFunctionBindingAnalyzer.Analyze(statements, _stableSelfCallFunctions);
+        ExactCompactRecordFunctionAnalyzer.Analyze(
+            statements, _typeMap, _features, _stableSelfCallFunctions,
+            _exactCompactRecordParameters, _exactCompactRecordReturns);
     }
 
     #region Compile Phases
@@ -1317,6 +1324,9 @@ public partial class ILCompiler
         {
             PreScanBuiltInModuleImports(m.Statements, m.Path);
             StableFunctionBindingAnalyzer.Analyze(m.Statements, _stableSelfCallFunctions);
+            ExactCompactRecordFunctionAnalyzer.Analyze(
+                m.Statements, _typeMap, _features, _stableSelfCallFunctions,
+                _exactCompactRecordParameters, _exactCompactRecordReturns);
         }
         ModulePhase4_DefineModuleTypes(modules);
         // Captured top-level vars continue to share the entry-point display class

--- a/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
@@ -327,8 +327,9 @@ public partial class ILEmitter
                 return false;
         }
 
-        if (!JsonSerializationShapeAnalyzer.TryAnalyzeObjectLiteral(
-                literal, _ctx.TypeMap, out var record))
+        if (!JsonSerializationShapeAnalyzer.TryAnalyzeCompactObjectLiteral(
+                literal, _ctx.TypeMap,
+                _ctx.RuntimeFeatures.CompactObjectRecordShapes.Values, out var record))
             return false;
 
         string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(record);
@@ -340,10 +341,15 @@ public partial class ILEmitter
                 fingerprint, out var exactCtor))
             return false;
 
-        foreach (var property in literal.Properties)
+        var ctorParameters = exactCtor.GetParameters();
+        for (int index = 0; index < literal.Properties.Count; index++)
         {
+            var property = literal.Properties[index];
             EmitExpression(property.Value);
-            EmitBoxIfNeeded(property.Value);
+            if (ctorParameters[index].ParameterType == _ctx.Types.Object)
+                EmitBoxIfNeeded(property.Value);
+            else
+                EmitConversionForParameter(property.Value, ctorParameters[index].ParameterType);
         }
         IL.Emit(OpCodes.Newobj, exactCtor);
         return true;

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -40,6 +40,13 @@ public partial class ILEmitter
             return;
         }
 
+        // A carrier-typed, immutable parameter remains the exact generated CLR
+        // record throughout the function. When flow analysis has also narrowed
+        // away null, emit the recursive slot load directly: no isinst, materialized
+        // guard, descriptor probe, or general GetProperty fallback is observable.
+        if (TryEmitExactCompactRecordParameterGet(g))
+            return;
+
         // Syntactic shortcut: `arguments.length` → load $Arguments._length
         // directly. The static-type-driven dispatch path emits .NET
         // List<object>.Count (via a helper that bypasses GetProperty),
@@ -596,6 +603,41 @@ public partial class ILEmitter
 
         IL.MarkLabel(endLabel);
         SetStackUnknown();
+    }
+
+    private bool TryEmitExactCompactRecordParameterGet(Expr.Get g)
+    {
+        if (g.Optional || g.Object is not Expr.Variable receiver ||
+            !_ctx.HoistedCompactRecordParameters.TryGetValue(
+                receiver.Name.Lexeme, out var hoisted) ||
+            !hoisted.IsExact ||
+            _ctx.TypeMap?.Get(g.Object) is not TypeInfo.Record narrowedRecord ||
+            _ctx.RuntimeFeatures?.CanAssumeCompactObjectRecordIsUnmaterialized(
+                hoisted.Fingerprint) != true ||
+            _ctx.RuntimeFeatures.UsesDynamicPropertyDescriptors ||
+            !JsonSerializationShapeAnalyzer.TryAnalyze(narrowedRecord, out var analyzed) ||
+            analyzed is not JsonSerializationShape.Record recordShape ||
+            JsonSerializationShapeAnalyzer.Fingerprint(recordShape) != hoisted.Fingerprint)
+            return false;
+
+        int index = -1;
+        for (int candidate = 0; candidate < recordShape.Fields.Count; candidate++)
+        {
+            if (recordShape.Fields[candidate].Key == g.Name.Lexeme)
+            {
+                index = candidate;
+                break;
+            }
+        }
+        if (index < 0 ||
+            !_ctx.Runtime!.CompactObjectRecordValueFields.TryGetValue(
+                (hoisted.Fingerprint, index), out var field))
+            return false;
+
+        IL.Emit(OpCodes.Ldloc, hoisted.TypedLocal);
+        IL.Emit(OpCodes.Ldfld, field);
+        SetStackTypeForFieldType(field.FieldType);
+        return true;
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/JsonSerializationShape.cs
+++ b/src/SharpTS/Compilation/JsonSerializationShape.cs
@@ -70,6 +70,138 @@ internal static class JsonSerializationShapeAnalyzer
         return true;
     }
 
+    /// <summary>
+    /// Uses a literal's contextual record type when available, preventing recursive
+    /// initializers from producing a new fingerprint at every expansion depth.
+    /// </summary>
+    public static bool TryAnalyzeCompactObjectLiteral(
+        Expr.ObjectLiteral literal,
+        TypeMap? typeMap,
+        out JsonSerializationShape.Record shape)
+    {
+        if (typeMap?.Get(literal) is TypeInfo.Record contextualRecord &&
+            TryAnalyze(contextualRecord, out var contextual) &&
+            contextual is JsonSerializationShape.Record contextualShape &&
+            KeysMatch(literal, contextualShape))
+        {
+            shape = contextualShape;
+            return true;
+        }
+
+        return TryAnalyzeObjectLiteral(literal, typeMap, out shape);
+    }
+
+    public static bool TryAnalyzeCompactObjectLiteral(
+        Expr.ObjectLiteral literal,
+        TypeMap? typeMap,
+        IEnumerable<JsonSerializationShape.Record> canonicalShapes,
+        out JsonSerializationShape.Record shape)
+    {
+        if (!TryAnalyzeCompactObjectLiteral(literal, typeMap, out var inferred))
+        {
+            shape = null!;
+            return false;
+        }
+
+        foreach (var candidate in canonicalShapes)
+        {
+            if (MatchesRecursiveCanonicalShape(literal, typeMap, inferred, candidate))
+            {
+                shape = candidate;
+                return true;
+            }
+        }
+        shape = inferred;
+        return true;
+    }
+
+    private static bool MatchesRecursiveCanonicalShape(
+        Expr.ObjectLiteral literal,
+        TypeMap? typeMap,
+        JsonSerializationShape.Record inferred,
+        JsonSerializationShape.Record candidate)
+    {
+        if (!KeysMatch(literal, candidate) || inferred.Fields.Count != candidate.Fields.Count)
+            return false;
+        string candidateFingerprint = Fingerprint(candidate);
+        bool usedRecursiveEdge = false;
+        for (int index = 0; index < candidate.Fields.Count; index++)
+        {
+            if (Fingerprint(inferred.Fields[index].Value) ==
+                Fingerprint(candidate.Fields[index].Value))
+                continue;
+            if (candidate.Fields[index].Value is not JsonSerializationShape.Generic)
+                return false;
+            TypeInfo? valueType = typeMap?.Get(literal.Properties[index].Value);
+            if (IsNullishOnly(valueType))
+            {
+                usedRecursiveEdge = true;
+                continue;
+            }
+            if (!TryGetRecordShape(valueType, out var valueShape) ||
+                Fingerprint(valueShape) != candidateFingerprint)
+                return false;
+            usedRecursiveEdge = true;
+        }
+        return usedRecursiveEdge || Fingerprint(inferred) == candidateFingerprint;
+    }
+
+    internal static bool IsNullishOnly(TypeInfo? type) => type switch
+    {
+        TypeInfo.Null or TypeInfo.Undefined => true,
+        TypeInfo.Union union => union.FlattenedTypes.All(member =>
+            member is TypeInfo.Null or TypeInfo.Undefined),
+        _ => false
+    };
+
+    internal static bool TryGetRecordShape(
+        TypeInfo? type, out JsonSerializationShape.Record shape)
+    {
+        TypeInfo.Record? record = type as TypeInfo.Record;
+        if (type is TypeInfo.Union union)
+        {
+            var nonNullish = union.FlattenedTypes
+                .Where(member => member is not TypeInfo.Null and not TypeInfo.Undefined)
+                .ToArray();
+            if (nonNullish.Length == 1 && nonNullish[0] is TypeInfo.Record unionRecord)
+                record = unionRecord;
+        }
+        if (record is not null && TryAnalyze(record, out var analyzed) &&
+            analyzed is JsonSerializationShape.Record recordShape)
+        {
+            shape = recordShape;
+            return true;
+        }
+        shape = null!;
+        return false;
+    }
+
+    private static bool KeysMatch(
+        Expr.ObjectLiteral literal, JsonSerializationShape.Record shape)
+    {
+        if (literal.Properties.Count != shape.Fields.Count)
+            return false;
+        for (int index = 0; index < literal.Properties.Count; index++)
+        {
+            var property = literal.Properties[index];
+            if (property.IsSpread || property.Kind is not Expr.ObjectPropertyKind.Value ||
+                property.Key is Expr.ComputedKey)
+                return false;
+            string key = property.Key switch
+            {
+                Expr.IdentifierKey identifier => identifier.Name.Lexeme,
+                Expr.LiteralKey literalKey when literalKey.Literal.Type == TokenType.STRING
+                    => (string)literalKey.Literal.Literal!,
+                Expr.LiteralKey literalKey when literalKey.Literal.Type == TokenType.NUMBER
+                    => Convert.ToString(literalKey.Literal.Literal, CultureInfo.InvariantCulture)!,
+                _ => ""
+            };
+            if (key != shape.Fields[index].Key)
+                return false;
+        }
+        return true;
+    }
+
     public static string Fingerprint(JsonSerializationShape shape)
     {
         var builder = new System.Text.StringBuilder();

--- a/src/SharpTS/Compilation/RuntimeEmitter.CompactObjectRecord.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.CompactObjectRecord.cs
@@ -45,7 +45,12 @@ public partial class RuntimeEmitter
             runtime.CompactObjectRecordTypes.Add(fingerprint, typeBuilder);
 
             var valueFields = shape.Fields.Select((_, index) =>
-                typeBuilder.DefineField($"_v{index}", _types.Object, FieldAttributes.Assembly)).ToArray();
+                typeBuilder.DefineField(
+                    $"_v{index}",
+                    _features.CompactObjectRecordSelfFields.Contains((fingerprint, index))
+                        ? typeBuilder
+                        : _types.Object,
+                    FieldAttributes.Assembly)).ToArray();
             Type weakTableType = _types.MakeGenericType(
                 _types.ConditionalWeakTableOpen, _types.Object, _types.DictionaryStringObject);
             var materializedTable = typeBuilder.DefineField(
@@ -59,7 +64,7 @@ public partial class RuntimeEmitter
             var ctor = typeBuilder.DefineConstructor(
                 MethodAttributes.Public,
                 CallingConventions.Standard,
-                Enumerable.Repeat(_types.Object, valueFields.Length).ToArray());
+                valueFields.Select(field => field.FieldType).ToArray());
             runtime.CompactObjectRecordCtors.Add(fingerprint, ctor);
             var ctorIl = ctor.GetILGenerator();
             ctorIl.Emit(OpCodes.Ldarg_0);

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -32,6 +32,8 @@ public sealed class RuntimeFeatureDetector
     private readonly RuntimeFeatureSet _set;
     private readonly HashSet<string> _sourceFunctions = new(StringComparer.Ordinal);
     private readonly HashSet<string> _opaqueValueBindings = new(StringComparer.Ordinal);
+    private readonly HashSet<(string Fingerprint, int Index)> _invalidCompactRecordSelfFields = [];
+    private readonly Dictionary<string, JsonSerializationShape.Record> _canonicalCompactRecordShapes = [];
     private TypeMap? _typeMap;
 
     public RuntimeFeatureDetector()
@@ -96,6 +98,7 @@ public sealed class RuntimeFeatureDetector
     {
         _typeMap = typeMap;
         CollectStableSourceFunctionNames(statements);
+        CollectCanonicalCompactRecordShapes(statements);
         foreach (var stmt in statements)
             VisitStmt(stmt);
 
@@ -1090,8 +1093,9 @@ public sealed class RuntimeFeatureDetector
                 {
                     _set.UsesCompactObjectRecords = true;
                     if (_typeMap is not null &&
-                        JsonSerializationShapeAnalyzer.TryAnalyzeObjectLiteral(
-                            ol, _typeMap, out var compactShape))
+                        JsonSerializationShapeAnalyzer.TryAnalyzeCompactObjectLiteral(
+                            ol, _typeMap, _canonicalCompactRecordShapes.Values,
+                            out var compactShape))
                     {
                         if (!_set.CompactObjectRecordShapeFingerprints.TryGetValue(
                                 compactShape.Fields.Count, out var shapes))
@@ -1103,6 +1107,7 @@ public sealed class RuntimeFeatureDetector
                         string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(compactShape);
                         shapes.Add(fingerprint);
                         _set.CompactObjectRecordShapes.TryAdd(fingerprint, compactShape);
+                        AnalyzeCompactRecordSelfFields(ol, compactShape, fingerprint);
                     }
                 }
                 foreach (var prop in ol.Properties)
@@ -1184,6 +1189,37 @@ public sealed class RuntimeFeatureDetector
             // Leaves with no nested expressions worth walking.
             default:
                 break;
+        }
+    }
+
+    private void AnalyzeCompactRecordSelfFields(
+        Expr.ObjectLiteral literal,
+        JsonSerializationShape.Record shape,
+        string fingerprint)
+    {
+        for (int index = 0; index < shape.Fields.Count; index++)
+        {
+            if (shape.Fields[index].Value is not JsonSerializationShape.Generic)
+                continue;
+
+            var key = (fingerprint, index);
+            TypeInfo? valueType = _typeMap?.Get(literal.Properties[index].Value);
+            if (JsonSerializationShapeAnalyzer.IsNullishOnly(valueType))
+                continue;
+
+            if (JsonSerializationShapeAnalyzer.TryGetRecordShape(
+                    valueType, out var valueShape) &&
+                JsonSerializationShapeAnalyzer.Fingerprint(valueShape) == fingerprint &&
+                !_invalidCompactRecordSelfFields.Contains(key))
+            {
+                _set.CompactObjectRecordSelfFields.Add(key);
+                continue;
+            }
+
+            // Every non-nullish initializer for a typed slot must agree. Once a
+            // conflicting value is observed, later literals cannot re-enable it.
+            _invalidCompactRecordSelfFields.Add(key);
+            _set.CompactObjectRecordSelfFields.Remove(key);
         }
     }
 
@@ -1278,6 +1314,46 @@ public sealed class RuntimeFeatureDetector
             if (!hasOpaqueBoundary &&
                 declarations.Counts.GetValueOrDefault(function.Name.Lexeme) == 1)
                 _sourceFunctions.Add(function.Name.Lexeme);
+        }
+    }
+
+    private void CollectCanonicalCompactRecordShapes(IReadOnlyList<Stmt> statements)
+    {
+        if (_typeMap is null)
+            return;
+        foreach (var statement in statements)
+            Collect(statement);
+
+        void Collect(Stmt statement)
+        {
+            switch (statement)
+            {
+                case Stmt.Function function:
+                    if (_typeMap.GetFunctionType(function.Name.Lexeme) is { } functionType)
+                    {
+                        Add(functionType.ReturnType);
+                        foreach (var parameterType in functionType.ParamTypes)
+                            Add(parameterType);
+                    }
+                    break;
+                case Stmt.Export { Declaration: { } declaration }:
+                    Collect(declaration);
+                    break;
+                case Stmt.Sequence sequence:
+                    foreach (var inner in sequence.Statements)
+                        Collect(inner);
+                    break;
+            }
+        }
+
+        void Add(TypeInfo type)
+        {
+            if (!JsonSerializationShapeAnalyzer.TryGetRecordShape(type, out var shape) ||
+                shape.Fields.Count is < 1 or > 4 ||
+                !shape.Fields.Any(field => field.Value is JsonSerializationShape.Generic))
+                return;
+            _canonicalCompactRecordShapes.TryAdd(
+                JsonSerializationShapeAnalyzer.Fingerprint(shape), shape);
         }
     }
 
@@ -1440,8 +1516,9 @@ public sealed class RuntimeFeatureDetector
         }
 
         if (expression is Expr.ObjectLiteral literal &&
-            JsonSerializationShapeAnalyzer.TryAnalyzeObjectLiteral(
-                literal, _typeMap, out var shape))
+            JsonSerializationShapeAnalyzer.TryAnalyzeCompactObjectLiteral(
+                literal, _typeMap, _canonicalCompactRecordShapes.Values,
+                out var shape))
         {
             _set.PotentiallyMaterializedCompactObjectRecordShapes.Add(
                 JsonSerializationShapeAnalyzer.Fingerprint(shape));

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -40,6 +40,13 @@ public sealed class RuntimeFeatureSet
 
     internal Dictionary<string, JsonSerializationShape.Record> CompactObjectRecordShapes { get; } = [];
 
+    /// <summary>
+    /// Generic-looking compact-record slots whose literal initializers prove that the
+    /// value is either nullish or another instance of the same recursive shape.
+    /// These slots can carry the exact generated CLR record type instead of object.
+    /// </summary>
+    internal HashSet<(string Fingerprint, int Index)> CompactObjectRecordSelfFields { get; } = [];
+
     internal HashSet<string> PotentiallyMaterializedCompactObjectRecordShapes { get; } = [];
     internal bool PotentiallyMaterializesUnknownCompactObjectRecordShape { get; set; } = true;
 

--- a/tests/SharpTS.Tests/CompilerTests/CompactObjectRecordTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/CompactObjectRecordTests.cs
@@ -9,9 +9,9 @@ using Xunit;
 namespace SharpTS.Tests.CompilerTests;
 
 /// <summary>
-/// Regression coverage for #1412: exact small record shapes use slot-backed CLR
-/// reference types, while dynamic observation and mutation retain ordinary JS
-/// object behavior through lazy dictionary materialization.
+/// Regression coverage for #1412/#1419: exact small record shapes use slot-backed
+/// CLR reference types and stable recursive signatures preserve that type, while
+/// dynamic observation and mutation retain ordinary JS object behavior.
 /// </summary>
 public sealed class CompactObjectRecordTests
 {
@@ -40,6 +40,17 @@ public sealed class CompactObjectRecordTests
         MethodInfo buildTree = FindFunction(assembly, "buildTree");
         MethodInfo itemCheck = FindFunction(assembly, "itemCheck");
 
+        Type carrier = buildTree.ReturnType;
+        Assert.StartsWith("$CompactObjectRecord", carrier.Name, StringComparison.Ordinal);
+        Assert.Equal(carrier, Assert.Single(itemCheck.GetParameters()).ParameterType);
+        Assert.All(
+            carrier.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+                .Where(field => field.Name.StartsWith("_v", StringComparison.Ordinal)),
+            field => Assert.Equal(carrier, field.FieldType));
+        Assert.All(
+            Assert.Single(carrier.GetConstructors()).GetParameters(),
+            parameter => Assert.Equal(carrier, parameter.ParameterType));
+
         Assert.Contains(ReadMembers(buildTree), member =>
             member.OpCode == OpCodes.Newobj &&
             member.Member?.DeclaringType?.Name.StartsWith(
@@ -51,6 +62,9 @@ public sealed class CompactObjectRecordTests
         Assert.DoesNotContain(ReadMembers(itemCheck), member =>
             member.Member?.DeclaringType?.IsGenericType == true &&
             member.Member.DeclaringType.GetGenericTypeDefinition() == typeof(Dictionary<,>));
+        Assert.DoesNotContain(ReadMembers(itemCheck), member => member.OpCode == OpCodes.Isinst);
+        Assert.DoesNotContain(ReadMembers(itemCheck), member =>
+            member.Member?.Name == "GetProperty");
 
         var binaryTrees = FindFunction(assembly, "binaryTrees")
             .CreateDelegate<Func<double, double>>();
@@ -59,6 +73,7 @@ public sealed class CompactObjectRecordTests
         Assert.Equal(16383, binaryTrees(12));
         long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
         Assert.InRange(allocated, 250_000, 300_000);
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(TreeSource));
     }
 
     [Fact]
@@ -102,6 +117,82 @@ public sealed class CompactObjectRecordTests
             """;
 
         Assert.Equal("1 2 a b\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void ExportedOrValueUsedFunctionRetainsObjectSignature()
+    {
+        const string source = """
+            type Node = { left: Node | null; right: Node | null };
+
+            export function exportedRead(node: Node | null): number {
+                if (node === null) return 1;
+                return exportedRead(node.left);
+            }
+
+            function aliasedRead(node: Node | null): number {
+                if (node === null) return 1;
+                return aliasedRead(node.left);
+            }
+            const alias = aliasedRead;
+            console.log(alias({ left: null, right: null }));
+            """;
+
+        Assembly assembly = Compile(source);
+        Assert.Equal(typeof(object),
+            Assert.Single(FindFunction(assembly, "exportedRead").GetParameters()).ParameterType);
+        Assert.Equal(typeof(object),
+            Assert.Single(FindFunction(assembly, "aliasedRead").GetParameters()).ParameterType);
+        Assert.Equal("1\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void InternalWalkerCalledFromObjectBoundaryRetainsObjectSignature()
+    {
+        const string source = """
+            type Node = { left: Node | null; right: Node | null };
+
+            function walk(node: Node | null): number {
+                if (node === null) return 1;
+                return walk(node.left);
+            }
+
+            export function entry(node: Node | null): number {
+                return walk(node);
+            }
+            """;
+
+        Assembly assembly = Compile(source);
+        Assert.Equal(typeof(object),
+            Assert.Single(FindFunction(assembly, "walk").GetParameters()).ParameterType);
+        Assert.Equal(typeof(object),
+            Assert.Single(FindFunction(assembly, "entry").GetParameters()).ParameterType);
+    }
+
+    [Fact]
+    public void MutatedRecursiveRecordRetainsObjectSignatures()
+    {
+        const string source = """
+            type Node = { left: Node | null; right: Node | null };
+
+            function build(): Node {
+                return { left: null, right: null };
+            }
+            function walk(node: Node | null): number {
+                if (node === null) return 1;
+                return walk(node.left);
+            }
+
+            const node = build();
+            node.left = build();
+            console.log(walk(node));
+            """;
+
+        Assembly assembly = Compile(source);
+        Assert.Equal(typeof(object), FindFunction(assembly, "build").ReturnType);
+        Assert.Equal(typeof(object),
+            Assert.Single(FindFunction(assembly, "walk").GetParameters()).ParameterType);
+        Assert.Equal("1\n", TestHarness.RunCompiled(source));
     }
 
     private static Assembly Compile(string source)


### PR DESCRIPTION
## Summary

- canonicalize recursive compact-record literals to one carrier shape and type proven self-recursive fields with that carrier
- propagate exact carrier parameters and returns through module-private, stable, call-only function SCCs using conservative fixed-point flow analysis
- emit direct recursive field loads without `isinst` or general property fallback, while preserving object signatures for exports, aliases, mutation, undefined-return paths, and object-typed boundaries
- add emitted-signature, IL-shape, ILVerify, allocation, behavior, and bailout coverage

## Performance

Depth-16 binary trees on this machine:

| Measure | Before | After |
|---|---:|---:|
| Cross-runtime SharpTS compiled | 5.9645 ms | 2.09 ms |
| Cross-runtime Node | 1.5919 ms | 1.58 ms |
| SharpTS / Node | 3.75x | 1.32x |
| BenchmarkDotNet SharpTS | 11.204 ms | 1.910 ms |
| BenchmarkDotNet idiomatic C# | 1.892 ms | 1.847 ms |
| BenchmarkDotNet allocation | 4096.14 KB | 4095.98 KB |

The emitted `buildTree` return, `itemCheck` parameter, constructor parameters, and `_v0`/`_v1` fields are the exact carrier type. `itemCheck` contains no `isinst` and no `GetProperty` call.

## Validation

- `dotnet build SharpTS.sln -c Release --no-restore` (passes, including solution IL verification)
- compact-record + runtime-feature tests: 46 passed
- compiler tests excluding standalone environment probes: 478 passed
- BinaryTrees BenchmarkDotNet ShortRun: SharpTS 1.910 ms / 4095.98 KB at depth 16
- five cross-runtime samples: SharpTS 2.08-2.10 ms; Node 1.57-1.59 ms at depth 16

I also attempted the entire local suite. The sandbox cannot initialize Windows `HttpListener` (`The handle is invalid`) or private-key storage (`Access denied`), so HTTP/TLS and dependent child-process tests fail in both interpreter and compiled modes before exercising these changes. Unrestricted CI should provide the authoritative complete run.

Closes #1419