### PR TITLE
Optimize statically numeric bitwise lowering

### DIFF
--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -181,6 +181,8 @@ public class EmittedRuntime
     public MethodBuilder StringifyCoerce { get; set; } = null!;
     public MethodBuilder ToNumber { get; set; } = null!;
     public MethodBuilder ConvertToNumber { get; set; } = null!;
+    /// <summary>$Runtime.JsNumberToInt32(double) - allocation-free ECMA-262 ToInt32 for statically numeric operands.</summary>
+    public MethodBuilder JsNumberToInt32 { get; set; } = null!;
     public MethodBuilder JsToInt32 { get; set; } = null!;
     public MethodBuilder JsLessThan { get; set; } = null!;
     public MethodBuilder JsLessOrEqual { get; set; } = null!;

--- a/src/SharpTS/Compilation/ILEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Operators.cs
@@ -383,6 +383,12 @@ public partial class ILEmitter
 
     private void EmitBitwiseBinary(Expr.Binary b)
     {
+        if (IsStaticallyNumericBitwise(b))
+        {
+            EmitNumericBitwiseBinary(b);
+            return;
+        }
+
         // GetValue both operands before ToNumeric either operand.  Besides
         // preserving observable coercion order, this prevents a throwing RHS
         // from being masked by an eager LHS valueOf call.
@@ -428,6 +434,63 @@ public partial class ILEmitter
 
         // Convert back to double (for signed operations)
         EmitConvR8AndBox();
+    }
+
+    /// <summary>
+    /// Emits a Number-only bitwise expression without crossing the object stack.
+    /// Static numeric proof is essential: objects, Symbol, BigInt, and mixed unions
+    /// must retain the observable ToNumeric pipeline in <see cref="EmitBitwiseBinary"/>.
+    /// </summary>
+    private void EmitNumericBitwiseBinary(Expr.Binary b)
+    {
+        // Spill the converted left value before evaluating the right operand to
+        // preserve JavaScript's left-to-right evaluation order.
+        EmitExpressionAsDouble(b.Left);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.JsNumberToInt32);
+        var left = IL.DeclareLocal(_ctx.Types.Int32);
+        IL.Emit(OpCodes.Stloc, left);
+
+        EmitExpressionAsDouble(b.Right);
+        IL.Emit(OpCodes.Call, _ctx.Runtime.JsNumberToInt32);
+        var right = IL.DeclareLocal(_ctx.Types.Int32);
+        IL.Emit(OpCodes.Stloc, right);
+
+        IL.Emit(OpCodes.Ldloc, left);
+        IL.Emit(OpCodes.Ldloc, right);
+
+        switch (b.Operator.Type)
+        {
+            case TokenType.AMPERSAND:
+                IL.Emit(OpCodes.And);
+                break;
+            case TokenType.PIPE:
+                IL.Emit(OpCodes.Or);
+                break;
+            case TokenType.CARET:
+                IL.Emit(OpCodes.Xor);
+                break;
+            case TokenType.LESS_LESS:
+                IL.Emit(OpCodes.Ldc_I4, 0x1F);
+                IL.Emit(OpCodes.And);
+                IL.Emit(OpCodes.Shl);
+                break;
+            case TokenType.GREATER_GREATER:
+                IL.Emit(OpCodes.Ldc_I4, 0x1F);
+                IL.Emit(OpCodes.And);
+                IL.Emit(OpCodes.Shr);
+                break;
+            case TokenType.GREATER_GREATER_GREATER:
+                IL.Emit(OpCodes.Ldc_I4, 0x1F);
+                IL.Emit(OpCodes.And);
+                IL.Emit(OpCodes.Shr_Un);
+                IL.Emit(OpCodes.Conv_U8);
+                IL.Emit(OpCodes.Conv_R8);
+                SetStackType(StackType.Double);
+                return;
+        }
+
+        IL.Emit(OpCodes.Conv_R8);
+        SetStackType(StackType.Double);
     }
 
     /// <summary>
@@ -2503,6 +2566,13 @@ public partial class ILEmitter
         var rightType = _ctx.TypeMap.Get(b.Right);
 
         return IsStringTypeInfo(leftType) && IsStringTypeInfo(rightType);
+    }
+
+    private bool IsStaticallyNumericBitwise(Expr.Binary b)
+    {
+        if (_ctx.TypeMap == null) return false;
+        return IsNumericTypeInfo(_ctx.TypeMap.Get(b.Left))
+            && IsNumericTypeInfo(_ctx.TypeMap.Get(b.Right));
     }
 
     private bool IsStringComparison(Expr.Binary b)

--- a/src/SharpTS/Compilation/RuntimeEmitter.Coercion.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Coercion.cs
@@ -1681,19 +1681,59 @@ public partial class RuntimeEmitter
 
     private void EmitJsToInt32(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
+        var numberMethod = typeBuilder.DefineMethod(
+            "JsNumberToInt32",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Int32,
+            [_types.Double]);
+        numberMethod.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
+        runtime.JsNumberToInt32 = numberMethod;
+
+        EmitJsNumberToInt32Body(numberMethod.GetILGenerator());
+
         // Signature forward-declared by DefineRuntimeClassPhase1 so $RegExp
         // (which emits before $Runtime's body) can call it; reuse that slot.
         var method = (MethodBuilder)runtime.JsToInt32;
-
         var il = method.GetILGenerator();
 
+        // Dynamic operands retain the complete ToNumber / ToPrimitive pipeline,
+        // then share the exact numeric conversion used by the unboxed fast path.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.ToNumber);
+        il.Emit(OpCodes.Call, numberMethod);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits ECMA-262 ToInt32 for an already-unboxed JavaScript Number. The common
+    /// in-range case is a single checked-range branch pair plus <c>conv.i4</c>;
+    /// non-finite and out-of-range values use the full modulo-2^32 algorithm.
+    /// </summary>
+    private void EmitJsNumberToInt32Body(ILGenerator il)
+    {
         const double TWO_32 = 4294967296.0;
         const double TWO_31 = 2147483648.0;
 
-        // n = ToNumber(arg0)
+        var slowLabel = il.DefineLabel();
+
+        // Fast path: conversion is well-defined for every finite value in the
+        // signed int32 range and conv.i4 supplies the required truncation.
+        // blt.un also sends NaN to the slow path (unordered comparison).
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_R8, -2147483648.0);
+        il.Emit(OpCodes.Blt_Un, slowLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_R8, 2147483647.0);
+        il.Emit(OpCodes.Bgt, slowLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(slowLabel);
+
+        // Keep the argument in a local for the slow modulo path.
         var nLocal = il.DeclareLocal(_types.Double);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.ToNumber);
         il.Emit(OpCodes.Stloc, nLocal);
 
         // if (!double.IsFinite(n)) return 0

--- a/tests/SharpTS.Tests/CompilerTests/NumericBitwiseLoweringTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/NumericBitwiseLoweringTests.cs
@@ -1,0 +1,256 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>Structural regression coverage for the allocation-free #1421 bitwise path.</summary>
+public sealed class NumericBitwiseLoweringTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public NumericBitwiseLoweringTests(ITestOutputHelper output) => _output = output;
+
+    [Fact]
+    public void NumericTypedArrayUpdate_StaysUnboxedBetweenAccessors()
+    {
+        Assembly assembly = Compile("""
+            function update(index: number): number {
+                const tape = new Uint8Array(1);
+                tape[index] = (tape[index] + 1) & 255;
+                return tape[index];
+            }
+            """);
+
+        var instructions = ReadInstructions(FindFunction(assembly, "update")).ToArray();
+        int get = Array.FindIndex(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "GetUnboxed" });
+        int set = Array.FindIndex(instructions, get + 1, instruction =>
+            instruction.Operand is MethodBase { Name: "SetUnboxed" });
+
+        Assert.True(get >= 0,
+            "Expected typed-array GetUnboxed call. Calls: " +
+            string.Join(", ", instructions
+                .Where(instruction => instruction.Operand is MethodBase)
+                .Select(instruction => ((MethodBase)instruction.Operand!).Name)));
+        Assert.True(set > get, "Expected typed-array SetUnboxed call after GetUnboxed.");
+
+        var hotSlice = instructions[(get + 1)..set];
+        Assert.Contains(hotSlice, instruction =>
+            instruction.Operand is MethodBase { Name: "JsNumberToInt32" });
+        Assert.DoesNotContain(hotSlice, instruction =>
+            instruction.OpCode == OpCodes.Box && instruction.Operand == typeof(double));
+        Assert.DoesNotContain(hotSlice, instruction =>
+            instruction.Operand is MethodBase { Name: "JsToInt32" or "ConvertToNumber" });
+    }
+
+    [Fact]
+    public void DynamicOperands_RetainObjectCoercionPath()
+    {
+        Assembly assembly = Compile("""
+            function combine(left: any, right: any): number {
+                return left & right;
+            }
+            """);
+
+        var instructions = ReadInstructions(FindFunction(assembly, "combine")).ToArray();
+        Assert.Equal(2, instructions.Count(instruction =>
+            instruction.Operand is MethodBase { Name: "JsToInt32" }));
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "JsNumberToInt32" });
+    }
+
+    [Fact]
+    public void NumericBitwise_PassesIlVerification()
+    {
+        const string source = """
+            function update(index: number): number {
+                const tape = new Uint8Array(1);
+                tape[index] = (tape[index] + 1) & 255;
+                return tape[index];
+            }
+            console.log(update(0));
+            """;
+
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    [Fact]
+    public void NumericTypedArrayBitwiseLoop_HasNoPerIterationAllocation()
+    {
+        Assembly assembly = Compile("""
+            function hot(iterations: number): number {
+                const tape = new Uint8Array(1);
+                let i: number = 0;
+                while (i < iterations) {
+                    tape[0] = (tape[0] + 1) & 255;
+                    i = i + 1;
+                }
+                return tape[0];
+            }
+            """);
+
+        var hot = FindFunction(assembly, "hot").CreateDelegate<Func<double, double>>();
+        Assert.Equal(232, hot(1_000)); // Warm JIT and emitted runtime state.
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        double result = hot(1_000_000);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(64, result);
+        _output.WriteLine($"One million bitwise iterations allocated {allocated:N0} bytes.");
+        Assert.InRange(allocated, 0, 4_096);
+    }
+
+    [Fact]
+    public void BrainfuckN5000_MeetsAllocationGate()
+    {
+        Assembly assembly = Compile("""
+            function buildProgram(reps: number): string {
+                let s: string = "";
+                for (let i: number = 0; i < reps; i++) {
+                    s = s + "+++++[>+<-]>[<+>-]<";
+                }
+                return s;
+            }
+
+            function buildJumps(program: string): number[] {
+                const len: number = program.length;
+                const jumps: number[] = [];
+                for (let i: number = 0; i < len; i++) jumps.push(0);
+                const stack: number[] = [];
+                for (let i: number = 0; i < len; i++) {
+                    const c: number = program.charCodeAt(i);
+                    if (c === 91) {
+                        stack.push(i);
+                    } else if (c === 93) {
+                        const open: number = stack[stack.length - 1];
+                        stack.pop();
+                        jumps[open] = i;
+                        jumps[i] = open;
+                    }
+                }
+                return jumps;
+            }
+
+            function runBF(program: string, jumps: number[]): number {
+                const TAPE: number = 4096;
+                const tape = new Uint8Array(TAPE);
+                let ptr: number = 0;
+                let ip: number = 0;
+                const len: number = program.length;
+                while (ip < len) {
+                    const c: number = program.charCodeAt(ip);
+                    if (c === 43) {
+                        tape[ptr] = (tape[ptr] + 1) & 255;
+                    } else if (c === 45) {
+                        tape[ptr] = (tape[ptr] - 1) & 255;
+                    } else if (c === 62) {
+                        ptr = ptr + 1;
+                    } else if (c === 60) {
+                        ptr = ptr - 1;
+                    } else if (c === 91) {
+                        if (tape[ptr] === 0) ip = jumps[ip];
+                    } else if (c === 93) {
+                        if (tape[ptr] !== 0) ip = jumps[ip];
+                    }
+                    ip = ip + 1;
+                }
+                let sum: number = 0;
+                for (let i: number = 0; i < TAPE; i++) sum = sum + tape[i];
+                return sum;
+            }
+            """);
+
+        var run = FindFunction(assembly, "runBF")
+            .CreateDelegate<BrainfuckRunner>();
+
+        string program = (string)FindFunction(assembly, "buildProgram")
+            .Invoke(null, [5_000d])!;
+        object jumps = FindFunction(assembly, "buildJumps")
+            .Invoke(null, [program])!;
+        Assert.Equal(168, run(program, jumps)); // Warm JIT and emitted runtime state.
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        double result = run(program, jumps);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(168, result);
+        _output.WriteLine($"Brainfuck N=5,000 runBF allocated {allocated:N0} bytes.");
+        Assert.InRange(allocated, 0, 35_000_000);
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"issue_1421_bitwise_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token)
+                    : module.ResolveType(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+
+    private delegate double BrainfuckRunner(string program, object jumps);
+}

--- a/tests/SharpTS.Tests/SharedTests/OperatorTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/OperatorTests.cs
@@ -143,6 +143,95 @@ public class OperatorTests
         Assert.Equal("86\n", output);
     }
 
+    [Theory, ModeData]
+    public void NumericBitwise_FastPathPreservesToInt32Boundaries(ExecutionMode mode)
+    {
+        var source = """
+            function asInt32(value: number): number {
+                return value | 0;
+            }
+            console.log(asInt32(NaN));
+            console.log(asInt32(Infinity));
+            console.log(asInt32(-Infinity));
+            console.log(asInt32(-0));
+            console.log(asInt32(1.9));
+            console.log(asInt32(-1.9));
+            console.log(asInt32(4294967297));
+            console.log(asInt32(-4294967297));
+            console.log(asInt32(2147483648));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("0\n0\n0\n0\n1\n-1\n1\n-1\n-2147483648\n", output);
+    }
+
+    [Theory, ModeData]
+    public void NumericBitwise_FastPathCoversAllBinaryOperatorsAndShiftMask(ExecutionMode mode)
+    {
+        var source = """
+            function report(a: number, b: number): void {
+                console.log(a & b);
+                console.log(a | b);
+                console.log(a ^ b);
+                console.log(a << b);
+                console.log(a >> b);
+                console.log(a >>> b);
+            }
+            report(0x12345678, 255);
+            console.log(8 >>> 33);
+            console.log(1 << 33);
+            console.log(-8 >> 33);
+            console.log(-1 >>> 0);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("120\n305420031\n305419911\n0\n0\n0\n4\n2\n-4\n4294967295\n", output);
+    }
+
+    [Theory, ModeData]
+    public void DynamicBitwise_RetainsGetValueAndToNumericSemantics(ExecutionMode mode)
+    {
+        var source = """
+            const events: string[] = [];
+            const left: any = {
+                valueOf: () => { events.push("left-valueOf"); return 7; }
+            };
+            function right(): any {
+                events.push("right-expression");
+                return { valueOf: () => { events.push("right-valueOf"); return 3; } };
+            }
+            console.log(left & right());
+            console.log(events.join(","));
+
+            try { console.log((Symbol("s") as any) & 1); }
+            catch { console.log("symbol-error"); }
+            try { console.log((1n as any) & 1); }
+            catch { console.log("mixed-bigint-error"); }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal(
+            "3\nright-expression,left-valueOf,right-valueOf\nsymbol-error\nmixed-bigint-error\n",
+            output);
+    }
+
+    [Theory, ModeData]
+    public void NumericBitwise_ResultFlowsThroughTypedArrayStore(ExecutionMode mode)
+    {
+        var source = """
+            function update(tape: Uint8Array, index: number, delta: number): number {
+                tape[index] = (tape[index] + delta) & 255;
+                return tape[index];
+            }
+            const tape = new Uint8Array(1);
+            console.log(update(tape, 0, -1));
+            console.log(update(tape, 0, 2));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("255\n1\n", output);
+    }
+
     #endregion
 
     #region Nullish Coalescing


### PR DESCRIPTION
## Summary
- add an allocation-free `JsNumberToInt32(double)` runtime helper with a fast in-range conversion and spec-correct slow modulo path
- lower all binary Number bitwise/shift operators directly through int32 IL when both operands are statically numeric
- keep `any`, object, Symbol, BigInt, and heterogeneous operands on the existing observable coercion path
- add semantic, structural IL, IL-verification, allocation, and exact brainfuck regression coverage

## Measured result
Pinned workload: `benchmarks/cross-runtime/scripts/brainfuck.ts`, N=5,000.

| Measure | Before | After |
|---|---:|---:|
| SharpTS compiled median (3 independent means) | 66.5548 ms | **33.4852 ms** |
| Node median (same run) | 20.3813 ms | **20.5546 ms** |
| SharpTS / Node | 3.27x | **1.63x** |
| Exact `runBF` allocation | ~215.36 MB | **30,307,280 bytes** |
| Interpreter | 6,783.6408 ms | **6,435.0992 ms** |

Compiled samples: 33.4852, 33.7106, 33.0975 ms. Node samples: 21.6977, 20.1443, 20.5546 ms. Checksum remains 168 and emitted IL verification passes.

## Validation
- Release solution build
- 13 focused semantic/structural/allocation tests
- complete 90-case shared operator suite
- compile-only Test262, Test262 worker, and TypeScript conformance harnesses
- exact hot-slice IL assertion: no `box double`, `JsToInt32(object)`, or `ConvertToNumber(object)` between typed-array `GetUnboxed` and `SetUnboxed`
- one million typed-array bitwise iterations: 96 bytes total allocation

Closes #1421