### PR TITLE
Perf: keep stable numeric sort comparators unboxed

### DIFF
--- a/src/SharpTS/Compilation/ArrowBoxedAdapterEmitter.cs
+++ b/src/SharpTS/Compilation/ArrowBoxedAdapterEmitter.cs
@@ -47,7 +47,7 @@ internal sealed class ArrowBoxedAdapterEmitter
     // one containing its call site), so this per-context cache never double-defines;
     // the adapter NAME is derived from the arrow's globally-unique method name so it
     // stays collision-free across contexts that share the same $Program type.
-    private readonly Dictionary<(MethodBuilder, int, bool), MethodBuilder> _cache = [];
+    private readonly Dictionary<(MethodBuilder, int, bool, bool), MethodBuilder> _cache = [];
 
     /// <summary>
     /// Returns the boxed adapter for <paramref name="arrowMethod"/> bound to a delegate of
@@ -63,22 +63,33 @@ internal sealed class ArrowBoxedAdapterEmitter
     /// <c>Func&lt;object,bool&gt;</c> predicate helper is used, the adapter returns the unboxed
     /// <c>bool</c> directly (no rebox) so the <c>*DirectBool</c> helper skips the box + IsTruthy.
     /// </summary>
-    public MethodBuilder GetOrEmit(TypeBuilder carrierType, MethodBuilder arrowMethod, int funcArity, bool instance, bool boolReturn)
+    public MethodBuilder GetOrEmit(
+        TypeBuilder carrierType,
+        MethodBuilder arrowMethod,
+        int funcArity,
+        bool instance,
+        bool boolReturn,
+        bool numberReturn = false)
     {
-        var key = (arrowMethod, funcArity, boolReturn);
+        if (boolReturn && numberReturn)
+            throw new ArgumentException("An arrow adapter cannot have both bool and number return shapes.");
+
+        var key = (arrowMethod, funcArity, boolReturn, numberReturn);
         if (_cache.TryGetValue(key, out var existing)) return existing;
 
         var objectType = typeof(object);
         var adapterParams = new Type[funcArity];
         for (int i = 0; i < funcArity; i++) adapterParams[i] = objectType;
-        var adapterReturnType = boolReturn ? typeof(bool) : objectType;
+        var adapterReturnType = boolReturn
+            ? typeof(bool)
+            : numberReturn ? typeof(double) : objectType;
 
         // Name keyed off the arrow method's name ($Program-unique <>Arrow_N for static; "Invoke"
         // for instance, where the per-arrow display class scopes it) plus the return-shape marker.
         // Assembly-visible.
         var attrs = MethodAttributes.Assembly | (instance ? 0 : MethodAttributes.Static);
         var adapter = carrierType.DefineMethod(
-            $"{arrowMethod.Name}${(boolReturn ? "bbox" : "box")}{funcArity}",
+            $"{arrowMethod.Name}${(boolReturn ? "bbox" : numberReturn ? "nbox" : "box")}{funcArity}",
             attrs,
             adapterReturnType,
             adapterParams);
@@ -103,7 +114,7 @@ internal sealed class ArrowBoxedAdapterEmitter
 
         // bool-return: the arrow already returns bool (caller guarantees) — leave it unboxed for the
         // Func<object,bool> contract. Otherwise rebox the typed result to object for Func<object,…>.
-        if (!boolReturn)
+        if (!boolReturn && !numberReturn)
             DelegateAdapterEmitter.EmitBoxForTS(il, arrowMethod.ReturnType);
         il.Emit(OpCodes.Ret);
 

--- a/src/SharpTS/Compilation/CompilationContext.cs
+++ b/src/SharpTS/Compilation/CompilationContext.cs
@@ -38,7 +38,10 @@ public record struct HoistedArrayEntry(LocalBuilder TypedLocal, ArrayElementsDes
 public record struct HoistedTypedArrayEntry(LocalBuilder TypedLocal, Type XArrayType, string ElementType);
 
 public record struct HoistedCompactRecordEntry(
-    LocalBuilder TypedLocal, string Fingerprint, bool IsExact);
+    LocalBuilder TypedLocal,
+    string Fingerprint,
+    bool IsExact,
+    bool RequiresMaterializationGuard = false);
 
 /// <summary>
 /// Holds compilation state passed between ILCompiler and ILEmitter.
@@ -87,6 +90,13 @@ public partial class CompilationContext
     /// body, so property reads may reuse the typed local safely.
     /// </summary>
     public Dictionary<string, HoistedCompactRecordEntry> HoistedCompactRecordParameters { get; } = [];
+
+    /// <summary>
+    /// Compact-record fingerprints whose global materialization flag has been
+    /// checked on the current emitted control-flow branch. Property reads on an
+    /// exact typed local may skip repeating that global guard.
+    /// </summary>
+    public HashSet<string> HoistedCompactRecordMaterializationGuards { get; } = [];
 
     // Emitted runtime types and methods (for standalone DLLs)
     public EmittedRuntime? Runtime { get; set; }

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -292,6 +292,7 @@ public class EmittedRuntime
     public MethodBuilder ArrayFlatHelper { get; set; } = null!;
     public MethodBuilder ArraySort { get; set; } = null!;
     public MethodBuilder ArraySortDirect { get; set; } = null!;
+    public MethodBuilder ArraySortDirectNumber { get; set; } = null!;
     public MethodBuilder ArraySortProto { get; set; } = null!;
     public MethodBuilder ArraySortCanUseDenseFastPath { get; set; } = null!;
     public MethodBuilder ArrayToSorted { get; set; } = null!;

--- a/src/SharpTS/Compilation/Emitters/ArrayEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/ArrayEmitter.cs
@@ -983,7 +983,8 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         Expr.ArrowFunction af,
         System.Reflection.Emit.MethodBuilder arrowMethod,
         int funcArity,
-        bool boolReturn)
+        bool boolReturn,
+        bool numberReturn = false)
     {
         var ctx = emitter.Context;
 
@@ -999,6 +1000,8 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         // *DirectBool helper consumes an unboxed bool. Only the 1-arg predicate helpers pass it.
         Type funcType = boolReturn
             ? typeof(Func<object, bool>)
+            : numberReturn
+                ? typeof(Func<object, object, double>)
             : (funcArity == 2 ? typeof(Func<object, object, object>) : typeof(Func<object, object>));
         var funcCtor = funcType.GetConstructor([typeof(object), typeof(IntPtr)])!;
 
@@ -1008,7 +1011,10 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
             // Emit an INSTANCE adapter, build the display instance (capturing live locals), then bind
             // (displayInstance, ldftn adapter). The display instance is built fresh at the call site,
             // exactly as the reflective $TSFunction path does.
-            var adapter = ctx.ArrowBoxedAdapters.GetOrEmit(displayClass, arrowMethod, funcArity, instance: true, boolReturn: boolReturn);
+            var adapter = ctx.ArrowBoxedAdapters.GetOrEmit(
+                displayClass, arrowMethod, funcArity,
+                instance: true, boolReturn: boolReturn,
+                numberReturn: numberReturn);
             if (!emitter.TryEmitCapturingArrowDisplayInstance(af))
                 return false;                                          // Stack: [displayInstance]
             ctx.IL.Emit(OpCodes.Ldftn, adapter);
@@ -1020,7 +1026,10 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         // Using DeclaringType (rather than ctx.ProgramType, set only on the top-level context) lets the
         // adapter fire inside function/method bodies too. Bind (null, ldftn adapter).
         if (arrowMethod.DeclaringType is not TypeBuilder programType) return false;
-        var staticAdapter = ctx.ArrowBoxedAdapters.GetOrEmit(programType, arrowMethod, funcArity, instance: false, boolReturn: boolReturn);
+        var staticAdapter = ctx.ArrowBoxedAdapters.GetOrEmit(
+            programType, arrowMethod, funcArity,
+            instance: false, boolReturn: boolReturn,
+            numberReturn: numberReturn);
         ctx.IL.Emit(OpCodes.Ldnull);
         ctx.IL.Emit(OpCodes.Ldftn, staticAdapter);
         ctx.IL.Emit(OpCodes.Newobj, funcCtor);
@@ -1118,6 +1127,7 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
             }
         }
 
+        bool numberReturn = staticMethod.ReturnType == ctx.Types.Double;
         if (allObject)
         {
             if (!emitter.TryEmitArrowAsDelegate(af, typeof(Func<object, object, object>)))
@@ -1128,12 +1138,15 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
                      af,
                      staticMethod,
                      funcArity: 2,
-                     boolReturn: false))
+                     boolReturn: false,
+                     numberReturn: numberReturn))
         {
             return false;
         }
 
-        ctx.IL.Emit(OpCodes.Call, ctx.Runtime!.ArraySortDirect);
+        ctx.IL.Emit(OpCodes.Call, numberReturn
+            ? ctx.Runtime!.ArraySortDirectNumber
+            : ctx.Runtime!.ArraySortDirect);
         return true;
     }
 

--- a/src/SharpTS/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.ArrowFunctions.cs
@@ -1722,6 +1722,74 @@ public partial class ILCompiler
             createsArgumentsBinding: arrow.HasOwnThis,
             publishedArgsLeadingSkip: arrow.HasOwnThis ? 1 : 0);
 
+        // Record-typed numeric arrow parameters retain object CLR slots because an
+        // arbitrary JavaScript value may reach the callback despite its
+        // TypeScript annotation. Hoist the exact compact-carrier tests once per
+        // invocation so repeated property reads can reuse them. For an
+        // expression-bodied arrow, whole-program shape stability lets us emit a
+        // guarded exact branch that loads compact fields directly; the fallback
+        // is the unchanged observable property path.
+        List<string>? exactRecordFastBranchParameters = null;
+        if (arrow.ExpressionBody != null &&
+            _types.IsDouble(arrowReturnType) &&
+            _runtime is not null)
+        {
+            var assignedParameters = ParameterAssignmentAnalyzer.FindAssigned(
+                arrow.ExpressionBody);
+            var arrowFunctionType =
+                _typeMap?.Get(arrow) as TypeSystem.TypeInfo.Function;
+            ParameterInfo[] methodParameters = method.GetParameters();
+            for (int i = 0; i < arrow.Parameters.Count; i++)
+            {
+                string parameterName = arrow.Parameters[i].Name.Lexeme;
+                if (assignedParameters.Contains(parameterName))
+                    continue;
+
+                TypeSystem.TypeInfo? parameterType =
+                    i < arrowFunctionType?.ParamTypes.Count
+                        ? arrowFunctionType.ParamTypes[i]
+                        : null;
+                bool requiresMaterializationGuard =
+                    parameterType is TypeSystem.TypeInfo.Interface;
+                if ((parameterType is null ||
+                     !TryGetCompactRecordShape(parameterType, out var parameterShape)) &&
+                    !TryGetArrowParameterRecordShape(
+                        arrow.ExpressionBody,
+                        parameterName,
+                        out parameterShape,
+                        out requiresMaterializationGuard))
+                    continue;
+
+                string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(
+                    parameterShape);
+                if (!_runtime.CompactObjectRecordTypes.TryGetValue(
+                        fingerprint, out var compactType))
+                    continue;
+
+                int argumentIndex = environmentArgOffset + i;
+                var typedLocal = il.DeclareLocal(compactType);
+                il.Emit(OpCodes.Ldarg, argumentIndex);
+                bool isExact = argumentIndex < methodParameters.Length &&
+                    methodParameters[argumentIndex].ParameterType == compactType;
+                if (!isExact)
+                    il.Emit(OpCodes.Isinst, compactType);
+                il.Emit(OpCodes.Stloc, typedLocal);
+                ctx.HoistedCompactRecordParameters.Add(
+                    parameterName,
+                    new HoistedCompactRecordEntry(
+                        typedLocal,
+                        fingerprint,
+                        isExact,
+                        requiresMaterializationGuard));
+
+                if (!isExact &&
+                    ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == false)
+                {
+                    (exactRecordFastBranchParameters ??= []).Add(parameterName);
+                }
+            }
+        }
+
         // Initialize captured parameters into the arrow scope display class.
         // This mirrors the equivalent code in ILCompiler.Functions.cs.
         // Without this, inner arrows that read parameters via $arrowDC get null.
@@ -1757,33 +1825,48 @@ public partial class ILCompiler
 
         if (arrow.ExpressionBody != null)
         {
-            // Expression body: emit expression and return
-            emitter.EmitExpression(arrow.ExpressionBody);
+            if (exactRecordFastBranchParameters is { Count: > 0 })
+            {
+                var fallback = il.DefineLabel();
+                foreach (string parameterName in exactRecordFastBranchParameters)
+                {
+                    HoistedCompactRecordEntry entry =
+                        ctx.HoistedCompactRecordParameters[parameterName];
+                    il.Emit(OpCodes.Ldloc, entry.TypedLocal);
+                    il.Emit(OpCodes.Brfalse, fallback);
 
-            // Handle return based on method return type
-            if (arrowReturnType == _types.Object)
-            {
-                // Return type is object - box value types
-                emitter.EmitBoxIfNeeded(arrow.ExpressionBody);
-            }
-            else if (_types.IsDouble(arrowReturnType))
-            {
-                // Return type is double - ensure unboxed double on stack
-                emitter.EnsureDouble();
-            }
-            else if (_types.IsBoolean(arrowReturnType))
-            {
-                // Return type is bool - ensure unboxed bool on stack
-                emitter.EnsureBoolean();
-            }
-            // For reference-typed returns, no conversion needed. Note that `string`
-            // return types never reach here as a narrow `string` slot:
-            // ParameterTypeResolver.ResolveReturnType maps them to object, because an
-            // inferred-string arrow body can produce $Undefined at runtime
-            // (e.g. `(n: any) => cond ? "x" : undefined`), which no string-typed slot
-            // can carry. See #318.
+                    if ((entry.RequiresMaterializationGuard ||
+                         ctx.RuntimeFeatures?.CanAssumeCompactObjectRecordIsUnmaterialized(
+                             entry.Fingerprint) != true) &&
+                        ctx.HoistedCompactRecordMaterializationGuards.Add(
+                            entry.Fingerprint))
+                    {
+                        il.Emit(OpCodes.Ldsfld,
+                            ctx.Runtime!.CompactObjectRecordAnyMaterializedFields[
+                                entry.Fingerprint]);
+                        il.Emit(OpCodes.Brtrue, fallback);
+                    }
 
-            il.Emit(OpCodes.Ret);
+                    ctx.HoistedCompactRecordParameters[parameterName] =
+                        entry with { IsExact = true };
+                }
+
+                EmitArrowExpressionReturn(
+                    il, emitter, arrow.ExpressionBody, arrowReturnType);
+
+                il.MarkLabel(fallback);
+                ctx.HoistedCompactRecordMaterializationGuards.Clear();
+                foreach (string parameterName in exactRecordFastBranchParameters)
+                {
+                    HoistedCompactRecordEntry entry =
+                        ctx.HoistedCompactRecordParameters[parameterName];
+                    ctx.HoistedCompactRecordParameters[parameterName] =
+                        entry with { IsExact = false };
+                }
+            }
+
+            EmitArrowExpressionReturn(
+                il, emitter, arrow.ExpressionBody, arrowReturnType);
         }
         else if (arrow.BlockBody != null)
         {
@@ -1818,4 +1901,70 @@ public partial class ILCompiler
         }
 
     }
+
+    private void EmitArrowExpressionReturn(
+        ILGenerator il,
+        ILEmitter emitter,
+        Expr expression,
+        Type arrowReturnType)
+    {
+        emitter.EmitExpression(expression);
+
+        if (arrowReturnType == _types.Object)
+        {
+            emitter.EmitBoxIfNeeded(expression);
+        }
+        else if (_types.IsDouble(arrowReturnType))
+        {
+            emitter.EnsureDouble();
+        }
+        else if (_types.IsBoolean(arrowReturnType))
+        {
+            emitter.EnsureBoolean();
+        }
+
+        il.Emit(OpCodes.Ret);
+    }
+
+    private bool TryGetArrowParameterRecordShape(
+        Expr expression,
+        string parameterName,
+        out JsonSerializationShape.Record shape,
+        out bool requiresMaterializationGuard)
+    {
+        shape = null!;
+        requiresMaterializationGuard = false;
+        Expr.Variable? receiver = expression switch
+        {
+            Expr.Get { Object: Expr.Variable variable }
+                when variable.Name.Lexeme == parameterName => variable,
+            Expr.Binary binary =>
+                FindArrowParameterReceiver(binary.Left, parameterName) ??
+                FindArrowParameterReceiver(binary.Right, parameterName),
+            Expr.Grouping grouping =>
+                FindArrowParameterReceiver(grouping.Expression, parameterName),
+            _ => null
+        };
+
+        if (receiver is null || _typeMap?.Get(receiver) is not { } receiverType)
+            return false;
+
+        requiresMaterializationGuard =
+            receiverType is TypeSystem.TypeInfo.Interface;
+        return TryGetCompactRecordShape(receiverType, out shape);
+    }
+
+    private static Expr.Variable? FindArrowParameterReceiver(
+        Expr expression,
+        string parameterName) => expression switch
+    {
+        Expr.Get { Object: Expr.Variable variable }
+            when variable.Name.Lexeme == parameterName => variable,
+        Expr.Binary binary =>
+            FindArrowParameterReceiver(binary.Left, parameterName) ??
+            FindArrowParameterReceiver(binary.Right, parameterName),
+        Expr.Grouping grouping =>
+            FindArrowParameterReceiver(grouping.Expression, parameterName),
+        _ => null
+    };
 }

--- a/src/SharpTS/Compilation/ILCompiler.Functions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Functions.cs
@@ -603,9 +603,29 @@ public partial class ILCompiler
 
     }
 
-    private static bool TryGetCompactRecordShape(
+    internal static bool TryGetCompactRecordShape(
         SharpTS.TypeSystem.TypeInfo type, out JsonSerializationShape.Record shape)
     {
+        if (type is SharpTS.TypeSystem.TypeInfo.Interface interfaceType &&
+            interfaceType.Extends is not { Count: > 0 })
+        {
+            var recordView = new SharpTS.TypeSystem.TypeInfo.Record(
+                interfaceType.Members,
+                interfaceType.StringIndexType,
+                interfaceType.NumberIndexType,
+                interfaceType.SymbolIndexType,
+                interfaceType.OptionalMembers,
+                CallSignatures: interfaceType.CallSignatures,
+                ConstructorSignatures: interfaceType.ConstructorSignatures,
+                MethodMembers: interfaceType.MethodMembers);
+            if (JsonSerializationShapeAnalyzer.TryAnalyze(recordView, out var interfaceAnalyzed) &&
+                interfaceAnalyzed is JsonSerializationShape.Record interfaceShape)
+            {
+                shape = interfaceShape;
+                return true;
+            }
+        }
+
         if (type is SharpTS.TypeSystem.TypeInfo.Record record &&
             JsonSerializationShapeAnalyzer.TryAnalyze(record, out var analyzed) &&
             analyzed is JsonSerializationShape.Record direct)

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -611,12 +611,14 @@ public partial class ILEmitter
             !_ctx.HoistedCompactRecordParameters.TryGetValue(
                 receiver.Name.Lexeme, out var hoisted) ||
             !hoisted.IsExact ||
-            _ctx.TypeMap?.Get(g.Object) is not TypeInfo.Record narrowedRecord ||
-            _ctx.RuntimeFeatures?.CanAssumeCompactObjectRecordIsUnmaterialized(
-                hoisted.Fingerprint) != true ||
-            _ctx.RuntimeFeatures.UsesDynamicPropertyDescriptors ||
-            !JsonSerializationShapeAnalyzer.TryAnalyze(narrowedRecord, out var analyzed) ||
-            analyzed is not JsonSerializationShape.Record recordShape ||
+            _ctx.TypeMap?.Get(g.Object) is not { } narrowedRecord ||
+            _ctx.RuntimeFeatures is not { } features ||
+            (!features.CanAssumeCompactObjectRecordIsUnmaterialized(
+                hoisted.Fingerprint) &&
+                !_ctx.HoistedCompactRecordMaterializationGuards.Contains(
+                    hoisted.Fingerprint)) ||
+            features.UsesDynamicPropertyDescriptors ||
+            !ILCompiler.TryGetCompactRecordShape(narrowedRecord, out var recordShape) ||
             JsonSerializationShapeAnalyzer.Fingerprint(recordShape) != hoisted.Fingerprint)
             return false;
 

--- a/src/SharpTS/Compilation/ParameterAssignmentAnalyzer.cs
+++ b/src/SharpTS/Compilation/ParameterAssignmentAnalyzer.cs
@@ -13,6 +13,13 @@ internal static class ParameterAssignmentAnalyzer
         return visitor.Assigned;
     }
 
+    public static HashSet<string> FindAssigned(Expr expression)
+    {
+        var visitor = new AssignmentVisitor();
+        visitor.Visit(expression);
+        return visitor.Assigned;
+    }
+
     private sealed class AssignmentVisitor : AstVisitorBase
     {
         public HashSet<string> Assigned { get; } = new(StringComparer.Ordinal);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Mutators.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Mutators.cs
@@ -1752,6 +1752,30 @@ public partial class RuntimeEmitter
         il.MarkLabel(frozenLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ret);
+
+        var numericComparatorType = typeof(Func<object, object, double>);
+        var numericMethod = typeBuilder.DefineMethod(
+            "ArraySortDirectNumber",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.ListOfObject,
+            [_types.ListOfObject, numericComparatorType]);
+        runtime.ArraySortDirectNumber = numericMethod;
+
+        il = numericMethod.GetILGenerator();
+        frozenLabel = il.DefineLabel();
+        EmitArrayFrozenSealedCheck(
+            il, runtime, frozenLabel,
+            checkSealed: false, checkExtensible: false);
+
+        EmitSortBody(
+            il, runtime,
+            mutateInPlace: true,
+            directComparator: true,
+            numericDirectComparator: true);
+
+        il.MarkLabel(frozenLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ret);
     }
 
     /// <summary>
@@ -2018,7 +2042,8 @@ public partial class RuntimeEmitter
         ILGenerator il,
         EmittedRuntime runtime,
         bool mutateInPlace,
-        bool directComparator = false)
+        bool directComparator = false,
+        bool numericDirectComparator = false)
     {
         var listLocal = il.DeclareLocal(_types.ListOfObject);
         il.Emit(OpCodes.Ldarg_0);
@@ -2027,7 +2052,8 @@ public partial class RuntimeEmitter
         EmitSortBodyOnLocal(
             il, runtime, listLocal,
             observeProperties: mutateInPlace,
-            directComparator: directComparator);
+            directComparator: directComparator,
+            numericDirectComparator: numericDirectComparator);
     }
 
     /// <summary>
@@ -2039,7 +2065,8 @@ public partial class RuntimeEmitter
         EmittedRuntime runtime,
         LocalBuilder listLocal,
         bool observeProperties,
-        bool directComparator)
+        bool directComparator,
+        bool numericDirectComparator = false)
     {
         // JavaScript sort algorithm:
         // 1. Partition: separate defined values from undefined values
@@ -2251,6 +2278,7 @@ public partial class RuntimeEmitter
         var widthDouble = il.DefineLabel();
         var mergeCond = il.DefineLabel();
         var mergeBody = il.DefineLabel();
+        var takeLeft = il.DefineLabel();
         var takeRight = il.DefineLabel();
         var afterTake = il.DefineLabel();
         var drainLeftCond = il.DefineLabel();
@@ -2322,7 +2350,26 @@ public partial class RuntimeEmitter
 
         var checkCompareResult = il.DefineLabel();
 
-        if (directComparator)
+        if (numericDirectComparator)
+        {
+            // A numeric-returning typed adapter keeps the comparator result as
+            // an unboxed double through the merge loop. The merge only needs to
+            // distinguish positive from non-positive; bgt is false for NaN, so
+            // it also preserves JavaScript's NaN-as-zero stable-sort behavior.
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldloc, srcLocal);
+            il.Emit(OpCodes.Ldloc, iLocal);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Ldloc, srcLocal);
+            il.Emit(OpCodes.Ldloc, jLocal);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Callvirt,
+                typeof(Func<object, object, double>).GetMethod("Invoke")!);
+            il.Emit(OpCodes.Ldc_R8, 0.0);
+            il.Emit(OpCodes.Bgt, takeRight);
+            il.Emit(OpCodes.Br, takeLeft);
+        }
+        else if (directComparator)
         {
             // A statically resolved arrow comparator is already represented as a
             // Func<object, object, object>. Call it directly so every comparison
@@ -2439,6 +2486,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Bgt, takeRight);
 
+        il.MarkLabel(takeLeft);
         // dst[k] = src[i]; i++
         il.Emit(OpCodes.Ldloc, dstLocal);
         il.Emit(OpCodes.Ldloc, kLocal);

--- a/tests/SharpTS.Tests/CompilerTests/ArraySortDirectComparatorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/ArraySortDirectComparatorTests.cs
@@ -15,11 +15,22 @@ namespace SharpTS.Tests.CompilerTests;
 public sealed class ArraySortDirectComparatorTests
 {
     [Fact]
-    public void StableAnnotatedArrow_UsesDirectHelper_WhileDynamicComparatorDoesNot()
+    public void StableNumericArrow_UsesUnboxedHelper_WhileObjectAndDynamicComparatorsDoNot()
     {
         Assembly assembly = Compile("""
             function sortStable(values: number[]): number[] {
                 values.sort((a: number, b: number): number => a - b);
+                return values;
+            }
+
+            const stableCompare = (a: number, b: number): number => a - b;
+            function sortConst(values: number[]): number[] {
+                values.sort(stableCompare);
+                return values;
+            }
+
+            function sortObject(values: any[]): any[] {
+                values.sort((a: any, b: any): any => a.rank - b.rank);
                 return values;
             }
 
@@ -32,13 +43,100 @@ public sealed class ArraySortDirectComparatorTests
             }
             """);
 
+        Assembly recordAssembly = Compile("""
+            interface Item { rank: number; label: string; }
+            const sample: Item = { rank: 1, label: "sample" };
+
+            function sortRecords(values: Item[]): Item[] {
+                values.sort((a: Item, b: Item): number => a.rank - b.rank);
+                return values;
+            }
+            """);
+
         MethodInfo stable = FindFunction(assembly, "sortStable");
+        MethodInfo constBound = FindFunction(assembly, "sortConst");
+        MethodInfo records = FindFunction(recordAssembly, "sortRecords");
+        MethodInfo objectReturning = FindFunction(assembly, "sortObject");
         MethodInfo dynamic = FindFunction(assembly, "sortDynamic");
 
-        Assert.Contains(CalledMethods(stable), method => method.Name == "ArraySortDirect");
+        Assert.Contains(CalledMethods(stable), method => method.Name == "ArraySortDirectNumber");
+        Assert.DoesNotContain(CalledMethods(stable), method => method.Name == "ArraySortDirect");
         Assert.DoesNotContain(CalledMethods(stable), method => method.Name == "ArraySort");
+        Assert.Contains(CalledMethods(constBound), method => method.Name == "ArraySortDirectNumber");
+        Assert.Contains(CalledMethods(records), method => method.Name == "ArraySortDirectNumber");
+        Assert.Contains(CalledMethods(objectReturning), method => method.Name == "ArraySortDirect");
+        Assert.DoesNotContain(CalledMethods(objectReturning), method => method.Name == "ArraySortDirectNumber");
         Assert.Contains(CalledMethods(dynamic), method => method.Name == "ArraySort");
         Assert.DoesNotContain(CalledMethods(dynamic), method => method.Name == "ArraySortDirect");
+        Assert.DoesNotContain(CalledMethods(dynamic), method => method.Name == "ArraySortDirectNumber");
+
+        MethodInfo[] adapters = assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Where(method => method.Name.Contains("$nbox2", StringComparison.Ordinal))
+            .ToArray();
+        Assert.NotEmpty(adapters);
+        Assert.All(adapters, adapter =>
+        {
+            Assert.Equal(typeof(double), adapter.ReturnType);
+            Assert.DoesNotContain(Instructions(adapter), instruction =>
+                instruction.OpCode == OpCodes.Box &&
+                instruction.Operand is Type type && type == typeof(double));
+        });
+
+        var programMethods = recordAssembly.GetType("$Program")!
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .ToArray();
+        MethodInfo[] recordArrows = programMethods
+            .Where(method => Instructions(method).Any(instruction =>
+                instruction.OpCode == OpCodes.Ldfld &&
+                instruction.Operand is FieldInfo field &&
+                field.DeclaringType?.Name.StartsWith(
+                    "$CompactObjectRecord", StringComparison.Ordinal) == true))
+            .ToArray();
+        Assert.True(recordArrows.Length == 1,
+            "Expected one compact-record arrow; types were: " +
+            string.Join(", ", recordAssembly.GetTypes().Select(type => type.Name)) +
+            "; fields were: " +
+            string.Join(", ", programMethods.SelectMany(method =>
+                Instructions(method)
+                    .Where(instruction => instruction.Operand is FieldInfo)
+                    .Select(instruction =>
+                        $"{method.Name}:{((FieldInfo)instruction.Operand!).DeclaringType?.Name}.{((FieldInfo)instruction.Operand!).Name}"))));
+        Assert.Equal(typeof(double), recordArrows[0].ReturnType);
+    }
+
+    [Fact]
+    public void StableNumericArrow_DoesNotAllocateABoxPerComparison()
+    {
+        Assembly assembly = Compile("""
+            function sortStable(values: number[]): number {
+                values.sort((a: number, b: number): number => a - b);
+                return values[0];
+            }
+            """);
+        var sort = FindFunction(assembly, "sortStable")
+            .CreateDelegate<Func<List<object>, double>>();
+
+        sort([2.0, 1.0]);
+        var values = new List<object>(10_000);
+        long state = 123456789;
+        for (int i = 0; i < 10_000; i++)
+        {
+            state = state * 48271 % 2147483647;
+            values.Add((double)state);
+        }
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        double first = sort(values);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.True(first > 0);
+        Assert.True(
+            allocated <= 750_000,
+            $"Stable numeric sort allocated {allocated:N0} bytes; comparator results may be boxed.");
     }
 
     private static Assembly Compile(string source)
@@ -57,6 +155,11 @@ public sealed class ArraySortDirectComparatorTests
             .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
 
     private static IEnumerable<MethodBase> CalledMethods(MethodInfo method)
+        => Instructions(method)
+            .Where(instruction => instruction.Operand is MethodBase)
+            .Select(instruction => (MethodBase)instruction.Operand!);
+
+    private static IEnumerable<(OpCode OpCode, object? Operand)> Instructions(MethodInfo method)
     {
         byte[] il = method.GetMethodBody()?.GetILAsByteArray()
             ?? throw new InvalidOperationException(
@@ -74,9 +177,23 @@ public sealed class ArraySortDirectComparatorTests
             if (opCode.OperandType == OperandType.InlineMethod)
             {
                 int token = BitConverter.ToInt32(il, offset);
-                yield return module.ResolveMethod(token)
+                yield return (opCode, module.ResolveMethod(token)
                     ?? throw new InvalidOperationException(
-                        $"Could not resolve method token {token}.");
+                        $"Could not resolve method token {token}."));
+            }
+            else if (opCode.OperandType == OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                yield return (opCode, module.ResolveType(token));
+            }
+            else if (opCode.OperandType == OperandType.InlineField)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                yield return (opCode, module.ResolveField(token));
+            }
+            else
+            {
+                yield return (opCode, null);
             }
 
             int operandSize = opCode.OperandType switch

--- a/tests/SharpTS.Tests/SharedTests/ArraySortTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/ArraySortTests.cs
@@ -116,6 +116,88 @@ public class ArraySortTests
     }
 
     [Theory, ModeData]
+    public void Array_Sort_CompactRecordComparator_ObservesMaterializedWrites(
+        ExecutionMode mode)
+    {
+        var source = """
+            interface Item { key: number; tag: string; }
+            let high: Item = { key: 2, tag: "high" };
+            let low: Item = { key: 1, tag: "low" };
+            high.key = 0;
+            let items: Item[] = [low, high];
+            items.sort((left: Item, right: Item): number => left.key - right.key);
+            console.log(items[0].tag + "," + items[1].tag);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("high,low\n", output);
+    }
+
+    [Theory, ModeData]
+    public void Array_Sort_InlineRecordComparator_ObservesMaterializedWrites(
+        ExecutionMode mode)
+    {
+        var source = """
+            let high: { key: number; tag: string } = { key: 2, tag: "high" };
+            let low: { key: number; tag: string } = { key: 1, tag: "low" };
+            high.key = 0;
+            let items: { key: number; tag: string }[] = [low, high];
+            items.sort((
+                left: { key: number; tag: string },
+                right: { key: number; tag: string }
+            ): number => left.key - right.key);
+            console.log(items[0].tag + "," + items[1].tag);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("high,low\n", output);
+    }
+
+    [Theory, ModeData]
+    public void Array_Sort_CompactRecordComparator_FallsBackForOtherRuntimeTypes(
+        ExecutionMode mode)
+    {
+        var source = """
+            interface Item { key: number; tag: string; }
+            class Box {
+                key: number;
+                tag: string;
+                constructor(key: number, tag: string) {
+                    this.key = key;
+                    this.tag = tag;
+                }
+            }
+            let items: Item[] = [new Box(2, "high"), new Box(1, "low")];
+            items.sort((left: Item, right: Item): number => left.key - right.key);
+            console.log(items[0].tag + "," + items[1].tag);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("low,high\n", output);
+    }
+
+    [Theory, ModeData]
+    public void Array_Sort_CompactRecordComparator_ObservesPropertyDescriptors(
+        ExecutionMode mode)
+    {
+        var source = """
+            interface Item { key: number; tag: string; }
+            let high: Item = { key: 2, tag: "high" };
+            let low: Item = { key: 1, tag: "low" };
+            Object.defineProperty(high, "key", {
+                get(): number { return 0; },
+                configurable: true
+            });
+            let items: Item[] = [low, high];
+            items.sort((left: Item, right: Item): number => left.key - right.key);
+            console.log(items[0].tag + "," + items[1].tag);
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("high,low\n", output);
+    }
+
+    [Theory, ModeData]
     public void Array_Sort_SimplePropertyComparator_PreservesObservableGets(
         ExecutionMode mode)
     {


### PR DESCRIPTION
Closes #1423.

## What changed

- lower proven numeric-returning sort comparator arrows through `Func<object, object, double>` and a dedicated emitted helper, keeping comparator results unboxed
- reduce the numeric comparator result directly to the merge decision (`result > 0`), preserving NaN-as-zero and stable left selection
- emit a guarded exact compact-record branch for numeric expression arrows so stable record comparators can load fields directly
- retain the existing object-returning and fully dynamic callable paths
- fall back for materialized compact records, mismatched runtime types, dynamic property descriptors, and other unproven shapes

## Evidence

Faithful `ArraySortBenchmarks`, N=10,000 (post-#1421 baseline -> this PR):

| Case | Time | Allocated |
|---|---:|---:|
| SortNumbers | 3.921 ms -> 2.519 ms | 4,183.26 KB -> 1,285.33 KB |
| SortRecords | 11.150 ms -> 10.127 ms | 4,183.55 KB -> 1,285.09 KB |
| Combined | 15.452 ms -> 12.579 ms (**18.6% faster**) | 8,366.76 KB -> 2,570.67 KB |

The exact cross-runtime harness remains checksum-clean. Its short process-level N=10,000 samples were highly variable (individual compiled means 9.20-20.46 ms with large reported standard deviations), so #1423 uses the stable in-process acceptance measurement and reports those black-box samples as informational rather than selecting a favorable run. Three interpreter means had a 29.6803 ms median; three Node means had a 3.5539 ms median.

## Validation

- `dotnet test tests/SharpTS.Tests/SharpTS.Tests.csproj -c Release --no-restore --filter ArraySort --nologo` — 73 passed
- `dotnet build SharpTS.sln -c Release --nologo -p:NuGetAudit=false --no-restore` — clean, zero warnings, both IL verification passes
- full core suite — 17,065 passed, 3 skipped, 1 unrelated promise timing failure; the sole failure passed immediately in isolation
- structural IL assertions cover numeric helper selection, absence of `box double`, compact-record field loads, and unchanged object/dynamic dispatch
- runtime parity covers materialized named and inline records, alternate runtime types, and property descriptors in interpreted and compiled modes
