### PR TITLE
Perf: preserve typed compact records through stable array push

### DIFF
--- a/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
@@ -334,7 +334,8 @@ public partial class ILEmitter
 
         string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(record);
         if (!_ctx.RuntimeFeatures.CanAssumeCompactObjectRecordIsUnmaterialized(
-                fingerprint))
+                fingerprint) &&
+            !_ctx.RuntimeFeatures.CompactObjectRecordStablePushLiterals.Contains(literal))
             return false;
 
         if (!_ctx.Runtime!.CompactObjectRecordCtors.TryGetValue(

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -513,6 +513,8 @@ public partial class ILEmitter
                 }
                 IL.Emit(OpCodes.Ldloc, exactLocal);
                 IL.Emit(OpCodes.Ldfld, exactValueField);
+                if (exactValueField.FieldType.IsValueType)
+                    IL.Emit(OpCodes.Box, exactValueField.FieldType);
                 IL.Emit(OpCodes.Br, endLabel);
             }
             else if (scalarIndex >= 0 &&

--- a/src/SharpTS/Compilation/RuntimeEmitter.CompactObjectRecord.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.CompactObjectRecord.cs
@@ -32,6 +32,8 @@ public partial class RuntimeEmitter
             JsonSerializationShape.Record shape = pair.Value;
             if (shape.Fields.Count is < 1 or > 4)
                 continue;
+            bool specializeStablePushScalars =
+                _features.CompactObjectRecordStablePushShapes.Contains(fingerprint);
 
             var typeBuilder = EmitTypeDefinitions.DefineType(
                 moduleBuilder,
@@ -44,12 +46,14 @@ public partial class RuntimeEmitter
                 typeBuilder, runtime.CompactObjectRecordInterface);
             runtime.CompactObjectRecordTypes.Add(fingerprint, typeBuilder);
 
-            var valueFields = shape.Fields.Select((_, index) =>
+            var valueFields = shape.Fields.Select((field, index) =>
                 typeBuilder.DefineField(
                     $"_v{index}",
                     _features.CompactObjectRecordSelfFields.Contains((fingerprint, index))
                         ? typeBuilder
-                        : _types.Object,
+                        : specializeStablePushScalars
+                            ? GetJsonScalarRecordFieldType(field.Value)
+                            : _types.Object,
                     FieldAttributes.Assembly)).ToArray();
             Type weakTableType = _types.MakeGenericType(
                 _types.ConditionalWeakTableOpen, _types.Object, _types.DictionaryStringObject);
@@ -164,6 +168,8 @@ public partial class RuntimeEmitter
                     il.Emit(OpCodes.Ldstr, shape.Fields[index].Key);
                     il.Emit(OpCodes.Ldarg_0);
                     il.Emit(OpCodes.Ldfld, valueFields[index]);
+                    if (valueFields[index].FieldType.IsValueType)
+                        il.Emit(OpCodes.Box, valueFields[index].FieldType);
                     il.Emit(OpCodes.Callvirt, dictSet);
                 }
                 il.Emit(OpCodes.Ldsfld, materializedTable);
@@ -209,6 +215,8 @@ public partial class RuntimeEmitter
                     il.Emit(OpCodes.Brfalse_S, next);
                     il.Emit(OpCodes.Ldarg_0);
                     il.Emit(OpCodes.Ldfld, valueFields[index]);
+                    if (valueFields[index].FieldType.IsValueType)
+                        il.Emit(OpCodes.Box, valueFields[index].FieldType);
                     il.Emit(OpCodes.Ret);
                     il.MarkLabel(next);
                 }

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -102,6 +102,16 @@ public sealed class RuntimeFeatureDetector
         foreach (var stmt in statements)
             VisitStmt(stmt);
 
+        // The emitter selects the discarded one-element push intrinsic only
+        // while both of these whole-program guards remain clear. Keep literal
+        // eligibility synchronized with that exact boundary even when the
+        // observable mutation appears later in source order.
+        if (_set.UsesDynamicPropertyDescriptors || _set.UsesArrayPrototypeMutation)
+        {
+            _set.CompactObjectRecordStablePushLiterals.Clear();
+            _set.CompactObjectRecordStablePushShapes.Clear();
+        }
+
         // Implications between feature flags (one feature pulls in another's
         // emit machinery). Applied after the walk so flags-set-by-trigger
         // can cascade once.
@@ -591,6 +601,7 @@ public sealed class RuntimeFeatureDetector
                 break;
 
             case Stmt.Expression es:
+                MarkStableDiscardedArrayPushLiteral(es.Expr);
                 VisitExpr(es.Expr);
                 break;
 
@@ -1107,6 +1118,8 @@ public sealed class RuntimeFeatureDetector
                         string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(compactShape);
                         shapes.Add(fingerprint);
                         _set.CompactObjectRecordShapes.TryAdd(fingerprint, compactShape);
+                        if (_set.CompactObjectRecordStablePushLiterals.Contains(ol))
+                            _set.CompactObjectRecordStablePushShapes.Add(fingerprint);
                         AnalyzeCompactRecordSelfFields(ol, compactShape, fingerprint);
                     }
                 }
@@ -1280,6 +1293,24 @@ public sealed class RuntimeFeatureDetector
         }
 
         return _typeMap is null || _typeMap.Get(expr) is TypeInfo.Array;
+    }
+
+    private void MarkStableDiscardedArrayPushLiteral(Expr expression)
+    {
+        if (_typeMap is null || expression is not Expr.Call
+            {
+                Optional: false,
+                Callee: Expr.Get
+                {
+                    Optional: false,
+                    Object: { } receiver,
+                    Name.Lexeme: "push"
+                },
+                Arguments: [Expr.ObjectLiteral literal]
+            } || _typeMap.Get(receiver) is not TypeInfo.Array)
+            return;
+
+        _set.CompactObjectRecordStablePushLiterals.Add(literal);
     }
 
     private void MarkMutationOperand(Expr operand)

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -1,3 +1,5 @@
+using SharpTS.Parsing;
+
 namespace SharpTS.Compilation;
 
 /// <summary>
@@ -39,6 +41,22 @@ public sealed class RuntimeFeatureSet
     internal Dictionary<int, HashSet<string>> CompactObjectRecordShapeFingerprints { get; } = [];
 
     internal Dictionary<string, JsonSerializationShape.Record> CompactObjectRecordShapes { get; } = [];
+
+    /// <summary>
+    /// Object literals stored by the same guarded, discarded-result array-push
+    /// intrinsic used by the IL emitter. These literals may use their compact
+    /// carrier even though the conservative call-escape analysis keeps the
+    /// shape's materialization guard enabled.
+    /// </summary>
+    internal HashSet<Expr.ObjectLiteral> CompactObjectRecordStablePushLiterals { get; } =
+        new(ReferenceEqualityComparer.Instance);
+
+    /// <summary>
+    /// Compact-record shapes used by at least one stable discarded array push.
+    /// Only these shapes specialize scalar slots to native CLR field types.
+    /// </summary>
+    internal HashSet<string> CompactObjectRecordStablePushShapes { get; } =
+        new(StringComparer.Ordinal);
 
     /// <summary>
     /// Generic-looking compact-record slots whose literal initializers prove that the

--- a/tests/SharpTS.Tests/CompilerTests/ArraySortDirectComparatorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/ArraySortDirectComparatorTests.cs
@@ -15,6 +15,73 @@ namespace SharpTS.Tests.CompilerTests;
 public sealed class ArraySortDirectComparatorTests
 {
     [Fact]
+    public void BenchmarkRecordPush_PreservesTypedCompactCarrierAndComparatorLoads()
+    {
+        Assembly assembly = Compile("""
+            function makeRecords(n: number): { key: number; tag: string }[] {
+                const out: { key: number; tag: string }[] = [];
+                let state: number = 987654321;
+                for (let i: number = 0; i < n; i++) {
+                    state = (state * 48271) % 2147483647;
+                    out.push({ key: state, tag: "t" + (state % 1000) });
+                }
+                return out;
+            }
+
+            function sortRecords(src: { key: number; tag: string }[]): number {
+                const c = src.slice();
+                c.sort((a: { key: number; tag: string }, b: { key: number; tag: string }): number => a.key - b.key);
+                return c[0].key;
+            }
+            """);
+
+        MethodInfo makeRecords = FindFunction(assembly, "makeRecords");
+        var records = Assert.IsAssignableFrom<List<object>>(
+            makeRecords.Invoke(null, [32.0]));
+        Type carrier = records[0].GetType();
+        MethodInfo sortRecords = FindFunction(assembly, "sortRecords");
+        MethodInfo arrow = assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.StartsWith("<>Arrow_", StringComparison.Ordinal) &&
+                !method.Name.Contains('$'));
+
+        Assert.StartsWith("$CompactObjectRecord", carrier.Name, StringComparison.Ordinal);
+        Assert.Equal(
+            [typeof(double), typeof(string)],
+            carrier.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(field => field.Name.StartsWith("_v", StringComparison.Ordinal))
+                .Select(field => field.FieldType)
+                .ToArray());
+        Assert.Contains(CalledMethods(sortRecords), method =>
+            method.Name == "ArraySortDirectNumber");
+        Assert.Contains(Instructions(arrow), instruction =>
+            instruction.OpCode == OpCodes.Ldfld &&
+            instruction.Operand is FieldInfo { FieldType: { } fieldType } &&
+            fieldType == typeof(double));
+        Assert.Equal(2, CalledMethods(arrow).Count(method =>
+            method.Name == "ConvertToNumber"));
+
+        double first = Assert.IsType<double>(sortRecords.Invoke(null, [records]));
+        Assert.True(first > 0);
+    }
+
+    [Fact]
+    public void ObservedPushResult_RetainsOrdinaryRecordLiteral()
+    {
+        Assembly assembly = Compile("""
+            type Item = { key: number; tag: string };
+            function makeRecord(): Item {
+                const items: Item[] = [];
+                const length = items.push({ key: 1, tag: "x" });
+                return items[length - 1];
+            }
+            """);
+
+        object record = FindFunction(assembly, "makeRecord").Invoke(null, [])!;
+        Assert.IsType<Dictionary<string, object>>(record);
+    }
+
+    [Fact]
     public void StableNumericArrow_UsesUnboxedHelper_WhileObjectAndDynamicComparatorsDoNot()
     {
         Assembly assembly = Compile("""

--- a/tests/SharpTS.Tests/CompilerTests/CompactObjectRecordTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/CompactObjectRecordTests.cs
@@ -108,6 +108,41 @@ public sealed class CompactObjectRecordTests
     }
 
     [Fact]
+    public void StableArrayStoredScalarRecord_BoxesOnlyAtGenericMaterializationBoundary()
+    {
+        const string source = """
+            type Item = { count: number; enabled: boolean; label: string };
+
+            function exercise(): string {
+                const items: Item[] = [];
+                items.push({ count: 1, enabled: true, label: "before" });
+                const value: any = items[0];
+                const before = value.count + ":" + value.enabled + ":" + value.label;
+                value.count = 7;
+                value.enabled = false;
+                value.label = "after";
+                return before + "|" + value.count + ":" + value.enabled + ":" + value.label;
+            }
+
+            console.log(exercise());
+            """;
+
+        Assembly assembly = Compile(source);
+        Type carrier = assembly.GetTypes().Single(type =>
+            type.Name.StartsWith("$CompactObjectRecord", StringComparison.Ordinal));
+        Assert.Equal(
+            [typeof(double), typeof(bool), typeof(string)],
+            carrier.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+                .Where(field => field.Name.StartsWith("_v", StringComparison.Ordinal))
+                .Select(field => field.FieldType)
+                .ToArray());
+        Assert.Equal(
+            "1:true:before|7:false:after\n",
+            TestHarness.RunCompiled(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    [Fact]
     public void SameArityDifferentShapesRemainDistinct()
     {
         const string source = """

--- a/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
@@ -8,6 +8,36 @@ namespace SharpTS.Tests.CompilerTests;
 public class RuntimeFeatureDetectorTests
 {
     [Theory]
+    [InlineData("", true)]
+    [InlineData("const observed: number = items.push({ key: 2, tag: 'y' });", true)]
+    [InlineData("Object.defineProperty([], '0', { value: 1 });", false)]
+    [InlineData("const prototype = Array.prototype;", false)]
+    public void StableDiscardedArrayPush_TracksCompactLiteralEligibility(
+        string extra,
+        bool expectedEligible)
+    {
+        string source = $$"""
+            type Item = { key: number; tag: string };
+            const items: Item[] = [];
+            items.push({ key: 1, tag: "x" });
+            {{extra}}
+            """;
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var features = new RuntimeFeatureDetector().Detect(statements, typeMap);
+
+        Assert.Equal(
+            expectedEligible,
+            features.CompactObjectRecordStablePushLiterals.Count == 1);
+        Assert.Equal(
+            expectedEligible,
+            features.CompactObjectRecordStablePushShapes.Count == 1);
+        var shape = features.CompactObjectRecordShapes.Single(pair =>
+            pair.Value.Fields.Any(field => field.Key == "key"));
+        Assert.False(features.CanAssumeCompactObjectRecordIsUnmaterialized(shape.Key));
+    }
+
+    [Theory]
     [InlineData("const value = { x: 1 }; JSON.stringify(value);", 1)]
     [InlineData("const value = { x: 1 }; JSON.stringify(value, null, 2);", 0)]
     [InlineData("const value = { x: 1 }; const stringify = JSON.stringify; stringify(value);", 0)]


### PR DESCRIPTION
## Summary

- recognize the exact guarded `array.push({ ... })` form whose result is discarded and whose receiver is statically an Array
- preserve that literal as an exact compact-record carrier despite conservative call-escape marking
- specialize number, boolean, and string slots only for stable-push shapes, boxing at generic reads/materialization boundaries
- retain ordinary object emission for observed push results and disable the optimization when descriptor or Array-prototype mutation can affect semantics

Fixes #1425.

## Performance

Full cross-runtime sweep, `sort:10000`:

| | Compiled | Node | Compiled / Node |
|---|---:|---:|---:|
| merged HEAD | 9.2757 ms | 3.5684 ms | 2.60x |
| this PR | 4.2483 ms | 3.4922 ms | 1.22x |

Compiled time falls 54.2% and closes 84.4% of the prior excess over Node.

BenchmarkDotNet's record-sort phase falls from 10.127 ms to 2.883 ms (-71.5%), while allocations remain effectively unchanged (1285.09 KB vs 1285.18 KB). The combined sort benchmark falls from 12.579 ms to 5.656 ms (-55.0%).

## Verification

- Release build: clean, 0 warnings / 0 errors
- focused array-push / compact-record / direct-sort / feature-detector tests: 66/66
- compiler tests: 536/539; only sandboxed isolated-process failures (TLS certificate authentication and two child-exit detection timeouts whose stderr contains the expected exception)
- TypeScript conformance: 65/65
- full cross-runtime benchmark sweep: completed successfully
- compiled Test262 baseline: all 11,384 cases executed; the committed baseline currently reports broad pre-existing drift (42 regressions / 8 new passes). Representative Array, JSON, Object descriptor, and `defineProperty` failures reproduce identically on untouched parent `046b754d`.