### PR TITLE
Perf: eliminate discarded numeric indexed-write boxing

### DIFF
--- a/benchmarks/micro/SharpTS.Microbenchmarks/Baselines/NumericArrayWriteBaselines.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Baselines/NumericArrayWriteBaselines.cs
@@ -1,0 +1,32 @@
+namespace SharpTS.Microbenchmarks.Baselines;
+
+/// <summary>
+/// Direct ceiling and boxed-representation controls for the escaping
+/// <c>number[]</c> indexed-write workload.
+/// </summary>
+public static class NumericArrayWriteBaselines
+{
+    public static double Idiomatic(int n)
+    {
+        var values = new double[n];
+        for (int i = 0; i < n; i++)
+            values[i] = i * 3.0;
+
+        double sum = 0;
+        for (int i = 0; i < n; i++)
+            sum += values[i];
+        return sum;
+    }
+
+    public static double BoxedEquivalent(int n)
+    {
+        var values = new List<object?>(n);
+        for (int i = 0; i < n; i++)
+            values.Add(i * 3.0);
+
+        double sum = 0;
+        for (int i = 0; i < n; i++)
+            sum += (double)values[i]!;
+        return sum;
+    }
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/NumericArrayWriteBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/NumericArrayWriteBenchmarks.cs
@@ -1,0 +1,51 @@
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using SharpTS.Microbenchmarks.Baselines;
+using SharpTS.Microbenchmarks.Infrastructure;
+
+namespace SharpTS.Microbenchmarks.Benchmarks;
+
+/// <summary>
+/// Faithful in-process counterpart to cross-runtime <c>num-write</c>: an
+/// escaping <c>number[]</c> is grown by sequential index assignment through a
+/// helper, then read for a checksum.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class NumericArrayWriteBenchmarks
+{
+    private Func<double, double> _sharpTs = null!;
+
+    [Params(1_000_000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Assembly assembly = typeof(NumericArrayWriteBenchmarks).Assembly;
+        using Stream stream = assembly.GetManifestResourceStream(
+            "SharpTS.Microbenchmarks.TypeScriptSources.NumericArrayWrite.ts")
+            ?? throw new InvalidOperationException(
+                "Could not find embedded resource NumericArrayWrite.ts");
+        using var reader = new StreamReader(stream);
+        string dllPath = CompilationCache.GetOrCompile(
+            reader.ReadToEnd(), "NumericArrayWrite");
+        Assembly compiled = BenchmarkHarness.LoadCompiledAssembly(
+            dllPath, "numeric-array-write");
+        BenchmarkHarness.InitializeCompiledModules(compiled);
+        _sharpTs = BenchmarkHarness.GetCompiledNumberFunc(
+            compiled, "numericArrayWrite");
+    }
+
+    [Benchmark]
+    public double SharpTS() => _sharpTs(N);
+
+    [Benchmark(Baseline = true)]
+    public double IdiomaticCSharp() => NumericArrayWriteBaselines.Idiomatic(N);
+
+    [Benchmark]
+    public double BoxedEquivalentCSharp() =>
+        NumericArrayWriteBaselines.BoxedEquivalent(N);
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/NumericArrayWrite.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/NumericArrayWrite.ts
@@ -1,0 +1,15 @@
+function fillIndex(a: number[], n: number): void {
+    for (let i: number = 0; i < n; i++) {
+        a[i] = i * 3;
+    }
+}
+
+export function numericArrayWrite(n: number): number {
+    const a: number[] = [];
+    fillIndex(a, n);
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        sum = sum + a[i];
+    }
+    return sum;
+}

--- a/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -12,6 +12,13 @@ public partial class ILEmitter
 {
     protected override bool TryEmitDiscardedExpression(Expr expression)
     {
+        // A statement-position numeric index assignment has no result consumer.
+        // Own that narrow shape before the general expression emitter reloads
+        // and boxes the assigned double solely for Stmt.Expression to pop it.
+        if (expression is Expr.SetIndex setIndex
+            && TryEmitDiscardedNumberArraySetIndex(setIndex))
+            return true;
+
         if (expression is not Expr.Call
             {
                 Optional: false,

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -1293,6 +1293,105 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Call, _ctx.Runtime!.GetIndex);
     }
 
+    /// <summary>
+    /// Emits a stack-neutral statement-position write through a guarded numeric
+    /// <c>$Array</c>. The ordinary result-producing path must reload and box the
+    /// assigned double so arbitrary expression consumers see the JS assignment
+    /// value. A discarded expression has no such consumer, so this specialization
+    /// keeps the fast arm unboxed while retaining the guarded generic fallback
+    /// for non-<c>$Array</c> values passed through a cast. Loop-local receivers
+    /// reuse the existing hoisted guard; parameters use the same guard per write.
+    /// </summary>
+    private bool TryEmitDiscardedNumberArraySetIndex(Expr.SetIndex si)
+    {
+        if (_ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == true
+            || si.Object is not Expr.Variable arrayVariable)
+            return false;
+
+        var hoisted = _ctx.TryGetHoistedArray(arrayVariable.Name.Lexeme);
+        if (hoisted is not { Descriptor.Kind: ArrayElementsKind.Double }
+            && ArrayElements.Resolve(_ctx.TypeMap?.Get(si.Object)) is not
+                { Kind: ArrayElementsKind.Double })
+            return false;
+
+        // Parameters and captured bindings do not have a local eligible for the
+        // loop-preamble hoist. Spill those receivers once per write, preserving
+        // receiver-before-index-before-RHS evaluation, then guard the same
+        // $Array fast arm the ordinary result-producing emitter uses.
+        LocalBuilder? receiverLocal = null;
+        if (hoisted is null)
+        {
+            EmitExpression(si.Object);
+            EmitBoxIfNeeded(si.Object);
+            receiverLocal = IL.DeclareLocal(_ctx.Types.Object);
+            IL.Emit(OpCodes.Stloc, receiverLocal);
+        }
+
+        // Preserve reference evaluation order for the remaining operands:
+        // index before RHS. Keep the original numeric key as a double for the
+        // array-like fallback (3.5 must remain property "3.5" there); only the
+        // guarded $Array arm narrows it exactly as the ordinary fast path does.
+        EmitExpressionAsDouble(si.Index);
+        var indexLocal = IL.DeclareLocal(_ctx.Types.Double);
+        IL.Emit(OpCodes.Stloc, indexLocal);
+
+        EmitExpression(si.Value);
+        EnsureDouble();
+        var valueLocal = IL.DeclareLocal(_ctx.Types.Double);
+        IL.Emit(OpCodes.Stloc, valueLocal);
+
+        var fallbackLabel = IL.DefineLabel();
+        var endLabel = IL.DefineLabel();
+        if (hoisted is { } cached)
+        {
+            IL.Emit(OpCodes.Ldloc, cached.TypedLocal);
+            IL.Emit(OpCodes.Brfalse, fallbackLabel);
+            IL.Emit(OpCodes.Ldloc, cached.TypedLocal);
+        }
+        else
+        {
+            IL.Emit(OpCodes.Ldloc, receiverLocal!);
+            IL.Emit(OpCodes.Isinst, _ctx.Runtime!.TSArrayType);
+            IL.Emit(OpCodes.Brfalse, fallbackLabel);
+            IL.Emit(OpCodes.Ldloc, receiverLocal!);
+            IL.Emit(OpCodes.Castclass, _ctx.Runtime!.TSArrayType);
+        }
+        IL.Emit(OpCodes.Ldloc, indexLocal);
+        IL.Emit(OpCodes.Conv_I4);
+        IL.Emit(OpCodes.Ldloc, valueLocal);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArraySetDouble);
+        IL.Emit(OpCodes.Br, endLabel);
+
+        // A value asserted to number[] can still be an arbitrary array-like at
+        // runtime. Reuse the spec-complete setter on that guarded cold arm.
+        IL.MarkLabel(fallbackLabel);
+        if (receiverLocal != null)
+        {
+            IL.Emit(OpCodes.Ldloc, receiverLocal);
+        }
+        else
+        {
+            EmitExpression(si.Object);
+            EmitBoxIfNeeded(si.Object);
+        }
+        IL.Emit(OpCodes.Ldloc, indexLocal);
+        IL.Emit(OpCodes.Box, _ctx.Types.Double);
+        IL.Emit(OpCodes.Ldloc, valueLocal);
+        IL.Emit(OpCodes.Box, _ctx.Types.Double);
+        if (_ctx.IsStrictMode)
+        {
+            IL.Emit(OpCodes.Ldc_I4_1);
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.SetIndexStrict);
+        }
+        else
+        {
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.SetIndex);
+        }
+
+        IL.MarkLabel(endLabel);
+        return true;
+    }
+
     protected override void EmitSetIndex(Expr.SetIndex si)
     {
         if (TryResolveExternalReceiverType(si.Object, out var externalIndexerType) &&

--- a/tests/SharpTS.Tests/CompilerTests/DiscardedNumericArrayWriteTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/DiscardedNumericArrayWriteTests.cs
@@ -1,0 +1,209 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class DiscardedNumericArrayWriteTests
+{
+    [Fact]
+    public void StableLoopWrite_DoesNotMaterializeDiscardedAssignmentResult()
+    {
+        Assembly assembly = Compile("""
+            function fill(values: number[], n: number): void {
+                for (let i: number = 0; i < n; i++) {
+                    values[i] = i * 3;
+                }
+            }
+            """);
+
+        var instructions = ReadInstructions(FindFunction(assembly, "fill")).ToArray();
+        int setDouble = Array.FindIndex(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "SetDouble" });
+
+        Assert.True(setDouble >= 0, "Expected the numeric $Array SetDouble fast path.");
+        string following = string.Join(", ", instructions
+            .Skip(setDouble + 1)
+            .Take(5)
+            .Select(instruction => instruction.OpCode.Name));
+        Assert.True(
+            instructions[setDouble + 1].OpCode.FlowControl == FlowControl.Branch,
+            "The discarded assignment must branch directly after SetDouble instead of reloading and boxing its value. " +
+            $"Following IL: {following}");
+    }
+
+    [Fact]
+    public void ObservedAssignment_RetainsResultProducingPath()
+    {
+        Assembly assembly = Compile("""
+            function set(values: number[], index: number, value: number): number {
+                return values[index] = value;
+            }
+            """);
+
+        var instructions = ReadInstructions(FindFunction(assembly, "set")).ToArray();
+        int setDouble = Array.FindIndex(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "SetDouble" });
+        Assert.True(setDouble >= 0, "Expected the numeric $Array SetDouble fast path.");
+        Assert.StartsWith("ldloc", instructions[setDouble + 1].OpCode.Name);
+        Assert.Equal(OpCodes.Box, instructions[setDouble + 2].OpCode);
+        Assert.Equal(typeof(double), instructions[setDouble + 2].Operand);
+    }
+
+    [Fact]
+    public void DiscardedWrite_PreservesIndexBeforeValueEvaluation()
+    {
+        const string source = """
+            let trace: string = "";
+            function index(): number { trace = trace + "i"; return 0; }
+            function value(): number { trace = trace + "v"; return 7; }
+            function set(values: number[]): void {
+                values[index()] = value();
+            }
+            const values: number[] = [];
+            set(values);
+            console.log(trace, values[0]);
+            """;
+
+        Assert.Equal("iv 7\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void GenericFallback_PreservesFractionalPropertyKey()
+    {
+        const string source = """
+            function set(values: number[]): void {
+                values[3.5] = 7;
+            }
+            const receiver: any = {};
+            set(receiver as number[]);
+            console.log(receiver[3.5], receiver[3]);
+            """;
+
+        Assert.Equal("7 undefined\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void ObservableDescriptors_DisableDiscardedWriteIntrinsic()
+    {
+        Assembly assembly = Compile("""
+            Object.defineProperty([], '0', { value: 1 });
+            function fill(values: number[], n: number): void {
+                for (let i: number = 0; i < n; i++) {
+                    values[i] = i * 3;
+                }
+            }
+            """);
+
+        var instructions = ReadInstructions(FindFunction(assembly, "fill")).ToArray();
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "SetDouble" });
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "SetIndex" });
+    }
+
+    [Fact]
+    public void GuardFallback_PreservesArrayLikeReceiverWrites()
+    {
+        const string source = """
+            function fill(values: number[], n: number): void {
+                for (let i: number = 0; i < n; i++) {
+                    values[i] = i * 3;
+                }
+            }
+            const receiver: any = {};
+            fill(receiver as number[], 3);
+            console.log(receiver[0], receiver[1], receiver[2]);
+            """;
+
+        Assert.Equal("0 3 6\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void StableLoopWrite_PassesIlVerification()
+    {
+        const string source = """
+            function fill(values: number[], n: number): void {
+                for (let i: number = 0; i < n; i++) {
+                    values[i] = i * 3;
+                }
+            }
+            const values: number[] = [];
+            fill(values, 3);
+            console.log(values.join(','));
+            """;
+
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"issue_1427_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token)
+                    : module.ResolveType(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}


### PR DESCRIPTION
Closes #1427.

## Summary

- lower statement-position writes to statically numeric arrays through a stack-neutral guarded `SetDouble` path
- avoid reloading and boxing the assigned `double` solely for `Stmt.Expression` to pop it
- preserve observed assignment results, descriptor-sensitive programs, non-`$Array` fallbacks, fractional fallback keys, and index-before-value evaluation
- add a faithful BenchmarkDotNet workload with idiomatic and boxed C# controls

## Performance

Windows x64, .NET SDK 10.0.400/runtime 10.0.11, Node 24.19.0, N=1,000,000:

- controlled three-pair median: **17.9335 ms -> 11.6720 ms compiled** (-34.9%); Node was 9.0579 ms before and 10.1138 ms after, reducing the ratio from **1.98x to 1.15x**
- BenchmarkDotNet: **32.871 ms / 61.78 MB -> 20.550 ms / 38.89 MB** (-37.5% time, -22.89 MB allocation)
- full-corpus single sweep: **14.1076 ms compiled vs 10.5715 ms Node (1.33x)**; all 15 workloads completed in interpreter, compiled, and Node modes without harness or checksum failures

The allocation reduction is one boxed `double` per discarded indexed write. Remaining allocation belongs to checksum reads and geometric numeric backing-store growth, outside this write-side slice.

## Verification

- `DiscardedNumericArrayWriteTests`: 7/7
- core CI filter: 17,058 passed, 3 expected platform skips
- compiler-test slice: 545 passed; the isolated TLS certificate test requires the unsandboxed run and passes as part of core CI above
- TypeScript conformance: 65/65
- cross-runtime smoke: 15/15 workloads
- microbenchmark smoke: all sources and benchmark methods discovered/compiled
- full cross-runtime sweep: clean

### Existing Test262 baseline drift

The default Test262 run reports compiled baseline drift (42 regressions, 8 new passes). Targeted descriptor and array-search failures reproduce identically on merged `82f5b720` and pre-#1426 `046b754d`; they are not introduced by this branch. This PR adds no new path-level drift beyond that existing state.