### PR TITLE
Optimize one-byte typed-array accessors

### DIFF
--- a/src/SharpTS/Compilation/RuntimeEmitter.TSTypedArray.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSTypedArray.cs
@@ -754,16 +754,13 @@ public partial class RuntimeEmitter
 
     // double GetUnboxed(int index) / void SetUnboxed(int index, double value) on each concrete
     // numeric $XArray (#3, generalizing the Float64-only #878 path). They mirror the byte logic
-    // of the boxed Get/Set above but take/return a native `double` — no Box, no Convert.ToDouble
-    // coercion — reinterpreting over the byte[] backing store via Unsafe.Read/WriteUnaligned (no
-    // per-element allocation). The IL emitter binds them at statically-typed typed-array index
-    // sites, eliminating the GetIndex/SetIndex dispatch, the isinst ladder, and the per-element
-    // box on BOTH read and write. AggressiveInlining + a non-virtual `call` let the JIT fold them
-    // into the caller's loop and hoist the _buffer load / bounds check. The single ldelema
-    // bounds-checks the first byte; a correctly-sized buffer (length a multiple of bytesPerElement,
-    // byteOffset aligned) guarantees the rest are in range, so OOB faults exactly as the boxed
-    // path does today (semantics unchanged). The double→element narrowing matches the boxed Set's
-    // conv opcodes so the fast path and the boxed fallback always agree.
+    // of the boxed Get/Set above but take/return a native `double` — no Box or Convert.ToDouble.
+    // One-byte arrays use direct byte[] element operations (#1431); wider elements reinterpret the
+    // backing store via Unsafe.Read/WriteUnaligned. The IL emitter binds these methods at statically
+    // typed index sites, eliminating runtime dispatch and per-element boxing. AggressiveInlining +
+    // a non-virtual `call` let the JIT fold them into the caller's loop. Direct ldelem/stelem and
+    // the wider path's ldelema both preserve the current bounds fault. The double→element narrowing
+    // matches the boxed Set's conv opcodes so the fast path and boxed fallback agree.
     private void EmitUnboxedNumericAccessors(
         TypeBuilder typeBuilder, EmittedRuntime runtime, string elementType,
         int bytesPerElement, bool signed, bool isFloat)
@@ -776,8 +773,17 @@ public partial class RuntimeEmitter
         );
         getU.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
         var gil = getU.GetILGenerator();
-        EmitElementRef(gil, bytesPerElement);
-        EmitReadElementAsDouble(gil, bytesPerElement, signed, isFloat);
+        if (bytesPerElement == 1)
+        {
+            EmitOneByteArrayAndIndex(gil);
+            gil.Emit(signed ? OpCodes.Ldelem_I1 : OpCodes.Ldelem_U1);
+            gil.Emit(OpCodes.Conv_R8);
+        }
+        else
+        {
+            EmitElementRef(gil, bytesPerElement);
+            EmitReadElementAsDouble(gil, bytesPerElement, signed, isFloat);
+        }
         gil.Emit(OpCodes.Ret);
         runtime.TypedArrayGetUnboxedByElement[elementType] = getU;
 
@@ -789,9 +795,20 @@ public partial class RuntimeEmitter
         );
         setU.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
         var sil = setU.GetILGenerator();
-        EmitElementRef(sil, bytesPerElement);   // ref byte destination
-        sil.Emit(OpCodes.Ldarg_2);              // double value
-        EmitNarrowDoubleAndWrite(sil, bytesPerElement, signed, isFloat);
+        if (bytesPerElement == 1)
+        {
+            EmitOneByteArrayAndIndex(sil);
+            sil.Emit(OpCodes.Ldarg_2);
+            sil.Emit(OpCodes.Conv_I4);
+            sil.Emit(signed ? OpCodes.Conv_I1 : OpCodes.Conv_U1);
+            sil.Emit(OpCodes.Stelem_I1);
+        }
+        else
+        {
+            EmitElementRef(sil, bytesPerElement);   // ref byte destination
+            sil.Emit(OpCodes.Ldarg_2);              // double value
+            EmitNarrowDoubleAndWrite(sil, bytesPerElement, signed, isFloat);
+        }
         sil.Emit(OpCodes.Ret);
         runtime.TypedArraySetUnboxedByElement[elementType] = setU;
 
@@ -801,6 +818,19 @@ public partial class RuntimeEmitter
             _ = getU;
             _ = setU;
         }
+    }
+
+    // Pushes the byte[] and absolute element index for a one-byte typed-array access.
+    // Keeping the array reference (rather than taking a managed ref and calling Unsafe) lets
+    // RyuJIT optimize the ordinary ldelem/stelem sequence in hot loops.
+    private void EmitOneByteArrayAndIndex(ILGenerator il)
+    {
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _typedArrayBufferField!);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _typedArrayByteOffsetField!);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Add);
     }
 
     // Pushes `ref byte` at _buffer[_byteOffset + index * bytesPerElement] (this=arg0, index=arg1).

--- a/tests/SharpTS.Tests/CompilerTests/NumericBitwiseLoweringTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/NumericBitwiseLoweringTests.cs
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 
 namespace SharpTS.Tests.CompilerTests;
 
-/// <summary>Structural regression coverage for the allocation-free #1421 bitwise path.</summary>
+/// <summary>Structural regression coverage for #1421 bitwise and #1431 byte-array lowering.</summary>
 public sealed class NumericBitwiseLoweringTests
 {
     private readonly ITestOutputHelper _output;
@@ -47,6 +47,52 @@ public sealed class NumericBitwiseLoweringTests
             instruction.OpCode == OpCodes.Box && instruction.Operand == typeof(double));
         Assert.DoesNotContain(hotSlice, instruction =>
             instruction.Operand is MethodBase { Name: "JsToInt32" or "ConvertToNumber" });
+    }
+
+    [Fact]
+    public void OneByteTypedArrayAccessors_UseDirectElementOperations()
+    {
+        Assembly assembly = Compile("""
+            const signed = new Int8Array(1);
+            const unsigned = new Uint8Array(1);
+            const wider = new Int16Array(1);
+            signed[0] = -1;
+            unsigned[0] = 255;
+            wider[0] = -1;
+            """);
+
+        AssertDirectOneByteAccessors(assembly.GetType("$Int8Array")!, OpCodes.Ldelem_I1);
+        AssertDirectOneByteAccessors(assembly.GetType("$Uint8Array")!, OpCodes.Ldelem_U1);
+
+        Type widerType = assembly.GetType("$Int16Array")!;
+        Assert.Contains(ReadInstructions(FindAccessor(widerType, "GetUnboxed")),
+            instruction => instruction.Operand is MethodBase { Name: "ReadUnaligned" });
+        Assert.Contains(ReadInstructions(FindAccessor(widerType, "SetUnboxed")),
+            instruction => instruction.Operand is MethodBase { Name: "WriteUnaligned" });
+    }
+
+    [Fact]
+    public void OneByteTypedArrayAccessors_PreserveOffsetAliasingAndNarrowing()
+    {
+        Assembly assembly = Compile("""
+            function exercise(): number {
+                const buffer = new ArrayBuffer(8);
+                const unsigned = new Uint8Array(buffer, 2, 3);
+                const signed = new Int8Array(buffer, 2, 3);
+                unsigned[0] = 257.9;
+                unsigned[1] = -1;
+                signed[2] = 130;
+                return unsigned[0] * 100000000
+                    + unsigned[1] * 100000
+                    + signed[2] * 100
+                    + signed[0];
+            }
+            """);
+
+        double result = (double)FindFunction(assembly, "exercise")
+            .Invoke(null, null)!;
+
+        Assert.Equal(125_487_401, result);
     }
 
     [Fact]
@@ -199,6 +245,24 @@ public sealed class NumericBitwiseLoweringTests
         assembly.GetType("$Program")!
             .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
             .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static MethodInfo FindAccessor(Type type, string name) =>
+        type.GetMethod(name, BindingFlags.Public | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                $"Type '{type.Name}' has no '{name}' accessor.");
+
+    private static void AssertDirectOneByteAccessors(Type type, OpCode loadOpCode)
+    {
+        var get = ReadInstructions(FindAccessor(type, "GetUnboxed")).ToArray();
+        var set = ReadInstructions(FindAccessor(type, "SetUnboxed")).ToArray();
+
+        Assert.Contains(get, instruction => instruction.OpCode == loadOpCode);
+        Assert.Contains(set, instruction => instruction.OpCode == OpCodes.Stelem_I1);
+        Assert.DoesNotContain(get, instruction =>
+            instruction.Operand is MethodBase { Name: "ReadUnaligned" });
+        Assert.DoesNotContain(set, instruction =>
+            instruction.Operand is MethodBase { Name: "WriteUnaligned" });
+    }
 
     private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
         MethodInfo method)


### PR DESCRIPTION
## Summary

- specialize unboxed `Int8Array` and `Uint8Array` accessors to direct `byte[]` element IL
- preserve the existing unaligned reinterpretation path for every multi-byte numeric typed array
- cover signed/unsigned loads, direct stores, widening/narrowing, offsets, shared aliases, and the wider fallback structurally

## Performance

Pinned Windows x64 environment: .NET SDK 10.0.400/runtime 10.0.11, Node 24.19.0.

- pre-change Brainfuck N=5,000 controlled median: **35.7924 ms compiled / 21.6385 ms Node (1.65x)**
- this branch, eight alternated pairs: **33.5309 ms compiled / 21.3244 ms Node (1.57x)**
- compiled-time improvement: **6.3%**

The direct accessor is a material CPU improvement but does not alone clear the standing 1.5x threshold. During validation I corrected #1431's allocation attribution: the faithful internally built `number[]` jump table allocates **30,307,280 bytes/op** through object-returning `TSArrayGetLong`; the earlier ~4 KB figure used an externally supplied list control. That independent residual is isolated in #1432 rather than expanding this typed-array patch.

## Correctness

- one-byte getters emit `ldelem.i1` / `ldelem.u1`
- one-byte setters emit `stelem.i1` after the existing narrowing conversions
- non-zero byte offsets and shared `ArrayBuffer` aliases retain the same addressing
- `Uint8ClampedArray`, multi-byte arrays, dynamic accesses, and observable fallbacks are unchanged

## Validation

- focused typed-array/IL/allocation/standalone tests: **51 passed**
- full core suite: **17,091 passed, 3 skipped**
- TypeScript conformance: **65 passed**
- Test262: **3,219 passed, 4 diagnostic skips**
- Release solution build and IL verification: **0 warnings, 0 errors**

Closes #1431.

