### PR TITLE
Perf: keep guarded number[] reads unboxed

### DIFF
--- a/src/SharpTS/Compilation/ArrayHoistAnalyzer.cs
+++ b/src/SharpTS/Compilation/ArrayHoistAnalyzer.cs
@@ -23,6 +23,12 @@ public static class ArrayHoistAnalyzer
         var visitor = new ArrayAccessVisitor(typeMap);
         visitor.Visit(body);
 
+        // Direct eval executes in the current lexical environment and can
+        // replace an array binding without an Assign node in the outer AST.
+        // A loop-entry receiver cache would then become stale.
+        if (visitor.ContainsDirectEval)
+            return new();
+
         // Remove any variables that are reassigned within the loop
         foreach (var reassigned in visitor.ReassignedVariables)
             visitor.ArrayVariables.Remove(reassigned);
@@ -44,6 +50,9 @@ public static class ArrayHoistAnalyzer
         if (condition != null) visitor.VisitExpr(condition);
         if (increment != null) visitor.VisitExpr(increment);
 
+        if (visitor.ContainsDirectEval)
+            return new();
+
         foreach (var reassigned in visitor.ReassignedVariables)
             visitor.ArrayVariables.Remove(reassigned);
 
@@ -59,6 +68,8 @@ public static class ArrayHoistAnalyzer
 
         /// <summary>Variables that are reassigned within the loop body.</summary>
         public HashSet<string> ReassignedVariables { get; } = new();
+
+        public bool ContainsDirectEval { get; private set; }
 
         public ArrayAccessVisitor(TypeMap typeMap) => _typeMap = typeMap;
 
@@ -94,6 +105,13 @@ public static class ArrayHoistAnalyzer
         {
             ReassignedVariables.Add(expr.Name.Lexeme);
             base.VisitCompoundAssign(expr);
+        }
+
+        protected override void VisitCall(Expr.Call expr)
+        {
+            if (expr.Callee is Expr.Variable { Name.Lexeme: "eval" })
+                ContainsDirectEval = true;
+            base.VisitCall(expr);
         }
 
         protected override void VisitVar(Stmt.Var stmt)

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -1528,6 +1528,8 @@ public class EmittedRuntime
     // Unboxed packed-double elements-kind accessors (number[] unboxing project).
     // GetDouble/SetDouble/PushDouble are the fast paths the compiler emits at
     // statically-number[] sites; EnsureBoxed is the deopt (numeric -> boxed).
+    public MethodBuilder TSArrayCanGetDouble { get; set; } = null!;
+    public MethodBuilder TSArrayGetDouble { get; set; } = null!;
     public MethodBuilder TSArraySetDouble { get; set; } = null!;
     public MethodBuilder TSArrayPushDouble { get; set; } = null!;
     public MethodBuilder TSArrayEnsureBoxed { get; set; } = null!;

--- a/src/SharpTS/Compilation/ILEmitter.Expressions.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Expressions.cs
@@ -415,7 +415,20 @@ public partial class ILEmitter
             return;
         }
 
-        EmitExpression(a.Value);
+        // Direct numeric locals already coerce their RHS to double below. Ask the
+        // expression emitter for that representation up front for number[] reads,
+        // allowing the guarded GetDouble arm to avoid a box/unbox round trip.
+        var assignmentLocal = _ctx.Locals.GetLocal(a.Name.Lexeme);
+        if (a.Value is Expr.GetIndex
+            && assignmentLocal != null
+            && _ctx.Types.IsDouble(assignmentLocal.LocalType))
+        {
+            EmitExpressionAsDouble(a.Value);
+        }
+        else
+        {
+            EmitExpression(a.Value);
+        }
 
         if (_ctx.LexicalInitializerTdzName == a.Name.Lexeme)
         {

--- a/src/SharpTS/Compilation/ILEmitter.Helpers.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Helpers.cs
@@ -322,6 +322,12 @@ public partial class ILEmitter
 
     public override void EmitExpressionAsDouble(Expr expr)
     {
+        // A number[] read consumed as a number can keep the numeric-mode $Array
+        // result native while its guarded cold arm performs the same ordinary
+        // property lookup + ToNumber coercion this method used previously.
+        if (expr is Expr.GetIndex getIndex && TryEmitNumberArrayGetIndexAsDouble(getIndex))
+            return;
+
         // Emit expression and ensure result is a double on the stack
         if (expr is Expr.Literal lit && lit.Value is double d)
         {

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -1294,6 +1294,113 @@ public partial class ILEmitter
     }
 
     /// <summary>
+    /// Emits a native-double numeric-consumer path for a statically-number[] read.
+    /// The hot arm is limited to a dense numeric-mode $Array and an exactly integral,
+    /// Int32 index. Every unsupported receiver/index shape takes the ordinary GetIndex
+    /// path and then the caller's pre-existing ToNumber coercion, so raw/any consumers
+    /// never enter this specialization and continue to observe the original JS value.
+    /// </summary>
+    private bool TryEmitNumberArrayGetIndexAsDouble(Expr.GetIndex gi)
+    {
+        if (gi.Optional
+            || gi.Object is not Expr.Variable arrayVariable
+            || ArrayElements.Resolve(_ctx.TypeMap?.Get(gi.Object)) is not
+                { Kind: ArrayElementsKind.Double }
+            || _ctx.TryGetPromotedArrayLocal(arrayVariable.Name.Lexeme) != null
+            || !IsNumericType(_ctx.TypeMap?.Get(gi.Index))
+            || _ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == true
+            || _ctx.RuntimeFeatures?.UsesArrayPrototypeMutation == true)
+        {
+            return false;
+        }
+
+        var hoisted = _ctx.TryGetHoistedArray(arrayVariable.Name.Lexeme);
+        if (hoisted is { Descriptor.Kind: not ArrayElementsKind.Double })
+            return false;
+
+        // Capture the receiver before evaluating the key. A hoisted exact-$Array
+        // local already captured the stable binding at loop entry; parameters and
+        // non-hoisted locals are spilled at this read site.
+        LocalBuilder? receiverLocal = null;
+        LocalBuilder? arrayLocal = null;
+        if (hoisted is null)
+        {
+            EmitExpression(gi.Object);
+            EmitBoxIfNeeded(gi.Object);
+            receiverLocal = IL.DeclareLocal(_ctx.Types.Object);
+            IL.Emit(OpCodes.Stloc, receiverLocal);
+
+            arrayLocal = IL.DeclareLocal(_ctx.Runtime!.TSArrayType);
+            IL.Emit(OpCodes.Ldloc, receiverLocal);
+            IL.Emit(OpCodes.Isinst, _ctx.Runtime.TSArrayType);
+            IL.Emit(OpCodes.Stloc, arrayLocal);
+        }
+
+        EmitExpressionAsDouble(gi.Index);
+        var indexDouble = IL.DeclareLocal(_ctx.Types.Double);
+        var indexInt = IL.DeclareLocal(_ctx.Types.Int32);
+        IL.Emit(OpCodes.Stloc, indexDouble);
+        IL.Emit(OpCodes.Ldloc, indexDouble);
+        IL.Emit(OpCodes.Conv_I4);
+        IL.Emit(OpCodes.Stloc, indexInt);
+
+        var fallbackLabel = IL.DefineLabel();
+        var endLabel = IL.DefineLabel();
+
+        // Conv_I4 is used only as a candidate. Round-tripping to double proves
+        // exact integrality and Int32 range; Bne_Un also rejects NaN.
+        IL.Emit(OpCodes.Ldloc, indexDouble);
+        IL.Emit(OpCodes.Ldloc, indexInt);
+        IL.Emit(OpCodes.Conv_R8);
+        IL.Emit(OpCodes.Bne_Un, fallbackLabel);
+
+        var guardedArray = hoisted?.TypedLocal ?? arrayLocal!;
+        IL.Emit(OpCodes.Ldloc, guardedArray);
+        IL.Emit(OpCodes.Brfalse, fallbackLabel);
+        IL.Emit(OpCodes.Ldloc, guardedArray);
+        IL.Emit(OpCodes.Ldloc, indexInt);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArrayCanGetDouble);
+        IL.Emit(OpCodes.Brfalse, fallbackLabel);
+
+        IL.Emit(OpCodes.Ldloc, guardedArray);
+        IL.Emit(OpCodes.Ldloc, indexInt);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime.TSArrayGetDouble);
+        IL.Emit(OpCodes.Br, endLabel);
+
+        // Cold arm: preserve the numeric key exactly (including fractional,
+        // negative, and uint32-range values) and use the descriptor/prototype-
+        // aware runtime lookup before applying the numeric consumer's ToNumber.
+        IL.MarkLabel(fallbackLabel);
+        if (receiverLocal != null)
+        {
+            IL.Emit(OpCodes.Ldloc, receiverLocal);
+        }
+        else
+        {
+            // When the hoisted cast succeeded, it is the captured receiver. If it
+            // failed (ordinary object/list supplied through an alias), reload the
+            // side-effect-free variable binding for the generic fallback.
+            var haveReceiver = IL.DefineLabel();
+            IL.Emit(OpCodes.Ldloc, hoisted!.Value.TypedLocal);
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Brtrue, haveReceiver);
+            IL.Emit(OpCodes.Pop);
+            EmitExpression(gi.Object);
+            EmitBoxIfNeeded(gi.Object);
+            IL.MarkLabel(haveReceiver);
+        }
+        IL.Emit(OpCodes.Ldloc, indexDouble);
+        IL.Emit(OpCodes.Box, _ctx.Types.Double);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.GetIndex);
+        SetStackUnknown();
+        EnsureDouble();
+
+        IL.MarkLabel(endLabel);
+        SetStackType(StackType.Double);
+        return true;
+    }
+
+    /// <summary>
     /// Emits a stack-neutral statement-position write through a guarded numeric
     /// <c>$Array</c>. The ordinary result-producing path must reload and box the
     /// assigned double so arbitrary expression consumers see the JS assignment

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -402,7 +402,10 @@ public partial class ILEmitter
             // initializer is created as a NUMERIC $Array; otherwise emit the initializer normally.
             if (!TryEmitNumericEmptyArrayInit(v))
             {
-                EmitExpression(v.Initializer);
+                if (_ctx.Types.IsDouble(localType) && v.Initializer is Expr.GetIndex)
+                    EmitExpressionAsDouble(v.Initializer);
+                else
+                    EmitExpression(v.Initializer);
 
                 if (_ctx.Types.IsDouble(localType))
                 {
@@ -1930,7 +1933,10 @@ public partial class ILEmitter
 
         if (r.Value != null)
         {
-            EmitExpression(r.Value);
+            if (_ctx.Types.IsDouble(returnType) && r.Value is Expr.GetIndex)
+                EmitExpressionAsDouble(r.Value);
+            else
+                EmitExpression(r.Value);
             // Only box if return type is object; otherwise use typed value directly
             if (returnType == _ctx.Types.Object)
             {

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSArray.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSArray.cs
@@ -281,11 +281,14 @@ public partial class RuntimeEmitter
         var arrayResize = EmitGenerics.MakeGenericMethod(typeof(System.Array).GetMethod("Resize")!, _types.Double);
 
         // EnsureBoxed's builder was defined early (so base-list methods can guard
-        // on it); we only emit its body here. The other three are defined now.
+        // on it); we only emit its body here. The other accessors are defined now.
         var ensureBoxed = _tsArrayEnsureBoxedMethod;
+        var canGetDouble = typeBuilder.DefineMethod("CanGetDouble",
+            MethodAttributes.Public | MethodAttributes.HideBySig, _types.Boolean, [_types.Int32]);
+        runtime.TSArrayCanGetDouble = canGetDouble;
         var getDouble = typeBuilder.DefineMethod("GetDouble",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Double, [_types.Int32]);
-        _ = getDouble;
+        runtime.TSArrayGetDouble = getDouble;
         var setDouble = typeBuilder.DefineMethod("SetDouble",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, [_types.Int32, _types.Double]);
         runtime.TSArraySetDouble = setDouble;
@@ -296,6 +299,7 @@ public partial class RuntimeEmitter
         // sites. They are non-virtual (HideBySig), so a `callvirt` on a $Array-typed receiver
         // devirtualizes; AggressiveInlining lets the JIT fold the field loads + bounds check into the
         // caller's loop (the $Array-wrapper equivalent of List<double>.Add's inlined fast path).
+        canGetDouble.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
         getDouble.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
         setDouble.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
         pushDouble.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
@@ -345,6 +349,25 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldc_I4_0); il.Emit(OpCodes.Stfld, _tsArrayNumCountField);
 
             il.MarkLabel(done);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // ── bool CanGetDouble(int index) ── numeric-mode and dense in-range guard.
+        // The compiler calls this before GetDouble so boxed arrays, holes, and OOB
+        // reads retain the ordinary property lookup path.
+        {
+            var il = canGetDouble.GetILGenerator();
+            var unavailable = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayIsNumericField);
+            il.Emit(OpCodes.Brfalse, unavailable);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Clt_Un); // unsigned comparison rejects negative indices too
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(unavailable);
+            il.Emit(OpCodes.Ldc_I4_0);
             il.Emit(OpCodes.Ret);
         }
 

--- a/tests/SharpTS.Tests/CompilerTests/NumericBitwiseLoweringTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/NumericBitwiseLoweringTests.cs
@@ -228,7 +228,7 @@ public sealed class NumericBitwiseLoweringTests
 
         Assert.Equal(168, result);
         _output.WriteLine($"Brainfuck N=5,000 runBF allocated {allocated:N0} bytes.");
-        Assert.InRange(allocated, 0, 35_000_000);
+        Assert.InRange(allocated, 0, 8_192);
     }
 
     private static Assembly Compile(string source)

--- a/tests/SharpTS.Tests/CompilerTests/UnboxedNumberArrayReadTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/UnboxedNumberArrayReadTests.cs
@@ -1,0 +1,250 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class UnboxedNumberArrayReadTests
+{
+    [Fact]
+    public void NumericConsumer_UsesGuardedGetDoubleWithoutBoxingHotResult()
+    {
+        Assembly assembly = Compile("""
+            function read(values: number[], index: number): number {
+                return values[index];
+            }
+            """);
+
+        var instructions = ReadInstructions(FindFunction(assembly, "read")).ToArray();
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "CanGetDouble" });
+
+        int getDouble = Array.FindIndex(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "GetDouble" });
+        Assert.True(getDouble >= 0, "Expected the guarded numeric $Array read fast path.");
+        Assert.Equal(FlowControl.Branch, instructions[getDouble + 1].OpCode.FlowControl);
+        Assert.False(instructions.Skip(getDouble + 1).Take(2).Any(instruction =>
+            instruction.OpCode == OpCodes.Box && instruction.Operand == typeof(double)),
+            "The GetDouble hot result must branch to the native-double merge without boxing.");
+    }
+
+    [Fact]
+    public void RawConsumer_RetainsOrdinaryObjectRead()
+    {
+        Assembly assembly = Compile("""
+            function read(values: number[], index: number): any {
+                return values[index];
+            }
+            """);
+
+        var instructions = ReadInstructions(FindFunction(assembly, "read")).ToArray();
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "GetDouble" });
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "Get" });
+    }
+
+    [Fact]
+    public void FractionalIndex_PreservesOrdinaryPropertyKey()
+    {
+        const string source = """
+            function read(values: number[], index: number): number {
+                return values[index] * 2;
+            }
+            const receiver: any = {};
+            receiver[3] = 100;
+            receiver[3.5] = 7;
+            console.log(read(receiver as number[], 3.5));
+            """;
+
+        Assert.Equal("14\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void OutOfRangeAndNegativeReads_RetainOrdinarySemantics()
+    {
+        const string source = """
+            function read(values: number[], index: number): number {
+                return values[index] * 2;
+            }
+            const values: number[] = [];
+            values.push(4);
+            console.log(read(values, 5), read(values, -1), read(values, 4294967295));
+            """;
+
+        Assert.Equal("NaN NaN NaN\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void BoxedArrayAndDynamicGetter_UseOrdinaryFallback()
+    {
+        const string source = """
+            function read(values: number[], index: number): number {
+                return values[index] * 2;
+            }
+
+            const values: number[] = [];
+            values.push(4);
+            const alias: any = values;
+            alias[0] = "6";
+
+            let calls: number = 0;
+            const receiver: any = {
+                get 0(): number { calls = calls + 1; return 9; }
+            };
+
+            console.log(read(values, 0), read(receiver as number[], 0), calls);
+            """;
+
+        Assert.Equal("12 18 1\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void ObservableDescriptors_DisableGetDoubleIntrinsic()
+    {
+        Assembly assembly = Compile("""
+            Object.defineProperty([], "0", { get: (): number => 1 });
+            function read(values: number[], index: number): number {
+                return values[index];
+            }
+            """);
+
+        var instructions = ReadInstructions(FindFunction(assembly, "read")).ToArray();
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "GetDouble" });
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "GetIndex" });
+    }
+
+    [Fact]
+    public void HoistedLoopRead_PassesIlVerification()
+    {
+        const string source = """
+            function sum(values: number[]): number {
+                let result: number = 0;
+                let i: number = 0;
+                while (i < values.length) {
+                    result = result + values[i];
+                    i = i + 1;
+                }
+                return result;
+            }
+            const values: number[] = [];
+            values.push(1); values.push(2); values.push(3);
+            console.log(sum(values));
+            """;
+
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+        Assert.Equal("6\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void NumericRead_WorksInStandaloneOutput()
+    {
+        const string source = """
+            function read(values: number[], index: number): number {
+                return values[index] * 2;
+            }
+            const values: number[] = [];
+            values.push(21);
+            console.log(read(values, 0));
+            """;
+
+        Assert.Equal("42\n", TestHarness.RunCompiledStandalone(source));
+    }
+
+    [Fact]
+    public void DirectEvalInLoop_DisablesReceiverHoisting()
+    {
+        var statements = new Parser(new Lexer("""
+            function read(): number {
+                let values: number[] = [];
+                values.push(1);
+                let i: number = 0;
+                while (i < 2) {
+                    eval("values = [20]");
+                    console.log(values[0]);
+                    i = i + 1;
+                }
+                return values[0];
+            }
+            """).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var function = Assert.IsType<Stmt.Function>(Assert.Single(statements));
+        var loop = Assert.IsType<Stmt.While>(Assert.Single(function.Body!.OfType<Stmt.While>()));
+
+        Assert.Empty(ArrayHoistAnalyzer.AnalyzeFor(
+            loop.Body, loop.Condition, increment: null, typeMap));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"issue_1432_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token)
+                    : module.ResolveType(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}


### PR DESCRIPTION
Closes #1432

## Summary
- expose `$Array.GetDouble(int)` plus an inlined numeric-mode/bounds guard through `EmittedRuntime`
- lower statically numeric `number[]` reads to native `double` only when the consumer already requires numeric coercion, with exact integral Int32 index checks
- retain ordinary `GetIndex` behavior for boxed arrays, aliases, dynamic receivers, fractional/negative/large/OOB keys, descriptors, prototype-observable programs, and raw consumers
- disable loop-entry array receiver hoists when direct `eval` can rebind the local
- tighten the faithful Brainfuck allocation gate and add structural, semantic, IL-verification, and standalone regressions

## Results
- exact Brainfuck N=5,000 hot method: **30,307,280 -> 4,208 bytes/op**
- five controlled compiled/Node N=5,000 pairs: median paired ratio **1.28x** (target <= 1.5x)
- emitted numeric read contains guarded `CanGetDouble` / `GetDouble`; the hot result branches to a native-double merge without boxing

## Verification
- focused numeric read + Brainfuck allocation tests: 10 passed
- neighboring numeric-array / typed-array tests: 74 passed
- core: 17,076 passed, 0 failed, 3 skipped
- TypeScript conformance: 65 passed, 0 failed
- Test262 interpreter + compiled baselines: 3,219 passed, 0 failed, 4 diagnostic skips
- `dotnet build SharpTS.sln -c Release --no-restore`: 0 warnings, 0 errors; IL verification passed