### PR TITLE
Bench: add Map and Set performance coverage

### DIFF
--- a/benchmarks/cross-runtime/scripts/lib/algorithms.ts
+++ b/benchmarks/cross-runtime/scripts/lib/algorithms.ts
@@ -104,6 +104,85 @@ export function arrayMethodWork(n: number): number {
 // and typed-array kernels lean on hand-tuned engine builtins, binary-trees on
 // the GC. Each still funnels to a `number` so the BDN harness can reflect it.
 
+// Map insertion, lookup, and deletion with numeric keys and values. The
+// checksum observes both successful lookups and deletes while leaving half of
+// the entries live, so runtimes cannot discard any phase.
+export function mapOperations(n: number): number {
+    const map = new Map<number, number>();
+    for (let i: number = 0; i < n; i++) {
+        map.set(i, i * 3 + 1);
+    }
+
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const value = map.get(i);
+        if (value !== null && value !== undefined) {
+            sum = sum + value;
+        }
+    }
+
+    let deleted: number = 0;
+    for (let i: number = 0; i < n; i = i + 2) {
+        if (map.delete(i)) {
+            deleted = deleted + 1;
+        }
+    }
+    return sum + deleted + map.size;
+}
+
+// Map iteration is kept separate from lookup so iterator materialization and
+// entry-pair representation remain visible in the cross-runtime results.
+export function mapIteration(n: number): number {
+    const map = new Map<number, number>();
+    for (let i: number = 0; i < n; i++) {
+        map.set(i, i * 3 + 1);
+    }
+
+    let sum: number = 0;
+    for (const entry of map) {
+        sum = sum + entry[0] + entry[1];
+    }
+    return sum + map.size;
+}
+
+// Set insertion, lookup, and deletion. The even-number delete pass observes
+// mutation and size independently from the preceding membership checks.
+export function setOperations(n: number): number {
+    const set = new Set<number>();
+    for (let i: number = 0; i < n; i++) {
+        set.add(i);
+    }
+
+    let found: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        if (set.has(i)) {
+            found = found + 1;
+        }
+    }
+
+    let deleted: number = 0;
+    for (let i: number = 0; i < n; i = i + 2) {
+        if (set.delete(i)) {
+            deleted = deleted + 1;
+        }
+    }
+    return found + deleted + set.size;
+}
+
+// Set iteration has its own workload so it is not hidden by hash lookups.
+export function setIteration(n: number): number {
+    const set = new Set<number>();
+    for (let i: number = 0; i < n; i++) {
+        set.add(i);
+    }
+
+    let sum: number = 0;
+    for (const value of set) {
+        sum = sum + value;
+    }
+    return sum + set.size;
+}
+
 // JSON round-trip: build a record array, stringify, parse it back, sum a field.
 // The single most common server hot path; V8/JSC JSON are hand-tuned C++.
 export function jsonRoundTrip(n: number): number {

--- a/benchmarks/cross-runtime/scripts/map-set.ts
+++ b/benchmarks/cross-runtime/scripts/map-set.ts
@@ -1,0 +1,16 @@
+import {
+    mapIteration,
+    mapOperations,
+    setIteration,
+    setOperations,
+} from "./lib/algorithms.ts";
+import { bench } from "./lib/bench.ts";
+
+const params: number[] = [100, 1000, 10000];
+for (let p: number = 0; p < params.length; p++) {
+    const n: number = params[p];
+    bench("map-operations", n, () => mapOperations(n));
+    bench("map-iteration", n, () => mapIteration(n));
+    bench("set-operations", n, () => setOperations(n));
+    bench("set-iteration", n, () => setIteration(n));
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Baselines/MapSetCSharp.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Baselines/MapSetCSharp.cs
@@ -1,0 +1,160 @@
+namespace SharpTS.Microbenchmarks.Baselines;
+
+/// <summary>
+/// Native and boxed C# controls for the shared numeric Map/Set workloads.
+/// The boxed iteration controls deliberately reproduce the compiled runtime's
+/// key/value snapshots and entry-pair materialization.
+/// </summary>
+public static class MapSetCSharp
+{
+    public static double IdiomaticMapOperations(int n)
+    {
+        var map = new Dictionary<double, double>(n);
+        for (int i = 0; i < n; i++)
+            map[i] = i * 3 + 1;
+
+        double sum = 0;
+        for (int i = 0; i < n; i++)
+        {
+            if (map.TryGetValue(i, out double value))
+                sum += value;
+        }
+
+        int deleted = 0;
+        for (int i = 0; i < n; i += 2)
+        {
+            if (map.Remove(i))
+                deleted++;
+        }
+        return sum + deleted + map.Count;
+    }
+
+    public static double IdiomaticMapIteration(int n)
+    {
+        var map = new Dictionary<double, double>(n);
+        for (int i = 0; i < n; i++)
+            map[i] = i * 3 + 1;
+
+        double sum = 0;
+        foreach (var entry in map)
+            sum += entry.Key + entry.Value;
+        return sum + map.Count;
+    }
+
+    public static double IdiomaticSetOperations(int n)
+    {
+        var set = new HashSet<double>(n);
+        for (int i = 0; i < n; i++)
+            set.Add(i);
+
+        int found = 0;
+        for (int i = 0; i < n; i++)
+        {
+            if (set.Contains(i))
+                found++;
+        }
+
+        int deleted = 0;
+        for (int i = 0; i < n; i += 2)
+        {
+            if (set.Remove(i))
+                deleted++;
+        }
+        return found + deleted + set.Count;
+    }
+
+    public static double IdiomaticSetIteration(int n)
+    {
+        var set = new HashSet<double>(n);
+        for (int i = 0; i < n; i++)
+            set.Add(i);
+
+        double sum = 0;
+        foreach (double value in set)
+            sum += value;
+        return sum + set.Count;
+    }
+
+    public static object EquivalentMapOperations(double n)
+    {
+        int count = (int)n;
+        var map = new Dictionary<object, object?>(count);
+        for (int i = 0; i < count; i++)
+            map[(double)i] = (double)(i * 3 + 1);
+
+        double sum = 0;
+        for (int i = 0; i < count; i++)
+        {
+            if (map.TryGetValue((double)i, out object? value))
+                sum += Convert.ToDouble(value);
+        }
+
+        int deleted = 0;
+        for (int i = 0; i < count; i += 2)
+        {
+            if (map.Remove((double)i))
+                deleted++;
+        }
+        return sum + deleted + map.Count;
+    }
+
+    public static object EquivalentMapIteration(double n)
+    {
+        int count = (int)n;
+        var map = new Dictionary<object, object?>(count);
+        for (int i = 0; i < count; i++)
+            map[(double)i] = (double)(i * 3 + 1);
+
+        var keys = new List<object>(map.Keys);
+        double sum = 0;
+        foreach (object key in keys)
+        {
+            if (!map.TryGetValue(key, out object? value))
+                continue;
+
+            var pair = new List<object?>(2) { key, value };
+            sum += Convert.ToDouble(pair[0]) + Convert.ToDouble(pair[1]);
+        }
+        return sum + map.Count;
+    }
+
+    public static object EquivalentSetOperations(double n)
+    {
+        int count = (int)n;
+        var set = new HashSet<object>();
+        for (int i = 0; i < count; i++)
+            set.Add((double)i);
+
+        int found = 0;
+        for (int i = 0; i < count; i++)
+        {
+            if (set.Contains((double)i))
+                found++;
+        }
+
+        int deleted = 0;
+        for (int i = 0; i < count; i += 2)
+        {
+            if (set.Remove((double)i))
+                deleted++;
+        }
+        return (double)(found + deleted + set.Count);
+    }
+
+    public static object EquivalentSetIteration(double n)
+    {
+        int count = (int)n;
+        var set = new HashSet<object>();
+        for (int i = 0; i < count; i++)
+            set.Add((double)i);
+
+        var values = new List<object>(set);
+        double sum = 0;
+        foreach (object value in values)
+        {
+            if (set.Contains(value))
+                sum += Convert.ToDouble(value);
+        }
+        return sum + set.Count;
+    }
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/MapSetBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/MapSetBenchmarks.cs
@@ -1,0 +1,97 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using SharpTS.Microbenchmarks.Baselines;
+
+namespace SharpTS.Microbenchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class MapOperationsBenchmarks : ComputationalBenchmarkBase
+{
+    private Func<double, double> _mapOperations = null!;
+
+    [Params(10000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup() => _mapOperations = LoadCompiled("mapOperations");
+
+    [Benchmark]
+    public double SharpTS() => _mapOperations(N);
+
+    [Benchmark]
+    public double Idiomatic() => MapSetCSharp.IdiomaticMapOperations(N);
+
+    [Benchmark]
+    public object Equivalent() => MapSetCSharp.EquivalentMapOperations(N);
+}
+
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class MapIterationBenchmarks : ComputationalBenchmarkBase
+{
+    private Func<double, double> _mapIteration = null!;
+
+    [Params(10000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup() => _mapIteration = LoadCompiled("mapIteration");
+
+    [Benchmark]
+    public double SharpTS() => _mapIteration(N);
+
+    [Benchmark]
+    public double Idiomatic() => MapSetCSharp.IdiomaticMapIteration(N);
+
+    [Benchmark]
+    public object Equivalent() => MapSetCSharp.EquivalentMapIteration(N);
+}
+
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class SetOperationsBenchmarks : ComputationalBenchmarkBase
+{
+    private Func<double, double> _setOperations = null!;
+
+    [Params(10000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup() => _setOperations = LoadCompiled("setOperations");
+
+    [Benchmark]
+    public double SharpTS() => _setOperations(N);
+
+    [Benchmark]
+    public double Idiomatic() => MapSetCSharp.IdiomaticSetOperations(N);
+
+    [Benchmark]
+    public object Equivalent() => MapSetCSharp.EquivalentSetOperations(N);
+}
+
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class SetIterationBenchmarks : ComputationalBenchmarkBase
+{
+    private Func<double, double> _setIteration = null!;
+
+    [Params(10000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup() => _setIteration = LoadCompiled("setIteration");
+
+    [Benchmark]
+    public double SharpTS() => _setIteration(N);
+
+    [Benchmark]
+    public double Idiomatic() => MapSetCSharp.IdiomaticSetIteration(N);
+
+    [Benchmark]
+    public object Equivalent() => MapSetCSharp.EquivalentSetIteration(N);
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/README.md
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/README.md
@@ -27,9 +27,8 @@ the timed region**.
 | Path | Purpose |
 |------|---------|
 | `Program.cs` | BenchmarkDotNet entry point (GitHub-Markdown + HTML exporters, `MemoryDiagnoser`, rank/ops-per-sec columns). |
-| `Benchmarks/*.cs` | One file per workload family (computational, starter workloads, array helpers, property access, object literals, regex). |
-| `Baselines/IdiomaticCSharp.cs` | Native-type C# baselines — the ceiling. |
-| `Baselines/EquivalentCSharp.cs` | `object?`/boxing C# baselines — the dynamic-typing tax. |
+| `Benchmarks/*.cs` | One file per workload family (computational, starter workloads, arrays, Map/Set, property access, object literals, regex). |
+| `Baselines/*.cs` | Native-type C# ceilings plus `object?`/boxing controls for the dynamic-typing tax. |
 | `Infrastructure/BenchmarkHarness.cs` | Compile TS → DLL, load it, resolve compiled methods/delegates. |
 | `Infrastructure/CompilationCache.cs` | Compile each TS source once, reuse across benchmark classes. |
 | `TypeScriptSources/*.ts` | TS bodies for the non-computational workloads (embedded as resources). |


### PR DESCRIPTION
## Summary

- widen the shared cross-runtime corpus with numeric Map/Set insertion, lookup, deletion, and iteration workloads
- add matching BenchmarkDotNet cases with idiomatic typed and boxed-equivalent C# controls
- keep the TypeScript algorithm bodies byte-identical between the external and internal suites

## Findings

The post-#1432 sweep at merged commit `1974a3c8` left the close existing candidates below the 1.5x child threshold after controlled repeats: Int32 kernel approximately 1.46x by median paired ratio and RegExp approximately 1.47x.

The widened family found a new focused gap. Five independently launched and alternated N=10,000 pairs measured Map iteration at **1.4088 ms compiled** versus **0.4327 ms Node**, a **3.26x** median ratio. Map operations and both Set shapes remained near parity at the largest size.

BenchmarkDotNet attributes the Map-iteration residual:

| Implementation | Mean | Allocated |
|---|---:|---:|
| idiomatic typed C# | 187.1 us | 276.66 KB |
| boxed-equivalent C# | 698.2 us | 1,526.76 KB |
| SharpTS compiled | 2.7135 ms | 2,974.01 KB |

The current stable Map `for...of` path snapshots keys, re-probes the dictionary, and materializes every entry as a fresh two-element object list before generic element access. The focused lowering work is tracked by #1435.

## Validation

- expanded 16-workload interpreter/compiled/Node sweep completed without compile, runtime, or harness failures
- five controlled Map/Set compiled/Node pairs completed successfully
- Map/Set BenchmarkDotNet controls completed with allocation diagnostics
- Release solution build: 0 warnings, 0 errors; IL verification passed
- core tests: 17,100 passed, 0 failed, 3 expected skips

Tracks #1278.
