### PR TITLE
perf: eliminate stable Map iteration entry materialization

### DIFF
--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -650,6 +650,7 @@ public partial class ILCompiler
     private void AnalyzeClosuresAndPromotions(List<Stmt> statements)
     {
         Phase2_AnalyzeClosures(statements);
+        StableMapIterationAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         ArrayLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         StringAccumulatorPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         NonEscapingArrowLocalAnalyzer.Analyze(

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -951,6 +951,9 @@ public partial class ILEmitter
 
     protected override void EmitGetIndex(Expr.GetIndex gi)
     {
+        if (TryEmitStableMapEntryIndex(gi))
+            return;
+
         // A literal string key on a built-in constructor/namespace is the
         // computed-property spelling of the same ordinary property access:
         // Number["MAX_VALUE"] === Number.MAX_VALUE, Math["PI"] === Math.PI,
@@ -1291,6 +1294,34 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Ldloc, idxRecvLocal);
         IL.Emit(OpCodes.Ldloc, idxKeyLocal);
         IL.Emit(OpCodes.Call, _ctx.Runtime!.GetIndex);
+    }
+
+    /// <summary>
+    /// Loads the key/value local for a proven non-escaping Map entry binding.
+    /// The analyzer admits only non-optional literal index 0/1 reads, so this
+    /// preserves evaluation order while avoiding a per-iteration entry array.
+    /// </summary>
+    private bool TryEmitStableMapEntryIndex(Expr.GetIndex expression)
+    {
+        if (expression.Optional
+            || expression.Object is not Expr.Variable variable
+            || expression.Index is not Expr.Literal { Value: double index }
+            || index is not (0d or 1d))
+        {
+            return false;
+        }
+
+        foreach (var binding in _stableMapEntryBindings)
+        {
+            if (binding.Name != variable.Name.Lexeme)
+                continue;
+
+            IL.Emit(OpCodes.Ldloc, index == 0d ? binding.Key : binding.Value);
+            SetStackType(StackType.Double);
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -9,6 +9,8 @@ namespace SharpTS.Compilation;
 /// </summary>
 public partial class ILEmitter
 {
+    private readonly Stack<(string Name, LocalBuilder Key, LocalBuilder Value)> _stableMapEntryBindings = new();
+
     protected override void EmitConditionCheck(Expr condition)
     {
         EmitExpression(condition);
@@ -998,6 +1000,19 @@ public partial class ILEmitter
         TypeInfo? iterableType = _ctx.TypeMap?.Get(f.Iterable);
         EmitExpression(f.Iterable);
 
+        if (iterableType is TypeInfo.Map
+            && _ctx.TypeMap?.IsStableNumericMapIteration(f) == true)
+        {
+            // The analyzer proved that the receiver is a fresh, non-escaping
+            // Map<number, number> and that the entry binding is observed only
+            // through literal [0]/[1] reads.
+            EmitBoxIfNeeded(f.Iterable);
+            var stableMapIterable = IL.DeclareLocal(_ctx.Types.Object);
+            IL.Emit(OpCodes.Stloc, stableMapIterable);
+            EmitStableNumericMapIteration(f, stableMapIterable, labelNames);
+            return;
+        }
+
         // For Map/Set, convert to a List first
         if (iterableType is TypeInfo.Map)
         {
@@ -1278,6 +1293,85 @@ public partial class ILEmitter
 
         // Common exit point for both paths
         builder.MarkLabel(afterLoopLabel);
+        _ctx.Locals.ExitScope();
+    }
+
+    /// <summary>
+    /// Direct backing-dictionary loop for the non-escaping numeric Map shape
+    /// marked by <see cref="StableMapIterationAnalyzer"/>. Key/value objects are
+    /// held in locals and exposed to literal entry-index reads by
+    /// <c>TryEmitStableMapEntryIndex</c>; no JavaScript entry array is created.
+    /// </summary>
+    private void EmitStableNumericMapIteration(
+        Stmt.ForOf f,
+        LocalBuilder iterableLocal,
+        IReadOnlyList<string>? labelNames)
+    {
+        var builder = _ctx.ILBuilder;
+        var dictType = _ctx.Types.DictionaryObjectObject;
+        var kvpType = EmitGenerics.MakeGenericType(
+            _ctx.Types.KeyValuePairOpen, _ctx.Types.Object, _ctx.Types.Object);
+        var enumeratorType = EmitGenerics.MakeGenericType(
+            typeof(Dictionary<,>.Enumerator).GetGenericTypeDefinition(),
+            _ctx.Types.Object, _ctx.Types.Object);
+
+        var startLabel = builder.DefineLabel("forof_stable_map_start");
+        var endLabel = builder.DefineLabel("forof_stable_map_end");
+        var continueLabel = builder.DefineLabel("forof_stable_map_continue");
+
+        var dictLocal = IL.DeclareLocal(dictType);
+        IL.Emit(OpCodes.Ldloc, iterableLocal);
+        IL.Emit(OpCodes.Castclass, dictType);
+        IL.Emit(OpCodes.Stloc, dictLocal);
+
+        var enumeratorLocal = IL.DeclareLocal(enumeratorType);
+        var currentLocal = IL.DeclareLocal(kvpType);
+        var keyLocal = IL.DeclareLocal(_ctx.Types.Double);
+        var valueLocal = IL.DeclareLocal(_ctx.Types.Double);
+
+        IL.Emit(OpCodes.Ldloc, dictLocal);
+        IL.Emit(OpCodes.Callvirt, _ctx.Types.GetMethod(dictType, "GetEnumerator")!);
+        IL.Emit(OpCodes.Stloc, enumeratorLocal);
+
+        _ctx.EnterLoop(endLabel, continueLabel, labelNames ?? CompilationContext.NoLabels);
+        builder.MarkLabel(startLabel);
+        EmitCancellationCheck();
+
+        IL.Emit(OpCodes.Ldloca, enumeratorLocal);
+        IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(enumeratorType, "MoveNext")!);
+        builder.Emit_Brfalse(endLabel);
+
+        IL.Emit(OpCodes.Ldloca, enumeratorLocal);
+        IL.Emit(OpCodes.Call, _ctx.Types.GetProperty(enumeratorType, "Current")!.GetGetMethod()!);
+        IL.Emit(OpCodes.Stloc, currentLocal);
+
+        IL.Emit(OpCodes.Ldloca, currentLocal);
+        IL.Emit(OpCodes.Call, _ctx.Types.GetProperty(kvpType, "Key")!.GetGetMethod()!);
+        IL.Emit(OpCodes.Unbox_Any, _ctx.Types.Double);
+        IL.Emit(OpCodes.Stloc, keyLocal);
+
+        IL.Emit(OpCodes.Ldloca, currentLocal);
+        IL.Emit(OpCodes.Call, _ctx.Types.GetProperty(kvpType, "Value")!.GetGetMethod()!);
+        IL.Emit(OpCodes.Unbox_Any, _ctx.Types.Double);
+        IL.Emit(OpCodes.Stloc, valueLocal);
+
+        _stableMapEntryBindings.Push((f.Variable.Lexeme, keyLocal, valueLocal));
+        try
+        {
+            EmitStatement(f.Body);
+        }
+        finally
+        {
+            _stableMapEntryBindings.Pop();
+        }
+
+        builder.MarkLabel(continueLabel);
+        builder.Emit_Br(startLabel);
+
+        builder.MarkLabel(endLabel);
+        IL.Emit(OpCodes.Ldloca, enumeratorLocal);
+        IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(enumeratorType, "Dispose")!);
+        _ctx.ExitLoop();
         _ctx.Locals.ExitScope();
     }
 

--- a/src/SharpTS/Compilation/StableMapIterationAnalyzer.cs
+++ b/src/SharpTS/Compilation/StableMapIterationAnalyzer.cs
@@ -1,0 +1,374 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Finds the deliberately narrow Map-entry loop shape that can skip JavaScript
+/// entry-array materialization. The receiver must be a fresh numeric Map local
+/// that never escapes; the loop entry itself may only be observed through
+/// literal <c>[0]</c> and <c>[1]</c> reads.
+/// </summary>
+internal static class StableMapIterationAnalyzer
+{
+    public static void Analyze(List<Stmt> program, TypeMap? typeMap, ClosureAnalyzer? closures)
+    {
+        if (typeMap == null) return;
+
+        var visitor = new ReceiverVisitor(typeMap);
+        foreach (var statement in program)
+            visitor.Visit(statement);
+
+        if (visitor.ContainsDirectEval)
+            return;
+
+        foreach (var (key, loops) in visitor.Loops)
+        {
+            if (!visitor.Candidates.Contains(key)
+                || visitor.Disqualified.Contains(key)
+                || visitor.DeclarationCounts.GetValueOrDefault(key) != 1
+                || closures?.IsVariableCaptured(key.Name) == true)
+            {
+                continue;
+            }
+
+            foreach (var loop in loops)
+            {
+                if (loop.IsAsync
+                    || loop.Variable.Lexeme == key.Name
+                    || typeMap.Get(loop.Iterable) is not TypeInfo.Map map
+                    || !IsNumber(map.KeyType)
+                    || !IsNumber(map.ValueType)
+                    || !EntryUseVisitor.IsSafe(loop.Body, loop.Variable.Lexeme))
+                {
+                    continue;
+                }
+
+                typeMap.MarkStableNumericMapIteration(loop);
+            }
+        }
+    }
+
+    private static bool IsNumber(TypeInfo? type) =>
+        type is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral;
+
+    private sealed class ReceiverVisitor(TypeMap typeMap) : AstVisitorBase
+    {
+        private readonly TypeMap _typeMap = typeMap;
+        private readonly Stack<(int Scope, string Name)> _activeMapIterations = new();
+        private Expr.Call? _discardedCall;
+        private int _scope;
+        private int _nextScope;
+
+        public HashSet<(int Scope, string Name)> Candidates { get; } = [];
+        public HashSet<(int Scope, string Name)> Disqualified { get; } = [];
+        public Dictionary<(int Scope, string Name), int> DeclarationCounts { get; } = [];
+        public Dictionary<(int Scope, string Name), List<Stmt.ForOf>> Loops { get; } = [];
+        public bool ContainsDirectEval { get; private set; }
+
+        protected override void VisitFunction(Stmt.Function statement) =>
+            InScope(() => base.VisitFunction(statement));
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression) =>
+            InScope(() => base.VisitArrowFunction(expression));
+
+        private void InScope(Action visit)
+        {
+            int saved = _scope;
+            _scope = ++_nextScope;
+            visit();
+            _scope = saved;
+        }
+
+        protected override void VisitVar(Stmt.Var statement)
+        {
+            HandleDeclaration(statement.Name, statement.Initializer);
+        }
+
+        protected override void VisitConst(Stmt.Const statement)
+        {
+            HandleDeclaration(statement.Name, statement.Initializer);
+        }
+
+        private void HandleDeclaration(Token name, Expr? initializer)
+        {
+            var key = (_scope, name.Lexeme);
+            DeclarationCounts[key] = DeclarationCounts.GetValueOrDefault(key) + 1;
+
+            if (initializer is Expr.New
+                {
+                    Callee: Expr.Variable { Name.Lexeme: "Map" },
+                    Arguments.Count: 0
+                }
+                && _typeMap.Get(initializer) is TypeInfo.Map map
+                && IsNumber(map.KeyType)
+                && IsNumber(map.ValueType))
+            {
+                Candidates.Add(key);
+            }
+
+            if (initializer != null)
+                Visit(initializer);
+        }
+
+        protected override void VisitForOf(Stmt.ForOf statement)
+        {
+            if (statement.Iterable is Expr.Variable receiver)
+            {
+                var key = (_scope, receiver.Name.Lexeme);
+                if (!Loops.TryGetValue(key, out var loops))
+                    Loops[key] = loops = [];
+                loops.Add(statement);
+
+                // This receiver occurrence is the intended non-escaping use.
+                _activeMapIterations.Push(key);
+                try
+                {
+                    Visit(statement.Body);
+                }
+                finally
+                {
+                    _activeMapIterations.Pop();
+                }
+                return;
+            }
+
+            base.VisitForOf(statement);
+        }
+
+        protected override void VisitCall(Expr.Call expression)
+        {
+            if (!expression.Optional
+                && expression.Callee is Expr.Variable { Name.Lexeme: "eval" })
+            {
+                ContainsDirectEval = true;
+            }
+
+            // A typed set on the exact local preserves the numeric representation.
+            // Skip the receiver variable so the catch-all VisitVariable does not
+            // classify this permitted use as an escape.
+            if (!expression.Optional
+                && expression.Callee is Expr.Get
+                {
+                    Object: Expr.Variable receiver,
+                    Name.Lexeme: "set",
+                    Optional: false
+                }
+                && expression.Arguments is [var key, var value]
+                && IsNumber(_typeMap.Get(key))
+                && IsNumber(_typeMap.Get(value))
+                && ReferenceEquals(expression, _discardedCall)
+                && !_activeMapIterations.Contains((_scope, receiver.Name.Lexeme)))
+            {
+                Visit(key);
+                Visit(value);
+                return;
+            }
+
+            base.VisitCall(expression);
+        }
+
+        protected override void VisitExpression(Stmt.Expression statement)
+        {
+            var saved = _discardedCall;
+            _discardedCall = statement.Expr as Expr.Call;
+            try
+            {
+                Visit(statement.Expr);
+            }
+            finally
+            {
+                _discardedCall = saved;
+            }
+        }
+
+        protected override void VisitGet(Expr.Get expression)
+        {
+            if (!expression.Optional
+                && expression.Name.Lexeme == "size"
+                && expression.Object is Expr.Variable)
+            {
+                // Reading size neither aliases nor mutates the receiver.
+                return;
+            }
+
+            base.VisitGet(expression);
+        }
+
+        protected override void VisitVariable(Expr.Variable expression) =>
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+
+        protected override void VisitAssign(Expr.Assign expression)
+        {
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+            base.VisitAssign(expression);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
+        {
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+            base.VisitCompoundAssign(expression);
+        }
+
+        protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
+        {
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+            base.VisitLogicalAssign(expression);
+        }
+
+        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expression)
+        {
+            if (expression.Operand is Expr.Variable variable)
+                Disqualified.Add((_scope, variable.Name.Lexeme));
+            base.VisitPrefixIncrement(expression);
+        }
+
+        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expression)
+        {
+            if (expression.Operand is Expr.Variable variable)
+                Disqualified.Add((_scope, variable.Name.Lexeme));
+            base.VisitPostfixIncrement(expression);
+        }
+    }
+
+    private sealed class EntryUseVisitor(string entryName) : AstVisitorBase
+    {
+        private readonly string _entryName = entryName;
+        public bool Safe { get; private set; } = true;
+
+        public static bool IsSafe(Stmt body, string entryName)
+        {
+            var visitor = new EntryUseVisitor(entryName);
+            visitor.Visit(body);
+            return visitor.Safe;
+        }
+
+        protected override void VisitGetIndex(Expr.GetIndex expression)
+        {
+            if (expression.Object is Expr.Variable variable
+                && variable.Name.Lexeme == _entryName)
+            {
+                if (expression.Optional
+                    || expression.Index is not Expr.Literal { Value: double index }
+                    || index is not (0d or 1d))
+                {
+                    Safe = false;
+                }
+                return;
+            }
+
+            base.VisitGetIndex(expression);
+        }
+
+        protected override void VisitVar(Stmt.Var statement)
+        {
+            if (statement.Name.Lexeme == _entryName)
+                Safe = false;
+            base.VisitVar(statement);
+        }
+
+        protected override void VisitConst(Stmt.Const statement)
+        {
+            if (statement.Name.Lexeme == _entryName)
+                Safe = false;
+            base.VisitConst(statement);
+        }
+
+        protected override void VisitForOf(Stmt.ForOf statement)
+        {
+            if (statement.Variable.Lexeme == _entryName)
+                Safe = false;
+            base.VisitForOf(statement);
+        }
+
+        protected override void VisitForIn(Stmt.ForIn statement)
+        {
+            if (statement.Variable.Lexeme == _entryName)
+                Safe = false;
+            base.VisitForIn(statement);
+        }
+
+        protected override void VisitTryCatch(Stmt.TryCatch statement)
+        {
+            if (statement.CatchParam?.Lexeme == _entryName)
+                Safe = false;
+            base.VisitTryCatch(statement);
+        }
+
+        protected override void VisitFunction(Stmt.Function statement)
+        {
+            if (statement.Name.Lexeme == _entryName)
+                Safe = false;
+            base.VisitFunction(statement);
+        }
+
+        protected override void VisitClass(Stmt.Class statement)
+        {
+            if (statement.Name.Lexeme == _entryName)
+                Safe = false;
+            base.VisitClass(statement);
+        }
+
+        protected override void VisitUsing(Stmt.Using statement)
+        {
+            if (statement.Bindings.Any(binding => binding.Name?.Lexeme == _entryName))
+                Safe = false;
+            base.VisitUsing(statement);
+        }
+
+        protected override void VisitVariable(Expr.Variable expression)
+        {
+            if (expression.Name.Lexeme == _entryName)
+                Safe = false;
+        }
+
+        protected override void VisitAssign(Expr.Assign expression)
+        {
+            if (expression.Name.Lexeme == _entryName)
+                Safe = false;
+            base.VisitAssign(expression);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
+        {
+            if (expression.Name.Lexeme == _entryName)
+                Safe = false;
+            base.VisitCompoundAssign(expression);
+        }
+
+        protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
+        {
+            if (expression.Name.Lexeme == _entryName)
+                Safe = false;
+            base.VisitLogicalAssign(expression);
+        }
+
+        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expression)
+        {
+            if (IsEntryIndex(expression.Operand))
+                Safe = false;
+            base.VisitPrefixIncrement(expression);
+        }
+
+        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expression)
+        {
+            if (IsEntryIndex(expression.Operand))
+                Safe = false;
+            base.VisitPostfixIncrement(expression);
+        }
+
+        protected override void VisitDelete(Expr.Delete expression)
+        {
+            if (IsEntryIndex(expression.Operand))
+                Safe = false;
+            base.VisitDelete(expression);
+        }
+
+        private bool IsEntryIndex(Expr expression) =>
+            expression is Expr.GetIndex
+            {
+                Object: Expr.Variable variable
+            } && variable.Name.Lexeme == _entryName;
+    }
+}

--- a/src/SharpTS/TypeSystem/TypeMap.cs
+++ b/src/SharpTS/TypeSystem/TypeMap.cs
@@ -23,6 +23,7 @@ public class TypeMap
     private readonly Dictionary<Token, TokenType> _promotableArrayLocals = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Token> _promotableStringAccumulators = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<Token, ObjectShapeInfo> _promotableObjectLocals = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Stmt.ForOf> _stableNumericMapIterations = new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
     /// Associates an expression with its resolved type.
@@ -185,6 +186,23 @@ public class TypeMap
     /// the generated types). Empty when no object local was promoted.
     /// </summary>
     public IEnumerable<ObjectShapeInfo> PromotableObjectLocalShapes => _promotableObjectLocals.Values;
+
+    /// <summary>
+    /// Marks a <c>for...of</c> over a fresh, non-escaping <c>Map&lt;number, number&gt;</c>
+    /// whose entry binding is observed only through literal <c>[0]</c>/<c>[1]</c> reads.
+    /// The compiler may lower this shape directly over the backing dictionary without
+    /// materializing JavaScript entry arrays. This is a compiler hint only; the public
+    /// TypeScript type remains the ordinary Map iterator type.
+    /// </summary>
+    public void MarkStableNumericMapIteration(Stmt.ForOf loop) =>
+        _stableNumericMapIterations.Add(loop);
+
+    /// <summary>
+    /// True when <paramref name="loop"/> satisfies the non-escape and entry-use proof
+    /// recorded by the IL compiler's stable Map iteration analyzer.
+    /// </summary>
+    public bool IsStableNumericMapIteration(Stmt.ForOf loop) =>
+        _stableNumericMapIterations.Contains(loop);
 
     /// <summary>
     /// Gets the resolved type for an expression, or null if not found.

--- a/tests/SharpTS.Tests/CompilerTests/StableMapIterationTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableMapIterationTests.cs
@@ -1,0 +1,356 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class StableMapIterationTests
+{
+    [Fact]
+    public void StableNumericEntryReads_UseDirectDictionaryEnumerator()
+    {
+        Assembly assembly = Compile(StableSource);
+        var instructions = ReadInstructions(FindFunction(assembly, "sumMap")).ToArray();
+
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "GetEnumerator",
+                DeclaringType: { IsGenericType: true } declaringType
+            }
+            && declaringType.GetGenericTypeDefinition() == typeof(Dictionary<,>));
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "MapEntries" or "NormalizeToEnumerator" });
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is ConstructorInfo
+            {
+                DeclaringType: { IsGenericType: true } declaringType
+            }
+            && declaringType.GetGenericTypeDefinition() == typeof(List<>));
+        Assert.True(instructions.Count(instruction =>
+            instruction.OpCode == OpCodes.Unbox_Any && instruction.Operand == typeof(double)) >= 2);
+    }
+
+    [Fact]
+    public void StableNumericEntryReads_PreserveResultAndVerifyIl()
+    {
+        Assert.Equal("18\n", TestHarness.RunCompiled(StableSource));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(StableSource));
+    }
+
+    [Fact]
+    public void StableNumericEntryReads_WorkInStandaloneOutput()
+    {
+        Assert.Equal("18\n", TestHarness.RunCompiledStandalone(StableSource));
+    }
+
+    [Fact]
+    public void ReceiverAlias_RetainsMaterializedIteratorPath()
+    {
+        AssertUsesFallback("""
+            function read(): number {
+                const map = new Map<number, number>();
+                map.set(1, 2);
+                const alias: any = map;
+                let sum: number = 0;
+                for (const entry of map) sum = sum + entry[0] + entry[1];
+                return sum + alias.size - alias.size;
+            }
+            """);
+    }
+
+    [Fact]
+    public void ReceiverAliasThroughSetResult_RetainsMaterializedIteratorPath()
+    {
+        AssertUsesFallback("""
+            function read(): number {
+                const map = new Map<number, number>();
+                const alias: Map<number, number> = map.set(1, 2);
+                let sum: number = 0;
+                for (const entry of map) sum = sum + entry[0] + entry[1];
+                return sum + alias.size - alias.size;
+            }
+            """);
+    }
+
+    [Fact]
+    public void EntryEscape_RetainsMaterializedIteratorPath()
+    {
+        AssertUsesFallback("""
+            function consume(value: any): number { return value[0] + value[1]; }
+            function read(): number {
+                const map = new Map<number, number>();
+                map.set(1, 2);
+                let sum: number = 0;
+                for (const entry of map) sum = sum + consume(entry);
+                return sum;
+            }
+            """);
+    }
+
+    [Fact]
+    public void DynamicEntryIndex_RetainsMaterializedIteratorPath()
+    {
+        AssertUsesFallback("""
+            function read(index: number): number {
+                const map = new Map<number, number>();
+                map.set(1, 2);
+                let sum: number = 0;
+                for (const entry of map) sum = sum + entry[index];
+                return sum;
+            }
+            """);
+    }
+
+    [Fact]
+    public void DestructuredEntry_RetainsIteratorSemantics()
+    {
+        AssertUsesFallback("""
+            function read(): number {
+                const map = new Map<number, number>();
+                map.set(1, 2);
+                let sum: number = 0;
+                for (const [key, value] of map) sum = sum + key + value;
+                return sum;
+            }
+            """);
+    }
+
+    [Fact]
+    public void ShadowedEntryBinding_RetainsIteratorSemantics()
+    {
+        AssertUsesFallback("""
+            function read(): number {
+                const map = new Map<number, number>();
+                map.set(1, 2);
+                let sum: number = 0;
+                for (const entry of map) {
+                    {
+                        const entry: number[] = [10, 20];
+                        sum = sum + entry[0] + entry[1];
+                    }
+                }
+                return sum;
+            }
+            """);
+    }
+
+    [Fact]
+    public void DynamicMap_RetainsMaterializedIteratorPath()
+    {
+        AssertUsesFallback("""
+            function read(): number {
+                const map: any = new Map<number, number>();
+                map.set(1, 2);
+                let sum: number = 0;
+                for (const entry of map) sum = sum + entry[0] + entry[1];
+                return sum;
+            }
+            """);
+    }
+
+    [Fact]
+    public void MutationDuringIteration_RetainsLiveDeletionBehavior()
+    {
+        const string source = """
+            const map = new Map<number, number>();
+            map.set(1, 10);
+            map.set(2, 20);
+            map.set(3, 30);
+            let seen: string = "";
+            for (const entry of map) {
+                seen = seen + entry[0];
+                if (entry[0] === 1) map.delete(2);
+            }
+            console.log(seen);
+            """;
+
+        Assert.Equal("13\n", TestHarness.RunCompiled(source));
+
+        Assembly assembly = Compile(source);
+        var entryPoint = assembly.EntryPoint!;
+        Assert.Contains(ReadInstructions(entryPoint), instruction =>
+            instruction.Operand is MethodBase { Name: "MapEntries" });
+    }
+
+    [Fact]
+    public void InsertAndClearDuringIteration_RetainMaterializedIteratorPath()
+    {
+        AssertUsesFallback("""
+            function read(): number {
+                const map = new Map<number, number>();
+                map.set(1, 10);
+                map.set(2, 20);
+                let sum: number = 0;
+                for (const entry of map) {
+                    sum = sum + entry[0];
+                    if (entry[0] === 1) map.set(3, 30);
+                    if (entry[0] === 2) map.clear();
+                }
+                return sum;
+            }
+            """);
+    }
+
+    [Fact]
+    public void CustomIteratorAlias_RetainsMaterializedIteratorPath()
+    {
+        AssertUsesFallback("""
+            function read(): number {
+                const map = new Map<number, number>();
+                map.set(1, 2);
+                const observable: any = map;
+                observable[Symbol.iterator] = () => [][Symbol.iterator]();
+                let sum: number = 0;
+                for (const entry of map) sum = sum + entry[0] + entry[1];
+                return sum;
+            }
+            """);
+    }
+
+    [Fact]
+    public void StableEntryReads_PreserveEvaluationOrderAndExceptions()
+    {
+        const string source = """
+            let trace: string = "";
+            function note(label: string, value: number): number {
+                trace = trace + label + value;
+                return value;
+            }
+            function read(): number {
+                const map = new Map<number, number>();
+                map.set(1, 10);
+                map.set(2, 20);
+                let sum: number = 0;
+                try {
+                    for (const entry of map) {
+                        sum = sum + note("k", entry[0]) + note("v", entry[1]);
+                        if (entry[0] === 2) throw "stop";
+                    }
+                } catch (error) {
+                    trace = trace + ":caught";
+                }
+                return sum;
+            }
+            console.log(read());
+            console.log(trace);
+            """;
+
+        Assert.Equal("33\nk1v10k2v20:caught\n", TestHarness.RunCompiled(source));
+
+        Assembly assembly = Compile(source);
+        Assert.DoesNotContain(ReadInstructions(FindFunction(assembly, "read")), instruction =>
+            instruction.Operand is MethodBase { Name: "MapEntries" or "NormalizeToEnumerator" });
+    }
+
+    [Fact]
+    public void DirectEval_RetainsMaterializedIteratorPath()
+    {
+        AssertUsesFallback("""
+            function read(): number {
+                const map = new Map<number, number>();
+                map.set(1, 2);
+                eval("void 0");
+                let sum: number = 0;
+                for (const entry of map) sum = sum + entry[0] + entry[1];
+                return sum;
+            }
+            """);
+    }
+
+    private static void AssertUsesFallback(string source)
+    {
+        Assembly assembly = Compile(source);
+        var instructions = ReadInstructions(FindFunction(assembly, "read")).ToArray();
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "MapEntries" });
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "NormalizeToEnumerator" });
+    }
+
+    private const string StableSource = """
+        function sumMap(): number {
+            const map = new Map<number, number>();
+            for (let i: number = 0; i < 3; i++) {
+                map.set(i, i * 3 + 1);
+            }
+            let sum: number = 0;
+            for (const entry of map) {
+                sum = sum + entry[0] + entry[1];
+            }
+            return sum + map.size;
+        }
+        console.log(sumMap());
+        """;
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"issue_1435_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token)
+                    : module.ResolveType(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}


### PR DESCRIPTION
## Summary

- prove fresh non-escaping `Map<number, number>` bindings and literal `entry[0]` / `entry[1]` consumers
- lower eligible loops directly over the backing dictionary with native key/value locals
- retain the general live iterator path for aliases, mutation, dynamic Maps/indexes, iterator customization, escaping entries, direct eval, and shadowed bindings
- cover structural IL, semantic fallbacks, evaluation order, exceptions, standalone output, and IL verification

## Performance

At N=10,000, five alternated process launches measured compiled Map iteration at 0.420–0.466 ms versus Node at 0.439–0.454 ms; the median compiled result was slightly faster than Node (gate: <=1.5x).

An isolated out-of-process BenchmarkDotNet run measured:

| Implementation | Mean | Allocated |
|---|---:|---:|
| idiomatic C# | 138.8 us | 276.43 KB |
| boxed-equivalent C# | 524.2 us | 1,526.54 KB |
| SharpTS compiled | **565.0 us** | **1,388.85 KB** |

The SharpTS acceptance gates are <=900 us and <=1,600 KB/op. Relative to the issue baseline, this reduces mean time by about 79% and allocation by about 53%.

## Validation

- Release build: 0 warnings, 0 errors
- focused Map/iterator slice: 297 passed
- stable Map + AOT architecture gates: 18 passed
- full core suite: 17,115 passed, 3 skipped, 0 failed
- cross-runtime smoke: all 16 workloads compiled
- emitted benchmark assembly: IL verification passed

Closes #1435