### PR TITLE
Optimize stable primitive Promise.then chains

### DIFF
--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -1032,6 +1032,8 @@ public class EmittedRuntime
     public MethodBuilder PromiseAllKeyed { get; set; } = null!;
     public MethodBuilder PromiseRace { get; set; } = null!;
     public MethodBuilder PromiseThen { get; set; } = null!;
+    /// <summary>$Runtime.PromiseThenPrimitive(Task&lt;object?&gt;, Func&lt;double,double&gt;) -> Task&lt;object?&gt; — stable intrinsic fulfillment-only numeric continuation whose primitive callback result cannot require thenable adoption.</summary>
+    public MethodBuilder PromiseThenPrimitive { get; set; } = null!;
     public MethodBuilder PromiseCatch { get; set; } = null!;
     public MethodBuilder PromiseFinally { get; set; } = null!;
     public MethodBuilder PromiseAllSettled { get; set; } = null!;

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -1534,9 +1534,10 @@ public abstract partial class ExpressionEmitterBase
 
         // Promise instance methods: promise.then/catch/finally
         string methodName = methodGet.Name.Lexeme;
-        if (methodName is "then" or "catch" or "finally")
+        if (methodName is "then" or "catch" or "finally"
+            && Ctx.RuntimeFeatures?.UsesPromisePrototypeMutation != true)
         {
-            EmitPromiseInstanceMethodCall(methodGet.Object, methodName, c.Arguments);
+            EmitPromiseInstanceMethodCall(methodGet, methodName, c.Arguments);
             return true;
         }
 
@@ -2389,8 +2390,48 @@ public abstract partial class ExpressionEmitterBase
         return true;
     }
 
-    protected void EmitPromiseInstanceMethodCall(Expr promise, string methodName, List<Expr> arguments)
+    protected void EmitPromiseInstanceMethodCall(
+        Expr.Get methodGet,
+        string methodName,
+        List<Expr> arguments)
     {
+        Expr promise = methodGet.Object;
+
+        // #1438: a whole-program proof established that this receiver is a
+        // fresh intrinsic Promise binding which never aliases or escapes, and
+        // that its sole inline fulfillment callback returns a primitive. The
+        // callback result therefore cannot require Promise Resolve/thenable
+        // adoption, while the intrinsic receiver cannot require constructor /
+        // species observation or derived-result wrapping.
+        if (methodName == "then"
+            && Ctx.TypeMap?.IsStablePrimitivePromiseThen(methodGet) == true)
+        {
+            EmitExpression(promise);
+            EnsureBoxed();
+            IL.Emit(OpCodes.Castclass, Types.TaskOfObject);
+            var promiseLocal = IL.DeclareLocal(Types.TaskOfObject);
+            IL.Emit(OpCodes.Stloc, promiseLocal);
+            IL.Emit(OpCodes.Ldloc, promiseLocal);
+
+            var handler = (Expr.ArrowFunction)arguments[0];
+            if (TryEmitArrowAsDelegate(handler, typeof(Func<double, double>)))
+            {
+                IL.Emit(OpCodes.Call, Ctx.Runtime!.PromiseThenPrimitive);
+            }
+            else
+            {
+                // Defensive fallback if a future emitter cannot materialize the
+                // proven arrow as a typed delegate. The receiver is still stable,
+                // but callback behavior remains on the general state machine.
+                EmitExpression(handler);
+                EnsureBoxed();
+                IL.Emit(OpCodes.Ldnull);
+                IL.Emit(OpCodes.Call, Ctx.Runtime!.PromiseThen);
+            }
+            SetStackUnknown();
+            return;
+        }
+
         // Receivers may be raw Task<object?> OR $Promise objects (#242 Promise
         // subclasses derive from $Promise) — keep the receiver for derived-result
         // wrapping and unwrap to the task for the PromiseThen/Catch/Finally

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.cs
@@ -50,13 +50,39 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         => TryEmitArrowAsDelegate(af, delegateType);
 
     /// <summary>
-    /// Default: state-machine emitters and other contexts decline this fast
-    /// path. <see cref="ILEmitter"/> overrides to support it (handles both
-    /// non-capturing static methods and capturing display-class instance
-    /// methods). Callers must be prepared for false and fall back to the
-    /// legacy <c>$TSFunction</c> wrap.
+    /// Emits a synchronous unnamed arrow as a typed delegate. State-machine
+    /// emitters populate capturing display classes through their variable-
+    /// storage hooks; <see cref="ILEmitter"/> overrides this with its richer
+    /// direct-local/display-chain implementation.
     /// </summary>
-    protected virtual bool TryEmitArrowAsDelegate(Expr.ArrowFunction af, Type delegateType) => false;
+    protected virtual bool TryEmitArrowAsDelegate(Expr.ArrowFunction af, Type delegateType)
+    {
+        if (af.IsAsync || af.IsGenerator || af.Name != null
+            || Ctx.ArrowMethods == null
+            || !Ctx.ArrowMethods.TryGetValue(af, out var method))
+        {
+            return false;
+        }
+
+        var delegateCtor = Types.TryGetConstructor(
+            delegateType, typeof(object), typeof(IntPtr));
+        if (delegateCtor == null)
+            return false;
+
+        if (Ctx.DisplayClassConstructors?.TryGetValue(af, out var displayCtor) == true)
+        {
+            EmitCapturingArrowDisplayViaHooks(af, displayCtor);
+        }
+        else
+        {
+            IL.Emit(OpCodes.Ldnull);
+        }
+
+        IL.Emit(OpCodes.Ldftn, method);
+        IL.Emit(OpCodes.Newobj, delegateCtor);
+        SetStackUnknown();
+        return true;
+    }
 
     bool IEmitterContext.TryEmitCapturingArrowDisplayInstance(Expr.ArrowFunction af)
         => TryEmitCapturingArrowDisplayInstance(af);
@@ -1764,6 +1790,16 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
 
     private void EmitCapturingArrowViaHooks(Expr.ArrowFunction af, MethodBuilder method, ConstructorBuilder displayCtor)
     {
+        EmitCapturingArrowDisplayViaHooks(af, displayCtor);
+        Types.EmitLoadMethodInfoViaHandle(IL, method);
+        IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSFunctionCtor);
+        SetStackUnknown();
+    }
+
+    private void EmitCapturingArrowDisplayViaHooks(
+        Expr.ArrowFunction af,
+        ConstructorBuilder displayCtor)
+    {
         IL.Emit(OpCodes.Newobj, displayCtor);
 
         // Thread the entry-point display class into the arrow's $entryPointDC field so the arrow
@@ -1841,9 +1877,6 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             }
         }
 
-        Types.EmitLoadMethodInfoViaHandle(IL, method);
-        IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSFunctionCtor);
-        SetStackUnknown();
     }
 
     // EmitCall is virtual with a default implementation in ExpressionEmitterBase.CallHelpers.cs

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -651,6 +651,8 @@ public partial class ILCompiler
     {
         Phase2_AnalyzeClosures(statements);
         StableMapIterationAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
+        StablePrimitivePromiseThenAnalyzer.Analyze(
+            statements, _typeMap, _closures.Analyzer);
         ArrayLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         StringAccumulatorPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         NonEscapingArrowLocalAnalyzer.Analyze(

--- a/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -193,12 +193,13 @@ public partial class ILEmitter
 
         // Promise instance methods: then(), catch(), finally()
         // These work on Task<object?> returned by async functions
-        if (methodName is "then" or "catch" or "finally")
+        if (methodName is "then" or "catch" or "finally"
+            && _ctx.RuntimeFeatures?.UsesPromisePrototypeMutation != true)
         {
             // Check if we know it's a Promise at compile time
             if (objType is TypeSystem.TypeInfo.Promise)
             {
-                EmitPromiseInstanceMethodCall(methodGet.Object, methodName, arguments);
+                EmitPromiseInstanceMethodCall(methodGet, methodName, arguments);
                 return;
             }
         }

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.Then.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.Then.cs
@@ -546,6 +546,196 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
+    /// <summary>
+    /// Defines the smaller fulfillment-only state machine used after the compiler
+    /// proves that a direct intrinsic Promise.then callback returns a primitive.
+    /// </summary>
+    private PrimitivePromiseThenStateMachine DefinePrimitivePromiseThenStateMachine(
+        ModuleBuilder moduleBuilder)
+    {
+        var builderType = typeof(AsyncTaskMethodBuilder<object>);
+        var awaiterType = typeof(TaskAwaiter<object?>);
+        var smType = moduleBuilder.DefineType(
+            "$PromiseThenPrimitive_SM",
+            TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
+            typeof(ValueType),
+            [typeof(IAsyncStateMachine)]);
+
+        var stateField = smType.DefineField(
+            "<>1__state", typeof(int), FieldAttributes.Public);
+        var builderField = smType.DefineField(
+            "<>t__builder", builderType, FieldAttributes.Public);
+        var promiseField = smType.DefineField(
+            "promise", typeof(Task<object?>), FieldAttributes.Public);
+        var onFulfilledField = smType.DefineField(
+            "onFulfilled", typeof(Func<double, double>), FieldAttributes.Public);
+        var promiseAwaiterField = smType.DefineField(
+            "<>u__1", awaiterType, FieldAttributes.Private);
+
+        var moveNext = smType.DefineMethod(
+            "MoveNext",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final
+                | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
+            typeof(void),
+            Type.EmptyTypes);
+        smType.DefineMethodOverride(moveNext, _types.AsyncStateMachineMoveNext);
+
+        var setStateMachine = smType.DefineMethod(
+            "SetStateMachine",
+            MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final
+                | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
+            typeof(void),
+            [typeof(IAsyncStateMachine)]);
+        smType.DefineMethodOverride(setStateMachine, _types.AsyncStateMachineSetStateMachine);
+        setStateMachine.GetILGenerator().Emit(OpCodes.Ret);
+
+        return new PrimitivePromiseThenStateMachine
+        {
+            Type = smType,
+            StateField = stateField,
+            BuilderField = builderField,
+            PromiseField = promiseField,
+            OnFulfilledField = onFulfilledField,
+            PromiseAwaiterField = promiseAwaiterField,
+            MoveNextMethod = moveNext,
+            BuilderType = builderType
+        };
+    }
+
+    private void EmitPrimitivePromiseThenWrapper(
+        ILGenerator il,
+        PrimitivePromiseThenStateMachine sm)
+    {
+        var smLocal = il.DeclareLocal(sm.Type);
+        il.Emit(OpCodes.Ldloca, smLocal);
+        il.Emit(OpCodes.Initobj, sm.Type);
+
+        il.Emit(OpCodes.Ldloca, smLocal);
+        il.Emit(OpCodes.Ldc_I4_M1);
+        il.Emit(OpCodes.Stfld, sm.StateField);
+
+        il.Emit(OpCodes.Ldloca, smLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Stfld, sm.PromiseField);
+
+        il.Emit(OpCodes.Ldloca, smLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Stfld, sm.OnFulfilledField);
+
+        il.Emit(OpCodes.Ldloca, smLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            sm.BuilderType, "Create", BindingFlags.Public | BindingFlags.Static)!);
+        il.Emit(OpCodes.Stfld, sm.BuilderField);
+
+        il.Emit(OpCodes.Ldloca, smLocal);
+        il.Emit(OpCodes.Ldflda, sm.BuilderField);
+        il.Emit(OpCodes.Ldloca, smLocal);
+        var startMethod = EmitGenerics.MakeGenericMethod(
+            _types.GetMethods(sm.BuilderType, BindingFlags.Public | BindingFlags.Instance)
+                .First(method => method.Name == "Start" && method.IsGenericMethod),
+            sm.Type);
+        il.Emit(OpCodes.Call, startMethod);
+
+        il.Emit(OpCodes.Ldloca, smLocal);
+        il.Emit(OpCodes.Ldflda, sm.BuilderField);
+        il.Emit(OpCodes.Call, _types.GetProperty(
+            sm.BuilderType, "Task", BindingFlags.Public | BindingFlags.Instance)!
+            .GetGetMethod()!);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitPrimitivePromiseThenMoveNext(
+        PrimitivePromiseThenStateMachine sm)
+    {
+        var il = sm.MoveNextMethod.GetILGenerator();
+        var awaiterType = typeof(TaskAwaiter<object?>);
+        var awaiterLocal = il.DeclareLocal(awaiterType);
+        var valueLocal = il.DeclareLocal(typeof(object));
+        var resultLocal = il.DeclareLocal(typeof(object));
+        var exceptionLocal = il.DeclareLocal(typeof(Exception));
+        var resumeLabel = il.DefineLabel();
+        var continueLabel = il.DefineLabel();
+        var returnLabel = il.DefineLabel();
+
+        il.BeginExceptionBlock();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, sm.StateField);
+        il.Emit(OpCodes.Brfalse, resumeLabel);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, sm.PromiseField);
+        il.Emit(OpCodes.Callvirt, _types.TaskOfObjectGetAwaiter);
+        il.Emit(OpCodes.Stloc, awaiterLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, awaiterLocal);
+        il.Emit(OpCodes.Stfld, sm.PromiseAwaiterField);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldflda, sm.PromiseAwaiterField);
+        il.Emit(OpCodes.Call, awaiterType.GetProperty("IsCompleted")!.GetGetMethod()!);
+        il.Emit(OpCodes.Brtrue, continueLabel);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stfld, sm.StateField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldflda, sm.BuilderField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldflda, sm.PromiseAwaiterField);
+        il.Emit(OpCodes.Ldarg_0);
+        var awaitMethod = EmitGenerics.MakeGenericMethod(
+            _types.GetMethods(sm.BuilderType, BindingFlags.Public | BindingFlags.Instance)
+                .First(method => method.Name == "AwaitUnsafeOnCompleted" && method.IsGenericMethod),
+            awaiterType,
+            sm.Type);
+        il.Emit(OpCodes.Call, awaitMethod);
+        il.Emit(OpCodes.Leave, returnLabel);
+
+        il.MarkLabel(resumeLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_M1);
+        il.Emit(OpCodes.Stfld, sm.StateField);
+
+        il.MarkLabel(continueLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldflda, sm.PromiseAwaiterField);
+        il.Emit(OpCodes.Call, awaiterType.GetMethod("GetResult")!);
+        il.Emit(OpCodes.Stloc, valueLocal);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, sm.OnFulfilledField);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Unbox_Any, typeof(double));
+        il.Emit(OpCodes.Callvirt, typeof(Func<double, double>).GetMethod("Invoke")!);
+        il.Emit(OpCodes.Box, typeof(double));
+        il.Emit(OpCodes.Stloc, resultLocal);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4, -2);
+        il.Emit(OpCodes.Stfld, sm.StateField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldflda, sm.BuilderField);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(sm.BuilderType, "SetResult")!);
+        il.Emit(OpCodes.Leave, returnLabel);
+
+        il.BeginCatchBlock(typeof(Exception));
+        il.Emit(OpCodes.Stloc, exceptionLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4, -2);
+        il.Emit(OpCodes.Stfld, sm.StateField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldflda, sm.BuilderField);
+        il.Emit(OpCodes.Ldloc, exceptionLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(sm.BuilderType, "SetException")!);
+        il.Emit(OpCodes.Leave, returnLabel);
+        il.EndExceptionBlock();
+
+        il.MarkLabel(returnLabel);
+        il.Emit(OpCodes.Ret);
+    }
+
     #endregion
 }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.cs
@@ -59,6 +59,22 @@ internal class PromiseThenStateMachine
 }
 
 /// <summary>
+/// Holds information about the fulfillment-only Promise.then state machine used
+/// when the receiver and primitive callback result are statically stable.
+/// </summary>
+internal class PrimitivePromiseThenStateMachine
+{
+    public required TypeBuilder Type { get; init; }
+    public required FieldBuilder StateField { get; init; }
+    public required FieldBuilder BuilderField { get; init; }
+    public required FieldBuilder PromiseField { get; init; }
+    public required FieldBuilder OnFulfilledField { get; init; }
+    public required FieldBuilder PromiseAwaiterField { get; init; }
+    public required MethodBuilder MoveNextMethod { get; init; }
+    public required Type BuilderType { get; init; }
+}
+
+/// <summary>
 /// Holds information about the PromiseFinally state machine.
 /// </summary>
 internal class PromiseFinallyStateMachine
@@ -689,6 +705,24 @@ public partial class RuntimeEmitter
         EmitPromiseThenWrapper(then.GetILGenerator(), promiseThenSM);
         EmitPromiseThenMoveNext(promiseThenSM, runtime);
         promiseThenSM.Type.CreateType();
+
+        // Stable intrinsic Promise.then with a fulfillment-only callback whose
+        // static result is primitive/non-thenable. This state machine keeps the
+        // input await and callback exception-to-rejection behavior, but has no
+        // rejection dispatch or second thenable-flattening await.
+        var primitivePromiseThenSM = DefinePrimitivePromiseThenStateMachine(
+            moduleBuilder);
+        var primitiveThen = typeBuilder.DefineMethod(
+            "PromiseThenPrimitive",
+            MethodAttributes.Public | MethodAttributes.Static,
+            taskType,
+            [taskType, typeof(Func<double, double>)]
+        );
+        runtime.PromiseThenPrimitive = primitiveThen;
+        EmitPrimitivePromiseThenWrapper(
+            primitiveThen.GetILGenerator(), primitivePromiseThenSM);
+        EmitPrimitivePromiseThenMoveNext(primitivePromiseThenSM);
+        primitivePromiseThenSM.Type.CreateType();
 
         // Promise.prototype.catch - delegates to PromiseThen(promise, null, onRejected)
         var catchMethod = typeBuilder.DefineMethod(

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -88,6 +88,7 @@ public sealed class RuntimeFeatureDetector
             UsesSet = false,
             UsesDynamicPropertyDescriptors = false,
             UsesDatePrototypeMutation = false,
+            UsesPromisePrototypeMutation = false,
             UsesArrayPrototypeMutation = false,
             PotentiallyMaterializesUnknownCompactObjectRecordShape = false,
             TypedArrays = RuntimeFeatureSet.TypedArrayKinds.None,
@@ -763,6 +764,8 @@ public sealed class RuntimeFeatureDetector
             case Expr.Get g:
                 if (IsArrayPrototype(g) || g.Name.Lexeme == "__proto__")
                     _set.UsesArrayPrototypeMutation = true;
+                if (IsPromisePrototype(g))
+                    _set.UsesPromisePrototypeMutation = true;
                 if (g.Object is Expr.Variable ov)
                 {
                     HandleMemberAccess(ov.Name.Lexeme, g.Name.Lexeme);
@@ -833,6 +836,9 @@ public sealed class RuntimeFeatureDetector
                 MarkMutationTarget(s.Object);
                 if (IsDatePrototype(s.Object))
                     _set.UsesDatePrototypeMutation = true;
+                if (IsPromiseMutationTarget(s.Object)
+                    || s.Name.Lexeme is "then" or "constructor" or "__proto__")
+                    _set.UsesPromisePrototypeMutation = true;
                 if (IsArrayPrototype(s.Object)
                     || s.Name.Lexeme == "__proto__"
                     || (s.Name.Lexeme == "push" && CouldTargetArray(s.Object)))
@@ -870,6 +876,12 @@ public sealed class RuntimeFeatureDetector
                 MarkMutationTarget(si.Object);
                 if (IsDatePrototype(si.Object))
                     _set.UsesDatePrototypeMutation = true;
+                if (IsPromiseMutationTarget(si.Object)
+                    || si.Index is Expr.Literal
+                    {
+                        Value: "then" or "constructor" or "__proto__"
+                    })
+                    _set.UsesPromisePrototypeMutation = true;
                 if (IsArrayPrototype(si.Object)
                     || si.Index is Expr.Literal { Value: "__proto__" }
                     || (si.Index is Expr.Literal { Value: "push" }
@@ -881,6 +893,8 @@ public sealed class RuntimeFeatureDetector
                 break;
 
             case Expr.Call c:
+                if (c.Callee is Expr.Variable { Name.Lexeme: "eval" })
+                    _set.UsesPromisePrototypeMutation = true;
                 if (c.Callee is Expr.Get
                     {
                         Object: Expr.Variable { Name.Lexeme: "Object" or "Reflect" },
@@ -891,6 +905,18 @@ public sealed class RuntimeFeatureDetector
                     // attempted here. Any explicit prototype-chain mutation API
                     // disables the direct append path for the whole program.
                     _set.UsesArrayPrototypeMutation = true;
+                }
+                if (c.Callee is Expr.Get
+                    {
+                        Object: Expr.Variable { Name.Lexeme: "Object" or "Reflect" },
+                        Name.Lexeme: "assign" or "defineProperty" or "defineProperties"
+                            or "set" or "deleteProperty" or "setPrototypeOf"
+                    })
+                {
+                    // Aliases can hide either Promise.prototype or an intrinsic
+                    // promise receiver from this syntax-only pass. Retaining
+                    // value dispatch is conservative and preserves observability.
+                    _set.UsesPromisePrototypeMutation = true;
                 }
                 if (c.Callee is not Expr.Variable directSourceCall ||
                     !_sourceFunctions.Contains(directSourceCall.Name.Lexeme))
@@ -974,6 +1000,8 @@ public sealed class RuntimeFeatureDetector
                 break;
 
             case Expr.Assign asg:
+                if (asg.Name.Lexeme == "Promise")
+                    _set.UsesPromisePrototypeMutation = true;
                 if (_opaqueValueBindings.Contains(asg.Name.Lexeme))
                     MarkPotentiallyMaterialized(asg.Value);
                 VisitExpr(asg.Value);
@@ -983,6 +1011,9 @@ public sealed class RuntimeFeatureDetector
                 break;
             case Expr.CompoundSet cs:
                 MarkMutationTarget(cs.Object);
+                if (IsPromiseMutationTarget(cs.Object)
+                    || cs.Name.Lexeme is "then" or "constructor" or "__proto__")
+                    _set.UsesPromisePrototypeMutation = true;
                 if (cs.Name.Lexeme == "push" && CouldTargetArray(cs.Object))
                     _set.UsesArrayPrototypeMutation = true;
                 VisitExpr(cs.Object);
@@ -990,6 +1021,12 @@ public sealed class RuntimeFeatureDetector
                 break;
             case Expr.CompoundSetIndex csi:
                 MarkMutationTarget(csi.Object);
+                if (IsPromiseMutationTarget(csi.Object)
+                    || csi.Index is Expr.Literal
+                    {
+                        Value: "then" or "constructor" or "__proto__"
+                    })
+                    _set.UsesPromisePrototypeMutation = true;
                 if (csi.Index is Expr.Literal { Value: "push" }
                     && CouldTargetArray(csi.Object))
                     _set.UsesArrayPrototypeMutation = true;
@@ -1002,6 +1039,9 @@ public sealed class RuntimeFeatureDetector
                 break;
             case Expr.LogicalSet ls:
                 MarkMutationTarget(ls.Object);
+                if (IsPromiseMutationTarget(ls.Object)
+                    || ls.Name.Lexeme is "then" or "constructor" or "__proto__")
+                    _set.UsesPromisePrototypeMutation = true;
                 if (ls.Name.Lexeme == "push" && CouldTargetArray(ls.Object))
                     _set.UsesArrayPrototypeMutation = true;
                 VisitExpr(ls.Object);
@@ -1009,6 +1049,12 @@ public sealed class RuntimeFeatureDetector
                 break;
             case Expr.LogicalSetIndex lsi:
                 MarkMutationTarget(lsi.Object);
+                if (IsPromiseMutationTarget(lsi.Object)
+                    || lsi.Index is Expr.Literal
+                    {
+                        Value: "then" or "constructor" or "__proto__"
+                    })
+                    _set.UsesPromisePrototypeMutation = true;
                 if (lsi.Index is Expr.Literal { Value: "push" }
                     && CouldTargetArray(lsi.Object))
                     _set.UsesArrayPrototypeMutation = true;
@@ -1055,6 +1101,9 @@ public sealed class RuntimeFeatureDetector
                 if (d.Operand is Expr.Get deletedProperty)
                 {
                     MarkMutationTarget(deletedProperty.Object);
+                    if (IsPromiseMutationTarget(deletedProperty.Object)
+                        || deletedProperty.Name.Lexeme is "then" or "constructor" or "__proto__")
+                        _set.UsesPromisePrototypeMutation = true;
                     if (deletedProperty.Name.Lexeme == "push"
                         && CouldTargetArray(deletedProperty.Object))
                         _set.UsesArrayPrototypeMutation = true;
@@ -1062,6 +1111,12 @@ public sealed class RuntimeFeatureDetector
                 else if (d.Operand is Expr.GetIndex deletedIndex)
                 {
                     MarkMutationTarget(deletedIndex.Object);
+                    if (IsPromiseMutationTarget(deletedIndex.Object)
+                        || deletedIndex.Index is Expr.Literal
+                        {
+                            Value: "then" or "constructor" or "__proto__"
+                        })
+                        _set.UsesPromisePrototypeMutation = true;
                     if (deletedIndex.Index is Expr.Literal { Value: "push" }
                         && CouldTargetArray(deletedIndex.Object))
                         _set.UsesArrayPrototypeMutation = true;
@@ -1258,6 +1313,39 @@ public sealed class RuntimeFeatureDetector
         Object: Expr.Variable { Name.Lexeme: "Date" },
         Name.Lexeme: "prototype"
     };
+
+    private static bool IsPromisePrototype(Expr expr) => expr is Expr.Get
+    {
+        Object: Expr.Variable { Name.Lexeme: "Promise" },
+        Name.Lexeme: "prototype"
+    };
+
+    private bool IsPromiseMutationTarget(Expr expr)
+    {
+        while (true)
+        {
+            switch (expr)
+            {
+                case Expr.Grouping grouping:
+                    expr = grouping.Expression;
+                    continue;
+                case Expr.TypeAssertion assertion:
+                    expr = assertion.Expression;
+                    continue;
+                case Expr.Satisfies satisfies:
+                    expr = satisfies.Expression;
+                    continue;
+                case Expr.NonNullAssertion nonNull:
+                    expr = nonNull.Expression;
+                    continue;
+            }
+            break;
+        }
+
+        return expr is Expr.Variable { Name.Lexeme: "Promise" }
+            || IsPromisePrototype(expr)
+            || _typeMap?.Get(expr) is TypeInfo.Promise;
+    }
 
     private static bool IsArrayPrototype(Expr expr) => expr is Expr.Get
     {

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -138,6 +138,10 @@ public sealed class RuntimeFeatureSet
     // A Date.prototype write makes statically typed Date method calls observable
     // through the prototype object, so the direct DateEmitter fast path is unsafe.
     public bool UsesDatePrototypeMutation { get; set; } = true;
+    // Promise method/constructor/species mutation makes direct then lowering
+    // observable through ordinary property lookup. Such programs must retain
+    // value dispatch for then/catch/finally calls.
+    public bool UsesPromisePrototypeMutation { get; set; } = true;
     // Any observable access to Array.prototype, push-binding mutation,
     // prototype-chain mutation API, or __proto__ access makes a backing-list-only
     // array append unsafe. The discarded-result push fast path requires this false.

--- a/src/SharpTS/Compilation/StablePrimitivePromiseThenAnalyzer.cs
+++ b/src/SharpTS/Compilation/StablePrimitivePromiseThenAnalyzer.cs
@@ -1,0 +1,389 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Proves the deliberately narrow Promise.then shape used by the primitive-result
+/// continuation fast path. A qualifying binding starts at intrinsic Promise.resolve,
+/// never escapes or aliases, and is only advanced by assigning the result of its own
+/// eligible <c>then</c> call. Any observable Promise/prototype mutation or direct eval
+/// disables the optimization for the whole compilation.
+/// </summary>
+internal static class StablePrimitivePromiseThenAnalyzer
+{
+    public static void Analyze(
+        List<Stmt> program,
+        TypeMap? typeMap,
+        ClosureAnalyzer? closures)
+    {
+        if (typeMap is null)
+            return;
+
+        var mutationVisitor = new PromiseMutationVisitor(typeMap);
+        foreach (var statement in program)
+            mutationVisitor.Visit(statement);
+        if (mutationVisitor.HasObservableMutation)
+            return;
+
+        var visitor = new BindingVisitor(typeMap);
+        foreach (var statement in program)
+            visitor.Visit(statement);
+
+        foreach (var (key, calls) in visitor.Calls)
+        {
+            if (!visitor.Candidates.Contains(key)
+                || visitor.Disqualified.Contains(key)
+                || visitor.DeclarationCounts.GetValueOrDefault(key) != 1
+                || closures?.IsVariableCaptured(key.Name) == true)
+            {
+                continue;
+            }
+
+            foreach (var method in calls)
+                typeMap.MarkStablePrimitivePromiseThen(method);
+        }
+
+        foreach (var method in visitor.DirectSeedCalls)
+            typeMap.MarkStablePrimitivePromiseThen(method);
+    }
+
+    private static bool TryGetEligibleThen(
+        Expr expression,
+        TypeMap typeMap,
+        out Expr.Call call,
+        out Expr.Get method)
+    {
+        call = null!;
+        method = null!;
+        if (expression is not Expr.Call
+            {
+                Optional: false,
+                Callee: Expr.Get
+                {
+                    Optional: false,
+                    Name.Lexeme: "then"
+                } get,
+                Arguments: [Expr.ArrowFunction
+                {
+                    IsAsync: false,
+                    IsGenerator: false,
+                    HasOwnThis: false,
+                    Parameters: [
+                        {
+                            IsRest: false,
+                            IsOptional: false,
+                            DefaultValue: null
+                        }]
+                } handler]
+            } candidate
+            || typeMap.Get(get.Object) is not TypeInfo.Promise receiver
+            || !IsNumber(receiver.ValueType)
+            || typeMap.Get(handler) is not TypeInfo.Function function
+            || function.ParamTypes is not [var parameterType]
+            || !IsNumber(parameterType)
+            || !IsNumber(function.ReturnType))
+        {
+            return false;
+        }
+
+        call = candidate;
+        method = get;
+        return true;
+    }
+
+    private static bool IsNumber(TypeInfo type) => type is
+        TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral;
+
+    private static bool IsIntrinsicResolveSeed(Expr expression)
+    {
+        expression = Unwrap(expression);
+        return expression is Expr.Call
+        {
+            Optional: false,
+            Callee: Expr.Get
+            {
+                Optional: false,
+                Object: Expr.Variable { Name.Lexeme: "Promise" },
+                Name.Lexeme: "resolve"
+            }
+        };
+    }
+
+    private static Expr Unwrap(Expr expression)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case Expr.Grouping grouping:
+                    expression = grouping.Expression;
+                    continue;
+                case Expr.TypeAssertion assertion:
+                    expression = assertion.Expression;
+                    continue;
+                case Expr.Satisfies satisfies:
+                    expression = satisfies.Expression;
+                    continue;
+                case Expr.NonNullAssertion nonNull:
+                    expression = nonNull.Expression;
+                    continue;
+                default:
+                    return expression;
+            }
+        }
+    }
+
+    private sealed class BindingVisitor(TypeMap typeMap) : AstVisitorBase
+    {
+        private readonly TypeMap _typeMap = typeMap;
+        private int _scope;
+        private int _nextScope;
+
+        public HashSet<(int Scope, string Name)> Candidates { get; } = [];
+        public HashSet<(int Scope, string Name)> Disqualified { get; } = [];
+        public Dictionary<(int Scope, string Name), int> DeclarationCounts { get; } = [];
+        public Dictionary<(int Scope, string Name), List<Expr.Get>> Calls { get; } = [];
+        public HashSet<Expr.Get> DirectSeedCalls { get; } = new(ReferenceEqualityComparer.Instance);
+
+        protected override void VisitFunction(Stmt.Function statement) =>
+            InScope(() => base.VisitFunction(statement));
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression) =>
+            InScope(() => base.VisitArrowFunction(expression));
+
+        private void InScope(Action visit)
+        {
+            int saved = _scope;
+            _scope = ++_nextScope;
+            visit();
+            _scope = saved;
+        }
+
+        protected override void VisitVar(Stmt.Var statement) =>
+            HandleDeclaration(statement.Name, statement.Initializer);
+
+        protected override void VisitConst(Stmt.Const statement) =>
+            HandleDeclaration(statement.Name, statement.Initializer);
+
+        private void HandleDeclaration(Token name, Expr? initializer)
+        {
+            var key = (_scope, name.Lexeme);
+            DeclarationCounts[key] = DeclarationCounts.GetValueOrDefault(key) + 1;
+            // Top-level bindings can be observed through ESM exports (including
+            // under an imported alias), so this deliberately remains a local-
+            // binding optimization. Function-local bindings cannot become live
+            // module cells unless another use below proves that they escape.
+            if (_scope != 0
+                && initializer is not null
+                && IsIntrinsicResolveSeed(initializer))
+                Candidates.Add(key);
+            if (initializer is not null)
+                Visit(initializer);
+        }
+
+        protected override void VisitAssign(Expr.Assign expression)
+        {
+            var key = (_scope, expression.Name.Lexeme);
+            if (TryGetEligibleThen(expression.Value, _typeMap, out var call, out var method)
+                && method.Object is Expr.Variable receiver
+                && receiver.Name.Lexeme == expression.Name.Lexeme)
+            {
+                RecordCall(key, method);
+                VisitEligibleArguments(call);
+                return;
+            }
+
+            Disqualified.Add(key);
+            base.VisitAssign(expression);
+        }
+
+        protected override void VisitCall(Expr.Call expression)
+        {
+            if (TryGetEligibleThen(expression, _typeMap, out var call, out var method))
+            {
+                if (method.Object is Expr.Variable receiver)
+                {
+                    RecordCall((_scope, receiver.Name.Lexeme), method);
+                    VisitEligibleArguments(call);
+                    return;
+                }
+
+                if (IsIntrinsicResolveSeed(method.Object))
+                {
+                    DirectSeedCalls.Add(method);
+                    Visit(method.Object);
+                    VisitEligibleArguments(call);
+                    return;
+                }
+            }
+
+            base.VisitCall(expression);
+        }
+
+        private void RecordCall((int Scope, string Name) key, Expr.Get method)
+        {
+            if (!Calls.TryGetValue(key, out var calls))
+                Calls[key] = calls = [];
+            calls.Add(method);
+        }
+
+        private void VisitEligibleArguments(Expr.Call call)
+        {
+            foreach (var argument in call.Arguments)
+                Visit(argument);
+        }
+
+        protected override void VisitAwait(Expr.Await expression)
+        {
+            if (Unwrap(expression.Expression) is Expr.Variable)
+                return;
+            base.VisitAwait(expression);
+        }
+
+        protected override void VisitReturn(Stmt.Return statement)
+        {
+            if (statement.Value is not null && Unwrap(statement.Value) is Expr.Variable)
+                return;
+            base.VisitReturn(statement);
+        }
+
+        protected override void VisitVariable(Expr.Variable expression) =>
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
+        {
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+            base.VisitCompoundAssign(expression);
+        }
+
+        protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
+        {
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+            base.VisitLogicalAssign(expression);
+        }
+
+        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expression)
+        {
+            if (expression.Operand is Expr.Variable variable)
+                Disqualified.Add((_scope, variable.Name.Lexeme));
+            base.VisitPrefixIncrement(expression);
+        }
+
+        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expression)
+        {
+            if (expression.Operand is Expr.Variable variable)
+                Disqualified.Add((_scope, variable.Name.Lexeme));
+            base.VisitPostfixIncrement(expression);
+        }
+    }
+
+    private sealed class PromiseMutationVisitor(TypeMap typeMap) : AstVisitorBase
+    {
+        private readonly TypeMap _typeMap = typeMap;
+        public bool HasObservableMutation { get; private set; }
+
+        protected override void VisitCall(Expr.Call expression)
+        {
+            if (expression.Callee is Expr.Variable { Name.Lexeme: "eval" })
+                HasObservableMutation = true;
+
+            if (expression.Arguments.Count > 0
+                && expression.Callee is Expr.Get
+                {
+                    Object: Expr.Variable { Name.Lexeme: "Object" or "Reflect" },
+                    Name.Lexeme: "assign" or "defineProperty" or "defineProperties"
+                        or "set" or "deleteProperty" or "setPrototypeOf"
+                }
+                && IsPromiseTarget(expression.Arguments[0]))
+            {
+                HasObservableMutation = true;
+            }
+
+            base.VisitCall(expression);
+        }
+
+        protected override void VisitGet(Expr.Get expression)
+        {
+            if (IsPromisePrototype(expression))
+                HasObservableMutation = true;
+            base.VisitGet(expression);
+        }
+
+        protected override void VisitAssign(Expr.Assign expression)
+        {
+            if (expression.Name.Lexeme == "Promise")
+                HasObservableMutation = true;
+            base.VisitAssign(expression);
+        }
+
+        protected override void VisitSet(Expr.Set expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitSet(expression);
+        }
+
+        protected override void VisitSetIndex(Expr.SetIndex expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitSetIndex(expression);
+        }
+
+        protected override void VisitCompoundSet(Expr.CompoundSet expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitCompoundSet(expression);
+        }
+
+        protected override void VisitCompoundSetIndex(Expr.CompoundSetIndex expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitCompoundSetIndex(expression);
+        }
+
+        protected override void VisitLogicalSet(Expr.LogicalSet expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitLogicalSet(expression);
+        }
+
+        protected override void VisitLogicalSetIndex(Expr.LogicalSetIndex expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitLogicalSetIndex(expression);
+        }
+
+        protected override void VisitDelete(Expr.Delete expression)
+        {
+            Expr operand = Unwrap(expression.Operand);
+            if (operand is Expr.Get property && IsPromiseTarget(property.Object)
+                || operand is Expr.GetIndex index && IsPromiseTarget(index.Object))
+            {
+                HasObservableMutation = true;
+            }
+            base.VisitDelete(expression);
+        }
+
+        private bool IsPromiseTarget(Expr expression)
+        {
+            expression = Unwrap(expression);
+            return expression is Expr.Variable { Name.Lexeme: "Promise" }
+                || IsPromisePrototype(expression)
+                || _typeMap.Get(expression) is TypeInfo.Promise;
+        }
+
+        private static bool IsPromisePrototype(Expr expression) => Unwrap(expression) is Expr.Get
+        {
+            Optional: false,
+            Object: Expr.Variable { Name.Lexeme: "Promise" },
+            Name.Lexeme: "prototype"
+        };
+    }
+}

--- a/src/SharpTS/TypeSystem/TypeMap.cs
+++ b/src/SharpTS/TypeSystem/TypeMap.cs
@@ -24,6 +24,7 @@ public class TypeMap
     private readonly HashSet<Token> _promotableStringAccumulators = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<Token, ObjectShapeInfo> _promotableObjectLocals = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Stmt.ForOf> _stableNumericMapIterations = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Expr.Get> _stablePrimitivePromiseThenCalls = new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
     /// Associates an expression with its resolved type.
@@ -203,6 +204,22 @@ public class TypeMap
     /// </summary>
     public bool IsStableNumericMapIteration(Stmt.ForOf loop) =>
         _stableNumericMapIterations.Contains(loop);
+
+    /// <summary>
+    /// Marks a direct <c>Promise.prototype.then</c> access whose receiver is a fresh,
+    /// non-escaping intrinsic Promise binding and whose sole inline fulfillment
+    /// callback has a statically primitive result. The compiler may skip species,
+    /// dynamic callback-shape, and thenable-adoption machinery for this exact call.
+    /// </summary>
+    public void MarkStablePrimitivePromiseThen(Expr.Get method) =>
+        _stablePrimitivePromiseThenCalls.Add(method);
+
+    /// <summary>
+    /// True when <paramref name="method"/> satisfies the whole-program stability and
+    /// primitive-result proof recorded by the Promise.then analyzer.
+    /// </summary>
+    public bool IsStablePrimitivePromiseThen(Expr.Get method) =>
+        _stablePrimitivePromiseThenCalls.Contains(method);
 
     /// <summary>
     /// Gets the resolved type for an expression, or null if not found.

--- a/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
@@ -109,6 +109,22 @@ public class RuntimeFeatureDetectorTests
     }
 
     [Theory]
+    [InlineData("const p = Promise.resolve(1); p.then(x => x + 1);", false)]
+    [InlineData("const prototype = Promise.prototype;", true)]
+    [InlineData("const p: any = Promise.resolve(1); p.then = () => Promise.resolve(2);", true)]
+    [InlineData("Promise[Symbol.species] = Promise;", true)]
+    [InlineData("Object.defineProperty({}, 'x', { value: 1 });", true)]
+    [InlineData("eval('void 0');", true)]
+    public void DetectsPromisePrototypeMutationRisk(string source, bool expected)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var features = new RuntimeFeatureDetector().Detect(statements, typeMap);
+
+        Assert.Equal(expected, features.UsesPromisePrototypeMutation);
+    }
+
+    [Theory]
     [InlineData("const p = Array.prototype;", true)]
     [InlineData("Object.setPrototypeOf({}, null);", true)]
     [InlineData("Reflect.setPrototypeOf({}, null);", true)]

--- a/tests/SharpTS.Tests/CompilerTests/StablePrimitivePromiseThenTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StablePrimitivePromiseThenTests.cs
@@ -1,0 +1,328 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>
+/// Regression coverage for #1438: fresh, non-escaping intrinsic Promise chains
+/// with inline numeric handlers use the typed continuation ABI. Every observable
+/// or uncertain shape retains ordinary property / Promise resolution dispatch.
+/// </summary>
+public sealed class StablePrimitivePromiseThenTests
+{
+    private const string StableSource = """
+        async function sumChain(n: number): Promise<number> {
+            let chain: Promise<number> = Promise.resolve(0);
+            for (let i: number = 0; i < n; i++) {
+                chain = chain.then((sum: number): number => sum + i);
+            }
+            return await chain;
+        }
+        sumChain(10).then((value: number): void => console.log(value));
+        """;
+
+    [Theory, ModeData]
+    public void StableNumericChain_PreservesResult(ExecutionMode mode)
+    {
+        Assert.Equal("45\n", TestHarness.Run(StableSource, mode));
+    }
+
+    [Theory, ModeData]
+    public void StableNumericHandlerThrow_RejectsOnce(ExecutionMode mode)
+    {
+        const string source = """
+            let calls: number = 0;
+            async function run(): Promise<void> {
+                let chain: Promise<number> = Promise.resolve(1);
+                chain = chain.then((value: number): number => {
+                    calls = calls + 1;
+                    if (value === 1) throw new Error("boom");
+                    return value;
+                });
+                try {
+                    await chain;
+                } catch (_error) {
+                    console.log(calls);
+                }
+            }
+            run();
+            """;
+
+        Assert.Equal("1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void StableNumericChain_InImportedModulePreservesResult(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["chain.ts"] = """
+                export async function sumChain(n: number): Promise<number> {
+                    let chain: Promise<number> = Promise.resolve(0);
+                    for (let i: number = 0; i < n; i++) {
+                        chain = chain.then((sum: number): number => sum + i);
+                    }
+                    return await chain;
+                }
+                """,
+            ["main.ts"] = """
+                import { sumChain } from './chain';
+                async function main(): Promise<void> {
+                    console.log(await sumChain(10));
+                }
+                main();
+                """
+        };
+
+        Assert.Equal("45\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory, ModeData]
+    public void OwnThenOverride_RetainsValueDispatch(ExecutionMode mode)
+    {
+        const string source = """
+            async function run(): Promise<void> {
+                const promise: any = Promise.resolve(1);
+                promise.then = (_handler: any): Promise<number> => Promise.resolve(99);
+                console.log(await promise.then((value: number): number => value + 1));
+            }
+            run();
+            """;
+
+        Assert.Equal("99\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void PromisePrototypeThenOverride_RetainsValueDispatch(ExecutionMode mode)
+    {
+        const string source = """
+            async function run(): Promise<void> {
+                const prototype: any = Promise.prototype;
+                prototype.then = function (_handler: any): Promise<number> {
+                    return Promise.resolve(77);
+                };
+                console.log(await Promise.resolve(1).then(
+                    (value: number): number => value + 1));
+            }
+            run();
+            """;
+
+        Assert.Equal("77\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void StableNumericChain_UsesTypedContinuationWithoutDynamicCallbackArrays()
+    {
+        Assembly assembly = Compile(StableSource);
+        MethodInfo caller = FindSingleCaller(assembly, "PromiseThenPrimitive");
+        var instructions = ReadInstructions(caller).ToArray();
+
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "PromiseThenPrimitive" });
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "PromiseThen" or "PromiseResolveValue" or "InvokeCallback"
+                    or "ObservePromiseConstructor" or "WrapDerivedPromiseResult"
+            });
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.OpCode == OpCodes.Newarr
+            && instruction.Operand == typeof(object));
+
+        MethodInfo continuationMoveNext = assembly.GetType("$PromiseThenPrimitive_SM")!
+            .GetMethod("MoveNext")!;
+        var continuationInstructions = ReadInstructions(continuationMoveNext).ToArray();
+        Assert.Contains(continuationInstructions, instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "Invoke",
+                DeclaringType: { IsGenericType: true } declaringType
+            }
+            && declaringType.GetGenericTypeDefinition() == typeof(Func<,>));
+        Assert.DoesNotContain(continuationInstructions, instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "PromiseResolveValue" or "InvokeCallback"
+            });
+        Assert.DoesNotContain(continuationInstructions, instruction =>
+            instruction.OpCode == OpCodes.Newarr
+            && instruction.Operand == typeof(object));
+    }
+
+    [Fact]
+    public void StableNumericChain_VerifiesIlAndStandaloneOutput()
+    {
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(StableSource));
+        Assert.Equal("45\n", TestHarness.RunCompiledStandalone(StableSource));
+    }
+
+    [Theory]
+    [MemberData(nameof(FallbackSources))]
+    public void UncertainShapes_RetainGeneralPromiseThen(string source)
+    {
+        Assembly assembly = Compile(source);
+        Assert.Empty(FindCallers(assembly, "PromiseThenPrimitive"));
+        Assert.NotEmpty(FindCallers(assembly, "PromiseThen"));
+    }
+
+    public static TheoryData<string> FallbackSources => new()
+    {
+        """
+        async function work(): Promise<number> {
+            let chain: Promise<number> = Promise.resolve(1);
+            const alias: Promise<number> = chain;
+            chain = chain.then((value: number): number => value + 1);
+            await alias;
+            return await chain;
+        }
+        work();
+        """,
+        """
+        async function work(): Promise<number> {
+            let chain: Promise<number> = Promise.resolve(1);
+            chain = chain.then(
+                (value: number): number => value + 1,
+                (_error: any): number => 0);
+            return await chain;
+        }
+        work();
+        """,
+        """
+        async function work(): Promise<number> {
+            let chain: Promise<number> = Promise.resolve(1);
+            const next: Promise<{ value: number }> = chain.then(
+                (value: number): { value: number } => ({ value: value + 1 }));
+            return (await next).value;
+        }
+        work();
+        """,
+        """
+        function increment(value: number): number { return value + 1; }
+        async function work(): Promise<number> {
+            let chain: Promise<number> = Promise.resolve(1);
+            chain = chain.then(increment);
+            return await chain;
+        }
+        work();
+        """,
+        """
+        async function source(): Promise<number> { return 1; }
+        async function work(): Promise<number> {
+            let chain: Promise<number> = source();
+            chain = chain.then((value: number): number => value + 1);
+            return await chain;
+        }
+        work();
+        """,
+        """
+        let chain: Promise<number> = Promise.resolve(1);
+        chain = chain.then((value: number): number => value + 1);
+        chain.then((value: number): void => console.log(value));
+        """
+    };
+
+    [Fact]
+    public void PromiseMutation_RetainsOrdinaryMethodValueDispatch()
+    {
+        const string source = """
+            async function work(): Promise<number> {
+                const promise: any = Promise.resolve(1);
+                promise.then = (_handler: any): Promise<number> => Promise.resolve(9);
+                return await promise.then((value: number): number => value + 1);
+            }
+            work();
+            """;
+
+        Assembly assembly = Compile(source);
+        Assert.Empty(FindCallers(assembly, "PromiseThenPrimitive"));
+        Assert.NotEmpty(FindCallers(assembly, "InvokeMethodValue"));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"issue_1438_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindSingleCaller(Assembly assembly, string methodName) =>
+        Assert.Single(FindCallers(assembly, methodName));
+
+    private static List<MethodInfo> FindCallers(Assembly assembly, string methodName) =>
+        assembly.GetTypes()
+            .Where(type => type.Name != "$Runtime")
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic |
+                BindingFlags.Static | BindingFlags.Instance))
+            .Where(method => method.GetMethodBody() != null)
+            .Where(method => ReadInstructions(method).Any(instruction =>
+                instruction.Operand is MethodBase called
+                && called.Name == methodName))
+            .ToList();
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+        Type[]? typeArguments = method.DeclaringType?.IsGenericType == true
+            ? method.DeclaringType.GetGenericArguments()
+            : null;
+        Type[]? methodArguments = method.IsGenericMethod
+            ? method.GetGenericArguments()
+            : null;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token, typeArguments, methodArguments)
+                    : module.ResolveType(token, typeArguments, methodArguments);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}


### PR DESCRIPTION
## Summary

- prove a deliberately narrow stable `Promise<number>` chain shape rooted at intrinsic `Promise.resolve`
- lower eligible inline numeric fulfillment handlers to a typed `Func<double, double>` continuation state machine
- preserve ordinary Promise/value dispatch for aliases, escapes, captures, top-level live module bindings, patched Promise behavior, `onRejected`, object/unknown results, alternate sources, and every uncertain shape
- add structural IL, standalone, dual-mode, ESM, rejection, and fallback regression coverage

## Proof boundary

The fast path is limited to function-local bindings initialized from direct `Promise.resolve`, advanced only by `chain = chain.then((number) => number)`, and consumed only through await/return. A whole-program mutation pass disables it when Promise/prototype/constructor behavior can be observed. Promise instance lowering also falls back to ordinary property/value dispatch when own or prototype mutation is possible.

The typed continuation awaits the input, invokes the handler directly, boxes only its numeric result, and converts handler throws/input rejection into output rejection. It skips generic callback `object[]` dispatch, species/derived wrapping, and thenable adoption because the proven result cannot be thenable.

## Performance

Pinned Windows x64 environment (.NET SDK 10.0.400/runtime 10.0.11, Node 24.19.0), five independently launched alternating compiled/Node runs at N=1,000:

| Workload | Before | After median | Change |
|---|---:|---:|---:|
| Promise.then chain, compiled | 2.8009 ms | **0.0385 ms** | **-98.6%** |
| Promise.then chain, Node | 0.0246 ms | **0.0255 ms** | SharpTS now **1.51x Node** |
| resolved await, compiled | 0.1778 ms | **0.1803 ms** | +1.4% |
| async function calls, compiled | 0.0398 ms | **0.0390 ms** | -2.0% |
| Promise.all, compiled | 0.4151 ms | **0.4147 ms** | -0.1% |

Focused BenchmarkDotNet:

| Metric | Before | After | Change |
|---|---:|---:|---:|
| SharpTS time | 7.772 ms | **70.90 us** | **-99.1%** |
| SharpTS allocation | 1,359.69 KB | **226.82 KB** | **-83.3%** |
| Idiomatic C# | 93.009 us baseline | 50.65 us current | — |
| Boxed-equivalent C# | 107.183 us baseline | 62.92 us current | — |

All #1438 throughput, allocation, and neighbor-regression gates clear comfortably.

## Correctness note

Investigation exposed a pre-existing SharpTS deficit: already-settled `then` handlers are observably synchronous in both interpreter and compiled general paths. This optimization preserves that existing behavior rather than adding an isolated scheduler to only one path. The shared Promise-job scheduling fix is tracked separately in #1440.

## Validation

- Release solution build: passed; both IL verification passes succeeded
- focused Promise/feature suite: **271 passed**
- complete core suite: **17,140 passed**, 3 expected platform skips
- GUI conformance: **83 passed**
- cross-runtime smoke: all **17 workloads** compiled
- microbenchmark smoke: all embedded sources/module graphs and benchmark discovery passed
- Test262, worker, and TypeScript conformance harnesses: built successfully
- repository formatting and `git diff --check`: clean

Fixes #1438