### PR TITLE
Fix Promise reaction job scheduling

### DIFF
--- a/benchmarks/micro/SharpTS.Microbenchmarks/Infrastructure/BenchmarkHarness.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Infrastructure/BenchmarkHarness.cs
@@ -213,7 +213,38 @@ public static class BenchmarkHarness
                 $"{method.ReturnType.Name}({string.Join(", ", parameters.Select(p => p.ParameterType.Name))}); " +
                 "expected Task<Object>(Object)");
         }
-        return method.CreateDelegate<Func<object?, Task<object?>>>();
+        var invoke = method.CreateDelegate<Func<object?, Task<object?>>>();
+        var eventLoopType = assembly.GetType("$EventLoop")
+            ?? throw new InvalidOperationException(
+                "Compiled async benchmark assembly has no $EventLoop type");
+        var getInstance = eventLoopType.GetMethod(
+            "GetInstance", BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException("Compiled $EventLoop has no GetInstance method");
+        var run = eventLoopType.GetMethod(
+            "Run", BindingFlags.Public | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("Compiled $EventLoop has no Run method");
+        object eventLoop = getInstance.Invoke(null, null)
+            ?? throw new InvalidOperationException("Compiled $EventLoop.GetInstance returned null");
+
+        // Direct reflection calls bypass the generated program entry point,
+        // which normally performs the JavaScript job checkpoint. Pump once per
+        // invocation so queued Promise reactions run under the same scheduler
+        // measured by real standalone output (#1440). Run drains an entire
+        // nested microtask chain; the reflection call itself is constant setup
+        // overhead rather than per-link dynamic dispatch.
+        return argument =>
+        {
+            Task<object?> task = invoke(argument);
+            try
+            {
+                run.Invoke(eventLoop, null);
+            }
+            catch (TargetInvocationException ex)
+            {
+                throw ex.InnerException ?? ex;
+            }
+            return task;
+        };
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -1036,6 +1036,8 @@ public class EmittedRuntime
     public MethodBuilder PromiseThenPrimitive { get; set; } = null!;
     public MethodBuilder PromiseCatch { get; set; } = null!;
     public MethodBuilder PromiseFinally { get; set; } = null!;
+    /// <summary>Keeps standalone event-loop execution alive until a discarded top-level Promise reaction settles, without pumping it before the current script job completes.</summary>
+    public MethodBuilder TrackTopLevelPromiseReaction { get; set; } = null!;
     public MethodBuilder PromiseAllSettled { get; set; } = null!;
     public MethodBuilder PromiseAllSettledKeyed { get; set; } = null!;
     public MethodBuilder PromiseKeyedMapResult { get; set; } = null!;
@@ -1118,6 +1120,7 @@ public class EmittedRuntime
 
     // Microtask support
     public MethodBuilder QueueMicrotask { get; set; } = null!;
+    public MethodBuilder QueuePromiseJob { get; set; } = null!;
     public MethodBuilder ProcessMicrotasks { get; set; } = null!;
     public MethodBuilder HasMicrotasks { get; set; } = null!;
 

--- a/src/SharpTS/Compilation/ILCompiler.Modules.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Modules.cs
@@ -436,6 +436,52 @@ public partial class ILCompiler
     /// </remarks>
     private void EmitExpressionWithAsyncWait(ILGenerator il, ILEmitter emitter, Stmt.Expression exprStmt)
     {
+        // SharpTS historically pumps promise-valued expression statements as a
+        // convenience for discarded top-level async-function calls. A direct
+        // Promise reaction is different: pumping its returned promise here
+        // executes the reaction before the next statement in the same script
+        // job. Leave then/catch/finally results to the normal microtask
+        // checkpoint (#1440). Explicit `await` remains on the path below.
+        if (exprStmt.Expr is Expr.Call
+            {
+                Callee: Expr.Get { Name.Lexeme: "then" or "catch" or "finally" }
+            })
+        {
+            emitter.MarkStatementStart(exprStmt);
+            emitter.EmitExpression(exprStmt.Expr);
+            emitter.Helpers.EnsureBoxed();
+            var reactionResult = il.DeclareLocal(_types.Object);
+            il.Emit(OpCodes.Stloc, reactionResult);
+
+            var done = il.DefineLabel();
+            var task = il.DeclareLocal(_types.TaskOfObject);
+            il.Emit(OpCodes.Ldloc, reactionResult);
+            il.Emit(OpCodes.Call, _runtime.ShouldAutoAwaitPromiseMethod);
+            il.Emit(OpCodes.Brfalse, done);
+
+            il.Emit(OpCodes.Ldloc, reactionResult);
+            il.Emit(OpCodes.Isinst, _types.TaskOfObject);
+            il.Emit(OpCodes.Stloc, task);
+            il.Emit(OpCodes.Ldloc, task);
+            var haveTask = il.DefineLabel();
+            il.Emit(OpCodes.Brtrue, haveTask);
+
+            il.Emit(OpCodes.Ldloc, reactionResult);
+            il.Emit(OpCodes.Isinst, _runtime.TSPromiseType);
+            il.Emit(OpCodes.Brfalse, done);
+            il.Emit(OpCodes.Ldloc, reactionResult);
+            il.Emit(OpCodes.Castclass, _runtime.TSPromiseType);
+            il.Emit(OpCodes.Callvirt, _runtime.TSPromiseTaskGetter);
+            il.Emit(OpCodes.Stloc, task);
+
+            il.MarkLabel(haveTask);
+            il.Emit(OpCodes.Ldloc, task);
+            il.Emit(OpCodes.Call, _runtime.TrackTopLevelPromiseReaction);
+            il.Emit(OpCodes.Pop);
+            il.MarkLabel(done);
+            return;
+        }
+
         // This path drives expression emission itself instead of going through EmitStatement, so it
         // has to mark the statement or every top-level expression would be unsteppable.
         emitter.MarkStatementStart(exprStmt);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.Finally.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.Finally.cs
@@ -11,7 +11,10 @@ public partial class RuntimeEmitter
     /// <summary>
     /// Defines the PromiseFinally state machine type structure.
     /// </summary>
-    private PromiseFinallyStateMachine DefinePromiseFinallyStateMachine(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    private PromiseFinallyStateMachine DefinePromiseFinallyStateMachine(
+        ModuleBuilder moduleBuilder,
+        EmittedRuntime runtime,
+        Type promiseJobAwaiterType)
     {
         var builderType = typeof(AsyncTaskMethodBuilder<object>);
         var awaiterType = typeof(TaskAwaiter<object?>);
@@ -31,6 +34,8 @@ public partial class RuntimeEmitter
         var onFinallyField = smType.DefineField("onFinally", typeof(object), FieldAttributes.Public);
         var promiseAwaiterField = smType.DefineField("<>u__1", awaiterType, FieldAttributes.Private);
         var callbackAwaiterField = smType.DefineField("<>u__2", awaiterType, FieldAttributes.Private);
+        var jobAwaiterField = smType.DefineField(
+            "<>u__3", promiseJobAwaiterType, FieldAttributes.Private);
         var valueField = smType.DefineField("<value>5__1", typeof(object), FieldAttributes.Private);
         var exceptionField = smType.DefineField("<exception>5__2", typeof(Exception), FieldAttributes.Private);
 
@@ -63,6 +68,7 @@ public partial class RuntimeEmitter
             OnFinallyField = onFinallyField,
             PromiseAwaiterField = promiseAwaiterField,
             CallbackAwaiterField = callbackAwaiterField,
+            JobAwaiterField = jobAwaiterField,
             ValueField = valueField,
             ExceptionField = exceptionField,
             MoveNextMethod = moveNext,
@@ -123,7 +129,10 @@ public partial class RuntimeEmitter
     /// Simplified: await promise, invoke callback, return original value.
     /// Note: Exception capture from original promise is not fully implemented.
     /// </summary>
-    private void EmitPromiseFinallyMoveNext(PromiseFinallyStateMachine sm, EmittedRuntime runtime)
+    private void EmitPromiseFinallyMoveNext(
+        PromiseFinallyStateMachine sm,
+        EmittedRuntime runtime,
+        Type promiseJobAwaiterType)
     {
         var il = sm.MoveNextMethod.GetILGenerator();
         var awaiterType = typeof(TaskAwaiter<object?>);
@@ -135,6 +144,8 @@ public partial class RuntimeEmitter
         // Labels
         var state0Label = il.DefineLabel();  // Resume after promise await
         var state1Label = il.DefineLabel();  // Resume after callback await
+        var state2Label = il.DefineLabel();  // Resume in queued Promise job
+        var queueJobLabel = il.DefineLabel();
         var continue0Label = il.DefineLabel();
         var continue1Label = il.DefineLabel();
         var setResultLabel = il.DefineLabel();
@@ -151,6 +162,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldfld, sm.StateField);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Beq, state1Label);  // state == 1
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, sm.StateField);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Beq, state2Label);  // state == 2
 
         // ========== STATE -1: Initial - await input promise ==========
 
@@ -168,7 +183,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldflda, sm.PromiseAwaiterField);
         il.Emit(OpCodes.Call, awaiterType.GetProperty("IsCompleted")!.GetGetMethod()!);
-        il.Emit(OpCodes.Brtrue, continue0Label);
+        il.Emit(OpCodes.Brtrue, queueJobLabel);
 
         // Not completed - suspend at state 0
         il.Emit(OpCodes.Ldarg_0);
@@ -191,7 +206,29 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_M1);
         il.Emit(OpCodes.Stfld, sm.StateField);
 
-        // ========== Continue after promise await ==========
+        il.MarkLabel(queueJobLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Stfld, sm.StateField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldflda, sm.BuilderField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldflda, sm.JobAwaiterField);
+        il.Emit(OpCodes.Ldarg_0);
+        var jobAwaitMethod = EmitGenerics.MakeGenericMethod(
+            _types.GetMethods(sm.BuilderType, BindingFlags.Public | BindingFlags.Instance)
+                .First(m => m.Name == "AwaitUnsafeOnCompleted" && m.IsGenericMethod),
+            promiseJobAwaiterType,
+            sm.Type);
+        il.Emit(OpCodes.Call, jobAwaitMethod);
+        il.Emit(OpCodes.Leave, returnLabel);
+
+        il.MarkLabel(state2Label);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_M1);
+        il.Emit(OpCodes.Stfld, sm.StateField);
+
+        // ========== Continue inside Promise job ==========
         il.MarkLabel(continue0Label);
 
         // GetResult from promise - store in value field

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.Then.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.Then.cs
@@ -6,12 +6,72 @@ namespace SharpTS.Compilation;
 
 public partial class RuntimeEmitter
 {
+    /// <summary>
+    /// Emits a zero-allocation awaiter whose continuation is always appended to
+    /// the shared FIFO microtask queue. Promise state machines use it after the
+    /// source task settles so even completed Tasks cannot invoke reactions
+    /// inline in the caller's JavaScript job (#1440).
+    /// </summary>
+    private Type DefinePromiseJobAwaiter(
+        ModuleBuilder moduleBuilder,
+        EmittedRuntime runtime)
+    {
+        var awaiter = moduleBuilder.DefineType(
+            "$PromiseJobAwaiter",
+            TypeAttributes.Public | TypeAttributes.Sealed |
+                TypeAttributes.SequentialLayout | TypeAttributes.BeforeFieldInit,
+            typeof(ValueType),
+            [typeof(ICriticalNotifyCompletion)]);
+
+        var getResult = awaiter.DefineMethod(
+            "GetResult", MethodAttributes.Public, typeof(void), Type.EmptyTypes);
+        getResult.GetILGenerator().Emit(OpCodes.Ret);
+
+        var onCompleted = awaiter.DefineMethod(
+            "OnCompleted",
+            MethodAttributes.Public | MethodAttributes.Virtual |
+                MethodAttributes.Final | MethodAttributes.HideBySig |
+                MethodAttributes.NewSlot,
+            typeof(void),
+            [typeof(Action)]);
+        {
+            var il = onCompleted.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, runtime.QueuePromiseJob);
+            il.Emit(OpCodes.Ret);
+        }
+        awaiter.DefineMethodOverride(
+            onCompleted, typeof(INotifyCompletion).GetMethod("OnCompleted")!);
+
+        var unsafeOnCompleted = awaiter.DefineMethod(
+            "UnsafeOnCompleted",
+            MethodAttributes.Public | MethodAttributes.Virtual |
+                MethodAttributes.Final | MethodAttributes.HideBySig |
+                MethodAttributes.NewSlot,
+            typeof(void),
+            [typeof(Action)]);
+        {
+            var il = unsafeOnCompleted.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, runtime.QueuePromiseJob);
+            il.Emit(OpCodes.Ret);
+        }
+        awaiter.DefineMethodOverride(
+            unsafeOnCompleted,
+            typeof(ICriticalNotifyCompletion).GetMethod("UnsafeOnCompleted")!);
+
+        return awaiter.CreateType()!;
+    }
+
     #region PromiseThen State Machine
 
     /// <summary>
     /// Defines the PromiseThen state machine type structure.
     /// </summary>
-    private PromiseThenStateMachine DefinePromiseThenStateMachine(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    private PromiseThenStateMachine DefinePromiseThenStateMachine(
+        ModuleBuilder moduleBuilder,
+        EmittedRuntime runtime,
+        Type promiseJobAwaiterType)
     {
         var builderType = typeof(AsyncTaskMethodBuilder<object>);
         var awaiterType = typeof(TaskAwaiter<object?>);
@@ -32,6 +92,8 @@ public partial class RuntimeEmitter
         var onRejectedField = smType.DefineField("onRejected", typeof(object), FieldAttributes.Public);
         var promiseAwaiterField = smType.DefineField("<>u__1", awaiterType, FieldAttributes.Private);
         var flattenAwaiterField = smType.DefineField("<>u__2", awaiterType, FieldAttributes.Private);
+        var jobAwaiterField = smType.DefineField(
+            "<>u__3", promiseJobAwaiterType, FieldAttributes.Private);
         var valueField = smType.DefineField("<value>5__1", typeof(object), FieldAttributes.Private);
         var exceptionField = smType.DefineField("<exception>5__2", typeof(Exception), FieldAttributes.Private);
 
@@ -65,6 +127,7 @@ public partial class RuntimeEmitter
             OnRejectedField = onRejectedField,
             PromiseAwaiterField = promiseAwaiterField,
             FlattenAwaiterField = flattenAwaiterField,
+            JobAwaiterField = jobAwaiterField,
             ValueField = valueField,
             ExceptionField = exceptionField,
             MoveNextMethod = moveNext,
@@ -129,7 +192,10 @@ public partial class RuntimeEmitter
     /// Emits the MoveNext body for PromiseThen state machine.
     /// Implements: await promise, invoke callback, flatten nested tasks.
     /// </summary>
-    private void EmitPromiseThenMoveNext(PromiseThenStateMachine sm, EmittedRuntime runtime)
+    private void EmitPromiseThenMoveNext(
+        PromiseThenStateMachine sm,
+        EmittedRuntime runtime,
+        Type promiseJobAwaiterType)
     {
         var il = sm.MoveNextMethod.GetILGenerator();
         var awaiterType = typeof(TaskAwaiter<object?>);
@@ -142,6 +208,8 @@ public partial class RuntimeEmitter
         // Labels
         var state0Label = il.DefineLabel();  // Resume after promise await
         var state1Label = il.DefineLabel();  // Resume after flatten await (inside handler try)
+        var state3Label = il.DefineLabel();  // Resume in the queued Promise job
+        var queueJobLabel = il.DefineLabel();
         var continue0Label = il.DefineLabel();
         var continue1Label = il.DefineLabel();
         var setResultLabel = il.DefineLabel();
@@ -163,6 +231,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldfld, sm.StateField);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Beq, handlerTryStartLabel);  // state == 1
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, sm.StateField);
+        il.Emit(OpCodes.Ldc_I4_3);
+        il.Emit(OpCodes.Beq, state3Label);  // state == 3
         var notRejectionFlattenResumeLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, sm.StateField);
@@ -187,7 +259,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldflda, sm.PromiseAwaiterField);
         il.Emit(OpCodes.Call, awaiterType.GetProperty("IsCompleted")!.GetGetMethod()!);
-        il.Emit(OpCodes.Brtrue, continue0Label);
+        il.Emit(OpCodes.Brtrue, queueJobLabel);
 
         // Not completed - suspend at state 0
         il.Emit(OpCodes.Ldarg_0);
@@ -210,7 +282,33 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_M1);
         il.Emit(OpCodes.Stfld, sm.StateField);
 
-        // ========== Continue after promise await ==========
+        // A settled source only makes the reaction eligible. Always suspend
+        // once more into the shared Promise-job queue before observing the
+        // result or invoking either handler.
+        il.MarkLabel(queueJobLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_3);
+        il.Emit(OpCodes.Stfld, sm.StateField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldflda, sm.BuilderField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldflda, sm.JobAwaiterField);
+        il.Emit(OpCodes.Ldarg_0);
+        var jobAwaitMethod = EmitGenerics.MakeGenericMethod(
+            _types.GetMethods(sm.BuilderType, BindingFlags.Public | BindingFlags.Instance)
+                .First(m => m.Name == "AwaitUnsafeOnCompleted" && m.IsGenericMethod),
+            promiseJobAwaiterType,
+            sm.Type);
+        il.Emit(OpCodes.Call, jobAwaitMethod);
+        il.Emit(OpCodes.Leave, returnLabel);
+
+        // ========== STATE 3: Execute the queued Promise job ==========
+        il.MarkLabel(state3Label);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_M1);
+        il.Emit(OpCodes.Stfld, sm.StateField);
+
+        // ========== Continue inside Promise job ==========
         il.MarkLabel(continue0Label);
 
         // GetResult from promise - store in value field
@@ -551,7 +649,8 @@ public partial class RuntimeEmitter
     /// proves that a direct intrinsic Promise.then callback returns a primitive.
     /// </summary>
     private PrimitivePromiseThenStateMachine DefinePrimitivePromiseThenStateMachine(
-        ModuleBuilder moduleBuilder)
+        ModuleBuilder moduleBuilder,
+        Type promiseJobAwaiterType)
     {
         var builderType = typeof(AsyncTaskMethodBuilder<object>);
         var awaiterType = typeof(TaskAwaiter<object?>);
@@ -571,6 +670,8 @@ public partial class RuntimeEmitter
             "onFulfilled", typeof(Func<double, double>), FieldAttributes.Public);
         var promiseAwaiterField = smType.DefineField(
             "<>u__1", awaiterType, FieldAttributes.Private);
+        var jobAwaiterField = smType.DefineField(
+            "<>u__2", promiseJobAwaiterType, FieldAttributes.Private);
 
         var moveNext = smType.DefineMethod(
             "MoveNext",
@@ -597,6 +698,7 @@ public partial class RuntimeEmitter
             PromiseField = promiseField,
             OnFulfilledField = onFulfilledField,
             PromiseAwaiterField = promiseAwaiterField,
+            JobAwaiterField = jobAwaiterField,
             MoveNextMethod = moveNext,
             BuilderType = builderType
         };
@@ -645,7 +747,8 @@ public partial class RuntimeEmitter
     }
 
     private void EmitPrimitivePromiseThenMoveNext(
-        PrimitivePromiseThenStateMachine sm)
+        PrimitivePromiseThenStateMachine sm,
+        Type promiseJobAwaiterType)
     {
         var il = sm.MoveNextMethod.GetILGenerator();
         var awaiterType = typeof(TaskAwaiter<object?>);
@@ -654,6 +757,8 @@ public partial class RuntimeEmitter
         var resultLocal = il.DeclareLocal(typeof(object));
         var exceptionLocal = il.DeclareLocal(typeof(Exception));
         var resumeLabel = il.DefineLabel();
+        var jobResumeLabel = il.DefineLabel();
+        var queueJobLabel = il.DefineLabel();
         var continueLabel = il.DefineLabel();
         var returnLabel = il.DefineLabel();
 
@@ -662,6 +767,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, sm.StateField);
         il.Emit(OpCodes.Brfalse, resumeLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, sm.StateField);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Beq, jobResumeLabel);
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, sm.PromiseField);
@@ -674,7 +783,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldflda, sm.PromiseAwaiterField);
         il.Emit(OpCodes.Call, awaiterType.GetProperty("IsCompleted")!.GetGetMethod()!);
-        il.Emit(OpCodes.Brtrue, continueLabel);
+        il.Emit(OpCodes.Brtrue, queueJobLabel);
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldc_I4_0);
@@ -693,6 +802,28 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Leave, returnLabel);
 
         il.MarkLabel(resumeLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_M1);
+        il.Emit(OpCodes.Stfld, sm.StateField);
+
+        il.MarkLabel(queueJobLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stfld, sm.StateField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldflda, sm.BuilderField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldflda, sm.JobAwaiterField);
+        il.Emit(OpCodes.Ldarg_0);
+        var jobAwaitMethod = EmitGenerics.MakeGenericMethod(
+            _types.GetMethods(sm.BuilderType, BindingFlags.Public | BindingFlags.Instance)
+                .First(method => method.Name == "AwaitUnsafeOnCompleted" && method.IsGenericMethod),
+            promiseJobAwaiterType,
+            sm.Type);
+        il.Emit(OpCodes.Call, jobAwaitMethod);
+        il.Emit(OpCodes.Leave, returnLabel);
+
+        il.MarkLabel(jobResumeLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldc_I4_M1);
         il.Emit(OpCodes.Stfld, sm.StateField);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.cs
@@ -51,6 +51,7 @@ internal class PromiseThenStateMachine
     public required FieldBuilder OnFulfilledField { get; init; }    // callback
     public required FieldBuilder OnRejectedField { get; init; }     // error callback
     public required FieldBuilder PromiseAwaiterField { get; init; } // TaskAwaiter<object?> for input
+    public required FieldBuilder JobAwaiterField { get; init; }     // forced Promise-job boundary
     public required FieldBuilder FlattenAwaiterField { get; init; } // TaskAwaiter<object?> for flattening
     public required FieldBuilder ValueField { get; init; }          // intermediate value
     public required FieldBuilder ExceptionField { get; init; }      // stored exception
@@ -70,6 +71,7 @@ internal class PrimitivePromiseThenStateMachine
     public required FieldBuilder PromiseField { get; init; }
     public required FieldBuilder OnFulfilledField { get; init; }
     public required FieldBuilder PromiseAwaiterField { get; init; }
+    public required FieldBuilder JobAwaiterField { get; init; }
     public required MethodBuilder MoveNextMethod { get; init; }
     public required Type BuilderType { get; init; }
 }
@@ -85,6 +87,7 @@ internal class PromiseFinallyStateMachine
     public required FieldBuilder PromiseField { get; init; }        // Task<object?> input promise
     public required FieldBuilder OnFinallyField { get; init; }      // callback (no args)
     public required FieldBuilder PromiseAwaiterField { get; init; } // TaskAwaiter<object?> for input
+    public required FieldBuilder JobAwaiterField { get; init; }     // forced Promise-job boundary
     public required FieldBuilder CallbackAwaiterField { get; init; } // TaskAwaiter<object?> for callback result
     public required FieldBuilder ValueField { get; init; }          // preserved value
     public required FieldBuilder ExceptionField { get; init; }      // preserved exception
@@ -178,6 +181,8 @@ public partial class RuntimeEmitter
     {
         var taskType = _types.TaskOfObject;
         var moduleBuilder = (ModuleBuilder)typeBuilder.Module;
+        var promiseJobAwaiterType = DefinePromiseJobAwaiter(moduleBuilder, runtime);
+        EmitTrackTopLevelPromiseReaction(typeBuilder, runtime);
 
         // Static value-form methods need NewPromiseCapability before the
         // executor-support bodies are filled at the end of this emitter.
@@ -694,7 +699,8 @@ public partial class RuntimeEmitter
         EmitCallbackHelpers(typeBuilder, runtime);
 
         // Promise.prototype.then - async state machine with callback invocation
-        var promiseThenSM = DefinePromiseThenStateMachine(moduleBuilder, runtime);
+        var promiseThenSM = DefinePromiseThenStateMachine(
+            moduleBuilder, runtime, promiseJobAwaiterType);
         var then = typeBuilder.DefineMethod(
             "PromiseThen",
             MethodAttributes.Public | MethodAttributes.Static,
@@ -703,7 +709,7 @@ public partial class RuntimeEmitter
         );
         runtime.PromiseThen = then;
         EmitPromiseThenWrapper(then.GetILGenerator(), promiseThenSM);
-        EmitPromiseThenMoveNext(promiseThenSM, runtime);
+        EmitPromiseThenMoveNext(promiseThenSM, runtime, promiseJobAwaiterType);
         promiseThenSM.Type.CreateType();
 
         // Stable intrinsic Promise.then with a fulfillment-only callback whose
@@ -711,7 +717,7 @@ public partial class RuntimeEmitter
         // input await and callback exception-to-rejection behavior, but has no
         // rejection dispatch or second thenable-flattening await.
         var primitivePromiseThenSM = DefinePrimitivePromiseThenStateMachine(
-            moduleBuilder);
+            moduleBuilder, promiseJobAwaiterType);
         var primitiveThen = typeBuilder.DefineMethod(
             "PromiseThenPrimitive",
             MethodAttributes.Public | MethodAttributes.Static,
@@ -721,7 +727,8 @@ public partial class RuntimeEmitter
         runtime.PromiseThenPrimitive = primitiveThen;
         EmitPrimitivePromiseThenWrapper(
             primitiveThen.GetILGenerator(), primitivePromiseThenSM);
-        EmitPrimitivePromiseThenMoveNext(primitivePromiseThenSM);
+        EmitPrimitivePromiseThenMoveNext(
+            primitivePromiseThenSM, promiseJobAwaiterType);
         primitivePromiseThenSM.Type.CreateType();
 
         // Promise.prototype.catch - delegates to PromiseThen(promise, null, onRejected)
@@ -742,7 +749,8 @@ public partial class RuntimeEmitter
         }
 
         // Promise.prototype.finally - async state machine with callback invocation
-        var promiseFinallySM = DefinePromiseFinallyStateMachine(moduleBuilder, runtime);
+        var promiseFinallySM = DefinePromiseFinallyStateMachine(
+            moduleBuilder, runtime, promiseJobAwaiterType);
         var finallyMethod = typeBuilder.DefineMethod(
             "PromiseFinally",
             MethodAttributes.Public | MethodAttributes.Static,
@@ -751,11 +759,61 @@ public partial class RuntimeEmitter
         );
         runtime.PromiseFinally = finallyMethod;
         EmitPromiseFinallyWrapper(finallyMethod.GetILGenerator(), promiseFinallySM);
-        EmitPromiseFinallyMoveNext(promiseFinallySM, runtime);
+        EmitPromiseFinallyMoveNext(
+            promiseFinallySM, runtime, promiseJobAwaiterType);
         promiseFinallySM.Type.CreateType();
 
         // PromiseFromExecutor - emitted in RuntimeEmitter.Promises.Executor.cs
         EmitPromiseExecutorSupport(typeBuilder, runtime, moduleBuilder);
+    }
+
+    /// <summary>
+    /// Emits a lifetime-only tracker for SharpTS's standalone entry point. A
+    /// discarded top-level then/catch/finally result must not be synchronously
+    /// pumped between script statements, but a pending native source (for
+    /// example timers/promises) must still keep the process alive until its
+    /// reaction job can run.
+    /// </summary>
+    private void EmitTrackTopLevelPromiseReaction(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "TrackTopLevelPromiseReaction",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.TaskOfObject,
+            [_types.TaskOfObject]);
+        runtime.TrackTopLevelPromiseReaction = method;
+
+        var il = method.GetILGenerator();
+        var done = il.DefineLabel();
+        var eventLoopLocal = il.DeclareLocal(runtime.EventLoopType);
+        var awaiterLocal = il.DeclareLocal(typeof(TaskAwaiter<object?>));
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt,
+            typeof(Task).GetProperty("IsCompleted")!.GetGetMethod()!);
+        il.Emit(OpCodes.Brtrue, done);
+
+        il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+        il.Emit(OpCodes.Stloc, eventLoopLocal);
+        il.Emit(OpCodes.Ldloc, eventLoopLocal);
+        il.Emit(OpCodes.Callvirt, runtime.EventLoopRef);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.TaskOfObjectGetAwaiter);
+        il.Emit(OpCodes.Stloc, awaiterLocal);
+        il.Emit(OpCodes.Ldloca, awaiterLocal);
+        il.Emit(OpCodes.Ldloc, eventLoopLocal);
+        il.Emit(OpCodes.Ldftn, runtime.EventLoopUnref);
+        il.Emit(OpCodes.Newobj,
+            typeof(Action).GetConstructor([_types.Object, typeof(IntPtr)])!);
+        il.Emit(OpCodes.Call,
+            typeof(TaskAwaiter<object?>).GetMethod("UnsafeOnCompleted")!);
+
+        il.MarkLabel(done);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ret);
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -767,6 +767,14 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object]);
+        // Promise reaction state machines are emitted before the microtask
+        // infrastructure. Reserve the shared FIFO job-enqueue token now; its
+        // body is filled by EmitQueueMicrotaskMethod later in this method.
+        runtime.QueuePromiseJob ??= typeBuilder.DefineMethod(
+            "QueuePromiseJob",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            [typeof(Action)]);
         // Promise resolving callbacks are callable built-ins. Define their
         // representation before TypeOf so it can classify them as functions;
         // InvokeValue consumes the same types later in this method.

--- a/src/SharpTS/Compilation/RuntimeEmitter.Timer.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Timer.cs
@@ -695,16 +695,104 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitQueueMicrotaskMethod(TypeBuilder runtimeType, EmittedRuntime runtime)
     {
-        // Static field: Queue<$TSFunction> _microtaskQueue
-        var queueType = _types.MakeGenericType(_types.QueueOpen, runtime.TSFunctionType);
+        // queueMicrotask callbacks and Promise reactions are the same FIFO class
+        // of ECMAScript job. Store Actions so emitted async state-machine
+        // continuations and guest $TSFunction callbacks cannot overtake one
+        // another (#1440).
+        var queueType = _types.MakeGenericType(_types.QueueOpen, typeof(Action));
         var microtaskQueueField = runtimeType.DefineField(
             "_microtaskQueue",
             queueType,
             FieldAttributes.Private | FieldAttributes.Static
         );
-        _ = microtaskQueueField;
+        var microtaskDrainScheduledField = runtimeType.DefineField(
+            "_microtaskDrainScheduled",
+            _types.Boolean,
+            FieldAttributes.Private | FieldAttributes.Static);
+        var microtaskDrainActionField = runtimeType.DefineField(
+            "_microtaskDrainAction",
+            typeof(Action),
+            FieldAttributes.Private | FieldAttributes.Static);
 
-        // Emit QueueMicrotask method
+        // Reserve the drain method before filling QueuePromiseJob: standalone
+        // output posts this method as an event-loop marker so Promise-only
+        // programs cannot look quiescent before their first checkpoint.
+        runtime.ProcessMicrotasks = runtimeType.DefineMethod(
+            "ProcessMicrotasks",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            Type.EmptyTypes);
+
+        var moduleBuilder = (ModuleBuilder)runtimeType.Module;
+        var closure = EmitTypeDefinitions.DefineType(
+            moduleBuilder,
+            "$MicrotaskCallback",
+            TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
+            _types.Object);
+        var callbackField = closure.DefineField(
+            "Callback", runtime.TSFunctionType, FieldAttributes.Public);
+        var closureCtor = closure.DefineConstructor(
+            MethodAttributes.Public, CallingConventions.Standard, Type.EmptyTypes);
+        {
+            var ctorIl = closureCtor.GetILGenerator();
+            ctorIl.Emit(OpCodes.Ldarg_0);
+            ctorIl.Emit(OpCodes.Call, _types.GetDefaultConstructor(_types.Object));
+            ctorIl.Emit(OpCodes.Ret);
+        }
+        var runMethod = closure.DefineMethod(
+            "Run", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
+        {
+            var runIl = runMethod.GetILGenerator();
+            runIl.Emit(OpCodes.Ldarg_0);
+            runIl.Emit(OpCodes.Ldfld, callbackField);
+            runIl.Emit(OpCodes.Ldc_I4_0);
+            runIl.Emit(OpCodes.Newarr, _types.Object);
+            runIl.Emit(OpCodes.Callvirt, runtime.TSFunctionInvoke);
+            runIl.Emit(OpCodes.Pop);
+            runIl.Emit(OpCodes.Ret);
+        }
+        closure.CreateType();
+
+        // Fill the predeclared raw Promise-job enqueue helper.
+        var enqueueMethod = EmitterTypeHelpers.ResolveMethod(
+            queueType, _types.GetMethod(_types.QueueOpen, "Enqueue")!);
+        var queueIl = runtime.QueuePromiseJob.GetILGenerator();
+        var queueReady = queueIl.DefineLabel();
+        queueIl.Emit(OpCodes.Ldsfld, microtaskQueueField);
+        queueIl.Emit(OpCodes.Brtrue_S, queueReady);
+        var queueCtor = EmitterTypeHelpers.ResolveConstructor(
+            queueType, _types.GetConstructor(_types.QueueOpen, Type.EmptyTypes)!);
+        queueIl.Emit(OpCodes.Newobj, queueCtor);
+        queueIl.Emit(OpCodes.Stsfld, microtaskQueueField);
+        queueIl.MarkLabel(queueReady);
+        queueIl.Emit(OpCodes.Ldsfld, microtaskQueueField);
+        queueIl.Emit(OpCodes.Ldarg_0);
+        queueIl.Emit(OpCodes.Callvirt, enqueueMethod);
+        if (!_emitHosted)
+        {
+            var drainAlreadyScheduled = queueIl.DefineLabel();
+            var drainActionReady = queueIl.DefineLabel();
+            queueIl.Emit(OpCodes.Ldsfld, microtaskDrainScheduledField);
+            queueIl.Emit(OpCodes.Brtrue, drainAlreadyScheduled);
+            queueIl.Emit(OpCodes.Ldc_I4_1);
+            queueIl.Emit(OpCodes.Stsfld, microtaskDrainScheduledField);
+            queueIl.Emit(OpCodes.Ldsfld, microtaskDrainActionField);
+            queueIl.Emit(OpCodes.Brtrue, drainActionReady);
+            queueIl.Emit(OpCodes.Ldnull);
+            queueIl.Emit(OpCodes.Ldftn, runtime.ProcessMicrotasks);
+            queueIl.Emit(OpCodes.Newobj,
+                typeof(Action).GetConstructor([_types.Object, typeof(IntPtr)])!);
+            queueIl.Emit(OpCodes.Stsfld, microtaskDrainActionField);
+            queueIl.MarkLabel(drainActionReady);
+            queueIl.Emit(OpCodes.Call, runtime.EventLoopGetInstance);
+            queueIl.Emit(OpCodes.Ldsfld, microtaskDrainActionField);
+            queueIl.Emit(OpCodes.Callvirt, runtime.EventLoopSchedule);
+            queueIl.MarkLabel(drainAlreadyScheduled);
+        }
+        queueIl.Emit(OpCodes.Ret);
+
+        // Emit QueueMicrotask($TSFunction) as a thin adapter to the raw Action
+        // queue used by Promise state-machine continuations.
         var method = runtimeType.DefineMethod(
             "QueueMicrotask",
             MethodAttributes.Public | MethodAttributes.Static,
@@ -714,31 +802,25 @@ public partial class RuntimeEmitter
         runtime.QueueMicrotask = method;
 
         var il = method.GetILGenerator();
-        var hasQueueLabel = il.DefineLabel();
-
-        // if (_microtaskQueue == null) _microtaskQueue = new Queue<$TSFunction>();
-        il.Emit(OpCodes.Ldsfld, microtaskQueueField);
-        il.Emit(OpCodes.Brtrue_S, hasQueueLabel);
-
-        // _microtaskQueue = new Queue<$TSFunction>();
-        var queueOpenCtor = _types.GetConstructor(_types.QueueOpen, Type.EmptyTypes)!;
-        var queueCtor = EmitterTypeHelpers.ResolveConstructor(queueType, queueOpenCtor);
-        il.Emit(OpCodes.Newobj, queueCtor);
-        il.Emit(OpCodes.Stsfld, microtaskQueueField);
-
-        il.MarkLabel(hasQueueLabel);
-
-        // _microtaskQueue.Enqueue(callback);
-        var queueOpenEnqueue = _types.GetMethod(_types.QueueOpen, "Enqueue")!;
-        var enqueueMethod = EmitterTypeHelpers.ResolveMethod(queueType, queueOpenEnqueue);
-        il.Emit(OpCodes.Ldsfld, microtaskQueueField);
-        il.Emit(OpCodes.Ldarg_0); // callback
-        il.Emit(OpCodes.Callvirt, enqueueMethod);
-
+        var closureLocal = il.DeclareLocal(closure);
+        il.Emit(OpCodes.Newobj, closureCtor);
+        il.Emit(OpCodes.Stloc, closureLocal);
+        il.Emit(OpCodes.Ldloc, closureLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Stfld, callbackField);
+        il.Emit(OpCodes.Ldloc, closureLocal);
+        il.Emit(OpCodes.Ldftn, runMethod);
+        il.Emit(OpCodes.Newobj, typeof(Action).GetConstructor([_types.Object, typeof(IntPtr)])!);
+        il.Emit(OpCodes.Call, runtime.QueuePromiseJob);
         il.Emit(OpCodes.Ret);
 
         // Emit ProcessMicrotasks method
-        EmitProcessMicrotasksMethod(runtimeType, runtime, microtaskQueueField, queueType);
+        EmitProcessMicrotasksMethod(
+            runtimeType,
+            runtime,
+            microtaskQueueField,
+            microtaskDrainScheduledField,
+            queueType);
         EmitHasMicrotasksMethod(runtimeType, runtime, microtaskQueueField, queueType);
     }
 
@@ -760,8 +842,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldsfld, microtaskQueueField);
         il.Emit(OpCodes.Brfalse, none);
         var countGetter = EmitterTypeHelpers.ResolveMethod(
-            queueType,
-            _types.GetProperty(_types.QueueOpen, "Count")!.GetGetMethod()!);
+            queueType, _types.GetProperty(_types.QueueOpen, "Count")!.GetGetMethod()!);
         il.Emit(OpCodes.Ldsfld, microtaskQueueField);
         il.Emit(OpCodes.Callvirt, countGetter);
         il.Emit(OpCodes.Ldc_I4_0);
@@ -776,28 +857,27 @@ public partial class RuntimeEmitter
     /// Emits: public static void ProcessMicrotasks()
     /// Processes all pending microtasks until the queue is empty.
     /// </summary>
-    private void EmitProcessMicrotasksMethod(TypeBuilder runtimeType, EmittedRuntime runtime, FieldBuilder microtaskQueueField, Type queueType)
+    private void EmitProcessMicrotasksMethod(
+        TypeBuilder runtimeType,
+        EmittedRuntime runtime,
+        FieldBuilder microtaskQueueField,
+        FieldBuilder microtaskDrainScheduledField,
+        Type queueType)
     {
-        var method = runtimeType.DefineMethod(
-            "ProcessMicrotasks",
-            MethodAttributes.Public | MethodAttributes.Static,
-            _types.Void,
-            Type.EmptyTypes
-        );
-        runtime.ProcessMicrotasks = method;
+        var method = runtime.ProcessMicrotasks;
 
         var il = method.GetILGenerator();
 
         var loopStartLabel = il.DefineLabel();
         var doneLabel = il.DefineLabel();
 
-        // Get generic methods for Queue<$TSFunction>
+        // Get generic methods for Queue<Action>
         var queueOpenCountGetter = _types.GetProperty(_types.QueueOpen, "Count")!.GetGetMethod()!;
         var countGetter = EmitterTypeHelpers.ResolveMethod(queueType, queueOpenCountGetter);
         var queueOpenDequeue = _types.GetMethod(_types.QueueOpen, "Dequeue")!;
         var dequeueMethod = EmitterTypeHelpers.ResolveMethod(queueType, queueOpenDequeue);
 
-        var callbackLocal = il.DeclareLocal(runtime.TSFunctionType);
+        var callbackLocal = il.DeclareLocal(typeof(Action));
 
         il.MarkLabel(loopStartLabel);
 
@@ -815,14 +895,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, dequeueMethod);
         il.Emit(OpCodes.Stloc, callbackLocal);
 
-        // try { callback.Invoke(new object[0]); } catch { }
-        var tryStart = il.BeginExceptionBlock();
-
+        // try { callback.Invoke(); } catch { }
+        il.BeginExceptionBlock();
         il.Emit(OpCodes.Ldloc, callbackLocal);
-        il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Newarr, _types.Object); // new object[0]
-        il.Emit(OpCodes.Callvirt, runtime.TSFunctionInvoke);
-        il.Emit(OpCodes.Pop); // Discard result
+        il.Emit(OpCodes.Callvirt, typeof(Action).GetMethod("Invoke")!);
 
         il.BeginCatchBlock(typeof(Exception));
         il.Emit(OpCodes.Pop); // Discard exception
@@ -832,6 +908,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, loopStartLabel);
 
         il.MarkLabel(doneLabel);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stsfld, microtaskDrainScheduledField);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Execution/Interpreter.Hosting.cs
+++ b/src/SharpTS/Execution/Interpreter.Hosting.cs
@@ -452,15 +452,12 @@ public partial class Interpreter
 
     internal Task<object?> QueuePromiseReaction(Func<Task<object?>> reaction)
     {
-        // The ordinary console runtime already schedules continuations through
-        // its event-loop SynchronizationContext and must retain that path (it
-        // also carries AsyncLocalStorage state). Hosted execution has no private
-        // SynchronizationContext, so it explicitly models promise reactions as
-        // guest microtasks instead.
-        if (_hostedOwnerThreadId == null)
-            return reaction();
-
+        // Promise reactions are always jobs, including when the input promise is
+        // already settled.  Relying on an async-method await is insufficient:
+        // TaskAwaiter continues inline for a completed task, which lets a then
+        // handler run in the middle of the current JavaScript job (#1440).
         var completion = new TaskCompletionSource<object?>();
+        ExecutionContext? registrationContext = ExecutionContext.Capture();
         lock (_microtaskQueueLock)
         {
             _microtaskQueue.Enqueue(() =>
@@ -468,7 +465,19 @@ public partial class Interpreter
                 Task<object?> reactionTask;
                 try
                 {
-                    reactionTask = reaction();
+                    if (registrationContext == null)
+                    {
+                        reactionTask = reaction();
+                    }
+                    else
+                    {
+                        Task<object?>? contextualTask = null;
+                        ExecutionContext.Run(
+                            registrationContext,
+                            _ => contextualTask = reaction(),
+                            null);
+                        reactionTask = contextualTask!;
+                    }
                 }
                 catch (Exception exception)
                 {

--- a/src/SharpTS/Execution/Interpreter.cs
+++ b/src/SharpTS/Execution/Interpreter.cs
@@ -489,6 +489,12 @@ public partial class Interpreter : IDisposable
         }
     }
 
+    private bool HasMicrotasks()
+    {
+        lock (_microtaskQueueLock)
+            return _microtaskQueue.Count != 0;
+    }
+
     /// <summary>
     /// Enqueues a callback to be executed on the main event loop thread.
     /// Thread-safe - can be called from any thread (HTTP accept loop, async I/O, etc).
@@ -728,6 +734,7 @@ public partial class Interpreter : IDisposable
     {
         if (HasActiveHandles) return true;
         if (_callbackQueue.Count > 0) return true;
+        if (HasMicrotasks()) return true;
         lock (_virtualTimersLock)
         {
             while (_virtualTimerQueue.TryPeek(out var timer, out _))
@@ -823,7 +830,7 @@ public partial class Interpreter : IDisposable
             DebuggerIdleCheckpoint();
 
             // Exit immediately if there's no work keeping the loop alive
-            if (!HasActiveHandles && _callbackQueue.Count == 0)
+            if (!HasActiveHandles && _callbackQueue.Count == 0 && !HasMicrotasks())
             {
                 break;
             }
@@ -859,7 +866,7 @@ public partial class Interpreter : IDisposable
 
             // Exit condition: no active handles AND queue is empty
             // This ensures all queued callbacks are processed before exiting (like Node.js)
-            if (!HasActiveHandles && _callbackQueue.Count == 0)
+            if (!HasActiveHandles && _callbackQueue.Count == 0 && !HasMicrotasks())
             {
                 break;
             }
@@ -913,7 +920,8 @@ public partial class Interpreter : IDisposable
             }
 
             ProcessMicrotasks();
-            if (!hadListeners || (!HasActiveHandles && _callbackQueue.Count == 0))
+            if (!hadListeners ||
+                (!HasActiveHandles && _callbackQueue.Count == 0 && !HasMicrotasks()))
                 break; // no listeners, or listeners scheduled nothing new
 
             RunEventLoopCore(shutdownToken);

--- a/src/SharpTS/Runtime/BuiltIns/BuiltInAsyncMethod.cs
+++ b/src/SharpTS/Runtime/BuiltIns/BuiltInAsyncMethod.cs
@@ -188,7 +188,7 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable, IBuil
         {
             var task = _implementation(interpreter, _receiver, arguments);
             KeepEventLoopAliveUntilComplete(interpreter, task);
-            return WrapResult(interpreter, factory, task);
+            return SuppressLegacyReactionWait(WrapResult(interpreter, factory, task));
         }
         catch (Exception ex)
         {
@@ -200,11 +200,22 @@ public class BuiltInAsyncMethod : ISharpTSCallable, ISharpTSAsyncCallable, IBuil
                 _ => ex.Message
             };
             if (factory == null)
-                return SharpTSPromise.Reject(errorValue);
+                return SuppressLegacyReactionWait(SharpTSPromise.Reject(errorValue));
             var tcs = new TaskCompletionSource<object?>();
             tcs.SetException(new SharpTSPromiseRejectedException(errorValue));
-            return WrapResult(interpreter, factory, tcs.Task);
+            return SuppressLegacyReactionWait(WrapResult(interpreter, factory, tcs.Task));
         }
+    }
+
+    private object? SuppressLegacyReactionWait(object? result)
+    {
+        // A discarded reaction result must never turn the containing expression
+        // statement into an implicit top-level await. That legacy interpreter
+        // convention would drain the just-queued job before the following
+        // synchronous statement, reversing ECMAScript ordering (#1440).
+        if (_name is "then" or "catch" or "finally" && result is SharpTSPromise promise)
+            promise.SuppressImplicitTopLevelWait = true;
+        return result;
     }
 
     private static object? WrapResult(

--- a/src/SharpTS/Runtime/BuiltIns/PromiseBuiltIns.cs
+++ b/src/SharpTS/Runtime/BuiltIns/PromiseBuiltIns.cs
@@ -775,41 +775,44 @@ public static class PromiseBuiltIns
             error = ex;
         }
 
-        // Call the finally callback (with no arguments)
-        if (onFinally != null)
+        return await interpreter.QueuePromiseReaction(async () =>
         {
-            try
+            // Call the finally callback (with no arguments)
+            if (onFinally != null)
             {
-                var result = CallCallback(onFinally, [], interpreter);
-                // PromiseResolve observes an overridden `then`, not only the
-                // promise's internal host task.
-                if (RuntimeValue.FromBoxed(result).IsObject)
+                try
                 {
-                    await TaskFromResolvedValue(interpreter, result);
+                    var result = CallCallback(onFinally, [], interpreter);
+                    // PromiseResolve observes an overridden `then`, not only the
+                    // promise's internal host task.
+                    if (RuntimeValue.FromBoxed(result).IsObject)
+                    {
+                        await TaskFromResolvedValue(interpreter, result);
+                    }
+                }
+                catch (Exceptions.ThrowException thrown)
+                {
+                    throw new SharpTSPromiseRejectedException(thrown.Value);
+                }
+                catch (SharpTSPromiseRejectedException)
+                {
+                    throw;
+                }
+                catch (Exception callbackError)
+                {
+                    // If callback throws, that becomes the new rejection reason
+                    throw new SharpTSPromiseRejectedException(callbackError.Message);
                 }
             }
-            catch (Exceptions.ThrowException thrown)
-            {
-                throw new SharpTSPromiseRejectedException(thrown.Value);
-            }
-            catch (SharpTSPromiseRejectedException)
-            {
-                throw;
-            }
-            catch (Exception callbackError)
-            {
-                // If callback throws, that becomes the new rejection reason
-                throw new SharpTSPromiseRejectedException(callbackError.Message);
-            }
-        }
 
-        // Re-throw original error or return original value
-        if (error != null)
-        {
-            throw error;
-        }
+            // Re-throw original error or return original value
+            if (error != null)
+            {
+                throw error;
+            }
 
-        return value;
+            return value;
+        });
     }
 
     #endregion

--- a/tests/SharpTS.Tests/CompilerTests/ClassPrototypeGeneratorMethodTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/ClassPrototypeGeneratorMethodTests.cs
@@ -22,7 +22,7 @@ public sealed class ClassPrototypeGeneratorMethodTests
             console.log(first.generatorMethod().next().value);
             """;
 
-        Assert.Equal("true\nplain\nasync\ngenerator\n", TestHarness.RunCompiled(source));
+        Assert.Equal("true\nplain\ngenerator\nasync\n", TestHarness.RunCompiled(source));
     }
 
     [Fact]

--- a/tests/SharpTS.Tests/Hosting/HostedInterpreterRuntimeTests.cs
+++ b/tests/SharpTS.Tests/Hosting/HostedInterpreterRuntimeTests.cs
@@ -598,6 +598,58 @@ public sealed class HostedInterpreterRuntimeTests
     }
 
     [Fact]
+    public void PromiseReactions_RunAfterHostedInterpreterModuleJob()
+    {
+        const string source = """
+            const order: string[] = ["start"];
+            Promise.resolve(1).then((): void => { order.push("then"); });
+            order.push("after");
+            queueMicrotask((): void => console.log(order.join(":")));
+            export {};
+            """;
+        var dispatcher = new DeterministicHostDispatcher();
+        using var output = new StringWriter();
+        using var runtime = CreateRuntime(
+            source, dispatcher, new RecordingLifetime(), new RecordingErrorSink(), output);
+
+        Task initialization = runtime.InitializeAsync();
+        dispatcher.RunUntil(() => initialization.IsCompleted);
+        initialization.GetAwaiter().GetResult();
+
+        Assert.Equal(["start:after:then"], Lines(output));
+    }
+
+    [Fact]
+    public void PromiseReactions_RunAfterHostedCompiledModuleJob()
+    {
+        SharpTSProgram program = CreateProgram("""
+            const order: string[] = ["start"];
+            Promise.resolve(1).then((): void => { order.push("then"); });
+            order.push("after");
+            queueMicrotask((): void => console.log(order.join(":")));
+            export {};
+            """);
+        var compiler = new ILCompiler($"hosted_promise_jobs_{Guid.NewGuid():N}");
+        compiler.EnableHostedOutput();
+        compiler.CompileModules(
+            program.RuntimeModules.ToList(), program.Resolver, program.TypeMap);
+
+        var dispatcher = new DeterministicHostDispatcher();
+        using var output = Infrastructure.AsyncLocalConsoleRedirector.Capture();
+        using ISharpTSHostedRuntime runtime = SharpTSHostedAssembly.CreateRuntime(
+            System.Reflection.Assembly.Load(compiler.SaveToBytes()),
+            dispatcher,
+            new RecordingLifetime(),
+            new RecordingErrorSink());
+
+        Task initialization = runtime.InitializeAsync();
+        dispatcher.RunUntil(() => initialization.IsCompleted);
+        initialization.GetAwaiter().GetResult();
+
+        Assert.Equal("start:after:then\n", output.GetOutput().Replace("\r\n", "\n"));
+    }
+
+    [Fact]
     public void OffThreadNotifications_CoalesceWakeAndRunOnePerTurn()
     {
         var dispatcher = new DeterministicHostDispatcher();

--- a/tests/SharpTS.Tests/SharedTests/PromiseJobSchedulingTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/PromiseJobSchedulingTests.cs
@@ -1,0 +1,106 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Regression coverage for #1440: Promise reactions are FIFO microtasks and
+/// never run inline merely because their Task-backed source is already settled.
+/// </summary>
+public sealed class PromiseJobSchedulingTests
+{
+    private const string SettledOrderingSource = """
+        const order: string[] = ["start"];
+        Promise.resolve(1).then((): void => { order.push("then"); });
+        Promise.reject("reason").catch((): void => { order.push("catch"); });
+        Promise.resolve(1).finally((): void => { order.push("finally"); });
+        order.push("after");
+        queueMicrotask((): void => {
+            order.push("queueMicrotask");
+            console.log(order.join(":"));
+        });
+        """;
+
+    [Theory, ModeData]
+    public void SettledThenCatchFinally_RunAfterCurrentJobInFifoOrder(
+        ExecutionMode mode)
+    {
+        Assert.Equal(
+            "start:after:then:catch:finally:queueMicrotask\n",
+            TestHarness.Run(SettledOrderingSource, mode));
+    }
+
+    [Theory, ModeData]
+    public void NestedPromiseJobs_AppendToTheSharedMicrotaskFifo(
+        ExecutionMode mode)
+    {
+        const string source = """
+            const order: string[] = [];
+            Promise.resolve(1).then((): void => {
+                order.push("promise-1");
+                Promise.resolve(2).then((): void => { order.push("nested"); });
+            });
+            queueMicrotask((): void => { order.push("microtask"); });
+            Promise.resolve(3).then((): void => { order.push("promise-2"); });
+            setTimeout((): void => console.log(order.join(":")), 0);
+            """;
+
+        Assert.Equal(
+            "promise-1:microtask:promise-2:nested\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void PendingSource_QueuesReactionAtSettlementBeforeLaterMicrotasks(
+        ExecutionMode mode)
+    {
+        const string source = """
+            const order: string[] = [];
+            let settle!: (value: number) => void;
+            const pending: Promise<number> = new Promise<number>(
+                (resolve): void => { settle = resolve; });
+            pending.then((): void => { order.push("reaction"); });
+            settle(1);
+            queueMicrotask((): void => { order.push("microtask"); });
+            setTimeout((): void => console.log(order.join(":")), 0);
+            """;
+
+        Assert.Equal(
+            "reaction:microtask\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void QueuedReaction_AdoptsThenableAndRejectsThrownHandlerExactlyOnce(
+        ExecutionMode mode)
+    {
+        const string source = """
+            let calls: number = 0;
+            const adopted: Promise<number> = Promise.resolve(1)
+                .then((_value: number): any => ({
+                    then(resolve: (value: number) => void): void {
+                        resolve(41);
+                        resolve(99);
+                    }
+                }))
+                .then((value: number): number => {
+                    calls += 1;
+                    throw new Error(String(value + 1));
+                });
+            adopted.catch((error: Error): void => {
+                console.log(error.message + ":" + calls);
+            });
+            console.log("sync");
+            """;
+
+        Assert.Equal("sync\n42:1\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void StandaloneCompiledOutput_DrainsQueuedPromiseJobs()
+    {
+        Assert.Equal(
+            "start:after:then:catch:finally:queueMicrotask\n",
+            TestHarness.RunCompiledStandalone(SettledOrderingSource));
+    }
+}


### PR DESCRIPTION
## Summary

- route interpreted and emitted `then`, `catch`, and `finally` reactions through a shared FIFO microtask queue
- preserve standalone and hosted event-loop lifetime without restoring mid-statement auto-await behavior
- keep the #1438 typed primitive continuation fast path and adapt direct benchmark hosting to drain jobs correctly
- cover settled, pending, nested, adoption, rejection, exactly-once, standalone, hosted, and shared `queueMicrotask` ordering

## Validation

- Release solution build: passed, including both emitted-IL verification passes
- core suite: 17,151 passed, 3 skipped, 0 failed
- focused Test262 Promise parity: 291 passed, 0 failed
- short-run SharpTS Promise chain benchmark (`n=1000`): 156.746 us, 336.23 KB allocated (well below #1438 gates of 1.943 ms / 815.81 KB)

Fixes #1440