### PR TITLE
Optimize stable Promise.all fan-out

### DIFF
--- a/benchmarks/cross-runtime/scripts/lib/algorithms.ts
+++ b/benchmarks/cross-runtime/scripts/lib/algorithms.ts
@@ -325,3 +325,36 @@ export async function promiseAllFanOut(n: number): Promise<number> {
     }
     return sum;
 }
+
+// Promise.all phase probes used by the microbenchmark suite. The first keeps
+// the exact input-construction loop but omits aggregation; the second reuses a
+// single settled promise so Promise.all's per-element bookkeeping remains
+// visible without paying for n Promise.resolve allocations.
+export async function promiseResolveFanOutPhase(n: number): Promise<number> {
+    const promises: Promise<number>[] = [];
+    for (let i: number = 0; i < n; i++) {
+        promises.push(Promise.resolve(i));
+    }
+    return promises.length;
+}
+
+export async function promiseAllRepeatedResolvedPhase(n: number): Promise<number> {
+    const promise: Promise<number> = Promise.resolve(1);
+    const promises: Promise<number>[] = [];
+    for (let i: number = 0; i < n; i++) {
+        promises.push(promise);
+    }
+    const values: number[] = await (
+        Promise.all(promises) as Promise<number[]>
+    );
+    return values.length;
+}
+
+export async function promiseRepeatedResolvedBuildPhase(n: number): Promise<number> {
+    const promise: Promise<number> = Promise.resolve(1);
+    const promises: Promise<number>[] = [];
+    for (let i: number = 0; i < n; i++) {
+        promises.push(promise);
+    }
+    return promises.length;
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/AsyncPromiseBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/AsyncPromiseBenchmarks.cs
@@ -106,3 +106,32 @@ public class PromiseAllBenchmarks : AsyncPromiseBenchmarkBase
     [Benchmark]
     public Task<object?> Equivalent() => AsyncPromiseCSharp.EquivalentAll((double)N);
 }
+
+[MemoryDiagnoser]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class PromiseAllPhaseBenchmarks : AsyncPromiseBenchmarkBase
+{
+    private Func<object?, Task<object?>> _resolveFanOut = null!;
+    private Func<object?, Task<object?>> _repeatedResolved = null!;
+    private Func<object?, Task<object?>> _repeatedResolvedBuild = null!;
+
+    [Params(1000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _resolveFanOut = LoadCompiledAsync("promiseResolveFanOutPhase");
+        _repeatedResolved = LoadCompiledAsync("promiseAllRepeatedResolvedPhase");
+        _repeatedResolvedBuild = LoadCompiledAsync("promiseRepeatedResolvedBuildPhase");
+    }
+
+    [Benchmark]
+    public Task<object?> ResolveFanOut() => _resolveFanOut((double)N);
+
+    [Benchmark]
+    public Task<object?> RepeatedResolvedAll() => _repeatedResolved((double)N);
+
+    [Benchmark]
+    public Task<object?> RepeatedResolvedBuild() => _repeatedResolvedBuild((double)N);
+}

--- a/src/SharpTS/Compilation/Emitters/PromiseStaticEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/PromiseStaticEmitter.cs
@@ -27,6 +27,17 @@ public sealed class PromiseStaticEmitter : IStaticTypeEmitterStrategy
                 {
                     emitter.EmitExpression(arguments[0]);
                     emitter.EmitBoxIfNeeded(arguments[0]);
+
+                    // A statically non-null primitive cannot be a thenable.
+                    // Task.FromResult<object> creates a fresh Task for every
+                    // non-null boxed value, preserving JavaScript Promise
+                    // identity without the heavier TCS + dynamic `then` path.
+                    if (IsFreshCompletedTaskSafe(ctx.TypeMap?.Get(arguments[0])))
+                    {
+                        il.Emit(OpCodes.Call, EmitGenerics.MakeGenericMethod(
+                            typeof(Task).GetMethod("FromResult")!, typeof(object)));
+                        return true;
+                    }
                 }
                 else
                 {
@@ -197,4 +208,14 @@ public sealed class PromiseStaticEmitter : IStaticTypeEmitterStrategy
         ctx.IL.Emit(OpCodes.Call,
             ctx.Types.GetMethod(ctx.Types.Type, "GetTypeFromHandle", ctx.Types.RuntimeTypeHandle));
     }
+
+    private static bool IsFreshCompletedTaskSafe(TypeSystem.TypeInfo? type) => type is
+        TypeSystem.TypeInfo.Primitive
+        {
+            Type: TokenType.TYPE_NUMBER or TokenType.TYPE_BOOLEAN
+        }
+        or TypeSystem.TypeInfo.NumberLiteral
+        or TypeSystem.TypeInfo.BooleanLiteral
+        or TypeSystem.TypeInfo.String
+        or TypeSystem.TypeInfo.StringLiteral;
 }

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.All.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.All.cs
@@ -57,10 +57,12 @@ public partial class RuntimeEmitter
         var il = sm.MoveNextMethod.GetILGenerator();
         var listType = typeof(List<object?>);
         var taskListType = typeof(List<Task<object?>>);
+        var taskArrayType = typeof(Task<object?>[]);
 
         // Local variables
         var exceptionLocal = il.DeclareLocal(typeof(Exception));
         var resultLocal = il.DeclareLocal(typeof(object));
+        var taskArrayLocal = il.DeclareLocal(taskArrayType);
 
         // Labels
         var state0Label = il.DefineLabel();
@@ -80,6 +82,22 @@ public partial class RuntimeEmitter
 
         EmitNormalizeCombinatorIterable(il, runtime, sm.IterableField, sm.ConstructorField,
             sm.CapabilityField, combinatorKind: 3);
+
+        // NormalizePromiseList returns an exact task array for the stable
+        // intrinsic Promise.all case. It has already checked every element's
+        // observable own `then`, so bypass the generic list conversion.
+        var genericListLabel = il.DefineLabel();
+        var haveTaskArrayLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, sm.IterableField);
+        il.Emit(OpCodes.Isinst, taskArrayType);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brfalse, genericListLabel);
+        il.Emit(OpCodes.Stloc, taskArrayLocal);
+        il.Emit(OpCodes.Br, haveTaskArrayLabel);
+
+        il.MarkLabel(genericListLabel);
+        il.Emit(OpCodes.Pop);
 
         // ECMA-262 §27.2.4.1 Promise.all: If iterable is not Object → throw TypeError.
         // Without this, a non-iterable arg falls through to Castclass which throws
@@ -110,6 +128,10 @@ public partial class RuntimeEmitter
                    m.GetParameters()[0].ParameterType.IsArray), typeof(object));
         il.Emit(OpCodes.Ldloc, tasksLocal);
         il.Emit(OpCodes.Callvirt, taskListType.GetMethod("ToArray")!);
+        il.Emit(OpCodes.Stloc, taskArrayLocal);
+
+        il.MarkLabel(haveTaskArrayLabel);
+        il.Emit(OpCodes.Ldloc, taskArrayLocal);
         il.Emit(OpCodes.Call, whenAllMethod);
 
         // Await the WhenAll task (suspends at state 0 when not yet complete)

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.Executor.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.Executor.cs
@@ -243,6 +243,7 @@ public partial class RuntimeEmitter
         var listType = _types.ListOfObject;
         var listLocal = il.DeclareLocal(listType);
         var resultLocal = il.DeclareLocal(listType);
+        var taskArrayLocal = il.DeclareLocal(typeof(Task<object?>[]));
         var indexLocal = il.DeclareLocal(_types.Int32);
         var elementLocal = il.DeclareLocal(_types.Object);
         var resolvedElementLocal = il.DeclareLocal(_types.Object);
@@ -341,6 +342,86 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
         il.Emit(OpCodes.Call, runtime.IterateToList);
         il.Emit(OpCodes.Stloc, listLocal);
+
+        // The overwhelmingly common Promise.all case is a dense intrinsic
+        // array whose elements are already native promises. Preserve the own
+        // `then` checks required by PerformPromiseAll, but keep the proven
+        // tasks in their final array shape so the state machine can hand them
+        // straight to Task.WhenAll without two intermediate List copies.
+        var ordinaryListNormalizationLabel = il.DefineLabel();
+        var fastTaskScanLoopLabel = il.DefineLabel();
+        var fastTaskScanTSPromiseLabel = il.DefineLabel();
+        var fastTaskScanStoreLabel = il.DefineLabel();
+        var fastTaskScanDoneLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_3);
+        il.Emit(OpCodes.Ldc_I4_3);
+        il.Emit(OpCodes.Bne_Un, ordinaryListNormalizationLabel);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Brtrue, ordinaryListNormalizationLabel);
+        il.Emit(OpCodes.Ldloc, invokeResolveLocal);
+        il.Emit(OpCodes.Brtrue, ordinaryListNormalizationLabel);
+
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(listType, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Newarr, _types.TaskOfObject);
+        il.Emit(OpCodes.Stloc, taskArrayLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, indexLocal);
+
+        il.MarkLabel(fastTaskScanLoopLabel);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldloc, taskArrayLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Bge, fastTaskScanDoneLabel);
+        il.Emit(OpCodes.Ldloc, listLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(listType, "Item").GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, elementLocal);
+
+        il.Emit(OpCodes.Ldloc, elementLocal);
+        il.Emit(OpCodes.Isinst, _types.TaskOfObject);
+        il.Emit(OpCodes.Stloc, resolvedElementLocal);
+        il.Emit(OpCodes.Ldloc, resolvedElementLocal);
+        il.Emit(OpCodes.Brfalse, fastTaskScanTSPromiseLabel);
+        il.Emit(OpCodes.Ldloc, elementLocal);
+        il.Emit(OpCodes.Ldstr, "then");
+        il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
+        il.Emit(OpCodes.Brtrue, ordinaryListNormalizationLabel);
+        il.Emit(OpCodes.Br, fastTaskScanStoreLabel);
+
+        il.MarkLabel(fastTaskScanTSPromiseLabel);
+        il.Emit(OpCodes.Ldloc, elementLocal);
+        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Stloc, resolvedElementLocal);
+        il.Emit(OpCodes.Ldloc, resolvedElementLocal);
+        il.Emit(OpCodes.Brfalse, ordinaryListNormalizationLabel);
+        il.Emit(OpCodes.Ldloc, elementLocal);
+        il.Emit(OpCodes.Ldstr, "then");
+        il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
+        il.Emit(OpCodes.Brtrue, ordinaryListNormalizationLabel);
+        il.Emit(OpCodes.Ldloc, resolvedElementLocal);
+        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
+        il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);
+        il.Emit(OpCodes.Stloc, resolvedElementLocal);
+
+        il.MarkLabel(fastTaskScanStoreLabel);
+        il.Emit(OpCodes.Ldloc, taskArrayLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldloc, resolvedElementLocal);
+        il.Emit(OpCodes.Castclass, _types.TaskOfObject);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        il.Emit(OpCodes.Br, fastTaskScanLoopLabel);
+
+        il.MarkLabel(fastTaskScanDoneLabel);
+        il.Emit(OpCodes.Ldloc, taskArrayLocal);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(ordinaryListNormalizationLabel);
 
         // var result = new List<object?>(); for each element: $Promise → .Task
         il.Emit(OpCodes.Newobj, _types.GetConstructor(listType, _types.EmptyTypes));
@@ -680,7 +761,7 @@ public partial class RuntimeEmitter
             targetIl.Emit(OpCodes.Ldstr, "then");
             targetIl.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
             targetIl.Emit(OpCodes.Brtrue, invokeObservableThenLabel);
-            targetIl.Emit(OpCodes.Br, ordinaryResolutionLabel);
+            targetIl.Emit(OpCodes.Br, useOrdinaryCoercionLabel);
 
             targetIl.MarkLabel(checkNativePromiseObjectLabel);
             targetIl.Emit(OpCodes.Ldloc, resolvedElementLocal);
@@ -690,6 +771,7 @@ public partial class RuntimeEmitter
             targetIl.Emit(OpCodes.Ldstr, "then");
             targetIl.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
             targetIl.Emit(OpCodes.Brtrue, invokeObservableThenLabel);
+            targetIl.Emit(OpCodes.Br, useOrdinaryCoercionLabel);
 
             targetIl.MarkLabel(ordinaryResolutionLabel);
             targetIl.Emit(OpCodes.Ldloc, resolvedElementLocal);

--- a/src/SharpTS/Compilation/StatementEmitterBase.cs
+++ b/src/SharpTS/Compilation/StatementEmitterBase.cs
@@ -1,6 +1,7 @@
 using System.Reflection.Emit;
 using SharpTS.Diagnostics.Exceptions;
 using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
 
 namespace SharpTS.Compilation;
 
@@ -366,9 +367,71 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
     /// <summary>
     /// Gives an emitter a chance to lower an expression whose JavaScript value
     /// is discarded without first manufacturing a stack result. The default
-    /// keeps the ordinary expression-plus-pop behavior.
+    /// recognizes the object-backed array push shape shared by async/generator
+    /// state machines; specialized synchronous emitters may add narrower typed
+    /// paths before delegating here.
     /// </summary>
-    protected virtual bool TryEmitDiscardedExpression(Expr expression) => false;
+    protected virtual bool TryEmitDiscardedExpression(Expr expression)
+    {
+        if (expression is not Expr.Call
+            {
+                Optional: false,
+                Callee: Expr.Get
+                {
+                    Optional: false,
+                    Name.Lexeme: "push"
+                } methodGet,
+                Arguments: { Count: 1 } arguments
+            }
+            || Ctx.TypeMap?.Get(methodGet.Object) is not TypeSystem.TypeInfo.Array receiverType
+            || ArrayElements.Resolve(receiverType) is not { Kind: ArrayElementsKind.Object }
+            || arguments[0] is Expr.Spread
+            || ExpressionSuspensionDetector.Contains(arguments[0])
+            || Ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors != false
+            || Ctx.RuntimeFeatures.UsesArrayPrototypeMutation)
+        {
+            return false;
+        }
+
+        EmitExpression(methodGet.Object);
+        EnsureBoxed();
+        EmitExpression(arguments[0]);
+        EnsureBoxed();
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.ArrayPushOneDiscarded);
+        SetStackUnknown();
+        return true;
+    }
+
+    private sealed class ExpressionSuspensionDetector : AstVisitorBase
+    {
+        public bool Found { get; private set; }
+
+        public static bool Contains(Expr expression)
+        {
+            var detector = new ExpressionSuspensionDetector();
+            detector.Visit(expression);
+            return detector.Found;
+        }
+
+        protected override void VisitAwait(Expr.Await expression)
+        {
+            Found = true;
+            ShouldContinue = false;
+        }
+
+        protected override void VisitYield(Expr.Yield expression)
+        {
+            Found = true;
+            ShouldContinue = false;
+        }
+
+        // Creating a nested callable does not execute its body while the
+        // receiver is live on this state machine's evaluation stack.
+        protected override void VisitFunction(Stmt.Function statement) { }
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression) { }
+        protected override void VisitClass(Stmt.Class statement) { }
+        protected override void VisitClassExpr(Expr.ClassExpr expression) { }
+    }
 
     /// <summary>
     /// Emits a 'using' or 'await using' declaration.

--- a/tests/SharpTS.Tests/CompilerTests/StableDiscardedArrayPushTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableDiscardedArrayPushTests.cs
@@ -69,6 +69,41 @@ public sealed class StableDiscardedArrayPushTests
             instruction.Operand is MethodBase { Name: "ArrayPushOneDiscarded" });
     }
 
+    [Fact]
+    public void AsyncDiscardedStablePush_UsesVoidGuardedHelperWithoutArgumentArray()
+    {
+        Assembly assembly = Compile("""
+            async function append(items: Promise<number>[]): Promise<void> {
+                items.push(Promise.resolve(1));
+            }
+            """);
+
+        MethodInfo moveNext = Assert.Single(FindCallers(
+            assembly, "ArrayPushOneDiscarded"));
+        var instructions = ReadInstructions(moveNext).ToArray();
+
+        Assert.Equal("MoveNext", moveNext.Name);
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "ArrayPushProto" });
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.OpCode == OpCodes.Newarr
+            && instruction.Operand is Type type && type == typeof(object));
+    }
+
+    [Fact]
+    public void AsyncAwaitedPushArgument_RetainsSpillSafeGeneralPath()
+    {
+        Assembly assembly = Compile("""
+            async function value(): Promise<string> { return "ok"; }
+            async function append(items: string[]): Promise<void> {
+                items.push(await value());
+            }
+            """);
+
+        Assert.Empty(FindCallers(assembly, "ArrayPushOneDiscarded"));
+        Assert.NotEmpty(FindCallers(assembly, "ArrayPushProto"));
+    }
+
     [Theory]
     [InlineData("Object.defineProperty([], '0', { value: 1 });")]
     [InlineData("const p = Array.prototype;")]
@@ -141,12 +176,30 @@ public sealed class StableDiscardedArrayPushTests
             .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
             .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
 
+    private static List<MethodInfo> FindCallers(Assembly assembly, string methodName) =>
+        assembly.GetTypes()
+            .Where(type => type.Name != "$Runtime")
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic |
+                BindingFlags.Static | BindingFlags.Instance))
+            .Where(method => method.GetMethodBody() != null)
+            .Where(method => ReadInstructions(method).Any(instruction =>
+                instruction.Operand is MethodBase called
+                && called.Name == methodName))
+            .ToList();
+
     private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
         MethodInfo method)
     {
         byte[] il = method.GetMethodBody()?.GetILAsByteArray()
             ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
         Module module = method.Module;
+        Type[]? typeArguments = method.DeclaringType?.IsGenericType == true
+            ? method.DeclaringType.GetGenericArguments()
+            : null;
+        Type[]? methodArguments = method.IsGenericMethod
+            ? method.GetGenericArguments()
+            : null;
 
         for (int offset = 0; offset < il.Length;)
         {
@@ -160,8 +213,8 @@ public sealed class StableDiscardedArrayPushTests
             {
                 int token = BitConverter.ToInt32(il, offset);
                 operand = opCode.OperandType == OperandType.InlineMethod
-                    ? module.ResolveMethod(token)
-                    : module.ResolveType(token);
+                    ? module.ResolveMethod(token, typeArguments, methodArguments)
+                    : module.ResolveType(token, typeArguments, methodArguments);
             }
 
             int operandSize = opCode.OperandType switch

--- a/tests/SharpTS.Tests/CompilerTests/StablePrimitivePromiseThenTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StablePrimitivePromiseThenTests.cs
@@ -243,6 +243,73 @@ public sealed class StablePrimitivePromiseThenTests
         Assert.NotEmpty(FindCallers(assembly, "InvokeMethodValue"));
     }
 
+    [Fact]
+    public void PrimitiveResolve_UsesFreshCompletedTaskWithoutDynamicResolution()
+    {
+        Assembly assembly = Compile("""
+            function make(): Promise<number> {
+                return Promise.resolve(1);
+            }
+            """);
+
+        MethodInfo caller = assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic |
+                BindingFlags.Static)
+            .Single(method => method.Name.EndsWith("make", StringComparison.Ordinal));
+        Assert.Contains(ReadInstructions(caller), instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "FromResult",
+                DeclaringType: { } declaringType
+            }
+            && declaringType == typeof(Task));
+        Assert.DoesNotContain(ReadInstructions(caller), instruction =>
+            instruction.Operand is MethodBase { Name: "PromiseResolve" });
+    }
+
+    [Fact]
+    public void PromiseAllRuntime_HasNativeTaskArrayNormalizationPath()
+    {
+        Assembly assembly = Compile("""
+            async function gather(): Promise<number[]> {
+                return await Promise.all([Promise.resolve(1)]);
+            }
+            """);
+
+        MethodInfo normalize = assembly.GetType("$Runtime")!
+            .GetMethod("NormalizePromiseList")!;
+        Assert.Contains(ReadInstructions(normalize), instruction =>
+            instruction.OpCode == OpCodes.Newarr
+            && instruction.Operand is Type type
+            && type == typeof(Task<object?>));
+
+        MethodInfo moveNext = assembly.GetType("$PromiseAll_SM")!
+            .GetMethod("MoveNext")!;
+        Assert.Contains(ReadInstructions(moveNext), instruction =>
+            instruction.OpCode == OpCodes.Isinst
+            && instruction.Operand is Type type
+            && type == typeof(Task<object?>[]));
+    }
+
+    [Fact]
+    public void StablePromiseAllFanOut_VerifiesIlAndStandaloneOutput()
+    {
+        const string source = """
+            async function gather(): Promise<void> {
+                const promises: Promise<number>[] = [];
+                for (let i: number = 0; i < 4; i++) {
+                    promises.push(Promise.resolve(i));
+                }
+                const values: number[] = await Promise.all(promises);
+                console.log(values[0] + values[1] + values[2] + values[3]);
+            }
+            gather();
+            """;
+
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+        Assert.Equal("6\n", TestHarness.RunCompiledStandalone(source));
+    }
+
     private static Assembly Compile(string source)
     {
         var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();

--- a/tests/SharpTS.Tests/SharedTests/PromiseMethodTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/PromiseMethodTests.cs
@@ -472,6 +472,28 @@ public class PromiseMethodTests
         Assert.Equal("6\n", output);
     }
 
+    [Theory, ModeData]
+    public void All_IntrinsicTasksStillObserveOwnThenOverride(ExecutionMode mode)
+    {
+        var source = """
+            async function main(): Promise<void> {
+                const promise: any = Promise.resolve(1);
+                let calls: number = 0;
+                promise.then = function (resolve: any): void {
+                    calls = calls + 1;
+                    resolve(9);
+                };
+                const values: number[] = await Promise.all([promise]);
+                console.log(values[0]);
+                console.log(calls);
+            }
+            main();
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("9\n1\n", output);
+    }
+
     #endregion
 
     #region Promise.race() Tests
@@ -529,6 +551,33 @@ public class PromiseMethodTests
 
         var output = TestHarness.Run(source, mode);
         Assert.Equal("42\n", output);
+    }
+
+    [Theory, ModeData]
+    public void Resolve_PrimitivesRetainFreshPromiseIdentity(ExecutionMode mode)
+    {
+        var source = """
+            const numberFirst: any = Promise.resolve(1);
+            const numberSecond: any = Promise.resolve(1);
+            numberFirst.marker = 42;
+            console.log(numberFirst === numberSecond);
+            console.log(Object.hasOwn(numberSecond, "marker"));
+
+            const booleanFirst: any = Promise.resolve(true);
+            const booleanSecond: any = Promise.resolve(true);
+            booleanFirst.marker = 42;
+            console.log(booleanFirst === booleanSecond);
+            console.log(Object.hasOwn(booleanSecond, "marker"));
+
+            const stringFirst: any = Promise.resolve("value");
+            const stringSecond: any = Promise.resolve("value");
+            stringFirst.marker = 42;
+            console.log(stringFirst === stringSecond);
+            console.log(Object.hasOwn(stringSecond, "marker"));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal("false\nfalse\nfalse\nfalse\nfalse\nfalse\n", output);
     }
 
     [Theory, ModeData]


### PR DESCRIPTION
## Summary
- lower stable primitive `Promise.resolve` calls to fresh completed `Task<object?>` instances
- carry already-native promise tasks through `Promise.all` normalization as the final task array
- extend discarded single-element array `push` lowering to async/generator state machines, with a suspension-safe fallback
- retain observable `then`, custom-constructor, and Promise identity semantics

Fixes #1445

## Performance

`PromiseAllBenchmarks` (`N=1000`, in-process BenchmarkDotNet):

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| SharpTS mean | 734.862 us | 286.044 us | 61.1% faster |
| Allocated | 504.36 KB | 303.17 KB | 39.9% less |

The cross-runtime Promise.all median improved from approximately **13.37x Node** to **3.99x Node** (0.1034 ms SharpTS vs 0.0259 ms Node in the final run).

## Validation
- Release solution build, including two IL verification passes
- core test suite: 17,162 passed, 3 skipped
- TypeScript conformance: 65/65 passed
- focused Promise, emitted-IL, and async array-push regression tests
- complete cross-runtime benchmark suite

The local Test262 workers completed without reporting a failure, but the coordinator stopped making progress and did not exit; the run was stopped after approximately 40 minutes. The PR's Test262 CI job is the authoritative gate.