### PR TITLE
perf: fuse stable primitive Promise chains

### DIFF
--- a/benchmarks/micro/SharpTS.Microbenchmarks/Baselines/AsyncPromiseCSharp.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Baselines/AsyncPromiseCSharp.cs
@@ -84,6 +84,65 @@ public static class AsyncPromiseCSharp
         return await chain;
     }
 
+    /// <summary>
+    /// Scheduler-equivalent control for the fused SharpTS path: retain one
+    /// final Task and execute exactly one numeric reaction per FIFO job.
+    /// Unlike the ContinueWith ceilings above, this includes explicit Promise-
+    /// job queueing while excluding emitted-runtime lookup overhead.
+    /// </summary>
+    public static Task<object?> FifoScheduledThenChain(object? n)
+    {
+        int count = (int)Convert.ToDouble(n);
+        var chain = new FifoThenChain(0d);
+        for (int i = 0; i < count; i++)
+        {
+            double captured = i;
+            chain.Append(value => value + captured);
+        }
+        return chain.Run();
+    }
+
+    private sealed class FifoThenChain
+    {
+        private readonly List<Func<double, double>> _handlers = [];
+        private readonly Queue<Action> _jobs = [];
+        private readonly TaskCompletionSource<object?> _completion = new();
+        private readonly Action _runOne;
+        private int _index;
+        private double _value;
+
+        public FifoThenChain(double value)
+        {
+            _value = value;
+            _runOne = RunOne;
+        }
+
+        public void Append(Func<double, double> handler) => _handlers.Add(handler);
+
+        public Task<object?> Run()
+        {
+            if (_handlers.Count == 0)
+            {
+                _completion.SetResult(_value);
+                return _completion.Task;
+            }
+
+            _jobs.Enqueue(_runOne);
+            while (_jobs.TryDequeue(out Action? job))
+                job();
+            return _completion.Task;
+        }
+
+        private void RunOne()
+        {
+            _value = _handlers[_index++](_value);
+            if (_index < _handlers.Count)
+                _jobs.Enqueue(_runOne);
+            else
+                _completion.SetResult(_value);
+        }
+    }
+
     public static async Task<double> IdiomaticAll(int n)
     {
         var promises = new Task<double>[n];

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/AsyncPromiseBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/AsyncPromiseBenchmarks.cs
@@ -82,6 +82,10 @@ public class PromiseThenChainBenchmarks : AsyncPromiseBenchmarkBase
 
     [Benchmark]
     public Task<object?> Equivalent() => AsyncPromiseCSharp.EquivalentThenChain((double)N);
+
+    [Benchmark]
+    public Task<object?> FifoScheduled() =>
+        AsyncPromiseCSharp.FifoScheduledThenChain((double)N);
 }
 
 [MemoryDiagnoser]

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.Then.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.Then.cs
@@ -1127,12 +1127,12 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(createChain);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Callvirt, _types.TaskOfObject.GetProperty(
-            "IsCompletedSuccessfully")!.GetGetMethod()!);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(
+            _types.Task, "IsCompletedSuccessfully").GetGetMethod()!);
         il.Emit(OpCodes.Brfalse, fallbackLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Callvirt,
-            _types.TaskOfObject.GetProperty("Result")!.GetGetMethod()!);
+            _types.GetProperty(_types.TaskOfObject, "Result").GetGetMethod()!);
         il.Emit(OpCodes.Unbox_Any, typeof(double));
         il.Emit(OpCodes.Newobj, chain.Constructor);
         il.Emit(OpCodes.Stloc, chainLocal);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.Then.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.Then.cs
@@ -867,6 +867,297 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
+    private PrimitivePromiseChainClass DefinePrimitivePromiseChainClass(
+        ModuleBuilder moduleBuilder,
+        TypeBuilder runtimeType,
+        EmittedRuntime runtime)
+    {
+        var chainType = moduleBuilder.DefineType(
+            "$PrimitivePromiseChain",
+            TypeAttributes.Public | TypeAttributes.Sealed |
+                TypeAttributes.BeforeFieldInit,
+            typeof(object));
+        var handlerType = typeof(Func<double, double>);
+        var handlersType = typeof(List<Func<double, double>>);
+        var tcsType = typeof(TaskCompletionSource<object?>);
+        var tableType = _types.MakeGenericType(
+            typeof(Dictionary<,>), _types.TaskOfObject, chainType);
+        var tableField = runtimeType.DefineField(
+            "_primitivePromiseChains",
+            tableType,
+            FieldAttributes.Assembly | FieldAttributes.Static);
+        var tableRemove = EmitterTypeHelpers.ResolveMethod(
+            tableType,
+            typeof(Dictionary<,>).GetMethods()
+                .Single(method => method.Name == "Remove"
+                    && method.GetParameters().Length == 1));
+
+        var handlersField = chainType.DefineField(
+            "_handlers", handlersType,
+            FieldAttributes.Private | FieldAttributes.InitOnly);
+        var completionField = chainType.DefineField(
+            "_completion", tcsType,
+            FieldAttributes.Private | FieldAttributes.InitOnly);
+        var runActionField = chainType.DefineField(
+            "_runAction", typeof(Action),
+            FieldAttributes.Private | FieldAttributes.InitOnly);
+        var indexField = chainType.DefineField(
+            "_index", typeof(int), FieldAttributes.Private);
+        var valueField = chainType.DefineField(
+            "_value", typeof(double), FieldAttributes.Private);
+        var exceptionField = chainType.DefineField(
+            "_exception", typeof(Exception), FieldAttributes.Private);
+
+        var runOne = chainType.DefineMethod(
+            "RunOne",
+            MethodAttributes.Private | MethodAttributes.HideBySig,
+            typeof(void),
+            Type.EmptyTypes);
+        var constructor = chainType.DefineConstructor(
+            MethodAttributes.Public,
+            CallingConventions.Standard,
+            [typeof(double)]);
+        var append = chainType.DefineMethod(
+            "Append",
+            MethodAttributes.Public | MethodAttributes.HideBySig,
+            typeof(void),
+            [handlerType]);
+        var taskGetter = chainType.DefineMethod(
+            "GetTask",
+            MethodAttributes.Public | MethodAttributes.HideBySig,
+            _types.TaskOfObject,
+            Type.EmptyTypes);
+
+        {
+            var il = constructor.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, _types.GetDefaultConstructor(typeof(object)));
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Newobj, handlersType.GetConstructor(Type.EmptyTypes)!);
+            il.Emit(OpCodes.Stfld, handlersField);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Newobj, tcsType.GetConstructor(Type.EmptyTypes)!);
+            il.Emit(OpCodes.Stfld, completionField);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Stfld, valueField);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldftn, runOne);
+            il.Emit(OpCodes.Newobj, typeof(Action).GetConstructor(
+                [typeof(object), typeof(IntPtr)])!);
+            il.Emit(OpCodes.Stfld, runActionField);
+            il.Emit(OpCodes.Ret);
+        }
+
+        {
+            var il = append.GetILGenerator();
+            var done = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, handlersField);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Callvirt, handlersType.GetMethod("Add")!);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, handlersField);
+            il.Emit(OpCodes.Callvirt,
+                handlersType.GetProperty("Count")!.GetGetMethod()!);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Bne_Un, done);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, runActionField);
+            il.Emit(OpCodes.Call, runtime.QueuePromiseJob);
+            il.MarkLabel(done);
+            il.Emit(OpCodes.Ret);
+        }
+
+        {
+            var il = taskGetter.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, completionField);
+            il.Emit(OpCodes.Callvirt, tcsType.GetProperty("Task")!.GetGetMethod()!);
+            il.Emit(OpCodes.Ret);
+        }
+
+        {
+            var il = runOne.GetILGenerator();
+            var exceptionLocal = il.DeclareLocal(typeof(Exception));
+            var afterHandler = il.DefineLabel();
+            var complete = il.DefineLabel();
+            var reject = il.DefineLabel();
+            var tableRemoved = il.DefineLabel();
+
+            // A rejected link still consumes one fulfillment reaction job per
+            // remaining handler. This preserves the observable number and FIFO
+            // position of Promise jobs without invoking those handlers.
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, exceptionField);
+            il.Emit(OpCodes.Brtrue, afterHandler);
+
+            il.BeginExceptionBlock();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, handlersField);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, indexField);
+            il.Emit(OpCodes.Callvirt,
+                handlersType.GetProperty("Item")!.GetGetMethod()!);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, valueField);
+            il.Emit(OpCodes.Callvirt, handlerType.GetMethod("Invoke")!);
+            il.Emit(OpCodes.Stfld, valueField);
+            il.Emit(OpCodes.Leave, afterHandler);
+            il.BeginCatchBlock(typeof(Exception));
+            il.Emit(OpCodes.Stloc, exceptionLocal);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, exceptionLocal);
+            il.Emit(OpCodes.Stfld, exceptionField);
+            il.Emit(OpCodes.Leave, afterHandler);
+            il.EndExceptionBlock();
+
+            il.MarkLabel(afterHandler);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Dup);
+            il.Emit(OpCodes.Ldfld, indexField);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stfld, indexField);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, indexField);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, handlersField);
+            il.Emit(OpCodes.Callvirt,
+                handlersType.GetProperty("Count")!.GetGetMethod()!);
+            il.Emit(OpCodes.Bge, complete);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, runActionField);
+            il.Emit(OpCodes.Call, runtime.QueuePromiseJob);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(complete);
+            // All proven appends happen in the originating JavaScript job, so
+            // the final Task-to-carrier association is dead once the last
+            // reaction runs. Removing it prevents completed chains from
+            // accumulating in long-lived benchmark/server processes.
+            il.Emit(OpCodes.Ldsfld, tableField);
+            il.Emit(OpCodes.Brfalse, tableRemoved);
+            il.Emit(OpCodes.Ldsfld, tableField);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, completionField);
+            il.Emit(OpCodes.Callvirt,
+                tcsType.GetProperty("Task")!.GetGetMethod()!);
+            il.Emit(OpCodes.Callvirt, tableRemove);
+            il.Emit(OpCodes.Pop);
+            il.MarkLabel(tableRemoved);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, handlersField);
+            il.Emit(OpCodes.Callvirt, handlersType.GetMethod("Clear")!);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, exceptionField);
+            il.Emit(OpCodes.Brtrue, reject);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, completionField);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, valueField);
+            il.Emit(OpCodes.Box, typeof(double));
+            il.Emit(OpCodes.Callvirt, tcsType.GetMethod(
+                "SetResult", [typeof(object)])!);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(reject);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, completionField);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, exceptionField);
+            il.Emit(OpCodes.Callvirt, tcsType.GetMethod(
+                "SetException", [typeof(Exception)])!);
+            il.Emit(OpCodes.Ret);
+        }
+
+        return new PrimitivePromiseChainClass
+        {
+            Type = chainType,
+            TableType = tableType,
+            TableField = tableField,
+            Constructor = constructor,
+            AppendMethod = append,
+            TaskGetter = taskGetter
+        };
+    }
+
+    private void EmitPrimitivePromiseChainAppend(
+        ILGenerator il,
+        PrimitivePromiseChainClass chain,
+        MethodBuilder fallback)
+    {
+        var chainLocal = il.DeclareLocal(chain.Type);
+        var tableReady = il.DefineLabel();
+        var createChain = il.DefineLabel();
+        var append = il.DefineLabel();
+        var fallbackLabel = il.DefineLabel();
+
+        var tableConstructor = EmitterTypeHelpers.ResolveConstructor(
+            chain.TableType,
+            typeof(Dictionary<,>).GetConstructor(Type.EmptyTypes)!);
+        var tryGetValue = EmitterTypeHelpers.ResolveMethod(
+            chain.TableType,
+            typeof(Dictionary<,>).GetMethod("TryGetValue")!);
+        var add = EmitterTypeHelpers.ResolveMethod(
+            chain.TableType,
+            typeof(Dictionary<,>).GetMethod("Add")!);
+
+        il.Emit(OpCodes.Ldsfld, chain.TableField);
+        il.Emit(OpCodes.Brtrue, tableReady);
+        il.Emit(OpCodes.Newobj, tableConstructor);
+        il.Emit(OpCodes.Stsfld, chain.TableField);
+        il.MarkLabel(tableReady);
+
+        il.Emit(OpCodes.Ldsfld, chain.TableField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloca, chainLocal);
+        il.Emit(OpCodes.Callvirt, tryGetValue);
+        il.Emit(OpCodes.Brfalse, createChain);
+        il.Emit(OpCodes.Br, append);
+
+        il.MarkLabel(createChain);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.TaskOfObject.GetProperty(
+            "IsCompletedSuccessfully")!.GetGetMethod()!);
+        il.Emit(OpCodes.Brfalse, fallbackLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt,
+            _types.TaskOfObject.GetProperty("Result")!.GetGetMethod()!);
+        il.Emit(OpCodes.Unbox_Any, typeof(double));
+        il.Emit(OpCodes.Newobj, chain.Constructor);
+        il.Emit(OpCodes.Stloc, chainLocal);
+
+        il.Emit(OpCodes.Ldsfld, chain.TableField);
+        il.Emit(OpCodes.Ldloc, chainLocal);
+        il.Emit(OpCodes.Callvirt, chain.TaskGetter);
+        il.Emit(OpCodes.Ldloc, chainLocal);
+        il.Emit(OpCodes.Callvirt, add);
+
+        il.MarkLabel(append);
+        il.Emit(OpCodes.Ldloc, chainLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, chain.AppendMethod);
+        il.Emit(OpCodes.Ldloc, chainLocal);
+        il.Emit(OpCodes.Callvirt, chain.TaskGetter);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(fallbackLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, fallback);
+        il.Emit(OpCodes.Ret);
+    }
+
     #endregion
 }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.cs
@@ -77,6 +77,20 @@ internal class PrimitivePromiseThenStateMachine
 }
 
 /// <summary>
+/// Holds the emitted carrier used to fuse a proven-linear primitive Promise
+/// chain while retaining one observable FIFO job per reaction.
+/// </summary>
+internal class PrimitivePromiseChainClass
+{
+    public required TypeBuilder Type { get; init; }
+    public required Type TableType { get; init; }
+    public required FieldBuilder TableField { get; init; }
+    public required ConstructorBuilder Constructor { get; init; }
+    public required MethodBuilder AppendMethod { get; init; }
+    public required MethodBuilder TaskGetter { get; init; }
+}
+
+/// <summary>
 /// Holds information about the PromiseFinally state machine.
 /// </summary>
 internal class PromiseFinallyStateMachine
@@ -712,12 +726,24 @@ public partial class RuntimeEmitter
         EmitPromiseThenMoveNext(promiseThenSM, runtime, promiseJobAwaiterType);
         promiseThenSM.Type.CreateType();
 
-        // Stable intrinsic Promise.then with a fulfillment-only callback whose
-        // static result is primitive/non-thenable. This state machine keeps the
-        // input await and callback exception-to-rejection behavior, but has no
-        // rejection dispatch or second thenable-flattening await.
+        // Retain the small state machine as a defensive fallback for an input
+        // that violates the completed intrinsic seed invariant. Proven-linear
+        // chains use one fused carrier and one final Task instead.
         var primitivePromiseThenSM = DefinePrimitivePromiseThenStateMachine(
             moduleBuilder, promiseJobAwaiterType);
+        var primitiveThenFallback = typeBuilder.DefineMethod(
+            "PromiseThenPrimitiveFallback",
+            MethodAttributes.Private | MethodAttributes.Static,
+            taskType,
+            [taskType, typeof(Func<double, double>)]
+        );
+        EmitPrimitivePromiseThenWrapper(
+            primitiveThenFallback.GetILGenerator(), primitivePromiseThenSM);
+        EmitPrimitivePromiseThenMoveNext(
+            primitivePromiseThenSM, promiseJobAwaiterType);
+
+        var primitiveChain = DefinePrimitivePromiseChainClass(
+            moduleBuilder, typeBuilder, runtime);
         var primitiveThen = typeBuilder.DefineMethod(
             "PromiseThenPrimitive",
             MethodAttributes.Public | MethodAttributes.Static,
@@ -725,10 +751,11 @@ public partial class RuntimeEmitter
             [taskType, typeof(Func<double, double>)]
         );
         runtime.PromiseThenPrimitive = primitiveThen;
-        EmitPrimitivePromiseThenWrapper(
-            primitiveThen.GetILGenerator(), primitivePromiseThenSM);
-        EmitPrimitivePromiseThenMoveNext(
-            primitivePromiseThenSM, promiseJobAwaiterType);
+        EmitPrimitivePromiseChainAppend(
+            primitiveThen.GetILGenerator(),
+            primitiveChain,
+            primitiveThenFallback);
+        primitiveChain.Type.CreateType();
         primitivePromiseThenSM.Type.CreateType();
 
         // Promise.prototype.catch - delegates to PromiseThen(promise, null, onRejected)

--- a/src/SharpTS/Compilation/StablePrimitivePromiseThenAnalyzer.cs
+++ b/src/SharpTS/Compilation/StablePrimitivePromiseThenAnalyzer.cs
@@ -36,6 +36,7 @@ internal static class StablePrimitivePromiseThenAnalyzer
             if (!visitor.Candidates.Contains(key)
                 || visitor.Disqualified.Contains(key)
                 || visitor.DeclarationCounts.GetValueOrDefault(key) != 1
+                || visitor.TerminalCounts.GetValueOrDefault(key) != 1
                 || closures?.IsVariableCaptured(key.Name) == true)
             {
                 continue;
@@ -140,12 +141,15 @@ internal static class StablePrimitivePromiseThenAnalyzer
         private readonly TypeMap _typeMap = typeMap;
         private int _scope;
         private int _nextScope;
+        private Expr.Assign? _linearAssignmentStatement;
 
         public HashSet<(int Scope, string Name)> Candidates { get; } = [];
         public HashSet<(int Scope, string Name)> Disqualified { get; } = [];
         public Dictionary<(int Scope, string Name), int> DeclarationCounts { get; } = [];
+        public Dictionary<(int Scope, string Name), int> TerminalCounts { get; } = [];
         public Dictionary<(int Scope, string Name), List<Expr.Get>> Calls { get; } = [];
         public HashSet<Expr.Get> DirectSeedCalls { get; } = new(ReferenceEqualityComparer.Instance);
+        private HashSet<(int Scope, string Name)> Terminated { get; } = [];
 
         protected override void VisitFunction(Stmt.Function statement) =>
             InScope(() => base.VisitFunction(statement));
@@ -183,13 +187,34 @@ internal static class StablePrimitivePromiseThenAnalyzer
                 Visit(initializer);
         }
 
+        protected override void VisitExpression(Stmt.Expression statement)
+        {
+            var saved = _linearAssignmentStatement;
+            _linearAssignmentStatement = Unwrap(statement.Expr) as Expr.Assign;
+            try
+            {
+                Visit(statement.Expr);
+            }
+            finally
+            {
+                _linearAssignmentStatement = saved;
+            }
+        }
+
         protected override void VisitAssign(Expr.Assign expression)
         {
             var key = (_scope, expression.Name.Lexeme);
-            if (TryGetEligibleThen(expression.Value, _typeMap, out var call, out var method)
+            // The assignment's resulting value is itself observable when it is
+            // nested in another expression (for example, consume(chain = ...)).
+            // Only a discarded expression statement proves that no intermediate
+            // Promise identity escapes the linear binding.
+            if (ReferenceEquals(expression, _linearAssignmentStatement)
+                && TryGetEligibleThen(expression.Value, _typeMap, out var call, out var method)
                 && method.Object is Expr.Variable receiver
                 && receiver.Name.Lexeme == expression.Name.Lexeme)
             {
+                if (Terminated.Contains(key))
+                    Disqualified.Add(key);
                 RecordCall(key, method);
                 VisitEligibleArguments(call);
                 return;
@@ -205,7 +230,10 @@ internal static class StablePrimitivePromiseThenAnalyzer
             {
                 if (method.Object is Expr.Variable receiver)
                 {
-                    RecordCall((_scope, receiver.Name.Lexeme), method);
+                    // Only `chain = chain.then(handler)` is a linear append.
+                    // A bare or sibling call observes a distinct intermediate
+                    // Promise and therefore cannot share the fused carrier.
+                    Disqualified.Add((_scope, receiver.Name.Lexeme));
                     VisitEligibleArguments(call);
                     return;
                 }
@@ -237,16 +265,29 @@ internal static class StablePrimitivePromiseThenAnalyzer
 
         protected override void VisitAwait(Expr.Await expression)
         {
-            if (Unwrap(expression.Expression) is Expr.Variable)
+            if (Unwrap(expression.Expression) is Expr.Variable variable)
+            {
+                RecordTerminal((_scope, variable.Name.Lexeme));
                 return;
+            }
             base.VisitAwait(expression);
         }
 
         protected override void VisitReturn(Stmt.Return statement)
         {
-            if (statement.Value is not null && Unwrap(statement.Value) is Expr.Variable)
+            if (statement.Value is not null
+                && Unwrap(statement.Value) is Expr.Variable variable)
+            {
+                RecordTerminal((_scope, variable.Name.Lexeme));
                 return;
+            }
             base.VisitReturn(statement);
+        }
+
+        private void RecordTerminal((int Scope, string Name) key)
+        {
+            TerminalCounts[key] = TerminalCounts.GetValueOrDefault(key) + 1;
+            Terminated.Add(key);
         }
 
         protected override void VisitVariable(Expr.Variable expression) =>

--- a/tests/SharpTS.Tests/CompilerTests/StablePrimitivePromiseThenTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StablePrimitivePromiseThenTests.cs
@@ -57,6 +57,29 @@ public sealed class StablePrimitivePromiseThenTests
     }
 
     [Theory, ModeData]
+    public void StableNumericChain_ReturnsFreshFinalPromiseForEveryInvocation(
+        ExecutionMode mode)
+    {
+        const string source = """
+            function make(n: number): Promise<number> {
+                let chain: Promise<number> = Promise.resolve(0);
+                for (let i: number = 0; i < n; i++) {
+                    chain = chain.then((value: number): number => value + 1);
+                }
+                return chain;
+            }
+            const first: any = make(0);
+            const second: any = make(3);
+            Promise.all([first, second]).then((values: number[]): void => {
+                console.log(String(first === second));
+                console.log(values.join(":"));
+            });
+            """;
+
+        Assert.Equal("false\n0:3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
     public void StableNumericChain_InImportedModulePreservesResult(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>
@@ -134,9 +157,19 @@ public sealed class StablePrimitivePromiseThenTests
             instruction.OpCode == OpCodes.Newarr
             && instruction.Operand == typeof(object));
 
-        MethodInfo continuationMoveNext = assembly.GetType("$PromiseThenPrimitive_SM")!
-            .GetMethod("MoveNext")!;
-        var continuationInstructions = ReadInstructions(continuationMoveNext).ToArray();
+        MethodInfo runtimeEntry = assembly.GetType("$Runtime")!
+            .GetMethod("PromiseThenPrimitive")!;
+        var runtimeInstructions = ReadInstructions(runtimeEntry).ToArray();
+        Assert.Contains(runtimeInstructions, instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "Append",
+                DeclaringType.Name: "$PrimitivePromiseChain"
+            });
+
+        MethodInfo runOne = assembly.GetType("$PrimitivePromiseChain")!
+            .GetMethod("RunOne", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var continuationInstructions = ReadInstructions(runOne).ToArray();
         Assert.Contains(continuationInstructions, instruction =>
             instruction.Operand is MethodBase
             {
@@ -148,6 +181,7 @@ public sealed class StablePrimitivePromiseThenTests
             instruction.Operand is MethodBase
             {
                 Name: "PromiseResolveValue" or "InvokeCallback"
+                    or "AwaitUnsafeOnCompleted"
             });
         Assert.DoesNotContain(continuationInstructions, instruction =>
             instruction.OpCode == OpCodes.Newarr
@@ -178,6 +212,46 @@ public sealed class StablePrimitivePromiseThenTests
             const alias: Promise<number> = chain;
             chain = chain.then((value: number): number => value + 1);
             await alias;
+            return await chain;
+        }
+        work();
+        """,
+        """
+        async function work(): Promise<number> {
+            let chain: Promise<number> = Promise.resolve(1);
+            const sibling: Promise<number> = chain.then(
+                (value: number): number => value + 1);
+            chain = chain.then((value: number): number => value + 2);
+            await sibling;
+            return await chain;
+        }
+        work();
+        """,
+        """
+        function consume(_promise: Promise<number>): void {}
+        async function work(): Promise<number> {
+            let chain: Promise<number> = Promise.resolve(1);
+            consume(chain = chain.then(
+                (value: number): number => value + 1));
+            return await chain;
+        }
+        work();
+        """,
+        """
+        async function work(): Promise<number> {
+            let chain: Promise<number> = Promise.resolve(1);
+            chain = chain.then((value: number): number => value + 1);
+            await chain;
+            chain = chain.then((value: number): number => value + 1);
+            return await chain;
+        }
+        work();
+        """,
+        """
+        async function work(): Promise<number> {
+            let chain: Promise<number> = Promise.resolve(1);
+            chain = chain.then((value: number): number => value + 1);
+            await chain;
             return await chain;
         }
         work();

--- a/tests/SharpTS.Tests/SharedTests/PromiseJobSchedulingTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/PromiseJobSchedulingTests.cs
@@ -96,6 +96,73 @@ public sealed class PromiseJobSchedulingTests
         Assert.Equal("sync\n42:1\n", TestHarness.Run(source, mode));
     }
 
+    [Theory, ModeData]
+    public void StablePrimitiveChain_QueuesEachLinkAsItsOwnFifoJob(
+        ExecutionMode mode)
+    {
+        const string source = """
+            const order: string[] = [];
+            async function run(): Promise<void> {
+                let chain: Promise<number> = Promise.resolve(0);
+                chain = chain.then((value: number): number => {
+                    order.push("first");
+                    queueMicrotask((): void => { order.push("inside"); });
+                    return value + 1;
+                });
+                queueMicrotask((): void => { order.push("between"); });
+                chain = chain.then((value: number): number => {
+                    order.push("second");
+                    return value + 1;
+                });
+                await chain;
+                order.push("after-await");
+                console.log(order.join(":"));
+            }
+            run();
+            """;
+
+        Assert.Equal(
+            "first:between:inside:second:after-await\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void StablePrimitiveChain_PropagatesRejectionThroughQueuedLinks(
+        ExecutionMode mode)
+    {
+        const string source = """
+            const order: string[] = [];
+            async function run(): Promise<void> {
+                let chain: Promise<number> = Promise.resolve(0);
+                chain = chain.then((_value: number): number => {
+                    order.push("throw");
+                    queueMicrotask((): void => { order.push("inside"); });
+                    throw new Error("boom");
+                });
+                queueMicrotask((): void => { order.push("between"); });
+                chain = chain.then((value: number): number => {
+                    order.push("skipped-1");
+                    return value;
+                });
+                chain = chain.then((value: number): number => {
+                    order.push("skipped-2");
+                    return value;
+                });
+                try {
+                    await chain;
+                } catch (_error) {
+                    order.push("caught");
+                }
+                console.log(order.join(":"));
+            }
+            run();
+            """;
+
+        Assert.Equal(
+            "throw:between:inside:caught\n",
+            TestHarness.Run(source, mode));
+    }
+
     [Fact]
     public void StandaloneCompiledOutput_DrainsQueuedPromiseJobs()
     {


### PR DESCRIPTION
## Summary
- tighten the stable Promise binding proof to a single self-assigned chain with one terminal consumer
- fuse eligible numeric reactions into one carrier, one final Task, and one cached FIFO job action
- preserve one Promise job per link, rejection propagation, fresh final identity, and the existing general fallback
- add a FIFO-scheduled managed benchmark control and focused semantic/IL regressions

The existing PromiseThenPrimitive call ABI remains as a narrow adapter. It uses a transient Task-to-carrier dictionary only while same-job appends can occur, removes the association before final settlement, and directly appends to the carrier. This avoids a wider local-representation rewrite while still eliminating every per-link async state machine.

## Performance (N=1,000)
Pinned BenchmarkDotNet baseline: 150.675 us / 336.20 KB.

- SharpTS: **78.16 us / 149.53 KB** (**-48.1% time, -55.5% allocation**)
- FIFO-scheduled managed control: 14.34 us / 102.51 KB
- equivalent C#: 62.86 us / 250.19 KB
- idiomatic C#: 54.34 us / 203.20 KB

Five alternated compiled/Node pairs:

- Promise.then median: **0.0385 / 0.0235 ms = 1.64x**, down from 4.75x
- Promise.all compiled median: 0.1243 ms, down from 0.1350 ms
- resolved await compiled median: 0.0367 ms, down from 0.0400 ms
- async calls compiled median: 0.0412 ms, down from 0.0440 ms

## Validation
- 41 focused Promise/compiler tests pass
- standalone output and ILVerify pass
- all 17 cross-runtime workloads smoke-compile
- core and microbenchmark projects build cleanly
- broad local run reached only HttpListener handle failures in the restricted Windows sandbox; CI is the authoritative full-suite/network check

Closes #1447