### PR TITLE
Perf: specialize stable primitive Promise.all fan-out

### DIFF
--- a/benchmarks/cross-runtime/scripts/lib/algorithms.ts
+++ b/benchmarks/cross-runtime/scripts/lib/algorithms.ts
@@ -350,6 +350,29 @@ export async function promiseAllRepeatedResolvedPhase(n: number): Promise<number
     return values.length;
 }
 
+export async function promiseAllDistinctResolvedPhase(n: number): Promise<number> {
+    const promises: Promise<number>[] = [];
+    for (let i: number = 0; i < n; i++) {
+        promises.push(Promise.resolve(i));
+    }
+    const values: number[] = await (
+        Promise.all(promises) as Promise<number[]>
+    );
+    return values.length;
+}
+
+export function promiseAllResultConsumptionPhase(n: number): number {
+    const values: number[] = [];
+    for (let i: number = 0; i < n; i++) {
+        values.push(i);
+    }
+    let sum: number = 0;
+    for (let i: number = 0; i < values.length; i++) {
+        sum = sum + values[i];
+    }
+    return sum;
+}
+
 export async function promiseRepeatedResolvedBuildPhase(n: number): Promise<number> {
     const promise: Promise<number> = Promise.resolve(1);
     const promises: Promise<number>[] = [];

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/AsyncPromiseBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/AsyncPromiseBenchmarks.cs
@@ -117,7 +117,9 @@ public class PromiseAllPhaseBenchmarks : AsyncPromiseBenchmarkBase
 {
     private Func<object?, Task<object?>> _resolveFanOut = null!;
     private Func<object?, Task<object?>> _repeatedResolved = null!;
+    private Func<object?, Task<object?>> _distinctResolved = null!;
     private Func<object?, Task<object?>> _repeatedResolvedBuild = null!;
+    private Func<double, double> _resultConsumption = null!;
 
     [Params(1000)]
     public int N { get; set; }
@@ -127,7 +129,13 @@ public class PromiseAllPhaseBenchmarks : AsyncPromiseBenchmarkBase
     {
         _resolveFanOut = LoadCompiledAsync("promiseResolveFanOutPhase");
         _repeatedResolved = LoadCompiledAsync("promiseAllRepeatedResolvedPhase");
+        _distinctResolved = LoadCompiledAsync("promiseAllDistinctResolvedPhase");
         _repeatedResolvedBuild = LoadCompiledAsync("promiseRepeatedResolvedBuildPhase");
+        _resultConsumption = Infrastructure.BenchmarkHarness.GetCompiledNumberFunc(
+            Infrastructure.BenchmarkHarness.LoadCompiledAssembly(
+                Infrastructure.CompilationCache.GetOrCompile(LoadTypeScriptSource(), "Algorithms"),
+                "algorithms"),
+            "promiseAllResultConsumptionPhase");
     }
 
     [Benchmark]
@@ -137,5 +145,11 @@ public class PromiseAllPhaseBenchmarks : AsyncPromiseBenchmarkBase
     public Task<object?> RepeatedResolvedAll() => _repeatedResolved((double)N);
 
     [Benchmark]
+    public Task<object?> DistinctResolvedAll() => _distinctResolved((double)N);
+
+    [Benchmark]
     public Task<object?> RepeatedResolvedBuild() => _repeatedResolvedBuild((double)N);
+
+    [Benchmark]
+    public double ResultConsumption() => _resultConsumption(N);
 }

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -1029,6 +1029,7 @@ public class EmittedRuntime
     public MethodBuilder PromiseAllSettledKeyedStatic { get; set; } = null!;
     public MethodBuilder PromiseAnyStatic { get; set; } = null!;
     public MethodBuilder PromiseAll { get; set; } = null!;
+    public MethodBuilder PromiseAllPrimitive { get; set; } = null!;
     public MethodBuilder PromiseAllKeyed { get; set; } = null!;
     public MethodBuilder PromiseRace { get; set; } = null!;
     public MethodBuilder PromiseThen { get; set; } = null!;
@@ -1046,7 +1047,7 @@ public class EmittedRuntime
     public MethodBuilder PromiseWithResolvers { get; set; } = null!;
     /// <summary>$Runtime.UnwrapPromiseReceiver(object) -> Task&lt;object?&gt; — $Promise (incl. #242 subclasses) → .Task; anything else is cast to Task&lt;object?&gt;. Used by then/catch/finally emission so promise-typed receivers work regardless of representation.</summary>
     public MethodBuilder UnwrapPromiseReceiverMethod { get; set; } = null!;
-    /// <summary>$Runtime.NormalizePromiseList(object, object, object, int) -> object — incrementally resolves and wires Promise combinator elements while preserving observable iterator order. Kind 3 is Promise.all with a shared result-capability reject callback.</summary>
+    /// <summary>$Runtime.NormalizePromiseList(object, object, object, int, bool) -> object — incrementally resolves and wires Promise combinator elements while preserving observable iterator order. Kind 3 is Promise.all; the final flag selects a compiler-proven stable primitive input.</summary>
     public MethodBuilder NormalizePromiseListMethod { get; set; } = null!;
     /// <summary>$Runtime.WrapDerivedPromiseResult(Task&lt;object?&gt; result, object receiver) -> object — completes species-based result construction for subclass then/catch/finally results after ObservePromiseConstructor has performed the synchronous own-constructor access (#242). For a $Promise SUBCLASS species, constructs a receiver-typed promise around the result task via the subclass's (object executor) constructor (PromiseFromExecutor adopts the task); for a general non-Promise species, routes to NewPromiseCapabilityResult (#349); for %Promise% (or no subclass receiver) returns the task unchanged.</summary>
     public MethodBuilder WrapDerivedPromiseResultMethod { get; set; } = null!;

--- a/src/SharpTS/Compilation/Emitters/PromiseStaticEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/PromiseStaticEmitter.cs
@@ -73,7 +73,11 @@ public sealed class PromiseStaticEmitter : IStaticTypeEmitterStrategy
                 }
                 EmitBasePromiseConstructor(ctx);
                 il.Emit(OpCodes.Ldnull); // no materialized capability on intrinsic Promise.all
-                il.Emit(OpCodes.Call, ctx.Runtime!.PromiseAll);
+                il.Emit(OpCodes.Call,
+                    arguments.Count > 0
+                    && ctx.TypeMap?.IsStablePrimitivePromiseAllIterable(arguments[0]) == true
+                        ? ctx.Runtime!.PromiseAllPrimitive
+                        : ctx.Runtime!.PromiseAll);
                 return true;
 
             case "allKeyed":

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.cs
@@ -525,6 +525,60 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     /// </summary>
     protected virtual void EmitGetIndex(Expr.GetIndex gi)
     {
+        // Stable primitive Promise.all result: the analyzer proved this local
+        // cannot escape and is observed only through numeric index reads and
+        // length, so PromiseAllPrimitive returns an internal List<double>.
+        // State-machine locals normally use object fields; cast that field
+        // directly instead of routing every read through Runtime.GetIndex.
+        if (!gi.Optional
+            && gi.Object is Expr.Variable stableAllResult
+            && Ctx.TypeMap?.IsStablePrimitivePromiseAllResultUse(stableAllResult) == true
+            && Ctx.TypeMap.Get(gi.Index) is SharpTS.TypeSystem.TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER }
+                or SharpTS.TypeSystem.TypeInfo.NumberLiteral)
+        {
+            EmitExpressionAsDouble(gi.Index);
+            var numericIndexLocal = IL.DeclareLocal(Types.Double);
+            IL.Emit(OpCodes.Stloc, numericIndexLocal);
+            var indexLocal = IL.DeclareLocal(Types.Int32);
+            var listLocal = IL.DeclareLocal(Types.ListOfDouble);
+            EmitExpression(gi.Object);
+            EnsureBoxed();
+            IL.Emit(OpCodes.Castclass, Types.ListOfDouble);
+            IL.Emit(OpCodes.Stloc, listLocal);
+
+            var outOfBoundsLabel = IL.DefineLabel();
+            var doneLabel = IL.DefineLabel();
+            IL.Emit(OpCodes.Ldloc, numericIndexLocal);
+            IL.Emit(OpCodes.Ldc_R8, 0.0);
+            IL.Emit(OpCodes.Blt_Un, outOfBoundsLabel);
+            IL.Emit(OpCodes.Ldloc, numericIndexLocal);
+            IL.Emit(OpCodes.Ldc_R8, (double)int.MaxValue);
+            IL.Emit(OpCodes.Bgt_Un, outOfBoundsLabel);
+            IL.Emit(OpCodes.Ldloc, numericIndexLocal);
+            IL.Emit(OpCodes.Ldloc, numericIndexLocal);
+            IL.Emit(OpCodes.Call, Types.GetMethod(Types.Math, "Truncate", Types.Double));
+            IL.Emit(OpCodes.Bne_Un, outOfBoundsLabel);
+            IL.Emit(OpCodes.Ldloc, numericIndexLocal);
+            IL.Emit(OpCodes.Conv_I4);
+            IL.Emit(OpCodes.Stloc, indexLocal);
+            IL.Emit(OpCodes.Ldloc, indexLocal);
+            IL.Emit(OpCodes.Ldloc, listLocal);
+            IL.Emit(OpCodes.Callvirt,
+                Types.GetProperty(Types.ListOfDouble, "Count").GetGetMethod()!);
+            IL.Emit(OpCodes.Bge_Un, outOfBoundsLabel);
+            IL.Emit(OpCodes.Ldloc, listLocal);
+            IL.Emit(OpCodes.Ldloc, indexLocal);
+            IL.Emit(OpCodes.Callvirt,
+                Types.GetMethod(Types.ListOfDouble, "get_Item", Types.Int32));
+            IL.Emit(OpCodes.Box, Types.Double);
+            IL.Emit(OpCodes.Br, doneLabel);
+            IL.MarkLabel(outOfBoundsLabel);
+            IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.UndefinedInstance);
+            IL.MarkLabel(doneLabel);
+            SetStackUnknown();
+            return;
+        }
+
         // globalThis[key] → GlobalThisGetProperty(key)
         if (gi.Object is Expr.Variable gtGetIdx && gtGetIdx.Name.Lexeme == "globalThis")
         {
@@ -2695,6 +2749,21 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
         // snapshot. Lives here in the shared base (not just ILEmitter) so state-machine bodies
         // (async/generator MoveNext emitters) observe live bindings too (#656).
         if (TryEmitNamespaceVarGet(g)) return;
+
+        if (!g.Optional
+            && g.Name.Lexeme == "length"
+            && g.Object is Expr.Variable stableAllResult
+            && Ctx.TypeMap?.IsStablePrimitivePromiseAllResultUse(stableAllResult) == true)
+        {
+            EmitExpression(g.Object);
+            EnsureBoxed();
+            IL.Emit(OpCodes.Castclass, Types.ListOfDouble);
+            IL.Emit(OpCodes.Callvirt,
+                Types.GetProperty(Types.ListOfDouble, "Count").GetGetMethod()!);
+            IL.Emit(OpCodes.Conv_R8);
+            SetStackType(StackType.Double);
+            return;
+        }
 
         if (TryEmitSymbolWellKnown(g)) return;
         if (TryEmitStaticClassMethodValue(g)) return;

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -653,6 +653,8 @@ public partial class ILCompiler
         StableMapIterationAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         StablePrimitivePromiseThenAnalyzer.Analyze(
             statements, _typeMap, _closures.Analyzer);
+        StablePrimitivePromiseAllAnalyzer.Analyze(
+            statements, _typeMap, _closures.Analyzer);
         ArrayLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         StringAccumulatorPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         NonEscapingArrowLocalAnalyzer.Analyze(

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.All.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.All.cs
@@ -17,6 +17,8 @@ public partial class RuntimeEmitter
             MethodAttributes.Public);
         var awaiterField = shell.Type.DefineField("<>u__1", awaiterType, FieldAttributes.Private);
         var capabilityField = shell.Type.DefineField("capability", _types.Object, FieldAttributes.Public);
+        var stablePrimitiveField = shell.Type.DefineField(
+            "stablePrimitive", _types.Boolean, FieldAttributes.Public);
 
         return new EmittedStateMachine
         {
@@ -26,6 +28,7 @@ public partial class RuntimeEmitter
             IterableField = shell.InputField,
             ConstructorField = shell.ConstructorField,
             CapabilityField = capabilityField,
+            StablePrimitiveField = stablePrimitiveField,
             AwaiterField = awaiterField,
             MoveNextMethod = shell.MoveNextMethod,
             BuilderType = shell.BuilderType,
@@ -36,7 +39,11 @@ public partial class RuntimeEmitter
     /// <summary>
     /// Emits the PromiseAll wrapper method that creates and starts the state machine.
     /// </summary>
-    private void EmitPromiseAllWrapper(ILGenerator il, EmittedStateMachine sm, EmittedRuntime runtime)
+    private void EmitPromiseAllWrapper(
+        ILGenerator il,
+        EmittedStateMachine sm,
+        EmittedRuntime runtime,
+        bool stablePrimitive)
         => EmitCombinatorWrapper(il, sm.Type, sm.StateField, sm.IterableField, sm.BuilderField, sm.BuilderType,
             () =>
             {
@@ -46,7 +53,10 @@ public partial class RuntimeEmitter
             }, sm.ConstructorField, () => il.Emit(OpCodes.Ldarg_1),
             sm.CapabilityField, () => il.Emit(OpCodes.Ldarg_2),
             markNonAutoAwaitMethod: runtime.MarkNonAutoAwaitPromiseMethod,
-            adoptResultMethod: runtime.AdoptPromiseCombinatorResultMethod);
+            adoptResultMethod: runtime.AdoptPromiseCombinatorResultMethod,
+            stablePrimitiveField: sm.StablePrimitiveField,
+            emitStablePrimitiveValue: () => il.Emit(
+                stablePrimitive ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0));
 
     /// <summary>
     /// Emits the MoveNext body for PromiseAll state machine.
@@ -81,11 +91,12 @@ public partial class RuntimeEmitter
         // ========== STATE -1: Initial execution ==========
 
         EmitNormalizeCombinatorIterable(il, runtime, sm.IterableField, sm.ConstructorField,
-            sm.CapabilityField, combinatorKind: 3);
+            sm.CapabilityField, combinatorKind: 3,
+            stablePrimitiveField: sm.StablePrimitiveField);
 
-        // NormalizePromiseList returns an exact task array for the stable
-        // intrinsic Promise.all case. It has already checked every element's
-        // observable own `then`, so bypass the generic list conversion.
+        // NormalizePromiseList returns an exact task array for the intrinsic
+        // Promise.all case. It either checked every element's observable own
+        // `then` or received the compiler proof that those checks are inert.
         var genericListLabel = il.DefineLabel();
         var haveTaskArrayLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
@@ -111,7 +122,16 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, notEmptyLabel);
 
         // Empty list - return empty list immediately (jump to success path)
+        var emptyOrdinaryLabel = il.DefineLabel();
+        var emptyDoneLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, sm.StablePrimitiveField!);
+        il.Emit(OpCodes.Brfalse, emptyOrdinaryLabel);
+        il.Emit(OpCodes.Newobj, typeof(List<double>).GetConstructor(Type.EmptyTypes)!);
+        il.Emit(OpCodes.Br, emptyDoneLabel);
+        il.MarkLabel(emptyOrdinaryLabel);
         il.Emit(OpCodes.Newobj, listType.GetConstructor(Type.EmptyTypes)!);
+        il.MarkLabel(emptyDoneLabel);
         il.Emit(OpCodes.Stloc, resultLocal);
         il.Emit(OpCodes.Leave, setResultLabel);
 
@@ -150,12 +170,56 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldflda, sm.AwaiterField);
         il.Emit(OpCodes.Call, _types.GetMethod(sm.AwaiterType, "GetResult")!);
 
-        // Convert object?[] to List<object?> using constructor
+        // Convert object?[] to the ordinary boxed List<object?>, or to the
+        // internal List<double> carrier selected only for a proven non-escaping
+        // Promise<number>[] result.
         var arrayResultLocal = il.DeclareLocal(typeof(object?[]));
         il.Emit(OpCodes.Stloc, arrayResultLocal);
+        var ordinaryResultLabel = il.DefineLabel();
+        var resultDoneLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, sm.StablePrimitiveField!);
+        il.Emit(OpCodes.Brfalse, ordinaryResultLabel);
+
+        var doubleListType = typeof(List<double>);
+        var doubleListLocal = il.DeclareLocal(doubleListType);
+        var resultIndexLocal = il.DeclareLocal(typeof(int));
+        il.Emit(OpCodes.Ldloc, arrayResultLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Newobj, doubleListType.GetConstructor([typeof(int)])!);
+        il.Emit(OpCodes.Stloc, doubleListLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, resultIndexLocal);
+        var resultLoopLabel = il.DefineLabel();
+        var resultLoopDoneLabel = il.DefineLabel();
+        il.MarkLabel(resultLoopLabel);
+        il.Emit(OpCodes.Ldloc, resultIndexLocal);
+        il.Emit(OpCodes.Ldloc, arrayResultLocal);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Bge, resultLoopDoneLabel);
+        il.Emit(OpCodes.Ldloc, doubleListLocal);
+        il.Emit(OpCodes.Ldloc, arrayResultLocal);
+        il.Emit(OpCodes.Ldloc, resultIndexLocal);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Call, runtime.ConvertToNumber);
+        il.Emit(OpCodes.Callvirt, doubleListType.GetMethod("Add")!);
+        il.Emit(OpCodes.Ldloc, resultIndexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, resultIndexLocal);
+        il.Emit(OpCodes.Br, resultLoopLabel);
+        il.MarkLabel(resultLoopDoneLabel);
+        il.Emit(OpCodes.Ldloc, doubleListLocal);
+        il.Emit(OpCodes.Stloc, resultLocal);
+        il.Emit(OpCodes.Br, resultDoneLabel);
+
+        il.MarkLabel(ordinaryResultLabel);
         il.Emit(OpCodes.Ldloc, arrayResultLocal);
         il.Emit(OpCodes.Newobj, listType.GetConstructor([typeof(IEnumerable<object>)])!);
         il.Emit(OpCodes.Stloc, resultLocal);
+        il.MarkLabel(resultDoneLabel);
 
         // ========== Success path - both normal and empty list converge here ==========
         il.MarkLabel(setResultLabel);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.CombinatorShared.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.CombinatorShared.cs
@@ -96,7 +96,9 @@ public partial class RuntimeEmitter
         FieldBuilder? constructorField = null, System.Action? emitConstructorValue = null,
         FieldBuilder? capabilityField = null, System.Action? emitCapabilityValue = null,
         MethodInfo? markNonAutoAwaitMethod = null,
-        MethodInfo? adoptResultMethod = null)
+        MethodInfo? adoptResultMethod = null,
+        FieldBuilder? stablePrimitiveField = null,
+        System.Action? emitStablePrimitiveValue = null)
     {
         var smLocal = il.DeclareLocal(smType);
 
@@ -126,6 +128,13 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldloca, smLocal);
             emitCapabilityValue();
             il.Emit(OpCodes.Stfld, capabilityField);
+        }
+
+        if (stablePrimitiveField is not null && emitStablePrimitiveValue is not null)
+        {
+            il.Emit(OpCodes.Ldloca, smLocal);
+            emitStablePrimitiveValue();
+            il.Emit(OpCodes.Stfld, stablePrimitiveField);
         }
 
         // sm.<>t__builder = AsyncTaskMethodBuilder<object>.Create();
@@ -189,7 +198,8 @@ public partial class RuntimeEmitter
     /// </summary>
     private static void EmitNormalizeCombinatorIterable(ILGenerator il, EmittedRuntime runtime,
         FieldBuilder iterableField, FieldBuilder constructorField,
-        FieldBuilder? capabilityField = null, int combinatorKind = 0)
+        FieldBuilder? capabilityField = null, int combinatorKind = 0,
+        FieldBuilder? stablePrimitiveField = null)
     {
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_0);
@@ -206,6 +216,15 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldfld, capabilityField);
         }
         il.Emit(OpCodes.Ldc_I4, combinatorKind);
+        if (stablePrimitiveField is null)
+        {
+            il.Emit(OpCodes.Ldc_I4_0);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, stablePrimitiveField);
+        }
         il.Emit(OpCodes.Call, runtime.NormalizePromiseListMethod);
         il.Emit(OpCodes.Stfld, iterableField);
     }

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.Executor.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.Executor.cs
@@ -87,7 +87,8 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
-    /// Emits NormalizePromiseList(object iterable, object constructor, object capability) -> object:
+    /// Emits NormalizePromiseList(object iterable, object constructor, object capability,
+    /// int kind, bool stablePrimitive) -> object:
     /// materializes supported finite iterables and returns a list normalized through constructor C's
     /// current <c>resolve</c> method. The built-in path unwraps
     /// $Promise elements (including #242 subclasses) to their backing Task;
@@ -384,6 +385,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, resolvedElementLocal);
         il.Emit(OpCodes.Ldloc, resolvedElementLocal);
         il.Emit(OpCodes.Brfalse, fastTaskScanTSPromiseLabel);
+        il.Emit(OpCodes.Ldarg_S, 4);
+        il.Emit(OpCodes.Brtrue, fastTaskScanStoreLabel);
         il.Emit(OpCodes.Ldloc, elementLocal);
         il.Emit(OpCodes.Ldstr, "then");
         il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
@@ -396,10 +399,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, resolvedElementLocal);
         il.Emit(OpCodes.Ldloc, resolvedElementLocal);
         il.Emit(OpCodes.Brfalse, ordinaryListNormalizationLabel);
+        var stableTSPromiseTaskLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_S, 4);
+        il.Emit(OpCodes.Brtrue, stableTSPromiseTaskLabel);
         il.Emit(OpCodes.Ldloc, elementLocal);
         il.Emit(OpCodes.Ldstr, "then");
         il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
         il.Emit(OpCodes.Brtrue, ordinaryListNormalizationLabel);
+        il.MarkLabel(stableTSPromiseTaskLabel);
         il.Emit(OpCodes.Ldloc, resolvedElementLocal);
         il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
         il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.cs
@@ -15,6 +15,7 @@ internal class EmittedStateMachine
     public required FieldBuilder IterableField { get; init; }
     public required FieldBuilder ConstructorField { get; init; }
     public FieldBuilder? CapabilityField { get; init; }
+    public FieldBuilder? StablePrimitiveField { get; init; }
     public required FieldBuilder AwaiterField { get; init; }
     public required MethodBuilder MoveNextMethod { get; init; }
     public required Type BuilderType { get; init; }
@@ -560,7 +561,7 @@ public partial class RuntimeEmitter
             "NormalizePromiseList",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
-            [_types.Object, _types.Object, _types.Object, _types.Int32]);
+            [_types.Object, _types.Object, _types.Object, _types.Int32, _types.Boolean]);
         runtime.AdoptPromiseCombinatorResultMethod = typeBuilder.DefineMethod(
             "AdoptPromiseCombinatorResult",
             MethodAttributes.Public | MethodAttributes.Static,
@@ -581,7 +582,16 @@ public partial class RuntimeEmitter
             [_types.Object, _types.Object, _types.Object]
         );
         runtime.PromiseAll = all;
-        EmitPromiseAllWrapper(all.GetILGenerator(), promiseAllSM, runtime);
+        EmitPromiseAllWrapper(all.GetILGenerator(), promiseAllSM, runtime, stablePrimitive: false);
+
+        var allPrimitive = typeBuilder.DefineMethod(
+            "PromiseAllPrimitive",
+            MethodAttributes.Public | MethodAttributes.Static,
+            taskType,
+            [_types.Object, _types.Object, _types.Object]
+        );
+        runtime.PromiseAllPrimitive = allPrimitive;
+        EmitPromiseAllWrapper(allPrimitive.GetILGenerator(), promiseAllSM, runtime, stablePrimitive: true);
         EmitPromiseAllMoveNext(promiseAllSM, runtime);
         promiseAllSM.Type.CreateType();
 

--- a/src/SharpTS/Compilation/StablePrimitivePromiseAllAnalyzer.cs
+++ b/src/SharpTS/Compilation/StablePrimitivePromiseAllAnalyzer.cs
@@ -1,0 +1,454 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Proves the narrow end-to-end primitive Promise.all shape used by the
+/// unboxed result fast path. Both the promise array and the fulfilled-value
+/// array are function-local, single-use bindings: the former is populated
+/// only by intrinsic Promise.resolve(number), and the latter is observed only
+/// through numeric index reads and length.
+/// </summary>
+internal static class StablePrimitivePromiseAllAnalyzer
+{
+    public static void Analyze(
+        List<Stmt> program,
+        TypeMap? typeMap,
+        ClosureAnalyzer? closures)
+    {
+        if (typeMap is null)
+            return;
+
+        var mutations = new PromiseMutationVisitor(typeMap);
+        foreach (var statement in program)
+            mutations.Visit(statement);
+        if (mutations.HasObservableMutation)
+            return;
+
+        var visitor = new BindingVisitor(typeMap);
+        foreach (var statement in program)
+            visitor.Visit(statement);
+
+        foreach (var (resultKey, candidate) in visitor.Results)
+        {
+            var inputKey = candidate.InputKey;
+            if (visitor.Disqualified.Contains(resultKey)
+                || visitor.Disqualified.Contains(inputKey)
+                || visitor.DeclarationCounts.GetValueOrDefault(resultKey) != 1
+                || visitor.DeclarationCounts.GetValueOrDefault(inputKey) != 1
+                || visitor.TerminalCounts.GetValueOrDefault(inputKey) != 1
+                || visitor.InputSeeds.GetValueOrDefault(inputKey, []).Any(seed =>
+                    !visitor.IsProvablyPrimitiveNumber(seed, inputKey.Scope))
+                || closures?.IsVariableCaptured(resultKey.Name) == true
+                || closures?.IsVariableCaptured(inputKey.Name) == true)
+            {
+                continue;
+            }
+
+            typeMap.MarkStablePrimitivePromiseAllIterable(candidate.Iterable);
+            foreach (var use in visitor.ResultUses.GetValueOrDefault(resultKey, []))
+                typeMap.MarkStablePrimitivePromiseAllResultUse(use);
+        }
+    }
+
+    private static bool IsNumber(TypeInfo? type) => type is
+        TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral;
+
+    private static bool TryGetIntrinsicNumberResolve(
+        Expr expression,
+        TypeMap typeMap,
+        out Expr value)
+    {
+        value = null!;
+        expression = Unwrap(expression);
+        if (expression is not Expr.Call
+        {
+            Optional: false,
+            Callee: Expr.Get
+            {
+                Optional: false,
+                Object: Expr.Variable { Name.Lexeme: "Promise" },
+                Name.Lexeme: "resolve"
+            },
+            Arguments: [var resolvedValue]
+        } || !IsNumber(typeMap.Get(resolvedValue)))
+        {
+            return false;
+        }
+
+        value = resolvedValue;
+        return true;
+    }
+
+    private static bool TryGetIntrinsicAll(
+        Expr? expression,
+        out Expr.Variable iterable)
+    {
+        iterable = null!;
+        if (expression is null)
+            return false;
+
+        expression = Unwrap(expression);
+        if (expression is not Expr.Await awaitExpression)
+            return false;
+
+        Expr awaited = Unwrap(awaitExpression.Expression);
+        if (awaited is not Expr.Call
+            {
+                Optional: false,
+                Callee: Expr.Get
+                {
+                    Optional: false,
+                    Object: Expr.Variable { Name.Lexeme: "Promise" },
+                    Name.Lexeme: "all"
+                },
+                Arguments: [Expr.Variable source]
+            })
+        {
+            return false;
+        }
+
+        iterable = source;
+        return true;
+    }
+
+    private static Expr Unwrap(Expr expression)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case Expr.Grouping grouping:
+                    expression = grouping.Expression;
+                    continue;
+                case Expr.TypeAssertion assertion:
+                    expression = assertion.Expression;
+                    continue;
+                case Expr.Satisfies satisfies:
+                    expression = satisfies.Expression;
+                    continue;
+                case Expr.NonNullAssertion nonNull:
+                    expression = nonNull.Expression;
+                    continue;
+                default:
+                    return expression;
+            }
+        }
+    }
+
+    private sealed class BindingVisitor(TypeMap typeMap) : AstVisitorBase
+    {
+        private readonly TypeMap _typeMap = typeMap;
+        private int _scope;
+        private int _nextScope;
+        private readonly Stack<int> _enclosingScopes = [];
+
+        public Dictionary<(int Scope, string Name), int> DeclarationCounts { get; } = [];
+        public Dictionary<(int Scope, string Name), int> TerminalCounts { get; } = [];
+        public HashSet<(int Scope, string Name)> Inputs { get; } = [];
+        public Dictionary<(int Scope, string Name), ResultCandidate> Results { get; } = [];
+        public Dictionary<(int Scope, string Name), List<Expr.Variable>> ResultUses { get; } = [];
+        public Dictionary<(int Scope, string Name), List<Expr>> InputSeeds { get; } = [];
+        public HashSet<(int Scope, string Name)> StableNumericLocals { get; } = [];
+        public Dictionary<(int Scope, string Name), int> StableNumericDeclarationCounts { get; } = [];
+        public HashSet<(int Scope, string Name)> MutatedNumericLocals { get; } = [];
+        public HashSet<(int Scope, string Name)> PotentiallyCapturedLocals { get; } = [];
+        public HashSet<(int Scope, string Name)> Disqualified { get; } = [];
+
+        protected override void VisitFunction(Stmt.Function statement) =>
+            InScope(() => base.VisitFunction(statement));
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression) =>
+            InScope(() => base.VisitArrowFunction(expression));
+
+        private void InScope(Action visit)
+        {
+            int saved = _scope;
+            if (saved != 0)
+                _enclosingScopes.Push(saved);
+            _scope = ++_nextScope;
+            try
+            {
+                visit();
+            }
+            finally
+            {
+                _scope = saved;
+                if (saved != 0)
+                    _enclosingScopes.Pop();
+            }
+        }
+
+        protected override void VisitVar(Stmt.Var statement) =>
+            HandleDeclaration(statement.Name, statement.TypeAnnotation, statement.Initializer);
+
+        protected override void VisitConst(Stmt.Const statement) =>
+            HandleDeclaration(statement.Name, statement.TypeAnnotation, statement.Initializer);
+
+        private void HandleDeclaration(Token name, string? annotation, Expr? initializer)
+        {
+            var key = (_scope, name.Lexeme);
+            DeclarationCounts[key] = DeclarationCounts.GetValueOrDefault(key) + 1;
+
+            if (annotation == "number"
+                && initializer is Expr.Literal { Value: double })
+            {
+                StableNumericLocals.Add(key);
+                StableNumericDeclarationCounts[key] =
+                    StableNumericDeclarationCounts.GetValueOrDefault(key) + 1;
+            }
+
+            if (_scope != 0
+                && annotation?.Replace(" ", "", StringComparison.Ordinal) == "Promise<number>[]"
+                && initializer is Expr.ArrayLiteral { Elements.Count: 0 })
+            {
+                Inputs.Add(key);
+            }
+
+            if (_scope != 0
+                && annotation?.Replace(" ", "", StringComparison.Ordinal) == "number[]"
+            && TryGetIntrinsicAll(initializer, out var iterable))
+            {
+                var inputKey = (_scope, iterable.Name.Lexeme);
+                Results[key] = new ResultCandidate(inputKey, iterable);
+                TerminalCounts[inputKey] = TerminalCounts.GetValueOrDefault(inputKey) + 1;
+                return;
+            }
+
+            if (initializer is not null)
+                Visit(initializer);
+        }
+
+        protected override void VisitCall(Expr.Call expression)
+        {
+            if (expression.Callee is Expr.Get
+                {
+                    Optional: false,
+                    Object: Expr.Variable receiver,
+                    Name.Lexeme: "push"
+                })
+            {
+                var key = (_scope, receiver.Name.Lexeme);
+                if (Inputs.Contains(key)
+                    && expression.Arguments is [var argument]
+                    && TryGetIntrinsicNumberResolve(argument, _typeMap, out var value))
+                {
+                    if (!InputSeeds.TryGetValue(key, out var seeds))
+                        InputSeeds[key] = seeds = [];
+                    seeds.Add(value);
+                    Visit(argument);
+                    return;
+                }
+            }
+
+            base.VisitCall(expression);
+        }
+
+        protected override void VisitGet(Expr.Get expression)
+        {
+            if (!expression.Optional
+                && expression.Name.Lexeme == "length"
+                && expression.Object is Expr.Variable receiver
+                && Results.ContainsKey((_scope, receiver.Name.Lexeme)))
+            {
+                RecordResultUse(receiver);
+                return;
+            }
+
+            base.VisitGet(expression);
+        }
+
+        protected override void VisitGetIndex(Expr.GetIndex expression)
+        {
+            if (!expression.Optional
+                && expression.Object is Expr.Variable receiver
+                && Results.ContainsKey((_scope, receiver.Name.Lexeme))
+                && IsNumber(_typeMap.Get(expression.Index)))
+            {
+                RecordResultUse(receiver);
+                Visit(expression.Index);
+                return;
+            }
+
+            base.VisitGetIndex(expression);
+        }
+
+        private void RecordResultUse(Expr.Variable variable)
+        {
+            var key = (_scope, variable.Name.Lexeme);
+            if (!ResultUses.TryGetValue(key, out var uses))
+                ResultUses[key] = uses = [];
+            uses.Add(variable);
+        }
+
+        protected override void VisitVariable(Expr.Variable expression)
+        {
+            MarkPotentialCapture(expression.Name.Lexeme);
+            var key = (_scope, expression.Name.Lexeme);
+            if (Inputs.Contains(key) || Results.ContainsKey(key))
+                Disqualified.Add(key);
+        }
+
+        protected override void VisitAssign(Expr.Assign expression)
+        {
+            MarkPotentialCapture(expression.Name.Lexeme);
+            MutatedNumericLocals.Add((_scope, expression.Name.Lexeme));
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+            base.VisitAssign(expression);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
+        {
+            MarkPotentialCapture(expression.Name.Lexeme);
+            MutatedNumericLocals.Add((_scope, expression.Name.Lexeme));
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+            base.VisitCompoundAssign(expression);
+        }
+
+        protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
+        {
+            MarkPotentialCapture(expression.Name.Lexeme);
+            MutatedNumericLocals.Add((_scope, expression.Name.Lexeme));
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+            base.VisitLogicalAssign(expression);
+        }
+
+        public bool IsProvablyPrimitiveNumber(
+            Expr expression,
+            int scope)
+        {
+            expression = Unwrap(expression);
+            if (expression is Expr.Literal { Value: double })
+                return true;
+
+            if (expression is not Expr.Variable variable)
+                return false;
+
+            var key = (scope, variable.Name.Lexeme);
+            return StableNumericLocals.Contains(key)
+                && !MutatedNumericLocals.Contains(key)
+                && StableNumericDeclarationCounts.GetValueOrDefault(key)
+                    == DeclarationCounts.GetValueOrDefault(key)
+                && !PotentiallyCapturedLocals.Contains(key);
+        }
+
+        private void MarkPotentialCapture(string name)
+        {
+            foreach (int scope in _enclosingScopes)
+                PotentiallyCapturedLocals.Add((scope, name));
+        }
+
+        public sealed record ResultCandidate(
+            (int Scope, string Name) InputKey,
+            Expr.Variable Iterable);
+    }
+
+    private sealed class PromiseMutationVisitor(TypeMap typeMap) : AstVisitorBase
+    {
+        private readonly TypeMap _typeMap = typeMap;
+        public bool HasObservableMutation { get; private set; }
+
+        protected override void VisitCall(Expr.Call expression)
+        {
+            if (expression.Callee is Expr.Variable { Name.Lexeme: "eval" })
+                HasObservableMutation = true;
+
+            if (expression.Arguments.Count > 0
+                && expression.Callee is Expr.Get
+                {
+                    Object: Expr.Variable { Name.Lexeme: "Object" or "Reflect" },
+                    Name.Lexeme: "assign" or "defineProperty" or "defineProperties"
+                        or "set" or "deleteProperty" or "setPrototypeOf"
+                }
+                && IsPromiseTarget(expression.Arguments[0]))
+            {
+                HasObservableMutation = true;
+            }
+            base.VisitCall(expression);
+        }
+
+        protected override void VisitGet(Expr.Get expression)
+        {
+            if (IsPromisePrototype(expression))
+                HasObservableMutation = true;
+            base.VisitGet(expression);
+        }
+
+        protected override void VisitAssign(Expr.Assign expression)
+        {
+            if (expression.Name.Lexeme == "Promise")
+                HasObservableMutation = true;
+            base.VisitAssign(expression);
+        }
+
+        protected override void VisitSet(Expr.Set expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitSet(expression);
+        }
+
+        protected override void VisitSetIndex(Expr.SetIndex expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitSetIndex(expression);
+        }
+
+        protected override void VisitCompoundSet(Expr.CompoundSet expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitCompoundSet(expression);
+        }
+
+        protected override void VisitCompoundSetIndex(Expr.CompoundSetIndex expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitCompoundSetIndex(expression);
+        }
+
+        protected override void VisitLogicalSet(Expr.LogicalSet expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitLogicalSet(expression);
+        }
+
+        protected override void VisitLogicalSetIndex(Expr.LogicalSetIndex expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitLogicalSetIndex(expression);
+        }
+
+        protected override void VisitDelete(Expr.Delete expression)
+        {
+            Expr operand = Unwrap(expression.Operand);
+            if (operand is Expr.Get property && IsPromiseTarget(property.Object)
+                || operand is Expr.GetIndex index && IsPromiseTarget(index.Object))
+            {
+                HasObservableMutation = true;
+            }
+            base.VisitDelete(expression);
+        }
+
+        private bool IsPromiseTarget(Expr expression)
+        {
+            expression = Unwrap(expression);
+            return expression is Expr.Variable { Name.Lexeme: "Promise" }
+                || IsPromisePrototype(expression)
+                || _typeMap.Get(expression) is TypeInfo.Promise;
+        }
+
+        private static bool IsPromisePrototype(Expr expression) => Unwrap(expression) is Expr.Get
+        {
+            Optional: false,
+            Object: Expr.Variable { Name.Lexeme: "Promise" },
+            Name.Lexeme: "prototype"
+        };
+    }
+}

--- a/src/SharpTS/Compilation/StatementEmitterBase.cs
+++ b/src/SharpTS/Compilation/StatementEmitterBase.cs
@@ -587,6 +587,9 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
     /// </summary>
     protected virtual void EmitFor(Stmt.For f)
     {
+        if (TryEmitStablePrimitivePromiseAllReduction(f))
+            return;
+
         // Create scope for loop variables (ES6 let/const block scoping)
         Ctx.Locals.EnterScope();
 
@@ -647,6 +650,208 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
 
         // Exit loop scope
         Ctx.Locals.ExitScope();
+    }
+
+    /// <summary>
+    /// Emits the canonical reduction of a proven stable primitive Promise.all result as a
+    /// native loop. The ordinary state-machine path boxes the counter, accumulator, and indexed
+    /// value on every iteration; here the non-escaping <c>List&lt;double&gt;</c> carrier lets all three
+    /// remain unboxed until the final accumulator store.
+    /// </summary>
+    private bool TryEmitStablePrimitivePromiseAllReduction(Stmt.For loop)
+    {
+        if (!TryMatchStablePrimitivePromiseAllReduction(
+                loop,
+                out string counterName,
+                out string resultName,
+                out string accumulatorName)
+            || !Resolver.HasVariable(resultName)
+            || !Resolver.HasVariable(accumulatorName)
+            || Ctx.ClosureAnalyzer?.IsVariableCaptured(accumulatorName) == true)
+        {
+            return false;
+        }
+
+        Ctx.Locals.EnterScope();
+
+        var valuesLocal = IL.DeclareLocal(Ctx.Types.ListOfDouble);
+        var accumulatorLocal = IL.DeclareLocal(Ctx.Types.Double);
+        var counterLocal = IL.DeclareLocal(Ctx.Types.Int32);
+
+        var resultStackType = Resolver.TryLoadVariable(resultName);
+        if (resultStackType is null)
+            throw new InvalidOperationException($"Unable to load stable Promise.all result '{resultName}'.");
+        SetStackType(resultStackType.Value);
+        EnsureBoxed();
+        IL.Emit(OpCodes.Castclass, Ctx.Types.ListOfDouble);
+        IL.Emit(OpCodes.Stloc, valuesLocal);
+
+        var accumulatorStackType = Resolver.TryLoadVariable(accumulatorName);
+        if (accumulatorStackType is null)
+            throw new InvalidOperationException($"Unable to load Promise.all accumulator '{accumulatorName}'.");
+        SetStackType(accumulatorStackType.Value);
+        EnsureDouble();
+        IL.Emit(OpCodes.Stloc, accumulatorLocal);
+
+        IL.Emit(OpCodes.Ldc_I4_0);
+        IL.Emit(OpCodes.Stloc, counterLocal);
+
+        var startLabel = IL.DefineLabel();
+        var endLabel = IL.DefineLabel();
+        var continueLabel = IL.DefineLabel();
+
+        EnterLoop(endLabel, continueLabel);
+        IL.MarkLabel(startLabel);
+        EmitCancellationCheckWithAccumulatorFlush(accumulatorName, accumulatorLocal);
+
+        IL.Emit(OpCodes.Ldloc, counterLocal);
+        IL.Emit(OpCodes.Ldloc, valuesLocal);
+        IL.Emit(OpCodes.Callvirt,
+            Ctx.Types.GetProperty(Ctx.Types.ListOfDouble, "Count").GetGetMethod()!);
+        IL.Emit(OpCodes.Bge, endLabel);
+
+        IL.Emit(OpCodes.Ldloc, accumulatorLocal);
+        IL.Emit(OpCodes.Ldloc, valuesLocal);
+        IL.Emit(OpCodes.Ldloc, counterLocal);
+        IL.Emit(OpCodes.Callvirt,
+            Ctx.Types.GetMethod(Ctx.Types.ListOfDouble, "get_Item", Ctx.Types.Int32));
+        IL.Emit(OpCodes.Add);
+        IL.Emit(OpCodes.Stloc, accumulatorLocal);
+
+        IL.MarkLabel(continueLabel);
+        IL.Emit(OpCodes.Ldloc, counterLocal);
+        IL.Emit(OpCodes.Ldc_I4_1);
+        IL.Emit(OpCodes.Add);
+        IL.Emit(OpCodes.Stloc, counterLocal);
+        IL.Emit(OpCodes.Br, startLabel);
+
+        IL.MarkLabel(endLabel);
+        ExitLoop();
+        EmitBoxedAccumulatorStore(accumulatorName, accumulatorLocal);
+        Ctx.Locals.ExitScope();
+        SetStackUnknown();
+        return true;
+    }
+
+    private bool TryMatchStablePrimitivePromiseAllReduction(
+        Stmt.For loop,
+        out string counterName,
+        out string resultName,
+        out string accumulatorName)
+    {
+        counterName = resultName = accumulatorName = string.Empty;
+
+        if (loop.Initializer is not Stmt.Var
+            {
+                IsVar: false,
+                TypeAnnotation: "number",
+                Initializer: Expr.Literal { Value: double initialValue }
+            } counterDeclaration
+            || initialValue != 0.0)
+        {
+            return false;
+        }
+
+        counterName = counterDeclaration.Name.Lexeme;
+        if (loop.Condition is not Expr.Binary
+            {
+                Left: Expr.Variable conditionCounter,
+                Operator.Type: TokenType.LESS,
+                Right: Expr.Get
+                {
+                    Optional: false,
+                    Object: Expr.Variable lengthReceiver,
+                    Name.Lexeme: "length"
+                }
+            }
+            || conditionCounter.Name.Lexeme != counterName
+            || Ctx.TypeMap?.IsStablePrimitivePromiseAllResultUse(lengthReceiver) != true
+            || !IsIncrementOf(loop.Increment, counterName))
+        {
+            return false;
+        }
+
+        Stmt body = loop.Body is Stmt.Block { Statements: [var onlyStatement] }
+            ? onlyStatement
+            : loop.Body;
+        if (body is not Stmt.Expression
+            {
+                Expr: Expr.Assign
+                {
+                    Name: var accumulatorToken,
+                    Value: Expr.Binary
+                    {
+                        Left: Expr.Variable accumulatorRead,
+                        Operator.Type: TokenType.PLUS,
+                        Right: Expr.GetIndex
+                        {
+                            Optional: false,
+                            Object: Expr.Variable indexReceiver,
+                            Index: Expr.Variable indexCounter
+                        }
+                    }
+                }
+            }
+            || accumulatorRead.Name.Lexeme != accumulatorToken.Lexeme
+            || indexCounter.Name.Lexeme != counterName
+            || indexReceiver.Name.Lexeme != lengthReceiver.Name.Lexeme
+            || Ctx.TypeMap?.IsStablePrimitivePromiseAllResultUse(indexReceiver) != true
+            || !IsNumberType(Ctx.TypeMap.Get(accumulatorRead)))
+        {
+            return false;
+        }
+
+        resultName = lengthReceiver.Name.Lexeme;
+        accumulatorName = accumulatorToken.Lexeme;
+        return true;
+    }
+
+    private static bool IsIncrementOf(Expr? expression, string name) => expression switch
+    {
+        Expr.PostfixIncrement
+        {
+            Operator.Type: TokenType.PLUS_PLUS,
+            Operand: Expr.Variable variable
+        } => variable.Name.Lexeme == name,
+        Expr.PrefixIncrement
+        {
+            Operator.Type: TokenType.PLUS_PLUS,
+            Operand: Expr.Variable variable
+        } => variable.Name.Lexeme == name,
+        _ => false
+    };
+
+    private static bool IsNumberType(SharpTS.TypeSystem.TypeInfo? type) => type is
+        SharpTS.TypeSystem.TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER }
+        or SharpTS.TypeSystem.TypeInfo.NumberLiteral;
+
+    private void EmitBoxedAccumulatorStore(string name, LocalBuilder accumulator)
+    {
+        IL.Emit(OpCodes.Ldloc, accumulator);
+        IL.Emit(OpCodes.Box, Ctx.Types.Double);
+        if (!Resolver.TryStoreVariable(name))
+            throw new InvalidOperationException($"Unable to store Promise.all accumulator '{name}'.");
+    }
+
+    private void EmitCancellationCheckWithAccumulatorFlush(string name, LocalBuilder accumulator)
+    {
+        if (Ctx.Runtime?.BuildCancellationExceptionMethod == null
+            || Ctx.Runtime.CancelRequestedField == null)
+        {
+            return;
+        }
+
+        var notCancelled = IL.DefineLabel();
+        IL.Emit(OpCodes.Volatile);
+        IL.Emit(OpCodes.Ldsfld, Ctx.Runtime.CancelRequestedField);
+        IL.Emit(OpCodes.Brfalse, notCancelled);
+
+        // The generic loop stores after each iteration. Mirror its observable partial value on
+        // the cold cancellation path without introducing a hot-path box.
+        EmitBoxedAccumulatorStore(name, accumulator);
+        IL.Emit(OpCodes.Call, Ctx.Runtime.BuildCancellationExceptionMethod);
+        IL.Emit(OpCodes.Throw);
+        IL.MarkLabel(notCancelled);
     }
 
     /// <summary>

--- a/src/SharpTS/TypeSystem/TypeMap.cs
+++ b/src/SharpTS/TypeSystem/TypeMap.cs
@@ -25,6 +25,8 @@ public class TypeMap
     private readonly Dictionary<Token, ObjectShapeInfo> _promotableObjectLocals = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Stmt.ForOf> _stableNumericMapIterations = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.Get> _stablePrimitivePromiseThenCalls = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Expr> _stablePrimitivePromiseAllIterables = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Expr.Variable> _stablePrimitivePromiseAllResultUses = new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
     /// Associates an expression with its resolved type.
@@ -220,6 +222,28 @@ public class TypeMap
     /// </summary>
     public bool IsStablePrimitivePromiseThen(Expr.Get method) =>
         _stablePrimitivePromiseThenCalls.Contains(method);
+
+    /// <summary>
+    /// Marks the exact iterable expression of a proven fresh, non-escaping
+    /// <c>Promise&lt;number&gt;[]</c> consumed once by intrinsic <c>Promise.all</c>.
+    /// The compiler may return its result in the internal unboxed numeric-list
+    /// representation and omit per-element own-<c>then</c> probes.
+    /// </summary>
+    public void MarkStablePrimitivePromiseAllIterable(Expr iterable) =>
+        _stablePrimitivePromiseAllIterables.Add(iterable);
+
+    public bool IsStablePrimitivePromiseAllIterable(Expr iterable) =>
+        _stablePrimitivePromiseAllIterables.Contains(iterable);
+
+    /// <summary>
+    /// Marks a permitted length/index receiver use of the non-escaping numeric
+    /// result produced by a stable primitive <c>Promise.all</c> call.
+    /// </summary>
+    public void MarkStablePrimitivePromiseAllResultUse(Expr.Variable variable) =>
+        _stablePrimitivePromiseAllResultUses.Add(variable);
+
+    public bool IsStablePrimitivePromiseAllResultUse(Expr.Variable variable) =>
+        _stablePrimitivePromiseAllResultUses.Contains(variable);
 
     /// <summary>
     /// Gets the resolved type for an expression, or null if not found.

--- a/tests/SharpTS.Tests/CompilerTests/StablePrimitivePromiseThenTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StablePrimitivePromiseThenTests.cs
@@ -384,6 +384,150 @@ public sealed class StablePrimitivePromiseThenTests
         Assert.Equal("6\n", TestHarness.RunCompiledStandalone(source));
     }
 
+    [Fact]
+    public void StablePromiseAllFanOut_UsesPrimitiveResultCarrier()
+    {
+        Assembly assembly = Compile("""
+            async function gather(n: number): Promise<number> {
+                const promises: Promise<number>[] = [];
+                for (let i: number = 0; i < n; i++) {
+                    promises.push(Promise.resolve(i));
+                }
+                const values: number[] = await Promise.all(promises);
+                let sum: number = 0;
+                for (let i: number = 0; i < values.length; i++) {
+                    sum = sum + values[i];
+                }
+                return sum;
+            }
+            gather(10);
+            """);
+
+        MethodInfo caller = FindSingleCaller(assembly, "PromiseAllPrimitive");
+        var instructions = ReadInstructions(caller).ToList();
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "GetIndex" or "GetLength" });
+        Assert.Contains(instructions, instruction =>
+            instruction.OpCode == OpCodes.Castclass
+            && instruction.Operand is Type type
+            && type == typeof(List<double>));
+
+        int itemRead = instructions.FindIndex(instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "get_Item",
+                DeclaringType: { } declaringType
+            }
+            && declaringType == typeof(List<double>));
+        Assert.True(itemRead >= 0);
+        Assert.Equal(OpCodes.Add, instructions[itemRead + 1].OpCode);
+    }
+
+    [Theory, ModeData]
+    public void StablePromiseAllReductionLoop_PreservesOutput(ExecutionMode mode)
+    {
+        const string source = """
+            async function gather(n: number): Promise<void> {
+                const promises: Promise<number>[] = [];
+                for (let i: number = 0; i < n; i++) {
+                    promises.push(Promise.resolve(i));
+                }
+                const values: number[] = await Promise.all(promises);
+                let sum: number = 0;
+                for (let i: number = 0; i < values.length; i++) {
+                    sum = sum + values[i];
+                }
+                console.log(sum);
+            }
+            gather(1000);
+            """;
+
+        Assert.Equal("499500\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void StablePromiseAllFanOut_PreservesOutOfBoundsUndefined(ExecutionMode mode)
+    {
+        const string source = """
+            async function gather(): Promise<void> {
+                const promises: Promise<number>[] = [];
+                promises.push(Promise.resolve(1));
+                const values: number[] = await Promise.all(promises);
+                console.log(String(values[4]));
+            }
+            gather();
+            """;
+
+        Assert.Equal("undefined\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void StablePromiseAllFanOut_PreservesNonIndexNumericKeys(ExecutionMode mode)
+    {
+        const string source = """
+            async function gather(): Promise<void> {
+                const promises: Promise<number>[] = [];
+                promises.push(Promise.resolve(1));
+                const values: number[] = await Promise.all(promises);
+                console.log(String(values[0.5]));
+                console.log(String(values[NaN]));
+                console.log(String(values[-1]));
+                console.log(String(values[Infinity]));
+                console.log(values[-0]);
+            }
+            gather();
+            """;
+
+        Assert.Equal(
+            "undefined\nundefined\nundefined\nundefined\n1\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void RuntimeUncertainPromiseAllElement_RetainsOrdinaryResult()
+    {
+        const string source = """
+            function uncertain(): number {
+                return undefined as any;
+            }
+            async function gather(): Promise<void> {
+                const promises: Promise<number>[] = [];
+                promises.push(Promise.resolve(uncertain()));
+                const values: number[] = await Promise.all(promises);
+                console.log(String(values[0]));
+            }
+            gather();
+            """;
+
+        Assembly assembly = Compile(source);
+        Assert.Empty(FindCallers(assembly, "PromiseAllPrimitive"));
+        Assert.NotEmpty(FindCallers(assembly, "PromiseAll"));
+        Assert.Equal("undefined\n", TestHarness.RunCompiledStandalone(source));
+    }
+
+    [Theory]
+    [InlineData("const alias: Promise<number>[] = promises;")]
+    [InlineData("consume(values);")]
+    public void ObservablePromiseAllShapes_RetainOrdinaryResult(string observableUse)
+    {
+        string source = $$"""
+            function consume(_value: number[]): void {}
+            async function gather(): Promise<number> {
+                const promises: Promise<number>[] = [];
+                promises.push(Promise.resolve(1));
+                {{(observableUse.Contains("alias", StringComparison.Ordinal) ? observableUse : "")}}
+                const values: number[] = await Promise.all(promises);
+                {{(observableUse.Contains("values", StringComparison.Ordinal) ? observableUse : "")}}
+                return values.length;
+            }
+            gather();
+            """;
+
+        Assembly assembly = Compile(source);
+        Assert.Empty(FindCallers(assembly, "PromiseAllPrimitive"));
+        Assert.NotEmpty(FindCallers(assembly, "PromiseAll"));
+    }
+
     private static Assembly Compile(string source)
     {
         var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();


### PR DESCRIPTION
## Summary

- prove a narrow function-local Promise<number>[] fan-out whose seeds are runtime-stable primitive numbers and whose Promise.all result cannot escape
- reuse the native task-array path, omit inert per-element then probes, and materialize the fulfilled values as an internal List<double> carrier
- lower the canonical counted result-reduction loop to direct List<double> reads with an unboxed counter and accumulator while preserving cancellation-state flushes and JavaScript index semantics
- retain ordinary Promise.all lowering for aliases, escapes, runtime-uncertain values, Promise mutation, and other observable shapes
- add phase probes and IL, behavior, bounds, and fallback coverage

## Performance

PromiseAllBenchmarks, N=1000, BenchmarkDotNet ShortRun in-process:

| | main baseline | this PR | improvement |
|---|---:|---:|---:|
| Mean | 286.55 us | 87.47 us | 69.5% faster |
| Allocated | 303.17 KB | 165.77 KB | 45.3% less |

## Validation

- dotnet build SharpTS.sln -c Release --no-restore: clean, including both IL verification passes
- StablePrimitivePromiseThenTests: 38/38 passed
- CompilerTests: 622/625 passed; the three unrelated failures were sandbox restrictions in isolated-process timeout detection and TLS certificate access
- full-suite attempt was stopped after Windows HttpListener, TLS key storage, and IPC facilities consistently failed under the sandbox

Closes #1449