### PR TITLE
perf: elide suspension-free async state machines

### DIFF
--- a/src/SharpTS/Compilation/AsyncFunctionMoveNextEmitter.Await.cs
+++ b/src/SharpTS/Compilation/AsyncFunctionMoveNextEmitter.Await.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Reflection.Emit;
+using SharpTS.Diagnostics.Exceptions;
 using SharpTS.Parsing;
 
 namespace SharpTS.Compilation;
@@ -40,14 +41,100 @@ public abstract partial class AsyncFunctionMoveNextEmitter
     /// <summary>The builder's <c>AwaitUnsafeOnCompleted&lt;TAwaiter, TStateMachine&gt;</c>, specialized for this machine.</summary>
     protected abstract MethodInfo BuilderAwaitUnsafeOnCompletedMethod();
 
+    /// <summary>
+    /// True only for an async declaration whose exception routing can accept a direct synchronous
+    /// core call. Async arrows and functions with JavaScript try/catch retain the ordinary await path.
+    /// </summary>
+    protected virtual bool AllowSuspensionFreePrimitiveAsyncCoreAwait => false;
+
     protected override void EmitAwait(Expr.Await a)
     {
+        if (AllowSuspensionFreePrimitiveAsyncCoreAwait
+            && Ctx.SuspensionFreePrimitiveAsyncCoreAwaits?.Contains(a) == true)
+        {
+            if (TryEmitSuspensionFreePrimitiveAsyncCoreCall(a.Expression))
+                return;
+            throw new CompileException(
+                "A pre-proven suspension-free async core call could not be emitted.");
+        }
+
         // 1. Emit the awaited expression (should produce Task<object> or $Promise or any value)
         EmitExpression(a.Expression);
         EnsureBoxed();
 
         // 2+. Coerce to Task<object>, suspend/resume, and leave the awaited result on the stack.
         EmitAwaitFromValueOnStack(NextAwaitState());
+    }
+
+    private bool TryEmitSuspensionFreePrimitiveAsyncCoreCall(Expr expression)
+    {
+        if (expression is not Expr.Call
+            {
+                Callee: Expr.Variable functionVariable,
+                Arguments: var arguments
+            }
+            || arguments.Any(argument => argument is Expr.Spread)
+            || AnyContainsSuspension(arguments))
+        {
+            return false;
+        }
+
+        string simpleName = functionVariable.Name.Lexeme;
+        string resolvedName = Ctx.ResolveFunctionName(simpleName);
+        bool isSameScopeDeclaration = string.Equals(
+            resolvedName,
+            Ctx.GetQualifiedFunctionName(simpleName),
+            StringComparison.Ordinal);
+        bool shadowedByLocalBinding = Resolver.HasVariable(simpleName);
+        if (shadowedByLocalBinding
+            && isSameScopeDeclaration
+            && Ctx.TopLevelStaticVars?.ContainsKey(simpleName) == true
+            && !Ctx.TryGetParameter(simpleName, out _)
+            && !Ctx.CellBindingLocals.ContainsKey(simpleName)
+            && !Ctx.Locals.HasLocal(simpleName)
+            && Ctx.CapturedFunctionLocals?.Contains(simpleName) != true
+            && Ctx.CapturedArrowLocals?.Contains(simpleName) != true
+            && Ctx.ParentArrowCapturedLocals?.Contains(simpleName) != true
+            && Ctx.ExtraArrowScopeBindings?.ContainsKey(simpleName) != true
+            && Ctx.CapturedFields?.ContainsKey(simpleName) != true)
+        {
+            shadowedByLocalBinding = false;
+        }
+
+        Dictionary<string, MethodBuilder>? stableCores =
+            Ctx.SuspensionFreePrimitiveAsyncCores;
+        if (stableCores == null
+            || !stableCores.TryGetValue(resolvedName, out MethodBuilder? coreMethod)
+            || !isSameScopeDeclaration
+            || arguments.Count != coreMethod.GetParameters().Length
+            || shadowedByLocalBinding)
+        {
+            return false;
+        }
+
+        ParameterInfo[] parameters = coreMethod.GetParameters();
+        var argumentLocals = new LocalBuilder[arguments.Count];
+        for (int index = 0; index < arguments.Count; index++)
+        {
+            EmitExpression(arguments[index]);
+            EmitConversionForParameter(arguments[index], parameters[index].ParameterType);
+            var argumentLocal = IL.DeclareLocal(parameters[index].ParameterType);
+            IL.Emit(OpCodes.Stloc, argumentLocal);
+            argumentLocals[index] = argumentLocal;
+        }
+        foreach (LocalBuilder argumentLocal in argumentLocals)
+            IL.Emit(OpCodes.Ldloc, argumentLocal);
+
+        IL.Emit(OpCodes.Call, coreMethod);
+        if (coreMethod.ReturnType == typeof(double))
+            SetStackType(StackType.Double);
+        else if (coreMethod.ReturnType == typeof(bool))
+            SetStackType(StackType.Boolean);
+        else if (coreMethod.ReturnType == typeof(string))
+            SetStackType(StackType.String);
+        else
+            SetStackUnknown();
+        return true;
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/AsyncMoveNextEmitter.Expressions.cs
+++ b/src/SharpTS/Compilation/AsyncMoveNextEmitter.Expressions.cs
@@ -19,4 +19,6 @@ public partial class AsyncMoveNextEmitter
     protected override FieldBuilder AsyncStateField => _builder.StateField;
     protected override FieldBuilder AsyncBuilderField => _builder.BuilderField;
     protected override MethodInfo BuilderAwaitUnsafeOnCompletedMethod() => _builder.GetBuilderAwaitUnsafeOnCompletedMethod();
+    protected override bool AllowSuspensionFreePrimitiveAsyncCoreAwait =>
+        !_analysis.HasTryCatch;
 }

--- a/src/SharpTS/Compilation/AsyncStateAnalyzer.Expressions.cs
+++ b/src/SharpTS/Compilation/AsyncStateAnalyzer.Expressions.cs
@@ -11,7 +11,8 @@ public partial class AsyncStateAnalyzer
         // Visit await expression BEFORE marking _seenAwait, so variables in the await
         // expression are not incorrectly marked as "used after await"
         base.VisitAwait(expr);
-        RecordAwaitPoint(expr);
+        if (_nonSuspendingAwaits?.Contains(expr) != true)
+            RecordAwaitPoint(expr);
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/AsyncStateAnalyzer.cs
+++ b/src/SharpTS/Compilation/AsyncStateAnalyzer.cs
@@ -78,6 +78,7 @@ public partial class AsyncStateAnalyzer : AstVisitorBase
     private bool _usesThis = false;
     private int _asyncArrowNestingLevel = 0;
     private Expr.ArrowFunction? _currentParentArrow = null;  // Track parent for nested arrows
+    private IReadOnlySet<Expr.Await>? _nonSuspendingAwaits;
 
     // Try block tracking
     private int _tryBlockCounter = 0;
@@ -113,9 +114,12 @@ public partial class AsyncStateAnalyzer : AstVisitorBase
     /// <summary>
     /// Analyzes an async function to determine await points and hoisted variables.
     /// </summary>
-    public AsyncFunctionAnalysis Analyze(Stmt.Function func)
+    public AsyncFunctionAnalysis Analyze(
+        Stmt.Function func,
+        IReadOnlySet<Expr.Await>? nonSuspendingAwaits = null)
     {
         Reset();
+        _nonSuspendingAwaits = nonSuspendingAwaits;
 
         // Disambiguate block-scoped let/const declarations that shadow an enclosing binding so the
         // hoisting decision below is made per-binding rather than per-name (#766, async analog of #711).
@@ -216,6 +220,7 @@ public partial class AsyncStateAnalyzer : AstVisitorBase
         _tryBlockIdStack.Clear();
         _currentTryRegion = TryRegion.None;
         _tryBlockAwaitFlags.Clear();
+        _nonSuspendingAwaits = null;
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/CompilationContext.Functions.cs
+++ b/src/SharpTS/Compilation/CompilationContext.Functions.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Reflection.Emit;
+using SharpTS.Parsing;
 
 namespace SharpTS.Compilation;
 
@@ -10,6 +11,19 @@ public partial class CompilationContext
     // ============================================
 
     public Dictionary<string, MethodBuilder> Functions { get; }
+
+    /// <summary>
+    /// Assembly-internal typed cores for primitive async functions proven to have no suspension points.
+    /// An immediately awaited, statically direct call may target the core without materializing
+    /// the public function's otherwise-observable Promise wrapper.
+    /// </summary>
+    public Dictionary<string, MethodBuilder>? SuspensionFreePrimitiveAsyncCores { get; set; }
+
+    /// <summary>
+    /// Await nodes whose direct-core proof was established before state-machine layout. These
+    /// nodes do not consume a state number or force locals into hoisted object fields.
+    /// </summary>
+    public IReadOnlySet<Expr.Await>? SuspensionFreePrimitiveAsyncCoreAwaits { get; set; }
 
     /// <summary>
     /// The exact emitted method that may bypass a value-backed module binding for recursive

--- a/src/SharpTS/Compilation/ILCompiler.Async.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Async.cs
@@ -2,6 +2,8 @@ using System.Reflection;
 using System.Reflection.Emit;
 using SharpTS.Diagnostics.Exceptions;
 using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using TypeSystem = SharpTS.TypeSystem;
 
 namespace SharpTS.Compilation;
 
@@ -21,6 +23,22 @@ public partial class ILCompiler
         // (the builder's counter already disambiguates `<name>d__N`).
         var ctx = GetDefinitionContext();
         string qualifiedFunctionName = ctx.GetQualifiedFunctionName(funcStmt.Name.Lexeme);
+
+        HashSet<Expr.Await> directCoreAwaits = FindDirectCoreAwaits(
+            funcStmt, ctx, analysis);
+        if (directCoreAwaits.Count > 0)
+        {
+            analysis = _async.Analyzer.Analyze(funcStmt, directCoreAwaits);
+            _async.DirectCoreAwaits[qualifiedFunctionName] = directCoreAwaits;
+        }
+
+        if (CanEmitSuspensionFreePrimitiveAsyncFunction(
+                funcStmt, qualifiedFunctionName, analysis))
+        {
+            DefineSuspensionFreePrimitiveAsyncFunction(
+                funcStmt, qualifiedFunctionName);
+            return;
+        }
 
         // Create state machine builder
         var smBuilder = new AsyncStateMachineBuilder(_moduleBuilder, _types, _async.StateMachineCounter++);
@@ -54,6 +72,7 @@ public partial class ILCompiler
         _functions.Builders[qualifiedFunctionName] = stubMethod;
         _async.StateMachines[qualifiedFunctionName] = smBuilder;
         _async.Functions[qualifiedFunctionName] = funcStmt;
+        _async.Analyses[qualifiedFunctionName] = analysis;
 
         // #925: an async function used as a value (imported cross-module, stored, passed as a
         // callback → $TSFunction.Invoke) must pad omitted trailing optional args with the `undefined`
@@ -75,6 +94,223 @@ public partial class ILCompiler
 
         // Build state machines for any async arrows found in this function
         DefineAsyncArrowStateMachines(analysis.AsyncArrows, smBuilder);
+    }
+
+    private HashSet<Expr.Await> FindDirectCoreAwaits(
+        Stmt.Function function,
+        CompilationContext definitionContext,
+        AsyncStateAnalyzer.AsyncFunctionAnalysis analysis)
+    {
+        if (analysis.HasTryCatch || analysis.AsyncArrows.Count != 0 || function.Body == null)
+            return [];
+
+        var localBindings = new FunctionLocalBindingCollector(function.Parameters);
+        foreach (Stmt statement in function.Body)
+            localBindings.Visit(statement);
+
+        var collector = new DirectCoreAwaitCollector(
+            definitionContext,
+            _async.StableSuspensionFreePrimitiveCores,
+            localBindings.Names);
+        foreach (Stmt statement in function.Body)
+            collector.Visit(statement);
+        return collector.Awaits;
+    }
+
+    private sealed class FunctionLocalBindingCollector(
+        IEnumerable<Stmt.Parameter> parameters) : AstVisitorBase
+    {
+        public HashSet<string> Names { get; } =
+            new(parameters.Select(parameter => parameter.Name.Lexeme), StringComparer.Ordinal);
+
+        protected override void VisitVar(Stmt.Var statement)
+        {
+            Names.Add(statement.Name.Lexeme);
+            base.VisitVar(statement);
+        }
+
+        protected override void VisitConst(Stmt.Const statement)
+        {
+            Names.Add(statement.Name.Lexeme);
+            base.VisitConst(statement);
+        }
+
+        protected override void VisitForOf(Stmt.ForOf statement)
+        {
+            Names.Add(statement.Variable.Lexeme);
+            base.VisitForOf(statement);
+        }
+
+        protected override void VisitForIn(Stmt.ForIn statement)
+        {
+            if (statement.IsDeclaration)
+                Names.Add(statement.Variable.Lexeme);
+            base.VisitForIn(statement);
+        }
+
+        protected override void VisitTryCatch(Stmt.TryCatch statement)
+        {
+            if (statement.CatchParam != null)
+                Names.Add(statement.CatchParam.Lexeme);
+            base.VisitTryCatch(statement);
+        }
+
+        protected override void VisitFunction(Stmt.Function statement) =>
+            Names.Add(statement.Name.Lexeme);
+
+        protected override void VisitClass(Stmt.Class statement) =>
+            Names.Add(statement.Name.Lexeme);
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression) { }
+        protected override void VisitClassExpr(Expr.ClassExpr expression) { }
+    }
+
+    private sealed class DirectCoreAwaitCollector(
+        CompilationContext context,
+        IReadOnlyDictionary<string, MethodBuilder> stableCores,
+        IReadOnlySet<string> localBindings) : AstVisitorBase
+    {
+        public HashSet<Expr.Await> Awaits { get; } =
+            new(ReferenceEqualityComparer.Instance);
+
+        protected override void VisitAwait(Expr.Await expression)
+        {
+            if (expression.Expression is Expr.Call
+                {
+                    Callee: Expr.Variable variable,
+                    Arguments: var arguments
+                }
+                && !localBindings.Contains(variable.Name.Lexeme)
+                && !arguments.Any(argument => argument is Expr.Spread)
+                && !arguments.Any(ContainsSuspension)
+                && context.ResolveFunctionName(variable.Name.Lexeme) is var resolvedName
+                && string.Equals(
+                    resolvedName,
+                    context.GetQualifiedFunctionName(variable.Name.Lexeme),
+                    StringComparison.Ordinal)
+                && stableCores.TryGetValue(resolvedName, out MethodBuilder? core)
+                && arguments.Count == core.GetParameters().Length)
+            {
+                Awaits.Add(expression);
+            }
+            base.VisitAwait(expression);
+        }
+
+        private static bool ContainsSuspension(Expr expression)
+        {
+            var detector = new SuspensionDetector();
+            detector.Visit(expression);
+            return detector.Found;
+        }
+
+        protected override void VisitFunction(Stmt.Function statement) { }
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression) { }
+        protected override void VisitClass(Stmt.Class statement) { }
+        protected override void VisitClassExpr(Expr.ClassExpr expression) { }
+
+        private sealed class SuspensionDetector : AstVisitorBase
+        {
+            public bool Found { get; private set; }
+            protected override void VisitAwait(Expr.Await expression) => Found = true;
+            protected override void VisitYield(Expr.Yield expression) => Found = true;
+            protected override void VisitFunction(Stmt.Function statement) { }
+            protected override void VisitArrowFunction(Expr.ArrowFunction expression) { }
+            protected override void VisitClass(Stmt.Class statement) { }
+            protected override void VisitClassExpr(Expr.ClassExpr expression) { }
+        }
+    }
+
+    /// <summary>
+    /// A primitive async function with no suspension points does not need an
+    /// <see cref="System.Runtime.CompilerServices.AsyncTaskMethodBuilder{TResult}"/> state
+    /// machine. Keep the proof deliberately narrow: a free function with a final primitive
+    /// return, simple required parameters, no closure/dynamic-receiver machinery, and only awaits
+    /// already proven to target stable suspension-free primitive cores. Its public
+    /// Task&lt;object?&gt; ABI remains identical to the ordinary async stub.
+    /// </summary>
+    private bool CanEmitSuspensionFreePrimitiveAsyncFunction(
+        Stmt.Function function,
+        string qualifiedFunctionName,
+        AsyncStateAnalyzer.AsyncFunctionAnalysis analysis)
+    {
+        if (analysis.AwaitPointCount != 0
+            || analysis.AsyncArrows.Count != 0
+            || analysis.HasTryCatch
+            || analysis.UsesThis
+            || function.TypeParams is { Count: > 0 }
+            || function.Decorators is { Count: > 0 }
+            || function.Parameters.Any(parameter =>
+                parameter.DefaultValue != null
+                || parameter.IsRest
+                || parameter.IsOptional
+                || parameter.Decorators is { Count: > 0 })
+            || function.Body is not { Count: > 0 }
+            || function.Body[^1] is not Stmt.Return { Value: not null } statement
+            || ReferencesArgumentsIdentifier(function.Body)
+            || _closures.Analyzer.GetCapturedLocals(function).Count != 0)
+        {
+            return false;
+        }
+
+        var functionType = _typeMap?.GetFunctionType(qualifiedFunctionName)
+            ?? _typeMap?.GetFunctionType(function.Name.Lexeme);
+        if (functionType?.ReturnType is not TypeSystem.TypeInfo.Promise promised
+            || !IsStableNonThenablePrimitive(promised.ValueType))
+        {
+            return false;
+        }
+
+        return IsStableNonThenablePrimitive(_typeMap?.Get(statement.Value));
+    }
+
+    private static bool IsStableNonThenablePrimitive(TypeSystem.TypeInfo? type) => type is
+        TypeSystem.TypeInfo.Primitive
+        {
+            Type: TokenType.TYPE_NUMBER or TokenType.TYPE_BOOLEAN
+        }
+        or TypeSystem.TypeInfo.NumberLiteral
+        or TypeSystem.TypeInfo.BooleanLiteral
+        or TypeSystem.TypeInfo.String
+        or TypeSystem.TypeInfo.StringLiteral;
+
+    private void DefineSuspensionFreePrimitiveAsyncFunction(
+        Stmt.Function function,
+        string qualifiedFunctionName)
+    {
+        var functionType = _typeMap?.GetFunctionType(qualifiedFunctionName)
+            ?? _typeMap?.GetFunctionType(function.Name.Lexeme)
+            ?? throw new CompileException(
+                $"Missing type information for async function '{function.Name.Lexeme}'.");
+        var promisedType = ((TypeSystem.TypeInfo.Promise)functionType.ReturnType).ValueType;
+        Type[] coreParameterTypes = ParameterTypeResolver.ResolveParameters(
+            function.Parameters, _typeMapper, functionType, _typeMap);
+        Type coreReturnType = ParameterTypeResolver.ResolveReturnType(
+            promisedType, isAsync: false, _typeMapper);
+
+        var coreMethod = _programType.DefineMethod(
+            $"$asyncCore${qualifiedFunctionName}",
+            MethodAttributes.Assembly | MethodAttributes.Static | MethodAttributes.HideBySig,
+            coreReturnType,
+            coreParameterTypes);
+        MarkCompilerGenerated(coreMethod);
+
+        var stubMethod = _programType.DefineMethod(
+            qualifiedFunctionName,
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.TaskOfObject,
+            BuildStateMachineStubParamTypes(function));
+
+        _functions.Builders[qualifiedFunctionName] = stubMethod;
+        _async.SuspensionFreePrimitiveFunctions[qualifiedFunctionName] = function;
+        _async.SuspensionFreePrimitiveCores[qualifiedFunctionName] = coreMethod;
+        if (_stableSelfCallFunctions.Contains(function))
+            _async.StableSuspensionFreePrimitiveCores[qualifiedFunctionName] = coreMethod;
+        _closures.FunctionAstNodes[qualifiedFunctionName] = function;
+
+        MarkPadsUndefined(stubMethod);
+        MarkFunctionLength(stubMethod, function.Parameters);
+        MarkFunctionName(stubMethod, function.RuntimeName ?? function.Name.Lexeme);
+        MarkNonConstructible(stubMethod);
     }
 
     /// <summary>
@@ -729,6 +965,8 @@ public partial class ILCompiler
 
     private void EmitAsyncStateMachineBodies()
     {
+        EmitSuspensionFreePrimitiveAsyncFunctionBodies();
+
         var savedPath = _modules.CurrentPath;
         var savedNamespacePath = _currentNamespacePath;
         foreach (var (funcName, smBuilder) in _async.StateMachines)
@@ -742,7 +980,7 @@ public partial class ILCompiler
             _currentNamespacePath = _functionDefinitionNamespace.GetValueOrDefault(funcName);
             var func = _async.Functions[funcName];
             var stubMethod = _functions.Builders[funcName];
-            var analysis = _async.Analyzer.Analyze(func);
+            var analysis = _async.Analyses[funcName];
 
             // Emit stub method body
             EmitAsyncStubMethod(
@@ -763,6 +1001,8 @@ public partial class ILCompiler
             ctx.CommonJsGetExportsMethods = _modules.CommonJsGetExportsMethods;
             // Check for function-level "use strict" directive
             ctx.IsStrictMode = _isStrictMode || BodyDeclaresUseStrict(func.Body);
+            ctx.SuspensionFreePrimitiveAsyncCoreAwaits =
+                _async.DirectCoreAwaits.GetValueOrDefault(funcName);
             // Entry-point display class for captured top-level variables
             ApplyCapturedTopLevelVariableAccess(ctx);
             ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;
@@ -814,6 +1054,131 @@ public partial class ILCompiler
             if (arrowBuilder.IsStandalone) continue;
             arrowBuilder.CreateType();
         }
+    }
+
+    /// <summary>
+    /// Emits the typed core and public Task&lt;object?&gt; wrapper for the narrow no-suspension
+    /// primitive shape. The body runs synchronously, as an async function body does before its first
+    /// await. A successful value becomes a fresh completed task; a synchronous exception becomes
+    /// a fresh faulted task instead of escaping from the call.
+    /// </summary>
+    private void EmitSuspensionFreePrimitiveAsyncFunctionBodies()
+    {
+        if (_async.SuspensionFreePrimitiveFunctions.Count == 0)
+            return;
+
+        var savedPath = _modules.CurrentPath;
+        var savedNamespacePath = _currentNamespacePath;
+        MethodInfo fromResult = EmitGenerics.MakeGenericMethod(
+            typeof(Task).GetMethod(nameof(Task.FromResult))!, _types.Object);
+        MethodInfo fromException = EmitGenerics.MakeGenericMethod(
+            _types.GetMethods(typeof(Task), BindingFlags.Public | BindingFlags.Static)
+                .Single(method => method.Name == nameof(Task.FromException)
+                    && method.IsGenericMethodDefinition
+                    && method.GetParameters() is [{ ParameterType: var parameterType }]
+                    && parameterType == typeof(Exception)),
+            _types.Object);
+
+        foreach (var (functionName, function) in
+                 _async.SuspensionFreePrimitiveFunctions)
+        {
+            if (_functionDefinitionModule.TryGetValue(functionName, out var functionModule))
+                _modules.CurrentPath = NormalizeToEmissionPath(functionModule);
+            _currentNamespacePath =
+                _functionDefinitionNamespace.GetValueOrDefault(functionName);
+
+            MethodBuilder coreMethod =
+                _async.SuspensionFreePrimitiveCores[functionName];
+            ILGenerator coreIl = coreMethod.GetILGenerator();
+            var coreContext = CreateSuspensionFreePrimitiveFunctionContext(
+                coreIl, coreMethod, function);
+            coreContext.CurrentMethodReturnType = coreMethod.ReturnType;
+            coreContext.SuspensionFreePrimitiveAsyncCoreAwaits =
+                _async.DirectCoreAwaits.GetValueOrDefault(functionName);
+            ParameterInfo[] coreParameters = coreMethod.GetParameters();
+            for (int index = 0; index < function.Parameters.Count; index++)
+            {
+                coreContext.DefineParameter(
+                    function.Parameters[index].Name.Lexeme,
+                    index,
+                    coreParameters[index].ParameterType);
+            }
+            var coreEmitter = new SuspensionFreeAsyncCoreEmitter(coreContext);
+            foreach (Stmt statement in function.Body!)
+                coreEmitter.EmitStatement(statement);
+
+            MethodBuilder stubMethod = _functions.Builders[functionName];
+            ILGenerator il = stubMethod.GetILGenerator();
+            var ctx = CreateSuspensionFreePrimitiveFunctionContext(
+                il, stubMethod, function);
+
+            ParameterInfo[] emittedParameters = stubMethod.GetParameters();
+            for (int index = 0; index < function.Parameters.Count; index++)
+            {
+                Type parameterType = index < emittedParameters.Length
+                    ? emittedParameters[index].ParameterType
+                    : _types.Object;
+                ctx.DefineParameter(
+                    function.Parameters[index].Name.Lexeme,
+                    index,
+                    parameterType);
+            }
+
+            var emitter = new ILEmitter(ctx);
+            var resultTask = il.DeclareLocal(_types.TaskOfObject);
+            Label completed = il.BeginExceptionBlock();
+
+            for (int index = 0; index < function.Parameters.Count; index++)
+            {
+                var parameterExpression = new Expr.Variable(
+                    function.Parameters[index].Name);
+                emitter.EmitExpression(parameterExpression);
+                emitter.EmitConversionForParameter(
+                    parameterExpression,
+                    coreParameters[index].ParameterType);
+            }
+            il.Emit(OpCodes.Call, coreMethod);
+            if (coreMethod.ReturnType.IsValueType)
+                il.Emit(OpCodes.Box, coreMethod.ReturnType);
+            il.Emit(OpCodes.Call, fromResult);
+            il.Emit(OpCodes.Stloc, resultTask);
+            il.Emit(OpCodes.Leave, completed);
+
+            il.BeginCatchBlock(typeof(Exception));
+            il.Emit(OpCodes.Call, fromException);
+            il.Emit(OpCodes.Stloc, resultTask);
+            il.Emit(OpCodes.Leave, completed);
+            il.EndExceptionBlock();
+
+            il.Emit(OpCodes.Ldloc, resultTask);
+            il.Emit(OpCodes.Ret);
+        }
+
+        _modules.CurrentPath = savedPath;
+        _currentNamespacePath = savedNamespacePath;
+    }
+
+    private CompilationContext CreateSuspensionFreePrimitiveFunctionContext(
+        ILGenerator il,
+        MethodBuilder method,
+        Stmt.Function function)
+    {
+        var ctx = CreateModuleMemberContext(il, method);
+        ctx.FunctionOverloads = _functions.Overloads;
+        ctx.AsyncArrowBuilders = _async.ArrowBuilders.Count > 0
+            ? _async.ArrowBuilders : null;
+        ctx.UnionGenerator = _unionGenerator;
+        ctx.IsStrictMode = _isStrictMode || BodyDeclaresUseStrict(function.Body);
+        ApplyCommonJsModuleAccess(ctx);
+        ApplyCapturedTopLevelVariableAccess(ctx);
+        ctx.TopLevelStaticVars =
+            BuildModuleMemberTopLevelStaticVarsForModule(_modules.CurrentPath);
+        ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0
+            ? _closures.ArrowEntryPointDCFields : null;
+        ctx.ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0
+            ? _closures.ArrowFunctionDCFields : null;
+        ApplyInnerFunctionSupport(ctx);
+        return ctx;
     }
 
     private void EmitAsyncArrowMoveNext(AsyncArrowStateMachineBuilder arrowBuilder, Expr.ArrowFunction arrow, CompilationContext parentCtx)

--- a/src/SharpTS/Compilation/ILCompiler.ContextFactories.cs
+++ b/src/SharpTS/Compilation/ILCompiler.ContextFactories.cs
@@ -57,6 +57,10 @@ public partial class ILCompiler
             MethodsCapturingArguments = _functions.MethodsCapturingArguments,
             FunctionGenericParams = _functions.GenericParams,
             IsGenericFunction = _functions.IsGeneric,
+            SuspensionFreePrimitiveAsyncCores =
+                _async.StableSuspensionFreePrimitiveCores.Count > 0
+                    ? _async.StableSuspensionFreePrimitiveCores
+                    : null,
             // Enum tables
             EnumMembers = _enums.Members,
             EnumReverse = _enums.Reverse,

--- a/src/SharpTS/Compilation/ILCompiler.State.cs
+++ b/src/SharpTS/Compilation/ILCompiler.State.cs
@@ -291,6 +291,11 @@ public partial class ILCompiler
         public AsyncStateAnalyzer Analyzer { get; } = new();
         public Dictionary<string, AsyncStateMachineBuilder> StateMachines { get; } = [];
         public Dictionary<string, Stmt.Function> Functions { get; } = [];
+        public Dictionary<string, AsyncStateAnalyzer.AsyncFunctionAnalysis> Analyses { get; } = [];
+        public Dictionary<string, HashSet<Expr.Await>> DirectCoreAwaits { get; } = [];
+        public Dictionary<string, Stmt.Function> SuspensionFreePrimitiveFunctions { get; } = [];
+        public Dictionary<string, MethodBuilder> SuspensionFreePrimitiveCores { get; } = [];
+        public Dictionary<string, MethodBuilder> StableSuspensionFreePrimitiveCores { get; } = [];
         public int StateMachineCounter { get; set; }
         public int ArrowCounter { get; set; }
 

--- a/src/SharpTS/Compilation/SuspensionFreeAsyncCoreEmitter.cs
+++ b/src/SharpTS/Compilation/SuspensionFreeAsyncCoreEmitter.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Diagnostics.Exceptions;
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Emits a synchronous primitive core for an async function after analysis proved every retained
+/// await is a stable call to another suspension-free primitive core.
+/// </summary>
+internal sealed class SuspensionFreeAsyncCoreEmitter(CompilationContext context) : ILEmitter(context)
+{
+    protected override void EmitAwait(Expr.Await expression)
+    {
+        if (Ctx.SuspensionFreePrimitiveAsyncCoreAwaits?.Contains(expression) != true
+            || expression.Expression is not Expr.Call
+            {
+                Callee: Expr.Variable variable,
+                Arguments: var arguments
+            })
+        {
+            throw new CompileException("Await is not suspension-free in this async core.");
+        }
+
+        string resolvedName = Ctx.ResolveFunctionName(variable.Name.Lexeme);
+        Dictionary<string, MethodBuilder>? stableCores =
+            Ctx.SuspensionFreePrimitiveAsyncCores;
+        if (stableCores == null
+            || !stableCores.TryGetValue(resolvedName, out MethodBuilder? coreMethod)
+            || arguments.Count != coreMethod.GetParameters().Length)
+        {
+            throw new CompileException(
+                "A pre-proven suspension-free async core call could not be emitted.");
+        }
+
+        ParameterInfo[] parameters = coreMethod.GetParameters();
+        var argumentLocals = new LocalBuilder[arguments.Count];
+        for (int index = 0; index < arguments.Count; index++)
+        {
+            EmitExpression(arguments[index]);
+            EmitConversionForParameter(arguments[index], parameters[index].ParameterType);
+            LocalBuilder local = IL.DeclareLocal(parameters[index].ParameterType);
+            IL.Emit(OpCodes.Stloc, local);
+            argumentLocals[index] = local;
+        }
+        foreach (LocalBuilder local in argumentLocals)
+            IL.Emit(OpCodes.Ldloc, local);
+
+        IL.Emit(OpCodes.Call, coreMethod);
+        if (coreMethod.ReturnType == typeof(double))
+            SetStackType(StackType.Double);
+        else if (coreMethod.ReturnType == typeof(bool))
+            SetStackType(StackType.Boolean);
+        else if (coreMethod.ReturnType == typeof(string))
+            SetStackType(StackType.String);
+        else
+            SetStackUnknown();
+    }
+}

--- a/tests/SharpTS.Tests/CompilerTests/SuspensionFreePrimitiveAsyncTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/SuspensionFreePrimitiveAsyncTests.cs
@@ -1,0 +1,437 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>
+/// Regression coverage for #1451. A deliberately narrow async function with no
+/// suspension points and a primitive result completes through a typed core and fresh Task wrapper;
+/// observable or uncertain shapes retain the ordinary async state machine.
+/// </summary>
+public sealed class SuspensionFreePrimitiveAsyncTests
+{
+    private const string EligibleSource = """
+        async function identity(value: number): Promise<number> {
+            return value;
+        }
+        identity(7).then((value: number): void => console.log(value));
+        """;
+
+    [Theory, ModeData]
+    public void PrimitiveResult_PreservesFulfillment(ExecutionMode mode)
+    {
+        Assert.Equal("7\n", TestHarness.Run(EligibleSource, mode));
+    }
+
+    [Theory, ModeData]
+    public void ReturnExpression_RunsSynchronouslyBeforeCallReturns(ExecutionMode mode)
+    {
+        const string source = """
+            let bodyRan: boolean = false;
+            function mark(value: number): number {
+                bodyRan = true;
+                return value;
+            }
+            async function identity(value: number): Promise<number> {
+                return mark(value);
+            }
+            const result: Promise<number> = identity(9);
+            console.log(bodyRan);
+            result.then((value: number): void => console.log(value));
+            """;
+
+        Assert.Equal("true\n9\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void SynchronousThrow_BecomesRejectedPromise(ExecutionMode mode)
+    {
+        const string source = """
+            function fail(): number {
+                throw new Error("boom");
+            }
+            async function work(): Promise<number> {
+                return fail();
+            }
+            let returned: boolean = false;
+            let promise: Promise<number>;
+            try {
+                promise = work();
+                returned = true;
+            } catch (_error) {
+                console.log("escaped");
+                promise = Promise.resolve(0);
+            }
+            console.log(returned);
+            promise.catch((error: Error): void => console.log(error.message));
+            """;
+
+        Assert.Equal("true\nboom\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void EveryInvocation_ReturnsFreshPromise(ExecutionMode mode)
+    {
+        const string source = """
+            async function identity(value: number): Promise<number> {
+                return value;
+            }
+            const first: any = identity(1);
+            const second: any = identity(1);
+            console.log(first === second);
+            Promise.all([first, second]).then(
+                (values: number[]): void => console.log(values.join(":")));
+            """;
+
+        Assert.Equal("false\n1:1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void Reactions_RemainAsynchronousJobs(ExecutionMode mode)
+    {
+        const string source = """
+            async function identity(value: number): Promise<number> {
+                return value;
+            }
+            const order: string[] = ["start"];
+            identity(1).then((_value: number): void => {
+                order.push("then");
+                console.log(order.join(":"));
+            });
+            order.push("after");
+            console.log(order.join(":"));
+            """;
+
+        Assert.Equal(
+            "start:after\nstart:after:then\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void ImmediatelyAwaitedDirectCall_PreservesResult(ExecutionMode mode)
+    {
+        const string source = """
+            async function identity(value: number): Promise<number> {
+                return value;
+            }
+            async function run(value: number): Promise<number> {
+                return await identity(value);
+            }
+            run(12).then((value: number): void => console.log(value));
+            """;
+
+        Assert.Equal("12\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void ReassignedBinding_DoesNotUseTypedCore()
+    {
+        const string source = """
+            async function identity(value: number): Promise<number> {
+                return value;
+            }
+            async function replacement(value: number): Promise<number> {
+                return value + 10;
+            }
+            identity = replacement;
+            async function run(): Promise<number> {
+                return await identity(1);
+            }
+            run();
+            """;
+
+        Assembly assembly = Compile(source);
+        MethodInfo moveNext = assembly.GetTypes()
+            .Single(type => type.Name.Contains("<run>d__", StringComparison.Ordinal))
+            .GetMethod("MoveNext")!;
+        var calls = ReadInstructions(moveNext)
+            .Select(instruction => instruction.Operand)
+            .OfType<MethodBase>()
+            .ToArray();
+
+        Assert.DoesNotContain(calls, method => method.Name.Contains(
+            "$asyncCore$identity", StringComparison.Ordinal));
+        Assert.Contains(calls, method => method.Name == "identity");
+    }
+
+    [Theory, ModeData]
+    public void LocallyShadowedBinding_RetainsValueCall(ExecutionMode mode)
+    {
+        const string source = """
+            async function identity(value: number): Promise<number> {
+                return value;
+            }
+            async function run(): Promise<number> {
+                const identity = (value: number): Promise<number> =>
+                    Promise.resolve(value + 20);
+                return await identity(1);
+            }
+            run().then((value: number): void => console.log(value));
+            """;
+
+        Assert.Equal("21\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void MixedDirectAndRealAwaits_PreserveStateNumbering(ExecutionMode mode)
+    {
+        const string source = """
+            async function identity(value: number): Promise<number> {
+                return value;
+            }
+            async function run(value: number): Promise<number> {
+                const first: number = await identity(value);
+                const second: number = await Promise.resolve(first + 1);
+                return await identity(second + 1);
+            }
+            run(5).then((value: number): void => console.log(value));
+            """;
+
+        Assert.Equal("7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void DirectCoreThrow_IsRejectedByOuterWrapper(ExecutionMode mode)
+    {
+        const string source = """
+            function fail(): number {
+                throw new Error("nested boom");
+            }
+            async function work(): Promise<number> {
+                return fail();
+            }
+            async function run(): Promise<number> {
+                return await work();
+            }
+            run().catch((error: Error): void => console.log(error.message));
+            """;
+
+        Assert.Equal("nested boom\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void EligibleFunction_UsesCompletedAndFaultedTasksWithoutStateMachine()
+    {
+        Assembly assembly = Compile(EligibleSource);
+        MethodInfo identity = FindFunction(assembly, "identity");
+        var instructions = ReadInstructions(identity).ToArray();
+
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "FromResult",
+                DeclaringType: { } declaringType
+            }
+            && declaringType == typeof(Task));
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "FromException",
+                DeclaringType: { } declaringType
+            }
+            && declaringType == typeof(Task));
+        Assert.DoesNotContain(assembly.GetTypes(), type =>
+            type.Name.Contains("<identity>d__", StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            identity.GetCustomAttributesData(),
+            attribute => attribute.AttributeType.Name == "AsyncStateMachineAttribute");
+    }
+
+    [Fact]
+    public void ImmediatelyAwaitedDirectCall_UsesTypedCoreWithoutTaskCall()
+    {
+        Assembly assembly = Compile("""
+            async function identity(value: number): Promise<number> {
+                return value;
+            }
+            async function run(value: number): Promise<number> {
+                return await identity(value);
+            }
+            run(1);
+            """);
+
+        MethodInfo runCore = assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.Contains(
+                "$asyncCore$run", StringComparison.Ordinal));
+        var calls = ReadInstructions(runCore)
+            .Select(instruction => instruction.Operand)
+            .OfType<MethodBase>()
+            .ToArray();
+
+        Assert.Contains(calls, method => method.Name.Contains(
+            "$asyncCore$identity", StringComparison.Ordinal));
+        Assert.DoesNotContain(calls, method => method.Name == "identity");
+        Assert.DoesNotContain(assembly.GetTypes(), type =>
+            type.Name.Contains("<run>d__", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [MemberData(nameof(FallbackSources))]
+    public void UncertainShapes_RetainAsyncStateMachine(string source, string functionName)
+    {
+        Assembly assembly = Compile(source);
+
+        Assert.Contains(assembly.GetTypes(), type =>
+            type.Name.Contains($"<{functionName}>d__", StringComparison.Ordinal));
+    }
+
+    public static TheoryData<string, string> FallbackSources => new()
+    {
+        {
+            """
+            async function suspended(value: number): Promise<number> {
+                return await Promise.resolve(value);
+            }
+            suspended(1);
+            """,
+            "suspended"
+        },
+        {
+            """
+            async function objectResult(): Promise<{ value: number }> {
+                return { value: 1 };
+            }
+            objectResult();
+            """,
+            "objectResult"
+        },
+        {
+            """
+            async function defaulted(value: number = 1): Promise<number> {
+                return value;
+            }
+            defaulted();
+            """,
+            "defaulted"
+        },
+    };
+
+    [Fact]
+    public void PrimitiveLocalsAndDirectCoreAwaits_ElideOuterStateMachine()
+    {
+        const string source = """
+            async function identity(value: number): Promise<number> {
+                return value;
+            }
+            async function sum(count: number): Promise<number> {
+                let total: number = 0;
+                for (let index: number = 0; index < count; index++) {
+                    total = total + await identity(index);
+                }
+                return total;
+            }
+            sum(5).then((value: number): void => console.log(value));
+            """;
+
+        Assembly assembly = Compile(source);
+        Assert.DoesNotContain(assembly.GetTypes(), type =>
+            type.Name.Contains("<sum>d__", StringComparison.Ordinal));
+        Assert.Equal("10\n", TestHarness.RunCompiled(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    [Fact]
+    public void EligibleFunction_VerifiesIlAndStandaloneOutput()
+    {
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(EligibleSource));
+        Assert.Equal("7\n", TestHarness.RunCompiledStandalone(EligibleSource));
+    }
+
+    [Fact]
+    public void ImmediatelyAwaitedDirectCall_VerifiesIlAndStandaloneOutput()
+    {
+        const string source = """
+            async function identity(value: number): Promise<number> {
+                return value;
+            }
+            async function run(value: number): Promise<number> {
+                return await identity(value);
+            }
+            run(12).then((value: number): void => console.log(value));
+            """;
+
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+        Assert.Equal("12\n", TestHarness.RunCompiledStandalone(source));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"issue_1451_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method =>
+                method.Name.EndsWith(name, StringComparison.Ordinal)
+                && !method.Name.StartsWith("$asyncCore$", StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+        Type[]? typeArguments = method.DeclaringType?.IsGenericType == true
+            ? method.DeclaringType.GetGenericArguments()
+            : null;
+        Type[]? methodArguments = method.IsGenericMethod
+            ? method.GetGenericArguments()
+            : null;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token, typeArguments, methodArguments)
+                    : module.ResolveType(token, typeArguments, methodArguments);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}


### PR DESCRIPTION
Closes #1451.

## Summary

- emit a typed synchronous core plus the existing `Task<object?>` wrapper for primitive async functions proven not to suspend
- turn synchronous exceptions into fresh faulted tasks and successful results into fresh completed tasks, preserving the public callable ABI
- propagate the proof through same-scope, stable, immediately awaited core calls so non-suspending callers also avoid state machines and boxed locals
- retain normal await/state-machine lowering for imported, reassigned, shadowed, nested-suspension, async-arrow, try/catch, default/rest/optional, captured, `this`, `arguments`, object/unknown, and decorated shapes
- teach async liveness/state numbering to ignore only the exact pre-proven direct-core await nodes

## Performance

`AsyncFunctionCallsBenchmarks`, N=1,000, ShortRun/in-process:

| | Baseline | This PR | Change |
|---|---:|---:|---:|
| Mean | 149.55 us | 422.9 ns | -99.7% |
| Allocated | 140.79 KB | 120 B | -99.9% |

Five alternated cross-runtime pairs at N=1,000:

| Runtime | Median mean |
|---|---:|
| SharpTS compiled | 0.0005 ms |
| Node | 0.0227 ms |
| Ratio | 0.02x Node |

The wrapper-only version was measured first: it reduced allocations to 93.92 KB but reached only 126.93 us. That evidence is why the issue and implementation include the conservative transitive direct-await proof.

## Validation

- Release solution build, including both IL-verification passes
- 27 new dual-mode/structural/standalone/IL-verification regression tests
- 252 focused async/Promise/module tests
- 604 compiler-focused tests
- TypeScript conformance: 65 passed
- GUI conformance: 83 passed
- Test262: all 11,384 cases executed in both modes; the sole compiled Pass -> Timeout also reproduces 3/3 on exact base commit `f0798233`, while existing baseline drift reports unrelated new passes in both modes

The unrestricted local suite is currently affected by machine-wide Windows HTTP/TLS/IPC failures (including interpreter-only cases and test constructors); the relevant compiler/conformance suites above are green.
