### PR TITLE
Optimize proven completed primitive Promise.all fan-out

### DIFF
--- a/src/SharpTS/Compilation/CallHandlers/StaticTypeHandler.cs
+++ b/src/SharpTS/Compilation/CallHandlers/StaticTypeHandler.cs
@@ -31,7 +31,17 @@ public class StaticTypeHandler : ICallHandler
         if (!staticStrategy.TryEmitStaticCall(emitter, staticGet.Name.Lexeme, call.Arguments))
             return false;
 
-        emitter.SetStackUnknown();
+        if (staticVar.Name.Lexeme == "Promise"
+            && staticGet.Name.Lexeme == "resolve"
+            && call.Arguments is [var resolvedValue]
+            && ctx.TypeMap?.IsStablePrimitivePromiseAllSeedValue(resolvedValue) == true)
+        {
+            emitter.SetStackType(StackType.Double);
+        }
+        else
+        {
+            emitter.SetStackUnknown();
+        }
         return true;
     }
 }

--- a/src/SharpTS/Compilation/Emitters/ArrayEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/ArrayEmitter.cs
@@ -26,6 +26,20 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         var ctx = emitter.Context;
         var il = ctx.IL;
 
+        if (methodName == "push"
+            && receiver is Expr.Variable stableReceiver
+            && ctx.TypeMap?.IsStablePrimitivePromiseAllPushReceiver(stableReceiver) == true
+            && arguments is [var value])
+        {
+            emitter.EmitExpression(receiver);
+            emitter.EnsureBoxed();
+            il.Emit(OpCodes.Castclass, ctx.Types.ListOfDouble);
+            emitter.EmitExpressionAsDouble(value);
+            il.Emit(OpCodes.Call, ctx.Runtime!.ArrayPushDouble);
+            emitter.SetStackType(StackType.Double);
+            return true;
+        }
+
         // Methods whose spec says "return this" — the caller expects the same reference the receiver
         // started with (sort/reverse/fill/copyWithin). Since we unwrap to a List, the helper returns the
         // inner List, not the $Array wrapper; to preserve `arr === arr.sort()` we stash the wrapper and

--- a/src/SharpTS/Compilation/Emitters/PromiseStaticEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/PromiseStaticEmitter.cs
@@ -25,6 +25,18 @@ public sealed class PromiseStaticEmitter : IStaticTypeEmitterStrategy
                 // Promise.resolve(value?) - returns Task<object?> directly
                 if (arguments.Count > 0)
                 {
+                    // The whole-program Promise.all proof established that
+                    // this fresh promise and its private input array cannot be
+                    // observed independently. Its producer is a promoted
+                    // List<double>, so carry the unboxed fulfilled primitive
+                    // directly instead of allocating a completed Task.
+                    if (ctx.TypeMap?.IsStablePrimitivePromiseAllSeedValue(arguments[0]) == true)
+                    {
+                        emitter.EmitExpressionAsDouble(arguments[0]);
+                        emitter.SetStackType(StackType.Double);
+                        return true;
+                    }
+
                     emitter.EmitExpression(arguments[0]);
                     emitter.EmitBoxIfNeeded(arguments[0]);
 

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.cs
@@ -1302,6 +1302,13 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     /// </summary>
     protected virtual void EmitArrayLiteral(Expr.ArrayLiteral a)
     {
+        if (Ctx.TypeMap?.IsStablePrimitivePromiseAllInputInitializer(a) == true)
+        {
+            IL.Emit(OpCodes.Newobj, Types.GetDefaultConstructor(Types.ListOfDouble));
+            SetStackUnknown();
+            return;
+        }
+
         bool hasSpreads = a.Elements.Any(e => e is Expr.Spread);
 
         // Evaluate all elements into locals first so an await inside any element

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -654,7 +654,7 @@ public partial class ILCompiler
         StablePrimitivePromiseThenAnalyzer.Analyze(
             statements, _typeMap, _closures.Analyzer);
         StablePrimitivePromiseAllAnalyzer.Analyze(
-            statements, _typeMap, _closures.Analyzer);
+            statements, _typeMap, _closures.Analyzer, _features);
         ArrayLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         StringAccumulatorPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         NonEscapingArrowLocalAnalyzer.Analyze(

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.All.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.All.cs
@@ -7,6 +7,59 @@ public partial class RuntimeEmitter
 {
     #region PromiseAll State Machine
 
+    private sealed record PrimitiveAllSettlement(
+        TypeBuilder Type,
+        ConstructorBuilder Constructor,
+        FieldBuilder CompletionField,
+        MethodBuilder RunMethod);
+
+    private PrimitiveAllSettlement DefineCompletedPrimitivePromiseAllSettlement(
+        ModuleBuilder moduleBuilder)
+    {
+        var type = EmitTypeDefinitions.DefineType(
+            moduleBuilder,
+            "$PrimitivePromiseAllSettlement",
+            TypeAttributes.Public | TypeAttributes.Sealed |
+                TypeAttributes.BeforeFieldInit,
+            _types.Object);
+        var completionField = type.DefineField(
+            "Completion", _types.TaskCompletionSourceOfObject,
+            FieldAttributes.Public);
+        var resultField = type.DefineField(
+            "Result", _types.Object, FieldAttributes.Public);
+        var constructor = type.DefineConstructor(
+            MethodAttributes.Public, CallingConventions.Standard,
+            [_types.Object]);
+        {
+            var il = constructor.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, _types.GetDefaultConstructor(_types.Object));
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(
+                _types.TaskCompletionSourceOfObject));
+            il.Emit(OpCodes.Stfld, completionField);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Stfld, resultField);
+            il.Emit(OpCodes.Ret);
+        }
+
+        var run = type.DefineMethod(
+            "Run", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
+        {
+            var il = run.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, completionField);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, resultField);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(
+                _types.TaskCompletionSourceOfObject, "SetResult", _types.Object));
+            il.Emit(OpCodes.Ret);
+        }
+
+        return new PrimitiveAllSettlement(type, constructor, completionField, run);
+    }
+
     /// <summary>
     /// Defines the PromiseAll state machine type structure.
     /// </summary>
@@ -57,6 +110,46 @@ public partial class RuntimeEmitter
             stablePrimitiveField: sm.StablePrimitiveField,
             emitStablePrimitiveValue: () => il.Emit(
                 stablePrimitive ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0));
+
+    /// <summary>
+    /// Emits the compiler-proven completed primitive Promise.all path. The
+    /// analyzer guarantees a fresh, non-escaping Promise&lt;number&gt;[] whose
+    /// elements all come from the intrinsic Promise.resolve(number), so the
+    /// fulfilled values are carried directly in its private typed backing list
+    /// and no per-element promise identity or then observation is possible. Copy
+    /// those values into the typed result carrier without constructing input
+    /// Tasks, a Task array, Task.WhenAll state machine, object result array, or
+    /// numeric reconversion pass. One FIFO job fulfills the result, preserving
+    /// the asynchronous ordering of await/then observation without building the
+    /// generic fan-in graph or capability-adoption facade.
+    /// </summary>
+    private void EmitCompletedPrimitivePromiseAll(
+        ILGenerator il,
+        EmittedRuntime runtime,
+        PrimitiveAllSettlement settlement)
+    {
+        var listType = typeof(List<double>);
+        var enumerableType = typeof(IEnumerable<double>);
+        var settlementLocal = il.DeclareLocal(settlement.Type);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, listType);
+        il.Emit(OpCodes.Newobj, listType.GetConstructor([enumerableType])!);
+        il.Emit(OpCodes.Newobj, settlement.Constructor);
+        il.Emit(OpCodes.Stloc, settlementLocal);
+
+        il.Emit(OpCodes.Ldloc, settlementLocal);
+        il.Emit(OpCodes.Ldftn, settlement.RunMethod);
+        il.Emit(OpCodes.Newobj,
+            typeof(Action).GetConstructor([typeof(object), typeof(IntPtr)])!);
+        il.Emit(OpCodes.Call, runtime.QueuePromiseJob);
+
+        il.Emit(OpCodes.Ldloc, settlementLocal);
+        il.Emit(OpCodes.Ldfld, settlement.CompletionField);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(
+            _types.TaskCompletionSourceOfObject, "Task").GetGetMethod()!);
+        il.Emit(OpCodes.Ret);
+    }
 
     /// <summary>
     /// Emits the MoveNext body for PromiseAll state machine.

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.cs
@@ -591,7 +591,11 @@ public partial class RuntimeEmitter
             [_types.Object, _types.Object, _types.Object]
         );
         runtime.PromiseAllPrimitive = allPrimitive;
-        EmitPromiseAllWrapper(allPrimitive.GetILGenerator(), promiseAllSM, runtime, stablePrimitive: true);
+        var primitiveAllSettlement = DefineCompletedPrimitivePromiseAllSettlement(
+            moduleBuilder);
+        EmitCompletedPrimitivePromiseAll(
+            allPrimitive.GetILGenerator(), runtime, primitiveAllSettlement);
+        primitiveAllSettlement.Type.CreateType();
         EmitPromiseAllMoveNext(promiseAllSM, runtime);
         promiseAllSM.Type.CreateType();
 

--- a/src/SharpTS/Compilation/StablePrimitivePromiseAllAnalyzer.cs
+++ b/src/SharpTS/Compilation/StablePrimitivePromiseAllAnalyzer.cs
@@ -16,9 +16,12 @@ internal static class StablePrimitivePromiseAllAnalyzer
     public static void Analyze(
         List<Stmt> program,
         TypeMap? typeMap,
-        ClosureAnalyzer? closures)
+        ClosureAnalyzer? closures,
+        RuntimeFeatureSet? features)
     {
-        if (typeMap is null)
+        if (typeMap is null
+            || features?.UsesArrayPrototypeMutation == true
+            || features?.UsesDynamicPropertyDescriptors == true)
             return;
 
         var mutations = new PromiseMutationVisitor(typeMap);
@@ -48,6 +51,12 @@ internal static class StablePrimitivePromiseAllAnalyzer
             }
 
             typeMap.MarkStablePrimitivePromiseAllIterable(candidate.Iterable);
+            typeMap.MarkStablePrimitivePromiseAllInputInitializer(
+                visitor.InputInitializers[inputKey]);
+            foreach (var receiver in visitor.InputPushReceivers.GetValueOrDefault(inputKey, []))
+                typeMap.MarkStablePrimitivePromiseAllPushReceiver(receiver);
+            foreach (var seed in visitor.InputSeeds.GetValueOrDefault(inputKey, []))
+                typeMap.MarkStablePrimitivePromiseAllSeedValue(seed);
             foreach (var use in visitor.ResultUses.GetValueOrDefault(resultKey, []))
                 typeMap.MarkStablePrimitivePromiseAllResultUse(use);
         }
@@ -148,6 +157,8 @@ internal static class StablePrimitivePromiseAllAnalyzer
         public Dictionary<(int Scope, string Name), int> DeclarationCounts { get; } = [];
         public Dictionary<(int Scope, string Name), int> TerminalCounts { get; } = [];
         public HashSet<(int Scope, string Name)> Inputs { get; } = [];
+        public Dictionary<(int Scope, string Name), Expr.ArrayLiteral> InputInitializers { get; } = [];
+        public Dictionary<(int Scope, string Name), List<Expr.Variable>> InputPushReceivers { get; } = [];
         public Dictionary<(int Scope, string Name), ResultCandidate> Results { get; } = [];
         public Dictionary<(int Scope, string Name), List<Expr.Variable>> ResultUses { get; } = [];
         public Dictionary<(int Scope, string Name), List<Expr>> InputSeeds { get; } = [];
@@ -202,9 +213,10 @@ internal static class StablePrimitivePromiseAllAnalyzer
 
             if (_scope != 0
                 && annotation?.Replace(" ", "", StringComparison.Ordinal) == "Promise<number>[]"
-                && initializer is Expr.ArrayLiteral { Elements.Count: 0 })
+                && initializer is Expr.ArrayLiteral { Elements.Count: 0 } emptyArray)
             {
                 Inputs.Add(key);
+                InputInitializers[key] = emptyArray;
             }
 
             if (_scope != 0
@@ -223,7 +235,8 @@ internal static class StablePrimitivePromiseAllAnalyzer
 
         protected override void VisitCall(Expr.Call expression)
         {
-            if (expression.Callee is Expr.Get
+            if (!expression.Optional
+                && expression.Callee is Expr.Get
                 {
                     Optional: false,
                     Object: Expr.Variable receiver,
@@ -238,6 +251,9 @@ internal static class StablePrimitivePromiseAllAnalyzer
                     if (!InputSeeds.TryGetValue(key, out var seeds))
                         InputSeeds[key] = seeds = [];
                     seeds.Add(value);
+                    if (!InputPushReceivers.TryGetValue(key, out var receivers))
+                        InputPushReceivers[key] = receivers = [];
+                    receivers.Add(receiver);
                     Visit(argument);
                     return;
                 }

--- a/src/SharpTS/Compilation/StatementEmitterBase.cs
+++ b/src/SharpTS/Compilation/StatementEmitterBase.cs
@@ -373,6 +373,29 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
     /// </summary>
     protected virtual bool TryEmitDiscardedExpression(Expr expression)
     {
+        if (expression is Expr.Call
+            {
+                Optional: false,
+                Callee: Expr.Get
+                {
+                    Optional: false,
+                    Object: Expr.Variable stableReceiver,
+                    Name.Lexeme: "push"
+                },
+                Arguments: [var stableValue]
+            }
+            && Ctx.TypeMap?.IsStablePrimitivePromiseAllPushReceiver(stableReceiver) == true)
+        {
+            EmitExpression(stableReceiver);
+            EnsureBoxed();
+            IL.Emit(OpCodes.Castclass, Ctx.Types.ListOfDouble);
+            EmitExpressionAsDouble(stableValue);
+            IL.Emit(OpCodes.Call, Ctx.Runtime!.ArrayPushDouble);
+            IL.Emit(OpCodes.Pop);
+            SetStackUnknown();
+            return true;
+        }
+
         if (expression is not Expr.Call
             {
                 Optional: false,
@@ -587,6 +610,8 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
     /// </summary>
     protected virtual void EmitFor(Stmt.For f)
     {
+        if (TryEmitStablePrimitivePromiseAllFill(f))
+            return;
         if (TryEmitStablePrimitivePromiseAllReduction(f))
             return;
 
@@ -650,6 +675,109 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
 
         // Exit loop scope
         Ctx.Locals.ExitScope();
+    }
+
+    /// <summary>
+    /// Emits the canonical producer loop of a proven stable primitive Promise.all
+    /// input with a native counter and direct typed-list append. The condition is
+    /// still evaluated on every iteration and cancellation remains observable at
+    /// the same loop boundary as the general emitter.
+    /// </summary>
+    private bool TryEmitStablePrimitivePromiseAllFill(Stmt.For loop)
+    {
+        if (loop.Initializer is not Stmt.Var
+            {
+                IsVar: false,
+                TypeAnnotation: "number",
+                Initializer: Expr.Literal { Value: double initialValue }
+            } counterDeclaration
+            || initialValue != 0.0
+            || loop.Condition is not Expr.Binary
+            {
+                Left: Expr.Variable conditionCounter,
+                Operator.Type: TokenType.LESS,
+                Right: var bound
+            }
+            || conditionCounter.Name.Lexeme != counterDeclaration.Name.Lexeme
+            || !IsIncrementOf(loop.Increment, counterDeclaration.Name.Lexeme)
+            || bound is not (Expr.Variable or Expr.Literal)
+            || bound is Expr.Variable boundVariable
+                && boundVariable.Name.Lexeme == counterDeclaration.Name.Lexeme
+            || !IsNumberType(Ctx.TypeMap?.Get(bound)))
+        {
+            return false;
+        }
+
+        Stmt body = loop.Body is Stmt.Block { Statements: [var onlyStatement] }
+            ? onlyStatement
+            : loop.Body;
+        if (body is not Stmt.Expression
+            {
+                Expr: Expr.Call
+                {
+                    Optional: false,
+                    Callee: Expr.Get
+                    {
+                        Optional: false,
+                        Object: Expr.Variable receiver,
+                        Name.Lexeme: "push"
+                    },
+                    Arguments:
+                    [
+                        Expr.Call
+                        {
+                            Optional: false,
+                            Callee: Expr.Get
+                            {
+                                Optional: false,
+                                Object: Expr.Variable { Name.Lexeme: "Promise" },
+                                Name.Lexeme: "resolve"
+                            },
+                            Arguments: [Expr.Variable seed]
+                        }
+                    ]
+                }
+            }
+            || seed.Name.Lexeme != counterDeclaration.Name.Lexeme
+            || Ctx.TypeMap?.IsStablePrimitivePromiseAllPushReceiver(receiver) != true
+            || Ctx.TypeMap.IsStablePrimitivePromiseAllSeedValue(seed) != true)
+        {
+            return false;
+        }
+
+        var valuesLocal = IL.DeclareLocal(Ctx.Types.ListOfDouble);
+        var counterLocal = IL.DeclareLocal(Ctx.Types.Double);
+
+        EmitExpression(receiver);
+        EnsureBoxed();
+        IL.Emit(OpCodes.Castclass, Ctx.Types.ListOfDouble);
+        IL.Emit(OpCodes.Stloc, valuesLocal);
+        IL.Emit(OpCodes.Ldc_R8, 0.0);
+        IL.Emit(OpCodes.Stloc, counterLocal);
+
+        var startLabel = IL.DefineLabel();
+        var endLabel = IL.DefineLabel();
+        IL.MarkLabel(startLabel);
+        EmitCancellationCheck();
+
+        IL.Emit(OpCodes.Ldloc, counterLocal);
+        EmitExpressionAsDouble(bound);
+        IL.Emit(OpCodes.Bge_Un, endLabel);
+
+        IL.Emit(OpCodes.Ldloc, valuesLocal);
+        IL.Emit(OpCodes.Ldloc, counterLocal);
+        IL.Emit(OpCodes.Callvirt,
+            Ctx.Types.GetMethod(Ctx.Types.ListOfDouble, "Add", Ctx.Types.Double));
+
+        IL.Emit(OpCodes.Ldloc, counterLocal);
+        IL.Emit(OpCodes.Ldc_R8, 1.0);
+        IL.Emit(OpCodes.Add);
+        IL.Emit(OpCodes.Stloc, counterLocal);
+        IL.Emit(OpCodes.Br, startLabel);
+
+        IL.MarkLabel(endLabel);
+        SetStackUnknown();
+        return true;
     }
 
     /// <summary>

--- a/src/SharpTS/TypeSystem/TypeMap.cs
+++ b/src/SharpTS/TypeSystem/TypeMap.cs
@@ -26,6 +26,9 @@ public class TypeMap
     private readonly HashSet<Stmt.ForOf> _stableNumericMapIterations = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.Get> _stablePrimitivePromiseThenCalls = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr> _stablePrimitivePromiseAllIterables = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Expr.ArrayLiteral> _stablePrimitivePromiseAllInputInitializers = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Expr.Variable> _stablePrimitivePromiseAllPushReceivers = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Expr> _stablePrimitivePromiseAllSeedValues = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.Variable> _stablePrimitivePromiseAllResultUses = new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
@@ -234,6 +237,37 @@ public class TypeMap
 
     public bool IsStablePrimitivePromiseAllIterable(Expr iterable) =>
         _stablePrimitivePromiseAllIterables.Contains(iterable);
+
+    /// <summary>
+    /// Marks the empty literal backing the proven non-escaping Promise.all input.
+    /// It may use the private typed numeric-list carrier instead of a $Array.
+    /// </summary>
+    public void MarkStablePrimitivePromiseAllInputInitializer(Expr.ArrayLiteral initializer) =>
+        _stablePrimitivePromiseAllInputInitializers.Add(initializer);
+
+    public bool IsStablePrimitivePromiseAllInputInitializer(Expr.ArrayLiteral initializer) =>
+        _stablePrimitivePromiseAllInputInitializers.Contains(initializer);
+
+    /// <summary>
+    /// Marks an exact permitted push receiver for that private typed input.
+    /// </summary>
+    public void MarkStablePrimitivePromiseAllPushReceiver(Expr.Variable receiver) =>
+        _stablePrimitivePromiseAllPushReceivers.Add(receiver);
+
+    public bool IsStablePrimitivePromiseAllPushReceiver(Expr.Variable receiver) =>
+        _stablePrimitivePromiseAllPushReceivers.Contains(receiver);
+
+    /// <summary>
+    /// Marks the numeric argument of an intrinsic <c>Promise.resolve</c> whose
+    /// result is stored only in a proven stable primitive Promise.all input.
+    /// The compiler may carry the unboxed value in that private list instead of
+    /// materializing an otherwise-unobservable completed Task.
+    /// </summary>
+    public void MarkStablePrimitivePromiseAllSeedValue(Expr value) =>
+        _stablePrimitivePromiseAllSeedValues.Add(value);
+
+    public bool IsStablePrimitivePromiseAllSeedValue(Expr value) =>
+        _stablePrimitivePromiseAllSeedValues.Contains(value);
 
     /// <summary>
     /// Marks a permitted length/index receiver use of the non-escaping numeric

--- a/tests/SharpTS.Tests/CompilerTests/StablePrimitivePromiseThenTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StablePrimitivePromiseThenTests.cs
@@ -423,6 +423,84 @@ public sealed class StablePrimitivePromiseThenTests
         Assert.Equal(OpCodes.Add, instructions[itemRead + 1].OpCode);
     }
 
+    [Fact]
+    public void StablePromiseAllFanOut_AvoidsPerElementTasksAndWhenAll()
+    {
+        Assembly assembly = Compile("""
+            async function gather(n: number): Promise<number> {
+                const promises: Promise<number>[] = [];
+                for (let i: number = 0; i < n; i++) {
+                    promises.push(Promise.resolve(i));
+                }
+                const values: number[] = await Promise.all(promises);
+                return values.length;
+            }
+            gather(10);
+            """);
+
+        MethodInfo caller = FindSingleCaller(assembly, "PromiseAllPrimitive");
+        Assert.DoesNotContain(ReadInstructions(caller), instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "FromResult" or "PromiseResolve"
+            });
+        Assert.Contains(ReadInstructions(caller), instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "Add",
+                DeclaringType: { } declaringType
+            }
+            && declaringType == typeof(List<double>));
+
+        MethodInfo primitiveAll = assembly.GetType("$Runtime")!
+            .GetMethod("PromiseAllPrimitive")!;
+        var instructions = ReadInstructions(primitiveAll).ToList();
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "WhenAll" or "get_Result" or
+                    "FromResult" or "AdoptPromiseCombinatorResult" or
+                    "MarkNonAutoAwaitPromise"
+            });
+        Assert.Single(instructions, instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "QueuePromiseJob"
+            });
+    }
+
+    [Theory, ModeData]
+    public void StablePromiseAllFanOut_PreservesPromiseJobOrdering(ExecutionMode mode)
+    {
+        const string source = """
+            async function gather(): Promise<void> {
+                const promises: Promise<number>[] = [];
+                promises.push(Promise.resolve(1));
+                Promise.resolve(0).then((): void => console.log("queued"));
+                const values: number[] = await Promise.all(promises);
+                console.log("all:" + values.length);
+            }
+            gather();
+            """;
+
+        Assert.Equal("queued\nall:1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void StablePromiseAllFanOut_PreservesEmptyInput(ExecutionMode mode)
+    {
+        const string source = """
+            async function gather(): Promise<void> {
+                const promises: Promise<number>[] = [];
+                const values: number[] = await Promise.all(promises);
+                console.log(values.length);
+            }
+            gather();
+            """;
+
+        Assert.Equal("0\n", TestHarness.Run(source, mode));
+    }
+
     [Theory, ModeData]
     public void StablePromiseAllReductionLoop_PreservesOutput(ExecutionMode mode)
     {
@@ -518,6 +596,27 @@ public sealed class StablePrimitivePromiseThenTests
                 {{(observableUse.Contains("alias", StringComparison.Ordinal) ? observableUse : "")}}
                 const values: number[] = await Promise.all(promises);
                 {{(observableUse.Contains("values", StringComparison.Ordinal) ? observableUse : "")}}
+                return values.length;
+            }
+            gather();
+            """;
+
+        Assembly assembly = Compile(source);
+        Assert.Empty(FindCallers(assembly, "PromiseAllPrimitive"));
+        Assert.NotEmpty(FindCallers(assembly, "PromiseAll"));
+    }
+
+    [Fact]
+    public void ArrayPrototypePushMutation_RetainsOrdinaryPromiseAllPath()
+    {
+        const string source = """
+            (Array.prototype as any).push = function(value: any): number {
+                return 0;
+            };
+            async function gather(): Promise<number> {
+                const promises: Promise<number>[] = [];
+                promises.push(Promise.resolve(1));
+                const values: number[] = await Promise.all(promises);
                 return values.length;
             }
             gather();


### PR DESCRIPTION
Fixes #1453

## Summary

- prove the narrow non-escaping `Promise<number>[]` / `Promise.resolve(number)` / `Promise.all` pipeline end to end
- carry completed primitive values in a private `List<double>` instead of allocating a `Task` for every element
- lower the canonical producer loop to native numeric iteration and direct typed-list appends
- copy the completed values directly and schedule one FIFO promise job, avoiding `Task.WhenAll` and the generic adoption facade while preserving observable promise ordering
- retain the ordinary Promise path when bindings escape, inputs are uncertain, or Promise/Array behavior may be mutated

## Performance

`Promise.all` completed primitive fan-out, N=1000 (BenchmarkDotNet):

| | Before | After |
|---|---:|---:|
| Mean | 93.67 us | 16.247 us |
| Allocated | 165.77 KB | 24.46 KB |

Five independently launched process samples now measure SharpTS at about 0.20x Node for the target workload (compiled median 0.0119 ms; Node median 0.0599 ms). The issue targets were <=47 us, <=125 KB, and <=1.25x Node.

## Validation

- `dotnet build SharpTS.sln -c Release --nologo -p:NuGetAudit=false --no-restore` (IL verification passed)
- focused stable primitive promise tests: 44 passed
- compiler test suite: 656 passed; the isolated standalone TLS test is unavailable in the sandbox because certificate access is denied
- microbenchmark source smoke and all 17 cross-runtime workloads compile
- Test262, worker, and TypeScript conformance projects build
- compiled and Node ordering both produce `queued` before `all:1`

