### PR TITLE
Optimize stable primitive class field lowering

### DIFF
--- a/benchmarks/cross-runtime/scripts/classes.ts
+++ b/benchmarks/cross-runtime/scripts/classes.ts
@@ -1,0 +1,14 @@
+import {
+    classConstruction,
+    classFieldReuse,
+    classMethodReuse,
+} from "./lib/algorithms.ts";
+import { bench } from "./lib/bench.ts";
+
+const params: number[] = [1000, 10000, 100000];
+for (let p: number = 0; p < params.length; p++) {
+    const n: number = params[p];
+    bench("class-field-reuse", n, () => classFieldReuse(n));
+    bench("class-method-reuse", n, () => classMethodReuse(n));
+    bench("class-construction", n, () => classConstruction(n));
+}

--- a/benchmarks/cross-runtime/scripts/lib/algorithms.ts
+++ b/benchmarks/cross-runtime/scripts/lib/algorithms.ts
@@ -272,6 +272,50 @@ export function binaryTrees(depth: number): number {
     return itemCheck(buildTree(depth));
 }
 
+// Exact class-field workloads. Keeping construction, direct field traffic,
+// and method traffic separate makes representation/dispatch regressions
+// attributable instead of averaging them together.
+class BenchmarkCounter {
+    value: number;
+
+    constructor(value: number) {
+        this.value = value;
+    }
+
+    step(): number {
+        this.value = this.value + 1;
+        return this.value;
+    }
+}
+
+export function classFieldReuse(n: number): number {
+    const counter: BenchmarkCounter = new BenchmarkCounter(0);
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        counter.value = counter.value + 1;
+        sum = sum + counter.value;
+    }
+    return sum;
+}
+
+export function classMethodReuse(n: number): number {
+    const counter: BenchmarkCounter = new BenchmarkCounter(0);
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        sum = sum + counter.step();
+    }
+    return sum;
+}
+
+export function classConstruction(n: number): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const counter: BenchmarkCounter = new BenchmarkCounter(i);
+        sum = sum + counter.value;
+    }
+    return sum;
+}
+
 // ── Async / Promise workloads ─────────────────────────────────────────────
 
 // Await already-resolved promises serially. This isolates the cost of promise

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Baselines/ClassFieldCSharp.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Baselines/ClassFieldCSharp.cs
@@ -1,0 +1,103 @@
+using System.Runtime.CompilerServices;
+
+namespace SharpTS.Microbenchmarks.Baselines;
+
+public static class ClassFieldCSharp
+{
+    private sealed class Counter(double value)
+    {
+        public double Value = value;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public double Step() => ++Value;
+    }
+
+    private sealed class BoxedCounter
+    {
+        private readonly Dictionary<string, object?> _fields = [];
+        private object? _value;
+
+        public int DynamicFieldCount => _fields.Count;
+
+        public BoxedCounter(object? value) => SetValue(value);
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public object? GetValue() => _value;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public object? SetValue(object? value)
+        {
+            _value = value;
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public object? Step()
+        {
+            object? next = Convert.ToDouble(GetValue()) + 1;
+            SetValue(next);
+            return GetValue();
+        }
+    }
+
+    public static double FieldReuse(int n)
+    {
+        var counter = new Counter(0);
+        double sum = 0;
+        for (int i = 0; i < n; i++)
+        {
+            counter.Value++;
+            sum += counter.Value;
+        }
+        return sum;
+    }
+
+    public static double MethodReuse(int n)
+    {
+        var counter = new Counter(0);
+        double sum = 0;
+        for (int i = 0; i < n; i++)
+            sum += counter.Step();
+        return sum;
+    }
+
+    public static double Construction(int n)
+    {
+        double sum = 0;
+        for (int i = 0; i < n; i++)
+            sum += new Counter(i).Value;
+        return sum;
+    }
+
+    public static object? BoxedFieldReuse(int n)
+    {
+        var counter = new BoxedCounter(0.0);
+        double sum = 0;
+        for (int i = 0; i < n; i++)
+        {
+            counter.SetValue(Convert.ToDouble(counter.GetValue()) + 1);
+            sum += Convert.ToDouble(counter.GetValue());
+        }
+        return sum;
+    }
+
+    public static object? BoxedMethodReuse(int n)
+    {
+        var counter = new BoxedCounter(0.0);
+        double sum = 0;
+        for (int i = 0; i < n; i++)
+            sum += Convert.ToDouble(counter.Step());
+        return sum;
+    }
+
+    public static object? BoxedConstruction(int n)
+    {
+        double sum = 0;
+        for (int i = 0; i < n; i++)
+        {
+            var counter = new BoxedCounter((double)i);
+            sum += Convert.ToDouble(counter.GetValue()) + counter.DynamicFieldCount;
+        }
+        return sum;
+    }
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ClassFieldBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ClassFieldBenchmarks.cs
@@ -1,0 +1,69 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using SharpTS.Microbenchmarks.Baselines;
+
+namespace SharpTS.Microbenchmarks.Benchmarks;
+
+public abstract class ClassFieldBenchmarkBase : ComputationalBenchmarkBase
+{
+    protected Func<double, double> SharpTs = null!;
+
+    [Params(100_000)]
+    public int N { get; set; }
+
+    protected void Load(string functionName) => SharpTs = LoadCompiled(functionName);
+}
+
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class ClassFieldReuseBenchmarks : ClassFieldBenchmarkBase
+{
+    [GlobalSetup]
+    public void Setup() => Load("classFieldReuse");
+
+    [Benchmark]
+    public double SharpTS() => SharpTs(N);
+
+    [Benchmark(Baseline = true)]
+    public double IdiomaticCSharp() => ClassFieldCSharp.FieldReuse(N);
+
+    [Benchmark]
+    public object? BoxedEquivalentCSharp() => ClassFieldCSharp.BoxedFieldReuse(N);
+}
+
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class ClassMethodReuseBenchmarks : ClassFieldBenchmarkBase
+{
+    [GlobalSetup]
+    public void Setup() => Load("classMethodReuse");
+
+    [Benchmark]
+    public double SharpTS() => SharpTs(N);
+
+    [Benchmark(Baseline = true)]
+    public double IdiomaticCSharp() => ClassFieldCSharp.MethodReuse(N);
+
+    [Benchmark]
+    public object? BoxedEquivalentCSharp() => ClassFieldCSharp.BoxedMethodReuse(N);
+}
+
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class ClassConstructionBenchmarks : ClassFieldBenchmarkBase
+{
+    [GlobalSetup]
+    public void Setup() => Load("classConstruction");
+
+    [Benchmark]
+    public double SharpTS() => SharpTs(N);
+
+    [Benchmark(Baseline = true)]
+    public double IdiomaticCSharp() => ClassFieldCSharp.Construction(N);
+
+    [Benchmark]
+    public object? BoxedEquivalentCSharp() => ClassFieldCSharp.BoxedConstruction(N);
+}

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -2081,9 +2081,21 @@ public partial class ILEmitter
         // Field properties have typed getters, but explicit accessors return object
         var getterReturnType = getterBuilder.ReturnType;
 
-        if (getterReturnType.IsValueType)
+        if (_ctx.Types.IsDouble(getterReturnType))
         {
-            // Getter returns a native value type - box it for internal code that expects object
+            // A declared `number` field is already a native double. Keep that representation
+            // through arithmetic and loop consumers; they will box only if an object boundary
+            // actually requires it.
+            SetStackType(StackType.Double);
+        }
+        else if (_ctx.Types.IsBoolean(getterReturnType))
+        {
+            SetStackType(StackType.Boolean);
+        }
+        else if (getterReturnType.IsValueType)
+        {
+            // Other CLR value types are not represented by StackType and must retain the
+            // established boxed-object contract.
             IL.Emit(OpCodes.Box, getterReturnType);
             SetStackUnknown();
         }
@@ -2159,15 +2171,19 @@ public partial class ILEmitter
         var setterParams = setterBuilder.GetParameters();
         var setterParamType = setterParams.Length > 0 ? setterParams[0].ParameterType : _ctx.Types.Object;
 
-        // Emit: ((ClassName)receiver).set_PropertyName(value)
-        // Also need to keep the value on the stack as the expression result
-        // But first check if object is frozen - if so, skip setter call
+        // Emit: ((ClassName)receiver).set_PropertyName(value), while retaining the value as the
+        // assignment expression result. Primitive field values stay in typed locals across the
+        // frozen-object branch so the common path does not box merely to duplicate a value.
 
         // Emit receiver and save for freeze check and potential setter call
         EmitExpression(receiver);
         EmitBoxIfNeeded(receiver);
         var receiverTemp = IL.DeclareLocal(_ctx.Types.Object);
         IL.Emit(OpCodes.Stloc, receiverTemp);
+
+        if (TryEmitTypedDirectSetter(
+                receiverTemp, castType, setterBuilder, setterTarget, setterParamType, value))
+            return true;
 
         // Check if frozen: _frozenObjects.TryGetValue(obj, out _)
         var notFrozenLabel = IL.DefineLabel();
@@ -2238,6 +2254,85 @@ public partial class ILEmitter
         IL.MarkLabel(endLabel);
         SetStackUnknown();  // Result is boxed object
         return true;
+    }
+
+    /// <summary>
+    /// Emits a direct class-field setter without erasing a statically matching primitive value.
+    /// The frozen-object check and setter invocation semantics are identical to the boxed path;
+    /// only the temporary/result representation differs.
+    /// </summary>
+    private bool TryEmitTypedDirectSetter(
+        LocalBuilder receiverTemp,
+        Type castType,
+        MethodBuilder setterBuilder,
+        System.Reflection.MethodInfo setterTarget,
+        Type setterParamType,
+        Expr value)
+    {
+        StackType resultStackType;
+        if (_ctx.Types.IsDouble(setterParamType) && IsNumericType(_ctx.TypeMap?.Get(value)))
+            resultStackType = StackType.Double;
+        else if (_ctx.Types.IsBoolean(setterParamType)
+                 && _ctx.TypeMap?.Get(value) is TypeInfo.Primitive { Type: TokenType.TYPE_BOOLEAN })
+            resultStackType = StackType.Boolean;
+        else if (_ctx.Types.IsString(setterParamType)
+                 && _ctx.TypeMap?.Get(value) is TypeInfo.String)
+            resultStackType = StackType.String;
+        else
+            return false;
+
+        EmitExpression(value);
+        switch (resultStackType)
+        {
+            case StackType.Double: EnsureDouble(); break;
+            case StackType.Boolean: EnsureBoolean(); break;
+            case StackType.String: EnsureString(); break;
+        }
+
+        var valueTemp = IL.DeclareLocal(setterParamType);
+        IL.Emit(OpCodes.Stloc, valueTemp);
+
+        if (_ctx.RuntimeFeatures?.UsesObjectIntegrityMutation == false)
+        {
+            EmitTypedDirectSetterCall(
+                receiverTemp, castType, setterBuilder, setterTarget, valueTemp);
+            IL.Emit(OpCodes.Ldloc, valueTemp);
+            SetStackType(resultStackType);
+            return true;
+        }
+
+        var endLabel = IL.DefineLabel();
+        var frozenCheckLocal = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.FrozenObjectsField);
+        IL.Emit(OpCodes.Ldloc, receiverTemp);
+        IL.Emit(OpCodes.Ldloca, frozenCheckLocal);
+        IL.Emit(OpCodes.Callvirt, _ctx.Types.GetMethod(
+            _ctx.Types.ConditionalWeakTable, "TryGetValue",
+            _ctx.Types.Object, _ctx.Types.Object.MakeByRefType()));
+        IL.Emit(OpCodes.Brtrue, endLabel);
+
+        EmitTypedDirectSetterCall(
+            receiverTemp, castType, setterBuilder, setterTarget, valueTemp);
+
+        IL.MarkLabel(endLabel);
+        IL.Emit(OpCodes.Ldloc, valueTemp);
+        SetStackType(resultStackType);
+        return true;
+    }
+
+    private void EmitTypedDirectSetterCall(
+        LocalBuilder receiverTemp,
+        Type castType,
+        MethodBuilder setterBuilder,
+        System.Reflection.MethodInfo setterTarget,
+        LocalBuilder valueTemp)
+    {
+        IL.Emit(OpCodes.Ldloc, receiverTemp);
+        IL.Emit(OpCodes.Castclass, castType);
+        IL.Emit(OpCodes.Ldloc, valueTemp);
+        IL.Emit(OpCodes.Callvirt, setterTarget);
+        if (!_ctx.Types.IsVoid(setterBuilder.ReturnType))
+            IL.Emit(OpCodes.Pop);
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -87,6 +87,7 @@ public sealed class RuntimeFeatureDetector
             UsesMap = false,
             UsesSet = false,
             UsesDynamicPropertyDescriptors = false,
+            UsesObjectIntegrityMutation = false,
             UsesDatePrototypeMutation = false,
             UsesPromisePrototypeMutation = false,
             UsesArrayPrototypeMutation = false,
@@ -280,6 +281,15 @@ public sealed class RuntimeFeatureDetector
     {
         switch (name)
         {
+            // A value-form reference can alias the integrity mutators
+            // (`const O = Object; O.freeze(value)`). Conservatively disable
+            // the direct class-setter shortcut for any opaque Object access
+            // or dynamic source execution.
+            case "Object":
+            case "eval":
+            case "Function":
+                _set.UsesObjectIntegrityMutation = true; break;
+
             // Fetch family
             case "fetch":
             case "Headers":
@@ -412,6 +422,7 @@ public sealed class RuntimeFeatureDetector
             // We flag Reflect generally; the metadata-specific arms are still
             // flagged separately via HandleMemberAccess for finer granularity.
             case "Reflect":
+                _set.UsesObjectIntegrityMutation = true;
                 _set.UsesReflect = true; break;
 
             // Date — bare identifier covers `new Date()`, `Date.now()`,
@@ -490,6 +501,7 @@ public sealed class RuntimeFeatureDetector
             // valve; the fine-grained ones still get set by their own triggers.
             case "globalThis":
             case "global":
+                _set.UsesObjectIntegrityMutation = true;
                 _set.UsesFetch = true;
                 _set.UsesTextEncoding = true;
                 _set.UsesWebStreams = true;
@@ -762,6 +774,8 @@ public sealed class RuntimeFeatureDetector
                 break;
 
             case Expr.Get g:
+                if (g.Name.Lexeme is "Object" or "Reflect")
+                    _set.UsesObjectIntegrityMutation = true;
                 if (IsArrayPrototype(g) || g.Name.Lexeme == "__proto__")
                     _set.UsesArrayPrototypeMutation = true;
                 if (IsPromisePrototype(g))

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -135,6 +135,10 @@ public sealed class RuntimeFeatureSet
     // Object/Reflect descriptor APIs can install indexed accessors on arrays.
     // Such programs must not use backing-list-only indexed-read fast paths.
     public bool UsesDynamicPropertyDescriptors { get; set; } = true;
+    // Object.freeze/seal/preventExtensions (or an opaque route to those intrinsics)
+    // can populate the emitted runtime's object-integrity tables. Direct typed
+    // class setters may omit that table probe only while this is false.
+    public bool UsesObjectIntegrityMutation { get; set; } = true;
     // A Date.prototype write makes statically typed Date method calls observable
     // through the prototype object, so the direct DateEmitter fast path is unsafe.
     public bool UsesDatePrototypeMutation { get; set; } = true;

--- a/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
@@ -96,6 +96,22 @@ public class RuntimeFeatureDetectorTests
     }
 
     [Theory]
+    [InlineData("const value = { x: 1 }; value.x = 2;", false)]
+    [InlineData("Object.freeze({ x: 1 });", true)]
+    [InlineData("const O = Object; O.seal({ x: 1 });", true)]
+    [InlineData("Reflect.preventExtensions({ x: 1 });", true)]
+    [InlineData("globalThis.Object.freeze({ x: 1 });", true)]
+    [InlineData("this.Object.freeze({ x: 1 });", true)]
+    [InlineData("eval('Object.freeze({ x: 1 })');", true)]
+    public void DetectsObjectIntegrityMutationRisk(string source, bool expected)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var features = new RuntimeFeatureDetector().Detect(statements);
+
+        Assert.Equal(expected, features.UsesObjectIntegrityMutation);
+    }
+
+    [Theory]
     [InlineData("Date.prototype.toString = Object.prototype.toString;", true)]
     [InlineData("Date.prototype['valueOf'] = function() { return 0; };", true)]
     [InlineData("Object.defineProperty(Date.prototype, 'x', { value: 1 });", true)]

--- a/tests/SharpTS.Tests/CompilerTests/StableClassFieldLoweringTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableClassFieldLoweringTests.cs
@@ -1,0 +1,161 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class StableClassFieldLoweringTests
+{
+    [Fact]
+    public void PrimitiveFieldReadWrite_StaysTypedAndSkipsIntegrityProbe()
+    {
+        Assembly assembly = Compile("""
+            class Counter {
+                value: number;
+                constructor(value: number) { this.value = value; }
+            }
+            function bump(counter: Counter, next: number): number {
+                counter.value = next;
+                return counter.value + 1;
+            }
+            """);
+
+        var instructions = ReadInstructions(FindFunction(assembly, "bump")).ToArray();
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "set_Value" });
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "get_Value" });
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.OpCode == OpCodes.Box && instruction.Operand == typeof(double));
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "TryGetValue" });
+    }
+
+    [Fact]
+    public void IntegrityMutationReference_RetainsFrozenObjectProbe()
+    {
+        Assembly assembly = Compile("""
+            class Counter {
+                value: number;
+                constructor(value: number) { this.value = value; }
+            }
+            function setValue(counter: Counter, next: number): number {
+                counter.value = next;
+                return counter.value;
+            }
+            const frozen = new Counter(1);
+            Object.freeze(frozen);
+            """);
+
+        Assert.Contains(ReadInstructions(FindFunction(assembly, "setValue")), instruction =>
+            instruction.Operand is MethodBase { Name: "TryGetValue" });
+    }
+
+    [Fact]
+    public void FrozenFieldWrite_PreservesAssignmentResultAndStoredValue()
+    {
+        const string source = """
+            class Counter {
+                value: number;
+                constructor(value: number) { this.value = value; }
+            }
+            const counter = new Counter(1);
+            Object.freeze(counter);
+            console.log(counter.value = 5, counter.value);
+            """;
+
+        Assert.Equal("5 1\n", TestHarness.RunCompiled(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    [Fact]
+    public void NumberBooleanAndStringFields_PassIlVerification()
+    {
+        const string source = """
+            class Values {
+                count: number = 1;
+                ready: boolean = false;
+                name: string = "a";
+            }
+            const values = new Values();
+            values.count = values.count + 1;
+            values.ready = true;
+            values.name = values.name + "b";
+            console.log(values.count, values.ready, values.name);
+            """;
+
+        Assert.Equal("2 true ab\n", TestHarness.RunCompiled(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"issue_1455_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token)
+                    : module.ResolveType(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}


### PR DESCRIPTION
## Summary

- keep exact `number`, `boolean`, and `string` class-field reads and writes in their native IL representation
- omit the frozen-object table probe when whole-program feature detection proves object-integrity mutation is unavailable
- retain the conservative boxed/probed path for uncertain values and programs that can reach `Object.freeze`, `Object.seal`, or `Object.preventExtensions`
- add permanent cross-runtime and BenchmarkDotNet workloads for field reuse, method reuse, and construction

## Results

Five alternated process runs at `n = 100,000` (median `meanMs`):

| Workload | Before | After | Change | Node | SharpTS / Node |
| --- | ---: | ---: | ---: | ---: | ---: |
| Direct field reuse | 2.4292 ms | 0.0545 ms | -97.8% | 0.0918 ms | 0.59x |
| Exact method reuse | 2.3662 ms | 0.4904 ms | -79.3% | 0.0998 ms | 4.91x |
| Construction | 2.7214 ms | 0.7627 ms | -72.0% | 0.3866 ms | 1.97x |

BenchmarkDotNet confirms the direct field loop no longer allocates per iteration: 179.83 us / 113 B for SharpTS versus 1.560 ms / 2,400,169 B for the boxed-equivalent C# baseline.

The separated workloads also identify the next costs cleanly: primitive class-method returns still box once per call, and construction still eagerly allocates dynamic field storage.

## Correctness boundary

- direct getters change only the tracked IL stack representation; consumers still box at actual object boundaries
- typed setters evaluate receiver and RHS once and preserve the assignment expression result
- any detected object-integrity mutation route retains the frozen-object lookup
- frozen writes remain no-ops while returning the RHS
- unknown or mismatched value types retain the existing boxed lowering

## Validation

- Release solution build, including IL verification: passed
- focused class-field, feature-detector, parity, and strict-mode tests: 144 passed
- 18-workload cross-runtime compile smoke: passed
- `git diff --check`: passed
- full-suite sandbox sample reached only pre-existing environment failures in HTTP/TLS/IPC tests (`HttpListenerException: The handle is invalid` and dependent timeouts); stopped after five minutes

Closes #1455
