### PR TITLE
Perf: add typed companions for stable primitive class methods

### DIFF
--- a/src/SharpTS/Compilation/CompilationContext.Classes.cs
+++ b/src/SharpTS/Compilation/CompilationContext.Classes.cs
@@ -25,6 +25,14 @@ public partial class CompilationContext
     public bool IsInstanceMethod { get; set; }
 
     /// <summary>
+    /// Primitive-returning non-virtual method companions keyed by qualified class
+    /// and JavaScript method name. Only analyzer-marked exact receiver calls may
+    /// bypass the public virtual object-returning method.
+    /// </summary>
+    public Dictionary<string, Dictionary<string, MethodBuilder>>?
+        TypedPrimitiveInstanceMethodCores { get; set; }
+
+    /// <summary>
     /// True when the current method body is an inner <c>function</c> declaration
     /// emitted onto a display class. In that case <see cref="IsInstanceMethod"/> is
     /// also true (arg0 is the display-class self — needed for capture access), but

--- a/src/SharpTS/Compilation/ILCompiler.Classes.Methods.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.Methods.cs
@@ -412,6 +412,7 @@ public partial class ILCompiler
         returnType = _types.Object;
         if (classStatement.Decorators is { Count: > 0 }
             || classStatement.TypeParams is { Count: > 0 }
+            || classStatement.Fields.Any(field => field.IsDeclare)
             || method.Body is not { Count: > 0 } body
             || method.IsStatic
             || method.IsPrivate

--- a/src/SharpTS/Compilation/ILCompiler.Classes.Methods.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.Methods.cs
@@ -1,6 +1,8 @@
 using System.Reflection;
 using System.Reflection.Emit;
 using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
 using TSTypeInfo = SharpTS.TypeSystem.TypeInfo;
 
 namespace SharpTS.Compilation;
@@ -221,6 +223,33 @@ public partial class ILCompiler
                 paramTypes
             );
 
+            if (TryResolveTypedPrimitiveMethodCoreReturnType(
+                    classStmt, method, out Type? coreReturnType))
+            {
+                int coreId = _classes.TypedPrimitiveMethodCoreBuilders.Count;
+                string coreName;
+                do
+                {
+                    coreName = $"$typed${method.Name.Lexeme}${coreId++}";
+                }
+                while (classStmt.Methods.Any(candidate =>
+                    candidate.Name.Lexeme == coreName));
+                var coreBuilder = typeBuilder.DefineMethod(
+                    coreName,
+                    MethodAttributes.Assembly | MethodAttributes.HideBySig,
+                    coreReturnType,
+                    paramTypes);
+                MarkCompilerGenerated(coreBuilder);
+                _classes.TypedPrimitiveMethodCoreBuilders[method] = coreBuilder;
+                if (!_classes.TypedPrimitiveInstanceMethodCores.TryGetValue(
+                        qualifiedClassName, out var classCores))
+                {
+                    classCores = [];
+                    _classes.TypedPrimitiveInstanceMethodCores[qualifiedClassName] = classCores;
+                }
+                classCores[method.Name.Lexeme] = coreBuilder;
+            }
+
             // Track instance method for direct dispatch
             if (!_classes.InstanceMethods.TryGetValue(qualifiedClassName, out var classMethods))
             {
@@ -373,6 +402,93 @@ public partial class ILCompiler
             // Create PropertyBuilders for explicit accessors
             CreateExplicitAccessorProperties(typeBuilder, className);
         }
+    }
+
+    private bool TryResolveTypedPrimitiveMethodCoreReturnType(
+        Stmt.Class classStatement,
+        Stmt.Function method,
+        out Type returnType)
+    {
+        returnType = _types.Object;
+        if (classStatement.Decorators is { Count: > 0 }
+            || classStatement.TypeParams is { Count: > 0 }
+            || method.Body is not { Count: > 0 } body
+            || method.IsStatic
+            || method.IsPrivate
+            || method.IsAbstract
+            || method.IsAsync
+            || method.IsGenerator
+            || method.ComputedKey is not null
+            || method.Decorators is { Count: > 0 }
+            || method.TypeParams is { Count: > 0 }
+            || method.HasDynamicThis
+            || method.Parameters.Any(parameter =>
+                parameter.DefaultValue is not null
+                || parameter.IsOptional
+                || parameter.IsRest
+                || parameter.Decorators is { Count: > 0 })
+            || body[^1] is not Stmt.Return { Value: not null }
+            || ReferencesArgumentsIdentifier(body)
+            || classStatement.Methods.Count(candidate =>
+                !candidate.IsStatic && candidate.Name.Lexeme == method.Name.Lexeme) != 1)
+        {
+            return false;
+        }
+
+        var classType = _typeMap?.GetClassType(classStatement.Name.Lexeme);
+        if (classType?.Methods.GetValueOrDefault(method.Name.Lexeme) is not { } methodType)
+            return false;
+        var functionType = methodType switch
+        {
+            TSTypeInfo.Function function => function,
+            TSTypeInfo.OverloadedFunction overload => overload.Implementation,
+            _ => null
+        };
+        if (functionType is null
+            || ReturnSlotAnalysis.BlockReturnsMayBeUndefined(body, _typeMap))
+            return false;
+
+        returnType = ParameterTypeResolver.ResolveReturnType(
+            functionType.ReturnType, isAsync: false, _typeMapper);
+        if (returnType != _types.Double && returnType != _types.Boolean)
+            return false;
+
+        var validator = new PrimitiveMethodReturnValidator(_typeMap, returnType == _types.Double);
+        foreach (var statement in body)
+            validator.Visit(statement);
+        return validator.IsValid && validator.SawReturn;
+    }
+
+    private sealed class PrimitiveMethodReturnValidator(TypeMap? typeMap, bool expectsNumber)
+        : AstVisitorBase
+    {
+        public bool IsValid { get; private set; } = true;
+        public bool SawReturn { get; private set; }
+
+        protected override void VisitReturn(Stmt.Return statement)
+        {
+            SawReturn = true;
+            if (statement.Value is null)
+            {
+                IsValid = false;
+                return;
+            }
+
+            TSTypeInfo? valueType = typeMap?.Get(statement.Value);
+            bool matches = expectsNumber
+                ? valueType is TSTypeInfo.Primitive { Type: TokenType.TYPE_NUMBER }
+                    or TSTypeInfo.NumberLiteral
+                : valueType is TSTypeInfo.Primitive { Type: TokenType.TYPE_BOOLEAN }
+                    or TSTypeInfo.BooleanLiteral;
+            if (!matches)
+                IsValid = false;
+        }
+
+        // Returns in nested callables/classes do not belong to this method.
+        protected override void VisitFunction(Stmt.Function statement) { }
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression) { }
+        protected override void VisitClass(Stmt.Class statement) { }
+        protected override void VisitClassExpr(Expr.ClassExpr expression) { }
     }
 
     /// <summary>
@@ -979,11 +1095,15 @@ public partial class ILCompiler
             return;
         }
 
+        _classes.TypedPrimitiveMethodCoreBuilders.TryGetValue(method, out var typedCoreBuilder);
+        MethodBuilder bodyBuilder = typedCoreBuilder ?? methodBuilder;
+
         // Check if method has @lock decorator
         bool hasLock = HasLockDecorator(method);
 
-        var il = methodBuilder.GetILGenerator();
-        var ctx = CreateModuleMemberContext(il, methodBuilder);
+        var il = bodyBuilder.GetILGenerator();
+        var ctx = CreateModuleMemberContext(il, bodyBuilder);
+        ctx.CurrentMethodReturnType = bodyBuilder.ReturnType;
         ctx.FieldsField = fieldsField;
         ctx.IsInstanceMethod = true;
         // Async arrow support (for async arrows inside non-async methods)
@@ -1015,7 +1135,7 @@ public partial class ILCompiler
         }
 
         // Define parameters with their types
-        var methodParams = methodBuilder.GetParameters();
+        var methodParams = bodyBuilder.GetParameters();
         for (int i = 0; i < method.Parameters.Count; i++)
         {
             // Instance methods have 'this' at index 0, so params start at index 1
@@ -1080,7 +1200,7 @@ public partial class ILCompiler
             ctx.ILBuilder.BeginExceptionBlock();
         }
 
-        var defaultParamTypes = methodBuilder.GetParameters().Select(p => p.ParameterType).ToArray();
+        var defaultParamTypes = bodyBuilder.GetParameters().Select(p => p.ParameterType).ToArray();
         EmitFunctionEnvironmentPrologue(
             il,
             ctx,
@@ -1090,7 +1210,7 @@ public partial class ILCompiler
             defaultParamTypes,
             argumentOffset: 1);
         InitializeSyncMethodCapturedParameters(
-            ctx, il, method, methodBuilder, argumentOffset: 1);
+            ctx, il, method, bodyBuilder, argumentOffset: 1);
 
         // Abstract methods have no body to emit
         if (method.Body != null)
@@ -1163,9 +1283,26 @@ public partial class ILCompiler
             // Falling off the end completes with `undefined` (ECMA-262). Route through
             // EmitDefaultReturnValue so an `object` slot materializes the `$Undefined`
             // sentinel instead of CLR null. (#588)
-            EmitDefaultReturnValue(il, methodBuilder.ReturnType);
+            EmitDefaultReturnValue(il, bodyBuilder.ReturnType);
             il.Emit(OpCodes.Ret);
         }
 
+        if (typedCoreBuilder is not null)
+            EmitTypedPrimitiveMethodWrapper(methodBuilder, typedCoreBuilder);
+
+    }
+
+    private void EmitTypedPrimitiveMethodWrapper(
+        MethodBuilder wrapper,
+        MethodBuilder core)
+    {
+        var il = wrapper.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        var parameters = core.GetParameters();
+        for (int i = 0; i < parameters.Length; i++)
+            il.Emit(OpCodes.Ldarg, i + 1);
+        il.Emit(OpCodes.Call, core);
+        il.Emit(OpCodes.Box, core.ReturnType);
+        il.Emit(OpCodes.Ret);
     }
 }

--- a/src/SharpTS/Compilation/ILCompiler.ContextFactories.cs
+++ b/src/SharpTS/Compilation/ILCompiler.ContextFactories.cs
@@ -55,6 +55,10 @@ public partial class ILCompiler
             FunctionNames = _functions.Names,
             FunctionsCapturingArguments = _functions.CapturingArguments,
             MethodsCapturingArguments = _functions.MethodsCapturingArguments,
+            TypedPrimitiveInstanceMethodCores =
+                _classes.TypedPrimitiveInstanceMethodCores.Count > 0
+                    ? _classes.TypedPrimitiveInstanceMethodCores
+                    : null,
             FunctionGenericParams = _functions.GenericParams,
             IsGenericFunction = _functions.IsGeneric,
             SuspensionFreePrimitiveAsyncCores =

--- a/src/SharpTS/Compilation/ILCompiler.State.cs
+++ b/src/SharpTS/Compilation/ILCompiler.State.cs
@@ -50,6 +50,13 @@ public partial class ILCompiler
         public Dictionary<string, Dictionary<string, FieldBuilder>> StaticFields { get; } = [];
         public Dictionary<string, Dictionary<string, MethodBuilder>> StaticMethods { get; } = [];
         public Dictionary<string, Dictionary<string, MethodBuilder>> InstanceMethods { get; } = [];
+        /// <summary>
+        /// Assembly-internal primitive-returning companions for eligible public
+        /// instance methods. The public method remains the virtual object ABI.
+        /// </summary>
+        public Dictionary<string, Dictionary<string, MethodBuilder>> TypedPrimitiveInstanceMethodCores { get; } = [];
+        public Dictionary<Stmt.Function, MethodBuilder> TypedPrimitiveMethodCoreBuilders { get; } =
+            new(ReferenceEqualityComparer.Instance);
         public Dictionary<string, Dictionary<string, MethodBuilder>> InstanceGetters { get; } = [];
         public Dictionary<string, Dictionary<string, MethodBuilder>> InstanceSetters { get; } = [];
         public Dictionary<string, Dictionary<string, MethodBuilder>> StaticGetters { get; } = [];

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -655,6 +655,7 @@ public partial class ILCompiler
             statements, _typeMap, _closures.Analyzer);
         StablePrimitivePromiseAllAnalyzer.Analyze(
             statements, _typeMap, _closures.Analyzer, _features);
+        StableExactClassMethodCallAnalyzer.Analyze(statements, _typeMap, _features);
         ArrayLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         StringAccumulatorPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         NonEscapingArrowLocalAnalyzer.Analyze(

--- a/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -176,7 +176,7 @@ public partial class ILEmitter
         // Try direct dispatch for known class instance methods
         TypeSystem.TypeInfo? objType = _ctx.TypeMap?.Get(methodGet.Object);
         if (TryEmitDirectMethodCall(
-                methodGet.Object, objType, methodName, arguments,
+                methodGet, methodGet.Object, objType, methodName, arguments,
                 genericTypeArguments, contextualResultType))
             return;
 
@@ -416,7 +416,8 @@ public partial class ILEmitter
     /// Try to emit a direct method call for known class instance types.
     /// Returns true if direct dispatch was emitted, false to fall back to runtime dispatch.
     /// </summary>
-    private bool TryEmitDirectMethodCall(Expr receiver, TypeSystem.TypeInfo? receiverType,
+    private bool TryEmitDirectMethodCall(Expr.Get methodGet, Expr receiver,
+        TypeSystem.TypeInfo? receiverType,
         string methodName, List<Expr> arguments, List<string>? genericTypeArguments,
         TypeSystem.TypeInfo? contextualResultType)
     {
@@ -472,6 +473,14 @@ public partial class ILEmitter
         if (methodBuilder == null)
             return false;
 
+        MethodBuilder dispatchBuilder = methodBuilder;
+        MethodBuilder? typedCore = null;
+        bool useTypedCore = _ctx.TypeMap?.IsStableExactPrimitiveMethodCall(methodGet) == true
+            && _ctx.TypedPrimitiveInstanceMethodCores?.TryGetValue(className, out var classCores) == true
+            && classCores.TryGetValue(methodName, out typedCore);
+        if (useTypedCore)
+            dispatchBuilder = typedCore!;
+
         // Get the class type builder to cast the receiver
         if (!_ctx.Classes.TryGetValue(className, out var classType))
             return false;
@@ -479,11 +488,11 @@ public partial class ILEmitter
         // Generic classes need instantiated tokens (Stack<!T>), only expressible inside
         // the class's own bodies; otherwise fall back to runtime dispatch (#178)
         if (!EmitterTypeHelpers.TryResolveInstanceDispatch(
-                classType, methodBuilder, _ctx.EmittingTypeBuilder, out var castType, out var callTarget))
+                classType, dispatchBuilder, _ctx.EmittingTypeBuilder, out var castType, out var callTarget))
             return false;
 
         // Get target parameter types for proper conversion
-        var targetParams = methodBuilder.GetParameters();
+        var targetParams = dispatchBuilder.GetParameters();
         int expectedParamCount = targetParams.Length;
 
         // Detect rest parameter: the ParameterTypeResolver compiles rest params to a
@@ -611,9 +620,13 @@ public partial class ILEmitter
             }
         }
 
-        // Emit the virtual call
-        IL.Emit(OpCodes.Callvirt, callTarget);
-        SetStackUnknown();
+        IL.Emit(useTypedCore ? OpCodes.Call : OpCodes.Callvirt, callTarget);
+        if (useTypedCore && _ctx.Types.IsDouble(dispatchBuilder.ReturnType))
+            SetStackType(StackType.Double);
+        else if (useTypedCore && _ctx.Types.IsBoolean(dispatchBuilder.ReturnType))
+            SetStackType(StackType.Boolean);
+        else
+            SetStackUnknown();
         return true;
     }
 

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -88,6 +88,7 @@ public sealed class RuntimeFeatureDetector
             UsesSet = false,
             UsesDynamicPropertyDescriptors = false,
             UsesObjectIntegrityMutation = false,
+            UsesClassPrototypeMutation = false,
             UsesDatePrototypeMutation = false,
             UsesPromisePrototypeMutation = false,
             UsesArrayPrototypeMutation = false,
@@ -776,6 +777,8 @@ public sealed class RuntimeFeatureDetector
             case Expr.Get g:
                 if (g.Name.Lexeme is "Object" or "Reflect")
                     _set.UsesObjectIntegrityMutation = true;
+                if (g.Name.Lexeme is "prototype" or "__proto__")
+                    _set.UsesClassPrototypeMutation = true;
                 if (IsArrayPrototype(g) || g.Name.Lexeme == "__proto__")
                     _set.UsesArrayPrototypeMutation = true;
                 if (IsPromisePrototype(g))
@@ -848,6 +851,8 @@ public sealed class RuntimeFeatureDetector
 
             case Expr.Set s:
                 MarkMutationTarget(s.Object);
+                if (CouldTargetClassMethod(s.Object, s.Name.Lexeme))
+                    _set.UsesClassPrototypeMutation = true;
                 if (IsDatePrototype(s.Object))
                     _set.UsesDatePrototypeMutation = true;
                 if (IsPromiseMutationTarget(s.Object)
@@ -888,6 +893,10 @@ public sealed class RuntimeFeatureDetector
                 break;
             case Expr.SetIndex si:
                 MarkMutationTarget(si.Object);
+                if (si.Index is Expr.Literal { Value: string methodName }
+                        ? CouldTargetClassMethod(si.Object, methodName)
+                        : IsClassInstance(si.Object))
+                    _set.UsesClassPrototypeMutation = true;
                 if (IsDatePrototype(si.Object))
                     _set.UsesDatePrototypeMutation = true;
                 if (IsPromiseMutationTarget(si.Object)
@@ -1327,6 +1336,18 @@ public sealed class RuntimeFeatureDetector
         Object: Expr.Variable { Name.Lexeme: "Date" },
         Name.Lexeme: "prototype"
     };
+
+    private bool CouldTargetClassMethod(Expr receiver, string methodName) =>
+        _typeMap?.Get(receiver) is TypeInfo.Instance instance
+        && instance.ResolvedClassType switch
+        {
+            TypeInfo.Class c => c.Methods.ContainsKey(methodName),
+            TypeInfo.MutableClass c => c.Methods.ContainsKey(methodName),
+            _ => false
+        };
+
+    private bool IsClassInstance(Expr receiver) =>
+        _typeMap?.Get(receiver) is TypeInfo.Instance;
 
     private static bool IsPromisePrototype(Expr expr) => expr is Expr.Get
     {

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -139,6 +139,10 @@ public sealed class RuntimeFeatureSet
     // can populate the emitted runtime's object-integrity tables. Direct typed
     // class setters may omit that table probe only while this is false.
     public bool UsesObjectIntegrityMutation { get; set; } = true;
+    // Any observable access to a class prototype (or an opaque Object/eval/
+    // Function route checked alongside this flag) can replace a method binding.
+    // Exact-instance typed companion calls require this to remain false.
+    public bool UsesClassPrototypeMutation { get; set; } = true;
     // A Date.prototype write makes statically typed Date method calls observable
     // through the prototype object, so the direct DateEmitter fast path is unsafe.
     public bool UsesDatePrototypeMutation { get; set; } = true;

--- a/src/SharpTS/Compilation/StableExactClassMethodCallAnalyzer.cs
+++ b/src/SharpTS/Compilation/StableExactClassMethodCallAnalyzer.cs
@@ -1,0 +1,193 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Records deliberately narrow exact-instance method calls. A local candidate must
+/// be a uniquely declared <c>const</c> initialized directly with <c>new C(...)</c> in
+/// the same function/arrow scope as the call, and its static receiver type must still
+/// be that same class. Nested functions get independent scopes, so captured aliases
+/// and shadowed names stay on the public virtual method path.
+/// </summary>
+internal static class StableExactClassMethodCallAnalyzer
+{
+    public static void Analyze(
+        List<Stmt> program,
+        TypeMap? typeMap,
+        RuntimeFeatureSet? features)
+    {
+        if (typeMap is null
+            || features?.UsesDynamicPropertyDescriptors != false
+            || features.UsesObjectIntegrityMutation
+            || features.UsesClassPrototypeMutation)
+            return;
+
+        var visitor = new Visitor(typeMap);
+        foreach (var statement in program)
+            visitor.Visit(statement);
+
+        foreach (var (key, candidateClassName) in visitor.Candidates)
+        {
+            if (visitor.DeclarationCounts.GetValueOrDefault(key) != 1
+                || visitor.DisqualifiedCandidates.Contains(key)
+                || !visitor.Calls.TryGetValue(key, out var calls))
+                continue;
+
+            foreach (var method in calls)
+            {
+                if (TryGetInstanceClassName(typeMap.Get(method.Object), out string? receiverClass)
+                    && receiverClass == candidateClassName)
+                    typeMap.MarkStableExactPrimitiveMethodCall(method);
+            }
+        }
+
+        foreach (var method in visitor.ImmediateCalls)
+            typeMap.MarkStableExactPrimitiveMethodCall(method);
+    }
+
+    private static bool TryGetInstanceClassName(TypeInfo? type, out string? className)
+    {
+        className = type is TypeInfo.Instance instance
+            ? instance.ResolvedClassType switch
+            {
+                TypeInfo.Class c => c.Name,
+                TypeInfo.MutableClass c => c.Name,
+                _ => null
+            }
+            : null;
+        return className is not null;
+    }
+
+    private sealed class Visitor(TypeMap typeMap) : AstVisitorBase
+    {
+        private readonly TypeMap _typeMap = typeMap;
+        private int _scope;
+        private int _nextScope;
+        private readonly Dictionary<int, int> _scopeParents = [];
+
+        public Dictionary<(int Scope, string Name), string> Candidates { get; } = [];
+        public Dictionary<(int Scope, string Name), int> DeclarationCounts { get; } = [];
+        public Dictionary<(int Scope, string Name), List<Expr.Get>> Calls { get; } = [];
+        public HashSet<(int Scope, string Name)> DisqualifiedCandidates { get; } = [];
+        public HashSet<Expr.Get> ImmediateCalls { get; } = new(ReferenceEqualityComparer.Instance);
+
+        protected override void VisitFunction(Stmt.Function statement) =>
+            InScope(() => base.VisitFunction(statement));
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression) =>
+            InScope(() => base.VisitArrowFunction(expression));
+
+        private void InScope(Action visit)
+        {
+            int saved = _scope;
+            _scope = ++_nextScope;
+            _scopeParents[_scope] = saved;
+            visit();
+            _scope = saved;
+        }
+
+        protected override void VisitVar(Stmt.Var statement)
+        {
+            RecordDeclaration(statement.Name);
+            if (statement.Initializer is not null)
+                Visit(statement.Initializer);
+        }
+
+        protected override void VisitConst(Stmt.Const statement)
+        {
+            var key = RecordDeclaration(statement.Name);
+            if (TryGetDirectNewClass(statement.Initializer, out string? className)
+                && TryGetInstanceClassName(_typeMap.Get(statement.Initializer), out string? resolved)
+                && resolved == className)
+                Candidates[key] = className!;
+            Visit(statement.Initializer);
+        }
+
+        protected override void VisitTryCatch(Stmt.TryCatch statement)
+        {
+            // A catch binding has block scope. Treating it as a same-function
+            // redeclaration is deliberately more conservative: an outer exact
+            // candidate with the same name is then never selected inside the catch.
+            if (statement.CatchParam is not null)
+                RecordDeclaration(statement.CatchParam);
+            base.VisitTryCatch(statement);
+        }
+
+        private (int Scope, string Name) RecordDeclaration(Token name)
+        {
+            var key = (_scope, name.Lexeme);
+            DeclarationCounts[key] = DeclarationCounts.GetValueOrDefault(key) + 1;
+            return key;
+        }
+
+        protected override void VisitCall(Expr.Call expression)
+        {
+            if (!expression.Optional && expression.Callee is Expr.Get { Optional: false } method)
+            {
+                if (method.Object is Expr.Variable receiver)
+                {
+                    var key = (_scope, receiver.Name.Lexeme);
+                    RecordAncestorUse(receiver.Name.Lexeme);
+                    if (!Calls.TryGetValue(key, out var calls))
+                        Calls[key] = calls = [];
+                    calls.Add(method);
+                    foreach (var argument in expression.Arguments)
+                        Visit(argument);
+                    return;
+                }
+
+                if (TryGetDirectNewClass(method.Object, out string? newClass)
+                    && TryGetInstanceClassName(_typeMap.Get(method.Object), out string? receiverClass)
+                    && receiverClass == newClass)
+                    ImmediateCalls.Add(method);
+            }
+
+            base.VisitCall(expression);
+        }
+
+        protected override void VisitVariable(Expr.Variable expression)
+        {
+            DisqualifiedCandidates.Add((_scope, expression.Name.Lexeme));
+            RecordAncestorUse(expression.Name.Lexeme);
+        }
+
+        private void RecordAncestorUse(string name)
+        {
+            int scope = _scope;
+            while (_scopeParents.TryGetValue(scope, out int parent))
+            {
+                DisqualifiedCandidates.Add((parent, name));
+                scope = parent;
+            }
+        }
+
+        private static bool TryGetDirectNewClass(Expr expression, out string? className)
+        {
+            expression = Unwrap(expression);
+            className = expression is Expr.New { Callee: Expr.Variable variable }
+                ? variable.Name.Lexeme
+                : null;
+            return className is not null;
+        }
+
+        private static Expr Unwrap(Expr expression)
+        {
+            while (true)
+            {
+                expression = expression switch
+                {
+                    Expr.Grouping grouping => grouping.Expression,
+                    Expr.TypeAssertion assertion => assertion.Expression,
+                    Expr.Satisfies satisfies => satisfies.Expression,
+                    Expr.NonNullAssertion nonNull => nonNull.Expression,
+                    _ => expression
+                };
+                if (expression is not (Expr.Grouping or Expr.TypeAssertion
+                    or Expr.Satisfies or Expr.NonNullAssertion))
+                    return expression;
+            }
+        }
+    }
+}

--- a/src/SharpTS/TypeSystem/TypeMap.cs
+++ b/src/SharpTS/TypeSystem/TypeMap.cs
@@ -25,6 +25,7 @@ public class TypeMap
     private readonly Dictionary<Token, ObjectShapeInfo> _promotableObjectLocals = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Stmt.ForOf> _stableNumericMapIterations = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.Get> _stablePrimitivePromiseThenCalls = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Expr.Get> _stableExactPrimitiveMethodCalls = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr> _stablePrimitivePromiseAllIterables = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.ArrayLiteral> _stablePrimitivePromiseAllInputInitializers = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.Variable> _stablePrimitivePromiseAllPushReceivers = new(ReferenceEqualityComparer.Instance);
@@ -225,6 +226,18 @@ public class TypeMap
     /// </summary>
     public bool IsStablePrimitivePromiseThen(Expr.Get method) =>
         _stablePrimitivePromiseThenCalls.Contains(method);
+
+    /// <summary>
+    /// Marks a class method access whose receiver is provably the exact instance
+    /// created for a stable local binding (or an immediate <c>new C().m()</c>).
+    /// The compiler may target a private typed method companion without changing
+    /// the public virtual method ABI used by uncertain and value-backed calls.
+    /// </summary>
+    public void MarkStableExactPrimitiveMethodCall(Expr.Get method) =>
+        _stableExactPrimitiveMethodCalls.Add(method);
+
+    public bool IsStableExactPrimitiveMethodCall(Expr.Get method) =>
+        _stableExactPrimitiveMethodCalls.Contains(method);
 
     /// <summary>
     /// Marks the exact iterable expression of a proven fresh, non-escaping

--- a/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
@@ -112,6 +112,20 @@ public class RuntimeFeatureDetectorTests
     }
 
     [Theory]
+    [InlineData("class Counter { step(): number { return 1; } } new Counter().step();", false)]
+    [InlineData("class Counter { step(): number { return 1; } } const p = Counter.prototype;", true)]
+    [InlineData("class Counter { step(): number { return 1; } } const c = new Counter(); c.step = () => 2;", true)]
+    [InlineData("const value = ({} as any).__proto__;", true)]
+    public void DetectsClassPrototypeMutationRisk(string source, bool expected)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var features = new RuntimeFeatureDetector().Detect(statements, typeMap);
+
+        Assert.Equal(expected, features.UsesClassPrototypeMutation);
+    }
+
+    [Theory]
     [InlineData("Date.prototype.toString = Object.prototype.toString;", true)]
     [InlineData("Date.prototype['valueOf'] = function() { return 0; };", true)]
     [InlineData("Object.defineProperty(Date.prototype, 'x', { value: 1 });", true)]

--- a/tests/SharpTS.Tests/CompilerTests/StablePrimitiveClassMethodTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StablePrimitiveClassMethodTests.cs
@@ -1,0 +1,287 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class StablePrimitiveClassMethodTests
+{
+    [Fact]
+    public void ExactConstReceiver_UsesTypedCoreWhilePublicMethodKeepsObjectAbi()
+    {
+        Assembly assembly = Compile("""
+            class Counter {
+                value: number;
+                constructor(value: number) { this.value = value; }
+                step(): number {
+                    this.value = this.value + 1;
+                    return this.value;
+                }
+            }
+            function exact(n: number): number {
+                const counter = new Counter(0);
+                let sum: number = 0;
+                for (let i: number = 0; i < n; i++) sum = sum + counter.step();
+                return sum;
+            }
+            function uncertain(counter: Counter): number {
+                return counter.step();
+            }
+            """);
+
+        Type counterType = assembly.GetType("Counter")!;
+        MethodInfo core = Assert.Single(counterType.GetMethods(
+            BindingFlags.Instance | BindingFlags.NonPublic),
+            method => method.Name.StartsWith("$typed$step$", StringComparison.Ordinal));
+        MethodInfo wrapper = counterType.GetMethod("step")!;
+        Assert.Equal(typeof(double), core.ReturnType);
+        Assert.Equal(typeof(object), wrapper.ReturnType);
+
+        var exact = ReadInstructions(FindFunction(assembly, "exact")).ToArray();
+        Assert.Contains(exact, instruction =>
+            instruction.Operand is MethodBase method && method.Name == core.Name);
+        Assert.DoesNotContain(exact, instruction =>
+            instruction.OpCode == OpCodes.Box && instruction.Operand == typeof(double));
+
+        var uncertain = ReadInstructions(FindFunction(assembly, "uncertain")).ToArray();
+        Assert.Contains(uncertain, instruction =>
+            instruction.Operand is MethodInfo { Name: "step" } method
+            && method.ReturnType == typeof(object));
+
+        var wrapperIl = ReadInstructions(wrapper).ToArray();
+        Assert.Contains(wrapperIl, instruction =>
+            instruction.Operand is MethodBase method && method.Name == core.Name);
+        Assert.Contains(wrapperIl, instruction =>
+            instruction.OpCode == OpCodes.Box && instruction.Operand == typeof(double));
+    }
+
+    [Fact]
+    public void ImmediateNewAndBooleanResult_UseTypedCores()
+    {
+        Assembly assembly = Compile("""
+            class Probe {
+                positive(value: number): boolean { return value > 0; }
+                value(): number { return 7; }
+            }
+            function numberResult(): number { return new Probe().value(); }
+            function booleanResult(): boolean {
+                const probe = new Probe();
+                return probe.positive(1);
+            }
+            """);
+
+        Assert.Contains(ReadInstructions(FindFunction(assembly, "numberResult")), instruction =>
+            instruction.Operand is MethodInfo method
+            && method.Name.StartsWith("$typed$value$", StringComparison.Ordinal)
+            && method.ReturnType == typeof(double));
+        Assert.Contains(ReadInstructions(FindFunction(assembly, "booleanResult")), instruction =>
+            instruction.Operand is MethodInfo method
+            && method.Name.StartsWith("$typed$positive$", StringComparison.Ordinal)
+            && method.ReturnType == typeof(bool));
+    }
+
+    [Fact]
+    public void MutableAndArgumentsSensitiveMethods_RetainPublicWrapperPath()
+    {
+        Assembly assembly = Compile("""
+            class Counter {
+                step(): number { return 1; }
+                withDefault(value: number = 1): number { return value; }
+                countArgs(): number { return arguments.length; }
+            }
+            function mutable(): number {
+                let counter = new Counter();
+                return counter.step();
+            }
+            """);
+
+        Type counterType = assembly.GetType("Counter")!;
+        Assert.DoesNotContain(counterType.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic),
+            method => method.Name.Contains("withDefault", StringComparison.Ordinal)
+                || method.Name.Contains("countArgs", StringComparison.Ordinal));
+        Assert.Contains(ReadInstructions(FindFunction(assembly, "mutable")), instruction =>
+            instruction.Operand is MethodInfo { Name: "step" } method
+            && method.ReturnType == typeof(object));
+    }
+
+    [Fact]
+    public void CatchShadowAndSyntheticNameCollision_StayConservative()
+    {
+        Assembly assembly = Compile("""
+            class Counter {
+                step(): number { return 1; }
+                $typed$step$0(): number { return 99; }
+            }
+            function shadowed(): number {
+                const counter = new Counter();
+                try { throw counter; }
+                catch (counter: unknown) { }
+                return counter.step();
+            }
+            function exact(): number {
+                const counter = new Counter();
+                return counter.step();
+            }
+            """);
+
+        Type counterType = assembly.GetType("Counter")!;
+        MethodInfo core = Assert.Single(counterType.GetMethods(
+            BindingFlags.Instance | BindingFlags.NonPublic),
+            method => method.Name.StartsWith("$typed$step$", StringComparison.Ordinal));
+        Assert.NotEqual("$typed$step$0", core.Name);
+
+        Assert.Contains(ReadInstructions(FindFunction(assembly, "shadowed")), instruction =>
+            instruction.Operand is MethodInfo { Name: "step", ReturnType: not null } method
+            && method.ReturnType == typeof(object));
+        Assert.Contains(ReadInstructions(FindFunction(assembly, "exact")), instruction =>
+            instruction.Operand is MethodBase method && method.Name == core.Name);
+    }
+
+    [Fact]
+    public void EscapedCapturedAndPrototypeObservableReceivers_RetainWrapperPath()
+    {
+        Assembly escapedAssembly = Compile("""
+            class Counter { step(): number { return 1; } }
+            function escape(value: Counter): void { }
+            function escaped(): number {
+                const counter = new Counter();
+                escape(counter);
+                return counter.step();
+            }
+            function captured(): number {
+                const counter = new Counter();
+                const read = (): number => counter.step();
+                return counter.step();
+            }
+            """);
+
+        Assert.Contains(ReadInstructions(FindFunction(escapedAssembly, "escaped")), instruction =>
+            instruction.Operand is MethodInfo { Name: "step" } method
+            && method.ReturnType == typeof(object));
+        Assert.Contains(ReadInstructions(FindFunction(escapedAssembly, "captured")), instruction =>
+            instruction.Operand is MethodInfo { Name: "step" } method
+            && method.ReturnType == typeof(object));
+
+        Assembly prototypeAssembly = Compile("""
+            class Counter { step(): number { return 1; } }
+            const observed = Counter.prototype;
+            function exact(): number {
+                const counter = new Counter();
+                return counter.step();
+            }
+            """);
+        Assert.Contains(ReadInstructions(FindFunction(prototypeAssembly, "exact")), instruction =>
+            instruction.Operand is MethodInfo { Name: "step" } method
+            && method.ReturnType == typeof(object));
+    }
+
+    [Fact]
+    public void VirtualOverridesAndExtractedMethods_PreserveBehavior()
+    {
+        const string source = """
+            class Base {
+                step(): number { return 1; }
+            }
+            class Derived extends Base {
+                step(): number { return 2; }
+            }
+            function invoke(value: Base): number { return value.step(); }
+            const derived = new Derived();
+            const extracted = derived.step.bind(derived);
+            console.log(invoke(derived), derived.step(), extracted());
+            """;
+
+        Assert.Equal("2 2 2\n", TestHarness.RunCompiled(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    [Fact]
+    public void NumberAndBooleanTypedCompanions_PassIlVerification()
+    {
+        const string source = """
+            class Values {
+                next(value: number): number { return value + 1; }
+                ready(value: number): boolean { return value > 0; }
+            }
+            function run(): number {
+                const values = new Values();
+                return values.ready(1) ? values.next(2) : 0;
+            }
+            console.log(run());
+            """;
+
+        Assert.Equal("3\n", TestHarness.RunCompiled(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"issue_1457_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token)
+                    : module.ResolveType(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}

--- a/tests/SharpTS.Tests/CompilerTests/StablePrimitiveClassMethodTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StablePrimitiveClassMethodTests.cs
@@ -180,6 +180,28 @@ public sealed class StablePrimitiveClassMethodTests
     }
 
     [Fact]
+    public void DeclaredPrimitiveField_PreservesAbsentValueThroughObjectWrapper()
+    {
+        const string source = """
+            class Model {
+                declare private value: number;
+                getValue(): number { return this.value; }
+            }
+            const model = new Model();
+            console.log(model.getValue());
+            """;
+
+        Assert.Equal("null\n", TestHarness.RunCompiled(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+
+        Assembly assembly = Compile(source);
+        Type modelType = assembly.GetType("Model")!;
+        Assert.DoesNotContain(modelType.GetMethods(BindingFlags.Instance | BindingFlags.NonPublic),
+            method => method.Name.StartsWith("$typed$getValue$", StringComparison.Ordinal));
+        Assert.Equal(typeof(object), modelType.GetMethod("getValue")!.ReturnType);
+    }
+
+    [Fact]
     public void VirtualOverridesAndExtractedMethods_PreserveBehavior()
     {
         const string source = """


### PR DESCRIPTION
Closes #1457.

## What changed

- emit an assembly-internal `double`/`bool` companion for eligible synchronous primitive-returning instance methods
- keep the public virtual object-returning method as the JavaScript/reflection/override ABI, forwarding to and boxing the companion result
- call the companion only for a unique exact `const x = new C(...)` receiver or immediate `new C().m()` shape
- reject aliases, escapes, captures, shadowing, mutable bindings, optional/default/rest parameters, `arguments`, decorators, generics, computed/private/async/generator methods, partial primitive returns, and uncertain/base-typed receivers
- retain the public wrapper whenever descriptors, `Object`, `eval`, `Function`, method reassignment, or class-prototype observation can make lookup observable

## Results

N=100,000, five independently launched paired runs:

| Runtime | Median |
|---|---:|
| SharpTS compiled | **0.0526 ms** |
| Node 24.19.0 | **0.0973 ms** |

The compiled result is 89.3% below the 0.4904 ms baseline and is now 0.54x Node.

BenchmarkDotNet ShortRun:

| Method | Mean | Allocated |
|---|---:|---:|
| Idiomatic C# | 168.6 us | 25 B |
| SharpTS | **307.8 us** | **114 B** |
| Boxed-equivalent C# | 1,381.5 us | 2,400,167 B |

The selected IL calls the primitive-returning companion directly and contains no result boxing; the public wrapper still boxes at observable boundaries.

## Validation

- Release solution build: green; standalone IL verification passed
- focused class/method/feature regression slice: 295/295 passed
- compiler test slice: 677 passed; three environment-only standalone failures (local TLS authentication and two child-process timeout classifications after the expected error was printed)
- focused BenchmarkDotNet and five paired cross-runtime launches completed successfully