### PR TITLE
Perf: lazily allocate dynamic class storage

### DIFF
--- a/src/SharpTS/Compilation/ILCompiler.Classes.ClassExpressions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.ClassExpressions.cs
@@ -486,7 +486,7 @@ public partial class ILCompiler
         var fieldsField = _classes.InstanceFieldsField[className];
 
         // Emit the constructor-free prototype path before the .cctor that uses it.
-        EmitClassPrototypeConstructor(typeBuilder, fieldsField);
+        EmitClassPrototypeConstructor(typeBuilder);
 
         // Emit static constructor and prototype registration.
         EmitClassExpressionStaticConstructor(classExpr, typeBuilder);
@@ -683,10 +683,10 @@ public partial class ILCompiler
                 ctx.GenericTypeParameters[gp.Name] = gp;
         }
 
-        // Initialize _fields dictionary FIRST
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Newobj, _types.DictionaryStringObjectCtor);
-        il.Emit(OpCodes.Stfld, fieldsField);
+        // Dynamic property storage is materialized only by the first expando write.
+        // This is also safe for base-constructor virtual dispatch because SetProperty
+        // calls the derived type's ensure helper before touching its private field.
+        var ensureFields = _classes.HasFieldsStubs[className].EnsureFields;
 
         // Emit constructor body first if present (contains super() call)
         var emitter = new ILEmitter(ctx);
@@ -838,7 +838,7 @@ public partial class ILCompiler
                 {
                     // Fallback to _fields dictionary
                     il.Emit(OpCodes.Ldarg_0);
-                    il.Emit(OpCodes.Ldfld, fieldsField);
+                    il.Emit(OpCodes.Call, EmitterTypeHelpers.SelfMethodReference(ensureFields));
                     il.Emit(OpCodes.Ldstr, fieldName);
                     emitter.EmitExpression(field.Initializer!);
                     emitter.EmitBoxIfNeeded(field.Initializer!);
@@ -854,7 +854,7 @@ public partial class ILCompiler
                 string fieldName = field.Name.Lexeme;
                 // Store null in _fields dictionary
                 il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Ldfld, fieldsField);
+                il.Emit(OpCodes.Call, EmitterTypeHelpers.SelfMethodReference(ensureFields));
                 il.Emit(OpCodes.Ldstr, fieldName);
                 il.Emit(OpCodes.Ldnull);
                 il.Emit(OpCodes.Callvirt, _types.DictionaryStringObjectSetItem);

--- a/src/SharpTS/Compilation/ILCompiler.Classes.Constructors.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.Constructors.cs
@@ -96,11 +96,10 @@ public partial class ILCompiler
                 ctx.GenericTypeParameters[gp.Name] = gp;
         }
 
-        // Initialize _extras dictionary FIRST (before calling parent constructor)
-        // This allows parent constructor to access fields via SetFieldsProperty
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Newobj, _types.DictionaryStringObjectCtor);
-        il.Emit(OpCodes.Stfld, fieldsField);
+        // Dynamic property storage stays absent until a write needs it. Generated
+        // SetProperty overrides use $EnsureFields, including when a base constructor
+        // dispatches through the derived override before this constructor resumes.
+        var ensureFields = _classes.HasFieldsStubs[className].EnsureFields;
 
         // Initialize @lock decorator fields if present
         if (_locks.SyncLockFields.TryGetValue(className, out var syncLockField))
@@ -319,7 +318,7 @@ public partial class ILCompiler
                 {
                     // Fallback: store in _extras dictionary (for fields without backing fields)
                     il.Emit(OpCodes.Ldarg_0);
-                    il.Emit(OpCodes.Ldfld, fieldsField);
+                    il.Emit(OpCodes.Call, EmitterTypeHelpers.SelfMethodReference(ensureFields));
                     il.Emit(OpCodes.Ldstr, fieldName);
                     // number[] unboxing: an `arr: number[] = []` field is created as a numeric $Array
                     // (escaping by nature — a field is aliasable), so `this.arr[i]=v` writes unboxed.
@@ -342,7 +341,7 @@ public partial class ILCompiler
             string fieldName = field.Name.Lexeme;
             // Store null in _extras dictionary
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Ldfld, fieldsField);
+            il.Emit(OpCodes.Call, EmitterTypeHelpers.SelfMethodReference(ensureFields));
             il.Emit(OpCodes.Ldstr, fieldName);
             il.Emit(OpCodes.Ldnull);
             il.Emit(OpCodes.Callvirt, _types.DictionaryStringObjectSetItem);

--- a/src/SharpTS/Compilation/ILCompiler.Classes.HasFields.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.HasFields.cs
@@ -15,6 +15,20 @@ public partial class ILCompiler
     {
         var methodAttrs = MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig;
 
+        // The expando dictionary is deliberately absent from a newly constructed instance.
+        // JavaScript cannot observe the backing store itself, so allocate it only when a
+        // dynamic own property is actually created or the compatibility Fields surface is
+        // requested. Keeping this helper on the emitted type also makes base-constructor
+        // virtual dispatch safe: an override can materialize its own store before the
+        // derived constructor has resumed after super().
+        var ensureFields = typeBuilder.DefineMethod(
+            "$EnsureFields",
+            MethodAttributes.Private | MethodAttributes.HideBySig,
+            _types.DictionaryStringObject,
+            Type.EmptyTypes
+        );
+        EmitEnsureFieldsBody(ensureFields, fieldsField);
+
         // get_Fields: Dictionary<string, object?> Fields { get; }
         var fieldsGetter = typeBuilder.DefineMethod(
             "get_Fields",
@@ -64,12 +78,35 @@ public partial class ILCompiler
         // Store stubs for later body emission
         _classes.HasFieldsStubs[className] = new HasFieldsMethodStubs
         {
+            EnsureFields = ensureFields,
             GetFields = fieldsGetter,
             GetProperty = getPropertyMethod,
             SetProperty = setPropertyMethod,
             HasProperty = hasPropertyMethod,
             FieldsField = fieldsField
         };
+    }
+
+    private void EmitEnsureFieldsBody(MethodBuilder method, FieldInfo fieldsField)
+    {
+        var il = method.GetILGenerator();
+        var readyLabel = il.DefineLabel();
+        var fieldsLocal = il.DeclareLocal(_types.DictionaryStringObject);
+
+        // return _fields ??= new Dictionary<string, object?>();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, fieldsField);
+        il.Emit(OpCodes.Stloc, fieldsLocal);
+        il.Emit(OpCodes.Ldloc, fieldsLocal);
+        il.Emit(OpCodes.Brtrue_S, readyLabel);
+        il.Emit(OpCodes.Newobj, _types.DictionaryStringObjectCtor);
+        il.Emit(OpCodes.Stloc, fieldsLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, fieldsLocal);
+        il.Emit(OpCodes.Stfld, fieldsField);
+        il.MarkLabel(readyLabel);
+        il.Emit(OpCodes.Ldloc, fieldsLocal);
+        il.Emit(OpCodes.Ret);
     }
 
     /// <summary>
@@ -85,13 +122,13 @@ public partial class ILCompiler
         var fieldsField = stubs.FieldsField;
 
         // Emit get_Fields body: returns a dictionary combining typed backing fields + dynamic _fields
-        EmitGetFieldsBody(stubs.GetFields, className, fieldsField);
+        EmitGetFieldsBody(stubs.GetFields, className, stubs.EnsureFields);
 
         // Emit GetProperty body with compile-time dispatch
         EmitGetPropertyBody(stubs.GetProperty, className, classStmt, fieldsField);
 
         // Emit SetProperty body with compile-time dispatch for typed properties
-        EmitSetPropertyBody(stubs.SetProperty, className, classStmt, fieldsField);
+        EmitSetPropertyBody(stubs.SetProperty, className, classStmt, stubs.EnsureFields);
 
         // Emit HasProperty body with compile-time dispatch for typed backing fields
         EmitHasPropertyBody(stubs.HasProperty, className, fieldsField);
@@ -101,22 +138,28 @@ public partial class ILCompiler
     /// Emits the get_Fields body that returns a combined dictionary of typed backing fields + dynamic _fields.
     /// Typed properties stored in backing fields are not in the _fields dictionary, so we must include them.
     /// </summary>
-    private void EmitGetFieldsBody(MethodBuilder method, string className, FieldInfo fieldsField)
+    private void EmitGetFieldsBody(
+        MethodBuilder method,
+        string className,
+        MethodInfo ensureFields)
     {
         _typedInterop.PropertyBackingFields.TryGetValue(className, out var backingFields);
-        EmitGetFieldsBodyCore(method, backingFields, fieldsField);
+        EmitGetFieldsBodyCore(method, backingFields, ensureFields);
     }
 
-    private void EmitGetFieldsBodyCore(MethodBuilder method, Dictionary<string, FieldBuilder>? backingFields, FieldInfo fieldsField)
+    private void EmitGetFieldsBodyCore(
+        MethodBuilder method,
+        Dictionary<string, FieldBuilder>? backingFields,
+        MethodInfo ensureFields)
     {
         var il = method.GetILGenerator();
 
         // Check if this class has typed backing fields
         if (backingFields == null || backingFields.Count == 0)
         {
-            // No typed backing fields - just return _fields directly
+            // No typed backing fields - materialize the compatibility dictionary on demand.
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Ldfld, fieldsField);
+            il.Emit(OpCodes.Call, EmitterTypeHelpers.SelfMethodReference(ensureFields));
             il.Emit(OpCodes.Ret);
             return;
         }
@@ -126,9 +169,9 @@ public partial class ILCompiler
         var copyCtor = _types.GetConstructor(_types.DictionaryStringObject, [iDictType])!;
         var setItem = _types.GetMethod(_types.DictionaryStringObject, "set_Item");
 
-        // var result = new Dictionary<string, object?>(this._fields);
+        // var result = new Dictionary<string, object?>(this.EnsureFields());
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldfld, fieldsField);
+        il.Emit(OpCodes.Call, EmitterTypeHelpers.SelfMethodReference(ensureFields));
         il.Emit(OpCodes.Newobj, copyCtor);
 
         // result["propName"] = this._BackingField; for each typed property
@@ -162,6 +205,7 @@ public partial class ILCompiler
     {
         var il = method.GetILGenerator();
         var returnTrueLabel = il.DefineLabel();
+        var haveFieldsLabel = il.DefineLabel();
 
         // Check typed backing field names
         if (backingFields != null)
@@ -178,9 +222,17 @@ public partial class ILCompiler
             }
         }
 
-        // Fall back to _fields.ContainsKey(name)
+        // A missing expando store is observably equivalent to an empty one. Do not
+        // allocate merely to answer a property probe.
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, fieldsField);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brtrue_S, haveFieldsLabel);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(haveFieldsLabel);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "ContainsKey", [_types.String])!);
         il.Emit(OpCodes.Ret);
@@ -248,10 +300,15 @@ public partial class ILCompiler
         il.MarkLabel(notCtorLabel);
     }
 
-    private void EmitGetPropertyBody(MethodBuilder method, string className, Stmt.Class classStmt, FieldInfo fieldsField)
+    private void EmitGetPropertyBody(
+        MethodBuilder method,
+        string className,
+        Stmt.Class classStmt,
+        FieldInfo fieldsField)
     {
         var il = method.GetILGenerator();
         var valueLocal = il.DeclareLocal(_types.Object);
+        var fieldsLocal = il.DeclareLocal(_types.DictionaryStringObject);
         var returnValueLabel = il.DefineLabel();
         var tryFieldsLabel = il.DefineLabel();
         var tryMethodsLabel = il.DefineLabel();
@@ -293,6 +350,10 @@ public partial class ILCompiler
         il.MarkLabel(tryFieldsLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, fieldsField);
+        il.Emit(OpCodes.Stloc, fieldsLocal);
+        il.Emit(OpCodes.Ldloc, fieldsLocal);
+        il.Emit(OpCodes.Brfalse, tryMethodsLabel);
+        il.Emit(OpCodes.Ldloc, fieldsLocal);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldloca, valueLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "TryGetValue", [_types.String, _types.Object.MakeByRefType()])!);
@@ -447,7 +508,11 @@ public partial class ILCompiler
     /// Emits the SetProperty method body with compile-time dispatch.
     /// Handles typed properties with backing fields first, then falls back to _fields dictionary.
     /// </summary>
-    private void EmitSetPropertyBody(MethodBuilder method, string className, Stmt.Class classStmt, FieldInfo fieldsField)
+    private void EmitSetPropertyBody(
+        MethodBuilder method,
+        string className,
+        Stmt.Class classStmt,
+        MethodInfo ensureFields)
     {
         var il = method.GetILGenerator();
         var setFieldsLabel = il.DefineLabel();
@@ -530,7 +595,7 @@ public partial class ILCompiler
         // 2. Fall back to _fields dictionary
         il.MarkLabel(setFieldsLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldfld, fieldsField);
+        il.Emit(OpCodes.Call, EmitterTypeHelpers.SelfMethodReference(ensureFields));
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldarg_2);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item", [_types.String, _types.Object])!);
@@ -592,13 +657,15 @@ public partial class ILCompiler
 
         // Emit get_Fields body: returns a dictionary combining typed backing fields + dynamic _fields
         _classExprs.BackingFields.TryGetValue(classExpr, out var backingFields);
-        EmitGetFieldsBodyCore(stubs.GetFields, backingFields, fieldsField);
+        EmitGetFieldsBodyCore(stubs.GetFields, backingFields, stubs.EnsureFields);
 
         // Emit GetProperty body with compile-time dispatch
-        EmitGetPropertyBodyForClassExpr(stubs.GetProperty, className, classExpr, fieldsField);
+        EmitGetPropertyBodyForClassExpr(
+            stubs.GetProperty, className, classExpr, fieldsField);
 
         // Emit SetProperty body with compile-time dispatch
-        EmitSetPropertyBodyForClassExpr(stubs.SetProperty, className, classExpr, fieldsField);
+        EmitSetPropertyBodyForClassExpr(
+            stubs.SetProperty, className, classExpr, stubs.EnsureFields);
 
         // Emit HasProperty body with compile-time dispatch for typed backing fields
         EmitHasPropertyBodyCore(stubs.HasProperty, backingFields, fieldsField);
@@ -608,10 +675,15 @@ public partial class ILCompiler
     /// Emits the GetProperty method body for a class expression with compile-time dispatch.
     /// Uses _classExprs.InstanceMethods for method lookup.
     /// </summary>
-    private void EmitGetPropertyBodyForClassExpr(MethodBuilder method, string className, Expr.ClassExpr classExpr, FieldInfo fieldsField)
+    private void EmitGetPropertyBodyForClassExpr(
+        MethodBuilder method,
+        string className,
+        Expr.ClassExpr classExpr,
+        FieldInfo fieldsField)
     {
         var il = method.GetILGenerator();
         var valueLocal = il.DeclareLocal(_types.Object);
+        var fieldsLocal = il.DeclareLocal(_types.DictionaryStringObject);
         var returnValueLabel = il.DefineLabel();
         var tryFieldsLabel = il.DefineLabel();
         var tryMethodsLabel = il.DefineLabel();
@@ -647,6 +719,10 @@ public partial class ILCompiler
         il.MarkLabel(tryFieldsLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, fieldsField);
+        il.Emit(OpCodes.Stloc, fieldsLocal);
+        il.Emit(OpCodes.Ldloc, fieldsLocal);
+        il.Emit(OpCodes.Brfalse, tryMethodsLabel);
+        il.Emit(OpCodes.Ldloc, fieldsLocal);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldloca, valueLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "TryGetValue", [_types.String, _types.Object.MakeByRefType()])!);
@@ -917,7 +993,11 @@ public partial class ILCompiler
     /// Emits the SetProperty method body for a class expression with compile-time dispatch.
     /// Handles typed properties with backing fields first, then falls back to _fields dictionary.
     /// </summary>
-    private void EmitSetPropertyBodyForClassExpr(MethodBuilder method, string className, Expr.ClassExpr classExpr, FieldInfo fieldsField)
+    private void EmitSetPropertyBodyForClassExpr(
+        MethodBuilder method,
+        string className,
+        Expr.ClassExpr classExpr,
+        MethodInfo ensureFields)
     {
         var il = method.GetILGenerator();
         var setFieldsLabel = il.DefineLabel();
@@ -999,7 +1079,7 @@ public partial class ILCompiler
         // 2. Fall back to _fields dictionary
         il.MarkLabel(setFieldsLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldfld, fieldsField);
+        il.Emit(OpCodes.Call, EmitterTypeHelpers.SelfMethodReference(ensureFields));
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldarg_2);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item", [_types.String, _types.Object])!);

--- a/src/SharpTS/Compilation/ILCompiler.Classes.Methods.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.Methods.cs
@@ -586,7 +586,7 @@ public partial class ILCompiler
 
         // Emit the compiler-only constructor used to create Constructor.prototype
         // without running JavaScript constructor bodies or field initializers.
-        EmitClassPrototypeConstructor(typeBuilder, fieldsField);
+        EmitClassPrototypeConstructor(typeBuilder);
 
         // Emit method bodies (skip overload signatures with no body, and computed
         // symbol-keyed methods — emitted by EmitSymbolMethods below).

--- a/src/SharpTS/Compilation/ILCompiler.Classes.Prototypes.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.Prototypes.cs
@@ -17,7 +17,7 @@ public partial class ILCompiler
             [_runtime.ClassPrototypeMarkerType]);
     }
 
-    private void EmitClassPrototypeConstructor(TypeBuilder typeBuilder, FieldInfo fieldsField)
+    private void EmitClassPrototypeConstructor(TypeBuilder typeBuilder)
     {
         DefineClassPrototypeConstructor(typeBuilder);
         var constructor = _classes.PrototypeConstructors[typeBuilder];
@@ -26,10 +26,9 @@ public partial class ILCompiler
         EmitClassPrototypeBaseConstructorCall(il, typeBuilder);
 
         // Only compiler bookkeeping is initialized. JavaScript fields, private
-        // slots, decorators, and constructor bodies deliberately do not run.
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Newobj, _types.DictionaryStringObjectCtor);
-        il.Emit(OpCodes.Stfld, fieldsField);
+        // slots, decorators, constructor bodies, and dynamic property storage
+        // deliberately do not run. The latter materializes through $EnsureFields
+        // if the prototype later receives an ordinary dynamic property.
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/ILCompiler.State.cs
+++ b/src/SharpTS/Compilation/ILCompiler.State.cs
@@ -101,6 +101,7 @@ public partial class ILCompiler
     /// </summary>
     private sealed class HasFieldsMethodStubs
     {
+        public required MethodBuilder EnsureFields { get; init; }
         public required MethodBuilder GetFields { get; init; }
         public required MethodBuilder GetProperty { get; init; }
         public required MethodBuilder SetProperty { get; init; }

--- a/tests/SharpTS.Tests/CompilerTests/LazyClassFieldStorageTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/LazyClassFieldStorageTests.cs
@@ -1,0 +1,197 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class LazyClassFieldStorageTests
+{
+    [Fact]
+    public void TypedOnlyConstructor_LeavesStoreNullAndReadsDoNotMaterialize()
+    {
+        Assembly assembly = Compile("""
+            class Counter {
+                value: number;
+                constructor(value: number) { this.value = value; }
+            }
+            """);
+
+        Type counterType = assembly.GetType("Counter")!;
+        ConstructorInfo constructor = Assert.Single(counterType.GetConstructors());
+        var instructions = ReadInstructions(constructor).ToArray();
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.OpCode == OpCodes.Newobj
+            && instruction.Operand is ConstructorInfo called
+            && called.DeclaringType?.IsGenericType == true
+            && called.DeclaringType.GetGenericTypeDefinition() == typeof(Dictionary<,>));
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "$EnsureFields" });
+
+        object instance = constructor.Invoke([1d]);
+        FieldInfo fields = counterType.GetField(
+            "_fields", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        Assert.Null(fields.GetValue(instance));
+
+        _ = counterType.GetMethod("GetProperty")!.Invoke(instance, ["missing"]);
+        Assert.False((bool)counterType.GetMethod("HasProperty")!.Invoke(
+            instance, ["missing"])!);
+        Assert.Null(fields.GetValue(instance));
+    }
+
+    [Fact]
+    public void FirstDynamicWrite_CreatesOneRetainedStore()
+    {
+        Assembly assembly = Compile("""
+            class Counter {
+                value: number = 1;
+            }
+            """);
+
+        Type counterType = assembly.GetType("Counter")!;
+        object instance = Assert.Single(counterType.GetConstructors()).Invoke([]);
+        FieldInfo fields = counterType.GetField(
+            "_fields", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        MethodInfo setProperty = counterType.GetMethod("SetProperty")!;
+
+        Assert.Null(fields.GetValue(instance));
+        setProperty.Invoke(instance, ["extra", 2d]);
+        var first = Assert.IsType<Dictionary<string, object>>(fields.GetValue(instance));
+        Assert.Equal(2d, first["extra"]);
+
+        setProperty.Invoke(instance, ["second", 3d]);
+        Assert.Same(first, fields.GetValue(instance));
+        Assert.Equal(3d, first["second"]);
+    }
+
+    [Fact]
+    public void DynamicSemantics_WorkForDeclarationsExpressionsAndInheritance()
+    {
+        const string source = """
+            class Base {
+                constructor() { (this as any).fromBase = 7; }
+            }
+            class Model extends Base {
+                value: number = 1;
+            }
+
+            const model: any = new Model();
+            console.log(model.fromBase, model.value, model.missing === undefined);
+            model.extra = 2;
+            console.log(model.extra, Object.keys(model).sort().join(","));
+            const roundTrip: any = JSON.parse(JSON.stringify(model));
+            console.log(roundTrip.fromBase, roundTrip.value, roundTrip.extra);
+
+            Object.defineProperty(model, "hidden", {
+                value: 3, enumerable: false, configurable: true, writable: true
+            });
+            console.log(model.hidden, Object.keys(model).includes("hidden"));
+            Object.freeze(model);
+            model.blocked = 4;
+            console.log(Object.isFrozen(model), model.blocked === undefined);
+
+            const Expression: any = class { value: number = 5; };
+            const expression: any = new Expression();
+            console.log(expression.missing === undefined);
+            expression.extra = 6;
+            console.log(expression.value, expression.extra,
+                Object.keys(expression).sort().join(","));
+            """;
+
+        Assert.Equal(
+            "7 1 true\n" +
+            "2 extra,fromBase,value\n" +
+            "7 1 2\n" +
+            "3 false\n" +
+            "true true\n" +
+            "true\n" +
+            "5 6 extra,value\n",
+            TestHarness.RunCompiled(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    [Fact]
+    public void GenericDeclareAndComputedInitializers_MaterializeAndVerify()
+    {
+        const string source = """
+            const key: string = "computed";
+            class Box<T> {
+                value: T;
+                declare absent: any;
+                [key]: number = 2;
+                constructor(value: T) { this.value = value; }
+            }
+            const box: any = new Box<number>(3);
+            console.log(box.value, box.absent, box.computed,
+                Object.hasOwn(box, "absent"), Object.hasOwn(box, "computed"));
+            """;
+
+        Assert.Equal("3 null 2 true true\n", TestHarness.RunCompiled(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"issue_1459_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodBase method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token)
+                    : module.ResolveType(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}


### PR DESCRIPTION
Fixes #1459

## Summary

- leave emitted class-instance dynamic-property storage null after construction
- materialize and retain it through a private `$EnsureFields` helper only for expando writes or the `$IHasFields.Fields` compatibility surface
- make missing `GetProperty` / `HasProperty` probes allocation-free
- apply the lowering to declarations, expressions, generic classes, field initializers, inheritance, and compiler-created prototype instances

## Performance

At N=100,000 on the same Windows x64 host:

- BenchmarkDotNet `ClassConstructionBenchmarks.SharpTS`: **1.173 ms / 10.68 MB -> 410.4 us / 3.05 MB** (about **65% faster** and **71% less allocation**)
- five paired cross-runtime medians: **0.6376 ms -> 0.1849 ms** compiled; Node measured **0.3365 ms**, making SharpTS **0.55x Node**
- the exact typed-only constructor contains neither a `Dictionary<string, object>` allocation nor an `$EnsureFields` call

The allocation and cross-runtime gates clear. The repeat ShortRun result is about 2.6% above the issue's provisional 400 us stretch gate, while still improving by roughly 65%.

## Verification

- `dotnet build src/SharpTS/SharpTS.csproj -c Release --no-restore -m:1`
- 20 focused class definition, field/method lowering, and lazy-storage tests
- IL verification for the class benchmark and new semantic cases
- all 18 cross-runtime smoke workloads
- microbenchmark smoke compilation

A broad local core-suite attempt reached the affected class/property coverage successfully, but this host's networking stack returned `HttpListenerException: The handle is invalid` across unrelated HTTP tests and timed out IPC socket tests in both compiled and interpreted modes. CI is the clean-environment full-suite gate.
