### PR TITLE
Specialize closed JSON record array serialization

### DIFF
--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -173,6 +173,9 @@ public class EmittedRuntime
     /// Byte-for-byte equivalent of SharpTS.Compilation.RuntimeTypes.FormatNumber so interpreted
     /// and compiled output match. Emitted in RuntimeEmitter.NumberFormat.cs.</summary>
     public MethodBuilder FormatNumber { get; set; } = null!;
+    /// <summary>$Runtime.ConcatStringInt64(string, long, bool) -> string —
+    /// allocation-minimal concatenation for proven integer loop counters.</summary>
+    public MethodBuilder ConcatStringInt64 { get; set; } = null!;
     public MethodBuilder Stringify { get; set; } = null!;
     public MethodBuilder ToJsString { get; set; } = null!;
     /// <summary>$Runtime.StringFromValue(object) -> string — ECMA-262 §22.1.1.1 String(value) call form: Symbol → SymbolDescriptiveString (via $TSSymbol.ToString()); everything else → ToJsString. Only the String() constructor-call form is exempt from ToString's Symbol TypeError; implicit coercions (template literals, concat) must keep throwing.</summary>

--- a/src/SharpTS/Compilation/ILEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Operators.cs
@@ -63,12 +63,13 @@ public partial class ILEmitter
                     break;
                 }
 
-                // A primitive string/number pair has no observable ToPrimitive
-                // work. Keep the number native, format it with the emitted
-                // ECMAScript Number::toString implementation, and concatenate
-                // the two strings directly. This avoids boxing the number and
-                // routing every mixed pair through $Runtime.Add.
-                if (TryEmitPrimitiveStringNumberConcat(b))
+                // A proven integer loop counter already has native Int64
+                // storage. Format it directly into the final string, avoiding
+                // boxing and $Runtime.Add. Other statically narrowed numbers
+                // can still be object-backed (for example a number|string
+                // parameter after typeof narrowing), so they stay on the
+                // sound dynamic path.
+                if (TryEmitIntegerCounterStringConcat(b))
                     break;
 
                 // If both operands are statically string, emit a direct
@@ -1279,6 +1280,25 @@ public partial class ILEmitter
         }
         return false;
     }
+
+    /// <summary>
+    /// Reports whether <paramref name="e"/> is one of the pure expressions that
+    /// <see cref="TryEmitIntegerCounterValueI8"/> can load from native Int64 storage.
+    /// This non-emitting probe keeps callers from partially emitting a fallback.
+    /// </summary>
+    private bool IsIntegerCounterValueI8(Expr e) => e switch
+    {
+        Expr.Variable v => IsIntegerCounterLocal(v.Name.Lexeme),
+        Expr.Binary { Operator.Type: TokenType.PLUS or TokenType.MINUS } b
+            when b.Left is Expr.Variable lv
+                 && IsIntegerCounterLocal(lv.Name.Lexeme)
+                 && TryGetIntLiteralValue(b.Right, out _) => true,
+        Expr.Binary { Operator.Type: TokenType.PLUS } b
+            when b.Right is Expr.Variable rv
+                 && IsIntegerCounterLocal(rv.Name.Lexeme)
+                 && TryGetIntLiteralValue(b.Left, out _) => true,
+        _ => false
+    };
 
     /// <summary>
     /// Native int64 increment for an integer-counter local: <c>i++</c>/<c>i--</c> (postfix) or
@@ -2576,75 +2596,47 @@ public partial class ILEmitter
         return IsStringTypeInfo(leftType) && IsStringTypeInfo(rightType);
     }
 
-    private bool TryEmitPrimitiveStringNumberConcat(Expr.Binary b)
+    private bool TryEmitIntegerCounterStringConcat(Expr.Binary b)
     {
         if (_ctx.TypeMap is null)
             return false;
 
         bool leftString = IsStringTypeInfo(_ctx.TypeMap.Get(b.Left));
         bool rightString = IsStringTypeInfo(_ctx.TypeMap.Get(b.Right));
-        bool leftNumber = IsNumericTypeInfo(_ctx.TypeMap.Get(b.Left));
-        bool rightNumber = IsNumericTypeInfo(_ctx.TypeMap.Get(b.Right));
-        if (!(leftString && rightNumber) && !(leftNumber && rightString))
+        bool leftCounter = IsIntegerCounterValueI8(b.Left);
+        bool rightCounter = IsIntegerCounterValueI8(b.Right);
+        if (!(leftString && rightCounter) && !(leftCounter && rightString))
             return false;
 
         if (leftString)
         {
             EmitExpression(b.Left);
             EnsureString();
-            if (TryEmitIntegerCounterValueI8(b.Right))
-            {
-                // Integer loop counters already live as Int64. Formatting that
-                // value directly avoids a double conversion plus the general
-                // ECMAScript number formatter on every iteration. The counter
-                // analysis restricts values to the exact-integer Number range,
-                // where invariant Int64 decimal text is byte-for-byte identical.
-                IL.Emit(OpCodes.Ldc_I4_0);
-                IL.Emit(OpCodes.Call, _ctx.Runtime!.ConcatStringInt64);
-                SetStackType(StackType.String);
-                return true;
-            }
-            else
-            {
-                EmitExpressionAsDouble(b.Right);
-                IL.Emit(OpCodes.Call, _ctx.Runtime!.FormatNumber);
-            }
+            _ = TryEmitIntegerCounterValueI8(b.Right);
+            // Integer loop counters already live as Int64. Formatting that
+            // value directly avoids a double conversion plus the general
+            // ECMAScript number formatter on every iteration. The counter
+            // analysis restricts values to the exact-integer Number range,
+            // where invariant Int64 decimal text is byte-for-byte identical.
+            IL.Emit(OpCodes.Ldc_I4_0);
         }
         else
         {
-            // Preserve source evaluation order even though primitive number
-            // formatting itself is unobservable.
-            bool integerCounter = TryEmitIntegerCounterValueI8(b.Left);
-            var left = IL.DeclareLocal(integerCounter ? _ctx.Types.Int64 : _ctx.Types.Double);
-            if (!integerCounter)
-                EmitExpressionAsDouble(b.Left);
+            // Preserve source evaluation order: evaluate the counter before
+            // the string expression, then arrange the helper arguments.
+            _ = TryEmitIntegerCounterValueI8(b.Left);
+            var left = IL.DeclareLocal(_ctx.Types.Int64);
             IL.Emit(OpCodes.Stloc, left);
             EmitExpression(b.Right);
             EnsureString();
             var right = IL.DeclareLocal(_ctx.Types.String);
             IL.Emit(OpCodes.Stloc, right);
-            if (integerCounter)
-            {
-                IL.Emit(OpCodes.Ldloc, right);
-                IL.Emit(OpCodes.Ldloc, left);
-                IL.Emit(OpCodes.Ldc_I4_1);
-                IL.Emit(OpCodes.Call, _ctx.Runtime!.ConcatStringInt64);
-                SetStackType(StackType.String);
-                return true;
-            }
-            else
-            {
-                IL.Emit(OpCodes.Ldloc, left);
-                IL.Emit(OpCodes.Call, _ctx.Runtime!.FormatNumber);
-            }
             IL.Emit(OpCodes.Ldloc, right);
+            IL.Emit(OpCodes.Ldloc, left);
+            IL.Emit(OpCodes.Ldc_I4_1);
         }
 
-        IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(
-            _ctx.Types.String,
-            "Concat",
-            _ctx.Types.String,
-            _ctx.Types.String));
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.ConcatStringInt64);
         SetStackType(StackType.String);
         return true;
     }

--- a/src/SharpTS/Compilation/ILEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Operators.cs
@@ -63,6 +63,14 @@ public partial class ILEmitter
                     break;
                 }
 
+                // A primitive string/number pair has no observable ToPrimitive
+                // work. Keep the number native, format it with the emitted
+                // ECMAScript Number::toString implementation, and concatenate
+                // the two strings directly. This avoids boxing the number and
+                // routing every mixed pair through $Runtime.Add.
+                if (TryEmitPrimitiveStringNumberConcat(b))
+                    break;
+
                 // If both operands are statically string, emit a direct
                 // String.Concat(string, string) — skipping the dynamic
                 // $Runtime.Add type-dispatch + ToNumber/ToString probing every
@@ -2566,6 +2574,79 @@ public partial class ILEmitter
         var rightType = _ctx.TypeMap.Get(b.Right);
 
         return IsStringTypeInfo(leftType) && IsStringTypeInfo(rightType);
+    }
+
+    private bool TryEmitPrimitiveStringNumberConcat(Expr.Binary b)
+    {
+        if (_ctx.TypeMap is null)
+            return false;
+
+        bool leftString = IsStringTypeInfo(_ctx.TypeMap.Get(b.Left));
+        bool rightString = IsStringTypeInfo(_ctx.TypeMap.Get(b.Right));
+        bool leftNumber = IsNumericTypeInfo(_ctx.TypeMap.Get(b.Left));
+        bool rightNumber = IsNumericTypeInfo(_ctx.TypeMap.Get(b.Right));
+        if (!(leftString && rightNumber) && !(leftNumber && rightString))
+            return false;
+
+        if (leftString)
+        {
+            EmitExpression(b.Left);
+            EnsureString();
+            if (TryEmitIntegerCounterValueI8(b.Right))
+            {
+                // Integer loop counters already live as Int64. Formatting that
+                // value directly avoids a double conversion plus the general
+                // ECMAScript number formatter on every iteration. The counter
+                // analysis restricts values to the exact-integer Number range,
+                // where invariant Int64 decimal text is byte-for-byte identical.
+                IL.Emit(OpCodes.Ldc_I4_0);
+                IL.Emit(OpCodes.Call, _ctx.Runtime!.ConcatStringInt64);
+                SetStackType(StackType.String);
+                return true;
+            }
+            else
+            {
+                EmitExpressionAsDouble(b.Right);
+                IL.Emit(OpCodes.Call, _ctx.Runtime!.FormatNumber);
+            }
+        }
+        else
+        {
+            // Preserve source evaluation order even though primitive number
+            // formatting itself is unobservable.
+            bool integerCounter = TryEmitIntegerCounterValueI8(b.Left);
+            var left = IL.DeclareLocal(integerCounter ? _ctx.Types.Int64 : _ctx.Types.Double);
+            if (!integerCounter)
+                EmitExpressionAsDouble(b.Left);
+            IL.Emit(OpCodes.Stloc, left);
+            EmitExpression(b.Right);
+            EnsureString();
+            var right = IL.DeclareLocal(_ctx.Types.String);
+            IL.Emit(OpCodes.Stloc, right);
+            if (integerCounter)
+            {
+                IL.Emit(OpCodes.Ldloc, right);
+                IL.Emit(OpCodes.Ldloc, left);
+                IL.Emit(OpCodes.Ldc_I4_1);
+                IL.Emit(OpCodes.Call, _ctx.Runtime!.ConcatStringInt64);
+                SetStackType(StackType.String);
+                return true;
+            }
+            else
+            {
+                IL.Emit(OpCodes.Ldloc, left);
+                IL.Emit(OpCodes.Call, _ctx.Runtime!.FormatNumber);
+            }
+            IL.Emit(OpCodes.Ldloc, right);
+        }
+
+        IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(
+            _ctx.Types.String,
+            "Concat",
+            _ctx.Types.String,
+            _ctx.Types.String));
+        SetStackType(StackType.String);
+        return true;
     }
 
     private bool IsStaticallyNumericBitwise(Expr.Binary b)

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.Shape.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.Shape.cs
@@ -668,26 +668,45 @@ public partial class RuntimeEmitter
         var typedRecordAppenders = _features.JsonScalarRecordShapes
             .OrderBy(pair => pair.Key, StringComparer.Ordinal)
             .Where(pair => runtime.JsonTypedScalarRecordTypes.ContainsKey(pair.Key))
-            .Select((pair, ordinal) => (
-                Fingerprint: pair.Key,
-                Shape: pair.Value,
-                Method: typeBuilder.DefineMethod(
-                    $"AppendJsonTypedScalarRecord{ordinal}",
-                    MethodAttributes.Private | MethodAttributes.Static,
-                    _types.Boolean,
-                    [
-                        _types.StringBuilder,
-                        runtime.JsonTypedScalarRecordTypes[pair.Key],
-                        _types.ObjectArray,
-                        _types.Int32
-                    ])))
+            .Select((pair, ordinal) =>
+            {
+                TypeBuilder exactType = runtime.JsonTypedScalarRecordTypes[pair.Key];
+                return (
+                    Fingerprint: pair.Key,
+                    Shape: pair.Value,
+                    Method: typeBuilder.DefineMethod(
+                        $"AppendJsonTypedScalarRecord{ordinal}",
+                        MethodAttributes.Private | MethodAttributes.Static,
+                        _types.Boolean,
+                        [
+                            _types.StringBuilder,
+                            exactType,
+                            _types.ObjectArray,
+                            _types.Int32
+                        ]),
+                    ArrayMethod: typeBuilder.DefineMethod(
+                        $"AppendJsonTypedScalarRecordArray{ordinal}",
+                        MethodAttributes.Private | MethodAttributes.Static,
+                        _types.Boolean,
+                        [
+                            _types.StringBuilder,
+                            _types.ListOfObject,
+                            _types.ObjectArray,
+                            _types.Int32
+                        ]));
+            })
             .ToArray();
         foreach (var appender in typedRecordAppenders)
+        {
             appender.Method.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
+            appender.ArrayMethod.SetImplementationFlags(
+                MethodImplAttributes.AggressiveOptimization);
+        }
 
         var il = method.GetILGenerator();
         var tagLocal = il.DeclareLocal(_types.String);
         var shapeLocal = il.DeclareLocal(_types.ObjectArray);
+        var childShapeLocal = il.DeclareLocal(_types.ObjectArray);
         var listLocal = il.DeclareLocal(_types.ListOfObject);
         var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
         var scalarLocal = il.DeclareLocal(runtime.JsonScalarRecordType);
@@ -837,6 +856,40 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Castclass, _types.ListOfObject);
         il.Emit(OpCodes.Stloc, listLocal);
+
+        // A closed array of exact scalar-record carriers is the dominant JSON
+        // workload shape. Select the emitted record writer once for the array,
+        // then keep the element loop out of the generic shape-tag dispatcher.
+        // Each helper still validates the exact carrier, materialization state,
+        // and descriptor identity and reports a miss to the whole-call fallback.
+        var genericArrayPath = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, closedLocal);
+        il.Emit(OpCodes.Brfalse, genericArrayPath);
+        il.Emit(OpCodes.Ldloc, shapeLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Isinst, _types.ObjectArray);
+        il.Emit(OpCodes.Stloc, childShapeLocal);
+        il.Emit(OpCodes.Ldloc, childShapeLocal);
+        il.Emit(OpCodes.Brfalse, invalidShape);
+        foreach (var appender in typedRecordAppenders)
+        {
+            var nextArrayAppender = il.DefineLabel();
+            il.Emit(OpCodes.Ldsfld,
+                runtime.JsonTypedScalarRecordShapeFields[appender.Fingerprint]);
+            il.Emit(OpCodes.Ldloc, childShapeLocal);
+            il.Emit(OpCodes.Bne_Un, nextArrayAppender);
+            EmitAppendShapedPropertyPrefix(il);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, listLocal);
+            il.Emit(OpCodes.Ldloc, childShapeLocal);
+            il.Emit(OpCodes.Ldarg_3);
+            il.Emit(OpCodes.Call, appender.ArrayMethod);
+            il.Emit(OpCodes.Brfalse, invalidShape);
+            EmitTrueReturn(il);
+            il.MarkLabel(nextArrayAppender);
+        }
+        il.MarkLabel(genericArrayPath);
         EmitAppendShapedPropertyPrefix(il);
         EmitAppendChar(il, '[');
         il.Emit(OpCodes.Ldc_I4_0);
@@ -1075,8 +1128,12 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         foreach (var appender in typedRecordAppenders)
+        {
             EmitTypedRecordAppender(
                 appender.Fingerprint, appender.Shape, appender.Method);
+            EmitTypedRecordArrayAppender(
+                appender.Fingerprint, appender.Method, appender.ArrayMethod);
+        }
         return method;
 
         void EmitTypedRecordAppender(
@@ -1085,17 +1142,15 @@ public partial class RuntimeEmitter
             MethodBuilder appenderMethod)
         {
             var appenderIl = appenderMethod.GetILGenerator();
-            EmitAppendChar(appenderIl, '{');
             for (int index = 0; index < shape.Fields.Count; index++)
             {
-                if (index != 0)
-                    EmitAppendChar(appenderIl, ',');
                 appenderIl.Emit(OpCodes.Ldarg_0);
-                appenderIl.Emit(OpCodes.Ldstr,
+                appenderIl.Emit(OpCodes.Ldstr, string.Concat(
+                    index == 0 ? "{" : ",",
                     Runtime.BuiltIns.JsonStringEscaper.Quote(
-                        shape.Fields[index].Key));
+                        shape.Fields[index].Key),
+                    ":"));
                 EmitStringBuilderAppendString(appenderIl);
-                EmitAppendChar(appenderIl, ':');
 
                 FieldBuilder valueField =
                     runtime.JsonTypedScalarRecordValueFields[(fingerprint, index)];
@@ -1159,6 +1214,99 @@ public partial class RuntimeEmitter
             }
             EmitAppendChar(appenderIl, '}');
             appenderIl.Emit(OpCodes.Ldc_I4_1);
+            appenderIl.Emit(OpCodes.Ret);
+        }
+
+        void EmitTypedRecordArrayAppender(
+            string fingerprint,
+            MethodBuilder recordAppender,
+            MethodBuilder arrayAppender)
+        {
+            TypeBuilder exactType = runtime.JsonTypedScalarRecordTypes[fingerprint];
+            bool mayHaveDescriptors =
+                _features.UsesDynamicPropertyDescriptors ||
+                _features.UsesObjectIntegrityMutation ||
+                _features.PotentiallyMaterializesUnknownCompactObjectRecordShape;
+            bool mayHavePrototypeEntry =
+                _features.UsesArrayPrototypeMutation ||
+                _features.UsesClassPrototypeMutation ||
+                _features.UsesObjectIntegrityMutation ||
+                _features.PotentiallyMaterializesUnknownCompactObjectRecordShape;
+
+            var appenderIl = arrayAppender.GetILGenerator();
+            var index = appenderIl.DeclareLocal(_types.Int32);
+            var exact = appenderIl.DeclareLocal(exactType);
+            var loop = appenderIl.DefineLabel();
+            var noComma = appenderIl.DefineLabel();
+            var failed = appenderIl.DefineLabel();
+            var done = appenderIl.DefineLabel();
+
+            EmitAppendChar(appenderIl, '[');
+            appenderIl.Emit(OpCodes.Ldc_I4_0);
+            appenderIl.Emit(OpCodes.Stloc, index);
+            appenderIl.MarkLabel(loop);
+            appenderIl.Emit(OpCodes.Ldloc, index);
+            appenderIl.Emit(OpCodes.Ldarg_1);
+            appenderIl.Emit(OpCodes.Callvirt, _types.GetProperty(
+                _types.ListOfObject, "Count").GetGetMethod()!);
+            appenderIl.Emit(OpCodes.Bge, done);
+            appenderIl.Emit(OpCodes.Ldloc, index);
+            appenderIl.Emit(OpCodes.Brfalse, noComma);
+            EmitAppendChar(appenderIl, ',');
+            appenderIl.MarkLabel(noComma);
+
+            appenderIl.Emit(OpCodes.Ldarg_1);
+            appenderIl.Emit(OpCodes.Ldloc, index);
+            appenderIl.Emit(OpCodes.Callvirt, _types.GetMethod(
+                _types.ListOfObject, "get_Item", [_types.Int32])!);
+            appenderIl.Emit(OpCodes.Isinst, exactType);
+            appenderIl.Emit(OpCodes.Stloc, exact);
+            appenderIl.Emit(OpCodes.Ldloc, exact);
+            appenderIl.Emit(OpCodes.Brfalse, failed);
+
+            if (mayHaveDescriptors)
+            {
+                appenderIl.Emit(OpCodes.Ldloc, exact);
+                appenderIl.Emit(OpCodes.Call, runtime.PDSHasPropertyDescriptors);
+                appenderIl.Emit(OpCodes.Brtrue, failed);
+            }
+            if (mayHavePrototypeEntry)
+            {
+                appenderIl.Emit(OpCodes.Ldloc, exact);
+                appenderIl.Emit(OpCodes.Call, runtime.PDSHasPrototypeEntry);
+                appenderIl.Emit(OpCodes.Brtrue, failed);
+            }
+
+            appenderIl.Emit(OpCodes.Ldloc, exact);
+            appenderIl.Emit(OpCodes.Callvirt,
+                runtime.JsonScalarRecordIsMaterializedGetter);
+            appenderIl.Emit(OpCodes.Brtrue, failed);
+            appenderIl.Emit(OpCodes.Ldloc, exact);
+            appenderIl.Emit(OpCodes.Callvirt, runtime.JsonScalarRecordShapeGetter);
+            appenderIl.Emit(OpCodes.Ldarg_2);
+            appenderIl.Emit(OpCodes.Bne_Un, failed);
+
+            appenderIl.Emit(OpCodes.Ldarg_0);
+            appenderIl.Emit(OpCodes.Ldloc, exact);
+            appenderIl.Emit(OpCodes.Ldarg_2);
+            appenderIl.Emit(OpCodes.Ldarg_3);
+            appenderIl.Emit(OpCodes.Ldc_I4_1);
+            appenderIl.Emit(OpCodes.Add);
+            appenderIl.Emit(OpCodes.Call, recordAppender);
+            appenderIl.Emit(OpCodes.Brfalse, failed);
+
+            appenderIl.Emit(OpCodes.Ldloc, index);
+            appenderIl.Emit(OpCodes.Ldc_I4_1);
+            appenderIl.Emit(OpCodes.Add);
+            appenderIl.Emit(OpCodes.Stloc, index);
+            appenderIl.Emit(OpCodes.Br, loop);
+
+            appenderIl.MarkLabel(done);
+            EmitAppendChar(appenderIl, ']');
+            appenderIl.Emit(OpCodes.Ldc_I4_1);
+            appenderIl.Emit(OpCodes.Ret);
+            appenderIl.MarkLabel(failed);
+            appenderIl.Emit(OpCodes.Ldc_I4_0);
             appenderIl.Emit(OpCodes.Ret);
         }
     }

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.cs
@@ -7,6 +7,10 @@ namespace SharpTS.Compilation;
 
 public partial class RuntimeEmitter
 {
+    private delegate int JsonIndexOfAnyDelegate(
+        ReadOnlySpan<char> span,
+        SearchValues<char> values);
+
     private MethodBuilder? _escapeJsonStringMethod;
     private MethodBuilder? _appendEscapedJsonStringMethod;
     private MethodBuilder? _jsonGetDictionaryPropertyMethod;
@@ -769,20 +773,10 @@ public partial class RuntimeEmitter
 
         MethodInfo asSpan = typeof(MemoryExtensions).GetMethod(
             "AsSpan", [typeof(string)])!;
-        MethodInfo indexOfAny = typeof(MemoryExtensions).GetMethods(
-                BindingFlags.Public | BindingFlags.Static)
-            .Single(candidate =>
-                candidate.Name == "IndexOfAny" &&
-                candidate.IsGenericMethodDefinition &&
-                candidate.GetParameters() is var parameters &&
-                parameters.Length == 2 &&
-                parameters[0].ParameterType.IsGenericType &&
-                parameters[0].ParameterType.GetGenericTypeDefinition() ==
-                    typeof(ReadOnlySpan<>) &&
-                parameters[1].ParameterType.IsGenericType &&
-                parameters[1].ParameterType.GetGenericTypeDefinition() ==
-                    typeof(SearchValues<>))
-            .MakeGenericMethod(typeof(char));
+        // The strongly typed method group yields the closed generic MethodInfo
+        // without MakeGenericMethod, keeping the compiler NativeAOT-safe.
+        MethodInfo indexOfAny =
+            ((JsonIndexOfAnyDelegate)MemoryExtensions.IndexOfAny).Method;
 
         il.Emit(OpCodes.Ldsfld, searchValuesField);
         il.Emit(OpCodes.Dup);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Text;
@@ -742,46 +743,69 @@ public partial class RuntimeEmitter
             MethodAttributes.Private | MethodAttributes.Static,
             _types.Void,
             [_types.StringBuilder, _types.String]);
+        method.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
         var il = method.GetILGenerator();
-        var indexLocal = il.DeclareLocal(_types.Int32);
-        var charLocal = il.DeclareLocal(_types.Char);
-        var loop = il.DefineLabel();
-        var next = il.DefineLabel();
+        Type searchValuesType = typeof(SearchValues<char>);
+        var searchValuesField = typeBuilder.DefineField(
+            "_jsonEscapeSearchValues",
+            searchValuesType,
+            FieldAttributes.Private | FieldAttributes.Static);
+        var searchValuesLocal = il.DeclareLocal(searchValuesType);
+        var spanLocal = il.DeclareLocal(typeof(ReadOnlySpan<char>));
+        var searchReady = il.DefineLabel();
         var fast = il.DefineLabel();
         var slow = il.DefineLabel();
 
+        // SearchValues performs a single vectorized scan for every character
+        // that requires JSON escaping: controls, quote, backslash, and UTF-16
+        // surrogate code units. The table is immutable and initialized once.
+        var escapeCharacters = new char[32 + 2 + 0x800];
+        for (int index = 0; index < 32; index++)
+            escapeCharacters[index] = (char)index;
+        escapeCharacters[32] = '"';
+        escapeCharacters[33] = '\\';
+        for (int index = 0; index < 0x800; index++)
+            escapeCharacters[34 + index] = (char)(0xD800 + index);
+
+        MethodInfo asSpan = typeof(MemoryExtensions).GetMethod(
+            "AsSpan", [typeof(string)])!;
+        MethodInfo indexOfAny = typeof(MemoryExtensions).GetMethods(
+                BindingFlags.Public | BindingFlags.Static)
+            .Single(candidate =>
+                candidate.Name == "IndexOfAny" &&
+                candidate.IsGenericMethodDefinition &&
+                candidate.GetParameters() is var parameters &&
+                parameters.Length == 2 &&
+                parameters[0].ParameterType.IsGenericType &&
+                parameters[0].ParameterType.GetGenericTypeDefinition() ==
+                    typeof(ReadOnlySpan<>) &&
+                parameters[1].ParameterType.IsGenericType &&
+                parameters[1].ParameterType.GetGenericTypeDefinition() ==
+                    typeof(SearchValues<>))
+            .MakeGenericMethod(typeof(char));
+
+        il.Emit(OpCodes.Ldsfld, searchValuesField);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brtrue, searchReady);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldstr, new string(escapeCharacters));
+        il.Emit(OpCodes.Call, asSpan);
+        il.Emit(OpCodes.Call, typeof(SearchValues).GetMethod(
+            "Create", [typeof(ReadOnlySpan<char>)])!);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Stsfld, searchValuesField);
+        il.MarkLabel(searchReady);
+        il.Emit(OpCodes.Stloc, searchValuesLocal);
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, asSpan);
+        il.Emit(OpCodes.Stloc, spanLocal);
+        il.Emit(OpCodes.Ldloc, spanLocal);
+        il.Emit(OpCodes.Ldloc, searchValuesLocal);
+        il.Emit(OpCodes.Call, indexOfAny);
         il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Stloc, indexLocal);
-        il.MarkLabel(loop);
-        il.Emit(OpCodes.Ldloc, indexLocal);
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.String, "Length").GetGetMethod()!);
-        il.Emit(OpCodes.Bge, fast);
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Ldloc, indexLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "get_Chars", [_types.Int32]));
-        il.Emit(OpCodes.Stloc, charLocal);
-        il.Emit(OpCodes.Ldloc, charLocal);
-        il.Emit(OpCodes.Ldc_I4, (int)'"');
-        il.Emit(OpCodes.Beq, slow);
-        il.Emit(OpCodes.Ldloc, charLocal);
-        il.Emit(OpCodes.Ldc_I4, (int)'\\');
-        il.Emit(OpCodes.Beq, slow);
-        il.Emit(OpCodes.Ldloc, charLocal);
-        il.Emit(OpCodes.Ldc_I4, 32);
-        il.Emit(OpCodes.Blt, slow);
-        il.Emit(OpCodes.Ldloc, charLocal);
-        il.Emit(OpCodes.Ldc_I4, 0xD800);
-        il.Emit(OpCodes.Blt, next);
-        il.Emit(OpCodes.Ldloc, charLocal);
-        il.Emit(OpCodes.Ldc_I4, 0xE000);
-        il.Emit(OpCodes.Blt, slow);
-        il.MarkLabel(next);
-        il.Emit(OpCodes.Ldloc, indexLocal);
-        il.Emit(OpCodes.Ldc_I4_1);
-        il.Emit(OpCodes.Add);
-        il.Emit(OpCodes.Stloc, indexLocal);
-        il.Emit(OpCodes.Br, loop);
+        il.Emit(OpCodes.Bge, slow);
+        il.Emit(OpCodes.Br, fast);
 
         il.MarkLabel(fast);
         il.Emit(OpCodes.Ldarg_0);

--- a/src/SharpTS/Compilation/RuntimeEmitter.NumberFormat.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.NumberFormat.cs
@@ -1,11 +1,107 @@
 using System;
 using System.Globalization;
+using System.Reflection;
 using System.Reflection.Emit;
 
 namespace SharpTS.Compilation;
 
 public partial class RuntimeEmitter
 {
+    /// <summary>
+    /// Concatenates a proven integer loop counter with a string without first
+    /// allocating the counter's decimal representation. A bounded thread-local
+    /// buffer supplies the formatting span; <see cref="string.Concat(ReadOnlySpan{char}, ReadOnlySpan{char})"/>
+    /// then creates only the final JavaScript string.
+    /// </summary>
+    private void EmitConcatStringInt64Method(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "ConcatStringInt64",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.String,
+            [_types.String, _types.Int64, _types.Boolean]);
+        method.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
+        runtime.ConcatStringInt64 = method;
+
+        var bufferField = typeBuilder.DefineField(
+            "_concatInt64Buffer",
+            typeof(char[]),
+            FieldAttributes.Private | FieldAttributes.Static);
+        bufferField.SetCustomAttribute(
+            typeof(ThreadStaticAttribute).GetConstructor(Type.EmptyTypes)!,
+            CustomAttributeEncoder.EmptyBlob);
+
+        var il = method.GetILGenerator();
+        var bufferLocal = il.DeclareLocal(typeof(char[]));
+        var spanLocal = il.DeclareLocal(typeof(Span<char>));
+        var formatLocal = il.DeclareLocal(typeof(ReadOnlySpan<char>));
+        var numberSpanLocal = il.DeclareLocal(typeof(ReadOnlySpan<char>));
+        var charsWrittenLocal = il.DeclareLocal(_types.Int32);
+        var bufferReady = il.DefineLabel();
+        var textFirst = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldsfld, bufferField);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Brtrue, bufferReady);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldc_I4, 20);
+        il.Emit(OpCodes.Newarr, _types.Char);
+        il.Emit(OpCodes.Dup);
+        il.Emit(OpCodes.Stsfld, bufferField);
+        il.MarkLabel(bufferReady);
+        il.Emit(OpCodes.Stloc, bufferLocal);
+
+        il.Emit(OpCodes.Ldloc, bufferLocal);
+        il.Emit(OpCodes.Call, typeof(Span<char>).GetMethod(
+            "op_Implicit", [typeof(char[])])!);
+        il.Emit(OpCodes.Stloc, spanLocal);
+        il.Emit(OpCodes.Ldloca, formatLocal);
+        il.Emit(OpCodes.Initobj, typeof(ReadOnlySpan<char>));
+        il.Emit(OpCodes.Ldarga_S, (byte)1);
+        il.Emit(OpCodes.Ldloc, spanLocal);
+        il.Emit(OpCodes.Ldloca, charsWrittenLocal);
+        il.Emit(OpCodes.Ldloc, formatLocal);
+        il.Emit(OpCodes.Call, typeof(CultureInfo)
+            .GetProperty("InvariantCulture")!.GetGetMethod()!);
+        il.Emit(OpCodes.Call, typeof(long).GetMethod(
+            "TryFormat",
+            [
+                typeof(Span<char>),
+                typeof(int).MakeByRefType(),
+                typeof(ReadOnlySpan<char>),
+                typeof(IFormatProvider)
+            ])!);
+        il.Emit(OpCodes.Pop);
+
+        il.Emit(OpCodes.Ldloc, bufferLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldloc, charsWrittenLocal);
+        il.Emit(OpCodes.Newobj, typeof(ReadOnlySpan<char>).GetConstructor(
+            [typeof(char[]), typeof(int), typeof(int)])!);
+        il.Emit(OpCodes.Stloc, numberSpanLocal);
+
+        MethodInfo asSpan = typeof(MemoryExtensions).GetMethod(
+            "AsSpan", [typeof(string)])!;
+        MethodInfo concat = typeof(string).GetMethod(
+            "Concat", [typeof(ReadOnlySpan<char>), typeof(ReadOnlySpan<char>)])!;
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Brfalse, textFirst);
+        il.Emit(OpCodes.Ldloc, numberSpanLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, asSpan);
+        il.Emit(OpCodes.Call, concat);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(textFirst);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, asSpan);
+        il.Emit(OpCodes.Ldloc, numberSpanLocal);
+        il.Emit(OpCodes.Call, concat);
+        il.Emit(OpCodes.Ret);
+    }
+
     /// <summary>
     /// Emits the body of <c>$Runtime.FormatNumber(double) -> string</c>, a byte-for-byte
     /// port of <see cref="RuntimeTypes.FormatNumber(double)"/> (ECMA-262 7.1.12.1

--- a/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -710,6 +710,7 @@ public partial class RuntimeEmitter
         DeclareUnwrapIfBoxed(typeBuilder, runtime);
 
         EmitFormatNumberMethod(typeBuilder, runtime);
+        EmitConcatStringInt64Method(typeBuilder, runtime);
         EmitStringify(typeBuilder, runtime);
         // EmitStringRaw is moved later in this method (after ToJsString/
         // ToNumber/GetProperty are emitted) so the spec-form String.raw can

--- a/tests/SharpTS.Tests/CompilerTests/JsonTypedScalarRecordTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/JsonTypedScalarRecordTests.cs
@@ -96,6 +96,115 @@ public sealed class JsonTypedScalarRecordTests
     }
 
     [Fact]
+    public void ClosedRecordArraySelectsExactWriterOutsideTheElementLoop()
+    {
+        Assembly assembly = Compile(Source);
+        Type runtime = assembly.GetType("$Runtime")!;
+        Type itemCarrier = assembly.GetTypes().Single(type =>
+            type.Name.StartsWith("$JsonTypedScalarRecord", StringComparison.Ordinal) &&
+            type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+                .Count(field => field.Name.StartsWith("_v", StringComparison.Ordinal)) == 3);
+        MethodInfo recordAppender = runtime
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method =>
+                method.Name.StartsWith("AppendJsonTypedScalarRecord", StringComparison.Ordinal) &&
+                method.GetParameters()[1].ParameterType == itemCarrier);
+        MethodInfo arrayAppender = runtime
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method =>
+                method.Name.StartsWith("AppendJsonTypedScalarRecordArray", StringComparison.Ordinal) &&
+                ReadMembers(method).Any(member => member.Member == recordAppender));
+
+        var members = ReadMembers(arrayAppender).ToArray();
+        Assert.Contains(members, member => member.Member == recordAppender);
+        Assert.DoesNotContain(members, member =>
+            member.Member?.Name == "AppendJsonShapedValue" ||
+            member.Member?.Name == "PDSHasPropertyDescriptors" ||
+            member.Member?.Name == "PDSHasPrototypeEntry");
+        Assert.DoesNotContain(members, member =>
+            member.Member?.DeclaringType == typeof(string) &&
+            member.Member.Name == "op_Equality");
+        Assert.DoesNotContain(members, member => member.OpCode == OpCodes.Box);
+
+        MethodInfo dispatcher = runtime.GetMethod(
+            "AppendJsonShapedValue",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        Assert.Contains(ReadMembers(dispatcher), member => member.Member == arrayAppender);
+    }
+
+    [Fact]
+    public void ClosedRecordArrayFallsBackAfterElementMaterialization()
+    {
+        const string source = """
+            type Item = { id: number; name: string; value: number };
+            const items: Item[] = [
+                { id: 1, name: "a", value: 2 },
+                { id: 3, name: "b", value: 4 }
+            ];
+            const changed: any = items[1];
+            changed.value = "changed";
+            delete changed.name;
+            changed.extra = true;
+            console.log(JSON.stringify({ items: items }));
+            """;
+
+        Assert.Equal(
+            "{\"items\":[{\"id\":1,\"name\":\"a\",\"value\":2},{\"id\":3,\"value\":\"changed\",\"extra\":true}]}\n",
+            TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void ClosedRecordArrayFallsBackForDescriptorAndPrototypeSemantics()
+    {
+        const string source = """
+            type Item = { id: number; name: string; value: number };
+            const first: Item = { id: 1, name: "a", value: 2 };
+            const second: Item = { id: 3, name: "b", value: 4 };
+            Object.defineProperty(second, "value", {
+                get: (): number => 99,
+                enumerable: true,
+                configurable: true
+            });
+            Object.setPrototypeOf(first, {
+                toJSON: function(): any { return { observed: this.name }; }
+            });
+            console.log(JSON.stringify({ items: [first, second] }));
+            """;
+
+        Assert.Equal(
+            "{\"items\":[{\"observed\":\"a\"},{\"id\":3,\"name\":\"b\",\"value\":99}]}\n",
+            TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void IntegerCounterStringConcatFormatsIntoTheFinalString()
+    {
+        const string source = """
+            function labels(): string {
+                const values: string[] = [];
+                for (let i: number = -2; i < 3; i++) {
+                    values.push("item-" + i);
+                    values.push(i + "!");
+                }
+                return values.join("|");
+            }
+            console.log(labels());
+            """;
+
+        Assembly assembly = Compile(source);
+        MethodInfo labels = FindFunction(assembly, "labels");
+        var members = ReadMembers(labels).ToArray();
+        Assert.Contains(members, member => member.Member?.Name == "ConcatStringInt64");
+        Assert.DoesNotContain(members, member =>
+            member.Member?.DeclaringType?.Name == "$Runtime" &&
+            member.Member.Name is ("Add" or "FormatNumber"));
+        Assert.DoesNotContain(members, member => member.OpCode == OpCodes.Box);
+        Assert.Equal(
+            "item--2|-2!|item--1|-1!|item-0|0!|item-1|1!|item-2|2!\n",
+            TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
     public void DynamicMutationMaterializesAndPreservesJsonObjectSemantics()
     {
         const string source = """


### PR DESCRIPTION
Closes #1461.

## Summary

- select an exact typed scalar-record array writer once per stable closed array instead of re-entering `AppendJsonShapedValue` for every element
- keep exact carrier, materialization, shape, descriptor, and prototype guards; discard partial output and invoke the existing spec-complete serializer once on any miss
- combine constant record punctuation/property prefixes and vectorize the ordinary-string escape scan with `SearchValues<char>`
- lower string/proven-integer-counter `+` without boxing or `$Runtime.Add`; the native Int64 counter formats through a thread-local span directly into the final string, avoiding 10,000 temporary numeric strings in the benchmark

## Correctness boundary

The exact array path is emitted only for closed statically shaped records. Descriptor/prototype probes are omitted only when whole-program feature detection proves those mutation routes absent. Materialized/replaced elements, accessors, custom prototypes/`toJSON`, open shapes, and uncertain cases retain the generic serializer. Native concat requires proven Int64 loop-counter storage; flow-narrowed numbers in object-backed parameters retain dynamic `+`. New tests inspect the selected IL and exercise materialization, descriptor, and prototype fallbacks.

## Performance

Pinned baseline: merged #1460 (`3415fa5a`), Windows x64, .NET SDK 10.0.400/runtime 10.0.11, Node 24.19.0.

- five launched N=10,000 medians: **4.0928 -> 3.6905 ms** compiled (-9.8%); Node **2.3378 -> 2.2607 ms**; ratio **1.75x -> 1.63x**
- BenchmarkDotNet full allocation: **3,851.34 -> 3,313.73 KB/op** (-14.0%)
- build allocation: **1,554.47 -> 1,016.97 KB/op** (-34.6%)
- build+stringify: **2.515 ms / 1,885.83 KB**, with an incremental stringify cost of about **2.193 ms**
- full round trip ShortRun: **4.014 ms / 3,313.73 KB** versus the pinned **4.264 ms / 3,851.34 KB**
- selected-path process minimum: **0.7605 ms** compiled versus **1.9199 ms** Node

The remaining mean/minimum spread is collection policy, not per-element dispatch: changing only the diagnostic runtimeconfig to concurrent server GC produced a **2.0488 ms** compiled median, faster than the paired Node reference. #1462 records the cross-platform throughput/memory/startup decision rather than changing every application's GC policy here.

## Validation

- `dotnet build SharpTS.sln -c Release --no-restore -m:1 -nr:false` (pass; only offline NU1900 audit warnings)
- 641 non-standalone compiler tests (pass)
- 424 JSON, operator, and unboxed-arithmetic tests (pass)
- 10 typed JSON scalar-record specialization/fallback tests (pass)
- standalone/IL batch: 127 pass; three unrelated environment cases fail (two child-process timeout assertions after the expected stderr was emitted, one local TLS authentication failure)
- generated JSON workload compiles with `--verify` (pass)

Follow-up: #1462