### PR TITLE
perf: batch local lab and stable representation optimizations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
       - name: Smoke test benchmark harnesses
         shell: pwsh
         run: |
+          ./scripts/test-perf-local.ps1
           ./benchmarks/cross-runtime/run-benchmarks.ps1 -Smoke -NoBuild
           dotnet run --configuration Release --no-build `
             --project benchmarks/micro/SharpTS.Microbenchmarks -- --smoke

--- a/benchmarks/cross-runtime/README.md
+++ b/benchmarks/cross-runtime/README.md
@@ -36,6 +36,13 @@ pipeline), so it reflects what a user actually experiences invoking each runtime
 # Run everything; results land in $TEMP/bench-results/results.txt
 ./benchmarks/cross-runtime/run-benchmarks.ps1
 
+# Repeat only numeric-loop workloads, excluding the advisory Bun result
+./benchmarks/cross-runtime/run-benchmarks.ps1 `
+  -Workloads int-arrays,brainfuck,accumulate `
+  -Runtimes compiled,node `
+  -Launches 3 `
+  -OutputDirectory .perf-cross-runtime
+
 # Render the table from a results file
 ./benchmarks/cross-runtime/format-results.ps1 -ResultsFile $env:TEMP/bench-results/results.txt
 ```
@@ -47,8 +54,19 @@ same inexpensive guard used by CI):
 ./benchmarks/cross-runtime/run-benchmarks.ps1 -Smoke
 ```
 
-Override the output directory with `$env:OUTPUT_DIR`. Node and Bun are detected
-automatically; Bun is skipped if not on `PATH`.
+`-Workloads` accepts script basenames and `-Runtimes` accepts `interpreter`,
+`compiled`, `node`, and `bun`. Override the output directory with
+`-OutputDirectory` or `$env:OUTPUT_DIR`. Node and Bun are detected only when
+selected; Bun is skipped if not on `PATH`.
+
+`-RepositoryRoot` is intended for the paired local performance harness. It lets
+the current runner compile and execute a frozen source worktree, so the baseline
+does not need to be modified when harness features are added later.
+`-NodeExecutable` selects a specific Node binary when more than one version is
+installed.
+
+For repeatable candidate-vs-baseline runs on native Windows and WSL, see
+[`../local-perf/README.md`](../local-perf/README.md).
 
 ## How timing works
 

--- a/benchmarks/cross-runtime/run-benchmarks.ps1
+++ b/benchmarks/cross-runtime/run-benchmarks.ps1
@@ -1,14 +1,40 @@
 [CmdletBinding()]
 param(
     [switch]$Smoke,
-    [switch]$NoBuild
+    [switch]$NoBuild,
+
+    [string[]]$Workloads = @(),
+
+    [string[]]$Runtimes = @('interpreter', 'compiled', 'node', 'bun'),
+
+    [ValidateRange(1, 20)]
+    [int]$Launches = 1,
+
+    [string]$OutputDirectory,
+
+    # Keep the harness on the candidate branch while measuring a frozen
+    # baseline worktree that may predate these filtering options.
+    [string]$RepositoryRoot,
+
+    [string]$NodeExecutable = 'node'
 )
 
 $ErrorActionPreference = 'Stop'
 
-$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
-$RepoRoot = (Resolve-Path (Join-Path $ScriptDir '../..')).Path
-$OutputDir = if ($env:OUTPUT_DIR) { $env:OUTPUT_DIR } else { Join-Path ([System.IO.Path]::GetTempPath()) 'bench-results' }
+$HarnessDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$RepoRoot = if ($RepositoryRoot) {
+    (Resolve-Path -LiteralPath $RepositoryRoot).Path
+} else {
+    (Resolve-Path (Join-Path $HarnessDir '../..')).Path
+}
+$ScriptDir = Join-Path $RepoRoot 'benchmarks/cross-runtime'
+$OutputDir = if ($OutputDirectory) {
+    [IO.Path]::GetFullPath($OutputDirectory)
+} elseif ($env:OUTPUT_DIR) {
+    [IO.Path]::GetFullPath($env:OUTPUT_DIR)
+} else {
+    Join-Path ([System.IO.Path]::GetTempPath()) 'bench-results'
+}
 $ScriptsDir = Join-Path $ScriptDir 'scripts'
 $SharpTSProject = Join-Path $RepoRoot 'src/SharpTS/SharpTS.csproj'
 
@@ -16,9 +42,38 @@ if (-not (Test-Path -LiteralPath $SharpTSProject -PathType Leaf)) {
     throw "Could not find SharpTS.csproj from runner root '$RepoRoot'"
 }
 
-$scripts = @(Get-ChildItem -Path $ScriptsDir -Filter '*.ts' | Sort-Object Name)
-if ($scripts.Count -eq 0) {
+$availableScripts = @(Get-ChildItem -Path $ScriptsDir -Filter '*.ts' | Sort-Object Name)
+if ($availableScripts.Count -eq 0) {
     throw "No benchmark workloads found in '$ScriptsDir'"
+}
+
+$Workloads = @($Workloads | ForEach-Object { $_ -split ',' } |
+    ForEach-Object { $_.Trim() } | Where-Object { $_ } | Select-Object -Unique)
+if ($Workloads.Count -gt 0) {
+    $requested = [Collections.Generic.HashSet[string]]::new(
+        $Workloads,
+        [StringComparer]::OrdinalIgnoreCase)
+    $scripts = @($availableScripts | Where-Object { $requested.Contains($_.BaseName) })
+    $missing = @($Workloads | Where-Object {
+        $name = $_
+        -not ($scripts | Where-Object { $_.BaseName -eq $name })
+    })
+    if ($missing.Count -gt 0) {
+        throw "Unknown workload(s): $($missing -join ', '). Available: $($availableScripts.BaseName -join ', ')"
+    }
+} else {
+    $scripts = $availableScripts
+}
+
+$Runtimes = @($Runtimes | ForEach-Object { $_ -split ',' } |
+    ForEach-Object { $_.Trim().ToLowerInvariant() } | Where-Object { $_ } | Select-Object -Unique)
+$knownRuntimes = @('interpreter', 'compiled', 'node', 'bun')
+$unknownRuntimes = @($Runtimes | Where-Object { $_ -notin $knownRuntimes })
+if ($unknownRuntimes.Count -gt 0) {
+    throw "Unknown runtime(s): $($unknownRuntimes -join ', '). Available: $($knownRuntimes -join ', ')"
+}
+if (-not $Smoke -and $Runtimes.Count -eq 0) {
+    throw 'At least one runtime must be selected.'
 }
 
 $failures = [System.Collections.Generic.List[string]]::new()
@@ -68,10 +123,10 @@ if (-not $NoBuild) {
 # Detect Node.js version for --experimental-strip-types
 $node = $null
 $nodeFlags = @()
-if (-not $Smoke) {
-    $node = Get-Command node -ErrorAction SilentlyContinue
+if (-not $Smoke -and $Runtimes -contains 'node') {
+    $node = Get-Command $NodeExecutable -ErrorAction SilentlyContinue
     if ($node) {
-        $nodeVersion = Invoke-Captured { node -v }
+        $nodeVersion = Invoke-Captured { & $node.Source -v }
         if ($nodeVersion.ExitCode -eq 0) {
             $nodeVersionFull = ([string]$nodeVersion.Output[0]) -replace '^v', ''
             $nodeMajor = [int]($nodeVersionFull -split '\.')[0]
@@ -86,6 +141,12 @@ if (-not $Smoke) {
     } else {
         Write-Warning 'Node.js is not installed; Node workloads will be reported as failures'
     }
+}
+
+$bun = if (-not $Smoke -and $Runtimes -contains 'bun') {
+    Get-Command bun -ErrorAction SilentlyContinue
+} else {
+    $null
 }
 
 # Tag and persist a runtime's BENCH output. If none was produced (a crash, a
@@ -154,23 +215,18 @@ try {
             continue
         }
 
-        # --- Interpreter ---
-        Write-Host '  [interpreter] running...'
-        $interp = Invoke-Captured {
-            dotnet run -c Release --no-build --project $SharpTSProject -- $script.FullName
-        }
-        Complete-Runtime $benchName 'interpreter' $interp $ResultsFile
+        $compiledReady = $false
+        if ($Runtimes -contains 'compiled') {
+            Write-Host '  [compiled] compiling...'
+            $compile = Invoke-Captured {
+                dotnet run -c Release --no-build --project $SharpTSProject -- --compile $script.FullName -o $dllPath
+            }
 
-        # --- Compiled ---
-        Write-Host '  [compiled] compiling...'
-        $compile = Invoke-Captured {
-            dotnet run -c Release --no-build --project $SharpTSProject -- --compile $script.FullName -o $dllPath
-        }
-
-        if ($compile.ExitCode -eq 0 -and (Test-Path -LiteralPath $dllPath -PathType Leaf)) {
-            $rcPath = Join-Path $compiledDir "$benchName.runtimeconfig.json"
-            if (-not (Test-Path $rcPath)) {
-                @'
+            if ($compile.ExitCode -eq 0 -and (Test-Path -LiteralPath $dllPath -PathType Leaf)) {
+                $compiledReady = $true
+                $rcPath = Join-Path $compiledDir "$benchName.runtimeconfig.json"
+                if (-not (Test-Path $rcPath)) {
+                    @'
 {
   "runtimeOptions": {
     "tfm": "net10.0",
@@ -181,33 +237,52 @@ try {
   }
 }
 '@ | Set-Content $rcPath
+                }
+            } else {
+                Add-Failure "$benchName [compiled] failed to compile (exit code $($compile.ExitCode))"
+                Show-Diagnostics 'compiled' $compile.Output
             }
-
-            Write-Host '  [compiled] running...'
-            $compiled = Invoke-Captured { dotnet $dllPath }
-            Complete-Runtime $benchName 'compiled' $compiled $ResultsFile
-        } else {
-            Add-Failure "$benchName [compiled] failed to compile (exit code $($compile.ExitCode))"
-            Show-Diagnostics 'compiled' $compile.Output
         }
 
-        # --- Node.js ---
-        if ($node) {
-            Write-Host '  [node] running...'
-            $nodeArgs = $nodeFlags + @($script.FullName)
-            $nodeResult = Invoke-Captured { & node @nodeArgs }
-            Complete-Runtime $benchName 'node' $nodeResult $ResultsFile
-        } else {
-            Add-Failure "$benchName [node] could not run because Node.js is unavailable"
-        }
+        for ($launch = 1; $launch -le $Launches; $launch++) {
+            $offset = ($launch - 1) % $Runtimes.Count
+            $orderedRuntimes = @($Runtimes[$offset..($Runtimes.Count - 1)])
+            if ($offset -gt 0) { $orderedRuntimes += $Runtimes[0..($offset - 1)] }
 
-        # --- Bun ---
-        if (Get-Command bun -ErrorAction SilentlyContinue) {
-            Write-Host '  [bun] running...'
-            $bunResult = Invoke-Captured { & bun run $script.FullName }
-            Complete-Runtime $benchName 'bun' $bunResult $ResultsFile
-        } else {
-            Write-Host '  [bun] not installed, skipping'
+            foreach ($runtime in $orderedRuntimes) {
+                Write-Host "  [$runtime] launch $launch/$Launches..."
+                switch ($runtime) {
+                    'interpreter' {
+                        $result = Invoke-Captured {
+                            dotnet run -c Release --no-build --project $SharpTSProject -- $script.FullName
+                        }
+                        Complete-Runtime $benchName 'interpreter' $result $ResultsFile
+                    }
+                    'compiled' {
+                        if ($compiledReady) {
+                            $result = Invoke-Captured { dotnet $dllPath }
+                            Complete-Runtime $benchName 'compiled' $result $ResultsFile
+                        }
+                    }
+                    'node' {
+                        if ($node) {
+                            $nodeArgs = $nodeFlags + @($script.FullName)
+                            $result = Invoke-Captured { & $node.Source @nodeArgs }
+                            Complete-Runtime $benchName 'node' $result $ResultsFile
+                        } else {
+                            Add-Failure "$benchName [node] could not run because Node.js is unavailable"
+                        }
+                    }
+                    'bun' {
+                        if ($bun) {
+                            $result = Invoke-Captured { & bun run $script.FullName }
+                            Complete-Runtime $benchName 'bun' $result $ResultsFile
+                        } else {
+                            Write-Host '  [bun] not installed, skipping'
+                        }
+                    }
+                }
+            }
         }
     }
 } finally {

--- a/benchmarks/local-perf/README.md
+++ b/benchmarks/local-perf/README.md
@@ -10,7 +10,9 @@ The defaults target the current numeric-loop tranche:
 
 - `int-arrays`
 - `brainfuck`
-- `accumulate`
+- `count-primes`
+
+The `int-arrays` script reports both `int32-kernel` and `accumulate` cases.
 
 Node 22.23.2 is the competitive reference. Bun is deliberately absent from the
 acceptance comparison: a locally installed Bun can still be run directly with
@@ -73,7 +75,7 @@ workloads. Commit a coherent checkpoint before adding WSL:
 ./scripts/perf-local.ps1 -Action sync
 ./scripts/perf-local.ps1 -Action measure `
   -Platforms windows,wsl `
-  -Workloads int-arrays,brainfuck,accumulate `
+  -Workloads int-arrays,brainfuck,count-primes `
   -Runs 5 `
   -Enforce
 ```

--- a/benchmarks/local-perf/README.md
+++ b/benchmarks/local-perf/README.md
@@ -80,8 +80,10 @@ workloads. Commit a coherent checkpoint before adding WSL:
   -Enforce
 ```
 
-Each launch alternates which variant runs first. The report uses the median of
-the launches and records raw data, commits, dirty state, host facts, JSON, and a
+Each launch alternates which variant runs first. The report uses medians for the
+displayed timings and the median of per-launch paired changes for decisions, so
+thermal or host-load drift cannot turn mismatched independent medians into a
+false result. It records raw data, commits, dirty state, host facts, JSON, and a
 Markdown summary under the ignored `.perf-local/` directory. A regression is
 material only when it exceeds both defaults: 10% and 0.05 ms. Override either
 threshold explicitly when a workload needs a different noise floor.

--- a/benchmarks/local-perf/README.md
+++ b/benchmarks/local-perf/README.md
@@ -1,0 +1,109 @@
+# Local performance lab
+
+The local lab is the primary feedback loop for performance work. It compares a
+frozen `main` worktree with the current candidate on the same Windows machine
+and again in an ext4-backed WSL worktree. GitHub CI remains the final ARM/macOS
+and clean-environment check, rather than the place where performance changes are
+discovered one at a time.
+
+The defaults target the current numeric-loop tranche:
+
+- `int-arrays`
+- `brainfuck`
+- `accumulate`
+
+Node 22.23.2 is the competitive reference. Bun is deliberately absent from the
+acceptance comparison: a locally installed Bun can still be run directly with
+the cross-runtime harness, but its version is advisory and need not match the
+repository pin.
+
+## One-time worktrees
+
+Keep all four source trees separate. Benchmark Windows sources on NTFS and Linux
+sources on WSL's ext4 filesystem; `/mnt/d` is useful as a Git transport, not as a
+Linux benchmark location.
+
+This checkout uses the following conventional paths:
+
+| Role | Path |
+|---|---|
+| Windows baseline | sibling `.perf-baseline-worktree` |
+| Windows candidate | the current worktree |
+| WSL bare transport | `~/src/SharpTS-perf.git` |
+| WSL baseline | `~/src/SharpTS-perf-baseline` |
+| WSL candidate | `~/src/SharpTS-perf-candidate` |
+
+Create the Windows baseline from the exact `origin/main` commit that starts a
+performance tranche. Keep it detached until the whole tranche is ready for a
+PR. The WSL bare repository should have a `windows` remote pointing at the
+Windows repository through `/mnt/d`; create detached baseline and candidate
+worktrees from it.
+
+The sync operation refuses a dirty Windows candidate or tracked changes in the
+WSL candidate. This makes each cross-OS checkpoint reproducible:
+
+```powershell
+git add -A
+git commit -m "perf: checkpoint numeric loop work"
+./scripts/perf-local.ps1 -Action sync
+```
+
+The WSL toolchain is initialized explicitly by the script: .NET comes from
+`~/.dotnet`, NVM selects Node 22.23.2, and Bun is not part of acceptance.
+On Windows, install the pinned Node version side by side with
+`nvm install 22.23.2`. The lab invokes that binary directly and does not change
+the global NVM selection, so unrelated worktrees can continue using Node 24.
+
+## Fast loop
+
+Use the Windows checkpoint gate while editing, then measure one or two focused
+workloads. Commit a coherent checkpoint before adding WSL:
+
+```powershell
+# Fast correctness checks on the active platform
+./scripts/perf-local.ps1 -Action gate -Platforms windows -GateLevel checkpoint
+
+# Alternating baseline/candidate launches on Windows
+./scripts/perf-local.ps1 -Action measure `
+  -Platforms windows `
+  -Workloads int-arrays,brainfuck `
+  -Runs 3
+
+# After committing: sync and repeat on both operating systems
+./scripts/perf-local.ps1 -Action sync
+./scripts/perf-local.ps1 -Action measure `
+  -Platforms windows,wsl `
+  -Workloads int-arrays,brainfuck,accumulate `
+  -Runs 5 `
+  -Enforce
+```
+
+Each launch alternates which variant runs first. The report uses the median of
+the launches and records raw data, commits, dirty state, host facts, JSON, and a
+Markdown summary under the ignored `.perf-local/` directory. A regression is
+material only when it exceeds both defaults: 10% and 0.05 ms. Override either
+threshold explicitly when a workload needs a different noise floor.
+
+## Gates and PR cadence
+
+`checkpoint` builds Release, smoke-compiles the selected cross-runtime and
+microbenchmark workloads, and runs the compiler-focused core tests. `full` runs
+the entire hermetic core suite and adds GUI and conformance checks, packaging
+helpers, the analyzer ratchet, and a compact WSL Native AOT publish/execute
+check.
+
+Run the full gate and a five-launch paired measurement when a performance
+tranche is ready:
+
+```powershell
+./scripts/perf-local.ps1 -Action all `
+  -Platforms windows,wsl `
+  -GateLevel full `
+  -Runs 5 `
+  -Enforce
+```
+
+Batch several related, independently tested optimizations into one PR. Preserve
+the intermediate commits and include the final `.perf-local/.../summary.md`
+table in the PR description. GitHub then validates the architectures not covered
+locally instead of serving as the development loop.

--- a/scripts/PerfLocal.psm1
+++ b/scripts/PerfLocal.psm1
@@ -1,0 +1,161 @@
+Set-StrictMode -Version Latest
+
+$script:InvariantCulture = [Globalization.CultureInfo]::InvariantCulture
+
+function Get-SharpTSMedian {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [double[]]$Values)
+
+    if ($Values.Count -eq 0) {
+        return [double]::NaN
+    }
+
+    $sorted = @($Values | Sort-Object)
+    $middle = [int][Math]::Floor($sorted.Count / 2)
+    if (($sorted.Count % 2) -eq 1) {
+        return [double]$sorted[$middle]
+    }
+
+    return ([double]$sorted[$middle - 1] + [double]$sorted[$middle]) / 2.0
+}
+
+function ConvertFrom-SharpTSBenchmarkResults {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$Text,
+        [Parameter(Mandatory)] [string]$Platform,
+        [Parameter(Mandatory)] [ValidateSet('baseline', 'candidate')] [string]$Variant,
+        [Parameter(Mandatory)] [ValidateRange(1, 100)] [int]$Launch
+    )
+
+    foreach ($line in $Text -split "`r?`n") {
+        if (-not $line.Trim()) { continue }
+        $runtimeAndPayload = $line -split '\|', 2
+        if ($runtimeAndPayload.Count -ne 2) {
+            throw "Malformed benchmark result line: $line"
+        }
+
+        $fields = $runtimeAndPayload[1] -split ':'
+        if ($fields.Count -ne 5) {
+            throw "Malformed benchmark payload: $line"
+        }
+
+        $runtime = $runtimeAndPayload[0]
+        $label = if ($runtime -eq 'node') { 'node' } elseif ($runtime -eq 'compiled') { $Variant } else { $runtime }
+        [pscustomobject]@{
+            platform = $Platform
+            variant = $Variant
+            label = $label
+            runtime = $runtime
+            launch = $Launch
+            benchmark = $fields[0]
+            parameter = [double]::Parse($fields[1], $script:InvariantCulture)
+            meanMilliseconds = [double]::Parse($fields[2], $script:InvariantCulture)
+            minimumMilliseconds = [double]::Parse($fields[3], $script:InvariantCulture)
+            standardDeviationMilliseconds = [double]::Parse($fields[4], $script:InvariantCulture)
+        }
+    }
+}
+
+function Get-SharpTSPerfComparisons {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [object[]]$Samples,
+        [ValidateRange(0, 1000)] [double]$RegressionThresholdPercent = 10,
+        [ValidateRange(0, 1000)] [double]$RegressionMinimumMilliseconds = 0.05
+    )
+
+    $groups = $Samples | Group-Object platform, benchmark, parameter
+    foreach ($group in $groups | Sort-Object Name) {
+        $baseline = @($group.Group | Where-Object label -eq 'baseline')
+        $candidate = @($group.Group | Where-Object label -eq 'candidate')
+        $node = @($group.Group | Where-Object label -eq 'node')
+        if ($baseline.Count -eq 0 -or $candidate.Count -eq 0) {
+            throw "Missing baseline or candidate samples for $($group.Name)"
+        }
+
+        $baselineMedian = Get-SharpTSMedian @($baseline.meanMilliseconds)
+        $candidateMedian = Get-SharpTSMedian @($candidate.meanMilliseconds)
+        $nodeMedian = if ($node.Count -gt 0) { Get-SharpTSMedian @($node.meanMilliseconds) } else { [double]::NaN }
+        $deltaMilliseconds = $candidateMedian - $baselineMedian
+        $changePercent = if ($baselineMedian -eq 0) {
+            [double]::NaN
+        } else {
+            (($candidateMedian / $baselineMedian) - 1.0) * 100.0
+        }
+        $material = [Math]::Abs($deltaMilliseconds) -ge $RegressionMinimumMilliseconds
+        $status = if ($material -and $changePercent -gt $RegressionThresholdPercent) {
+            'regression'
+        } elseif ($material -and $changePercent -lt -$RegressionThresholdPercent) {
+            'improvement'
+        } else {
+            'neutral'
+        }
+
+        $first = $group.Group[0]
+        [pscustomobject]@{
+            platform = $first.platform
+            benchmark = $first.benchmark
+            parameter = [double]$first.parameter
+            baselineMedianMilliseconds = [Math]::Round($baselineMedian, 6)
+            candidateMedianMilliseconds = [Math]::Round($candidateMedian, 6)
+            deltaMilliseconds = [Math]::Round($deltaMilliseconds, 6)
+            changePercent = [Math]::Round($changePercent, 2)
+            nodeMedianMilliseconds = if ([double]::IsNaN($nodeMedian)) { $null } else { [Math]::Round($nodeMedian, 6) }
+            candidateVsNode = if ([double]::IsNaN($nodeMedian) -or $nodeMedian -eq 0) {
+                $null
+            } else {
+                [Math]::Round($candidateMedian / $nodeMedian, 3)
+            }
+            baselineSamples = $baseline.Count
+            candidateSamples = $candidate.Count
+            nodeSamples = $node.Count
+            status = $status
+        }
+    }
+}
+
+function ConvertTo-SharpTSPerfMarkdown {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [object[]]$Comparisons,
+        [Parameter(Mandatory)] [Collections.IDictionary]$Metadata
+    )
+
+    $lines = [Collections.Generic.List[string]]::new()
+    $lines.Add('# SharpTS paired performance comparison')
+    $lines.Add('')
+    $lines.Add("Baseline: ``$($Metadata.baselineCommit)``  ")
+    $lines.Add("Candidate: ``$($Metadata.candidateCommit)``  ")
+    $lines.Add("Runs per variant/platform: $($Metadata.runs)")
+    $lines.Add('')
+    $lines.Add('| Platform | Benchmark | Input | Baseline | Candidate | Change | Node | Candidate/Node | Status |')
+    $lines.Add('|---|---|---:|---:|---:|---:|---:|---:|---|')
+
+    foreach ($row in $Comparisons | Sort-Object platform, benchmark, parameter) {
+        $parameter = $row.parameter.ToString('G17', $script:InvariantCulture)
+        $baseline = $row.baselineMedianMilliseconds.ToString('F4', $script:InvariantCulture)
+        $candidate = $row.candidateMedianMilliseconds.ToString('F4', $script:InvariantCulture)
+        $change = $row.changePercent.ToString('+0.00;-0.00;0.00', $script:InvariantCulture)
+        $node = if ($null -eq $row.nodeMedianMilliseconds) {
+            '-'
+        } else {
+            $row.nodeMedianMilliseconds.ToString('F4', $script:InvariantCulture)
+        }
+        $candidateVsNode = if ($null -eq $row.candidateVsNode) {
+            '-'
+        } else {
+            $row.candidateVsNode.ToString('F3', $script:InvariantCulture) + 'x'
+        }
+        $lines.Add("| $($row.platform) | $($row.benchmark) | $parameter | $baseline ms | $candidate ms | $change% | $node ms | $candidateVsNode | $($row.status) |")
+    }
+
+    return $lines
+}
+
+Export-ModuleMember -Function @(
+    'Get-SharpTSMedian',
+    'ConvertFrom-SharpTSBenchmarkResults',
+    'Get-SharpTSPerfComparisons',
+    'ConvertTo-SharpTSPerfMarkdown'
+)

--- a/scripts/PerfLocal.psm1
+++ b/scripts/PerfLocal.psm1
@@ -77,12 +77,35 @@ function Get-SharpTSPerfComparisons {
         $baselineMedian = Get-SharpTSMedian @($baseline.meanMilliseconds)
         $candidateMedian = Get-SharpTSMedian @($candidate.meanMilliseconds)
         $nodeMedian = if ($node.Count -gt 0) { Get-SharpTSMedian @($node.meanMilliseconds) } else { [double]::NaN }
-        $deltaMilliseconds = $candidateMedian - $baselineMedian
-        $changePercent = if ($baselineMedian -eq 0) {
-            [double]::NaN
-        } else {
-            (($candidateMedian / $baselineMedian) - 1.0) * 100.0
+
+        # Preserve the alternating launch pairs. Independent medians can report
+        # a large change when CPU frequency or host load drifts during a run,
+        # even if every nearby baseline/candidate pair agrees.
+        $pairedDeltas = [Collections.Generic.List[double]]::new()
+        $pairedChanges = [Collections.Generic.List[double]]::new()
+        $pairedNodeRatios = [Collections.Generic.List[double]]::new()
+        foreach ($launch in @($baseline.launch | Sort-Object -Unique)) {
+            $baselineLaunch = @($baseline | Where-Object launch -eq $launch)
+            $candidateLaunch = @($candidate | Where-Object launch -eq $launch)
+            if ($candidateLaunch.Count -eq 0) { continue }
+            $baselineValue = Get-SharpTSMedian @($baselineLaunch.meanMilliseconds)
+            $candidateValue = Get-SharpTSMedian @($candidateLaunch.meanMilliseconds)
+            $pairedDeltas.Add($candidateValue - $baselineValue)
+            if ($baselineValue -ne 0) {
+                $pairedChanges.Add((($candidateValue / $baselineValue) - 1.0) * 100.0)
+            }
+
+            $nodeLaunch = @($node | Where-Object launch -eq $launch)
+            if ($nodeLaunch.Count -gt 0) {
+                $nodeValue = Get-SharpTSMedian @($nodeLaunch.meanMilliseconds)
+                if ($nodeValue -ne 0) { $pairedNodeRatios.Add($candidateValue / $nodeValue) }
+            }
         }
+        if ($pairedDeltas.Count -eq 0 -or $pairedChanges.Count -eq 0) {
+            throw "Missing paired launch samples for $($group.Name)"
+        }
+        $deltaMilliseconds = Get-SharpTSMedian $pairedDeltas.ToArray()
+        $changePercent = Get-SharpTSMedian $pairedChanges.ToArray()
         $material = [Math]::Abs($deltaMilliseconds) -ge $RegressionMinimumMilliseconds
         $status = if ($material -and $changePercent -gt $RegressionThresholdPercent) {
             'regression'
@@ -102,10 +125,10 @@ function Get-SharpTSPerfComparisons {
             deltaMilliseconds = [Math]::Round($deltaMilliseconds, 6)
             changePercent = [Math]::Round($changePercent, 2)
             nodeMedianMilliseconds = if ([double]::IsNaN($nodeMedian)) { $null } else { [Math]::Round($nodeMedian, 6) }
-            candidateVsNode = if ([double]::IsNaN($nodeMedian) -or $nodeMedian -eq 0) {
+            candidateVsNode = if ($pairedNodeRatios.Count -eq 0) {
                 $null
             } else {
-                [Math]::Round($candidateMedian / $nodeMedian, 3)
+                [Math]::Round((Get-SharpTSMedian $pairedNodeRatios.ToArray()), 3)
             }
             baselineSamples = $baseline.Count
             candidateSamples = $candidate.Count

--- a/scripts/perf-local.ps1
+++ b/scripts/perf-local.ps1
@@ -128,10 +128,10 @@ function Get-WslHome {
 }
 
 function Initialize-WslPaths {
-    $home = Get-WslHome
-    if (-not $script:WslBareRepository) { $script:WslBareRepository = "$home/src/SharpTS-perf.git" }
-    if (-not $script:WslBaselinePath) { $script:WslBaselinePath = "$home/src/SharpTS-perf-baseline" }
-    if (-not $script:WslCandidatePath) { $script:WslCandidatePath = "$home/src/SharpTS-perf-candidate" }
+    $wslUserHome = Get-WslHome
+    if (-not $script:WslBareRepository) { $script:WslBareRepository = "$wslUserHome/src/SharpTS-perf.git" }
+    if (-not $script:WslBaselinePath) { $script:WslBaselinePath = "$wslUserHome/src/SharpTS-perf-baseline" }
+    if (-not $script:WslCandidatePath) { $script:WslCandidatePath = "$wslUserHome/src/SharpTS-perf-candidate" }
 }
 
 function Get-WslEnvironmentPrefix {

--- a/scripts/perf-local.ps1
+++ b/scripts/perf-local.ps1
@@ -6,7 +6,7 @@ param(
 
     [string[]]$Platforms = @('windows', 'wsl'),
 
-    [string[]]$Workloads = @('int-arrays', 'brainfuck', 'accumulate'),
+    [string[]]$Workloads = @('int-arrays', 'brainfuck', 'count-primes'),
 
     [ValidateRange(1, 20)]
     [int]$Runs = 3,

--- a/scripts/perf-local.ps1
+++ b/scripts/perf-local.ps1
@@ -1,0 +1,551 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateSet('sync', 'measure', 'gate', 'all')]
+    [string]$Action,
+
+    [string[]]$Platforms = @('windows', 'wsl'),
+
+    [string[]]$Workloads = @('int-arrays', 'brainfuck', 'accumulate'),
+
+    [ValidateRange(1, 20)]
+    [int]$Runs = 3,
+
+    [ValidateSet('checkpoint', 'full')]
+    [string]$GateLevel = 'checkpoint',
+
+    [string]$BaselinePath,
+
+    [string]$OutputDirectory,
+
+    [string]$WslDistro = 'Ubuntu-26.04',
+
+    [string]$WslBareRepository,
+
+    [string]$WslBaselinePath,
+
+    [string]$WslCandidatePath,
+
+    [ValidateRange(0, 1000)]
+    [double]$RegressionThresholdPercent = 10,
+
+    [ValidateRange(0, 1000)]
+    [double]$RegressionMinimumMilliseconds = 0.05,
+
+    [switch]$Enforce,
+
+    [switch]$NoBuild
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$RepoParent = Split-Path -Parent $RepoRoot
+$Runner = Join-Path $RepoRoot 'benchmarks/cross-runtime/run-benchmarks.ps1'
+$BaselinePath = if ($BaselinePath) {
+    (Resolve-Path -LiteralPath $BaselinePath).Path
+} else {
+    (Resolve-Path -LiteralPath (Join-Path $RepoParent '.perf-baseline-worktree')).Path
+}
+$OutputDirectory = if ($OutputDirectory) {
+    [IO.Path]::GetFullPath($OutputDirectory)
+} else {
+    Join-Path $RepoRoot ".perf-local/$([DateTime]::UtcNow.ToString('yyyyMMdd-HHmmss'))"
+}
+
+$Platforms = @($Platforms | ForEach-Object { $_ -split ',' } |
+    ForEach-Object { $_.Trim().ToLowerInvariant() } | Where-Object { $_ } | Select-Object -Unique)
+$Workloads = @($Workloads | ForEach-Object { $_ -split ',' } |
+    ForEach-Object { $_.Trim() } | Where-Object { $_ } | Select-Object -Unique)
+$unknownPlatforms = @($Platforms | Where-Object { $_ -notin @('windows', 'wsl') })
+if ($unknownPlatforms.Count -gt 0) {
+    throw "Unknown platform(s): $($unknownPlatforms -join ', '). Available: windows, wsl"
+}
+if ($Platforms.Count -eq 0) {
+    throw 'At least one platform must be selected.'
+}
+if ($Workloads.Count -eq 0 -and $Action -in @('measure', 'all')) {
+    throw 'At least one workload must be selected for measurement.'
+}
+
+Import-Module (Join-Path $PSScriptRoot 'PerfLocal.psm1') -Force
+
+function Quote-BashArgument {
+    param([AllowEmptyString()] [string]$Value)
+    $escaped = $Value.Replace('\', '\\').Replace('"', '\"').Replace('$', '\$').Replace('`', '\`')
+    return '"' + $escaped + '"'
+}
+
+function Join-BashCommand {
+    param([Parameter(Mandatory)] [string[]]$Arguments)
+    return ($Arguments | ForEach-Object { Quote-BashArgument $_ }) -join ' '
+}
+
+function Invoke-NativeChecked {
+    param(
+        [Parameter(Mandatory)] [string]$FilePath,
+        [string[]]$Arguments = @(),
+        [Parameter(Mandatory)] [string]$WorkingDirectory,
+        [switch]$Capture
+    )
+
+    Push-Location $WorkingDirectory
+    try {
+        if ($Capture) {
+            $output = @(& $FilePath @Arguments 2>&1)
+        } else {
+            & $FilePath @Arguments
+        }
+        if ($LASTEXITCODE -ne 0) {
+            throw "Command failed with exit code ${LASTEXITCODE}: $FilePath $($Arguments -join ' ')"
+        }
+        if ($Capture) { return $output }
+    } finally {
+        Pop-Location
+    }
+}
+
+function Invoke-GitCapture {
+    param(
+        [Parameter(Mandatory)] [string]$Repository,
+        [Parameter(Mandatory)] [string[]]$Arguments
+    )
+
+    $output = @(& git -C $Repository @Arguments 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        throw "git failed in '$Repository': $($output -join [Environment]::NewLine)"
+    }
+    return ($output -join "`n").Trim()
+}
+
+function Get-WslHome {
+    $output = @(& wsl.exe -d $WslDistro --exec bash -c 'printf %s "$HOME"' 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not query HOME in WSL distro '$WslDistro': $($output -join [Environment]::NewLine)"
+    }
+    return ($output -join '').Trim()
+}
+
+function Initialize-WslPaths {
+    $home = Get-WslHome
+    if (-not $script:WslBareRepository) { $script:WslBareRepository = "$home/src/SharpTS-perf.git" }
+    if (-not $script:WslBaselinePath) { $script:WslBaselinePath = "$home/src/SharpTS-perf-baseline" }
+    if (-not $script:WslCandidatePath) { $script:WslCandidatePath = "$home/src/SharpTS-perf-candidate" }
+}
+
+function Get-WslEnvironmentPrefix {
+    return @'
+set -euo pipefail
+export DOTNET_ROOT="$HOME/.dotnet"
+export BUN_INSTALL="$HOME/.bun"
+export NVM_DIR="$HOME/.nvm"
+export PATH="$DOTNET_ROOT:$DOTNET_ROOT/tools:$BUN_INSTALL/bin:$PATH"
+. "$NVM_DIR/nvm.sh"
+nvm use 22.23.2 >/dev/null
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+'@
+}
+
+function Invoke-WslChecked {
+    param(
+        [Parameter(Mandatory)] [string]$Command,
+        [switch]$Capture,
+        [switch]$WithoutToolchain
+    )
+
+    $scriptText = if ($WithoutToolchain) { "set -euo pipefail`n$Command" } else { "$(Get-WslEnvironmentPrefix)`n$Command" }
+    if ($Capture) {
+        $output = @(& wsl.exe -d $WslDistro --exec bash -c $scriptText 2>&1)
+    } else {
+        & wsl.exe -d $WslDistro --exec bash -c $scriptText
+    }
+    if ($LASTEXITCODE -ne 0) {
+        throw "WSL command failed with exit code $LASTEXITCODE in '$WslDistro'."
+    }
+    if ($Capture) { return $output }
+}
+
+function Get-RepositoryMetadata {
+    param([Parameter(Mandatory)] [string]$Repository)
+
+    $status = Invoke-GitCapture $Repository @('status', '--porcelain')
+    return [ordered]@{
+        commit = Invoke-GitCapture $Repository @('rev-parse', 'HEAD')
+        branch = Invoke-GitCapture $Repository @('branch', '--show-current')
+        dirty = [bool]$status
+    }
+}
+
+function Sync-WslWorktrees {
+    Initialize-WslPaths
+    $candidate = Get-RepositoryMetadata $RepoRoot
+    $baseline = Get-RepositoryMetadata $BaselinePath
+    if ($candidate.dirty) {
+        throw 'The Windows candidate worktree must be clean before WSL sync. Commit the checkpoint first.'
+    }
+    if (-not $candidate.branch) {
+        throw 'The Windows candidate must be on a branch before WSL sync.'
+    }
+
+    $trackedStatusCommand = "git -C $(Quote-BashArgument $WslCandidatePath) status --porcelain --untracked-files=no"
+    $trackedStatus = @(Invoke-WslChecked $trackedStatusCommand -Capture -WithoutToolchain)
+    if (($trackedStatus -join '').Trim()) {
+        throw "The WSL candidate has tracked changes. Preserve or discard them before syncing '$WslCandidatePath'."
+    }
+
+    $fetch = Join-BashCommand @(
+        'git', "--git-dir=$WslBareRepository", 'fetch', 'windows',
+        "refs/heads/$($candidate.branch):refs/remotes/windows/candidate", '--force'
+    )
+    $checkoutBaseline = Join-BashCommand @('git', '-C', $WslBaselinePath, 'checkout', '--detach', $baseline.commit)
+    $checkoutCandidate = Join-BashCommand @('git', '-C', $WslCandidatePath, 'checkout', '--detach', $candidate.commit)
+    Invoke-WslChecked "$fetch`n$checkoutBaseline`n$checkoutCandidate" -WithoutToolchain
+
+    Write-Host "WSL baseline:  $($baseline.commit.Substring(0, 12))"
+    Write-Host "WSL candidate: $($candidate.commit.Substring(0, 12))"
+}
+
+function Invoke-BuildForMeasurement {
+    param(
+        [Parameter(Mandatory)] [ValidateSet('windows', 'wsl')] [string]$Platform,
+        [Parameter(Mandatory)] [string]$Repository
+    )
+
+    Write-Host "=== Building $Platform measurement tree: $Repository ==="
+    if ($Platform -eq 'windows') {
+        Invoke-NativeChecked dotnet @('build', 'src/SharpTS/SharpTS.csproj', '--configuration', 'Release', '--nologo') $Repository
+    } else {
+        $command = "cd $(Quote-BashArgument $Repository)`n" +
+            (Join-BashCommand @('dotnet', 'build', 'src/SharpTS/SharpTS.csproj', '--configuration', 'Release', '--nologo'))
+        Invoke-WslChecked $command
+    }
+}
+
+function Invoke-OneMeasurement {
+    param(
+        [Parameter(Mandatory)] [ValidateSet('windows', 'wsl')] [string]$Platform,
+        [Parameter(Mandatory)] [ValidateSet('baseline', 'candidate')] [string]$Variant,
+        [Parameter(Mandatory)] [int]$Launch,
+        [Parameter(Mandatory)] [string]$SourceRepository,
+        [Parameter(Mandatory)] [string]$HarnessRepository,
+        [Parameter(Mandatory)] [string]$Destination
+    )
+
+    $runtimeList = if ($Variant -eq 'candidate') { 'compiled,node' } else { 'compiled' }
+    $workloadList = $Workloads -join ','
+    if ($Platform -eq 'windows') {
+        $scratch = Join-Path $OutputDirectory "scratch/windows-$Variant-$Launch"
+        $arguments = @(
+            '-NoProfile', '-File', (Join-Path $HarnessRepository 'benchmarks/cross-runtime/run-benchmarks.ps1'),
+            '-RepositoryRoot', $SourceRepository,
+            '-Workloads', $workloadList,
+            '-Runtimes', $runtimeList,
+            '-Launches', '1',
+            '-OutputDirectory', $scratch,
+            '-NoBuild'
+        )
+        if ($Variant -eq 'candidate') {
+            $arguments += @('-NodeExecutable', (Get-WindowsNodeExecutable))
+        }
+        Invoke-NativeChecked pwsh $arguments $HarnessRepository
+        Copy-Item -LiteralPath (Join-Path $scratch 'results.txt') -Destination $Destination
+        return
+    }
+
+    $scratch = "$SourceRepository/.perf-local-results/$($script:MeasurementId)/$Variant-$Launch"
+    $runner = "$HarnessRepository/benchmarks/cross-runtime/run-benchmarks.ps1"
+    $arguments = @(
+        'pwsh', '-NoProfile', '-File', $runner,
+        '-RepositoryRoot', $SourceRepository,
+        '-Workloads', $workloadList,
+        '-Runtimes', $runtimeList,
+        '-Launches', '1',
+        '-OutputDirectory', $scratch,
+        '-NoBuild'
+    )
+    Invoke-WslChecked (Join-BashCommand $arguments)
+    $raw = @(Invoke-WslChecked (Join-BashCommand @('cat', "$scratch/results.txt")) -Capture -WithoutToolchain)
+    [IO.File]::WriteAllLines($Destination, [string[]]$raw)
+}
+
+function Get-HostFacts {
+    param([Parameter(Mandatory)] [ValidateSet('windows', 'wsl')] [string]$Platform)
+
+    if ($Platform -eq 'windows') {
+        $nodeExecutable = Get-WindowsNodeExecutable
+        return [ordered]@{
+            os = [Runtime.InteropServices.RuntimeInformation]::OSDescription
+            architecture = [Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+            dotnet = ((& dotnet --version) -join '').Trim()
+            node = ((& $nodeExecutable --version) -join '').Trim()
+        }
+    }
+
+    $facts = @(Invoke-WslChecked @'
+printf 'os=%s\n' "$(uname -sr)"
+printf 'architecture=%s\n' "$(uname -m)"
+printf 'dotnet=%s\n' "$(dotnet --version)"
+printf 'node=%s\n' "$(node --version)"
+'@ -Capture)
+    $map = [ordered]@{}
+    foreach ($line in $facts) {
+        $pair = ([string]$line) -split '=', 2
+        if ($pair.Count -eq 2) { $map[$pair[0]] = $pair[1] }
+    }
+    return $map
+}
+
+function Get-WindowsNodeExecutable {
+    $requiredVersion = (Get-Content -LiteralPath (Join-Path $RepoRoot '.node-version') -Raw).Trim()
+    $currentNode = Get-Command node -ErrorAction SilentlyContinue
+    if ($currentNode) {
+        $currentVersion = ((& $currentNode.Source --version) -join '').Trim().TrimStart('v')
+        if ($currentVersion -eq $requiredVersion) { return $currentNode.Source }
+    }
+
+    if ($env:NVM_HOME) {
+        $nvmNode = Join-Path $env:NVM_HOME "v$requiredVersion/node.exe"
+        if (Test-Path -LiteralPath $nvmNode -PathType Leaf) { return $nvmNode }
+    }
+    throw "Node $requiredVersion is required for Windows measurements. Install it side-by-side with 'nvm install $requiredVersion'; the harness will invoke it directly without changing the global Node selection."
+}
+
+function Invoke-PairedMeasurement {
+    New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+    New-Item -ItemType Directory -Force -Path (Join-Path $OutputDirectory 'raw') | Out-Null
+    $script:MeasurementId = [Guid]::NewGuid().ToString('N').Substring(0, 12)
+
+    $baseline = Get-RepositoryMetadata $BaselinePath
+    $candidate = Get-RepositoryMetadata $RepoRoot
+    $samples = [Collections.Generic.List[object]]::new()
+    $hostFacts = [ordered]@{}
+
+    foreach ($platform in $Platforms) {
+        if ($platform -eq 'windows') {
+            $platformBaseline = $BaselinePath
+            $platformCandidate = $RepoRoot
+            $harness = $RepoRoot
+        } else {
+            Initialize-WslPaths
+            $wslHead = @(
+                Invoke-WslChecked (Join-BashCommand @('git', '-C', $WslCandidatePath, 'rev-parse', 'HEAD')) -Capture -WithoutToolchain
+            ) -join ''
+            if ($wslHead.Trim() -ne $candidate.commit) {
+                throw "WSL candidate is not synced to $($candidate.commit). Run -Action sync after committing the checkpoint."
+            }
+            $platformBaseline = $WslBaselinePath
+            $platformCandidate = $WslCandidatePath
+            $harness = $WslCandidatePath
+        }
+
+        if (-not $NoBuild) {
+            Invoke-BuildForMeasurement $platform $platformBaseline
+            Invoke-BuildForMeasurement $platform $platformCandidate
+        }
+        $hostFacts[$platform] = Get-HostFacts $platform
+
+        for ($launch = 1; $launch -le $Runs; $launch++) {
+            $variants = if (($launch % 2) -eq 1) { @('baseline', 'candidate') } else { @('candidate', 'baseline') }
+            foreach ($variant in $variants) {
+                $source = if ($variant -eq 'baseline') { $platformBaseline } else { $platformCandidate }
+                $rawPath = Join-Path $OutputDirectory "raw/$platform-$variant-$launch.txt"
+                Write-Host "=== $platform $variant launch $launch/$Runs ==="
+                Invoke-OneMeasurement $platform $variant $launch $source $harness $rawPath
+                $text = [IO.File]::ReadAllText($rawPath)
+                foreach ($sample in @(ConvertFrom-SharpTSBenchmarkResults $text $platform $variant $launch)) {
+                    $samples.Add($sample)
+                }
+            }
+        }
+    }
+
+    $comparisons = @(Get-SharpTSPerfComparisons $samples `
+        -RegressionThresholdPercent $RegressionThresholdPercent `
+        -RegressionMinimumMilliseconds $RegressionMinimumMilliseconds)
+    $metadata = [ordered]@{
+        generatedAtUtc = [DateTime]::UtcNow.ToString('o')
+        baselineCommit = $baseline.commit
+        candidateCommit = $candidate.commit
+        candidateDirty = $candidate.dirty
+        runs = $Runs
+        workloads = $Workloads
+        platforms = $Platforms
+        regressionThresholdPercent = $RegressionThresholdPercent
+        regressionMinimumMilliseconds = $RegressionMinimumMilliseconds
+        hosts = $hostFacts
+    }
+    $metadata | ConvertTo-Json -Depth 8 | Set-Content (Join-Path $OutputDirectory 'metadata.json')
+    $comparisons | ConvertTo-Json -Depth 5 | Set-Content (Join-Path $OutputDirectory 'comparison.json')
+    ConvertTo-SharpTSPerfMarkdown $comparisons $metadata |
+        Set-Content (Join-Path $OutputDirectory 'summary.md')
+
+    Write-Host "Performance report: $OutputDirectory"
+    Get-Content (Join-Path $OutputDirectory 'summary.md')
+    $regressions = @($comparisons | Where-Object status -eq 'regression')
+    if ($Enforce -and $regressions.Count -gt 0) {
+        throw "$($regressions.Count) material performance regression(s) exceeded the configured thresholds."
+    }
+}
+
+function Invoke-WindowsGate {
+    Write-Host "=== Windows $GateLevel gate ==="
+    $oldAvaloniaOptOut = $env:AVALONIA_TELEMETRY_OPTOUT
+    $env:AVALONIA_TELEMETRY_OPTOUT = '1'
+    try {
+        # Serial graph traversal avoids opaque child-MSBuild exits observed on
+        # high-core-count developer machines and makes the failure log useful.
+        Invoke-NativeChecked dotnet @(
+            'restore', 'SharpTS.sln', '-m:1', '-p:RestoreDisableParallel=true', '-p:NuGetAudit=false'
+        ) $RepoRoot
+        Invoke-NativeChecked dotnet @(
+            'build', 'SharpTS.sln', '--configuration', 'Release', '--nologo', '--no-restore',
+            '-m:1', '-p:NuGetAudit=false'
+        ) $RepoRoot
+        Invoke-NativeChecked pwsh @(
+            '-NoProfile', '-File', (Join-Path $PSScriptRoot 'test-perf-local.ps1')
+        ) $RepoRoot
+        Invoke-NativeChecked pwsh @(
+            '-NoProfile', '-File', $Runner, '-RepositoryRoot', $RepoRoot,
+            '-Workloads', ($Workloads -join ','), '-Smoke', '-NoBuild'
+        ) $RepoRoot
+        Invoke-NativeChecked dotnet @(
+            'run', '--configuration', 'Release', '--no-build',
+            '--project', 'benchmarks/micro/SharpTS.Microbenchmarks', '--', '--smoke'
+        ) $RepoRoot
+        $testFilter = 'Category!=LiveNetwork&Category!=LoadSensitive&Category!=npm'
+        if ($GateLevel -eq 'checkpoint') {
+            $testFilter += '&FullyQualifiedName~SharpTS.Tests.CompilerTests'
+        }
+        Invoke-NativeChecked dotnet @(
+            'test', 'tests/SharpTS.Tests/SharpTS.Tests.csproj', '--no-build', '--configuration', 'Release',
+            '--filter', $testFilter
+        ) $RepoRoot
+
+        if ($GateLevel -eq 'full') {
+            Invoke-NativeChecked dotnet @(
+                'test', 'tests/gui-conformance/SharpTS.Gui.Conformance.Tests/SharpTS.Gui.Conformance.Tests.csproj',
+                '--no-build', '--configuration', 'Release',
+                '--filter', 'Category!=LiveNetwork&Category!=LoadSensitive&Category!=npm'
+            ) $RepoRoot
+            foreach ($project in @(
+                'tests/conformance/SharpTS.Test262/SharpTS.Test262.csproj',
+                'tests/conformance/SharpTS.Test262.Worker/SharpTS.Test262.Worker.csproj',
+                'tests/conformance/SharpTS.TypeScriptConformance/SharpTS.TypeScriptConformance.csproj'
+            )) {
+                Invoke-NativeChecked dotnet @('build', $project, '--configuration', 'Release', '-p:NuGetAudit=false') $RepoRoot
+            }
+            foreach ($script in @('test-nuget-release.ps1', 'test-gui-version.ps1', 'test-packaged-sdk.ps1')) {
+                Invoke-NativeChecked pwsh @('-NoProfile', '-File', (Join-Path $PSScriptRoot $script)) $RepoRoot
+            }
+            Invoke-NativeChecked pwsh @(
+                '-NoProfile', '-File', (Join-Path $PSScriptRoot 'aot-analyzer-report.ps1'), '-EnforceBaseline'
+            ) $RepoRoot
+        }
+    } finally {
+        $env:AVALONIA_TELEMETRY_OPTOUT = $oldAvaloniaOptOut
+    }
+}
+
+function Invoke-WslGate {
+    Initialize-WslPaths
+    $candidate = Get-RepositoryMetadata $RepoRoot
+    $wslHead = @(Invoke-WslChecked (Join-BashCommand @(
+        'git', '-C', $WslCandidatePath, 'rev-parse', 'HEAD'
+    )) -Capture -WithoutToolchain) -join ''
+    if ($wslHead.Trim() -ne $candidate.commit) {
+        throw 'The WSL candidate does not match the Windows candidate. Commit and run -Action sync first.'
+    }
+
+    Write-Host "=== WSL $GateLevel gate ==="
+    $repo = Quote-BashArgument $WslCandidatePath
+    $commands = [Collections.Generic.List[string]]::new()
+    $commands.Add("cd $repo")
+    $commands.Add('export AVALONIA_TELEMETRY_OPTOUT=1')
+    $commands.Add((Join-BashCommand @(
+        'dotnet', 'restore', 'SharpTS.sln', '-m:1', '-p:RestoreDisableParallel=true', '-p:NuGetAudit=false'
+    )))
+    $commands.Add((Join-BashCommand @(
+        'dotnet', 'build', 'SharpTS.sln', '--configuration', 'Release', '--nologo', '--no-restore',
+        '-m:1', '-p:NuGetAudit=false'
+    )))
+    $commands.Add((Join-BashCommand @('pwsh', '-NoProfile', '-File', 'scripts/test-perf-local.ps1')))
+    $commands.Add((Join-BashCommand @(
+        'pwsh', '-NoProfile', '-File', 'benchmarks/cross-runtime/run-benchmarks.ps1',
+        '-RepositoryRoot', $WslCandidatePath, '-Workloads', ($Workloads -join ','), '-Smoke', '-NoBuild'
+    )))
+    $commands.Add((Join-BashCommand @(
+        'dotnet', 'run', '--configuration', 'Release', '--no-build',
+        '--project', 'benchmarks/micro/SharpTS.Microbenchmarks', '--', '--smoke'
+    )))
+    $testFilter = 'Category!=LiveNetwork&Category!=LoadSensitive&Category!=npm'
+    if ($GateLevel -eq 'checkpoint') {
+        $testFilter += '&FullyQualifiedName~SharpTS.Tests.CompilerTests'
+    }
+    $commands.Add((Join-BashCommand @(
+        'dotnet', 'test', 'tests/SharpTS.Tests/SharpTS.Tests.csproj', '--no-build', '--configuration', 'Release',
+        '--filter', $testFilter
+    )))
+
+    if ($GateLevel -eq 'full') {
+        $commands.Add((Join-BashCommand @(
+            'dotnet', 'test', 'tests/gui-conformance/SharpTS.Gui.Conformance.Tests/SharpTS.Gui.Conformance.Tests.csproj',
+            '--no-build', '--configuration', 'Release',
+            '--filter', 'Category!=LiveNetwork&Category!=LoadSensitive&Category!=npm'
+        )))
+        foreach ($project in @(
+            'tests/conformance/SharpTS.Test262/SharpTS.Test262.csproj',
+            'tests/conformance/SharpTS.Test262.Worker/SharpTS.Test262.Worker.csproj',
+            'tests/conformance/SharpTS.TypeScriptConformance/SharpTS.TypeScriptConformance.csproj'
+        )) {
+            $commands.Add((Join-BashCommand @('dotnet', 'build', $project, '--configuration', 'Release')))
+        }
+        foreach ($script in @('test-nuget-release.ps1', 'test-gui-version.ps1', 'test-packaged-sdk.ps1')) {
+            $commands.Add((Join-BashCommand @('pwsh', '-NoProfile', '-File', "scripts/$script")))
+        }
+        $commands.Add((Join-BashCommand @('pwsh', '-NoProfile', '-File', 'scripts/aot-analyzer-report.ps1', '-EnforceBaseline')))
+
+        # Linux is the local architecture that can exercise the native compiler.
+        # This is intentionally a compact publish/execute gate; CI retains the
+        # exhaustive native feature corpus and the ARM/macOS checks.
+        $aotRoot = "$WslCandidatePath/.perf-local-aot"
+        $commands.Add((Join-BashCommand @(
+            'dotnet', 'publish', 'src/SharpTS/SharpTS.csproj', '--configuration', 'Release',
+            '-p:PlatformTarget=AnyCPU', '-p:DebugType=None', '-p:DebugSymbols=false',
+            '-o', "$aotRoot/managed-runtime"
+        )))
+        $commands.Add((Join-BashCommand @(
+            'dotnet', 'publish', 'src/SharpTS/SharpTS.csproj', '--configuration', 'Release', '-r', 'linux-x64',
+            '-p:PublishAot=true', '-p:DebugType=None', '-p:DebugSymbols=false',
+            "-p:SharpTSManagedRuntimePayloadPath=$aotRoot/managed-runtime/SharpTS.dll",
+            '-o', "$aotRoot/native"
+        )))
+        $commands.Add((Join-BashCommand @("$aotRoot/native/SharpTS", 'samples/AotCompileGate/main.ts')) +
+            " | grep -qx '42'")
+    }
+    Invoke-WslChecked ($commands -join "`n")
+}
+
+function Invoke-LocalGate {
+    foreach ($platform in $Platforms) {
+        if ($platform -eq 'windows') { Invoke-WindowsGate } else { Invoke-WslGate }
+    }
+}
+
+switch ($Action) {
+    'sync' {
+        if ($Platforms -notcontains 'wsl') {
+            Write-Host 'Nothing to sync: the selected platforms do not include WSL.'
+        } else {
+            Sync-WslWorktrees
+        }
+    }
+    'measure' { Invoke-PairedMeasurement }
+    'gate' { Invoke-LocalGate }
+    'all' {
+        if ($Platforms -contains 'wsl') { Sync-WslWorktrees }
+        Invoke-LocalGate
+        Invoke-PairedMeasurement
+    }
+}

--- a/scripts/test-perf-local.ps1
+++ b/scripts/test-perf-local.ps1
@@ -67,6 +67,19 @@ if ($regression.status -ne 'regression' -or $regression.changePercent -ne 20) {
     throw "Material regression was not detected: $($regression | ConvertTo-Json -Compress)"
 }
 
+$driftSamples = @(
+    ConvertFrom-SharpTSBenchmarkResults 'compiled|drift:1:10:9:1' linux baseline 1
+    ConvertFrom-SharpTSBenchmarkResults 'compiled|drift:1:11:10:1' linux candidate 1
+    ConvertFrom-SharpTSBenchmarkResults 'compiled|drift:1:20:19:1' linux baseline 2
+    ConvertFrom-SharpTSBenchmarkResults 'compiled|drift:1:15:14:1' linux candidate 2
+    ConvertFrom-SharpTSBenchmarkResults 'compiled|drift:1:30:29:1' linux baseline 3
+    ConvertFrom-SharpTSBenchmarkResults 'compiled|drift:1:28:27:1' linux candidate 3
+)
+$drift = @(Get-SharpTSPerfComparisons $driftSamples)[0]
+if ($drift.status -ne 'neutral' -or $drift.changePercent -ne -6.67) {
+    throw "Paired launch comparison did not suppress cross-launch drift: $($drift | ConvertTo-Json -Compress)"
+}
+
 $markdown = ConvertTo-SharpTSPerfMarkdown $comparisons ([ordered]@{
     baselineCommit = 'baseline'
     candidateCommit = 'candidate'

--- a/scripts/test-perf-local.ps1
+++ b/scripts/test-perf-local.ps1
@@ -1,0 +1,70 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot 'PerfLocal.psm1') -Force
+
+foreach ($relativePath in @(
+    'perf-local.ps1',
+    '../benchmarks/cross-runtime/run-benchmarks.ps1'
+)) {
+    $path = (Resolve-Path (Join-Path $PSScriptRoot $relativePath)).Path
+    $tokens = $null
+    $errors = $null
+    [Management.Automation.Language.Parser]::ParseFile($path, [ref]$tokens, [ref]$errors) | Out-Null
+    if ($errors.Count -gt 0) {
+        throw "PowerShell parser errors in '$path': $($errors.Message -join '; ')"
+    }
+}
+
+$baselineText = @'
+compiled|kernel:1000:10:9:1
+compiled|kernel:1000:12:10:1
+compiled|tiny:1:0.010:0.009:0.001
+'@
+$candidateText = @'
+compiled|kernel:1000:8:7:1
+node|kernel:1000:6:5:1
+compiled|kernel:1000:9:8:1
+node|kernel:1000:7:6:1
+compiled|tiny:1:0.0115:0.010:0.001
+node|tiny:1:0.005:0.004:0.001
+'@
+
+$samples = @(
+    ConvertFrom-SharpTSBenchmarkResults $baselineText windows baseline 1
+    ConvertFrom-SharpTSBenchmarkResults $candidateText windows candidate 1
+)
+$comparisons = @(Get-SharpTSPerfComparisons $samples -RegressionThresholdPercent 10 -RegressionMinimumMilliseconds 0.05)
+$kernel = $comparisons | Where-Object benchmark -eq 'kernel'
+$tiny = $comparisons | Where-Object benchmark -eq 'tiny'
+
+if ($kernel.baselineMedianMilliseconds -ne 11 -or
+    $kernel.candidateMedianMilliseconds -ne 8.5 -or
+    $kernel.nodeMedianMilliseconds -ne 6.5 -or
+    $kernel.status -ne 'improvement') {
+    throw "Unexpected kernel comparison: $($kernel | ConvertTo-Json -Compress)"
+}
+if ($tiny.status -ne 'neutral') {
+    throw "The absolute-noise floor did not suppress the tiny percentage change: $($tiny | ConvertTo-Json -Compress)"
+}
+
+$regressionSamples = @(
+    ConvertFrom-SharpTSBenchmarkResults 'compiled|kernel:1000:10:9:1' linux baseline 1
+    ConvertFrom-SharpTSBenchmarkResults 'compiled|kernel:1000:12:11:1' linux candidate 1
+)
+$regression = @(Get-SharpTSPerfComparisons $regressionSamples)[0]
+if ($regression.status -ne 'regression' -or $regression.changePercent -ne 20) {
+    throw "Material regression was not detected: $($regression | ConvertTo-Json -Compress)"
+}
+
+$markdown = ConvertTo-SharpTSPerfMarkdown $comparisons ([ordered]@{
+    baselineCommit = 'baseline'
+    candidateCommit = 'candidate'
+    runs = 2
+})
+if (($markdown -join "`n") -notmatch '\| windows \| kernel \| 1000 .* improvement \|') {
+    throw 'Markdown summary did not contain the expected invariant comparison row.'
+}
+
+Write-Host 'Local performance comparison tests passed.'

--- a/scripts/test-perf-local.ps1
+++ b/scripts/test-perf-local.ps1
@@ -11,9 +11,18 @@ foreach ($relativePath in @(
     $path = (Resolve-Path (Join-Path $PSScriptRoot $relativePath)).Path
     $tokens = $null
     $errors = $null
-    [Management.Automation.Language.Parser]::ParseFile($path, [ref]$tokens, [ref]$errors) | Out-Null
+    $syntaxTree = [Management.Automation.Language.Parser]::ParseFile($path, [ref]$tokens, [ref]$errors)
     if ($errors.Count -gt 0) {
         throw "PowerShell parser errors in '$path': $($errors.Message -join '; ')"
+    }
+    $reservedHomeAssignments = @($syntaxTree.FindAll({
+        param($node)
+        $node -is [Management.Automation.Language.AssignmentStatementAst] -and
+            $node.Left -is [Management.Automation.Language.VariableExpressionAst] -and
+            $node.Left.VariablePath.UserPath -ieq 'HOME'
+    }, $true))
+    if ($reservedHomeAssignments.Count -gt 0) {
+        throw "'$path' assigns PowerShell's reserved HOME variable."
     }
 }
 

--- a/src/SharpTS/Compilation/AsyncFunctionMoveNextEmitter.Await.cs
+++ b/src/SharpTS/Compilation/AsyncFunctionMoveNextEmitter.Await.cs
@@ -49,8 +49,11 @@ public abstract partial class AsyncFunctionMoveNextEmitter
 
     protected override void EmitAwait(Expr.Await a)
     {
+        if (TryEmitStablePrimitivePromiseResolveAwait(a))
+            return;
+
         if (AllowSuspensionFreePrimitiveAsyncCoreAwait
-            && Ctx.SuspensionFreePrimitiveAsyncCoreAwaits?.Contains(a) == true)
+            && Ctx.SuspensionFreePrimitiveAsyncAwaits?.Contains(a) == true)
         {
             if (TryEmitSuspensionFreePrimitiveAsyncCoreCall(a.Expression))
                 return;
@@ -65,6 +68,58 @@ public abstract partial class AsyncFunctionMoveNextEmitter
         // 2+. Coerce to Task<object>, suspend/resume, and leave the awaited result on the stack.
         EmitAwaitFromValueOnStack(NextAwaitState());
     }
+
+    /// <summary>
+    /// Elides the fresh completed <c>Task&lt;object&gt;</c> created for an immediately
+    /// awaited intrinsic <c>Promise.resolve(primitive)</c>. The generated await path
+    /// already continues synchronously for that completed task, so its identity and
+    /// the boxed primitive cannot be observed. Programs that can replace Promise
+    /// behavior, shadow the global binding, or pass a thenable retain ordinary
+    /// Promise resolution and await lowering.
+    /// </summary>
+    private bool TryEmitStablePrimitivePromiseResolveAwait(Expr.Await awaitExpression)
+    {
+        Expr expression = awaitExpression.Expression;
+        if (Ctx.RuntimeFeatures?.UsesPromisePrototypeMutation == true
+            || Resolver.HasVariable("Promise")
+            || expression is not Expr.Call
+            {
+                Optional: false,
+                Callee: Expr.Get
+                {
+                    Optional: false,
+                    Object: Expr.Variable { Name.Lexeme: "Promise" },
+                    Name.Lexeme: "resolve"
+                },
+                Arguments: [var value]
+            }
+            || value is Expr.Spread
+            || !IsStaticallyNonNullPrimitive(Ctx.TypeMap?.Get(value)))
+        {
+            return false;
+        }
+
+        if (Ctx.SuspensionFreePrimitiveAsyncAwaits?.Contains(awaitExpression) != true)
+        {
+            // AsyncStateAnalyzer reserved a dispatch label for every syntactic
+            // await that was not proven non-suspending before state-machine
+            // definition. This path never stores that state, but the persisted
+            // switch target must still be marked.
+            MarkAwaitResumeLabel(NextAwaitState());
+        }
+        EmitExpression(value);
+        return true;
+    }
+
+    private static bool IsStaticallyNonNullPrimitive(TypeSystem.TypeInfo? type) => type is
+        TypeSystem.TypeInfo.Primitive
+        {
+            Type: TokenType.TYPE_NUMBER or TokenType.TYPE_BOOLEAN
+        }
+        or TypeSystem.TypeInfo.NumberLiteral
+        or TypeSystem.TypeInfo.BooleanLiteral
+        or TypeSystem.TypeInfo.String
+        or TypeSystem.TypeInfo.StringLiteral;
 
     private bool TryEmitSuspensionFreePrimitiveAsyncCoreCall(Expr expression)
     {

--- a/src/SharpTS/Compilation/CompactClassStorageAnalyzer.cs
+++ b/src/SharpTS/Compilation/CompactClassStorageAnalyzer.cs
@@ -1,0 +1,369 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Finds deliberately narrow user classes whose instances never escape exact, typed local use.
+/// Those classes can move their rarely-used dynamic-property dictionary to weak side storage,
+/// avoiding an otherwise permanent reference slot on every instance. Any value-position class
+/// use, non-local construction, dynamic/indexed access, assertion, export, inheritance, or local
+/// escape keeps the ordinary per-instance storage layout.
+/// </summary>
+internal static class CompactClassStorageAnalyzer
+{
+    public static HashSet<Stmt.Class> Analyze(
+        List<Stmt> program,
+        TypeMap? typeMap,
+        RuntimeFeatureSet? features)
+    {
+        if (typeMap is null
+            || features?.UsesDynamicPropertyDescriptors != false
+            || features.UsesObjectIntegrityMutation
+            || features.UsesClassPrototypeMutation)
+            return [];
+
+        var declarations = new DeclarationCollector();
+        foreach (var statement in program)
+            declarations.Visit(statement);
+
+        var eligibleByName = declarations.Classes
+            .Where(pair => pair.Value.Count == 1)
+            .Select(pair => pair.Value[0])
+            .Where(IsLayoutCandidate)
+            .Where(statement => !declarations.ExportedNames.Contains(statement.Name.Lexeme))
+            .ToDictionary(statement => statement.Name.Lexeme, StringComparer.Ordinal);
+        if (eligibleByName.Count == 0)
+            return [];
+
+        var visitor = new UsageVisitor(typeMap, eligibleByName);
+        foreach (var statement in program)
+            visitor.Visit(statement);
+
+        foreach (var candidate in visitor.Locals.Values)
+        {
+            if (visitor.DeclarationCounts.GetValueOrDefault(candidate.Key) != 1
+                || visitor.DisqualifiedLocals.Contains(candidate.Key))
+                visitor.UnsafeClasses.Add(candidate.ClassStatement);
+        }
+
+        return new HashSet<Stmt.Class>(
+            eligibleByName.Values
+                .Where(statement => visitor.AllocationCounts.GetValueOrDefault(statement) > 0)
+                .Where(statement => !visitor.UnsafeClasses.Contains(statement)),
+            ReferenceEqualityComparer.Instance);
+    }
+
+    private static bool IsLayoutCandidate(Stmt.Class statement) =>
+        statement.SuperclassExpr is null
+        && statement.TypeParams is null or { Count: 0 }
+        && !statement.IsAbstract
+        && !statement.IsDeclare
+        && statement.Decorators is null or { Count: 0 }
+        && statement.IndexSignatures is null or { Count: 0 }
+        && statement.AutoAccessors is null or { Count: 0 }
+        && statement.Fields.All(field =>
+            !field.IsPrivate && field.ComputedKey is null
+            && (field.Decorators is null or { Count: 0 }))
+        && statement.Methods.All(method =>
+            !method.IsPrivate && method.ComputedKey is null
+            && (method.Decorators is null or { Count: 0 }))
+        && (statement.Accessors?.All(accessor =>
+            accessor.ComputedKey is null
+            && (accessor.Decorators is null or { Count: 0 })) ?? true);
+
+    private sealed class DeclarationCollector : AstVisitorBase
+    {
+        private int _namespaceDepth;
+
+        public Dictionary<string, List<Stmt.Class>> Classes { get; } =
+            new(StringComparer.Ordinal);
+        public HashSet<string> ExportedNames { get; } = new(StringComparer.Ordinal);
+
+        protected override void VisitNamespace(Stmt.Namespace statement)
+        {
+            _namespaceDepth++;
+            base.VisitNamespace(statement);
+            _namespaceDepth--;
+        }
+
+        protected override void VisitClass(Stmt.Class statement)
+        {
+            if (_namespaceDepth == 0)
+            {
+                if (!Classes.TryGetValue(statement.Name.Lexeme, out var declarations))
+                    Classes[statement.Name.Lexeme] = declarations = [];
+                declarations.Add(statement);
+            }
+            base.VisitClass(statement);
+        }
+
+        protected override void VisitExport(Stmt.Export statement)
+        {
+            if (statement.Declaration is Stmt.Class exportedClass)
+                ExportedNames.Add(exportedClass.Name.Lexeme);
+            if (statement.NamedExports != null && statement.FromModulePath is null)
+            {
+                foreach (var specifier in statement.NamedExports.Where(item => !item.IsTypeOnly))
+                    ExportedNames.Add(specifier.LocalName.Lexeme);
+            }
+            base.VisitExport(statement);
+        }
+    }
+
+    private sealed class UsageVisitor(
+        TypeMap typeMap,
+        Dictionary<string, Stmt.Class> eligibleByName) : AstVisitorBase
+    {
+        private readonly TypeMap _typeMap = typeMap;
+        private readonly Dictionary<string, Stmt.Class> _eligibleByName = eligibleByName;
+        private readonly Dictionary<int, int> _scopeParents = [];
+        private int _scope;
+        private int _nextScope;
+
+        public Dictionary<(int Scope, string Name), LocalCandidate> Locals { get; } = [];
+        public Dictionary<(int Scope, string Name), int> DeclarationCounts { get; } = [];
+        public HashSet<(int Scope, string Name)> DisqualifiedLocals { get; } = [];
+        public Dictionary<Stmt.Class, int> AllocationCounts { get; } =
+            new(ReferenceEqualityComparer.Instance);
+        public HashSet<Stmt.Class> UnsafeClasses { get; } =
+            new(ReferenceEqualityComparer.Instance);
+
+        protected override void VisitFunction(Stmt.Function statement) =>
+            InScope(() => base.VisitFunction(statement));
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression) =>
+            InScope(() => base.VisitArrowFunction(expression));
+
+        private void InScope(Action visit)
+        {
+            int saved = _scope;
+            _scope = ++_nextScope;
+            _scopeParents[_scope] = saved;
+            visit();
+            _scope = saved;
+        }
+
+        protected override void VisitVar(Stmt.Var statement)
+        {
+            var key = RecordDeclaration(statement.Name.Lexeme);
+            if (TryBindLocal(statement.Initializer, key))
+                return;
+            if (statement.Initializer != null)
+                Visit(statement.Initializer);
+        }
+
+        protected override void VisitConst(Stmt.Const statement)
+        {
+            var key = RecordDeclaration(statement.Name.Lexeme);
+            if (!TryBindLocal(statement.Initializer, key))
+                Visit(statement.Initializer);
+        }
+
+        private (int Scope, string Name) RecordDeclaration(string name)
+        {
+            var key = (_scope, name);
+            DeclarationCounts[key] = DeclarationCounts.GetValueOrDefault(key) + 1;
+            return key;
+        }
+
+        private bool TryBindLocal(Expr? initializer, (int Scope, string Name) key)
+        {
+            if (!TryGetDirectNew(initializer, out var construction, out var classStatement)
+                || !HasExactClassType(initializer!, classStatement.Name.Lexeme))
+                return false;
+
+            Locals[key] = new LocalCandidate(key, classStatement);
+            AllocationCounts[classStatement] = AllocationCounts.GetValueOrDefault(classStatement) + 1;
+            foreach (var argument in construction.Arguments)
+                Visit(argument);
+            return true;
+        }
+
+        protected override void VisitNew(Expr.New expression)
+        {
+            if (expression.Callee is Expr.Variable variable
+                && _eligibleByName.TryGetValue(variable.Name.Lexeme, out var classStatement))
+            {
+                AllocationCounts[classStatement] = AllocationCounts.GetValueOrDefault(classStatement) + 1;
+                UnsafeClasses.Add(classStatement);
+            }
+            foreach (var argument in expression.Arguments)
+                Visit(argument);
+        }
+
+        protected override void VisitGet(Expr.Get expression)
+        {
+            if (TryAllowDeclaredRead(expression.Object, expression.Name.Lexeme, expression.Optional))
+                return;
+            base.VisitGet(expression);
+        }
+
+        protected override void VisitSet(Expr.Set expression)
+        {
+            if (TryAllowDeclaredWrite(expression.Object, expression.Name.Lexeme))
+            {
+                Visit(expression.Value);
+                return;
+            }
+            base.VisitSet(expression);
+        }
+
+        protected override void VisitCompoundSet(Expr.CompoundSet expression)
+        {
+            if (TryAllowDeclaredWrite(expression.Object, expression.Name.Lexeme))
+            {
+                Visit(expression.Value);
+                return;
+            }
+            base.VisitCompoundSet(expression);
+        }
+
+        protected override void VisitLogicalSet(Expr.LogicalSet expression)
+        {
+            if (TryAllowDeclaredWrite(expression.Object, expression.Name.Lexeme))
+            {
+                Visit(expression.Value);
+                return;
+            }
+            base.VisitLogicalSet(expression);
+        }
+
+        protected override void VisitDelete(Expr.Delete expression)
+        {
+            // Even a declared delete changes the object's dynamic own-property semantics.
+            if (expression.Operand is Expr.Get { Object: Expr.Variable variable }
+                && TryFindLocal(variable.Name.Lexeme, out var local))
+                Disqualify(local);
+            base.VisitDelete(expression);
+        }
+
+        protected override void VisitAssign(Expr.Assign expression)
+        {
+            if (TryFindLocal(expression.Name.Lexeme, out var local))
+                Disqualify(local);
+            base.VisitAssign(expression);
+        }
+
+        protected override void VisitVariable(Expr.Variable expression)
+        {
+            if (TryFindLocal(expression.Name.Lexeme, out var local))
+                Disqualify(local);
+            else if (_eligibleByName.TryGetValue(expression.Name.Lexeme, out var classStatement))
+                UnsafeClasses.Add(classStatement);
+        }
+
+        private bool TryAllowDeclaredRead(Expr receiver, string memberName, bool optional)
+        {
+            if (optional || receiver is not Expr.Variable variable
+                || !TryFindLocal(variable.Name.Lexeme, out var local)
+                || !HasExactClassType(receiver, local.ClassStatement.Name.Lexeme))
+                return false;
+            if (local.Key.Scope != _scope)
+            {
+                Disqualify(local);
+                return false;
+            }
+
+            var statement = local.ClassStatement;
+            bool declared = statement.Fields.Any(field =>
+                    !field.IsStatic && field.Name.Lexeme == memberName)
+                || statement.Methods.Any(method =>
+                    !method.IsStatic && method.Name.Lexeme == memberName)
+                || (statement.Accessors?.Any(accessor =>
+                    !accessor.IsStatic && accessor.Name.Lexeme == memberName) ?? false);
+            if (!declared)
+                Disqualify(local);
+            return declared;
+        }
+
+        private bool TryAllowDeclaredWrite(Expr receiver, string memberName)
+        {
+            if (receiver is not Expr.Variable variable
+                || !TryFindLocal(variable.Name.Lexeme, out var local)
+                || !HasExactClassType(receiver, local.ClassStatement.Name.Lexeme))
+                return false;
+            if (local.Key.Scope != _scope)
+            {
+                Disqualify(local);
+                return false;
+            }
+
+            var statement = local.ClassStatement;
+            bool declared = statement.Fields.Any(field =>
+                    !field.IsStatic && !field.IsReadonly && field.Name.Lexeme == memberName)
+                || (statement.Accessors?.Any(accessor =>
+                    !accessor.IsStatic && accessor.Kind.Type == TokenType.SET
+                    && accessor.Name.Lexeme == memberName) ?? false);
+            if (!declared)
+                Disqualify(local);
+            return declared;
+        }
+
+        private bool TryFindLocal(string name, out LocalCandidate local)
+        {
+            int scope = _scope;
+            while (true)
+            {
+                if (Locals.TryGetValue((scope, name), out local))
+                    return true;
+                if (!_scopeParents.TryGetValue(scope, out scope))
+                    break;
+            }
+            local = default;
+            return false;
+        }
+
+        private void Disqualify(LocalCandidate local)
+        {
+            DisqualifiedLocals.Add(local.Key);
+            UnsafeClasses.Add(local.ClassStatement);
+        }
+
+        private bool TryGetDirectNew(
+            Expr? expression,
+            out Expr.New construction,
+            out Stmt.Class classStatement)
+        {
+            expression = Unwrap(expression);
+            if (expression is Expr.New { Callee: Expr.Variable variable } direct
+                && _eligibleByName.TryGetValue(variable.Name.Lexeme, out var foundClass))
+            {
+                construction = direct;
+                classStatement = foundClass;
+                return true;
+            }
+            construction = null!;
+            classStatement = null!;
+            return false;
+        }
+
+        private bool HasExactClassType(Expr expression, string className) =>
+            _typeMap.Get(expression) is TypeInfo.Instance instance
+            && instance.ResolvedClassType switch
+            {
+                TypeInfo.Class type => type.Name == className,
+                TypeInfo.MutableClass type => type.Name == className,
+                _ => false
+            };
+
+        private static Expr? Unwrap(Expr? expression)
+        {
+            while (expression is Expr.Grouping or Expr.NonNullAssertion)
+            {
+                expression = expression switch
+                {
+                    Expr.Grouping grouping => grouping.Expression,
+                    Expr.NonNullAssertion assertion => assertion.Expression,
+                    _ => expression
+                };
+            }
+            return expression;
+        }
+
+        public readonly record struct LocalCandidate(
+            (int Scope, string Name) Key,
+            Stmt.Class ClassStatement);
+    }
+}

--- a/src/SharpTS/Compilation/CompilationContext.Functions.cs
+++ b/src/SharpTS/Compilation/CompilationContext.Functions.cs
@@ -20,10 +20,11 @@ public partial class CompilationContext
     public Dictionary<string, MethodBuilder>? SuspensionFreePrimitiveAsyncCores { get; set; }
 
     /// <summary>
-    /// Await nodes whose direct-core proof was established before state-machine layout. These
-    /// nodes do not consume a state number or force locals into hoisted object fields.
+    /// Await nodes proven non-suspending before state-machine layout, including stable direct
+    /// async-core calls and immediately awaited intrinsic primitive resolves. These nodes do not
+    /// consume a state number or force locals into hoisted object fields.
     /// </summary>
-    public IReadOnlySet<Expr.Await>? SuspensionFreePrimitiveAsyncCoreAwaits { get; set; }
+    public IReadOnlySet<Expr.Await>? SuspensionFreePrimitiveAsyncAwaits { get; set; }
 
     /// <summary>
     /// The exact emitted method that may bypass a value-backed module binding for recursive

--- a/src/SharpTS/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.ArrowFunctions.cs
@@ -399,7 +399,10 @@ public partial class ILCompiler
                         extraSrcFields.ContainsKey(capturedVar))
                         continue;
 
-                    var field = displayClass.DefineField(capturedVar, _types.Object, FieldAttributes.Public);
+                    var captureType = _typeMap?.IsStableNumericCaptureField(arrow, capturedVar) == true
+                        ? _types.Double
+                        : _types.Object;
+                    var field = displayClass.DefineField(capturedVar, captureType, FieldAttributes.Public);
                     fieldMap[capturedVar] = field;
                 }
                 _closures.DisplayClassFields[arrow] = fieldMap;

--- a/src/SharpTS/Compilation/ILCompiler.Async.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Async.cs
@@ -24,12 +24,12 @@ public partial class ILCompiler
         var ctx = GetDefinitionContext();
         string qualifiedFunctionName = ctx.GetQualifiedFunctionName(funcStmt.Name.Lexeme);
 
-        HashSet<Expr.Await> directCoreAwaits = FindDirectCoreAwaits(
+        HashSet<Expr.Await> suspensionFreeAwaits = FindSuspensionFreeAwaits(
             funcStmt, ctx, analysis);
-        if (directCoreAwaits.Count > 0)
+        if (suspensionFreeAwaits.Count > 0)
         {
-            analysis = _async.Analyzer.Analyze(funcStmt, directCoreAwaits);
-            _async.DirectCoreAwaits[qualifiedFunctionName] = directCoreAwaits;
+            analysis = _async.Analyzer.Analyze(funcStmt, suspensionFreeAwaits);
+            _async.SuspensionFreeAwaits[qualifiedFunctionName] = suspensionFreeAwaits;
         }
 
         if (CanEmitSuspensionFreePrimitiveAsyncFunction(
@@ -96,7 +96,7 @@ public partial class ILCompiler
         DefineAsyncArrowStateMachines(analysis.AsyncArrows, smBuilder);
     }
 
-    private HashSet<Expr.Await> FindDirectCoreAwaits(
+    private HashSet<Expr.Await> FindSuspensionFreeAwaits(
         Stmt.Function function,
         CompilationContext definitionContext,
         AsyncStateAnalyzer.AsyncFunctionAnalysis analysis)
@@ -108,10 +108,12 @@ public partial class ILCompiler
         foreach (Stmt statement in function.Body)
             localBindings.Visit(statement);
 
-        var collector = new DirectCoreAwaitCollector(
+        var collector = new SuspensionFreeAwaitCollector(
             definitionContext,
             _async.StableSuspensionFreePrimitiveCores,
-            localBindings.Names);
+            localBindings.Names,
+            _typeMap,
+            _features?.UsesPromisePrototypeMutation != true);
         foreach (Stmt statement in function.Body)
             collector.Visit(statement);
         return collector.Awaits;
@@ -165,16 +167,38 @@ public partial class ILCompiler
         protected override void VisitClassExpr(Expr.ClassExpr expression) { }
     }
 
-    private sealed class DirectCoreAwaitCollector(
+    private sealed class SuspensionFreeAwaitCollector(
         CompilationContext context,
         IReadOnlyDictionary<string, MethodBuilder> stableCores,
-        IReadOnlySet<string> localBindings) : AstVisitorBase
+        IReadOnlySet<string> localBindings,
+        TypeSystem.TypeMap? typeMap,
+        bool promiseBehaviorStable) : AstVisitorBase
     {
         public HashSet<Expr.Await> Awaits { get; } =
             new(ReferenceEqualityComparer.Instance);
 
         protected override void VisitAwait(Expr.Await expression)
         {
+            if (promiseBehaviorStable
+                && !localBindings.Contains("Promise")
+                && expression.Expression is Expr.Call
+                {
+                    Optional: false,
+                    Callee: Expr.Get
+                    {
+                        Optional: false,
+                        Object: Expr.Variable { Name.Lexeme: "Promise" },
+                        Name.Lexeme: "resolve"
+                    },
+                    Arguments: [var resolvedValue]
+                }
+                && resolvedValue is not Expr.Spread
+                && !ContainsSuspension(resolvedValue)
+                && IsStableNonThenablePrimitive(typeMap?.Get(resolvedValue)))
+            {
+                Awaits.Add(expression);
+            }
+
             if (expression.Expression is Expr.Call
                 {
                     Callee: Expr.Variable variable,
@@ -225,7 +249,7 @@ public partial class ILCompiler
     /// <see cref="System.Runtime.CompilerServices.AsyncTaskMethodBuilder{TResult}"/> state
     /// machine. Keep the proof deliberately narrow: a free function with a final primitive
     /// return, simple required parameters, no closure/dynamic-receiver machinery, and only awaits
-    /// already proven to target stable suspension-free primitive cores. Its public
+    /// already proven non-suspending (stable primitive cores or intrinsic primitive resolves). Its public
     /// Task&lt;object?&gt; ABI remains identical to the ordinary async stub.
     /// </summary>
     private bool CanEmitSuspensionFreePrimitiveAsyncFunction(
@@ -1001,8 +1025,8 @@ public partial class ILCompiler
             ctx.CommonJsGetExportsMethods = _modules.CommonJsGetExportsMethods;
             // Check for function-level "use strict" directive
             ctx.IsStrictMode = _isStrictMode || BodyDeclaresUseStrict(func.Body);
-            ctx.SuspensionFreePrimitiveAsyncCoreAwaits =
-                _async.DirectCoreAwaits.GetValueOrDefault(funcName);
+            ctx.SuspensionFreePrimitiveAsyncAwaits =
+                _async.SuspensionFreeAwaits.GetValueOrDefault(funcName);
             // Entry-point display class for captured top-level variables
             ApplyCapturedTopLevelVariableAccess(ctx);
             ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0 ? _closures.ArrowEntryPointDCFields : null;
@@ -1093,8 +1117,8 @@ public partial class ILCompiler
             var coreContext = CreateSuspensionFreePrimitiveFunctionContext(
                 coreIl, coreMethod, function);
             coreContext.CurrentMethodReturnType = coreMethod.ReturnType;
-            coreContext.SuspensionFreePrimitiveAsyncCoreAwaits =
-                _async.DirectCoreAwaits.GetValueOrDefault(functionName);
+            coreContext.SuspensionFreePrimitiveAsyncAwaits =
+                _async.SuspensionFreeAwaits.GetValueOrDefault(functionName);
             ParameterInfo[] coreParameters = coreMethod.GetParameters();
             for (int index = 0; index < function.Parameters.Count; index++)
             {

--- a/src/SharpTS/Compilation/ILCompiler.Classes.ClassExpressions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.ClassExpressions.cs
@@ -173,7 +173,8 @@ public partial class ILCompiler
         _classExprs.Getters[classExpr] = [];
         _classExprs.Setters[classExpr] = [];
 
-        // Add _fields dictionary for dynamic property storage (extras)
+        // Class expressions retain direct per-instance expando storage. Unlike the narrow
+        // declaration optimization, their runtime-valued identity commonly escapes.
         var fieldsField = typeBuilder.DefineField(
             "_fields",
             typeof(Dictionary<string, object>),

--- a/src/SharpTS/Compilation/ILCompiler.Classes.HasFields.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.HasFields.cs
@@ -18,9 +18,10 @@ public partial class ILCompiler
         // The expando dictionary is deliberately absent from a newly constructed instance.
         // JavaScript cannot observe the backing store itself, so allocate it only when a
         // dynamic own property is actually created or the compatibility Fields surface is
-        // requested. Keeping this helper on the emitted type also makes base-constructor
-        // virtual dispatch safe: an override can materialize its own store before the
-        // derived constructor has resumed after super().
+        // requested. The weak side table keeps the common typed-only object layout compact.
+        // Keeping this helper on the emitted type also makes base-constructor virtual dispatch
+        // safe: an override can materialize its own store before the derived constructor has
+        // resumed after super().
         var ensureFields = typeBuilder.DefineMethod(
             "$EnsureFields",
             MethodAttributes.Private | MethodAttributes.HideBySig,
@@ -90,23 +91,61 @@ public partial class ILCompiler
     private void EmitEnsureFieldsBody(MethodBuilder method, FieldInfo fieldsField)
     {
         var il = method.GetILGenerator();
-        var readyLabel = il.DefineLabel();
-        var fieldsLocal = il.DeclareLocal(_types.DictionaryStringObject);
 
-        // return _fields ??= new Dictionary<string, object?>();
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldfld, fieldsField);
-        il.Emit(OpCodes.Stloc, fieldsLocal);
-        il.Emit(OpCodes.Ldloc, fieldsLocal);
-        il.Emit(OpCodes.Brtrue_S, readyLabel);
-        il.Emit(OpCodes.Newobj, _types.DictionaryStringObjectCtor);
-        il.Emit(OpCodes.Stloc, fieldsLocal);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldloc, fieldsLocal);
-        il.Emit(OpCodes.Stfld, fieldsField);
-        il.MarkLabel(readyLabel);
-        il.Emit(OpCodes.Ldloc, fieldsLocal);
+        if (fieldsField.IsStatic)
+        {
+            // Compact layout: return _fields.GetOrCreateValue(this);
+            il.Emit(OpCodes.Ldsfld, fieldsField);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(
+                fieldsField.FieldType, "GetOrCreateValue", [_types.Object])!);
+        }
+        else
+        {
+            // General layout: return _fields ??= new Dictionary<string, object?>();
+            var readyLabel = il.DefineLabel();
+            var fieldsLocal = il.DeclareLocal(_types.DictionaryStringObject);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, fieldsField);
+            il.Emit(OpCodes.Stloc, fieldsLocal);
+            il.Emit(OpCodes.Ldloc, fieldsLocal);
+            il.Emit(OpCodes.Brtrue_S, readyLabel);
+            il.Emit(OpCodes.Newobj, _types.DictionaryStringObjectCtor);
+            il.Emit(OpCodes.Stloc, fieldsLocal);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, fieldsLocal);
+            il.Emit(OpCodes.Stfld, fieldsField);
+            il.MarkLabel(readyLabel);
+            il.Emit(OpCodes.Ldloc, fieldsLocal);
+        }
         il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitLoadDynamicFieldsOrBranch(
+        ILGenerator il,
+        FieldInfo fieldsField,
+        LocalBuilder fieldsLocal,
+        Label missingLabel)
+    {
+        if (fieldsField.IsStatic)
+        {
+            il.Emit(OpCodes.Ldsfld, fieldsField);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloca, fieldsLocal);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(
+                fieldsField.FieldType,
+                "TryGetValue",
+                [_types.Object, _types.DictionaryStringObject.MakeByRefType()])!);
+            il.Emit(OpCodes.Brfalse, missingLabel);
+        }
+        else
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, fieldsField);
+            il.Emit(OpCodes.Stloc, fieldsLocal);
+            il.Emit(OpCodes.Ldloc, fieldsLocal);
+            il.Emit(OpCodes.Brfalse, missingLabel);
+        }
     }
 
     /// <summary>
@@ -205,7 +244,7 @@ public partial class ILCompiler
     {
         var il = method.GetILGenerator();
         var returnTrueLabel = il.DefineLabel();
-        var haveFieldsLabel = il.DefineLabel();
+        var noFieldsLabel = il.DefineLabel();
 
         // Check typed backing field names
         if (backingFields != null)
@@ -224,17 +263,15 @@ public partial class ILCompiler
 
         // A missing expando store is observably equivalent to an empty one. Do not
         // allocate merely to answer a property probe.
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldfld, fieldsField);
-        il.Emit(OpCodes.Dup);
-        il.Emit(OpCodes.Brtrue_S, haveFieldsLabel);
-        il.Emit(OpCodes.Pop);
-        il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Ret);
-
-        il.MarkLabel(haveFieldsLabel);
+        var fieldsLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        EmitLoadDynamicFieldsOrBranch(il, fieldsField, fieldsLocal, noFieldsLabel);
+        il.Emit(OpCodes.Ldloc, fieldsLocal);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "ContainsKey", [_types.String])!);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(noFieldsLabel);
+        il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(returnTrueLabel);
@@ -348,11 +385,7 @@ public partial class ILCompiler
 
         // 2. Check _fields dictionary
         il.MarkLabel(tryFieldsLabel);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldfld, fieldsField);
-        il.Emit(OpCodes.Stloc, fieldsLocal);
-        il.Emit(OpCodes.Ldloc, fieldsLocal);
-        il.Emit(OpCodes.Brfalse, tryMethodsLabel);
+        EmitLoadDynamicFieldsOrBranch(il, fieldsField, fieldsLocal, tryMethodsLabel);
         il.Emit(OpCodes.Ldloc, fieldsLocal);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldloca, valueLocal);
@@ -717,11 +750,7 @@ public partial class ILCompiler
 
         // 2. Check _fields dictionary
         il.MarkLabel(tryFieldsLabel);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldfld, fieldsField);
-        il.Emit(OpCodes.Stloc, fieldsLocal);
-        il.Emit(OpCodes.Ldloc, fieldsLocal);
-        il.Emit(OpCodes.Brfalse, tryMethodsLabel);
+        EmitLoadDynamicFieldsOrBranch(il, fieldsField, fieldsLocal, tryMethodsLabel);
         il.Emit(OpCodes.Ldloc, fieldsLocal);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldloca, valueLocal);

--- a/src/SharpTS/Compilation/ILCompiler.Classes.Static.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.Static.cs
@@ -76,6 +76,15 @@ public partial class ILCompiler
 
         var emitter = new ILEmitter(ctx);
 
+        // A compact class uses weak side storage; initialize its table before
+        // user-observable static initialization can construct or mutate an instance.
+        var dynamicFieldsTable = _classes.InstanceFieldsField[qualifiedClassName];
+        if (dynamicFieldsTable.IsStatic)
+        {
+            il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(dynamicFieldsTable.FieldType));
+            il.Emit(OpCodes.Stsfld, dynamicFieldsTable);
+        }
+
         // ECMAScript creates Constructor.prototype as part of class evaluation.
         // Register it before user static fields/blocks so they can observe it.
         EmitClassPrototypeRegistration(

--- a/src/SharpTS/Compilation/ILCompiler.Classes.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.cs
@@ -257,13 +257,22 @@ public partial class ILCompiler
         _typedInterop.ReadonlyPropertyNames[className] = [];
         _typedInterop.PropertyTypes[className] = [];
 
-        // Add _fields dictionary for dynamic property storage
-        // Note: We keep this as _fields for now to maintain compatibility with RuntimeEmitter.Objects.cs
-        // In Phase 4, both this and the runtime will be updated to use _extras
+        // Proven non-escaping exact classes keep rare dynamic own properties in weak side
+        // storage instead of reserving a reference slot on every instance. All other classes
+        // retain the direct instance dictionary slot so dynamic property traffic stays fast.
+        bool useCompactStorage = _classes.CompactStorageClasses.Contains(classStmt);
+        var dynamicFieldsType = useCompactStorage
+            ? EmitGenerics.MakeGenericType(
+                typeof(System.Runtime.CompilerServices.ConditionalWeakTable<,>),
+                typeof(object),
+                typeof(Dictionary<string, object>))
+            : typeof(Dictionary<string, object>);
         var fieldsField = typeBuilder.DefineField(
             "_fields",
-            typeof(Dictionary<string, object>),
-            FieldAttributes.Private
+            dynamicFieldsType,
+            useCompactStorage
+                ? FieldAttributes.Private | FieldAttributes.Static | FieldAttributes.InitOnly
+                : FieldAttributes.Private
         );
         _typedInterop.ExtrasFields[className] = fieldsField;
         _classes.InstanceFieldsField[className] = fieldsField;

--- a/src/SharpTS/Compilation/ILCompiler.State.cs
+++ b/src/SharpTS/Compilation/ILCompiler.State.cs
@@ -77,6 +77,8 @@ public partial class ILCompiler
         public Dictionary<string, List<(Parsing.Stmt.Function Method, Parsing.Expr Key, MethodBuilder Builder)>> SymbolMethods { get; } = [];
         public Dictionary<Stmt.Class, (MethodBuilder Method, IReadOnlyList<Expr> Keys)> DeferredComputedClassKeys { get; } = new(ReferenceEqualityComparer.Instance);
         public Dictionary<string, FieldBuilder> InstanceFieldsField { get; } = [];
+        public HashSet<Stmt.Class> CompactStorageClasses { get; } =
+            new(ReferenceEqualityComparer.Instance);
         public Dictionary<string, GenericTypeParameterBuilder[]> GenericParams { get; } = [];
 
         // ES2022 Private Class Elements Support

--- a/src/SharpTS/Compilation/ILCompiler.State.cs
+++ b/src/SharpTS/Compilation/ILCompiler.State.cs
@@ -302,7 +302,7 @@ public partial class ILCompiler
         public Dictionary<string, AsyncStateMachineBuilder> StateMachines { get; } = [];
         public Dictionary<string, Stmt.Function> Functions { get; } = [];
         public Dictionary<string, AsyncStateAnalyzer.AsyncFunctionAnalysis> Analyses { get; } = [];
-        public Dictionary<string, HashSet<Expr.Await>> DirectCoreAwaits { get; } = [];
+        public Dictionary<string, HashSet<Expr.Await>> SuspensionFreeAwaits { get; } = [];
         public Dictionary<string, Stmt.Function> SuspensionFreePrimitiveFunctions { get; } = [];
         public Dictionary<string, MethodBuilder> SuspensionFreePrimitiveCores { get; } = [];
         public Dictionary<string, MethodBuilder> StableSuspensionFreePrimitiveCores { get; } = [];

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -656,6 +656,8 @@ public partial class ILCompiler
         StablePrimitivePromiseAllAnalyzer.Analyze(
             statements, _typeMap, _closures.Analyzer, _features);
         StableExactClassMethodCallAnalyzer.Analyze(statements, _typeMap, _features);
+        _classes.CompactStorageClasses.UnionWith(
+            CompactClassStorageAnalyzer.Analyze(statements, _typeMap, _features));
         ArrayLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         StringAccumulatorPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         NonEscapingArrowLocalAnalyzer.Analyze(

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -656,12 +656,14 @@ public partial class ILCompiler
         StablePrimitivePromiseAllAnalyzer.Analyze(
             statements, _typeMap, _closures.Analyzer, _features);
         StableExactClassMethodCallAnalyzer.Analyze(statements, _typeMap, _features);
+        NonEscapingArrowLocalAnalyzer.Analyze(
+            statements, _closures.DirectCallArrowBindings, _closures.Analyzer);
+        StableNumericLoopCaptureAnalyzer.Analyze(
+            statements, _typeMap, _closures.Analyzer, _closures.DirectCallArrowBindings);
         _classes.CompactStorageClasses.UnionWith(
             CompactClassStorageAnalyzer.Analyze(statements, _typeMap, _features));
         ArrayLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         StringAccumulatorPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
-        NonEscapingArrowLocalAnalyzer.Analyze(
-            statements, _closures.DirectCallArrowBindings, _closures.Analyzer);
         ObjectLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
     }
 

--- a/src/SharpTS/Compilation/ILEmitter.Calls.Closures.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.Closures.cs
@@ -522,12 +522,22 @@ public partial class ILEmitter
                 if (local != null)
                 {
                     IL.Emit(OpCodes.Ldloc, local);
-                    // The capture field is object-typed, so a value-type local (e.g. a
-                    // number stored in an unboxed `double` slot via CanUseUnboxedLocal)
-                    // must be boxed before Stfld. The captured-parameter path above
-                    // already does this; omitting it here left a float64 where the
-                    // verifier expects a reference, corrupting the stack (#431).
-                    if (local.LocalType.IsValueType)
+                    if (field.FieldType == _ctx.Types.Double)
+                    {
+                        // Stable numeric loop snapshots keep the already-unboxed
+                        // counter in an unboxed display field. The captured loop
+                        // binding cannot take the integer-counter path, but retain a
+                        // defensive widening for future numeric local shapes.
+                        if (local.LocalType != _ctx.Types.Double)
+                        {
+                            if (local.LocalType.IsValueType)
+                                IL.Emit(OpCodes.Box, local.LocalType);
+                            IL.Emit(OpCodes.Call, _ctx.Runtime!.ConvertToNumber);
+                        }
+                    }
+                    // General capture fields are object-typed, so a value-type local
+                    // must still be boxed before Stfld (#431).
+                    else if (local.LocalType.IsValueType)
                     {
                         IL.Emit(OpCodes.Box, local.LocalType);
                     }

--- a/src/SharpTS/Compilation/LocalVariableResolver.cs
+++ b/src/SharpTS/Compilation/LocalVariableResolver.cs
@@ -220,7 +220,11 @@ public class LocalVariableResolver : IVariableResolver
                 _ctx.EmitLexicalTdzValueCheck(_il, name);
                 return StackType.Unknown;
             }
-            _ctx.EmitLexicalTdzValueCheck(_il, name);
+            // A typed capture field is emitted only for a proven initialized
+            // numeric loop snapshot, so it cannot contain the object-valued TDZ
+            // sentinel. Running isinst on its native double would also be invalid IL.
+            if (!field.FieldType.IsValueType)
+                _ctx.EmitLexicalTdzValueCheck(_il, name);
             return MapTypeToStackType(field.FieldType);
         }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Strings.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Strings.cs
@@ -1134,6 +1134,11 @@ public partial class RuntimeEmitter
             _types.Double,
             [_types.String, _types.Double]
         );
+        // Statically typed string sites call this helper for every character in
+        // lexer/interpreter-style loops. Keep JS's NaN bounds semantics here,
+        // but let RyuJIT fold the tiny helper into the caller so Length and
+        // get_Chars can optimize with the surrounding loop.
+        method.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
         runtime.StringCharCodeAt = method;
 
         var il = method.GetILGenerator();

--- a/src/SharpTS/Compilation/StableNumericLoopCaptureAnalyzer.cs
+++ b/src/SharpTS/Compilation/StableNumericLoopCaptureAnalyzer.cs
@@ -1,0 +1,280 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Finds the deliberately narrow loop-capture shape whose display-class snapshot
+/// may be stored as an unboxed <c>double</c>. The binding must be an explicitly
+/// numeric, definitely initialized <c>for (let ...)</c> counter and the capturing
+/// arrow must already belong to the proven non-escaping direct-call path in a fully
+/// synchronous enclosing function.
+/// </summary>
+/// <remarks>
+/// Captures that need live binding semantics are excluded through the per-iteration
+/// cell analysis. Direct eval and lexically shadowed names also opt out. This changes
+/// only the representation of a fresh value-snapshot field; all general callable and
+/// ESM-visible paths retain object storage.
+/// </remarks>
+internal static class StableNumericLoopCaptureAnalyzer
+{
+    public static void Analyze(
+        List<Stmt> program,
+        TypeMap? typeMap,
+        ClosureAnalyzer? closures,
+        IReadOnlyDictionary<string, Expr.ArrowFunction> directCallBindings)
+    {
+        if (typeMap is null || closures is null)
+            return;
+
+        var evalVisitor = new DirectEvalVisitor();
+        foreach (var statement in program)
+            evalVisitor.Visit(statement);
+        if (evalVisitor.ContainsDirectEval)
+            return;
+
+        var directCallArrows = new HashSet<Expr.ArrowFunction>(
+            directCallBindings.Values,
+            ReferenceEqualityComparer.Instance);
+        var visitor = new LoopVisitor(typeMap, closures, directCallArrows);
+        foreach (var statement in program)
+            visitor.Visit(statement);
+    }
+
+    private static bool TryGetStableNumericBinding(
+        Stmt.For loop,
+        TypeMap typeMap,
+        out Stmt.Var declaration)
+    {
+        declaration = null!;
+        if (loop.Initializer is not Stmt.Var
+            {
+                IsVar: false,
+                TypeAnnotation: "number",
+                Initializer: { } initializer
+            } candidate
+            || !IsNumericLiteral(initializer)
+            || typeMap.Get(initializer) is not (TypeInfo.Primitive
+                { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral)
+            || typeMap.IsUndefinedReachableNumericLocal(candidate)
+            || typeMap.IsUndefinedReachableNumericLocal(initializer))
+        {
+            return false;
+        }
+
+        declaration = candidate;
+        return true;
+    }
+
+    private static bool IsNumericLiteral(Expr expression)
+    {
+        expression = Unwrap(expression);
+        return expression is Expr.Literal { Value: double }
+            or Expr.Unary
+            {
+                Operator.Type: TokenType.MINUS,
+                Right: Expr.Literal { Value: double }
+            };
+    }
+
+    private static Expr Unwrap(Expr expression)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case Expr.Grouping grouping:
+                    expression = grouping.Expression;
+                    continue;
+                case Expr.TypeAssertion assertion:
+                    expression = assertion.Expression;
+                    continue;
+                case Expr.Satisfies satisfies:
+                    expression = satisfies.Expression;
+                    continue;
+                case Expr.NonNullAssertion nonNull:
+                    expression = nonNull.Expression;
+                    continue;
+                default:
+                    return expression;
+            }
+        }
+    }
+
+    private sealed class LoopVisitor(
+        TypeMap typeMap,
+        ClosureAnalyzer closures,
+        HashSet<Expr.ArrowFunction> directCallArrows) : AstVisitorBase
+    {
+        private readonly TypeMap _typeMap = typeMap;
+        private readonly ClosureAnalyzer _closures = closures;
+        private readonly HashSet<Expr.ArrowFunction> _directCallArrows = directCallArrows;
+        private int _functionDepth;
+        private int _suspendingFunctionDepth;
+
+        protected override void VisitFunction(Stmt.Function statement)
+        {
+            _functionDepth++;
+            if (statement.IsAsync || statement.IsGenerator)
+                _suspendingFunctionDepth++;
+            try
+            {
+                base.VisitFunction(statement);
+            }
+            finally
+            {
+                if (statement.IsAsync || statement.IsGenerator)
+                    _suspendingFunctionDepth--;
+                _functionDepth--;
+            }
+        }
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression)
+        {
+            _functionDepth++;
+            if (expression.IsAsync || expression.IsGenerator)
+                _suspendingFunctionDepth++;
+            try
+            {
+                base.VisitArrowFunction(expression);
+            }
+            finally
+            {
+                if (expression.IsAsync || expression.IsGenerator)
+                    _suspendingFunctionDepth--;
+                _functionDepth--;
+            }
+        }
+
+        protected override void VisitFor(Stmt.For statement)
+        {
+            if (_functionDepth > 0
+                && _suspendingFunctionDepth == 0
+                && TryGetStableNumericBinding(statement, _typeMap, out var declaration))
+            {
+                var collector = new CandidateCollector(
+                    declaration.Name.Lexeme,
+                    _typeMap,
+                    _closures,
+                    _directCallArrows);
+                collector.Visit(statement.Body);
+            }
+
+            base.VisitFor(statement);
+        }
+    }
+
+    private sealed class CandidateCollector(
+        string bindingName,
+        TypeMap typeMap,
+        ClosureAnalyzer closures,
+        HashSet<Expr.ArrowFunction> directCallArrows) : AstVisitorBase
+    {
+        private readonly string _bindingName = bindingName;
+        private readonly TypeMap _typeMap = typeMap;
+        private readonly ClosureAnalyzer _closures = closures;
+        private readonly HashSet<Expr.ArrowFunction> _directCallArrows = directCallArrows;
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction arrow)
+        {
+            if (_directCallArrows.Contains(arrow)
+                && _closures.GetCaptures(arrow).Contains(_bindingName)
+                && !_closures.GetClosureCellFields(arrow).Contains(_bindingName))
+            {
+                _typeMap.MarkStableNumericCaptureField(arrow, _bindingName);
+            }
+
+            // A nested arrow has a separate creation scope and capture source.
+            // Its own loops are considered by LoopVisitor's ordinary traversal.
+        }
+
+        protected override void VisitFunction(Stmt.Function statement)
+        {
+            // Function declarations execute in their own lexical environment.
+        }
+
+        protected override void VisitClass(Stmt.Class statement)
+        {
+            // Class methods and field initializers are not created as loop-body arrows.
+        }
+
+        protected override void VisitBlock(Stmt.Block statement)
+        {
+            if (!DeclaresBinding(statement.Statements))
+                base.VisitBlock(statement);
+        }
+
+        protected override void VisitSequence(Stmt.Sequence statement)
+        {
+            if (!DeclaresBinding(statement.Statements))
+                base.VisitSequence(statement);
+        }
+
+        protected override void VisitFor(Stmt.For statement)
+        {
+            if (DeclaresBinding(statement.Initializer))
+                return;
+            base.VisitFor(statement);
+        }
+
+        protected override void VisitForOf(Stmt.ForOf statement)
+        {
+            Visit(statement.Iterable);
+            if (statement.Variable.Lexeme != _bindingName)
+                Visit(statement.Body);
+        }
+
+        protected override void VisitForIn(Stmt.ForIn statement)
+        {
+            Visit(statement.Object);
+            if (statement.Variable.Lexeme != _bindingName)
+                Visit(statement.Body);
+        }
+
+        protected override void VisitTryCatch(Stmt.TryCatch statement)
+        {
+            foreach (var child in statement.TryBlock)
+                Visit(child);
+            if (statement.CatchBlock is not null
+                && statement.CatchParam?.Lexeme != _bindingName)
+            {
+                foreach (var child in statement.CatchBlock)
+                    Visit(child);
+            }
+            if (statement.FinallyBlock is not null)
+            {
+                foreach (var child in statement.FinallyBlock)
+                    Visit(child);
+            }
+        }
+
+        private bool DeclaresBinding(IEnumerable<Stmt> statements) =>
+            statements.Any(DeclaresBinding);
+
+        private bool DeclaresBinding(Stmt? statement) => statement switch
+        {
+            Stmt.Var variable => variable.Name.Lexeme == _bindingName,
+            Stmt.Const constant => constant.Name.Lexeme == _bindingName,
+            Stmt.Function function => function.Name.Lexeme == _bindingName,
+            Stmt.Class @class => @class.Name.Lexeme == _bindingName,
+            Stmt.Sequence sequence => DeclaresBinding(sequence.Statements),
+            _ => false
+        };
+    }
+
+    private sealed class DirectEvalVisitor : AstVisitorBase
+    {
+        public bool ContainsDirectEval { get; private set; }
+
+        protected override void VisitCall(Expr.Call expression)
+        {
+            if (!expression.Optional
+                && expression.Callee is Expr.Variable { Name.Lexeme: "eval" })
+            {
+                ContainsDirectEval = true;
+            }
+            base.VisitCall(expression);
+        }
+    }
+}

--- a/src/SharpTS/Compilation/SuspensionFreeAsyncCoreEmitter.cs
+++ b/src/SharpTS/Compilation/SuspensionFreeAsyncCoreEmitter.cs
@@ -7,14 +7,33 @@ namespace SharpTS.Compilation;
 
 /// <summary>
 /// Emits a synchronous primitive core for an async function after analysis proved every retained
-/// await is a stable call to another suspension-free primitive core.
+/// await is either a stable call to another suspension-free primitive core or an immediately
+/// consumed intrinsic primitive resolve.
 /// </summary>
 internal sealed class SuspensionFreeAsyncCoreEmitter(CompilationContext context) : ILEmitter(context)
 {
     protected override void EmitAwait(Expr.Await expression)
     {
-        if (Ctx.SuspensionFreePrimitiveAsyncCoreAwaits?.Contains(expression) != true
-            || expression.Expression is not Expr.Call
+        if (Ctx.SuspensionFreePrimitiveAsyncAwaits?.Contains(expression) != true)
+            throw new CompileException("Await is not suspension-free in this async core.");
+
+        if (expression.Expression is Expr.Call
+            {
+                Optional: false,
+                Callee: Expr.Get
+                {
+                    Optional: false,
+                    Object: Expr.Variable { Name.Lexeme: "Promise" },
+                    Name.Lexeme: "resolve"
+                },
+                Arguments: [var resolvedValue]
+            })
+        {
+            EmitExpression(resolvedValue);
+            return;
+        }
+
+        if (expression.Expression is not Expr.Call
             {
                 Callee: Expr.Variable variable,
                 Arguments: var arguments

--- a/src/SharpTS/TypeSystem/TypeChecker.Expressions.cs
+++ b/src/SharpTS/TypeSystem/TypeChecker.Expressions.cs
@@ -232,6 +232,28 @@ public partial class TypeChecker
         }
 
         TypeInfo exprType = CheckExpr(awaitExpr.Expression);
+        // Promise is represented as an Any-valued special global, so the
+        // ordinary member-call path cannot preserve Promise.resolve<T>'s T.
+        // Recover it only for a directly awaited intrinsic resolve. Keeping
+        // the call itself Any retains the checker's intentionally permissive
+        // Promise method surface, while preventing a known primitive await
+        // from needlessly tainting numeric locals as possibly undefined.
+        if (_environment.Get("Promise") is null
+            && awaitExpr.Expression is Expr.Call
+            {
+                Optional: false,
+                Callee: Expr.Get
+                {
+                    Optional: false,
+                    Object: Expr.Variable { Name.Lexeme: "Promise" },
+                    Name.Lexeme: "resolve"
+                },
+                Arguments: [var resolvedValue]
+            }
+            && _typeMap.Get(resolvedValue) is { } resolvedType)
+        {
+            return ResolveAwaitedType(resolvedType);
+        }
         return ResolveAwaitedType(exprType);
     }
 

--- a/src/SharpTS/TypeSystem/TypeMap.cs
+++ b/src/SharpTS/TypeSystem/TypeMap.cs
@@ -25,6 +25,7 @@ public class TypeMap
     private readonly Dictionary<Token, ObjectShapeInfo> _promotableObjectLocals = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Stmt.ForOf> _stableNumericMapIterations = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.Get> _stablePrimitivePromiseThenCalls = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<Expr.ArrowFunction, HashSet<string>> _stableNumericCaptureFields = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.Get> _stableExactPrimitiveMethodCalls = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr> _stablePrimitivePromiseAllIterables = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.ArrayLiteral> _stablePrimitivePromiseAllInputInitializers = new(ReferenceEqualityComparer.Instance);
@@ -226,6 +227,22 @@ public class TypeMap
     /// </summary>
     public bool IsStablePrimitivePromiseThen(Expr.Get method) =>
         _stablePrimitivePromiseThenCalls.Contains(method);
+
+    /// <summary>
+    /// Marks a captured binding whose value-snapshot field may use an unboxed
+    /// <c>double</c>. Keying by the exact arrow node keeps same-named bindings in
+    /// unrelated scopes independent.
+    /// </summary>
+    public void MarkStableNumericCaptureField(Expr.ArrowFunction arrow, string name)
+    {
+        if (!_stableNumericCaptureFields.TryGetValue(arrow, out var names))
+            _stableNumericCaptureFields[arrow] = names = [];
+        names.Add(name);
+    }
+
+    public bool IsStableNumericCaptureField(Expr.ArrowFunction arrow, string name) =>
+        _stableNumericCaptureFields.TryGetValue(arrow, out var names)
+        && names.Contains(name);
 
     /// <summary>
     /// Marks a class method access whose receiver is provably the exact instance

--- a/tests/SharpTS.Tests/Compilation/DebugSymbolsTests.cs
+++ b/tests/SharpTS.Tests/Compilation/DebugSymbolsTests.cs
@@ -431,7 +431,7 @@ public class DebugSymbolsTests
         const string source = """
             async function asyncWork(input: number): Promise<number> {
               const before = input + 1;
-              const awaited = await Promise.resolve(before);
+              const awaited = await new Promise<number>((resolve): void => resolve(before));
               return awaited + 1;
             }
             function* numbers(limit: number): Generator<number> {
@@ -495,7 +495,7 @@ public class DebugSymbolsTests
             async function work(seed: number): Promise<number> {
               let carried = seed;
               const increment = () => ++carried;
-              await Promise.resolve(0);
+              await new Promise<number>((resolve): void => resolve(0));
               return increment();
             }
             function* sequence(limit: number): Generator<number> {

--- a/tests/SharpTS.Tests/CompilerTests/LazyClassFieldStorageTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/LazyClassFieldStorageTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
 using SharpTS.Compilation;
 using SharpTS.Parsing;
 using SharpTS.Tests.Infrastructure;
@@ -18,6 +19,8 @@ public sealed class LazyClassFieldStorageTests
                 value: number;
                 constructor(value: number) { this.value = value; }
             }
+            const counter = new Counter(1);
+            counter.value;
             """);
 
         Type counterType = assembly.GetType("Counter")!;
@@ -32,14 +35,18 @@ public sealed class LazyClassFieldStorageTests
             instruction.Operand is MethodBase { Name: "$EnsureFields" });
 
         object instance = constructor.Invoke([1d]);
+        Assert.Null(counterType.GetField(
+            "_fields", BindingFlags.Instance | BindingFlags.NonPublic));
         FieldInfo fields = counterType.GetField(
-            "_fields", BindingFlags.Instance | BindingFlags.NonPublic)!;
-        Assert.Null(fields.GetValue(instance));
+            "_fields", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var stores = Assert.IsType<ConditionalWeakTable<object, Dictionary<string, object>>>(
+            fields.GetValue(null));
+        Assert.False(stores.TryGetValue(instance, out _));
 
         _ = counterType.GetMethod("GetProperty")!.Invoke(instance, ["missing"]);
         Assert.False((bool)counterType.GetMethod("HasProperty")!.Invoke(
             instance, ["missing"])!);
-        Assert.Null(fields.GetValue(instance));
+        Assert.False(stores.TryGetValue(instance, out _));
     }
 
     [Fact]
@@ -49,22 +56,94 @@ public sealed class LazyClassFieldStorageTests
             class Counter {
                 value: number = 1;
             }
+            const counter = new Counter();
+            counter.value;
             """);
 
         Type counterType = assembly.GetType("Counter")!;
         object instance = Assert.Single(counterType.GetConstructors()).Invoke([]);
         FieldInfo fields = counterType.GetField(
-            "_fields", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            "_fields", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var stores = Assert.IsType<ConditionalWeakTable<object, Dictionary<string, object>>>(
+            fields.GetValue(null));
         MethodInfo setProperty = counterType.GetMethod("SetProperty")!;
 
-        Assert.Null(fields.GetValue(instance));
+        Assert.False(stores.TryGetValue(instance, out _));
         setProperty.Invoke(instance, ["extra", 2d]);
-        var first = Assert.IsType<Dictionary<string, object>>(fields.GetValue(instance));
+        Assert.True(stores.TryGetValue(instance, out var first));
         Assert.Equal(2d, first["extra"]);
 
         setProperty.Invoke(instance, ["second", 3d]);
-        Assert.Same(first, fields.GetValue(instance));
+        Assert.True(stores.TryGetValue(instance, out var second));
+        Assert.Same(first, second);
         Assert.Equal(3d, first["second"]);
+    }
+
+    [Fact]
+    public void DynamicOrEscapingUse_RetainsDirectInstanceStore()
+    {
+        Assembly assembly = Compile("""
+            class DynamicCounter {
+                value: number;
+                constructor(value: number) { this.value = value; }
+            }
+            function create(value: number): any {
+                const counter: any = new DynamicCounter(value);
+                counter.extra = value;
+                return counter;
+            }
+            """);
+
+        Type counterType = assembly.GetType("DynamicCounter")!;
+        FieldInfo fields = counterType.GetField(
+            "_fields", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        Assert.Equal(typeof(Dictionary<string, object>), fields.FieldType);
+        Assert.Null(counterType.GetField(
+            "_fields", BindingFlags.Static | BindingFlags.NonPublic));
+
+        object instance = Assert.Single(counterType.GetConstructors()).Invoke([1d]);
+        counterType.GetMethod("SetProperty")!.Invoke(instance, ["extra", 2d]);
+        var store = Assert.IsType<Dictionary<string, object>>(fields.GetValue(instance));
+        Assert.Equal(2d, store["extra"]);
+    }
+
+    [Fact]
+    public void CapturedExactLocal_RetainsDirectInstanceStore()
+    {
+        Assembly assembly = Compile("""
+            class CapturedCounter {
+                value: number;
+                constructor(value: number) { this.value = value; }
+            }
+            function readLater(): number {
+                const counter = new CapturedCounter(1);
+                const read = (): number => counter.value;
+                return read();
+            }
+            """);
+
+        Type counterType = assembly.GetType("CapturedCounter")!;
+        FieldInfo fields = counterType.GetField(
+            "_fields", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        Assert.Equal(typeof(Dictionary<string, object>), fields.FieldType);
+    }
+
+    [Fact]
+    public void ClassUsedAsValue_RetainsDirectInstanceStore()
+    {
+        Assembly assembly = Compile("""
+            class AliasedCounter {
+                value: number = 1;
+            }
+            const Constructor: any = AliasedCounter;
+            const counter: any = new Constructor();
+            counter.extra = 2;
+            """);
+
+        Type counterType = assembly.GetType("AliasedCounter")!;
+        FieldInfo fields = counterType.GetField(
+            "_fields", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        Assert.Equal(typeof(Dictionary<string, object>), fields.FieldType);
     }
 
     [Fact]

--- a/tests/SharpTS.Tests/CompilerTests/NonEscapingArrowDirectCallTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/NonEscapingArrowDirectCallTests.cs
@@ -1,4 +1,8 @@
+using System.Reflection;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
 using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
 using Xunit;
 
 namespace SharpTS.Tests.CompilerTests;
@@ -14,6 +18,110 @@ namespace SharpTS.Tests.CompilerTests;
 /// </summary>
 public class NonEscapingArrowDirectCallTests
 {
+    [Fact]
+    public void StableNumericLoopCapture_UsesUnboxedDisplayField()
+    {
+        const string source = """
+            function work(n: number): number {
+                let sum: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    const add = (a: number): number => a + i;
+                    sum = sum + add(i);
+                }
+                return sum;
+            }
+            console.log(work(1000));
+            """;
+
+        Assembly assembly = Compile(source);
+        Assert.Equal(typeof(double), FindCaptureField(assembly, "i").FieldType);
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+        Assert.Equal("999000\n", TestHarness.RunCompiledStandalone(source));
+    }
+
+    [Fact]
+    public void BodyMutatedLoopCapture_RetainsSharedObjectCell()
+    {
+        const string source = """
+            function work(n: number): number {
+                let sum: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    const read = (): number => i;
+                    i = i + 1;
+                    sum = sum + read();
+                }
+                return sum;
+            }
+            console.log(work(3));
+            """;
+
+        Assembly assembly = Compile(source);
+        Assert.Equal(typeof(object), FindCaptureField(assembly, "i").FieldType);
+        Assert.Equal("4\n", TestHarness.Run(source, ExecutionMode.Compiled));
+    }
+
+    [Fact]
+    public void NonLiteralLoopInitializer_RetainsObjectCaptureField()
+    {
+        const string source = """
+            function work(n: number): number {
+                const start: number = 0;
+                let sum: number = 0;
+                for (let i: number = start; i < n; i++) {
+                    const add = (a: number): number => a + i;
+                    sum = sum + add(i);
+                }
+                return sum;
+            }
+            console.log(work(10));
+            """;
+
+        Assembly assembly = Compile(source);
+        Assert.Equal(typeof(object), FindCaptureField(assembly, "i").FieldType);
+        Assert.Equal("90\n", TestHarness.Run(source, ExecutionMode.Compiled));
+    }
+
+    [Fact]
+    public void AsyncEnclosingFunction_RetainsObjectCaptureField()
+    {
+        const string source = """
+            async function work(n: number): Promise<number> {
+                let sum: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    const add = (a: number): number => a + i;
+                    sum = sum + add(i);
+                }
+                return sum;
+            }
+            work(10).then((value: number): void => console.log(value));
+            """;
+
+        Assembly assembly = Compile(source);
+        Assert.Equal(typeof(object), FindCaptureField(assembly, "i").FieldType);
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+        Assert.Equal("90\n", TestHarness.RunCompiledStandalone(source));
+    }
+
+    [Fact]
+    public void DirectEval_RetainsObjectCaptureField()
+    {
+        const string source = """
+            function work(n: number): number {
+                eval("");
+                let sum: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    const add = (a: number): number => a + i;
+                    sum = sum + add(i);
+                }
+                return sum;
+            }
+            console.log(work(10));
+            """;
+
+        Assembly assembly = Compile(source);
+        Assert.Equal(typeof(object), FindCaptureField(assembly, "i").FieldType);
+    }
+
     [Theory, ModeData]
     public void CapturingArrow_InvokedByName_IsCorrect(ExecutionMode mode)
     {
@@ -276,4 +384,21 @@ public class NonEscapingArrowDirectCallTests
             """;
         Assert.Equal("1005,6\n", TestHarness.Run(source, mode));
     }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"stable_numeric_capture_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static FieldInfo FindCaptureField(Assembly assembly, string name) =>
+        Assert.Single(assembly.GetTypes()
+            .SelectMany(type => type.GetFields(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)),
+            field => field.Name == name
+                && field.DeclaringType?.Name.Contains("DisplayClass", StringComparison.Ordinal) == true);
 }

--- a/tests/SharpTS.Tests/CompilerTests/NumericBitwiseLoweringTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/NumericBitwiseLoweringTests.cs
@@ -231,6 +231,21 @@ public sealed class NumericBitwiseLoweringTests
         Assert.InRange(allocated, 0, 8_192);
     }
 
+    [Fact]
+    public void StringCharCodeAtHelper_IsAggressivelyInlined()
+    {
+        Assembly assembly = Compile("""
+            function read(program: string, index: number): number {
+                return program.charCodeAt(index);
+            }
+            """);
+
+        MethodInfo helper = assembly.GetType("$Runtime")!
+            .GetMethod("StringCharCodeAt", BindingFlags.Public | BindingFlags.Static)!;
+
+        Assert.True((helper.MethodImplementationFlags & MethodImplAttributes.AggressiveInlining) != 0);
+    }
+
     private static Assembly Compile(string source)
     {
         var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();

--- a/tests/SharpTS.Tests/CompilerTests/SuspensionFreePrimitiveAsyncTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/SuspensionFreePrimitiveAsyncTests.cs
@@ -10,8 +10,9 @@ namespace SharpTS.Tests.CompilerTests;
 
 /// <summary>
 /// Regression coverage for #1451. A deliberately narrow async function with no
-/// suspension points and a primitive result completes through a typed core and fresh Task wrapper;
-/// observable or uncertain shapes retain the ordinary async state machine.
+/// suspension points and a primitive result completes through a typed core and fresh Task wrapper.
+/// Immediately consumed intrinsic primitive resolves can join that core; observable or uncertain
+/// shapes retain the ordinary async state machine.
 /// </summary>
 public sealed class SuspensionFreePrimitiveAsyncTests
 {
@@ -285,7 +286,7 @@ public sealed class SuspensionFreePrimitiveAsyncTests
     {
         {
             """
-            async function suspended(value: number): Promise<number> {
+            async function suspended(value: any): Promise<any> {
                 return await Promise.resolve(value);
             }
             suspended(1);
@@ -334,6 +335,118 @@ public sealed class SuspensionFreePrimitiveAsyncTests
             type.Name.Contains("<sum>d__", StringComparison.Ordinal));
         Assert.Equal("10\n", TestHarness.RunCompiled(source));
         Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    [Fact]
+    public void ImmediatelyAwaitedPrimitiveResolve_ElidesStateMachineAndCompletedTasks()
+    {
+        const string source = """
+            async function sum(count: number): Promise<number> {
+                let total: number = 0;
+                for (let index: number = 0; index < count; index++) {
+                    total = total + await Promise.resolve(index);
+                }
+                return total;
+            }
+            sum(5).then((value: number): void => console.log(value));
+            """;
+
+        var parsed = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var parsedSum = parsed.OfType<Stmt.Function>()
+            .Single(function => function.Name.Lexeme == "sum");
+        var totalDeclaration = parsedSum.Body!.OfType<Stmt.Var>()
+            .Single(statement => statement.Name.Lexeme == "total");
+        var inspectedTypeMap = new TypeChecker().Check(parsed);
+        var loop = parsedSum.Body!.OfType<Stmt.For>().Single();
+        var assignment = ((Stmt.Block)loop.Body).Statements
+            .OfType<Stmt.Expression>()
+            .Select(statement => statement.Expr)
+            .OfType<Expr.Assign>()
+            .Single();
+        var addition = Assert.IsType<Expr.Binary>(assignment.Value);
+        Assert.IsType<SharpTS.TypeSystem.TypeInfo.Primitive>(
+            inspectedTypeMap.Get(addition.Left));
+        Assert.IsType<SharpTS.TypeSystem.TypeInfo.Primitive>(
+            inspectedTypeMap.Get(addition.Right));
+        Assert.IsType<SharpTS.TypeSystem.TypeInfo.Primitive>(
+            inspectedTypeMap.Get(addition));
+        Assert.False(inspectedTypeMap.IsUndefinedReachableNumericLocal(totalDeclaration));
+        Assert.False(inspectedTypeMap.IsUndefinedReachableNumericLocal(
+            totalDeclaration.Initializer!));
+
+        Assembly assembly = Compile(source);
+        Assert.DoesNotContain(assembly.GetTypes(), type =>
+            type.Name.Contains("<sum>d__", StringComparison.Ordinal));
+        MethodInfo core = assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.Contains(
+                "$asyncCore$sum", StringComparison.Ordinal));
+        var instructions = ReadInstructions(core).ToArray();
+        var calls = instructions
+            .Select(instruction => instruction.Operand)
+            .OfType<MethodBase>()
+            .ToArray();
+
+        Assert.DoesNotContain(calls, method =>
+            method.Name == "FromResult" && method.DeclaringType == typeof(Task));
+        Assert.DoesNotContain(calls, method => method.Name == "PrepareHostedAwait");
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.OpCode == OpCodes.Box);
+        Assert.Equal("10\n", TestHarness.RunCompiled(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    [Fact]
+    public void ShadowedPromiseResolve_DoesNotElideAwait()
+    {
+        const string source = """
+            async function work(Promise: any): Promise<number> {
+                return await Promise.resolve(1);
+            }
+            const replacement = {
+                resolve(value: number): Promise<number> {
+                    return globalThis.Promise.resolve(value + 20);
+                }
+            };
+            work(replacement).then((value: number): void => console.log(value));
+            """;
+
+        Assembly assembly = Compile(source);
+        MethodInfo moveNext = assembly.GetTypes()
+            .Single(type => type.Name.Contains("<work>d__", StringComparison.Ordinal))
+            .GetMethod("MoveNext")!;
+        var calls = ReadInstructions(moveNext)
+            .Select(instruction => instruction.Operand)
+            .OfType<MethodBase>()
+            .ToArray();
+
+        Assert.Contains(calls, method =>
+            method.Name == "FromResult" && method.DeclaringType == typeof(Task));
+    }
+
+    [Fact]
+    public void PromiseMutation_RetainsCompletedTaskAwait()
+    {
+        const string source = """
+            (Promise as any).resolve = (value: number): Promise<number> =>
+                new Promise<number>((resolve): void => resolve(value + 30));
+            async function work(): Promise<number> {
+                return await Promise.resolve(1);
+            }
+            work().then((value: number): void => console.log(value));
+            """;
+
+        Assembly assembly = Compile(source);
+        MethodInfo moveNext = assembly.GetTypes()
+            .Single(type => type.Name.Contains("<work>d__", StringComparison.Ordinal))
+            .GetMethod("MoveNext")!;
+        var calls = ReadInstructions(moveNext)
+            .Select(instruction => instruction.Operand)
+            .OfType<MethodBase>()
+            .ToArray();
+
+        Assert.Contains(calls, method =>
+            method.Name == "FromResult" && method.DeclaringType == typeof(Task));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- add a paired local performance lab with frozen Windows and ext4-backed WSL baselines, alternating launches, pinned Node 22, checkpoint/full gates, and reproducible reports
- inline the emitted `charCodeAt` helper, lazily allocate dynamic class-instance storage, and elide stable resolved primitive awaits
- store proven synchronous non-escaping numeric loop captures directly as `double` display-class fields while preserving cells, shadowing, direct eval, async state machines, and general object-backed semantics
- keep debug-symbol state-machine coverage genuinely suspending after resolved-await elision

Advances #1278.

## Paired performance

Frozen baseline: `b4a561e2`; five alternating launches on each OS unless noted.

| Workload | Platform | Input | Baseline | Candidate | Change | Candidate / Node 22 |
|---|---|---:|---:|---:|---:|---:|
| resolved primitive await | Windows | 1,000 | 0.0470 ms | 0.0007 ms | -98.65% | 0.021x |
| resolved primitive await | WSL | 1,000 | 0.0589 ms | 0.0007 ms | -98.98% | 0.019x |
| numeric closure capture | Windows | 100,000 | 0.6553 ms | 0.1729 ms | -75.74% | 0.267x |
| numeric closure capture | WSL | 100,000 | 0.9454 ms | 0.2487 ms | -71.90% | 0.393x |
| class construction | WSL | 100,000 | 0.2969 ms | 0.2665 ms | -11.39% | 6.112x |

The `charCodeAt` tranche was neutral-to-small in the end-to-end Brainfuck benchmark (Windows -2.61% at input 5,000; WSL +1.47%, below the material-regression thresholds) while removing the helper's avoidable boxing path.

## Correctness boundary

Numeric capture fields are unboxed only when all of these are proven:

- synchronous enclosing function and synchronous arrow
- non-escaping direct-call arrow binding
- explicit `number` loop counter with a numeric-literal initializer
- no undefined-reachable numeric slot
- no shared per-iteration cell requirement
- no lexical shadow and no direct eval

All uncertain, mutable, async/generator, escaping, or live-binding shapes retain object storage.

## Local verification

Windows full gate:

- Release solution build and IL verification
- 17,253 passed / 3 expected skipped core tests
- 83/83 GUI conformance tests
- conformance tool builds, release/package helper tests, packaged SDK consumer build/run/publish
- AOT/trim/single-file analyzer inventory unchanged

WSL full gate (Ubuntu 26.04, ext4):

- Release solution build and IL verification
- 17,256/17,256 core tests
- 83/83 GUI conformance tests
- the same packaging and analyzer gates
- Linux x64 Native AOT publish and sample execution (`42`)

Both Windows and WSL candidate worktrees are clean at `76e03987`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved compiled async performance for immediately resolved primitive promises while preserving correct behavior for customized or shadowed promise implementations.
  * Reduced overhead for eligible numeric loop captures and compact class instances.
  * Improved string character-code operations through targeted runtime optimization.

* **Developer Tools**
  * Added local performance workflows for comparing Windows and WSL results, tracking regressions, and generating Markdown reports.
  * Expanded benchmark controls for selecting workloads, runtimes, launch counts, and output locations.

* **Documentation**
  * Added guidance for local performance testing, benchmark usage, validation gates, and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->