### PR TITLE
perf: eliminate stable class and async loop allocations

### DIFF
--- a/src/SharpTS/Compilation/AsyncStateMachineBuilder.cs
+++ b/src/SharpTS/Compilation/AsyncStateMachineBuilder.cs
@@ -86,7 +86,8 @@ public class AsyncStateMachineBuilder : AsyncBuilderBase
         bool isInstanceMethod = false,
         bool hasDynamicThis = false,
         bool hasAsyncArrows = false,
-        bool hasLock = false)
+        bool hasLock = false,
+        IReadOnlyDictionary<string, Type>? hoistedParameterTypes = null)
     {
         // Determine builder and task types based on return type
         if (returnType == _types.Void)
@@ -113,7 +114,8 @@ public class AsyncStateMachineBuilder : AsyncBuilderBase
 
         // Define hoisted variables using HoistingManager
         _hoisting = new HoistingManager(_stateMachineType, _types.Object);
-        _hoisting.DefineHoistedParameters(analysis.HoistedParameters);
+        _hoisting.DefineHoistedParameters(
+            analysis.HoistedParameters, hoistedParameterTypes);
         _hoisting.DefineHoistedLocals(analysis.HoistedLocals);
 
         // Define awaiter fields (one per await point)

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.Operators.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.Operators.cs
@@ -178,6 +178,9 @@ public abstract partial class ExpressionEmitterBase
             string name = v.Name.Lexeme;
             double delta = pi.Operator.Type == TokenType.PLUS_PLUS ? 1.0 : -1.0;
 
+            if (TryEmitNativeNumericLocalIncrement(v, delta, isPrefix: true))
+                return;
+
             // Load current value, convert to double, add delta, box.
             // ConvertToNumber implements ECMA-262 ToNumber (undefined→NaN);
             // Convert.ToDouble throws InvalidCastException on $Undefined (#190).
@@ -241,6 +244,9 @@ public abstract partial class ExpressionEmitterBase
             string name = v.Name.Lexeme;
             double delta = poi.Operator.Type == TokenType.PLUS_PLUS ? 1.0 : -1.0;
 
+            if (TryEmitNativeNumericLocalIncrement(v, delta, isPrefix: false))
+                return;
+
             // Load current value (this is the expression result — original value)
             EmitVariable(v);
             EnsureBoxed();
@@ -287,6 +293,31 @@ public abstract partial class ExpressionEmitterBase
 
         // Unknown operand — keep the stack state defined for the verifier.
         SetStackUnknown();
+    }
+
+    private bool TryEmitNativeNumericLocalIncrement(
+        Expr.Variable variable,
+        double delta,
+        bool isPrefix)
+    {
+        string name = variable.Name.Lexeme;
+        if (Ctx.CellBindingLocals.ContainsKey(name)
+            || !Ctx.Locals.TryGetLocal(name, out var local)
+            || local.LocalType != Types.Double)
+        {
+            return false;
+        }
+
+        IL.Emit(OpCodes.Ldloc, local);
+        if (!isPrefix)
+            IL.Emit(OpCodes.Dup);
+        IL.Emit(OpCodes.Ldc_R8, delta);
+        IL.Emit(OpCodes.Add);
+        if (isPrefix)
+            IL.Emit(OpCodes.Dup);
+        IL.Emit(OpCodes.Stloc, local);
+        SetStackType(StackType.Double);
+        return true;
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.cs
@@ -420,6 +420,9 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     /// </summary>
     protected virtual void EmitBinary(Expr.Binary b)
     {
+        if (TryEmitStableNumericLocalComparison(b))
+            return;
+
         // Bitwise and shift operators need int32 coercion of both operands per ECMA-262 ToInt32.
         if (IsBitwiseOrShiftOp(b.Operator.Type))
         {
@@ -459,6 +462,79 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             SetStackUnknown();
         }
     }
+
+    private bool TryEmitStableNumericLocalComparison(Expr.Binary expression)
+    {
+        if (expression.Operator.Type != TokenType.LESS
+            || !HasNativeNumericLocal(expression.Left)
+            || !IsSimpleNumericOperand(expression.Left)
+            || !IsSimpleNumericOperand(expression.Right)
+            || !IsNumericType(Ctx.TypeMap?.Get(expression.Left))
+            || !IsNumericType(Ctx.TypeMap?.Get(expression.Right)))
+        {
+            return false;
+        }
+
+        EmitExpressionAsDouble(expression.Left);
+        var left = IL.DeclareLocal(Types.Double);
+        IL.Emit(OpCodes.Stloc, left);
+        EmitExpressionAsDouble(expression.Right);
+        var right = IL.DeclareLocal(Types.Double);
+        IL.Emit(OpCodes.Stloc, right);
+        IL.Emit(OpCodes.Ldloc, left);
+        IL.Emit(OpCodes.Ldloc, right);
+        IL.Emit(OpCodes.Clt);
+        SetStackType(StackType.Boolean);
+        return true;
+    }
+
+    private bool HasNativeNumericLocal(Expr expression)
+    {
+        expression = UnwrapNumericOperand(expression);
+        return expression is Expr.Variable variable
+            && Ctx.Locals.TryGetLocal(variable.Name.Lexeme, out var local)
+            && local.LocalType == Types.Double;
+    }
+
+    private static bool IsSimpleNumericOperand(Expr expression)
+    {
+        expression = UnwrapNumericOperand(expression);
+        return expression is Expr.Variable
+            or Expr.Literal { Value: double }
+            or Expr.Unary
+        {
+            Operator.Type: TokenType.MINUS or TokenType.PLUS,
+            Right: Expr.Literal { Value: double }
+        };
+    }
+
+    private static Expr UnwrapNumericOperand(Expr expression)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case Expr.Grouping grouping:
+                    expression = grouping.Expression;
+                    continue;
+                case Expr.TypeAssertion assertion:
+                    expression = assertion.Expression;
+                    continue;
+                case Expr.Satisfies satisfies:
+                    expression = satisfies.Expression;
+                    continue;
+                case Expr.NonNullAssertion nonNull:
+                    expression = nonNull.Expression;
+                    continue;
+                default:
+                    return expression;
+            }
+        }
+    }
+
+    private static bool IsNumericType(TypeSystem.TypeInfo? type) => type is
+        TypeSystem.TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER }
+        or TypeSystem.TypeInfo.NumberLiteral;
 
     private static bool IsBitwiseOrShiftOp(TokenType op) => op is
         TokenType.AMPERSAND or TokenType.PIPE or TokenType.CARET or

--- a/src/SharpTS/Compilation/HoistingManager.cs
+++ b/src/SharpTS/Compilation/HoistingManager.cs
@@ -50,11 +50,14 @@ public class HoistingManager
     /// <summary>
     /// Defines fields for all hoisted parameters.
     /// </summary>
-    public void DefineHoistedParameters(IEnumerable<string> names)
+    public void DefineHoistedParameters(
+        IEnumerable<string> names,
+        IReadOnlyDictionary<string, Type>? fieldTypes = null)
     {
         foreach (var name in names)
         {
-            var field = _typeBuilder.DefineField(name, _objectType, FieldAttributes.Public);
+            Type fieldType = fieldTypes?.GetValueOrDefault(name) ?? _objectType;
+            var field = _typeBuilder.DefineField(name, fieldType, FieldAttributes.Public);
             HoistedParameters[name] = field;
         }
     }

--- a/src/SharpTS/Compilation/ILCompiler.Async.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Async.cs
@@ -49,7 +49,8 @@ public partial class ILCompiler
             _types.Object,
             isInstanceMethod: false,
             hasDynamicThis: analysis.UsesThis,
-            hasAsyncArrows: hasAsyncArrows);
+            hasAsyncArrows: hasAsyncArrows,
+            hoistedParameterTypes: GetStableAsyncParameterFieldTypes(funcStmt));
 
         // Define stub method (returns Task<object>).
         // A trailing rest parameter is typed List<object> so the indirect
@@ -94,6 +95,18 @@ public partial class ILCompiler
 
         // Build state machines for any async arrows found in this function
         DefineAsyncArrowStateMachines(analysis.AsyncArrows, smBuilder);
+    }
+
+    private IReadOnlyDictionary<string, Type>? GetStableAsyncParameterFieldTypes(
+        Stmt.Function function)
+    {
+        Dictionary<string, Type>? result = null;
+        foreach (var parameter in function.Parameters)
+        {
+            if (_typeMap?.IsStableNumericStateMachineParameter(parameter) == true)
+                (result ??= [])[parameter.Name.Lexeme] = _types.Double;
+        }
+        return result;
     }
 
     private HashSet<Expr.Await> FindSuspensionFreeAwaits(
@@ -1335,9 +1348,10 @@ public partial class ILCompiler
             }
         }
 
-        // Copy parameters to state machine fields
-        // For instance methods, parameters start at arg 1 (arg 0 is 'this')
-        // Hoisted parameter fields are typed as 'object', so we need to box value types
+        // Copy parameters to state machine fields. General fields are object-typed;
+        // proven numeric fields convert the object ABI value once here and remain
+        // native throughout MoveNext.
+        // For instance methods, parameters start at arg 1 (arg 0 is 'this').
         int paramOffset = isInstanceMethod ? 1 : 0;
         var stubParams = stubMethod.GetParameters();
         for (int i = 0; i < parameters.Count; i++)
@@ -1347,10 +1361,18 @@ public partial class ILCompiler
             {
                 il.Emit(OpCodes.Ldloca, smLocal);
                 il.Emit(OpCodes.Ldarg, i + paramOffset);
-                // Box value types since hoisted fields are typed as object
-                if (i < stubParams.Length && stubParams[i].ParameterType.IsValueType)
+                Type sourceType = i < stubParams.Length
+                    ? stubParams[i].ParameterType
+                    : _types.Object;
+                if (field.FieldType == _types.Double && sourceType != _types.Double)
                 {
-                    il.Emit(OpCodes.Box, stubParams[i].ParameterType);
+                    if (sourceType.IsValueType)
+                        il.Emit(OpCodes.Box, sourceType);
+                    il.Emit(OpCodes.Call, _runtime!.ConvertToNumber);
+                }
+                else if (field.FieldType == _types.Object && sourceType.IsValueType)
+                {
+                    il.Emit(OpCodes.Box, sourceType);
                 }
                 il.Emit(OpCodes.Stfld, field);
             }
@@ -1451,7 +1473,8 @@ public partial class ILCompiler
             _types.Object,
             isInstanceMethod: isInstanceMethod,
             hasAsyncArrows: hasAsyncArrows,
-            hasLock: hasLock
+            hasLock: hasLock,
+            hoistedParameterTypes: GetStableAsyncParameterFieldTypes(method)
         );
         RegisterStateMachine(
             methodBuilder,

--- a/src/SharpTS/Compilation/ILCompiler.Classes.Static.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.Static.cs
@@ -594,7 +594,8 @@ public partial class ILCompiler
             _types.Object,
             isInstanceMethod: false,  // Static method!
             hasAsyncArrows: hasAsyncArrows,
-            hasLock: hasLock
+            hasLock: hasLock,
+            hoistedParameterTypes: GetStableAsyncParameterFieldTypes(method)
         );
 
         // #682/#follow-up: attach the static method's function display class (registered in Phase 4) to

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -660,6 +660,8 @@ public partial class ILCompiler
             statements, _closures.DirectCallArrowBindings, _closures.Analyzer);
         StableNumericLoopCaptureAnalyzer.Analyze(
             statements, _typeMap, _closures.Analyzer, _closures.DirectCallArrowBindings);
+        StableClassLocalScalarReplacementAnalyzer.Analyze(
+            statements, _typeMap, _closures.Analyzer, _features);
         _classes.CompactStorageClasses.UnionWith(
             CompactClassStorageAnalyzer.Analyze(statements, _typeMap, _features));
         ArrayLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -107,7 +107,7 @@ public partial class ILEmitter
                 return;
             }
 
-            checkStaticField:
+        checkStaticField:
 
             // Check if this is a top-level variable - use static fields so all functions can access them
             if (_ctx.TopLevelStaticVars?.TryGetValue(v.Name.Lexeme, out var staticField) == true)
@@ -262,6 +262,46 @@ public partial class ILEmitter
             _ctx.ArrowMethods.ContainsKey(staticCallArrow))
         {
             _ctx.Locals.DeclareLocal(v.Name.Lexeme, _ctx.Types.Object, tag: staticCallArrow);
+            return;
+        }
+
+        // Exact non-escaping class allocation: when analysis proves that the
+        // constructor only copies primitive parameters into declared fields and
+        // the local is observed solely through constant-key field reads, reuse the
+        // generated value-type shape carrier. Evaluate every argument first in
+        // source order, then replay the constructor's pure field assignments; no
+        // class instance or dynamic property store is allocated.
+        if (_ctx.TypeMap != null && v.Initializer is Expr.New scalarNew
+            && _ctx.TypeMap.IsScalarReplaceableClassLocal(v.Name, out var scalarInfo)
+            && _ctx.TryGetObjectShapeType(scalarInfo.Shape.CanonicalKey) is { } scalarShape)
+        {
+            var argumentLocals = new LocalBuilder[scalarNew.Arguments.Count];
+            for (int index = 0; index < scalarNew.Arguments.Count; index++)
+            {
+                var kind = scalarInfo.ConstructorParameterKinds[index];
+                Type argumentType = kind switch
+                {
+                    TokenType.TYPE_NUMBER => _ctx.Types.Double,
+                    TokenType.TYPE_BOOLEAN => _ctx.Types.Boolean,
+                    _ => _ctx.Types.String
+                };
+                EmitExpression(scalarNew.Arguments[index]);
+                EnsureForFieldType(argumentType);
+                argumentLocals[index] = IL.DeclareLocal(argumentType);
+                IL.Emit(OpCodes.Stloc, argumentLocals[index]);
+            }
+
+            var scalarLocal = _ctx.Locals.DeclareLocal(
+                v.Name.Lexeme,
+                scalarShape.ClrType);
+            IL.Emit(OpCodes.Ldloca, scalarLocal);
+            IL.Emit(OpCodes.Initobj, scalarShape.ClrType);
+            foreach (var initialization in scalarInfo.FieldInitializations)
+            {
+                IL.Emit(OpCodes.Ldloca, scalarLocal);
+                IL.Emit(OpCodes.Ldloc, argumentLocals[initialization.ParameterIndex]);
+                IL.Emit(OpCodes.Stfld, scalarShape.FieldBuilders[initialization.FieldName]);
+            }
             return;
         }
 
@@ -1842,7 +1882,7 @@ public partial class ILEmitter
                 _ctx.Types.Type, "GetTypeFromHandle", _ctx.Types.RuntimeTypeHandle));
             IL.Emit(OpCodes.Stfld, displayField);
         }
-        skipCapturedClassStore:
+    skipCapturedClassStore:
 
         if (!isBlockScoped)
             return;

--- a/src/SharpTS/Compilation/StableClassLocalScalarReplacementAnalyzer.cs
+++ b/src/SharpTS/Compilation/StableClassLocalScalarReplacementAnalyzer.cs
@@ -1,0 +1,429 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Finds deliberately narrow exact class allocations that are observable only as
+/// primitive field values. Eligible constructors contain nothing except copies
+/// from primitive parameters into declared instance fields, so the allocation can
+/// use the generated value-type shape carrier already shared by object-local
+/// promotion. Any identity, alias, call, capture, dynamic property, prototype, or
+/// constructor-side-effect observation retains the ordinary class allocation.
+/// </summary>
+internal static class StableClassLocalScalarReplacementAnalyzer
+{
+    public static void Analyze(
+        List<Stmt> program,
+        TypeMap? typeMap,
+        ClosureAnalyzer? closures,
+        RuntimeFeatureSet? features)
+    {
+        if (typeMap is null
+            || features?.UsesDynamicPropertyDescriptors != false
+            || features.UsesObjectIntegrityMutation
+            || features.UsesClassPrototypeMutation)
+            return;
+
+        var declarations = new DeclarationCollector();
+        foreach (var statement in program)
+            declarations.Visit(statement);
+
+        var eligibleClasses = new Dictionary<string, ClassCandidate>(StringComparer.Ordinal);
+        foreach (var (name, classes) in declarations.Classes)
+        {
+            if (classes.Count != 1 || declarations.ExportedNames.Contains(name))
+                continue;
+            if (TryBuildClassCandidate(classes[0], out var candidate))
+                eligibleClasses[name] = candidate;
+        }
+        if (eligibleClasses.Count == 0)
+            return;
+
+        var visitor = new UsageVisitor(typeMap, eligibleClasses);
+        foreach (var statement in program)
+            visitor.Visit(statement);
+
+        foreach (var candidate in visitor.Locals.Values)
+        {
+            if (visitor.DeclarationCounts.GetValueOrDefault(candidate.Key) != 1
+                || visitor.DisqualifiedLocals.Contains(candidate.Key)
+                || visitor.UnsafeClasses.Contains(candidate.Class.Statement)
+                || closures?.IsVariableCaptured(candidate.Key.Name) == true)
+                continue;
+
+            typeMap.MarkScalarReplaceableClassLocal(
+                candidate.NameToken,
+                candidate.Class.Info);
+        }
+    }
+
+    private static bool TryBuildClassCandidate(
+        Stmt.Class statement,
+        out ClassCandidate candidate)
+    {
+        candidate = null!;
+        if (statement.SuperclassExpr is not null
+            || statement.TypeParams is { Count: > 0 }
+            || statement.IsAbstract
+            || statement.IsDeclare
+            || statement.Decorators is { Count: > 0 }
+            || statement.IndexSignatures is { Count: > 0 }
+            || statement.Accessors is { Count: > 0 }
+            || statement.AutoAccessors is { Count: > 0 }
+            || statement.Methods.Any(method =>
+                method.IsPrivate || method.ComputedKey is not null
+                || method.Decorators is { Count: > 0 }))
+            return false;
+
+        var fields = new List<ObjectShapeField>();
+        var fieldKinds = new Dictionary<string, TokenType>(StringComparer.Ordinal);
+        foreach (var field in statement.Fields.Where(field => !field.IsStatic))
+        {
+            if (field.IsPrivate || field.IsOptional || field.IsDeclare
+                || field.ComputedKey is not null || field.Initializer is not null
+                || field.Decorators is { Count: > 0 }
+                || ClassifyKind(field.TypeAnnotation) is not { } kind
+                || !fieldKinds.TryAdd(field.Name.Lexeme, kind))
+                return false;
+            fields.Add(new ObjectShapeField(field.Name.Lexeme, kind));
+        }
+        if (fields.Count == 0)
+            return false;
+
+        var constructors = statement.Methods
+            .Where(method => !method.IsStatic && method.Name.Lexeme == "constructor")
+            .ToList();
+        if (constructors.Count != 1 || constructors[0].Body is null)
+            return false;
+
+        var constructor = constructors[0];
+        var parameterKinds = new List<TokenType>(constructor.Parameters.Count);
+        var parameterIndexes = new Dictionary<string, int>(StringComparer.Ordinal);
+        for (int index = 0; index < constructor.Parameters.Count; index++)
+        {
+            var parameter = constructor.Parameters[index];
+            if (parameter.DefaultValue is not null || parameter.IsRest
+                || parameter.IsOptional || parameter.IsParameterProperty
+                || parameter.Decorators is { Count: > 0 }
+                || ClassifyKind(parameter.Type) is not { } kind
+                || !parameterIndexes.TryAdd(parameter.Name.Lexeme, index))
+                return false;
+            parameterKinds.Add(kind);
+        }
+
+        var initializations = new List<ClassScalarFieldInitialization>(fields.Count);
+        var initializedFields = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var bodyStatement in constructor.Body!)
+        {
+            if (bodyStatement is not Stmt.Expression
+                {
+                    Expr: Expr.Set
+                    {
+                        Object: Expr.This,
+                        Name: var fieldName,
+                        Value: Expr.Variable { Name: var parameterName }
+                    }
+                }
+                || !fieldKinds.TryGetValue(fieldName.Lexeme, out var fieldKind)
+                || !parameterIndexes.TryGetValue(parameterName.Lexeme, out int parameterIndex)
+                || parameterKinds[parameterIndex] != fieldKind
+                || !initializedFields.Add(fieldName.Lexeme))
+                return false;
+
+            initializations.Add(new ClassScalarFieldInitialization(
+                fieldName.Lexeme,
+                parameterIndex));
+        }
+        if (initializedFields.Count != fields.Count)
+            return false;
+
+        string key = string.Join(";", fields.Select(field => $"{field.Name}:{field.Kind}"));
+        var shape = new ObjectShapeInfo(key, fields);
+        candidate = new ClassCandidate(
+            statement,
+            new ClassScalarReplacementInfo(shape, parameterKinds, initializations),
+            fieldKinds);
+        return true;
+    }
+
+    private static TokenType? ClassifyKind(string? annotation) => annotation switch
+    {
+        "number" => TokenType.TYPE_NUMBER,
+        "boolean" => TokenType.TYPE_BOOLEAN,
+        "string" => TokenType.TYPE_STRING,
+        _ => null
+    };
+
+    private static TokenType? ClassifyKind(TypeInfo? type) => type switch
+    {
+        TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } => TokenType.TYPE_NUMBER,
+        TypeInfo.Primitive { Type: TokenType.TYPE_BOOLEAN } => TokenType.TYPE_BOOLEAN,
+        TypeInfo.NumberLiteral => TokenType.TYPE_NUMBER,
+        TypeInfo.BooleanLiteral => TokenType.TYPE_BOOLEAN,
+        TypeInfo.String or TypeInfo.StringLiteral => TokenType.TYPE_STRING,
+        _ => null
+    };
+
+    private sealed class DeclarationCollector : AstVisitorBase
+    {
+        private int _functionDepth;
+        private int _namespaceDepth;
+
+        public Dictionary<string, List<Stmt.Class>> Classes { get; } =
+            new(StringComparer.Ordinal);
+        public HashSet<string> ExportedNames { get; } = new(StringComparer.Ordinal);
+
+        protected override void VisitFunction(Stmt.Function statement)
+        {
+            _functionDepth++;
+            base.VisitFunction(statement);
+            _functionDepth--;
+        }
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression)
+        {
+            _functionDepth++;
+            base.VisitArrowFunction(expression);
+            _functionDepth--;
+        }
+
+        protected override void VisitNamespace(Stmt.Namespace statement)
+        {
+            _namespaceDepth++;
+            base.VisitNamespace(statement);
+            _namespaceDepth--;
+        }
+
+        protected override void VisitClass(Stmt.Class statement)
+        {
+            if (_functionDepth == 0 && _namespaceDepth == 0)
+            {
+                if (!Classes.TryGetValue(statement.Name.Lexeme, out var declarations))
+                    Classes[statement.Name.Lexeme] = declarations = [];
+                declarations.Add(statement);
+            }
+            base.VisitClass(statement);
+        }
+
+        protected override void VisitExport(Stmt.Export statement)
+        {
+            if (statement.Declaration is Stmt.Class exportedClass)
+                ExportedNames.Add(exportedClass.Name.Lexeme);
+            if (statement.NamedExports is not null && statement.FromModulePath is null)
+            {
+                foreach (var specifier in statement.NamedExports.Where(item => !item.IsTypeOnly))
+                    ExportedNames.Add(specifier.LocalName.Lexeme);
+            }
+            base.VisitExport(statement);
+        }
+    }
+
+    private sealed class UsageVisitor(
+        TypeMap typeMap,
+        Dictionary<string, ClassCandidate> eligibleClasses) : AstVisitorBase
+    {
+        private readonly TypeMap _typeMap = typeMap;
+        private readonly Dictionary<string, ClassCandidate> _eligibleClasses = eligibleClasses;
+        private readonly Dictionary<int, int> _scopeParents = [];
+        private int _scope;
+        private int _nextScope;
+
+        public Dictionary<(int Scope, string Name), LocalCandidate> Locals { get; } = [];
+        public Dictionary<(int Scope, string Name), int> DeclarationCounts { get; } = [];
+        public HashSet<(int Scope, string Name)> DisqualifiedLocals { get; } = [];
+        public HashSet<Stmt.Class> UnsafeClasses { get; } =
+            new(ReferenceEqualityComparer.Instance);
+
+        protected override void VisitFunction(Stmt.Function statement)
+        {
+            if (_eligibleClasses.TryGetValue(statement.Name.Lexeme, out var namedClass)
+                && statement.Name.Lexeme != "constructor")
+                UnsafeClasses.Add(namedClass.Statement);
+            InScope(statement.Parameters, () => base.VisitFunction(statement));
+        }
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression) =>
+            InScope(expression.Parameters, () => base.VisitArrowFunction(expression));
+
+        private void InScope(IReadOnlyList<Stmt.Parameter> parameters, Action visit)
+        {
+            int saved = _scope;
+            _scope = ++_nextScope;
+            _scopeParents[_scope] = saved;
+            foreach (var parameter in parameters)
+            {
+                if (_eligibleClasses.TryGetValue(parameter.Name.Lexeme, out var namedClass))
+                    UnsafeClasses.Add(namedClass.Statement);
+            }
+            visit();
+            _scope = saved;
+        }
+
+        protected override void VisitClass(Stmt.Class statement)
+        {
+            if (_eligibleClasses.TryGetValue(statement.Name.Lexeme, out var candidate)
+                && !ReferenceEquals(candidate.Statement, statement))
+                UnsafeClasses.Add(candidate.Statement);
+            base.VisitClass(statement);
+        }
+
+        protected override void VisitVar(Stmt.Var statement)
+        {
+            RecordDeclaration(statement.Name.Lexeme);
+            if (statement.Initializer is not null)
+                Visit(statement.Initializer);
+        }
+
+        protected override void VisitConst(Stmt.Const statement)
+        {
+            var key = RecordDeclaration(statement.Name.Lexeme);
+            if (TryBindLocal(statement.Name, statement.Initializer, key))
+                return;
+            Visit(statement.Initializer);
+        }
+
+        protected override void VisitTryCatch(Stmt.TryCatch statement)
+        {
+            if (statement.CatchParam is not null)
+                RecordDeclaration(statement.CatchParam.Lexeme);
+            base.VisitTryCatch(statement);
+        }
+
+        private (int Scope, string Name) RecordDeclaration(string name)
+        {
+            var key = (_scope, name);
+            DeclarationCounts[key] = DeclarationCounts.GetValueOrDefault(key) + 1;
+            if (_eligibleClasses.TryGetValue(name, out var namedClass))
+                UnsafeClasses.Add(namedClass.Statement);
+            return key;
+        }
+
+        private bool TryBindLocal(
+            Token nameToken,
+            Expr initializer,
+            (int Scope, string Name) key)
+        {
+            if (initializer is not Expr.New
+                {
+                    Callee: Expr.Variable classVariable
+                } construction
+                || !_eligibleClasses.TryGetValue(classVariable.Name.Lexeme, out var classCandidate)
+                || construction.Arguments.Count != classCandidate.Info.ConstructorParameterKinds.Count
+                || !HasExactClassType(initializer, classVariable.Name.Lexeme))
+                return false;
+
+            for (int index = 0; index < construction.Arguments.Count; index++)
+            {
+                if (ClassifyKind(_typeMap.Get(construction.Arguments[index]))
+                    != classCandidate.Info.ConstructorParameterKinds[index])
+                    return false;
+            }
+
+            Locals[key] = new LocalCandidate(key, nameToken, classCandidate);
+            foreach (var argument in construction.Arguments)
+                Visit(argument);
+            return true;
+        }
+
+        protected override void VisitNew(Expr.New expression)
+        {
+            if (expression.Callee is Expr.Variable classVariable
+                && _eligibleClasses.ContainsKey(classVariable.Name.Lexeme))
+            {
+                foreach (var argument in expression.Arguments)
+                    Visit(argument);
+                return;
+            }
+            base.VisitNew(expression);
+        }
+
+        protected override void VisitGet(Expr.Get expression)
+        {
+            if (expression.Object is Expr.Variable variable
+                && TryFindLocal(variable.Name.Lexeme, out var local))
+            {
+                if (!expression.Optional
+                    && local.Key.Scope == _scope
+                    && local.Class.FieldKinds.ContainsKey(expression.Name.Lexeme)
+                    && HasExactClassType(expression.Object, local.Class.Statement.Name.Lexeme))
+                    return;
+                Disqualify(local);
+            }
+            base.VisitGet(expression);
+        }
+
+        protected override void VisitDelete(Expr.Delete expression)
+        {
+            DisqualifyPropertyMutationOperand(expression.Operand);
+            base.VisitDelete(expression);
+        }
+
+        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expression)
+        {
+            DisqualifyPropertyMutationOperand(expression.Operand);
+            base.VisitPrefixIncrement(expression);
+        }
+
+        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expression)
+        {
+            DisqualifyPropertyMutationOperand(expression.Operand);
+            base.VisitPostfixIncrement(expression);
+        }
+
+        protected override void VisitVariable(Expr.Variable expression)
+        {
+            if (TryFindLocal(expression.Name.Lexeme, out var local))
+            {
+                Disqualify(local);
+                return;
+            }
+            if (_eligibleClasses.TryGetValue(expression.Name.Lexeme, out var classCandidate))
+                UnsafeClasses.Add(classCandidate.Statement);
+        }
+
+        private bool TryFindLocal(string name, out LocalCandidate local)
+        {
+            int scope = _scope;
+            while (true)
+            {
+                if (Locals.TryGetValue((scope, name), out local))
+                    return true;
+                if (!_scopeParents.TryGetValue(scope, out scope))
+                    break;
+            }
+            local = default;
+            return false;
+        }
+
+        private void Disqualify(LocalCandidate local) =>
+            DisqualifiedLocals.Add(local.Key);
+
+        private void DisqualifyPropertyMutationOperand(Expr expression)
+        {
+            if (expression is Expr.Get { Object: Expr.Variable variable }
+                && TryFindLocal(variable.Name.Lexeme, out var local))
+                Disqualify(local);
+        }
+
+        private bool HasExactClassType(Expr expression, string className) =>
+            _typeMap.Get(expression) is TypeInfo.Instance instance
+            && instance.ResolvedClassType switch
+            {
+                TypeInfo.Class type => type.Name == className,
+                TypeInfo.MutableClass type => type.Name == className,
+                _ => false
+            };
+    }
+
+    private sealed record ClassCandidate(
+        Stmt.Class Statement,
+        ClassScalarReplacementInfo Info,
+        IReadOnlyDictionary<string, TokenType> FieldKinds);
+
+    private readonly record struct LocalCandidate(
+        (int Scope, string Name) Key,
+        Token NameToken,
+        ClassCandidate Class);
+}

--- a/src/SharpTS/Compilation/StableNumericLoopCaptureAnalyzer.cs
+++ b/src/SharpTS/Compilation/StableNumericLoopCaptureAnalyzer.cs
@@ -9,7 +9,8 @@ namespace SharpTS.Compilation;
 /// may be stored as an unboxed <c>double</c>. The binding must be an explicitly
 /// numeric, definitely initialized <c>for (let ...)</c> counter and the capturing
 /// arrow must already belong to the proven non-escaping direct-call path in a fully
-/// synchronous enclosing function.
+/// synchronous enclosing function, or be the inline callback of a proven stable
+/// primitive Promise chain whose async loop counter never crosses a suspension.
 /// </summary>
 /// <remarks>
 /// Captures that need live binding semantics are excluded through the per-iteration
@@ -37,7 +38,12 @@ internal static class StableNumericLoopCaptureAnalyzer
         var directCallArrows = new HashSet<Expr.ArrowFunction>(
             directCallBindings.Values,
             ReferenceEqualityComparer.Instance);
-        var visitor = new LoopVisitor(typeMap, closures, directCallArrows);
+        var promiseHandlers = new StablePromiseHandlerVisitor(typeMap);
+        foreach (var statement in program)
+            promiseHandlers.Visit(statement);
+
+        var visitor = new LoopVisitor(
+            typeMap, closures, directCallArrows, promiseHandlers.Arrows);
         foreach (var statement in program)
             visitor.Visit(statement);
     }
@@ -56,7 +62,7 @@ internal static class StableNumericLoopCaptureAnalyzer
             } candidate
             || !IsNumericLiteral(initializer)
             || typeMap.Get(initializer) is not (TypeInfo.Primitive
-                { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral)
+            { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral)
             || typeMap.IsUndefinedReachableNumericLocal(candidate)
             || typeMap.IsUndefinedReachableNumericLocal(initializer))
         {
@@ -72,10 +78,10 @@ internal static class StableNumericLoopCaptureAnalyzer
         expression = Unwrap(expression);
         return expression is Expr.Literal { Value: double }
             or Expr.Unary
-            {
-                Operator.Type: TokenType.MINUS,
-                Right: Expr.Literal { Value: double }
-            };
+        {
+            Operator.Type: TokenType.MINUS,
+            Right: Expr.Literal { Value: double }
+        };
     }
 
     private static Expr Unwrap(Expr expression)
@@ -105,16 +111,20 @@ internal static class StableNumericLoopCaptureAnalyzer
     private sealed class LoopVisitor(
         TypeMap typeMap,
         ClosureAnalyzer closures,
-        HashSet<Expr.ArrowFunction> directCallArrows) : AstVisitorBase
+        HashSet<Expr.ArrowFunction> directCallArrows,
+        HashSet<Expr.ArrowFunction> stablePromiseHandlers) : AstVisitorBase
     {
         private readonly TypeMap _typeMap = typeMap;
         private readonly ClosureAnalyzer _closures = closures;
         private readonly HashSet<Expr.ArrowFunction> _directCallArrows = directCallArrows;
+        private readonly HashSet<Expr.ArrowFunction> _stablePromiseHandlers = stablePromiseHandlers;
+        private readonly Stack<object> _functionStack = new();
         private int _functionDepth;
         private int _suspendingFunctionDepth;
 
         protected override void VisitFunction(Stmt.Function statement)
         {
+            _functionStack.Push(statement);
             _functionDepth++;
             if (statement.IsAsync || statement.IsGenerator)
                 _suspendingFunctionDepth++;
@@ -127,11 +137,13 @@ internal static class StableNumericLoopCaptureAnalyzer
                 if (statement.IsAsync || statement.IsGenerator)
                     _suspendingFunctionDepth--;
                 _functionDepth--;
+                _functionStack.Pop();
             }
         }
 
         protected override void VisitArrowFunction(Expr.ArrowFunction expression)
         {
+            _functionStack.Push(expression);
             _functionDepth++;
             if (expression.IsAsync || expression.IsGenerator)
                 _suspendingFunctionDepth++;
@@ -144,24 +156,109 @@ internal static class StableNumericLoopCaptureAnalyzer
                 if (expression.IsAsync || expression.IsGenerator)
                     _suspendingFunctionDepth--;
                 _functionDepth--;
+                _functionStack.Pop();
             }
         }
 
         protected override void VisitFor(Stmt.For statement)
         {
             if (_functionDepth > 0
-                && _suspendingFunctionDepth == 0
                 && TryGetStableNumericBinding(statement, _typeMap, out var declaration))
             {
                 var collector = new CandidateCollector(
                     declaration.Name.Lexeme,
                     _typeMap,
                     _closures,
-                    _directCallArrows);
+                    _directCallArrows,
+                    _stablePromiseHandlers);
                 collector.Visit(statement.Body);
+
+                if (_suspendingFunctionDepth == 0)
+                {
+                    collector.MarkSynchronousCaptures();
+                }
+                else if (_functionStack.TryPeek(out var enclosing)
+                    && enclosing is Stmt.Function
+                    {
+                        IsAsync: true,
+                        IsGenerator: false
+                    } function
+                    && IsStableAsyncPromiseLoop(statement, declaration.Name.Lexeme)
+                    && collector.StablePromiseCaptures.Count > 0)
+                {
+                    _typeMap.MarkStableNumericStateMachineLocal(declaration);
+                    collector.MarkStablePromiseCaptures();
+                    MarkStableBoundParameter(statement, function, declaration.Name.Lexeme);
+                }
             }
 
             base.VisitFor(statement);
+        }
+
+        private void MarkStableBoundParameter(
+            Stmt.For loop,
+            Stmt.Function function,
+            string counterName)
+        {
+            if (loop.Condition is not Expr.Binary
+                {
+                    Operator.Type: TokenType.LESS,
+                    Left: Expr.Variable left,
+                    Right: Expr.Variable right
+                }
+                || left.Name.Lexeme != counterName)
+            {
+                return;
+            }
+
+            string boundName = right.Name.Lexeme;
+
+            var parameter = function.Parameters.SingleOrDefault(candidate =>
+                candidate.Name.Lexeme == boundName);
+            if (parameter is not
+                {
+                    Type: "number",
+                    IsOptional: false,
+                    IsRest: false,
+                    DefaultValue: null
+                }
+                || _typeMap.IsUndefinedReachableNumericParam(parameter)
+                || _closures.GetCapturedLocals(function).Contains(boundName))
+            {
+                return;
+            }
+
+            var writes = new BindingWriteVisitor(boundName);
+            if (function.Body is not null)
+                foreach (var statement in function.Body)
+                    writes.Visit(statement);
+            if (!writes.Written)
+                _typeMap.MarkStableNumericStateMachineParameter(parameter);
+        }
+
+        private static bool IsStableAsyncPromiseLoop(Stmt.For loop, string name)
+        {
+            if (loop.Condition is not Expr.Binary
+                {
+                    Operator.Type: TokenType.LESS,
+                    Left: Expr.Variable conditionCounter
+                }
+                || conditionCounter.Name.Lexeme != name
+                || loop.Increment is not Expr.PostfixIncrement
+                {
+                    Operand: Expr.Variable incrementCounter,
+                    Operator.Type: TokenType.PLUS_PLUS
+                }
+                || incrementCounter.Name.Lexeme != name)
+            {
+                return false;
+            }
+
+            var safety = new AsyncLoopSafetyVisitor(name);
+            if (loop.Condition is not null)
+                safety.Visit(loop.Condition);
+            safety.Visit(loop.Body);
+            return safety.Safe;
         }
     }
 
@@ -169,20 +266,28 @@ internal static class StableNumericLoopCaptureAnalyzer
         string bindingName,
         TypeMap typeMap,
         ClosureAnalyzer closures,
-        HashSet<Expr.ArrowFunction> directCallArrows) : AstVisitorBase
+        HashSet<Expr.ArrowFunction> directCallArrows,
+        HashSet<Expr.ArrowFunction> stablePromiseHandlers) : AstVisitorBase
     {
         private readonly string _bindingName = bindingName;
         private readonly TypeMap _typeMap = typeMap;
         private readonly ClosureAnalyzer _closures = closures;
         private readonly HashSet<Expr.ArrowFunction> _directCallArrows = directCallArrows;
+        private readonly HashSet<Expr.ArrowFunction> _stablePromiseHandlers = stablePromiseHandlers;
+        private readonly HashSet<Expr.ArrowFunction> _directCaptures =
+            new(ReferenceEqualityComparer.Instance);
+        public HashSet<Expr.ArrowFunction> StablePromiseCaptures { get; } =
+            new(ReferenceEqualityComparer.Instance);
 
         protected override void VisitArrowFunction(Expr.ArrowFunction arrow)
         {
-            if (_directCallArrows.Contains(arrow)
-                && _closures.GetCaptures(arrow).Contains(_bindingName)
+            if (_closures.GetCaptures(arrow).Contains(_bindingName)
                 && !_closures.GetClosureCellFields(arrow).Contains(_bindingName))
             {
-                _typeMap.MarkStableNumericCaptureField(arrow, _bindingName);
+                if (_directCallArrows.Contains(arrow))
+                    _directCaptures.Add(arrow);
+                if (_stablePromiseHandlers.Contains(arrow))
+                    StablePromiseCaptures.Add(arrow);
             }
 
             // A nested arrow has a separate creation scope and capture source.
@@ -261,6 +366,124 @@ internal static class StableNumericLoopCaptureAnalyzer
             Stmt.Sequence sequence => DeclaresBinding(sequence.Statements),
             _ => false
         };
+
+        public void MarkSynchronousCaptures()
+        {
+            foreach (var arrow in _directCaptures)
+                _typeMap.MarkStableNumericCaptureField(arrow, _bindingName);
+            foreach (var arrow in StablePromiseCaptures)
+                _typeMap.MarkStableNumericCaptureField(arrow, _bindingName);
+        }
+
+        public void MarkStablePromiseCaptures()
+        {
+            foreach (var arrow in StablePromiseCaptures)
+                _typeMap.MarkStableNumericCaptureField(arrow, _bindingName);
+        }
+    }
+
+    private sealed class StablePromiseHandlerVisitor(TypeMap typeMap) : AstVisitorBase
+    {
+        public HashSet<Expr.ArrowFunction> Arrows { get; } =
+            new(ReferenceEqualityComparer.Instance);
+
+        protected override void VisitCall(Expr.Call expression)
+        {
+            if (expression.Callee is Expr.Get method
+                && typeMap.IsStablePrimitivePromiseThen(method)
+                && expression.Arguments is [Expr.ArrowFunction handler])
+            {
+                Arrows.Add(handler);
+            }
+            base.VisitCall(expression);
+        }
+    }
+
+    private sealed class AsyncLoopSafetyVisitor(string bindingName) : AstVisitorBase
+    {
+        public bool Safe { get; private set; } = true;
+
+        protected override void VisitAwait(Expr.Await expression) => Safe = false;
+        protected override void VisitYield(Expr.Yield expression) => Safe = false;
+
+        protected override void VisitAssign(Expr.Assign expression)
+        {
+            if (expression.Name.Lexeme == bindingName)
+                Safe = false;
+            base.VisitAssign(expression);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
+        {
+            if (expression.Name.Lexeme == bindingName)
+                Safe = false;
+            base.VisitCompoundAssign(expression);
+        }
+
+        protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
+        {
+            if (expression.Name.Lexeme == bindingName)
+                Safe = false;
+            base.VisitLogicalAssign(expression);
+        }
+
+        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expression)
+        {
+            if (expression.Operand is Expr.Variable variable
+                && variable.Name.Lexeme == bindingName)
+                Safe = false;
+            base.VisitPrefixIncrement(expression);
+        }
+
+        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expression)
+        {
+            if (expression.Operand is Expr.Variable variable
+                && variable.Name.Lexeme == bindingName)
+                Safe = false;
+            base.VisitPostfixIncrement(expression);
+        }
+    }
+
+    private sealed class BindingWriteVisitor(string bindingName) : AstVisitorBase
+    {
+        public bool Written { get; private set; }
+
+        protected override void VisitAssign(Expr.Assign expression)
+        {
+            if (expression.Name.Lexeme == bindingName)
+                Written = true;
+            base.VisitAssign(expression);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
+        {
+            if (expression.Name.Lexeme == bindingName)
+                Written = true;
+            base.VisitCompoundAssign(expression);
+        }
+
+        protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
+        {
+            if (expression.Name.Lexeme == bindingName)
+                Written = true;
+            base.VisitLogicalAssign(expression);
+        }
+
+        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expression)
+        {
+            if (expression.Operand is Expr.Variable variable
+                && variable.Name.Lexeme == bindingName)
+                Written = true;
+            base.VisitPrefixIncrement(expression);
+        }
+
+        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expression)
+        {
+            if (expression.Operand is Expr.Variable variable
+                && variable.Name.Lexeme == bindingName)
+                Written = true;
+            base.VisitPostfixIncrement(expression);
+        }
     }
 
     private sealed class DirectEvalVisitor : AstVisitorBase

--- a/src/SharpTS/Compilation/StateMachineVariableResolver.cs
+++ b/src/SharpTS/Compilation/StateMachineVariableResolver.cs
@@ -66,14 +66,14 @@ public class StateMachineVariableResolver : IVariableResolver
         {
             _il.Emit(OpCodes.Ldarg_0);
             _il.Emit(OpCodes.Ldfld, field);
-            return StackType.Unknown;
+            return MapTypeToStackType(field.FieldType);
         }
 
         // 2. Check non-hoisted local
         if (_locals.TryGetLocal(name, out var local))
         {
             _il.Emit(OpCodes.Ldloc, local);
-            return StackType.Unknown;
+            return MapTypeToStackType(local.LocalType);
         }
 
         return null; // Not found - caller handles fallback
@@ -124,6 +124,14 @@ public class StateMachineVariableResolver : IVariableResolver
         }
 
         return false; // Not found
+    }
+
+    private static StackType MapTypeToStackType(Type type)
+    {
+        if (type == typeof(double)) return StackType.Double;
+        if (type == typeof(bool)) return StackType.Boolean;
+        if (type == typeof(string)) return StackType.String;
+        return StackType.Unknown;
     }
 
     /// <inheritdoc />

--- a/src/SharpTS/Compilation/StatementEmitterBase.cs
+++ b/src/SharpTS/Compilation/StatementEmitterBase.cs
@@ -87,13 +87,19 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
         else
         {
             // Not hoisted - use local variable
-            var local = IL.DeclareLocal(typeof(object));
+            bool stableNumeric = Ctx.TypeMap?.IsStableNumericStateMachineLocal(v) == true;
+            var local = IL.DeclareLocal(stableNumeric ? Types.Double : typeof(object));
             Ctx.Locals.RegisterLocal(name, local);
 
             if (v.Initializer != null)
             {
-                EmitExpression(v.Initializer);
-                EnsureBoxed();
+                if (stableNumeric)
+                    EmitExpressionAsDouble(v.Initializer);
+                else
+                {
+                    EmitExpression(v.Initializer);
+                    EnsureBoxed();
+                }
                 IL.Emit(OpCodes.Stloc, local);
             }
             else

--- a/src/SharpTS/TypeSystem/ObjectShapeInfo.cs
+++ b/src/SharpTS/TypeSystem/ObjectShapeInfo.cs
@@ -26,3 +26,21 @@ public sealed record ObjectShapeInfo(string CanonicalKey, IReadOnlyList<ObjectSh
 /// or <see cref="TokenType.TYPE_STRING"/> → <c>string</c>).
 /// </summary>
 public readonly record struct ObjectShapeField(string Name, TokenType Kind);
+
+/// <summary>
+/// Describes a class-local allocation that can reuse an <see cref="ObjectShapeInfo"/>
+/// value-type carrier. The constructor proof guarantees that every observable
+/// instance field is initialized by copying one primitive constructor parameter,
+/// and that the instance itself never escapes constant-key field access.
+/// </summary>
+public sealed record ClassScalarReplacementInfo(
+    ObjectShapeInfo Shape,
+    IReadOnlyList<TokenType> ConstructorParameterKinds,
+    IReadOnlyList<ClassScalarFieldInitialization> FieldInitializations);
+
+/// <summary>
+/// One side-effect-free constructor assignment, preserving constructor-body order.
+/// </summary>
+public readonly record struct ClassScalarFieldInitialization(
+    string FieldName,
+    int ParameterIndex);

--- a/src/SharpTS/TypeSystem/TypeMap.cs
+++ b/src/SharpTS/TypeSystem/TypeMap.cs
@@ -23,6 +23,8 @@ public class TypeMap
     private readonly Dictionary<Token, TokenType> _promotableArrayLocals = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Token> _promotableStringAccumulators = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<Token, ObjectShapeInfo> _promotableObjectLocals = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<Token, ClassScalarReplacementInfo> _scalarReplaceableClassLocals =
+        new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Stmt.ForOf> _stableNumericMapIterations = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.Get> _stablePrimitivePromiseThenCalls = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<Expr.ArrowFunction, HashSet<string>> _stableNumericCaptureFields = new(ReferenceEqualityComparer.Instance);
@@ -194,6 +196,25 @@ public class TypeMap
     /// the generated types). Empty when no object local was promoted.
     /// </summary>
     public IEnumerable<ObjectShapeInfo> PromotableObjectLocalShapes => _promotableObjectLocals.Values;
+
+    /// <summary>
+    /// Marks a fresh exact-class local whose allocation and pure constructor may be
+    /// represented by the same generated typed shape used for promoted object
+    /// literals. Registering the shape here also makes it available to the common
+    /// shape-type definition phase.
+    /// </summary>
+    public void MarkScalarReplaceableClassLocal(
+        Token nameToken,
+        ClassScalarReplacementInfo info)
+    {
+        _scalarReplaceableClassLocals[nameToken] = info;
+        _promotableObjectLocals[nameToken] = info.Shape;
+    }
+
+    public bool IsScalarReplaceableClassLocal(
+        Token nameToken,
+        out ClassScalarReplacementInfo info) =>
+        _scalarReplaceableClassLocals.TryGetValue(nameToken, out info!);
 
     /// <summary>
     /// Marks a <c>for...of</c> over a fresh, non-escaping <c>Map&lt;number, number&gt;</c>

--- a/src/SharpTS/TypeSystem/TypeMap.cs
+++ b/src/SharpTS/TypeSystem/TypeMap.cs
@@ -28,6 +28,8 @@ public class TypeMap
     private readonly HashSet<Stmt.ForOf> _stableNumericMapIterations = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.Get> _stablePrimitivePromiseThenCalls = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<Expr.ArrowFunction, HashSet<string>> _stableNumericCaptureFields = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Stmt.Var> _stableNumericStateMachineLocals = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Stmt.Parameter> _stableNumericStateMachineParameters = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.Get> _stableExactPrimitiveMethodCalls = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr> _stablePrimitivePromiseAllIterables = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.ArrayLiteral> _stablePrimitivePromiseAllInputInitializers = new(ReferenceEqualityComparer.Instance);
@@ -264,6 +266,23 @@ public class TypeMap
     public bool IsStableNumericCaptureField(Expr.ArrowFunction arrow, string name) =>
         _stableNumericCaptureFields.TryGetValue(arrow, out var names)
         && names.Contains(name);
+
+    /// <summary>
+    /// Marks an explicitly numeric local whose complete state-machine lifetime has
+    /// been proven to remain numeric and suspension-local. The state-machine emitter
+    /// may keep the binding in an unboxed <c>double</c> local.
+    /// </summary>
+    public void MarkStableNumericStateMachineLocal(Stmt.Var declaration) =>
+        _stableNumericStateMachineLocals.Add(declaration);
+
+    public bool IsStableNumericStateMachineLocal(Stmt.Var declaration) =>
+        _stableNumericStateMachineLocals.Contains(declaration);
+
+    public void MarkStableNumericStateMachineParameter(Stmt.Parameter parameter) =>
+        _stableNumericStateMachineParameters.Add(parameter);
+
+    public bool IsStableNumericStateMachineParameter(Stmt.Parameter parameter) =>
+        _stableNumericStateMachineParameters.Contains(parameter);
 
     /// <summary>
     /// Marks a class method access whose receiver is provably the exact instance

--- a/tests/SharpTS.Tests/CompilerTests/StableClassScalarReplacementTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableClassScalarReplacementTests.cs
@@ -1,0 +1,241 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class StableClassScalarReplacementTests
+{
+    [Fact]
+    public void ExactNonEscapingPrimitiveFields_UseShapeWithoutClassAllocation()
+    {
+        const string source = """
+            class Counter {
+                value: number;
+                constructor(value: number) { this.value = value; }
+            }
+            function construction(n: number): number {
+                let sum: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    const counter = new Counter(i);
+                    sum = sum + counter.value;
+                }
+                return sum;
+            }
+            console.log(construction(10));
+            """;
+
+        Assembly assembly = Compile(source);
+        var instructions = ReadInstructions(FindFunction(assembly, "construction")).ToArray();
+
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.OpCode == OpCodes.Newobj
+            && instruction.Operand is ConstructorInfo { DeclaringType.Name: "Counter" });
+        Assert.Contains(instructions, instruction =>
+            instruction.OpCode == OpCodes.Initobj
+            && instruction.Operand is Type type
+            && type.Name.StartsWith("$Shape_", StringComparison.Ordinal));
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.OpCode == OpCodes.Box && instruction.Operand == typeof(double));
+
+        Assert.Equal("45\n", TestHarness.RunCompiled(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    [Fact]
+    public void PrimitiveArguments_AreEvaluatedLeftToRightBeforeScalarInitialization()
+    {
+        const string source = """
+            let trace: string = "";
+            function mark(value: number): number {
+                trace = trace + value;
+                return value;
+            }
+            class Entry {
+                numberValue: number;
+                booleanValue: boolean;
+                stringValue: string;
+                constructor(numberValue: number, booleanValue: boolean, stringValue: string) {
+                    this.stringValue = stringValue;
+                    this.numberValue = numberValue;
+                    this.booleanValue = booleanValue;
+                }
+            }
+            function read(): string {
+                const entry = new Entry(mark(1), true, "ok");
+                return entry.booleanValue ? entry.stringValue + entry.numberValue : "bad";
+            }
+            console.log(read(), trace);
+            """;
+
+        Assert.Equal("ok1 1\n", TestHarness.RunCompiled(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+
+        Assembly assembly = Compile(source);
+        Assert.DoesNotContain(ReadInstructions(FindFunction(assembly, "read")), instruction =>
+            instruction.OpCode == OpCodes.Newobj
+            && instruction.Operand is ConstructorInfo { DeclaringType.Name: "Entry" });
+    }
+
+    [Fact]
+    public void EscapesMutationAndConstructorEffects_RetainClassAllocation()
+    {
+        Assembly assembly = Compile("""
+            let effects: number = 0;
+            class Counter {
+                value: number;
+                constructor(value: number) { this.value = value; }
+            }
+            class Effectful {
+                value: number;
+                constructor(value: number) {
+                    effects = effects + 1;
+                    this.value = value;
+                }
+            }
+            function exact(): number {
+                const exactCounter = new Counter(1);
+                return exactCounter.value;
+            }
+            function escaped(): Counter {
+                const escapedCounter = new Counter(2);
+                return escapedCounter;
+            }
+            function mutated(): number {
+                const mutatedCounter = new Counter(3);
+                mutatedCounter.value = 4;
+                return mutatedCounter.value;
+            }
+            function effectful(): number {
+                const value = new Effectful(5);
+                return value.value;
+            }
+            function incremented(): number {
+                const incrementedCounter = new Counter(6);
+                incrementedCounter.value++;
+                return incrementedCounter.value;
+            }
+            """);
+
+        Assert.DoesNotContain(ReadInstructions(FindFunction(assembly, "exact")), instruction =>
+            IsNewobjOf(instruction, "Counter"));
+        Assert.Contains(ReadInstructions(FindFunction(assembly, "escaped")), instruction =>
+            IsNewobjOf(instruction, "Counter"));
+        Assert.Contains(ReadInstructions(FindFunction(assembly, "mutated")), instruction =>
+            IsNewobjOf(instruction, "Counter"));
+        Assert.Contains(ReadInstructions(FindFunction(assembly, "effectful")), instruction =>
+            IsNewobjOf(instruction, "Effectful"));
+        Assert.Contains(ReadInstructions(FindFunction(assembly, "incremented")), instruction =>
+            IsNewobjOf(instruction, "Counter"));
+    }
+
+    [Fact]
+    public void PrototypeObservationAndDynamicDescriptors_DisableScalarReplacement()
+    {
+        Assembly prototypeAssembly = Compile("""
+            class Counter {
+                value: number;
+                constructor(value: number) { this.value = value; }
+            }
+            const observed = Counter.prototype;
+            function read(): number {
+                const counter = new Counter(1);
+                return counter.value;
+            }
+            """);
+        Assert.Contains(ReadInstructions(FindFunction(prototypeAssembly, "read")), instruction =>
+            IsNewobjOf(instruction, "Counter"));
+
+        Assembly descriptorAssembly = Compile("""
+            class Counter {
+                value: number;
+                constructor(value: number) { this.value = value; }
+            }
+            Object.defineProperty({}, "x", { value: 1 });
+            function read(): number {
+                const counter = new Counter(1);
+                return counter.value;
+            }
+            """);
+        Assert.Contains(ReadInstructions(FindFunction(descriptorAssembly, "read")), instruction =>
+            IsNewobjOf(instruction, "Counter"));
+    }
+
+    private static bool IsNewobjOf(
+        (OpCode OpCode, MemberInfo? Operand) instruction,
+        string typeName) =>
+        instruction.OpCode == OpCodes.Newobj
+        && instruction.Operand is ConstructorInfo constructor
+        && constructor.DeclaringType?.Name == typeName;
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"class_scalar_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token)
+                    : module.ResolveType(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}

--- a/tests/SharpTS.Tests/CompilerTests/StablePrimitivePromiseThenTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StablePrimitivePromiseThenTests.cs
@@ -189,6 +189,70 @@ public sealed class StablePrimitivePromiseThenTests
     }
 
     [Fact]
+    public void StableAsyncLoop_KeepsCounterAndHandlerSnapshotUnboxed()
+    {
+        Assembly assembly = Compile(StableSource);
+        Type stateMachine = Assert.Single(assembly.GetTypes(), type =>
+            type.Name.StartsWith("<sumChain>d__", StringComparison.Ordinal));
+        MethodInfo moveNext = stateMachine.GetMethod(
+            "MoveNext",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        Assert.Contains(moveNext.GetMethodBody()!.LocalVariables,
+            local => local.LocalType == typeof(double));
+        Assert.Contains(ReadInstructions(moveNext),
+            instruction => instruction.OpCode == OpCodes.Clt);
+        Assert.DoesNotContain(ReadInstructions(moveNext), instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "JsLessThan" or "ConvertToNumber"
+            });
+        Assert.Equal(typeof(double), stateMachine.GetField("n")!.FieldType);
+
+        FieldInfo capture = FindSingleDisplayClassField(assembly, "i");
+        Assert.Equal(typeof(double), capture.FieldType);
+    }
+
+    [Fact]
+    public void SuspendingPromiseLoop_RetainsObjectCounterSnapshot()
+    {
+        Assembly assembly = Compile("""
+            async function sumChain(n: number): Promise<number> {
+                let chain: Promise<number> = Promise.resolve(0);
+                for (let i: number = 0; i < n; i++) {
+                    await Promise.resolve(0);
+                    chain = chain.then((sum: number): number => sum + i);
+                }
+                return await chain;
+            }
+            sumChain(3);
+            """);
+
+        FieldInfo capture = FindSingleDisplayClassField(assembly, "i");
+        Assert.Equal(typeof(object), capture.FieldType);
+    }
+
+    [Fact]
+    public void ReassignedLoopBound_RetainsObjectStateField()
+    {
+        Assembly assembly = Compile("""
+            async function sumChain(n: number): Promise<number> {
+                n = n + 0;
+                let chain: Promise<number> = Promise.resolve(0);
+                for (let i: number = 0; i < n; i++) {
+                    chain = chain.then((sum: number): number => sum + i);
+                }
+                return await chain;
+            }
+            sumChain(3);
+            """);
+
+        Type stateMachine = Assert.Single(assembly.GetTypes(), type =>
+            type.Name.StartsWith("<sumChain>d__", StringComparison.Ordinal));
+        Assert.Equal(typeof(object), stateMachine.GetField("n")!.FieldType);
+    }
+
+    [Fact]
     public void StableNumericChain_VerifiesIlAndStandaloneOutput()
     {
         Assert.Empty(TestHarness.CompileAndVerifyOnly(StableSource));
@@ -636,6 +700,18 @@ public sealed class StablePrimitivePromiseThenTests
         compiler.Compile(statements, typeMap, deadCodeInfo);
         return Assembly.Load(compiler.SaveToBytes());
     }
+
+    private static FieldInfo FindSingleDisplayClassField(
+        Assembly assembly,
+        string name) =>
+        Assert.Single(
+            assembly.GetTypes().SelectMany(type =>
+                type.Name.Contains("DisplayClass", StringComparison.Ordinal)
+                    ? type.GetFields(
+                        BindingFlags.Public | BindingFlags.NonPublic |
+                        BindingFlags.Instance | BindingFlags.Static)
+                    : []),
+            field => field.Name == name);
 
     private static MethodInfo FindSingleCaller(Assembly assembly, string methodName) =>
         Assert.Single(FindCallers(assembly, methodName));


### PR DESCRIPTION
## Summary

This batches two proof-coupled representation improvements found after #1465:

- scalar-replace eligible non-escaping exact class locals with the compiler's typed emitted shape, eliminating the short-lived class allocation;
- keep stable primitive Promise-loop bounds, counters, and handler snapshots in native `double` storage through the async state machine and fused chain.

Both optimizations are deliberately narrow. Unsupported, escaping, mutable, dynamically observable, or suspending programs retain the existing object-valued lowering.

Closes #1466.
Closes #1467.
Parent: #1278.

## Measured results

Pinned baseline: `b78590aa68ccd52dc5a3e84c0102794687b923de`  
Candidate: `49127ffece35e0bac67bb6cf29a54d9111fdf8e7`

### Exact class construction, N=100,000

| Platform | Baseline | Candidate | Change | Node | Candidate / Node |
|---|---:|---:|---:|---:|---:|
| Windows | 0.1611 ms | 0.0405 ms | **-74.9%** | 0.0411 ms | **0.993x** |
| WSL / Linux | 0.3031 ms | 0.0447 ms | **-85.4%** | 0.0460 ms | **0.970x** |

BenchmarkDotNet measures the selected SharpTS path at **41.72 us / 0 B**, versus **153.39 us / 2.40 MB** for idiomatic allocating C# and **1.255 ms / 13.60 MB** for the boxed-equivalent control. Adjacent class field- and method-reuse workloads remain neutral.

### Stable Promise.then chain, N=1,000

| Platform | Baseline | Candidate | Change | Node | Candidate / Node |
|---|---:|---:|---:|---:|---:|
| Windows | 0.0358 ms | 0.0198 ms | **-39.4%** | 0.0253 ms | **0.802x** |
| WSL / Linux | 0.0404 ms | 0.0242 ms | **-40.5%** | 0.0250 ms | **0.948x** |

BenchmarkDotNet improves from approximately **33.77 us / 149.53 KB** to **18.96 us / 126.07 KB**: about **43.8% faster** with **23.46 KB** removed, matching one 24-byte numeric box per link. The typed FIFO ceiling is **12.78 us / 102.51 KB**. Resolved-await, async-function-call, and Promise.all neighbors remain neutral in both paired OS runs.

## Correctness boundaries

Class scalar replacement requires a unique module-local, non-exported, non-generic, non-inherited, undecorated class; primitive typed fields; an exact constructor made only of parameter-to-field assignments; and a `const` direct construction whose binding is observed only through direct field reads. Accessors, initializers, private/computed/optional/declared fields, aliases, escape, identity observation, writes, dynamic access, exports, shadowing, and direct eval all retain ordinary class construction.

Async numeric storage is enabled only inside the existing stable primitive Promise-chain proof for a literal-initialized numeric `for` loop, stable numeric bound, and inline synchronous handler. Counter/bound writes, closure cells, suspension in the condition or body, ambiguous shadowing, direct eval, and all general Promise shapes retain object fields/locals. Native values are boxed whenever they leave the proven fast path.

Focused semantic, fallback, layout, and structural-IL tests cover both boundaries. In particular, suspending handler captures and reassigned async bounds are asserted to remain object-backed.

## Validation

### Linux / WSL full local gate

- Release solution build and both IL-verification passes
- 17,263 / 17,263 core tests
- 83 / 83 GUI conformance tests
- cross-runtime and BenchmarkDotNet smoke suites
- Test262 worker/runner and TypeScript conformance tool builds
- NuGet release helper, GUI version staging, and packaged-SDK consumer smoke tests
- AOT/trim/single-file analyzer baseline: 0 warnings
- NativeAOT publish and executable acceptance gate

### Windows full local gate

- Release solution build, both IL-verification passes, and all smoke suites pass
- 17,258 core tests pass; 3 platform skips; 2 baseline-equivalent host-process failures remain:
  - `Isolated_Cluster_ThrowsClearly_WhenSharpTsRuntimeAbsent`
  - `Isolated_Vm_ThrowsClearly_WhenSharpTsRuntimeAbsent`
- both children emit the expected fatal stderr immediately but remain alive until the existing 15-second Windows timeout; the unchanged baseline reproduces this behavior
- all downstream stages run separately and pass: 83 GUI tests, all conformance tool builds, 10 NuGet release-helper tests, GUI version staging, packaged-SDK consumer build/run/rebuild/publish, and analyzer-baseline enforcement with 0 warnings

The focused class scalar-replacement suite passes 57 / 57. The final stable Promise and neighboring direct-call focused set passes 82 / 82.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved numeric comparisons and increment/decrement operations by reducing unnecessary conversions.
  * Optimized eligible asynchronous numeric loops and state handling.
  * Reduced allocations for simple, non-escaping classes with primitive fields while preserving normal behavior when objects escape or are modified.
* **Bug Fixes**
  * Preserved correct prefix/postfix results and constructor argument evaluation order.
  * Improved type handling for values captured across asynchronous operations.
* **Tests**
  * Added coverage for scalar replacement, async loop behavior, object escaping, mutations, suspension, and dynamic access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->