### PR TITLE
perf: native numeric compound and stable rest calls

### DIFF
--- a/benchmarks/cross-runtime/scripts/language-hot-paths.ts
+++ b/benchmarks/cross-runtime/scripts/language-hot-paths.ts
@@ -1,0 +1,87 @@
+import { bench } from "./lib/bench.ts";
+
+// Focused probes for scalar language constructs that can disappear into native
+// machine operations when their bindings and value types are stable. Keep each
+// optimized form beside an equivalent control so future regressions can be
+// attributed to lowering rather than to the surrounding loop.
+
+function numericCompound(n: number): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        sum += i;
+    }
+    return sum;
+}
+
+function numericAssignmentControl(n: number): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        sum = sum + i;
+    }
+    return sum;
+}
+
+function add4(...values: number[]): number {
+    return values[0] + values[1] + values[2] + values[3];
+}
+
+function stableNumericRest(n: number): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        sum = sum + add4(i, 1, 2, 3);
+    }
+    return sum;
+}
+
+function flattenedRestControl(n: number): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        sum = sum + i + 1 + 2 + 3;
+    }
+    return sum;
+}
+
+// Permanently retain the next three widened-corpus leads. These are not part
+// of the current optimization, but keeping assignment-form controls here stops
+// numeric compound assignment from obscuring their residual costs.
+function* numericRange(n: number): Generator<number> {
+    for (let i: number = 0; i < n; i++) {
+        yield i;
+    }
+}
+
+function generatorRange(n: number): number {
+    let sum: number = 0;
+    for (const value of numericRange(n)) {
+        sum = sum + value;
+    }
+    return sum;
+}
+
+function parseIntegers(n: number): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        sum = sum + parseInt(i.toString(), 10);
+    }
+    return sum;
+}
+
+function formatFixed(n: number): number {
+    let totalLength: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        totalLength = totalLength + (i * 0.125).toFixed(2).length;
+    }
+    return totalLength;
+}
+
+const params: number[] = [1000, 10000, 100000];
+for (let p: number = 0; p < params.length; p++) {
+    const n: number = params[p];
+    bench("numeric-compound", n, () => numericCompound(n));
+    bench("numeric-assignment-control", n, () => numericAssignmentControl(n));
+    bench("stable-numeric-rest", n, () => stableNumericRest(n));
+    bench("flattened-rest-control", n, () => flattenedRestControl(n));
+    bench("generator-range", n, () => generatorRange(n));
+    bench("parse-integers", n, () => parseIntegers(n));
+    bench("format-fixed", n, () => formatFixed(n));
+}

--- a/src/SharpTS/Compilation/CompilationContext.Functions.cs
+++ b/src/SharpTS/Compilation/CompilationContext.Functions.cs
@@ -44,6 +44,18 @@ public partial class CompilationContext
     // If a function has a rest param, restParamIndex is its index, regularParamCount is non-rest param count
     public Dictionary<string, (int RestParamIndex, int RegularParamCount)>? FunctionRestParams { get; set; }
 
+    /// <summary>
+    /// Private typed companions for stable <c>number[]</c> rest functions, keyed by
+    /// qualified function name and the number of trailing rest arguments.
+    /// </summary>
+    public Dictionary<string, Dictionary<int, MethodBuilder>>? FlattenedNumericRestMethods { get; set; }
+
+    /// <summary>
+    /// Set only while emitting one flattened companion body. Constant rest-element
+    /// reads are redirected to native double arguments and <c>length</c> to a literal.
+    /// </summary>
+    public FlattenedNumericRestParameter? FlattenedNumericRestParameter { get; set; }
+
     // Function overloads for default parameters: function name -> list of overload methods
     public Dictionary<string, List<MethodBuilder>>? FunctionOverloads { get; set; }
 
@@ -192,3 +204,8 @@ public partial class CompilationContext
             : ApplyNamespacePrefix(CurrentNamespacePath, baseName);
     }
 }
+
+public sealed record FlattenedNumericRestParameter(
+    string Name,
+    int FirstArgumentIndex,
+    int Length);

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -219,11 +219,34 @@ public abstract partial class ExpressionEmitterBase
                     }
                 }
 
-                var paramCount = targetMethod.GetParameters().Length;
-
-                // Rest parameter handling
                 (int RestParamIndex, int RegularParamCount) restInfo = default;
                 bool hasRestParam = Ctx.FunctionRestParams?.TryGetValue(resolvedFuncName, out restInfo) == true;
+
+                // A stable number[] rest function may have a private fixed-arity
+                // companion whose trailing values are native doubles. Select it
+                // only for a fixed call whose rest arguments are themselves
+                // statically numeric. The public List<object> ABI remains the
+                // target for spreads, any-typed values, aliases, imports, and all
+                // indirect calls.
+                bool usesFlattenedNumericRest = false;
+                if (hasRestParam
+                    && !hasSpreadArguments
+                    && c.Arguments.Count >= restInfo.RegularParamCount
+                    && c.Arguments.Skip(restInfo.RegularParamCount)
+                        .All(argument => IsNumericType(Ctx.TypeMap?.Get(argument))))
+                {
+                    int restArity = c.Arguments.Count - restInfo.RegularParamCount;
+                    if (Ctx.FlattenedNumericRestMethods?.TryGetValue(
+                            resolvedFuncName, out var companions) == true
+                        && companions.TryGetValue(restArity, out var companion))
+                    {
+                        targetMethod = companion;
+                        hasRestParam = false;
+                        usesFlattenedNumericRest = true;
+                    }
+                }
+
+                var paramCount = targetMethod.GetParameters().Length;
 
                 if (hasRestParam)
                 {
@@ -320,7 +343,8 @@ public abstract partial class ExpressionEmitterBase
                     // arguments object including extras past the declared arity (#64).
                     // Done *before* loading args onto the stack so we don't disturb
                     // the evaluation order for the call itself.
-                    if (Ctx.FunctionsCapturingArguments?.Contains(resolvedFuncName) == true &&
+                    if (!usesFlattenedNumericRest &&
+                        Ctx.FunctionsCapturingArguments?.Contains(resolvedFuncName) == true &&
                         Ctx.Runtime?.CurrentArgumentsField != null)
                     {
                         int publishCount = c.Arguments.Count;

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.Operators.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.Operators.cs
@@ -117,6 +117,9 @@ public abstract partial class ExpressionEmitterBase
     {
         string name = ca.Name.Lexeme;
 
+        if (TryEmitNativeNumericLocalCompound(ca))
+            return;
+
         // GetValue(left) precedes evaluation of the RHS. Spill it so a suspension
         // in the RHS still occurs with an empty evaluation stack.
         EmitVariable(new Expr.Variable(ca.Name));
@@ -139,6 +142,42 @@ public abstract partial class ExpressionEmitterBase
 
         SetStackUnknown();
     }
+
+    private bool TryEmitNativeNumericLocalCompound(Expr.CompoundAssign compound)
+    {
+        string name = compound.Name.Lexeme;
+        if (Ctx.CellBindingLocals.ContainsKey(name)
+            || !Ctx.Locals.TryGetLocal(name, out var local)
+            || local.LocalType != Types.Double
+            || !IsArithmeticCompound(compound.Operator.Type)
+            || !IsNumericType(Ctx.TypeMap?.Get(compound.Value)))
+        {
+            return false;
+        }
+
+        // Spill both values before applying the operator. In state-machine
+        // emitters the RHS may suspend, so no value may remain on the evaluation
+        // stack while it is evaluated.
+        IL.Emit(OpCodes.Ldloc, local);
+        var current = IL.DeclareLocal(Types.Double);
+        IL.Emit(OpCodes.Stloc, current);
+
+        EmitExpressionAsDouble(compound.Value);
+        var value = IL.DeclareLocal(Types.Double);
+        IL.Emit(OpCodes.Stloc, value);
+
+        IL.Emit(OpCodes.Ldloc, current);
+        IL.Emit(OpCodes.Ldloc, value);
+        IL.Emit(CompoundOperatorHelper.GetOpcode(compound.Operator.Type)!.Value);
+        IL.Emit(OpCodes.Dup);
+        IL.Emit(OpCodes.Stloc, local);
+        SetStackType(StackType.Double);
+        return true;
+    }
+
+    private static bool IsArithmeticCompound(TokenType op) => op is
+        TokenType.PLUS_EQUAL or TokenType.MINUS_EQUAL or TokenType.STAR_EQUAL or
+        TokenType.SLASH_EQUAL or TokenType.PERCENT_EQUAL;
 
     /// <summary>
     /// variable &&= value / variable ||= value / variable ??= value

--- a/src/SharpTS/Compilation/ILCompiler.ContextFactories.cs
+++ b/src/SharpTS/Compilation/ILCompiler.ContextFactories.cs
@@ -51,6 +51,7 @@ public partial class ILCompiler
             DisplayClassConstructors = _closures.DisplayClassConstructors,
             // Function metadata
             FunctionRestParams = _functions.RestParams,
+            FlattenedNumericRestMethods = _functions.FlattenedNumericRestMethods,
             FunctionLengths = _functions.Lengths,
             FunctionNames = _functions.Names,
             FunctionsCapturingArguments = _functions.CapturingArguments,
@@ -241,6 +242,7 @@ public partial class ILCompiler
             EnumKinds = parentCtx.EnumKinds,
             TopLevelStaticVars = parentCtx.TopLevelStaticVars,
             FunctionRestParams = parentCtx.FunctionRestParams,
+            FlattenedNumericRestMethods = parentCtx.FlattenedNumericRestMethods,
             FunctionLengths = parentCtx.FunctionLengths,
             FunctionNames = parentCtx.FunctionNames,
             FunctionGenericParams = parentCtx.FunctionGenericParams,

--- a/src/SharpTS/Compilation/ILCompiler.Functions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Functions.cs
@@ -247,6 +247,27 @@ public partial class ILCompiler
             int restIndex = funcStmt.Parameters.IndexOf(restParam);
             int regularCount = funcStmt.Parameters.Count(p => !p.IsRest);
             _functions.RestParams[qualifiedFunctionName] = (restIndex, regularCount);
+
+            if (_stableNumericRestFunctions.TryGetValue(funcStmt, out var flattenedInfo))
+            {
+                var companions = new Dictionary<int, MethodBuilder>();
+                foreach (int restArity in flattenedInfo.RestArities.Order())
+                {
+                    Type[] companionParameters = paramTypes
+                        .Take(flattenedInfo.RegularParameterCount)
+                        .Concat(Enumerable.Repeat(_types.Double, restArity))
+                        .ToArray();
+                    var companion = _programType.DefineMethod(
+                        $"{qualifiedFunctionName}$rest$arity{restArity}",
+                        MethodAttributes.Private | MethodAttributes.Static | MethodAttributes.HideBySig,
+                        returnType,
+                        companionParameters);
+                    MarkCompilerGenerated(companion);
+                    companions[restArity] = companion;
+                }
+
+                _functions.FlattenedNumericRestMethods[qualifiedFunctionName] = companions;
+            }
         }
 
         // Track function AST node for closure analysis lookups
@@ -601,6 +622,79 @@ public partial class ILCompiler
             il.Emit(OpCodes.Ret);
         }
 
+        EmitFlattenedNumericRestCompanionBodies(funcStmt, qualifiedFunctionName, methodBuilder);
+    }
+
+    private void EmitFlattenedNumericRestCompanionBodies(
+        Stmt.Function function,
+        string qualifiedFunctionName,
+        MethodBuilder ordinaryMethod)
+    {
+        if (!_stableNumericRestFunctions.TryGetValue(function, out var info)
+            || !_functions.FlattenedNumericRestMethods.TryGetValue(
+                qualifiedFunctionName, out var companions)
+            || function.Body == null)
+        {
+            return;
+        }
+
+        Dictionary<string, FieldBuilder>? topLevelVars =
+            BuildModuleMemberTopLevelStaticVarsForModule(_modules.CurrentPath);
+
+        foreach (var (restArity, companion) in companions.OrderBy(pair => pair.Key))
+        {
+            var il = companion.GetILGenerator();
+            var ctx = CreateModuleMemberContext(il, companion);
+            ctx.StableDirectSelfCallTarget = ordinaryMethod;
+            ctx.FunctionOverloads = _functions.Overloads;
+            ctx.AsyncArrowBuilders = _async.ArrowBuilders.Count > 0 ? _async.ArrowBuilders : null;
+            ApplyCommonJsModuleAccess(ctx);
+            ctx.UnionGenerator = _unionGenerator;
+            ctx.IsStrictMode = _isStrictMode || BodyDeclaresUseStrict(function.Body);
+            ApplyCapturedTopLevelVariableAccess(ctx);
+            ctx.TopLevelStaticVars = topLevelVars;
+            ctx.ArrowEntryPointDCFields = _closures.ArrowEntryPointDCFields.Count > 0
+                ? _closures.ArrowEntryPointDCFields
+                : null;
+            ctx.ArrowFunctionDCFields = _closures.ArrowFunctionDCFields.Count > 0
+                ? _closures.ArrowFunctionDCFields
+                : null;
+            ctx.ArrowScopeDCFields = _closures.ArrowScopeDCFields.Count > 0
+                ? _closures.ArrowScopeDCFields
+                : null;
+            ctx.ArrowScopeDCExtraFieldsByArrow = _arrowScopeDCExtraFields.Count > 0
+                ? _arrowScopeDCExtraFields
+                : null;
+            ApplyInnerFunctionSupport(ctx);
+            ctx.CurrentMethodReturnType = companion.ReturnType;
+            ctx.FlattenedNumericRestParameter = new FlattenedNumericRestParameter(
+                info.RestName,
+                info.RegularParameterCount,
+                restArity);
+
+            var parameters = companion.GetParameters();
+            for (int i = 0; i < info.RegularParameterCount; i++)
+            {
+                ctx.DefineParameter(
+                    function.Parameters[i].Name.Lexeme,
+                    i,
+                    parameters[i].ParameterType);
+            }
+
+            var emitter = new ILEmitter(ctx);
+            emitter.InitializeCapturedLexicalTdzBindings(function.Body);
+            emitter.EmitStatements(function.Body);
+
+            if (emitter.HasDeferredReturns)
+            {
+                emitter.FinalizeReturns();
+            }
+            else
+            {
+                EmitDefaultReturnValue(il, companion.ReturnType);
+                il.Emit(OpCodes.Ret);
+            }
+        }
     }
 
     internal static bool TryGetCompactRecordShape(

--- a/src/SharpTS/Compilation/ILCompiler.State.cs
+++ b/src/SharpTS/Compilation/ILCompiler.State.cs
@@ -120,6 +120,7 @@ public partial class ILCompiler
         public Dictionary<string, List<MethodBuilder>> Overloads { get; } = [];
         public Dictionary<string, Dictionary<string, List<MethodBuilder>>> MethodOverloads { get; } = [];
         public Dictionary<string, (int RestParamIndex, int RegularParamCount)> RestParams { get; } = [];
+        public Dictionary<string, Dictionary<int, MethodBuilder>> FlattenedNumericRestMethods { get; } = [];
         public Dictionary<string, GenericTypeParameterBuilder[]> GenericParams { get; } = [];
         public Dictionary<string, bool> IsGeneric { get; } = [];
         public Dictionary<MethodBase, int> Lengths { get; } = [];

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -70,6 +70,8 @@ public partial class ILCompiler
         new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<Stmt.Function, string> _exactCompactRecordReturns =
         new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<Stmt.Function, StableNumericRestFunctionAnalyzer.Info>
+        _stableNumericRestFunctions = new(ReferenceEqualityComparer.Instance);
     private TypeBuilder _programType = null!;
 
     // Organized state containers (see ILCompiler.State.cs for definitions)
@@ -680,6 +682,9 @@ public partial class ILCompiler
     {
         PreScanBuiltInModuleImports(statements);
         StableFunctionBindingAnalyzer.Analyze(statements, _stableSelfCallFunctions);
+        StableNumericRestFunctionAnalyzer.Analyze(
+            statements, _typeMap, _stableSelfCallFunctions, _closures.Analyzer,
+            _stableNumericRestFunctions);
         ExactCompactRecordFunctionAnalyzer.Analyze(
             statements, _typeMap, _features, _stableSelfCallFunctions,
             _exactCompactRecordParameters, _exactCompactRecordReturns);
@@ -1336,6 +1341,9 @@ public partial class ILCompiler
         {
             PreScanBuiltInModuleImports(m.Statements, m.Path);
             StableFunctionBindingAnalyzer.Analyze(m.Statements, _stableSelfCallFunctions);
+            StableNumericRestFunctionAnalyzer.Analyze(
+                m.Statements, _typeMap, _stableSelfCallFunctions, _closures.Analyzer,
+                _stableNumericRestFunctions);
             ExactCompactRecordFunctionAnalyzer.Analyze(
                 m.Statements, _typeMap, _features, _stableSelfCallFunctions,
                 _exactCompactRecordParameters, _exactCompactRecordReturns);

--- a/src/SharpTS/Compilation/ILEmitter.Helpers.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Helpers.cs
@@ -322,6 +322,10 @@ public partial class ILEmitter
 
     public override void EmitExpressionAsDouble(Expr expr)
     {
+        if (expr is Expr.GetIndex flattenedRestIndex
+            && TryEmitFlattenedNumericRestIndex(flattenedRestIndex))
+            return;
+
         // A number[] read consumed as a number can keep the numeric-mode $Array
         // result native while its guarded cold arm performs the same ordinary
         // property lookup + ToNumber coercion this method used previously.

--- a/src/SharpTS/Compilation/ILEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Operators.cs
@@ -779,6 +779,25 @@ public partial class ILEmitter
         var localType = local != null ? _ctx.Locals.GetLocalType(ca.Name.Lexeme) : null;
         bool isTypedDouble = localType != null && _ctx.Types.IsDouble(localType);
 
+        // A proven number local with a proven number RHS can remain in native
+        // double space for arithmetic compound assignment. The old path boxed
+        // both operands, dispatched through the generic compound helper, then
+        // converted the boxed result back to double on every iteration. Keep
+        // dynamic += (which may concatenate strings), captured/object slots,
+        // and undefined-capable values on that coercion-preserving path.
+        if (isTypedDouble
+            && local != null
+            && IsArithmeticCompound(ca.Operator.Type)
+            && IsNumericTypeInfo(_ctx.TypeMap?.Get(ca.Value)))
+        {
+            IL.Emit(OpCodes.Ldloc, local);
+            EmitCompoundArithmeticDoubleOnStack(ca.Operator.Type, ca.Value);
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Stloc, local);
+            SetStackType(StackType.Double);
+            return;
+        }
+
         // For += with unknown right-hand side types, use runtime Add (handles both string concat and numeric add)
         // When the target is a typed double local, we know it's numeric — skip runtime Add.
         if (!isTypedDouble && ca.Operator.Type == TokenType.PLUS_EQUAL)
@@ -2533,6 +2552,10 @@ public partial class ILEmitter
         TokenType.SLASH_EQUAL or TokenType.PERCENT_EQUAL or TokenType.AMPERSAND_EQUAL or
         TokenType.PIPE_EQUAL or TokenType.CARET_EQUAL or TokenType.LESS_LESS_EQUAL or
         TokenType.GREATER_GREATER_EQUAL;
+
+    private static bool IsArithmeticCompound(TokenType op) => op is
+        TokenType.PLUS_EQUAL or TokenType.MINUS_EQUAL or TokenType.STAR_EQUAL or
+        TokenType.SLASH_EQUAL or TokenType.PERCENT_EQUAL;
 
     // Stack in: [cur (double)]. Applies `cur OP value` in native double space (JS bitwise ops route
     // through int32) and leaves the numeric result as a double. Shared by the boxed compound path

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -17,6 +17,17 @@ public partial class ILEmitter
 {
     protected override void EmitGet(Expr.Get g)
     {
+        if (!g.Optional
+            && g.Name.Lexeme == "length"
+            && g.Object is Expr.Variable restLength
+            && _ctx.FlattenedNumericRestParameter is { } flattenedLength
+            && restLength.Name.Lexeme == flattenedLength.Name)
+        {
+            EmitDoubleConstant(flattenedLength.Length);
+            SetStackType(StackType.Double);
+            return;
+        }
+
         // CommonJS: `module.exports` reads → ldsfld $exports
         if (TryEmitCjsGet(g)) return;
 
@@ -951,6 +962,9 @@ public partial class ILEmitter
 
     protected override void EmitGetIndex(Expr.GetIndex gi)
     {
+        if (TryEmitFlattenedNumericRestIndex(gi))
+            return;
+
         if (TryEmitStableMapEntryIndex(gi))
             return;
 
@@ -1294,6 +1308,25 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Ldloc, idxRecvLocal);
         IL.Emit(OpCodes.Ldloc, idxKeyLocal);
         IL.Emit(OpCodes.Call, _ctx.Runtime!.GetIndex);
+    }
+
+    private bool TryEmitFlattenedNumericRestIndex(Expr.GetIndex expression)
+    {
+        if (expression.Optional
+            || expression.Object is not Expr.Variable restVariable
+            || _ctx.FlattenedNumericRestParameter is not { } flattened
+            || restVariable.Name.Lexeme != flattened.Name
+            || expression.Index is not Expr.Literal { Value: double index }
+            || index < 0
+            || index != Math.Truncate(index)
+            || index >= flattened.Length)
+        {
+            return false;
+        }
+
+        IL.Emit(OpCodes.Ldarg, flattened.FirstArgumentIndex + (int)index);
+        SetStackType(StackType.Double);
+        return true;
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/StableNumericRestFunctionAnalyzer.cs
+++ b/src/SharpTS/Compilation/StableNumericRestFunctionAnalyzer.cs
@@ -1,0 +1,330 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Finds stable synchronous functions whose numeric rest array can be represented by a
+/// fixed set of native <see cref="double"/> parameters at statically direct call sites.
+/// The ordinary List&lt;object&gt; ABI remains available for every indirect or dynamic call.
+/// </summary>
+internal static class StableNumericRestFunctionAnalyzer
+{
+    internal sealed record Info(
+        string RestName,
+        int RegularParameterCount,
+        int MaximumReadIndex,
+        IReadOnlySet<int> RestArities);
+
+    public static void Analyze(
+        IReadOnlyList<Stmt> statements,
+        TypeMap typeMap,
+        IReadOnlySet<Stmt.Function> stableFunctions,
+        ClosureAnalyzer closureAnalyzer,
+        IDictionary<Stmt.Function, Info> results)
+    {
+        var functions = new List<Stmt.Function>();
+        foreach (var statement in statements)
+            CollectTopLevelFunctions(statement, functions);
+
+        foreach (var function in functions)
+        {
+            if (!stableFunctions.Contains(function)
+                || function.Body == null
+                || function.IsAsync
+                || function.IsGenerator
+                || function.TypeParams is { Count: > 0 }
+                || function.Parameters.Count == 0
+                || function.Parameters[^1] is not { IsRest: true } rest
+                || function.Parameters.Take(function.Parameters.Count - 1)
+                    .Any(parameter => parameter.DefaultValue != null || parameter.IsOptional)
+                || closureAnalyzer.GetCapturedLocals(function).Count != 0
+                || !HasNumericRestType(function, typeMap))
+            {
+                continue;
+            }
+
+            var usage = new RestUsageAnalyzer(rest.Name.Lexeme);
+            foreach (var statement in function.Body)
+                usage.Visit(statement);
+            if (!usage.IsEligible)
+                continue;
+
+            int regularCount = function.Parameters.Count - 1;
+            var calls = new FixedArityCallAnalyzer(
+                function.Name.Lexeme,
+                regularCount,
+                usage.MaximumReadIndex,
+                typeMap);
+            foreach (var statement in statements)
+                calls.Visit(statement);
+            if (calls.RestArities.Count == 0)
+                continue;
+
+            results[function] = new Info(
+                rest.Name.Lexeme,
+                regularCount,
+                usage.MaximumReadIndex,
+                calls.RestArities);
+        }
+    }
+
+    private static bool HasNumericRestType(Stmt.Function function, TypeMap typeMap)
+    {
+        var functionType = typeMap.GetFunctionType(function.Name.Lexeme);
+        if (functionType == null || functionType.ParamTypes.Count != function.Parameters.Count)
+            return false;
+
+        return functionType.ParamTypes
+                .Take(functionType.ParamTypes.Count - 1)
+                .All(IsNumeric)
+            && functionType.ParamTypes[^1] is TypeInfo.Array
+            {
+                ElementType: TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER }
+            };
+    }
+
+    private static void CollectTopLevelFunctions(Stmt statement, ICollection<Stmt.Function> functions)
+    {
+        switch (statement)
+        {
+            case Stmt.Function function:
+                functions.Add(function);
+                break;
+            case Stmt.Export { Declaration: { } declaration }:
+                CollectTopLevelFunctions(declaration, functions);
+                break;
+            case Stmt.Sequence sequence:
+                foreach (var inner in sequence.Statements)
+                    CollectTopLevelFunctions(inner, functions);
+                break;
+        }
+    }
+
+    private sealed class RestUsageAnalyzer(string restName) : AstVisitorBase
+    {
+        public bool IsEligible { get; private set; } = true;
+        public int MaximumReadIndex { get; private set; } = -1;
+
+        protected override void VisitVariable(Expr.Variable expression)
+        {
+            if (expression.Name.Lexeme == restName
+                || expression.Name.Lexeme == "arguments")
+            {
+                IsEligible = false;
+                ShouldContinue = false;
+            }
+        }
+
+        protected override void VisitVar(Stmt.Var statement)
+        {
+            if (statement.Name.Lexeme == restName)
+            {
+                IsEligible = false;
+                ShouldContinue = false;
+                return;
+            }
+            base.VisitVar(statement);
+        }
+
+        protected override void VisitConst(Stmt.Const statement)
+        {
+            if (statement.Name.Lexeme == restName)
+            {
+                IsEligible = false;
+                ShouldContinue = false;
+                return;
+            }
+            base.VisitConst(statement);
+        }
+
+        protected override void VisitAssign(Expr.Assign expression)
+        {
+            if (expression.Name.Lexeme == restName)
+            {
+                Reject();
+                return;
+            }
+            base.VisitAssign(expression);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
+        {
+            if (expression.Name.Lexeme == restName)
+            {
+                Reject();
+                return;
+            }
+            base.VisitCompoundAssign(expression);
+        }
+
+        protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
+        {
+            if (expression.Name.Lexeme == restName)
+            {
+                Reject();
+                return;
+            }
+            base.VisitLogicalAssign(expression);
+        }
+
+        protected override void VisitDelete(Expr.Delete expression)
+        {
+            if (IsRestMember(expression.Operand))
+            {
+                Reject();
+                return;
+            }
+            base.VisitDelete(expression);
+        }
+
+        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expression)
+        {
+            if (IsRestMember(expression.Operand))
+            {
+                Reject();
+                return;
+            }
+            base.VisitPrefixIncrement(expression);
+        }
+
+        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expression)
+        {
+            if (IsRestMember(expression.Operand))
+            {
+                Reject();
+                return;
+            }
+            base.VisitPostfixIncrement(expression);
+        }
+
+        protected override void VisitForOf(Stmt.ForOf statement)
+        {
+            if (statement.Variable.Lexeme == restName)
+            {
+                Reject();
+                return;
+            }
+            base.VisitForOf(statement);
+        }
+
+        protected override void VisitForIn(Stmt.ForIn statement)
+        {
+            if (statement.Variable.Lexeme == restName)
+            {
+                Reject();
+                return;
+            }
+            base.VisitForIn(statement);
+        }
+
+        protected override void VisitTryCatch(Stmt.TryCatch statement)
+        {
+            if (statement.CatchParam?.Lexeme == restName)
+            {
+                Reject();
+                return;
+            }
+            base.VisitTryCatch(statement);
+        }
+
+        protected override void VisitGetIndex(Expr.GetIndex expression)
+        {
+            if (expression.Object is Expr.Variable variable && variable.Name.Lexeme == restName)
+            {
+                if (expression.Optional
+                    || expression.Index is not Expr.Literal { Value: double index }
+                    || index < 0
+                    || index != Math.Truncate(index)
+                    || index > int.MaxValue)
+                {
+                    IsEligible = false;
+                    ShouldContinue = false;
+                    return;
+                }
+
+                MaximumReadIndex = Math.Max(MaximumReadIndex, (int)index);
+                return;
+            }
+
+            base.VisitGetIndex(expression);
+        }
+
+        protected override void VisitGet(Expr.Get expression)
+        {
+            if (expression.Object is Expr.Variable variable && variable.Name.Lexeme == restName)
+            {
+                if (!expression.Optional && expression.Name.Lexeme == "length")
+                    return;
+
+                IsEligible = false;
+                ShouldContinue = false;
+                return;
+            }
+
+            base.VisitGet(expression);
+        }
+
+        // The specialized body deliberately has no closure/display-class setup.
+        // Retain the ordinary ABI for bodies containing nested callable scopes.
+        protected override void VisitFunction(Stmt.Function statement)
+        {
+            IsEligible = false;
+            ShouldContinue = false;
+        }
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression)
+        {
+            Reject();
+        }
+
+        private bool IsRestMember(Expr expression) => expression switch
+        {
+            Expr.Get { Object: Expr.Variable variable } => variable.Name.Lexeme == restName,
+            Expr.GetIndex { Object: Expr.Variable variable } => variable.Name.Lexeme == restName,
+            _ => false
+        };
+
+        private void Reject()
+        {
+            IsEligible = false;
+            ShouldContinue = false;
+        }
+    }
+
+    private sealed class FixedArityCallAnalyzer(
+        string functionName,
+        int regularCount,
+        int maximumReadIndex,
+        TypeMap typeMap) : AstVisitorBase
+    {
+        public HashSet<int> RestArities { get; } = [];
+
+        protected override void VisitCall(Expr.Call expression)
+        {
+            if (!expression.Optional
+                && expression.Callee is Expr.Variable variable
+                && variable.Name.Lexeme == functionName
+                && expression.Arguments.Count >= regularCount
+                && expression.Arguments.All(argument => argument is not Expr.Spread)
+                && expression.Arguments.Skip(regularCount).All(
+                    argument => IsNumeric(typeMap.Get(argument))))
+            {
+                int restArity = expression.Arguments.Count - regularCount;
+                if (restArity > maximumReadIndex)
+                    RestArities.Add(restArity);
+            }
+
+            base.VisitCall(expression);
+        }
+
+        private static bool IsNumeric(TypeInfo? type) => type is
+            TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER }
+            or TypeInfo.NumberLiteral;
+    }
+
+    private static bool IsNumeric(TypeInfo? type) => type is
+        TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER }
+        or TypeInfo.NumberLiteral;
+}

--- a/tests/SharpTS.Tests/CompilerTests/StableNumericHotPathTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableNumericHotPathTests.cs
@@ -1,0 +1,250 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class StableNumericHotPathTests
+{
+    private const string OptimizedSource = """
+        function add4(...values: number[]): number {
+            return values[0] + values[1] + values[2] + values[3];
+        }
+        function run(n: number): number {
+            let total: number = 0;
+            for (let i: number = 0; i < n; i++) {
+                total += add4(i, 1, 2, 3);
+            }
+            return total;
+        }
+        console.log(run(3));
+        """;
+
+    [Theory, ModeData]
+    public void NumericCompoundAndFixedRestCall_AreCorrect(ExecutionMode mode)
+    {
+        Assert.Equal("21\n", TestHarness.Run(OptimizedSource, mode));
+    }
+
+    [Fact]
+    public void NumericCompoundAndFixedRestCall_PassIlVerification()
+    {
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(OptimizedSource));
+    }
+
+    [Fact]
+    public void NumericCompoundLocal_UsesNativeDoubleArithmetic()
+    {
+        Assembly assembly = Compile(OptimizedSource);
+        var instructions = ReadInstructions(FindFunction(assembly, "run")).ToArray();
+
+        Assert.Contains(instructions, instruction => instruction.OpCode == OpCodes.Add);
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.OpCode == OpCodes.Box && instruction.Operand == typeof(double));
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "ConvertToNumber" or "Add" });
+    }
+
+    [Fact]
+    public void StableFixedNumericRestCall_UsesFlattenedTypedCompanion()
+    {
+        Assembly assembly = Compile(OptimizedSource);
+        MethodInfo caller = FindFunction(assembly, "run");
+        MethodInfo companion = assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.Contains("add4$rest$arity4", StringComparison.Ordinal));
+
+        var callerInstructions = ReadInstructions(caller).ToArray();
+        Assert.Contains(callerInstructions, instruction =>
+            instruction.OpCode == OpCodes.Call
+            && instruction.Operand is MethodBase called
+            && called.MetadataToken == companion.MetadataToken);
+        Assert.DoesNotContain(callerInstructions, instruction =>
+            instruction.OpCode == OpCodes.Newarr && instruction.Operand == typeof(object));
+        Assert.DoesNotContain(callerInstructions, instruction =>
+            instruction.Operand is MethodBase { Name: "CreateArray" });
+
+        Assert.All(companion.GetParameters(), parameter =>
+            Assert.Equal(typeof(double), parameter.ParameterType));
+        Assert.DoesNotContain(ReadInstructions(companion), instruction =>
+            instruction.OpCode == OpCodes.Box && instruction.Operand == typeof(double));
+        Assert.DoesNotContain(ReadInstructions(companion), instruction =>
+            instruction.Operand is MethodBase { Name: "GetIndex" or "GetLength" });
+
+        var compiled = caller.CreateDelegate<Func<double, double>>();
+        Assert.Equal(5000550000, compiled(100000));
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        double result = compiled(100000);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.Equal(5000550000, result);
+        Assert.Equal(0, allocated);
+    }
+
+    [Theory, ModeData]
+    public void DynamicRestUses_RetainOrdinaryArraySemantics(ExecutionMode mode)
+    {
+        const string source = """
+            function pick(index: number, ...values: number[]): number {
+                values[0] = values[0] + 10;
+                return values[index] + values.length;
+            }
+            const args: number[] = [1, 2, 3];
+            console.log(pick(1, ...args));
+            """;
+
+        Assert.Equal("5\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void DynamicRestUse_DoesNotDefineFlattenedCompanion()
+    {
+        Assembly assembly = Compile("""
+            function pick(index: number, ...values: number[]): number {
+                return values[index];
+            }
+            function run(): number { return pick(1, 1, 2, 3); }
+            """);
+
+        Assert.DoesNotContain(
+            assembly.GetType("$Program")!.GetMethods(BindingFlags.NonPublic | BindingFlags.Static),
+            method => method.Name.Contains("$rest$arity", StringComparison.Ordinal));
+    }
+
+    [Theory, ModeData]
+    public void RegularNumericParametersAndRestLength_AreCorrect(ExecutionMode mode)
+    {
+        const string source = """
+            function weighted(prefix: number, ...values: number[]): number {
+                return prefix + values[0] + values.length;
+            }
+            function run(): number { return weighted(10, 20, 30); }
+            console.log(run());
+            """;
+
+        Assert.Equal("32\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void AnyTypedRestArgument_UsesOrdinaryPackingAtThatCallSite()
+    {
+        Assembly assembly = Compile("""
+            function add(...values: number[]): number {
+                return values[0] + values[1];
+            }
+            function runNumeric(): number { return add(1, 2); }
+            function runDynamic(value: any): number { return add(value, 2); }
+            """);
+
+        MethodInfo companion = assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.Contains("add$rest$arity2", StringComparison.Ordinal));
+        Assert.Contains(ReadInstructions(FindFunction(assembly, "runNumeric")), instruction =>
+            instruction.OpCode == OpCodes.Call
+            && instruction.Operand is MethodBase called
+            && called.MetadataToken == companion.MetadataToken);
+        Assert.Contains(ReadInstructions(FindFunction(assembly, "runDynamic")), instruction =>
+            instruction.Operand is MethodBase { Name: "CreateArray" });
+    }
+
+    [Fact]
+    public void DynamicCompoundAssignment_RetainsRuntimeAdd()
+    {
+        Assembly assembly = Compile("""
+            function append(value: any): any {
+                let result: any = 1;
+                result += value;
+                return result;
+            }
+            """);
+
+        Assert.Contains(ReadInstructions(FindFunction(assembly, "append")), instruction =>
+            instruction.Operand is MethodBase { Name: "Add" });
+    }
+
+    [Fact]
+    public void ReassignedRestFunctionBinding_DoesNotDefineFlattenedCompanion()
+    {
+        const string source = """
+            function total(...values: number[]): number { return values[0] + values[1]; }
+            const original = total;
+            total = (...values: number[]): number => values[0] * values[1];
+            console.log(original(2, 3), total(2, 3));
+            """;
+
+        Assembly assembly = Compile(source);
+        Assert.DoesNotContain(
+            assembly.GetType("$Program")!.GetMethods(BindingFlags.NonPublic | BindingFlags.Static),
+            method => method.Name.Contains("$rest$arity", StringComparison.Ordinal));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        TypeMap typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"numeric_hot_paths_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token)
+                    : module.ResolveType(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}


### PR DESCRIPTION
## Summary

- keep arithmetic compound assignment on proven numeric locals in native `double` space
- add private typed companions for stable fixed-arity numeric rest calls while preserving the public `List<object?>` ABI and live ESM behavior
- add a permanent cross-runtime language hot-path corpus covering these wins and the remaining generator, `parseInt`, and `toFixed` gaps

## Correctness boundary

The compound path applies only to unboxed numeric locals, arithmetic compound operators, and statically numeric right-hand sides. Dynamic, string-capable, captured, and object-backed cases retain runtime dispatch.

Rest flattening applies only to stable top-level synchronous functions with numeric regular parameters and a trailing `...rest: number[]`, where rest use is limited to constant element reads and `.length`. Calls with spread arguments, dynamic values, mutation, aliasing, reassignment, or live bindings retain ordinary array packing and dispatch. The externally visible function ABI is unchanged.

## Performance

Representative warm N=100,000 results (milliseconds):

| Workload | Windows before | Windows after | WSL before | WSL after |
|---|---:|---:|---:|---:|
| numeric compound | 1.9185 | 0.0421 | 2.3817 | 0.0404 |
| stable numeric rest | 17.4926 | 0.0608 | 18.0252 | 0.0579 |

That is roughly 46x/59x faster for numeric compound assignment and 288x/311x faster for stable numeric rest calls on Windows/WSL respectively. The optimized hot loops allocate 0 bytes after warmup.

## Validation

- Windows: clean Release build, both IL verification passes, 17,273 core tests, 83 GUI tests, conformance harness builds, package/version helper tests, packaged SDK build/run/rebuild/publish smoke, and AOT/trim warning inventory
- WSL: clean Release build, both IL verification passes, 17,276 core tests, 83 GUI tests, conformance harness builds, package/version helper tests, packaged SDK build/run/rebuild/publish smoke, AOT/trim warning inventory, and Native AOT publish
- focused optimization and fallback coverage, including interpreter/compiler parity, emitted IL, zero-allocation assertions, dynamic indices, mutation, spreads, dynamic arguments, and reassigned functions

Closes #1469
Closes #1470

Parent: #1278


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved execution speed for numeric compound assignments through more efficient native arithmetic.
  * Optimized eligible function calls with numeric rest arguments, reducing overhead and avoiding unnecessary array allocation.
  * Added faster handling for numeric rest-parameter length checks and literal index access.
  * Preserved existing behavior for dynamic, unsupported, reassigned, or non-numeric rest-parameter usage.
* **Testing**
  * Added comprehensive coverage for optimized and fallback execution paths, including runtime correctness and generated-code validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->