### PR TITLE
perf: specialize stable numeric string conversions

### DIFF
--- a/src/SharpTS/Compilation/CallHandlers/GlobalFunctionHandler.cs
+++ b/src/SharpTS/Compilation/CallHandlers/GlobalFunctionHandler.cs
@@ -1,5 +1,6 @@
 using SharpTS.Compilation.Emitters;
 using SharpTS.Parsing;
+using SharpTS.TypeSystem;
 
 namespace SharpTS.Compilation.CallHandlers;
 
@@ -19,6 +20,15 @@ public class GlobalFunctionHandler : ICallHandler
         var il = emitter.IL;
         var ctx = emitter.Context;
 
+        if (emitter.HasVariable(v.Name.Lexeme))
+            return false;
+
+        if (v.Name.Lexeme == "parseInt"
+            && ctx.RuntimeFeatures?.UsesGlobalParseIntMutation == true)
+        {
+            return EmitLiveGlobalFunctionCall(emitter, il, ctx, call, "parseInt");
+        }
+
         return v.Name.Lexeme switch
         {
             "eval" => EmitEval(emitter, il, ctx, call),
@@ -35,6 +45,25 @@ public class GlobalFunctionHandler : ICallHandler
             "btoa" => EmitBase64Global(emitter, il, ctx, call, ctx.Runtime!.BufferBtoa),
             _ => false
         };
+    }
+
+    private static bool EmitLiveGlobalFunctionCall(
+        IEmitterContext emitter,
+        System.Reflection.Emit.ILGenerator il,
+        CompilationContext ctx,
+        Expr.Call call,
+        string name)
+    {
+        // A bare call to a mutable global binding must observe the current
+        // globalThis property. Undefined preserves ordinary call-this binding:
+        // sloppy functions receive globalThis and strict functions keep undefined.
+        il.Emit(System.Reflection.Emit.OpCodes.Ldsfld, ctx.Runtime!.UndefinedInstance);
+        il.Emit(System.Reflection.Emit.OpCodes.Ldstr, name);
+        il.Emit(System.Reflection.Emit.OpCodes.Call, ctx.Runtime.GlobalThisGetProperty);
+        emitter.EmitArgsArrayWithSpread(call.Arguments);
+        il.Emit(System.Reflection.Emit.OpCodes.Call, ctx.Runtime.InvokeMethodValue);
+        emitter.SetStackUnknown();
+        return true;
     }
 
     /// <summary>
@@ -157,12 +186,37 @@ public class GlobalFunctionHandler : ICallHandler
 
     private static bool EmitParseInt(IEmitterContext emitter, System.Reflection.Emit.ILGenerator il, CompilationContext ctx, Expr.Call call)
     {
+        if (call.Arguments.Count is 1 or 2
+            && IsStaticallyString(ctx.TypeMap?.Get(call.Arguments[0]))
+            && (call.Arguments.Count == 1
+                || ExpressionEmitterBase.TryGetInt32Literal(call.Arguments[1], out _)))
+        {
+            int radix = 0;
+            if (call.Arguments.Count == 2)
+                _ = ExpressionEmitterBase.TryGetInt32Literal(call.Arguments[1], out radix);
+
+            emitter.EmitExpression(call.Arguments[0]);
+            il.Emit(System.Reflection.Emit.OpCodes.Castclass, ctx.Types.String);
+            il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4, radix);
+            il.Emit(System.Reflection.Emit.OpCodes.Call, ctx.Runtime!.NumberParseIntString);
+            emitter.SetStackType(StackType.Double);
+            return true;
+        }
+
         if (call.Arguments.Count > 0) { emitter.EmitExpression(call.Arguments[0]); emitter.EmitBoxIfNeeded(call.Arguments[0]); } else { il.Emit(System.Reflection.Emit.OpCodes.Ldnull); }
         if (call.Arguments.Count > 1) { emitter.EmitExpression(call.Arguments[1]); emitter.EmitBoxIfNeeded(call.Arguments[1]); } else { il.Emit(System.Reflection.Emit.OpCodes.Ldc_I4, 10); il.Emit(System.Reflection.Emit.OpCodes.Box, ctx.Types.Int32); }
         il.Emit(System.Reflection.Emit.OpCodes.Call, ctx.Runtime!.NumberParseInt);
         emitter.SetStackType(StackType.Double);
         return true;
     }
+
+    private static bool IsStaticallyString(TypeInfo? type) => type switch
+    {
+        TypeInfo.String => true,
+        TypeInfo.StringLiteral => true,
+        TypeInfo.Union union => union.Types.Count > 0 && union.Types.All(IsStaticallyString),
+        _ => false
+    };
 
     private static bool EmitParseFloat(IEmitterContext emitter, System.Reflection.Emit.ILGenerator il, CompilationContext ctx, Expr.Call call)
     {

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -1148,6 +1148,8 @@ public class EmittedRuntime
 
     // Number methods
     public MethodBuilder NumberParseInt { get; set; } = null!;
+    /// <summary>Typed intrinsic parse path: already-coerced string plus native radix.</summary>
+    public MethodBuilder NumberParseIntString { get; set; } = null!;
     public MethodBuilder NumberParseFloat { get; set; } = null!;
     public MethodBuilder NumberIsNaN { get; set; } = null!;
     public MethodBuilder NumberIsFinite { get; set; } = null!;
@@ -1158,6 +1160,8 @@ public class EmittedRuntime
     public MethodBuilder GlobalEncodeURIComponent { get; set; } = null!;
     public MethodBuilder GlobalDecodeURIComponent { get; set; } = null!;
     public MethodBuilder NumberToFixed { get; set; } = null!;
+    /// <summary>Typed intrinsic fixed formatter: native receiver/digits plus precomputed format.</summary>
+    public MethodBuilder NumberToFixedDouble { get; set; } = null!;
     public MethodBuilder NumberToPrecision { get; set; } = null!;
     public MethodBuilder NumberToExponential { get; set; } = null!;
     public MethodBuilder NumberToStringRadix { get; set; } = null!;

--- a/src/SharpTS/Compilation/Emitters/IEmitterContext.cs
+++ b/src/SharpTS/Compilation/Emitters/IEmitterContext.cs
@@ -17,6 +17,13 @@ public interface IEmitterContext
     CompilationContext Context { get; }
 
     /// <summary>
+    /// Returns whether the current lexical scope contains a binding with this
+    /// name. Call handlers use this before selecting a global intrinsic so a
+    /// parameter or local with a built-in name retains ordinary value dispatch.
+    /// </summary>
+    bool HasVariable(string name);
+
+    /// <summary>
     /// Gets the current ILGenerator for emitting IL instructions.
     /// </summary>
     ILGenerator IL { get; }

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -597,7 +597,7 @@ public abstract partial class ExpressionEmitterBase
     /// lookups to the built-in string prototype, and <c>InvokeMethodValue</c> binds the
     /// receiver so the built-in can read it back.
     /// </summary>
-    private void EmitDynamicMethodCallPreservingThis(Expr obj, string methodName, List<Expr> arguments)
+    protected void EmitDynamicMethodCallPreservingThis(Expr obj, string methodName, List<Expr> arguments)
     {
         EmitExpression(obj);
         EnsureBoxed();
@@ -1558,6 +1558,9 @@ public abstract partial class ExpressionEmitterBase
 
         // Promise instance methods: promise.then/catch/finally
         string methodName = methodGet.Name.Lexeme;
+        if (TryEmitStableNumberConversionCall(methodGet, c.Arguments))
+            return true;
+
         if (methodName is "then" or "catch" or "finally"
             && Ctx.RuntimeFeatures?.UsesPromisePrototypeMutation != true)
         {

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.NumberConversions.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.NumberConversions.cs
@@ -1,0 +1,117 @@
+using System.Reflection.Emit;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+public abstract partial class ExpressionEmitterBase
+{
+    /// <summary>
+    /// Emits stable, typed Number formatting calls without crossing the boxed
+    /// object/object runtime ABI. All observable/dynamic cases return false.
+    /// </summary>
+    protected bool TryEmitStableNumberConversionCall(
+        Expr.Get methodGet,
+        IReadOnlyList<Expr> arguments)
+    {
+        if (methodGet.Optional
+            || Ctx.RuntimeFeatures?.UsesNumberPrototypeMutation == true
+            || !IsStaticallyNumber(Ctx.TypeMap?.Get(methodGet.Object)))
+        {
+            return false;
+        }
+
+        switch (methodGet.Name.Lexeme)
+        {
+            case "toString":
+                if (arguments.Count == 1
+                    && (!TryGetInt32Literal(arguments[0], out int radix) || radix != 10))
+                {
+                    return false;
+                }
+                if (arguments.Count > 1)
+                    return false;
+
+                if (TryEmitIntegerCounterDecimalString(methodGet.Object))
+                    return true;
+
+                EmitExpressionAsDouble(methodGet.Object);
+                IL.Emit(OpCodes.Call, Ctx.Runtime!.FormatNumber);
+                SetStackType(StackType.String);
+                return true;
+
+            case "toFixed":
+                int digits;
+                if (arguments.Count == 0)
+                {
+                    digits = 0;
+                }
+                else if (arguments.Count == 1
+                    && TryGetInt32Literal(arguments[0], out int literalDigits)
+                    && literalDigits is >= 0 and <= 100)
+                {
+                    digits = literalDigits;
+                }
+                else
+                {
+                    return false;
+                }
+
+                EmitExpressionAsDouble(methodGet.Object);
+                IL.Emit(OpCodes.Ldc_I4, digits);
+                IL.Emit(OpCodes.Ldstr, $"F{digits}");
+                IL.Emit(OpCodes.Call, Ctx.Runtime!.NumberToFixedDouble);
+                SetStackType(StackType.String);
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Sync ILEmitter overrides this for its native Int64 for-loop counters.
+    /// State machines and general doubles use FormatNumber(double).
+    /// </summary>
+    protected virtual bool TryEmitIntegerCounterDecimalString(Expr expression) => false;
+
+    private static bool IsStaticallyNumber(TypeInfo? type) => type switch
+    {
+        TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } => true,
+        TypeInfo.NumberLiteral => true,
+        TypeInfo.Union union => union.Types.Count > 0 && union.Types.All(IsStaticallyNumber),
+        _ => false
+    };
+
+    internal static bool TryGetInt32Literal(Expr expression, out int value)
+    {
+        double number;
+        switch (expression)
+        {
+            case Expr.Literal { Value: double literal }:
+                number = literal;
+                break;
+            case Expr.Unary
+            {
+                Operator.Type: TokenType.MINUS,
+                Right: Expr.Literal { Value: double literal }
+            }:
+                number = -literal;
+                break;
+            default:
+                value = 0;
+                return false;
+        }
+
+        if (!double.IsFinite(number)
+            || number != Math.Truncate(number)
+            || number < int.MinValue
+            || number > int.MaxValue)
+        {
+            value = 0;
+            return false;
+        }
+
+        value = (int)number;
+        return true;
+    }
+}

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.cs
@@ -102,6 +102,8 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
     protected abstract TypeProvider Types { get; }
     protected abstract IVariableResolver Resolver { get; }
 
+    bool IEmitterContext.HasVariable(string name) => Resolver.HasVariable(name);
+
     /// <summary>
     /// Gets the hoisted field for a variable name, or null if not hoisted.
     /// Override in state machine emitters to check the builder's variable fields.

--- a/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -70,6 +70,9 @@ public partial class ILEmitter
     {
         string methodName = methodGet.Name.Lexeme;
 
+        if (TryEmitStableNumberConversionCall(methodGet, arguments))
+            return;
+
         // Promoted typed-array local push (#857/#860): append unboxed elements directly to the
         // bare List<T> via the typed helper — bypassing ArrayEmitter's $Array unwrap/copy and the
         // per-element boxing. Handled here (not in ArrayEmitter) because EnsureDouble/EnsureBoolean
@@ -285,6 +288,12 @@ public partial class ILEmitter
             && !(_ctx.RuntimeFeatures?.UsesDatePrototypeMutation == true
                 && methodName is "valueOf" or "toString"))
         {
+            if (_ctx.RuntimeFeatures?.UsesNumberPrototypeMutation == true)
+            {
+                EmitDynamicMethodCallPreservingThis(methodGet.Object, methodName, arguments);
+                return;
+            }
+
             // Check if we know it's a number at compile time
             if (objType is TypeSystem.TypeInfo.Primitive { Type: Parsing.TokenType.TYPE_NUMBER } or TypeSystem.TypeInfo.NumberLiteral)
             {

--- a/src/SharpTS/Compilation/ILEmitter.Calls.NumberMethods.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.NumberMethods.cs
@@ -8,6 +8,19 @@ namespace SharpTS.Compilation;
 /// </summary>
 public partial class ILEmitter
 {
+    protected override bool TryEmitIntegerCounterDecimalString(Expr expression)
+    {
+        if (!IsIntegerCounterValueI8(expression))
+            return false;
+
+        IL.Emit(OpCodes.Ldstr, "");
+        _ = TryEmitIntegerCounterValueI8(expression);
+        IL.Emit(OpCodes.Ldc_I4_0);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.ConcatStringInt64);
+        SetStackType(StackType.String);
+        return true;
+    }
+
     /// <summary>
     /// Emits a BigInt instance-method call (receiver statically bigint). toString takes
     /// an optional radix (ECMA-262 21.2.3.3); toLocaleString is the decimal form;

--- a/src/SharpTS/Compilation/RuntimeEmitter.Number.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Number.cs
@@ -14,6 +14,7 @@ public partial class RuntimeEmitter
     {
         // Emit helper methods first (they're used by other methods)
         EmitGetDigitValue(typeBuilder, runtime);
+        EmitParseIntStringHelper(typeBuilder, runtime);
         EmitParseIntHelper(typeBuilder, runtime);
         EmitConvertIntToRadix(typeBuilder, runtime);
         EmitGetValidFloatPart(typeBuilder, runtime);
@@ -26,10 +27,205 @@ public partial class RuntimeEmitter
         EmitNumberIsSafeInteger(typeBuilder, runtime);
         EmitGlobalIsNaN(typeBuilder, runtime);
         EmitGlobalIsFinite(typeBuilder, runtime);
+        EmitNumberToFixedDouble(typeBuilder, runtime);
         EmitNumberToFixed(typeBuilder, runtime);
         EmitNumberToPrecision(typeBuilder, runtime);
         EmitNumberToExponential(typeBuilder, runtime);
         EmitNumberToStringRadix(typeBuilder, runtime);
+    }
+
+    /// <summary>
+    /// Emits the allocation-free typed parse core used when the caller has already
+    /// proved the input is a string and the radix is a native Int32. The general
+    /// object/object helper remains responsible for observable JS coercion.
+    /// </summary>
+    private void EmitParseIntStringHelper(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "NumberParseIntString",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Double,
+            [_types.String, _types.Int32]);
+        method.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
+        runtime.NumberParseIntString = method;
+
+        var il = method.GetILGenerator();
+        var strLocal = il.DeclareLocal(_types.String);
+        var radixLocal = il.DeclareLocal(_types.Int32);
+        var signLocal = il.DeclareLocal(_types.Int32);
+        var startLocal = il.DeclareLocal(_types.Int32);
+        var indexLocal = il.DeclareLocal(_types.Int32);
+        var digitLocal = il.DeclareLocal(_types.Int32);
+        var prefixCharLocal = il.DeclareLocal(_types.Char);
+        var resultLocal = il.DeclareLocal(_types.Double);
+        var hasDigitsLocal = il.DeclareLocal(_types.Boolean);
+
+        var notEmpty = il.DefineLabel();
+        var notMinus = il.DefineLabel();
+        var afterSign = il.DefineLabel();
+        var checkPrefix = il.DefineLabel();
+        var noPrefix = il.DefineLabel();
+        var prefixFound = il.DefineLabel();
+        var validateRadix = il.DefineLabel();
+        var radixAtLeastTwo = il.DefineLabel();
+        var radixValid = il.DefineLabel();
+        var loop = il.DefineLabel();
+        var endLoop = il.DefineLabel();
+        var returnResult = il.DefineLabel();
+
+        // Trim is allocation-free when no surrounding whitespace is present.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "Trim", Type.EmptyTypes)!);
+        il.Emit(OpCodes.Stloc, strLocal);
+        il.Emit(OpCodes.Ldloc, strLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.String, "Length")!.GetGetMethod()!);
+        il.Emit(OpCodes.Brtrue, notEmpty);
+        il.Emit(OpCodes.Ldc_R8, double.NaN);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notEmpty);
+
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, signLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, startLocal);
+
+        il.Emit(OpCodes.Ldloc, strLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "get_Chars", [_types.Int32])!);
+        il.Emit(OpCodes.Ldc_I4, (int)'-');
+        il.Emit(OpCodes.Bne_Un, notMinus);
+        il.Emit(OpCodes.Ldc_I4_M1);
+        il.Emit(OpCodes.Stloc, signLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, startLocal);
+        il.Emit(OpCodes.Br, afterSign);
+
+        il.MarkLabel(notMinus);
+        il.Emit(OpCodes.Ldloc, strLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "get_Chars", [_types.Int32])!);
+        il.Emit(OpCodes.Ldc_I4, (int)'+');
+        il.Emit(OpCodes.Bne_Un, afterSign);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, startLocal);
+        il.MarkLabel(afterSign);
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Stloc, radixLocal);
+        il.Emit(OpCodes.Ldloc, radixLocal);
+        il.Emit(OpCodes.Brfalse, checkPrefix);
+        il.Emit(OpCodes.Ldloc, radixLocal);
+        il.Emit(OpCodes.Ldc_I4, 16);
+        il.Emit(OpCodes.Beq, checkPrefix);
+        il.Emit(OpCodes.Br, validateRadix);
+
+        // Radix 0 and 16 both recognize and strip an optional 0x prefix.
+        il.MarkLabel(checkPrefix);
+        il.Emit(OpCodes.Ldloc, strLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.String, "Length")!.GetGetMethod()!);
+        il.Emit(OpCodes.Ldloc, startLocal);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Blt, noPrefix);
+        il.Emit(OpCodes.Ldloc, strLocal);
+        il.Emit(OpCodes.Ldloc, startLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "get_Chars", [_types.Int32])!);
+        il.Emit(OpCodes.Ldc_I4, (int)'0');
+        il.Emit(OpCodes.Bne_Un, noPrefix);
+        il.Emit(OpCodes.Ldloc, strLocal);
+        il.Emit(OpCodes.Ldloc, startLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "get_Chars", [_types.Int32])!);
+        il.Emit(OpCodes.Stloc, prefixCharLocal);
+        il.Emit(OpCodes.Ldloc, prefixCharLocal);
+        il.Emit(OpCodes.Ldc_I4, (int)'x');
+        il.Emit(OpCodes.Beq, prefixFound);
+        il.Emit(OpCodes.Ldloc, prefixCharLocal);
+        il.Emit(OpCodes.Ldc_I4, (int)'X');
+        il.Emit(OpCodes.Bne_Un, noPrefix);
+
+        il.MarkLabel(prefixFound);
+        il.Emit(OpCodes.Ldc_I4, 16);
+        il.Emit(OpCodes.Stloc, radixLocal);
+        il.Emit(OpCodes.Ldloc, startLocal);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, startLocal);
+        il.Emit(OpCodes.Br, validateRadix);
+
+        il.MarkLabel(noPrefix);
+        il.Emit(OpCodes.Ldloc, radixLocal);
+        il.Emit(OpCodes.Brtrue, validateRadix);
+        il.Emit(OpCodes.Ldc_I4, 10);
+        il.Emit(OpCodes.Stloc, radixLocal);
+
+        il.MarkLabel(validateRadix);
+        il.Emit(OpCodes.Ldloc, radixLocal);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Bge, radixAtLeastTwo);
+        il.Emit(OpCodes.Ldc_R8, double.NaN);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(radixAtLeastTwo);
+        il.Emit(OpCodes.Ldloc, radixLocal);
+        il.Emit(OpCodes.Ldc_I4, 36);
+        il.Emit(OpCodes.Ble, radixValid);
+        il.Emit(OpCodes.Ldc_R8, double.NaN);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(radixValid);
+
+        il.Emit(OpCodes.Ldc_R8, 0.0);
+        il.Emit(OpCodes.Stloc, resultLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, hasDigitsLocal);
+        il.Emit(OpCodes.Ldloc, startLocal);
+        il.Emit(OpCodes.Stloc, indexLocal);
+
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldloc, strLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.String, "Length")!.GetGetMethod()!);
+        il.Emit(OpCodes.Bge, endLoop);
+        il.Emit(OpCodes.Ldloc, strLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "get_Chars", [_types.Int32])!);
+        il.Emit(OpCodes.Call, runtime.GetDigitValue);
+        il.Emit(OpCodes.Stloc, digitLocal);
+        il.Emit(OpCodes.Ldloc, digitLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Blt, endLoop);
+        il.Emit(OpCodes.Ldloc, digitLocal);
+        il.Emit(OpCodes.Ldloc, radixLocal);
+        il.Emit(OpCodes.Bge, endLoop);
+
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Ldloc, radixLocal);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ldloc, digitLocal);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, resultLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, hasDigitsLocal);
+        il.Emit(OpCodes.Ldloc, indexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, indexLocal);
+        il.Emit(OpCodes.Br, loop);
+
+        il.MarkLabel(endLoop);
+        il.Emit(OpCodes.Ldloc, hasDigitsLocal);
+        il.Emit(OpCodes.Brtrue, returnResult);
+        il.Emit(OpCodes.Ldc_R8, double.NaN);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(returnResult);
+        il.Emit(OpCodes.Ldloc, signLocal);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Ldloc, resultLocal);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ret);
     }
 
     private void EmitNumberParseInt(TypeBuilder typeBuilder, EmittedRuntime runtime)
@@ -911,6 +1107,66 @@ public partial class RuntimeEmitter
         // default: return false
         il.MarkLabel(returnFalseLabel);
         il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private void EmitNumberToFixedDouble(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "NumberToFixedDouble",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.String,
+            [_types.Double, _types.Int32, _types.String]);
+        method.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
+        runtime.NumberToFixedDouble = method;
+
+        var il = method.GetILGenerator();
+        var valueLocal = il.DeclareLocal(_types.Double);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Stloc, valueLocal);
+
+        // Keep validation inside the standalone helper even though the current
+        // direct emitter only selects compile-time literals in range.
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_0);
+        var notNegative = il.DefineLabel();
+        il.Emit(OpCodes.Bge, notNegative);
+        GuestErrorEmitter.ThrowRangeError(
+            il, runtime, "toFixed() digits argument must be between 0 and 100");
+        il.MarkLabel(notNegative);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4, 100);
+        var inRange = il.DefineLabel();
+        il.Emit(OpCodes.Ble, inRange);
+        GuestErrorEmitter.ThrowRangeError(
+            il, runtime, "toFixed() digits argument must be between 0 and 100");
+        il.MarkLabel(inRange);
+
+        // Values at or above 1e21 use ordinary Number::toString. Blt_Un also
+        // sends NaN to the BCL fixed formatter, which returns the JS spelling.
+        var fixedNotation = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Abs", [_types.Double])!);
+        il.Emit(OpCodes.Ldc_R8, 1e21);
+        il.Emit(OpCodes.Blt_Un, fixedNotation);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Call, runtime.FormatNumber);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(fixedNotation);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Ldc_R8, 0.0);
+        var nonZero = il.DefineLabel();
+        il.Emit(OpCodes.Bne_Un, nonZero);
+        il.Emit(OpCodes.Ldc_R8, 0.0);
+        il.Emit(OpCodes.Stloc, valueLocal);
+        il.MarkLabel(nonZero);
+
+        il.Emit(OpCodes.Ldloca, valueLocal);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Call, typeof(CultureInfo).GetProperty("InvariantCulture")!.GetGetMethod()!);
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.Double, "ToString", [_types.String, typeof(IFormatProvider)])!);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -32,6 +32,11 @@ public sealed class RuntimeFeatureDetector
     private readonly RuntimeFeatureSet _set;
     private readonly HashSet<string> _sourceFunctions = new(StringComparer.Ordinal);
     private readonly HashSet<string> _opaqueValueBindings = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _numberConstructorAliases = new(StringComparer.Ordinal)
+    {
+        "Number"
+    };
+    private readonly HashSet<string> _numberPrototypeAliases = new(StringComparer.Ordinal);
     private readonly HashSet<(string Fingerprint, int Index)> _invalidCompactRecordSelfFields = [];
     private readonly Dictionary<string, JsonSerializationShape.Record> _canonicalCompactRecordShapes = [];
     private TypeMap? _typeMap;
@@ -92,6 +97,8 @@ public sealed class RuntimeFeatureDetector
             UsesDatePrototypeMutation = false,
             UsesPromisePrototypeMutation = false,
             UsesArrayPrototypeMutation = false,
+            UsesNumberPrototypeMutation = false,
+            UsesGlobalParseIntMutation = false,
             PotentiallyMaterializesUnknownCompactObjectRecordShape = false,
             TypedArrays = RuntimeFeatureSet.TypedArrayKinds.None,
         };
@@ -622,6 +629,7 @@ public sealed class RuntimeFeatureDetector
             case Stmt.Var var:
                 if (var.Initializer is not null)
                 {
+                    TrackNumberAlias(var.Name.Lexeme, var.Initializer);
                     if (_opaqueValueBindings.Contains(var.Name.Lexeme))
                         MarkPotentiallyMaterialized(var.Initializer);
                     VisitExpr(var.Initializer);
@@ -629,6 +637,7 @@ public sealed class RuntimeFeatureDetector
                 break;
 
             case Stmt.Const cst:
+                TrackNumberAlias(cst.Name.Lexeme, cst.Initializer);
                 if (_opaqueValueBindings.Contains(cst.Name.Lexeme))
                     MarkPotentiallyMaterialized(cst.Initializer);
                 VisitExpr(cst.Initializer);
@@ -783,6 +792,8 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesArrayPrototypeMutation = true;
                 if (IsPromisePrototype(g))
                     _set.UsesPromisePrototypeMutation = true;
+                if (IsNumberPrototype(g))
+                    _set.UsesNumberPrototypeMutation = true;
                 if (g.Object is Expr.Variable ov)
                 {
                     HandleMemberAccess(ov.Name.Lexeme, g.Name.Lexeme);
@@ -858,6 +869,10 @@ public sealed class RuntimeFeatureDetector
                 if (IsPromiseMutationTarget(s.Object)
                     || s.Name.Lexeme is "then" or "constructor" or "__proto__")
                     _set.UsesPromisePrototypeMutation = true;
+                if (IsNumberMutationTarget(s.Object))
+                    _set.UsesNumberPrototypeMutation = true;
+                if (IsGlobalObject(s.Object) && s.Name.Lexeme == "parseInt")
+                    _set.UsesGlobalParseIntMutation = true;
                 if (IsArrayPrototype(s.Object)
                     || s.Name.Lexeme == "__proto__"
                     || (s.Name.Lexeme == "push" && CouldTargetArray(s.Object)))
@@ -905,6 +920,11 @@ public sealed class RuntimeFeatureDetector
                         Value: "then" or "constructor" or "__proto__"
                     })
                     _set.UsesPromisePrototypeMutation = true;
+                if (IsNumberMutationTarget(si.Object))
+                    _set.UsesNumberPrototypeMutation = true;
+                if (IsGlobalObject(si.Object)
+                    && si.Index is Expr.Literal { Value: "parseInt" })
+                    _set.UsesGlobalParseIntMutation = true;
                 if (IsArrayPrototype(si.Object)
                     || si.Index is Expr.Literal { Value: "__proto__" }
                     || (si.Index is Expr.Literal { Value: "push" }
@@ -917,7 +937,11 @@ public sealed class RuntimeFeatureDetector
 
             case Expr.Call c:
                 if (c.Callee is Expr.Variable { Name.Lexeme: "eval" })
+                {
                     _set.UsesPromisePrototypeMutation = true;
+                    _set.UsesNumberPrototypeMutation = true;
+                    _set.UsesGlobalParseIntMutation = true;
+                }
                 if (c.Callee is Expr.Get
                     {
                         Object: Expr.Variable { Name.Lexeme: "Object" or "Reflect" },
@@ -940,6 +964,7 @@ public sealed class RuntimeFeatureDetector
                     // promise receiver from this syntax-only pass. Retaining
                     // value dispatch is conservative and preserves observability.
                     _set.UsesPromisePrototypeMutation = true;
+                    _set.UsesNumberPrototypeMutation = true;
                 }
                 if (c.Callee is not Expr.Variable directSourceCall ||
                     !_sourceFunctions.Contains(directSourceCall.Name.Lexeme))
@@ -1025,11 +1050,19 @@ public sealed class RuntimeFeatureDetector
             case Expr.Assign asg:
                 if (asg.Name.Lexeme == "Promise")
                     _set.UsesPromisePrototypeMutation = true;
+                if (asg.Name.Lexeme == "Number")
+                    _set.UsesNumberPrototypeMutation = true;
+                if (asg.Name.Lexeme == "parseInt")
+                    _set.UsesGlobalParseIntMutation = true;
                 if (_opaqueValueBindings.Contains(asg.Name.Lexeme))
                     MarkPotentiallyMaterialized(asg.Value);
                 VisitExpr(asg.Value);
                 break;
             case Expr.CompoundAssign ca:
+                if (ca.Name.Lexeme == "Number")
+                    _set.UsesNumberPrototypeMutation = true;
+                if (ca.Name.Lexeme == "parseInt")
+                    _set.UsesGlobalParseIntMutation = true;
                 VisitExpr(ca.Value);
                 break;
             case Expr.CompoundSet cs:
@@ -1037,6 +1070,10 @@ public sealed class RuntimeFeatureDetector
                 if (IsPromiseMutationTarget(cs.Object)
                     || cs.Name.Lexeme is "then" or "constructor" or "__proto__")
                     _set.UsesPromisePrototypeMutation = true;
+                if (IsNumberMutationTarget(cs.Object))
+                    _set.UsesNumberPrototypeMutation = true;
+                if (IsGlobalObject(cs.Object) && cs.Name.Lexeme == "parseInt")
+                    _set.UsesGlobalParseIntMutation = true;
                 if (cs.Name.Lexeme == "push" && CouldTargetArray(cs.Object))
                     _set.UsesArrayPrototypeMutation = true;
                 VisitExpr(cs.Object);
@@ -1050,6 +1087,11 @@ public sealed class RuntimeFeatureDetector
                         Value: "then" or "constructor" or "__proto__"
                     })
                     _set.UsesPromisePrototypeMutation = true;
+                if (IsNumberMutationTarget(csi.Object))
+                    _set.UsesNumberPrototypeMutation = true;
+                if (IsGlobalObject(csi.Object)
+                    && csi.Index is Expr.Literal { Value: "parseInt" })
+                    _set.UsesGlobalParseIntMutation = true;
                 if (csi.Index is Expr.Literal { Value: "push" }
                     && CouldTargetArray(csi.Object))
                     _set.UsesArrayPrototypeMutation = true;
@@ -1058,6 +1100,10 @@ public sealed class RuntimeFeatureDetector
                 VisitExpr(csi.Value);
                 break;
             case Expr.LogicalAssign la:
+                if (la.Name.Lexeme == "Number")
+                    _set.UsesNumberPrototypeMutation = true;
+                if (la.Name.Lexeme == "parseInt")
+                    _set.UsesGlobalParseIntMutation = true;
                 VisitExpr(la.Value);
                 break;
             case Expr.LogicalSet ls:
@@ -1065,6 +1111,10 @@ public sealed class RuntimeFeatureDetector
                 if (IsPromiseMutationTarget(ls.Object)
                     || ls.Name.Lexeme is "then" or "constructor" or "__proto__")
                     _set.UsesPromisePrototypeMutation = true;
+                if (IsNumberMutationTarget(ls.Object))
+                    _set.UsesNumberPrototypeMutation = true;
+                if (IsGlobalObject(ls.Object) && ls.Name.Lexeme == "parseInt")
+                    _set.UsesGlobalParseIntMutation = true;
                 if (ls.Name.Lexeme == "push" && CouldTargetArray(ls.Object))
                     _set.UsesArrayPrototypeMutation = true;
                 VisitExpr(ls.Object);
@@ -1078,6 +1128,11 @@ public sealed class RuntimeFeatureDetector
                         Value: "then" or "constructor" or "__proto__"
                     })
                     _set.UsesPromisePrototypeMutation = true;
+                if (IsNumberMutationTarget(lsi.Object))
+                    _set.UsesNumberPrototypeMutation = true;
+                if (IsGlobalObject(lsi.Object)
+                    && lsi.Index is Expr.Literal { Value: "parseInt" })
+                    _set.UsesGlobalParseIntMutation = true;
                 if (lsi.Index is Expr.Literal { Value: "push" }
                     && CouldTargetArray(lsi.Object))
                     _set.UsesArrayPrototypeMutation = true;
@@ -1127,6 +1182,11 @@ public sealed class RuntimeFeatureDetector
                     if (IsPromiseMutationTarget(deletedProperty.Object)
                         || deletedProperty.Name.Lexeme is "then" or "constructor" or "__proto__")
                         _set.UsesPromisePrototypeMutation = true;
+                    if (IsNumberMutationTarget(deletedProperty.Object))
+                        _set.UsesNumberPrototypeMutation = true;
+                    if (IsGlobalObject(deletedProperty.Object)
+                        && deletedProperty.Name.Lexeme == "parseInt")
+                        _set.UsesGlobalParseIntMutation = true;
                     if (deletedProperty.Name.Lexeme == "push"
                         && CouldTargetArray(deletedProperty.Object))
                         _set.UsesArrayPrototypeMutation = true;
@@ -1140,6 +1200,11 @@ public sealed class RuntimeFeatureDetector
                             Value: "then" or "constructor" or "__proto__"
                         })
                         _set.UsesPromisePrototypeMutation = true;
+                    if (IsNumberMutationTarget(deletedIndex.Object))
+                        _set.UsesNumberPrototypeMutation = true;
+                    if (IsGlobalObject(deletedIndex.Object)
+                        && deletedIndex.Index is Expr.Literal { Value: "parseInt" })
+                        _set.UsesGlobalParseIntMutation = true;
                     if (deletedIndex.Index is Expr.Literal { Value: "push" }
                         && CouldTargetArray(deletedIndex.Object))
                         _set.UsesArrayPrototypeMutation = true;
@@ -1336,6 +1401,54 @@ public sealed class RuntimeFeatureDetector
         Object: Expr.Variable { Name.Lexeme: "Date" },
         Name.Lexeme: "prototype"
     };
+
+    private static bool IsGlobalObject(Expr expr) => expr switch
+    {
+        Expr.Variable { Name.Lexeme: "globalThis" } => true,
+        Expr.Grouping grouping => IsGlobalObject(grouping.Expression),
+        Expr.TypeAssertion assertion => IsGlobalObject(assertion.Expression),
+        _ => false
+    };
+
+    private bool IsNumberConstructor(Expr expr) => expr switch
+    {
+        Expr.Variable variable => _numberConstructorAliases.Contains(variable.Name.Lexeme),
+        Expr.Get
+        {
+            Object: Expr.Variable { Name.Lexeme: "globalThis" },
+            Name.Lexeme: "Number"
+        } => true,
+        Expr.GetIndex
+        {
+            Object: Expr.Variable { Name.Lexeme: "globalThis" },
+            Index: Expr.Literal { Value: "Number" }
+        } => true,
+        Expr.Grouping grouping => IsNumberConstructor(grouping.Expression),
+        Expr.TypeAssertion assertion => IsNumberConstructor(assertion.Expression),
+        _ => false
+    };
+
+    private bool IsNumberPrototype(Expr expr) => expr switch
+    {
+        Expr.Variable variable => _numberPrototypeAliases.Contains(variable.Name.Lexeme),
+        Expr.Get { Name.Lexeme: "prototype" } get => IsNumberConstructor(get.Object),
+        Expr.GetIndex { Index: Expr.Literal { Value: "prototype" } } get =>
+            IsNumberConstructor(get.Object),
+        Expr.Grouping grouping => IsNumberPrototype(grouping.Expression),
+        Expr.TypeAssertion assertion => IsNumberPrototype(assertion.Expression),
+        _ => false
+    };
+
+    private bool IsNumberMutationTarget(Expr expr) =>
+        IsNumberConstructor(expr) || IsNumberPrototype(expr);
+
+    private void TrackNumberAlias(string name, Expr initializer)
+    {
+        if (IsNumberConstructor(initializer))
+            _numberConstructorAliases.Add(name);
+        if (IsNumberPrototype(initializer))
+            _numberPrototypeAliases.Add(name);
+    }
 
     private bool CouldTargetClassMethod(Expr receiver, string methodName) =>
         _typeMap?.Get(receiver) is TypeInfo.Instance instance

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -154,6 +154,12 @@ public sealed class RuntimeFeatureSet
     // prototype-chain mutation API, or __proto__ access makes a backing-list-only
     // array append unsafe. The discarded-result push fast path requires this false.
     public bool UsesArrayPrototypeMutation { get; set; } = true;
+    // Number prototype/static mutation makes typed number method calls observable
+    // through ordinary property lookup. Direct formatting requires this false.
+    public bool UsesNumberPrototypeMutation { get; set; } = true;
+    // A write to the global parseInt binding (or opaque eval) requires live
+    // globalThis lookup instead of the direct typed parsing intrinsic.
+    public bool UsesGlobalParseIntMutation { get; set; } = true;
 
     // ── Typed arrays ──────────────────────────────────────────────────────
     /// <summary>

--- a/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
@@ -175,6 +175,38 @@ public class RuntimeFeatureDetectorTests
     }
 
     [Theory]
+    [InlineData("const value: number = 1; value.toString();", false)]
+    [InlineData("const prototype = Number.prototype;", true)]
+    [InlineData("Number.prototype.toString = function() { return 'x'; };", true)]
+    [InlineData("Number.prototype['toFixed'] = function() { return 'x'; };", true)]
+    [InlineData("const N = Number; N.prototype.toString = function() { return 'x'; };", true)]
+    [InlineData("const p = Number.prototype; p.toFixed = function() { return 'x'; };", true)]
+    [InlineData("Object.defineProperty(Number.prototype, 'x', { value: 1 });", true)]
+    [InlineData("eval('void 0');", true)]
+    public void DetectsNumberPrototypeMutationRisk(string source, bool expected)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var features = new RuntimeFeatureDetector().Detect(statements, typeMap);
+
+        Assert.Equal(expected, features.UsesNumberPrototypeMutation);
+    }
+
+    [Theory]
+    [InlineData("parseInt('10', 10);", false)]
+    [InlineData("globalThis.parseInt = function() { return 1; };", true)]
+    [InlineData("globalThis['parseInt'] = function() { return 1; };", true)]
+    [InlineData("parseInt = function() { return 1; };", true)]
+    [InlineData("eval('void 0');", true)]
+    public void DetectsGlobalParseIntMutationRisk(string source, bool expected)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var features = new RuntimeFeatureDetector().Detect(statements);
+
+        Assert.Equal(expected, features.UsesGlobalParseIntMutation);
+    }
+
+    [Theory]
     [InlineData("const node: { left: object | null; right: object | null } = { left: null, right: null }; const isLeaf = node.left === null; console.log(isLeaf);", true)]
     [InlineData("const node: { left: object | null; right: object | null } = { left: null, right: null }; node.left = null;", false)]
     [InlineData("export const node: { left: object | null; right: object | null } = { left: null, right: null };", false)]

--- a/tests/SharpTS.Tests/CompilerTests/StableNumericStringConversionTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableNumericStringConversionTests.cs
@@ -1,0 +1,269 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class StableNumericStringConversionTests
+{
+    [Fact]
+    public void StableTypedConversions_PreserveNumericSemantics()
+    {
+        const string source = """
+            function format(value: number): string {
+                return value.toString() + "|" + value.toString(10)
+                    + "|" + value.toFixed() + "|" + value.toFixed(2);
+            }
+
+            console.log(format(12.34));
+            console.log((-0).toString(), (-0).toFixed(2));
+            console.log((1e21).toFixed(2), (1e-6).toString(), (1e-7).toString());
+            console.log((NaN).toFixed(1), (Infinity).toFixed(1));
+            console.log(
+                parseInt("42"),
+                parseInt("0x10"),
+                parseInt("0x10", 16),
+                Object.is(parseInt("-0", 10), -0),
+                parseInt("101tail", 2),
+                parseInt("z", 36),
+                Number.isNaN(parseInt("x", 10)));
+            """;
+
+        const string expected =
+            "12.34|12.34|12|12.34\n" +
+            "0 0.00\n" +
+            "1e+21 0.000001 1e-7\n" +
+            "NaN Infinity\n" +
+            "42 16 16 true 5 35 true\n";
+
+        Assert.Equal(expected, TestHarness.Run(source, ExecutionMode.Compiled));
+    }
+
+    [Fact]
+    public void StableTypedConversions_PassIlVerification()
+    {
+        Assert.Empty(TestHarness.CompileAndVerifyOnly("""
+            function render(value: number): string {
+                return value.toString(10) + value.toFixed(2);
+            }
+            function read(value: string): number {
+                return parseInt(value, 10);
+            }
+            console.log(render(read("12")));
+            """));
+    }
+
+    [Fact]
+    public void StableTypedConversions_CallTypedRuntimeHelpers()
+    {
+        Assembly assembly = Compile("""
+            function counterLengths(n: number): number {
+                let total: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    total += i.toString().length;
+                }
+                return total;
+            }
+            function render(value: number): string { return value.toString(10); }
+            function fixed(value: number): string { return value.toFixed(2); }
+            function read(value: string): number { return parseInt(value, 10); }
+            """);
+
+        AssertCalls(assembly, "counterLengths", "ConcatStringInt64");
+        AssertCalls(assembly, "render", "FormatNumber");
+        AssertCalls(assembly, "fixed", "NumberToFixedDouble");
+        AssertCalls(assembly, "read", "NumberParseIntString");
+
+        foreach (string function in new[] { "counterLengths", "render", "fixed", "read" })
+        {
+            MethodInfo method = FindFunction(assembly, function);
+            Assert.DoesNotContain(CalledMethods(method), called =>
+                called.Name is "NumberToStringRadix" or "NumberToFixed" or
+                    "NumberParseInt" or "InvokeMethodValue");
+        }
+
+        Assert.DoesNotContain(Instructions(FindFunction(assembly, "read")), instruction =>
+            instruction.OpCode == OpCodes.Box);
+        Assert.DoesNotContain(Instructions(FindFunction(assembly, "fixed")), instruction =>
+            instruction.OpCode == OpCodes.Box);
+    }
+
+    [Fact]
+    public void TypedParseIntLoop_DoesNotAllocatePerIteration()
+    {
+        Assembly assembly = Compile("""
+            function run(n: number): number {
+                let total: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    total += parseInt("12345", 10);
+                }
+                return total;
+            }
+            """);
+        var run = FindFunction(assembly, "run").CreateDelegate<Func<double, double>>();
+
+        Assert.Equal(123450, run(10));
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        double result = run(100_000);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(1_234_500_000, result);
+        Assert.True(allocated <= 256,
+            $"Typed parseInt allocated {allocated:N0} bytes in the hot loop.");
+    }
+
+    [Theory, ModeData]
+    public void NumberPrototypeMutation_RetainsLiveDispatch(ExecutionMode mode)
+    {
+        const string source = """
+            const originalToString: any = Number.prototype.toString;
+            const originalToFixed: any = Number.prototype.toFixed;
+
+            (Number.prototype as any).toString = function(): string { return "patched-string"; };
+            (Number.prototype as any).toFixed = function(): string { return "patched-fixed"; };
+            console.log((5).toString(), (5).toFixed(2));
+
+            (Number.prototype as any).toString = originalToString;
+            (Number.prototype as any).toFixed = originalToFixed;
+            """;
+
+        Assert.Equal("patched-string patched-fixed\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void ReassignedGlobalParseInt_RetainsLiveDispatch()
+    {
+        const string source = """
+            const originalParseInt: any = globalThis.parseInt;
+            (globalThis as any).parseInt = function(): number { return 77; };
+            console.log(parseInt("10", 10));
+            (globalThis as any).parseInt = originalParseInt;
+            """;
+
+        Assert.Equal("77\n", TestHarness.Run(source, ExecutionMode.Compiled));
+    }
+
+    [Theory, ModeData]
+    public void ShadowedParseInt_RetainsValueDispatch(ExecutionMode mode)
+    {
+        const string source = """
+            function invoke(
+                parseInt: (value: string, radix: number) => number
+            ): number {
+                return parseInt("10", 10);
+            }
+            console.log(invoke((_value, _radix) => 99));
+            """;
+
+        Assert.Equal("99\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void AsyncTypedConversions_AreCorrect(ExecutionMode mode)
+    {
+        const string source = """
+            async function convert(value: number): Promise<string> {
+                await Promise.resolve(0);
+                return value.toString() + "|" + value.toFixed(2)
+                    + "|" + parseInt("12", 10);
+            }
+            convert(3.5).then(value => console.log(value));
+            """;
+
+        Assert.Equal("3.5|3.50|12\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void DynamicArguments_KeepGeneralNumberConversionHelpers()
+    {
+        Assembly assembly = Compile("""
+            function render(value: number, radix: number): string {
+                return value.toString(radix);
+            }
+            function fixed(value: number, digits: number): string {
+                return value.toFixed(digits);
+            }
+            """);
+
+        AssertCalls(assembly, "render", "NumberToStringRadix");
+        AssertCalls(assembly, "fixed", "NumberToFixed");
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        TypeMap typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"numeric_string_conversions_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static void AssertCalls(Assembly assembly, string function, string helper) =>
+        Assert.Contains(CalledMethods(FindFunction(assembly, function)),
+            called => called.Name == helper);
+
+    private static IEnumerable<MethodBase> CalledMethods(MethodInfo method) =>
+        Instructions(method)
+            .Where(instruction => instruction.Operand is MethodBase)
+            .Select(instruction => (MethodBase)instruction.Operand!);
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> Instructions(MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token)
+                    : module.ResolveType(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch => 4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}


### PR DESCRIPTION
Closes #1473.
Closes #1474.
Parent: #1278.

## Summary

This batches the remaining stable numeric string-conversion boundaries from the widened performance corpus:

- lower statically numeric decimal `value.toString()` / `value.toString(10)` directly to native formatting, reusing the existing Int64 formatter for proven loop counters;
- lower typed `parseInt(string, <integral literal>)` to a `string, int -> double` parser with no boxed radix;
- lower typed `number.toFixed(<in-range integral literal>)` to a native receiver/digits helper with a compile-time `F0`-`F100` format string;
- retain ordinary property/value dispatch for dynamic radix/digits, optional calls, aliases, Number prototype mutation, global `parseInt` replacement, direct eval, and non-number/non-string inputs.

The global-call guard also fixes an existing correctness issue: a parameter/local named `parseInt` now keeps lexical value dispatch, and a bare compiled `parseInt(...)` observes a replacement installed on `globalThis`.

## Emitted-code and allocation boundary

Eligible call sites no longer box the number receiver or constant integer argument and no longer call `NumberToStringRadix(object, object)`, `NumberToFixed(object, object)`, or `NumberParseInt(object, object)`.

The structural tests assert the typed helper calls and absence of boxes/general dispatch. A warmed 100,000-iteration constant-string parse loop is held to <=256 bytes of thread-local allocation (observed near zero), replacing about 2.40 MB of boxed-radix allocation on the pinned baseline.

## Performance

Pinned baseline: `5eee7a70` (merged PR #1472). Candidate: `6a7321db`. Node: 22.23.2. Release builds, ext4-backed WSL worktrees, alternating paired launches.

Five-launch confirmation at N=100,000:

| Platform | Probe | Baseline | Candidate | Change | Node | Candidate / Node |
|---|---|---:|---:|---:|---:|---:|
| Windows | `parseInt(i.toString(), 10)` | 24.0811 ms | 1.8232 ms | -92.18% | 1.4383 ms | 1.275x |
| Windows | `(i * 0.125).toFixed(2)` | 31.9229 ms | 11.0759 ms | -65.30% | 9.6293 ms | 1.150x |
| WSL | `parseInt(i.toString(), 10)` | 26.8032 ms | 2.2503 ms | -91.93% | 1.4275 ms | 1.579x |
| WSL | `(i * 0.125).toFixed(2)` | 37.5333 ms | 12.9009 ms | -65.60% | 5.2840 ms | 2.659x |

The preceding independent three-launch run measured 1.8648/2.0781 ms for the Windows/WSL round trip and 11.2933/13.2049 ms for fixed formatting, confirming the same effect.

Unrelated numeric controls were neutral. The final strict report did flag the unchanged Windows generator probe at N=10,000 (+0.158 ms), while its N=100,000 case remained below the regression threshold (+8.02%), every WSL generator case was neutral, and the preceding Windows run reported the same N=10,000 case neutral. An immediate confirmation attempt encountered system-wide contention that inflated the baseline by 3-8x across all controls and was stopped. No generator lowering/runtime path is changed by this PR.

## Validation

- Release solution build: passed, including emitted IL verification.
- Focused numeric semantics/IL/allocation plus existing Number and wrapper tests: 208 passed on Windows.
- Hermetic compiler suite: 694 passed on Windows; 698 passed under WSL.
- New focused suite under WSL: 12 passed.
- Microbenchmark smoke compilation: passed.
- Local performance comparison harness tests: passed.

The restricted Windows execution environment could not complete three standalone process/TLS tests (two child-process exit waits and one local TLS authentication); those failures are unrelated to the numeric compiler paths and remain for CI's unrestricted runners.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved numeric string conversion with optimized `toString`, `toFixed`, and `parseInt` behavior.
  * Added radix validation, negative-zero normalization, and large-number formatting.
  * Preserved correct behavior when numeric prototypes or global parsing functions are customized.
  * Improved handling of shadowed functions, dynamic arguments, and asynchronous conversions.

* **Bug Fixes**
  * Prevented global functions from overriding same-named local variables.
  * Preserved JavaScript call context during dynamic method invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->