### PR TITLE
perf: format toFixed with exact integer arithmetic

### DIFF
--- a/benchmarks/cross-runtime/scripts/language-hot-paths.ts
+++ b/benchmarks/cross-runtime/scripts/language-hot-paths.ts
@@ -67,6 +67,11 @@ function parseIntegers(n: number): number {
 }
 
 function formatFixed(n: number): number {
+    // Content-sensitive guard: length-only checks cannot distinguish the BCL's
+    // ties-to-even "0.12" from JavaScript's exact "0.13" for this midpoint.
+    if ((0.125).toFixed(2) !== "0.13") {
+        throw new Error("incorrect Number.prototype.toFixed rounding");
+    }
     let totalLength: number = 0;
     for (let i: number = 0; i < n; i++) {
         totalLength = totalLength + (i * 0.125).toFixed(2).length;

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/NumberToFixedBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/NumberToFixedBenchmarks.cs
@@ -1,0 +1,52 @@
+using System.Globalization;
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using SharpTS.Microbenchmarks.Infrastructure;
+
+namespace SharpTS.Microbenchmarks.Benchmarks;
+
+/// <summary>
+/// Tracks the stable typed Number.prototype.toFixed path, including the exact
+/// binary64-to-decimal rounding and its per-result allocation cost.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class NumberToFixedBenchmarks
+{
+    private Func<double, double> _sharpTs = null!;
+
+    [Params(100_000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Assembly assembly = typeof(NumberToFixedBenchmarks).Assembly;
+        using Stream stream = assembly.GetManifestResourceStream(
+            "SharpTS.Microbenchmarks.TypeScriptSources.NumberToFixed.ts")
+            ?? throw new InvalidOperationException(
+                "Could not find embedded resource NumberToFixed.ts");
+        using var reader = new StreamReader(stream);
+        string dllPath = CompilationCache.GetOrCompile(
+            reader.ReadToEnd(), "NumberToFixed");
+        Assembly compiled = BenchmarkHarness.LoadCompiledAssembly(
+            dllPath, "number-to-fixed");
+        BenchmarkHarness.InitializeCompiledModules(compiled);
+        _sharpTs = BenchmarkHarness.GetCompiledNumberFunc(
+            compiled, "numberToFixedLoop");
+    }
+
+    [Benchmark]
+    public double SharpTSExact() => _sharpTs(N);
+
+    [Benchmark(Baseline = true)]
+    public int BclFixedPoint()
+    {
+        int totalLength = 0;
+        for (int i = 0; i < N; i++)
+            totalLength += (i * 0.125).ToString("F2", CultureInfo.InvariantCulture).Length;
+        return totalLength;
+    }
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/NumberToFixed.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/NumberToFixed.ts
@@ -1,0 +1,7 @@
+function numberToFixedLoop(n: number): number {
+    let totalLength: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        totalLength += (i * 0.125).toFixed(2).length;
+    }
+    return totalLength;
+}

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -1160,8 +1160,10 @@ public class EmittedRuntime
     public MethodBuilder GlobalEncodeURIComponent { get; set; } = null!;
     public MethodBuilder GlobalDecodeURIComponent { get; set; } = null!;
     public MethodBuilder NumberToFixed { get; set; } = null!;
-    /// <summary>Typed intrinsic fixed formatter: native receiver/digits plus precomputed format.</summary>
+    /// <summary>Typed intrinsic exact fixed formatter: native receiver and digits.</summary>
     public MethodBuilder NumberToFixedDouble { get; set; } = null!;
+    public FieldBuilder NumberFixedUInt64FormatterField { get; set; } = null!;
+    public MethodBuilder NumberFixedUInt64FormatterCallback { get; set; } = null!;
     public MethodBuilder NumberToPrecision { get; set; } = null!;
     public MethodBuilder NumberToExponential { get; set; } = null!;
     public MethodBuilder NumberToStringRadix { get; set; } = null!;

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.NumberConversions.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.NumberConversions.cs
@@ -59,7 +59,6 @@ public abstract partial class ExpressionEmitterBase
 
                 EmitExpressionAsDouble(methodGet.Object);
                 IL.Emit(OpCodes.Ldc_I4, digits);
-                IL.Emit(OpCodes.Ldstr, $"F{digits}");
                 IL.Emit(OpCodes.Call, Ctx.Runtime!.NumberToFixedDouble);
                 SetStackType(StackType.String);
                 return true;

--- a/src/SharpTS/Compilation/RuntimeEmitter.Number.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Number.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Globalization;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -10,6 +11,141 @@ namespace SharpTS.Compilation;
 /// </summary>
 public partial class RuntimeEmitter
 {
+    private void DefineNumberFixedFormattingInfrastructure(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime)
+    {
+        Type stateType = typeof(ValueTuple<ulong, int, bool>);
+        Type spanType = typeof(Span<char>);
+        Type formatterType = EmitGenerics.MakeGenericType(typeof(SpanAction<,>),
+            typeof(char), stateType);
+
+        runtime.NumberFixedUInt64FormatterField = typeBuilder.DefineField(
+            "_numberFixedUInt64Formatter",
+            formatterType,
+            FieldAttributes.Private | FieldAttributes.Static | FieldAttributes.InitOnly);
+
+        var method = typeBuilder.DefineMethod(
+            "FormatNumberFixedUInt64",
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.Void,
+            [spanType, stateType]);
+        runtime.NumberFixedUInt64FormatterCallback = method;
+
+        FieldInfo item1 = stateType.GetField("Item1")!;
+        FieldInfo item2 = stateType.GetField("Item2")!;
+        FieldInfo item3 = stateType.GetField("Item3")!;
+        MethodInfo spanLength = spanType.GetProperty("Length")!.GetGetMethod()!;
+        MethodInfo spanItem = spanType.GetProperty("Item")!.GetGetMethod()!;
+
+        var il = method.GetILGenerator();
+        var remaining = il.DeclareLocal(_types.UInt64);
+        var digits = il.DeclareLocal(_types.Int32);
+        var negative = il.DeclareLocal(_types.Boolean);
+        var start = il.DeclareLocal(_types.Int32);
+        var decimalIndex = il.DeclareLocal(_types.Int32);
+        var index = il.DeclareLocal(_types.Int32);
+
+        il.Emit(OpCodes.Ldarga_S, (byte)1);
+        il.Emit(OpCodes.Ldfld, item1);
+        il.Emit(OpCodes.Stloc, remaining);
+        il.Emit(OpCodes.Ldarga_S, (byte)1);
+        il.Emit(OpCodes.Ldfld, item2);
+        il.Emit(OpCodes.Stloc, digits);
+        il.Emit(OpCodes.Ldarga_S, (byte)1);
+        il.Emit(OpCodes.Ldfld, item3);
+        il.Emit(OpCodes.Stloc, negative);
+
+        var positiveStart = il.DefineLabel();
+        var startReady = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, negative);
+        il.Emit(OpCodes.Brfalse, positiveStart);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Br, startReady);
+        il.MarkLabel(positiveStart);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.MarkLabel(startReady);
+        il.Emit(OpCodes.Stloc, start);
+
+        var noDecimal = il.DefineLabel();
+        var decimalReady = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, digits);
+        il.Emit(OpCodes.Brfalse, noDecimal);
+        il.Emit(OpCodes.Ldarga_S, (byte)0);
+        il.Emit(OpCodes.Call, spanLength);
+        il.Emit(OpCodes.Ldloc, digits);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Br, decimalReady);
+        il.MarkLabel(noDecimal);
+        il.Emit(OpCodes.Ldc_I4_M1);
+        il.MarkLabel(decimalReady);
+        il.Emit(OpCodes.Stloc, decimalIndex);
+
+        il.Emit(OpCodes.Ldarga_S, (byte)0);
+        il.Emit(OpCodes.Call, spanLength);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Stloc, index);
+
+        var loopCheck = il.DefineLabel();
+        var writeDigit = il.DefineLabel();
+        var loopNext = il.DefineLabel();
+        il.Emit(OpCodes.Br, loopCheck);
+
+        il.MarkLabel(writeDigit);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldloc, decimalIndex);
+        var notDecimal = il.DefineLabel();
+        il.Emit(OpCodes.Bne_Un, notDecimal);
+        il.Emit(OpCodes.Ldarga_S, (byte)0);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Call, spanItem);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)'.');
+        il.Emit(OpCodes.Stind_I2);
+        il.Emit(OpCodes.Br, loopNext);
+
+        il.MarkLabel(notDecimal);
+        il.Emit(OpCodes.Ldarga_S, (byte)0);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Call, spanItem);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)'0');
+        il.Emit(OpCodes.Ldloc, remaining);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)10);
+        il.Emit(OpCodes.Conv_U8);
+        il.Emit(OpCodes.Rem_Un);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stind_I2);
+        il.Emit(OpCodes.Ldloc, remaining);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)10);
+        il.Emit(OpCodes.Conv_U8);
+        il.Emit(OpCodes.Div_Un);
+        il.Emit(OpCodes.Stloc, remaining);
+
+        il.MarkLabel(loopNext);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Stloc, index);
+        il.MarkLabel(loopCheck);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldloc, start);
+        il.Emit(OpCodes.Bge, writeDigit);
+
+        var done = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, negative);
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldarga_S, (byte)0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Call, spanItem);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)'-');
+        il.Emit(OpCodes.Stind_I2);
+        il.MarkLabel(done);
+        il.Emit(OpCodes.Ret);
+    }
+
     private void EmitNumberMethods(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         // Emit helper methods first (they're used by other methods)
@@ -1112,16 +1248,33 @@ public partial class RuntimeEmitter
 
     private void EmitNumberToFixedDouble(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
+        MethodBuilder bigIntegerFallback = EmitNumberToFixedBigInteger(typeBuilder);
         var method = typeBuilder.DefineMethod(
             "NumberToFixedDouble",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.String,
-            [_types.Double, _types.Int32, _types.String]);
+            [_types.Double, _types.Int32]);
         method.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
         runtime.NumberToFixedDouble = method;
 
         var il = method.GetILGenerator();
         var valueLocal = il.DeclareLocal(_types.Double);
+        var negativeLocal = il.DeclareLocal(_types.Boolean);
+        var bitsLocal = il.DeclareLocal(_types.UInt64);
+        var fractionLocal = il.DeclareLocal(_types.UInt64);
+        var rawExponentLocal = il.DeclareLocal(_types.Int32);
+        var significandLocal = il.DeclareLocal(_types.UInt64);
+        var binaryExponentLocal = il.DeclareLocal(_types.Int32);
+        var numeratorLocal = il.DeclareLocal(_types.UInt64);
+        var scaleIndexLocal = il.DeclareLocal(_types.Int32);
+        var shiftLocal = il.DeclareLocal(_types.Int32);
+        var rightShiftLocal = il.DeclareLocal(_types.Int32);
+        var scaledLocal = il.DeclareLocal(_types.UInt64);
+        var quotientLocal = il.DeclareLocal(_types.UInt64);
+        var remainingLocal = il.DeclareLocal(_types.UInt64);
+        var digitCountLocal = il.DeclareLocal(_types.Int32);
+        var wholeDigitsLocal = il.DeclareLocal(_types.Int32);
+        var lengthLocal = il.DeclareLocal(_types.Int32);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Stloc, valueLocal);
 
@@ -1142,32 +1295,404 @@ public partial class RuntimeEmitter
             il, runtime, "toFixed() digits argument must be between 0 and 100");
         il.MarkLabel(inRange);
 
-        // Values at or above 1e21 use ordinary Number::toString. Blt_Un also
-        // sends NaN to the BCL fixed formatter, which returns the JS spelling.
+        // Non-finite values and magnitudes at or above 1e21 use ordinary
+        // Number::toString. The remaining path works from the exact binary64
+        // significand, avoiding the BCL's ties-to-even fixed-point rounding.
+        var finite = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsFinite", [_types.Double])!);
+        il.Emit(OpCodes.Brtrue, finite);
+        il.Emit(OpCodes.Ldloc, valueLocal);
+        il.Emit(OpCodes.Call, runtime.FormatNumber);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(finite);
+
         var fixedNotation = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, valueLocal);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Abs", [_types.Double])!);
         il.Emit(OpCodes.Ldc_R8, 1e21);
-        il.Emit(OpCodes.Blt_Un, fixedNotation);
+        il.Emit(OpCodes.Blt, fixedNotation);
         il.Emit(OpCodes.Ldloc, valueLocal);
         il.Emit(OpCodes.Call, runtime.FormatNumber);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(fixedNotation);
+
+        // Preserve the sign for negative non-zero inputs even when rounding
+        // produces zero. Negative zero itself compares non-negative in JS.
         il.Emit(OpCodes.Ldloc, valueLocal);
         il.Emit(OpCodes.Ldc_R8, 0.0);
-        var nonZero = il.DefineLabel();
-        il.Emit(OpCodes.Bne_Un, nonZero);
-        il.Emit(OpCodes.Ldc_R8, 0.0);
-        il.Emit(OpCodes.Stloc, valueLocal);
-        il.MarkLabel(nonZero);
+        il.Emit(OpCodes.Clt);
+        il.Emit(OpCodes.Stloc, negativeLocal);
 
-        il.Emit(OpCodes.Ldloca, valueLocal);
-        il.Emit(OpCodes.Ldarg_2);
-        il.Emit(OpCodes.Call, typeof(CultureInfo).GetProperty("InvariantCulture")!.GetGetMethod()!);
+        il.Emit(OpCodes.Ldloc, valueLocal);
         il.Emit(OpCodes.Call, _types.GetMethod(
-            _types.Double, "ToString", [_types.String, typeof(IFormatProvider)])!);
+            typeof(BitConverter), "DoubleToInt64Bits", [_types.Double])!);
+        il.Emit(OpCodes.Ldc_I8, long.MaxValue);
+        il.Emit(OpCodes.And);
+        il.Emit(OpCodes.Stloc, bitsLocal);
+
+        il.Emit(OpCodes.Ldloc, bitsLocal);
+        il.Emit(OpCodes.Ldc_I8, 0x000f_ffff_ffff_ffffL);
+        il.Emit(OpCodes.And);
+        il.Emit(OpCodes.Stloc, fractionLocal);
+        il.Emit(OpCodes.Ldloc, bitsLocal);
+        il.Emit(OpCodes.Ldc_I4, 52);
+        il.Emit(OpCodes.Shr_Un);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Stloc, rawExponentLocal);
+
+        var normal = il.DefineLabel();
+        var decompositionReady = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, rawExponentLocal);
+        il.Emit(OpCodes.Brtrue, normal);
+        il.Emit(OpCodes.Ldloc, fractionLocal);
+        il.Emit(OpCodes.Stloc, significandLocal);
+        il.Emit(OpCodes.Ldc_I4, -1074);
+        il.Emit(OpCodes.Stloc, binaryExponentLocal);
+        il.Emit(OpCodes.Br, decompositionReady);
+        il.MarkLabel(normal);
+        il.Emit(OpCodes.Ldloc, fractionLocal);
+        il.Emit(OpCodes.Ldc_I8, 0x0010_0000_0000_0000L);
+        il.Emit(OpCodes.Or);
+        il.Emit(OpCodes.Stloc, significandLocal);
+        il.Emit(OpCodes.Ldloc, rawExponentLocal);
+        il.Emit(OpCodes.Ldc_I4, 1023 + 52);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Stloc, binaryExponentLocal);
+        il.MarkLabel(decompositionReady);
+
+        // Try the allocation-free UInt64 scaling path. Inputs that cannot fit
+        // exactly fall through to the BigInteger implementation below.
+        il.Emit(OpCodes.Ldloc, significandLocal);
+        il.Emit(OpCodes.Stloc, numeratorLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, scaleIndexLocal);
+        var scaleCheck = il.DefineLabel();
+        var scaleBody = il.DefineLabel();
+        var scaleReady = il.DefineLabel();
+        var fallback = il.DefineLabel();
+        il.Emit(OpCodes.Br, scaleCheck);
+        il.MarkLabel(scaleBody);
+        il.Emit(OpCodes.Ldloc, numeratorLocal);
+        il.Emit(OpCodes.Ldc_I8, 3_689_348_814_741_910_323L); // UInt64.MaxValue / 5
+        il.Emit(OpCodes.Bgt_Un, fallback);
+        il.Emit(OpCodes.Ldloc, numeratorLocal);
+        il.Emit(OpCodes.Ldc_I4_5);
+        il.Emit(OpCodes.Conv_U8);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Stloc, numeratorLocal);
+        il.Emit(OpCodes.Ldloc, scaleIndexLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, scaleIndexLocal);
+        il.MarkLabel(scaleCheck);
+        il.Emit(OpCodes.Ldloc, scaleIndexLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Blt, scaleBody);
+        il.MarkLabel(scaleReady);
+
+        il.Emit(OpCodes.Ldloc, binaryExponentLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, shiftLocal);
+
+        var negativeShift = il.DefineLabel();
+        var formatScaled = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, shiftLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Blt, negativeShift);
+        il.Emit(OpCodes.Ldloc, shiftLocal);
+        il.Emit(OpCodes.Ldc_I4, 64);
+        il.Emit(OpCodes.Bge, fallback);
+        il.Emit(OpCodes.Ldloc, numeratorLocal);
+        il.Emit(OpCodes.Ldc_I8, -1L);
+        il.Emit(OpCodes.Ldloc, shiftLocal);
+        il.Emit(OpCodes.Shr_Un);
+        il.Emit(OpCodes.Bgt_Un, fallback);
+        il.Emit(OpCodes.Ldloc, numeratorLocal);
+        il.Emit(OpCodes.Ldloc, shiftLocal);
+        il.Emit(OpCodes.Shl);
+        il.Emit(OpCodes.Stloc, scaledLocal);
+        il.Emit(OpCodes.Br, formatScaled);
+
+        il.MarkLabel(negativeShift);
+        il.Emit(OpCodes.Ldloc, shiftLocal);
+        il.Emit(OpCodes.Neg);
+        il.Emit(OpCodes.Stloc, rightShiftLocal);
+        var shiftAtMost64 = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, rightShiftLocal);
+        il.Emit(OpCodes.Ldc_I4, 64);
+        il.Emit(OpCodes.Ble, shiftAtMost64);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Conv_U8);
+        il.Emit(OpCodes.Stloc, scaledLocal);
+        il.Emit(OpCodes.Br, formatScaled);
+
+        il.MarkLabel(shiftAtMost64);
+        var shiftBelow64 = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, rightShiftLocal);
+        il.Emit(OpCodes.Ldc_I4, 64);
+        il.Emit(OpCodes.Blt, shiftBelow64);
+        var roundOneAt64 = il.DefineLabel();
+        var roundedAt64 = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, numeratorLocal);
+        il.Emit(OpCodes.Ldc_I8, long.MinValue);
+        il.Emit(OpCodes.Bge_Un, roundOneAt64);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Conv_U8);
+        il.Emit(OpCodes.Br, roundedAt64);
+        il.MarkLabel(roundOneAt64);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Conv_U8);
+        il.MarkLabel(roundedAt64);
+        il.Emit(OpCodes.Stloc, scaledLocal);
+        il.Emit(OpCodes.Br, formatScaled);
+
+        il.MarkLabel(shiftBelow64);
+        il.Emit(OpCodes.Ldloc, numeratorLocal);
+        il.Emit(OpCodes.Ldloc, rightShiftLocal);
+        il.Emit(OpCodes.Shr_Un);
+        il.Emit(OpCodes.Stloc, quotientLocal);
+        il.Emit(OpCodes.Ldloc, quotientLocal);
+        il.Emit(OpCodes.Stloc, scaledLocal);
+
+        // remainder >= 2^(rightShift - 1) rounds upward, including exact ties.
+        il.Emit(OpCodes.Ldloc, numeratorLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Conv_U8);
+        il.Emit(OpCodes.Ldloc, rightShiftLocal);
+        il.Emit(OpCodes.Shl);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Conv_U8);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.And);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Conv_U8);
+        il.Emit(OpCodes.Ldloc, rightShiftLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Shl);
+        var noRound = il.DefineLabel();
+        il.Emit(OpCodes.Blt_Un, noRound);
+        il.Emit(OpCodes.Ldloc, scaledLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Conv_U8);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, scaledLocal);
+        il.MarkLabel(noRound);
+
+        il.MarkLabel(formatScaled);
+        il.Emit(OpCodes.Ldloc, scaledLocal);
+        il.Emit(OpCodes.Stloc, remainingLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, digitCountLocal);
+        var digitLoop = il.DefineLabel();
+        var digitsReady = il.DefineLabel();
+        il.MarkLabel(digitLoop);
+        il.Emit(OpCodes.Ldloc, remainingLocal);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)10);
+        il.Emit(OpCodes.Conv_U8);
+        il.Emit(OpCodes.Blt_Un, digitsReady);
+        il.Emit(OpCodes.Ldloc, remainingLocal);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)10);
+        il.Emit(OpCodes.Conv_U8);
+        il.Emit(OpCodes.Div_Un);
+        il.Emit(OpCodes.Stloc, remainingLocal);
+        il.Emit(OpCodes.Ldloc, digitCountLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, digitCountLocal);
+        il.Emit(OpCodes.Br, digitLoop);
+        il.MarkLabel(digitsReady);
+
+        il.Emit(OpCodes.Ldloc, digitCountLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Stloc, wholeDigitsLocal);
+        var wholeReady = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, wholeDigitsLocal);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Bge, wholeReady);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, wholeDigitsLocal);
+        il.MarkLabel(wholeReady);
+
+        il.Emit(OpCodes.Ldloc, wholeDigitsLocal);
+        il.Emit(OpCodes.Ldloc, negativeLocal);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, lengthLocal);
+        var lengthReady = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Brfalse, lengthReady);
+        il.Emit(OpCodes.Ldloc, lengthLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, lengthLocal);
+        il.MarkLabel(lengthReady);
+
+        Type stateType = typeof(ValueTuple<ulong, int, bool>);
+        ConstructorInfo stateConstructor = stateType.GetConstructor(
+            [typeof(ulong), typeof(int), typeof(bool)])!;
+        MethodInfo stringCreateDefinition = typeof(string).GetMethods(
+                BindingFlags.Public | BindingFlags.Static)
+            .Single(candidate => candidate.Name == "Create"
+                && candidate.IsGenericMethodDefinition
+                && candidate.GetParameters().Length == 3
+                && candidate.GetParameters()[2].ParameterType.IsGenericType
+                && candidate.GetParameters()[2].ParameterType.GetGenericTypeDefinition()
+                    == typeof(SpanAction<,>));
+        MethodInfo stringCreate = EmitGenerics.MakeGenericMethod(
+            stringCreateDefinition, stateType);
+        il.Emit(OpCodes.Ldloc, lengthLocal);
+        il.Emit(OpCodes.Ldloc, scaledLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, negativeLocal);
+        il.Emit(OpCodes.Newobj, stateConstructor);
+        il.Emit(OpCodes.Ldsfld, runtime.NumberFixedUInt64FormatterField);
+        il.Emit(OpCodes.Call, stringCreate);
         il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(fallback);
+        il.Emit(OpCodes.Ldloc, significandLocal);
+        il.Emit(OpCodes.Ldloc, binaryExponentLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, negativeLocal);
+        il.Emit(OpCodes.Call, bigIntegerFallback);
+        il.Emit(OpCodes.Ret);
+    }
+
+    private MethodBuilder EmitNumberToFixedBigInteger(TypeBuilder typeBuilder)
+    {
+        Type bi = _types.BigInteger;
+        var method = typeBuilder.DefineMethod(
+            "NumberToFixedBigInteger",
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.String,
+            [_types.UInt64, _types.Int32, _types.Int32, _types.Boolean]);
+
+        MethodInfo multiply = _types.GetMethod(bi, "op_Multiply", bi, bi);
+        MethodInfo leftShift = _types.GetMethod(bi, "op_LeftShift", bi, _types.Int32);
+        MethodInfo add = _types.GetMethod(bi, "op_Addition", bi, bi);
+        MethodInfo greaterOrEqual = _types.GetMethod(
+            bi, "op_GreaterThanOrEqual", bi, bi);
+        MethodInfo divRem = _types.TryGetMethod(
+            bi, "DivRem", bi, bi, bi.MakeByRefType())
+            ?? throw new InvalidOperationException("BigInteger.DivRem overload not found.");
+
+        var il = method.GetILGenerator();
+        var numerator = il.DeclareLocal(bi);
+        var scaled = il.DeclareLocal(bi);
+        var divisor = il.DeclareLocal(bi);
+        var remainder = il.DeclareLocal(bi);
+        var shift = il.DeclareLocal(_types.Int32);
+        var integer = il.DeclareLocal(_types.String);
+        var fixedPoint = il.DeclareLocal(_types.String);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(bi, _types.UInt64));
+        il.Emit(OpCodes.Ldc_I4_5);
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(bi, _types.Int32));
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Call, _types.GetMethod(bi, "Pow", bi, _types.Int32));
+        il.Emit(OpCodes.Call, multiply);
+        il.Emit(OpCodes.Stloc, numerator);
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, shift);
+        var rightShift = il.DefineLabel();
+        var scaledReady = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, shift);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Blt, rightShift);
+        il.Emit(OpCodes.Ldloc, numerator);
+        il.Emit(OpCodes.Ldloc, shift);
+        il.Emit(OpCodes.Call, leftShift);
+        il.Emit(OpCodes.Stloc, scaled);
+        il.Emit(OpCodes.Br, scaledReady);
+
+        il.MarkLabel(rightShift);
+        il.Emit(OpCodes.Call, _types.GetMethod(bi, "get_One"));
+        il.Emit(OpCodes.Ldloc, shift);
+        il.Emit(OpCodes.Neg);
+        il.Emit(OpCodes.Call, leftShift);
+        il.Emit(OpCodes.Stloc, divisor);
+        il.Emit(OpCodes.Ldloc, numerator);
+        il.Emit(OpCodes.Ldloc, divisor);
+        il.Emit(OpCodes.Ldloca, remainder);
+        il.Emit(OpCodes.Call, divRem);
+        il.Emit(OpCodes.Stloc, scaled);
+        il.Emit(OpCodes.Ldloc, remainder);
+        il.Emit(OpCodes.Ldloc, remainder);
+        il.Emit(OpCodes.Call, add);
+        il.Emit(OpCodes.Ldloc, divisor);
+        var noRound = il.DefineLabel();
+        il.Emit(OpCodes.Call, greaterOrEqual);
+        il.Emit(OpCodes.Brfalse, noRound);
+        il.Emit(OpCodes.Ldloc, scaled);
+        il.Emit(OpCodes.Call, _types.GetMethod(bi, "get_One"));
+        il.Emit(OpCodes.Call, add);
+        il.Emit(OpCodes.Stloc, scaled);
+        il.MarkLabel(noRound);
+        il.MarkLabel(scaledReady);
+
+        il.Emit(OpCodes.Ldloca, scaled);
+        il.Emit(OpCodes.Call, typeof(CultureInfo).GetProperty(
+            "InvariantCulture")!.GetGetMethod()!);
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            bi, "ToString", typeof(IFormatProvider)));
+        il.Emit(OpCodes.Stloc, integer);
+
+        var hasFraction = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Brtrue, hasFraction);
+        var unsignedInteger = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_3);
+        il.Emit(OpCodes.Brfalse, unsignedInteger);
+        il.Emit(OpCodes.Ldstr, "-");
+        il.Emit(OpCodes.Ldloc, integer);
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.String, "Concat", _types.String, _types.String));
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(unsignedInteger);
+        il.Emit(OpCodes.Ldloc, integer);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(hasFraction);
+        il.Emit(OpCodes.Ldloc, integer);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)'0');
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.String, "PadLeft", _types.Int32, _types.Char));
+        il.Emit(OpCodes.Stloc, integer);
+        il.Emit(OpCodes.Ldloc, integer);
+        il.Emit(OpCodes.Ldloc, integer);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "get_Length"));
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Ldstr, ".");
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.String, "Insert", _types.Int32, _types.String));
+        il.Emit(OpCodes.Stloc, fixedPoint);
+
+        var unsignedFixed = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_3);
+        il.Emit(OpCodes.Brfalse, unsignedFixed);
+        il.Emit(OpCodes.Ldstr, "-");
+        il.Emit(OpCodes.Ldloc, fixedPoint);
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.String, "Concat", _types.String, _types.String));
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(unsignedFixed);
+        il.Emit(OpCodes.Ldloc, fixedPoint);
+        il.Emit(OpCodes.Ret);
+        return method;
     }
 
     private void EmitNumberToFixed(TypeBuilder typeBuilder, EmittedRuntime runtime)
@@ -1259,39 +1784,12 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ble, notTooLargeLabel);
         GuestErrorEmitter.ThrowRangeError(il, runtime, "toFixed() digits argument must be between 0 and 100");
 
-        // return value.ToString($"F{digits}", CultureInfo.InvariantCulture).
-        // ECMA-262: -0 formatted as "0" (no sign) — strip via abs on zero.
+        // The typed formatter shares the exact rounding implementation with
+        // stable literal-digit calls after the observable coercion above.
         il.MarkLabel(notTooLargeLabel);
-
-        // ECMA-262 21.1.3.3 step 10: values at or above 10^21 use the
-        // ordinary Number::toString representation, irrespective of the
-        // requested fraction digit count. The fixed-point formatter below
-        // would otherwise produce "1000000000000000000000" instead of
-        // "1e+21".
-        var fixedNotationLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, valueLocal);
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Abs", [_types.Double])!);
-        il.Emit(OpCodes.Ldc_R8, 1e21);
-        il.Emit(OpCodes.Blt_Un, fixedNotationLabel);
-        il.Emit(OpCodes.Ldloc, valueLocal);
-        il.Emit(OpCodes.Call, runtime.FormatNumber);
-        il.Emit(OpCodes.Ret);
-
-        il.Emit(OpCodes.Ldloc, valueLocal);
-        il.Emit(OpCodes.Ldc_R8, 0.0);
-        var nonZeroFLabel = il.DefineLabel();
-        il.Emit(OpCodes.Bne_Un, nonZeroFLabel);
-        il.Emit(OpCodes.Ldc_R8, 0.0);
-        il.Emit(OpCodes.Stloc, valueLocal);
-        il.MarkLabel(nonZeroFLabel);
-        il.MarkLabel(fixedNotationLabel);
-        il.Emit(OpCodes.Ldloca, valueLocal);
-        il.Emit(OpCodes.Ldstr, "F");
         il.Emit(OpCodes.Ldloc, digitsLocal);
-        il.Emit(OpCodes.Box, _types.Int32);
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "Concat", [_types.String, _types.Object])!);
-        il.Emit(OpCodes.Call, typeof(CultureInfo).GetProperty("InvariantCulture")!.GetGetMethod()!);
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "ToString", [_types.String, typeof(IFormatProvider)])!);
+        il.Emit(OpCodes.Call, runtime.NumberToFixedDouble);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Reflection.Emit;
+using System.Buffers;
 using System.Runtime.CompilerServices;
 
 namespace SharpTS.Compilation;
@@ -504,6 +505,11 @@ public partial class RuntimeEmitter
         DefineRegExpPrototypePopulateShell(typeBuilder, runtime);
         DefinePromisePrototypePopulateShell(typeBuilder, runtime);
 
+        // The exact toFixed fast path writes straight into the result string.
+        // Predeclare its cached callback before emitting the type initializer so
+        // hot calls do not allocate a delegate alongside every result string.
+        DefineNumberFixedFormattingInfrastructure(typeBuilder, runtime);
+
         // Static constructor to initialize Random and symbol storage
         var cctorBuilder = typeBuilder.DefineConstructor(
             MethodAttributes.Static | MethodAttributes.Private | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
@@ -511,6 +517,15 @@ public partial class RuntimeEmitter
             Type.EmptyTypes
         );
         var cctorIL = cctorBuilder.GetILGenerator();
+
+        Type fixedStateType = typeof(ValueTuple<ulong, int, bool>);
+        Type fixedFormatterType = EmitGenerics.MakeGenericType(typeof(SpanAction<,>),
+            typeof(char), fixedStateType);
+        cctorIL.Emit(OpCodes.Ldnull);
+        cctorIL.Emit(OpCodes.Ldftn, runtime.NumberFixedUInt64FormatterCallback);
+        cctorIL.Emit(OpCodes.Newobj, _types.GetConstructor(
+            fixedFormatterType, _types.Object, typeof(IntPtr)));
+        cctorIL.Emit(OpCodes.Stsfld, runtime.NumberFixedUInt64FormatterField);
 
         // Initialize _random = new Random()
         cctorIL.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.Random));

--- a/src/SharpTS/Compilation/RuntimeTypes.NumberFixed.cs
+++ b/src/SharpTS/Compilation/RuntimeTypes.NumberFixed.cs
@@ -1,0 +1,156 @@
+using System.Globalization;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace SharpTS.Compilation;
+
+public static partial class RuntimeTypes
+{
+    /// <summary>
+    /// ECMA-262 Number.prototype.toFixed formatting. Unlike the BCL fixed-point
+    /// format, JavaScript resolves an exact halfway case toward the larger
+    /// decimal integer rather than toward the even integer. The standalone
+    /// emitted twin in RuntimeEmitter.Number.cs must stay algorithmically aligned.
+    /// </summary>
+    internal static string FormatNumberFixed(double value, int fractionDigits)
+    {
+        if (double.IsNaN(value)) return "NaN";
+        if (double.IsPositiveInfinity(value)) return "Infinity";
+        if (double.IsNegativeInfinity(value)) return "-Infinity";
+        if (Math.Abs(value) >= 1e21) return FormatNumber(value);
+
+        bool negative = value < 0;
+        ulong bits = (ulong)BitConverter.DoubleToInt64Bits(value) & 0x7fff_ffff_ffff_ffffUL;
+        ulong fraction = bits & 0x000f_ffff_ffff_ffffUL;
+        int rawExponent = (int)(bits >> 52);
+        ulong significand = rawExponent == 0
+            ? fraction
+            : fraction | 0x0010_0000_0000_0000UL;
+        int binaryExponent = rawExponent == 0 ? -1074 : rawExponent - 1023 - 52;
+
+        if (TryScaleToUInt64(significand, binaryExponent, fractionDigits, out ulong scaled))
+            return FormatScaledUInt64(scaled, fractionDigits, negative);
+
+        return FormatScaledBigInteger(
+            significand, binaryExponent, fractionDigits, negative);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool TryScaleToUInt64(
+        ulong significand,
+        int binaryExponent,
+        int fractionDigits,
+        out ulong scaled)
+    {
+        ulong numerator = significand;
+        for (int i = 0; i < fractionDigits; i++)
+        {
+            if (numerator > ulong.MaxValue / 5)
+            {
+                scaled = 0;
+                return false;
+            }
+            numerator *= 5;
+        }
+
+        int shift = binaryExponent + fractionDigits;
+        if (shift >= 0)
+        {
+            if (shift >= 64 || numerator > (ulong.MaxValue >> shift))
+            {
+                scaled = 0;
+                return false;
+            }
+            scaled = numerator << shift;
+            return true;
+        }
+
+        int rightShift = -shift;
+        if (rightShift > 64)
+        {
+            scaled = 0;
+            return true;
+        }
+        if (rightShift == 64)
+        {
+            scaled = numerator >= 0x8000_0000_0000_0000UL ? 1UL : 0UL;
+            return true;
+        }
+
+        ulong quotient = numerator >> rightShift;
+        ulong remainderMask = (1UL << rightShift) - 1;
+        ulong halfway = 1UL << (rightShift - 1);
+        scaled = quotient + ((numerator & remainderMask) >= halfway ? 1UL : 0UL);
+        return true;
+    }
+
+    private static string FormatScaledUInt64(
+        ulong scaled,
+        int fractionDigits,
+        bool negative)
+    {
+        int digitCount = 1;
+        for (ulong remaining = scaled; remaining >= 10; remaining /= 10)
+            digitCount++;
+
+        int wholeDigits = Math.Max(1, digitCount - fractionDigits);
+        int length = (negative ? 1 : 0) + wholeDigits
+            + (fractionDigits == 0 ? 0 : fractionDigits + 1);
+
+        return string.Create(
+            length,
+            (scaled, fractionDigits, negative),
+            static (span, state) =>
+            {
+                (ulong remaining, int digits, bool isNegative) = state;
+                int start = isNegative ? 1 : 0;
+                int decimalIndex = digits == 0 ? -1 : span.Length - digits - 1;
+                for (int i = span.Length - 1; i >= start; i--)
+                {
+                    if (i == decimalIndex)
+                    {
+                        span[i] = '.';
+                        continue;
+                    }
+
+                    span[i] = (char)('0' + remaining % 10);
+                    remaining /= 10;
+                }
+
+                if (isNegative)
+                    span[0] = '-';
+            });
+    }
+
+    private static string FormatScaledBigInteger(
+        ulong significand,
+        int binaryExponent,
+        int fractionDigits,
+        bool negative)
+    {
+        BigInteger numerator = new(significand);
+        numerator *= BigInteger.Pow(5, fractionDigits);
+
+        int shift = binaryExponent + fractionDigits;
+        BigInteger scaled;
+        if (shift >= 0)
+        {
+            scaled = numerator << shift;
+        }
+        else
+        {
+            BigInteger divisor = BigInteger.One << -shift;
+            scaled = BigInteger.DivRem(numerator, divisor, out BigInteger remainder);
+            if (remainder + remainder >= divisor)
+                scaled += BigInteger.One;
+        }
+
+        string integer = scaled.ToString(CultureInfo.InvariantCulture);
+        if (fractionDigits == 0)
+            return negative ? "-" + integer : integer;
+
+        integer = integer.PadLeft(fractionDigits + 1, '0');
+        string fixedPoint = integer.Insert(integer.Length - fractionDigits, ".");
+        return negative ? "-" + fixedPoint : fixedPoint;
+    }
+}

--- a/src/SharpTS/Runtime/BuiltIns/NumberBuiltIns.cs
+++ b/src/SharpTS/Runtime/BuiltIns/NumberBuiltIns.cs
@@ -171,15 +171,8 @@ public static class NumberBuiltIns
             throw new ThrowException(new SharpTSRangeError(
                 "toFixed() digits argument must be between 0 and 100"));
 
-        if (double.IsNaN(value)) return RuntimeValue.FromString("NaN");
-        if (double.IsPositiveInfinity(value)) return RuntimeValue.FromString("Infinity");
-        if (double.IsNegativeInfinity(value)) return RuntimeValue.FromString("-Infinity");
-        if (Math.Abs(value) >= 1e21)
-            return RuntimeValue.FromString(Compilation.RuntimeTypes.FormatNumber(value));
-        if (value == 0) value = 0; // ECMA-262 treats -0 as non-negative.
-
-        return RuntimeValue.FromString(value.ToString(
-            $"F{(int)digits}", CultureInfo.InvariantCulture));
+        return RuntimeValue.FromString(
+            Compilation.RuntimeTypes.FormatNumberFixed(value, (int)digits));
     }
 
     private static RuntimeValue ToPrecisionV2(

--- a/tests/SharpTS.Tests/CompilerTests/StableNumericStringConversionTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableNumericStringConversionTests.cs
@@ -43,6 +43,42 @@ public sealed class StableNumericStringConversionTests
         Assert.Equal(expected, TestHarness.Run(source, ExecutionMode.Compiled));
     }
 
+    [Theory, ModeData]
+    public void ToFixed_UsesJavaScriptExactRounding(ExecutionMode mode)
+    {
+        const string source = """
+            function dynamicFixed(value: number, digits: number): string {
+                return value.toFixed(digits);
+            }
+
+            console.log(
+                (0.125).toFixed(2),
+                (1.125).toFixed(2),
+                (2.5).toFixed(0),
+                (3.5).toFixed(0),
+                (-2.5).toFixed(0));
+            console.log(
+                (2.55).toFixed(1),
+                (1.005).toFixed(2),
+                (-0.001).toFixed(2),
+                (-0).toFixed(2));
+            console.log(dynamicFixed(0.1, 100));
+            console.log(dynamicFixed(5e-324, 100));
+            console.log(dynamicFixed(999999999999999900000, 2));
+            """;
+
+        const string expected =
+            "0.13 1.13 3 4 -3\n" +
+            "2.5 1.00 -0.00 0.00\n" +
+            "0.1000000000000000055511151231257827021181583404541015625" +
+                "000000000000000000000000000000000000000000000\n" +
+            "0.0000000000000000000000000000000000000000000000000000000" +
+                "000000000000000000000000000000000000000000000\n" +
+            "999999999999999868928.00\n";
+
+        Assert.Equal(expected, TestHarness.Run(source, mode));
+    }
+
     [Fact]
     public void StableTypedConversions_PassIlVerification()
     {
@@ -114,6 +150,29 @@ public sealed class StableNumericStringConversionTests
         Assert.Equal(1_234_500_000, result);
         Assert.True(allocated <= 256,
             $"Typed parseInt allocated {allocated:N0} bytes in the hot loop.");
+    }
+
+    [Fact]
+    public void TypedToFixedLoop_AllocatesOnlyResultStrings()
+    {
+        Assembly assembly = Compile("""
+            function render(value: number): string {
+                return value.toFixed(2);
+            }
+            """);
+        var render = FindFunction(assembly, "render")
+            .CreateDelegate<Func<double, object>>();
+
+        Assert.Equal("1.25", (string)render(1.25));
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        string result = "";
+        for (int i = 0; i < 100_000; i++)
+            result = (string)render(i * 0.125);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal("12499.88", result);
+        Assert.True(allocated <= 4_100_000,
+            $"Typed toFixed allocated {allocated:N0} bytes for 100,000 result strings.");
     }
 
     [Theory, ModeData]


### PR DESCRIPTION
Closes #1478. Parent: #1278.

## What changed

- Replaced both interpreter and standalone-compiled `toFixed` formatting with ECMAScript-exact binary64 scaling and round-half-up selection.
- Added an allocation-free `UInt64` scaling path for common values/digit counts and an exact `BigInteger` fallback for the full 0-100 digit domain.
- Cached the standalone span writer once and writes the common path directly into the single returned string allocation.
- Routed stable literal-digit calls through the new two-argument typed helper; dynamic digits retain observable coercion before sharing the exact formatter.
- Made the permanent cross-runtime workload content-sensitive and added midpoint, negative-zero, subnormal, 100-digit, large-value, IL, allocation, and BenchmarkDotNet coverage.

This fixes existing semantic errors such as `(0.125).toFixed(2)` producing `"0.12"` and `(2.5).toFixed(0)` producing `"2"` under the BCL ties-to-even formatter.

## Performance

Five alternated launches on the local Windows/WSL lab, pinned to merged baseline `d861d8f9` and Node 22.23.2:

| Platform | Input | Baseline | Candidate | Change | Node | Candidate / Node |
|---|---:|---:|---:|---:|---:|---:|
| Windows | 1,000 | 0.2717 ms | 0.1142 ms | **-60.2%** | 0.0987 ms | 1.12x |
| Windows | 10,000 | 0.9956 ms | 0.4722 ms | **-52.6%** | 1.0171 ms | 0.46x |
| Windows | 100,000 | 10.7576 ms | 4.8888 ms | **-55.2%** | 10.2247 ms | **0.47x** |
| WSL | 1,000 | 0.3335 ms | 0.1180 ms | **-64.0%** | 0.0490 ms | 2.38x |
| WSL | 10,000 | 1.1215 ms | 0.5523 ms | **-50.8%** | 0.4908 ms | 1.13x |
| WSL | 100,000 | 12.3480 ms | 5.4924 ms | **-53.8%** | 5.0795 ms | **1.10x** |

All neighboring assignment, rest, generator, and parse controls were neutral. The measured implementation commit was followed only by Native-AOT-safe reflection-seam routing; emitted formatter IL is unchanged in the final commit.

## Validation

- WSL full local gate: **17,317/17,317** core tests and **106/106** GUI conformance tests passed.
- Full solution build, IL verification, cross-runtime/microbenchmark smoke compilation, conformance project builds, release/package helpers, and packaged SDK smoke passed.
- AOT/trim analyzer inventory remains at zero warnings.
- Linux x64 Native AOT publish and `samples/AotCompileGate/main.ts` execution passed.
- Windows targeted formatter tests: **15/15**; shared Number/wrapper tests: **122/122**.
- Windows checkpoint built the full solution and passed 756/759 compiler tests. The three failures were local process/TLS environment failures and reproduced identically on the frozen baseline: two expected standalone exceptions printed but the child processes did not exit before timeout, and the loopback TLS handshake failed.
- The common typed formatter allocation test verifies 100,000 calls stay within the returned-string allocation budget.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Number.prototype.toFixed()` to match JavaScript rounding behavior, including midpoint values, high precision, extreme magnitudes, negative zero, and special numeric values.
  * Improved performance and reduced unnecessary allocations when formatting numbers.

* **Tests**
  * Added coverage for exact rounding, edge cases, execution modes, and allocation behavior.
  * Added benchmarks comparing optimized formatting with standard fixed-point formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->