### PR TITLE
Promote closed numeric Maps to typed dictionaries

### DIFF
--- a/src/SharpTS/Compilation/CompilationContext.cs
+++ b/src/SharpTS/Compilation/CompilationContext.cs
@@ -384,6 +384,20 @@ public partial class CompilationContext
     }
 
     /// <summary>
+    /// Resolves a promoted numeric Map local. The concrete slot type is the
+    /// scope-correct source of truth, so same-named boxed Maps cannot enter the
+    /// direct typed-call path.
+    /// </summary>
+    public LocalBuilder? TryGetPromotedNumericMapLocal(string variableName)
+    {
+        if (!Locals.TryGetLocal(variableName, out var local))
+            return null;
+        return Locals.GetLocalType(variableName) == Types.DictionaryDoubleDouble
+            ? local
+            : null;
+    }
+
+    /// <summary>
     /// If <paramref name="variableName"/> currently binds to a promoted string-accumulator local
     /// (a slot whose CLR type is <c>StringBuilder</c>, declared by the #857 promotion path), returns its
     /// <see cref="LocalBuilder"/>; otherwise null. The slot's CLR type is the single source of truth, so

--- a/src/SharpTS/Compilation/CountedNumericMapSetLoopAnalyzer.cs
+++ b/src/SharpTS/Compilation/CountedNumericMapSetLoopAnalyzer.cs
@@ -1,0 +1,86 @@
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Recognizes a side-effect-free counted numeric Map fill:
+/// <code>for (let i = 0; i &lt; n; i++) map.set(pureKey, pureValue);</code>
+/// so promoted storage can reserve capacity once before the first iteration.
+/// </summary>
+internal static class CountedNumericMapSetLoopAnalyzer
+{
+    internal readonly record struct Reservation(
+        Expr.Variable Map,
+        Expr.Variable Bound);
+
+    internal static bool TryAnalyze(Stmt.For loop, out Reservation reservation)
+    {
+        reservation = default;
+        if (loop.Initializer is not Stmt.Var
+            {
+                Name.Lexeme: var counter,
+                Initializer: Expr.Literal { Value: double initial }
+            }
+            || initial != 0)
+        {
+            return false;
+        }
+
+        if (loop.Condition is not Expr.Binary
+            {
+                Left: Expr.Variable { Name.Lexeme: var conditionCounter },
+                Operator.Type: TokenType.LESS,
+                Right: Expr.Variable bound
+            }
+            || conditionCounter != counter)
+        {
+            return false;
+        }
+
+        if (loop.Increment is not Expr.PostfixIncrement
+            {
+                Operand: Expr.Variable { Name.Lexeme: var incrementCounter },
+                Operator.Type: TokenType.PLUS_PLUS
+            }
+            || incrementCounter != counter)
+        {
+            return false;
+        }
+
+        Stmt body = loop.Body is Stmt.Block { Statements.Count: 1 } block
+            ? block.Statements[0]
+            : loop.Body;
+        if (body is not Stmt.Expression
+            {
+                Expr: Expr.Call
+                {
+                    Optional: false,
+                    Callee: Expr.Get
+                    {
+                        Optional: false,
+                        Object: Expr.Variable map,
+                        Name.Lexeme: "set"
+                    },
+                    Arguments: [var key, var value]
+                }
+            }
+            || !IsPure(key)
+            || !IsPure(value))
+        {
+            return false;
+        }
+
+        reservation = new Reservation(map, bound);
+        return true;
+    }
+
+    private static bool IsPure(Expr expression) => expression switch
+    {
+        Expr.Literal => true,
+        Expr.Variable => true,
+        Expr.Grouping grouping => IsPure(grouping.Expression),
+        Expr.Unary unary => IsPure(unary.Right),
+        Expr.Binary binary => IsPure(binary.Left) && IsPure(binary.Right),
+        _ => false
+    };
+}

--- a/src/SharpTS/Compilation/Emitters/MapEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/MapEmitter.cs
@@ -17,6 +17,13 @@ public sealed class MapEmitter : ITypeEmitterStrategy
         var ctx = emitter.Context;
         var il = ctx.IL;
 
+        if (receiver is Expr.Variable variable
+            && ctx.TryGetPromotedNumericMapLocal(variable.Name.Lexeme) is { } numericMap)
+        {
+            return EmitNumericMapMethod(
+                emitter, numericMap, methodName, arguments);
+        }
+
         // Emit the Map object
         emitter.EmitExpression(receiver);
         emitter.EmitBoxIfNeeded(receiver);
@@ -76,6 +83,70 @@ public sealed class MapEmitter : ITypeEmitterStrategy
                 }
                 il.Emit(OpCodes.Call, ctx.Runtime!.MapForEach);
                 il.Emit(OpCodes.Ldsfld, ctx.Runtime!.UndefinedInstance);
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool EmitNumericMapMethod(
+        IEmitterContext emitter,
+        LocalBuilder map,
+        string methodName,
+        List<Expr> arguments)
+    {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+        Type mapType = ctx.Types.DictionaryDoubleDouble;
+
+        switch (methodName)
+        {
+            case "get" when arguments is [var key]:
+            {
+                var value = il.DeclareLocal(ctx.Types.Double);
+                var missing = il.DefineLabel();
+                var done = il.DefineLabel();
+                il.Emit(OpCodes.Ldloc, map);
+                emitter.EmitExpressionAsDouble(key);
+                il.Emit(OpCodes.Ldloca, value);
+                il.Emit(OpCodes.Callvirt, ctx.Types.GetMethod(
+                    mapType,
+                    "TryGetValue",
+                    ctx.Types.Double,
+                    ctx.Types.Double.MakeByRefType()));
+                il.Emit(OpCodes.Brfalse, missing);
+                il.Emit(OpCodes.Ldloc, value);
+                il.Emit(OpCodes.Box, ctx.Types.Double);
+                il.Emit(OpCodes.Br, done);
+                il.MarkLabel(missing);
+                il.Emit(OpCodes.Ldsfld, ctx.Runtime!.UndefinedInstance);
+                il.MarkLabel(done);
+                emitter.SetStackType(StackType.Unknown);
+                return true;
+            }
+
+            case "has" when arguments is [var key]:
+                il.Emit(OpCodes.Ldloc, map);
+                emitter.EmitExpressionAsDouble(key);
+                il.Emit(OpCodes.Callvirt, ctx.Types.GetMethod(
+                    mapType, "ContainsKey", ctx.Types.Double));
+                emitter.SetStackType(StackType.Boolean);
+                return true;
+
+            case "delete" when arguments is [var key]:
+                il.Emit(OpCodes.Ldloc, map);
+                emitter.EmitExpressionAsDouble(key);
+                il.Emit(OpCodes.Callvirt, ctx.Types.GetMethod(
+                    mapType, "Remove", ctx.Types.Double));
+                emitter.SetStackType(StackType.Boolean);
+                return true;
+
+            case "clear" when arguments.Count == 0:
+                il.Emit(OpCodes.Ldloc, map);
+                il.Emit(OpCodes.Callvirt, ctx.Types.GetMethodNoParams(mapType, "Clear"));
+                il.Emit(OpCodes.Ldsfld, ctx.Runtime!.UndefinedInstance);
+                emitter.SetStackType(StackType.Unknown);
                 return true;
 
             default:

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -653,6 +653,7 @@ public partial class ILCompiler
     {
         Phase2_AnalyzeClosures(statements);
         StableMapIterationAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
+        NumericMapLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         StablePrimitivePromiseThenAnalyzer.Analyze(
             statements, _typeMap, _closures.Analyzer);
         StablePrimitivePromiseAllAnalyzer.Analyze(

--- a/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -12,6 +12,35 @@ public partial class ILEmitter
 {
     protected override bool TryEmitDiscardedExpression(Expr expression)
     {
+        // Numeric Map.set returns its receiver in JavaScript, but promotion only
+        // admits statement-position calls. Emit Dictionary.set_Item directly and
+        // leave the evaluation stack empty instead of manufacturing a receiver
+        // value solely for the statement emitter to pop.
+        if (expression is Expr.Call
+            {
+                Optional: false,
+                Callee: Expr.Get
+                {
+                    Optional: false,
+                    Object: Expr.Variable receiver,
+                    Name.Lexeme: "set"
+                },
+                Arguments: [var key, var value]
+            }
+            && _ctx.TryGetPromotedNumericMapLocal(receiver.Name.Lexeme) is { } numericMap)
+        {
+            IL.Emit(OpCodes.Ldloc, numericMap);
+            EmitExpressionAsDouble(key);
+            EmitExpressionAsDouble(value);
+            IL.Emit(OpCodes.Callvirt, _ctx.Types.GetMethod(
+                _ctx.Types.DictionaryDoubleDouble,
+                "set_Item",
+                _ctx.Types.Double,
+                _ctx.Types.Double));
+            SetStackUnknown();
+            return true;
+        }
+
         // A statement-position numeric index assignment has no result consumer.
         // Own that narrow shape before the general expression emitter reloads
         // and boxes the assigned double solely for Stmt.Expression to pop it.

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -315,6 +315,20 @@ public partial class ILEmitter
             return;
         }
 
+        // Promoted numeric Map `.size` (#1482): keep Dictionary.Count as an
+        // unboxed TypeScript number. The registry property contract otherwise
+        // resets stack tracking to object because ordinary Map properties box.
+        if (!g.Optional && g.Name.Lexeme == "size" && g.Object is Expr.Variable mapSizeVar
+            && _ctx.TryGetPromotedNumericMapLocal(mapSizeVar.Name.Lexeme) is { } numericMap)
+        {
+            IL.Emit(OpCodes.Ldloc, numericMap);
+            IL.Emit(OpCodes.Callvirt, _ctx.Types.GetProperty(
+                _ctx.Types.DictionaryDoubleDouble, "Count").GetMethod!);
+            IL.Emit(OpCodes.Conv_R8);
+            SetStackType(StackType.Double);
+            return;
+        }
+
         // Try direct getter dispatch for known class instance types
         TypeInfo? objType = _ctx.TypeMap?.Get(g.Object);
         if (TryEmitDirectGetterCall(g.Object, objType, g.Name.Lexeme))

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -406,6 +406,24 @@ public partial class ILEmitter
             return;
         }
 
+        // Closed-lifetime numeric Map promotion (#1482). The analyzer admits
+        // only a fresh, empty Map<number, number> local with direct numeric
+        // set/get/has/delete/clear/size uses, so the slot can hold native doubles.
+        // EqualityComparer<double>.Default is explicit here: Double.Equals and
+        // Double.GetHashCode define NaN equality and signed-zero equivalence,
+        // matching SameValueZero for the admitted numeric key domain.
+        if (_ctx.TypeMap?.IsPromotableNumericMapLocal(v.Name) == true)
+        {
+            Type mapType = _ctx.Types.DictionaryDoubleDouble;
+            var mapLocal = _ctx.Locals.DeclareLocal(v.Name.Lexeme, mapType);
+            IL.Emit(OpCodes.Call, _ctx.Types.GetProperty(
+                _ctx.Types.EqualityComparerOfDouble, "Default").GetMethod!);
+            IL.Emit(OpCodes.Newobj, _ctx.Types.GetConstructor(
+                mapType, _ctx.Types.IEqualityComparerOfDouble));
+            IL.Emit(OpCodes.Stloc, mapLocal);
+            return;
+        }
+
         // Integer loop-counter prototype (#928): the analyzer-identified counter gets a native
         // Int64 slot initialized from its integer literal. Reads materialize a double (resolver),
         // the increment stays native int, and recognized index sites (a[i], a[i±k]) consume the
@@ -702,6 +720,7 @@ public partial class ILEmitter
             // evaluating any user expression early; unsupported runtime shapes
             // and unbounded/NaN counts simply retain normal List<T> growth.
             EmitCountedPushReservation(f);
+            EmitCountedNumericMapReservation(f);
 
             // Per-iteration reference cells (#650): for a loop binding that the body
             // both mutates and a closure captures, wrap its initial value in a fresh
@@ -823,6 +842,46 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Conv_I4);
         IL.Emit(OpCodes.Callvirt, _ctx.Types.GetMethod(
             listType,
+            "EnsureCapacity",
+            [_ctx.Types.Int32])!);
+        IL.Emit(OpCodes.Pop);
+
+        _ctx.ILBuilder.MarkLabel(skipLabel);
+        SetStackUnknown();
+    }
+
+    private void EmitCountedNumericMapReservation(Stmt.For loop)
+    {
+        if (!CountedNumericMapSetLoopAnalyzer.TryAnalyze(loop, out var reservation)
+            || _ctx.TryGetPromotedNumericMapLocal(reservation.Map.Name.Lexeme) is not { } mapLocal)
+        {
+            return;
+        }
+
+        var countLocal = IL.DeclareLocal(_ctx.Types.Double);
+        var skipLabel = _ctx.ILBuilder.DefineLabel("counted_numeric_map_reserve_skip");
+
+        SetStackUnknown();
+        EmitExpression(reservation.Bound);
+        EnsureDouble();
+        IL.Emit(OpCodes.Stloc, countLocal);
+
+        // Match the existing counted-array reservation boundary: reject NaN,
+        // infinities, negatives, and bounds above one million rather than
+        // changing allocation failure timing for unbounded guest input.
+        IL.Emit(OpCodes.Ldloc, countLocal);
+        IL.Emit(OpCodes.Ldc_R8, 0.0);
+        IL.Emit(OpCodes.Blt_Un, skipLabel);
+        IL.Emit(OpCodes.Ldloc, countLocal);
+        IL.Emit(OpCodes.Ldc_R8, 1_000_000.0);
+        IL.Emit(OpCodes.Bgt_Un, skipLabel);
+
+        IL.Emit(OpCodes.Ldloc, mapLocal);
+        IL.Emit(OpCodes.Ldloc, countLocal);
+        IL.Emit(OpCodes.Call, typeof(Math).GetMethod("Ceiling", [_ctx.Types.Double])!);
+        IL.Emit(OpCodes.Conv_I4);
+        IL.Emit(OpCodes.Callvirt, _ctx.Types.GetMethod(
+            _ctx.Types.DictionaryDoubleDouble,
             "EnsureCapacity",
             [_ctx.Types.Int32])!);
         IL.Emit(OpCodes.Pop);

--- a/src/SharpTS/Compilation/NumericMapLocalPromotionAnalyzer.cs
+++ b/src/SharpTS/Compilation/NumericMapLocalPromotionAnalyzer.cs
@@ -1,0 +1,226 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Proves the deliberately narrow local lifetime in which an exact
+/// <c>Map&lt;number, number&gt;</c> may use <c>Dictionary&lt;double, double&gt;</c>
+/// storage. Any bare receiver observation, escape, alias, iteration, dynamic
+/// member access, widening call, reassignment, capture, direct eval, or
+/// observable use of the intrinsic <c>Map</c> constructor disables promotion.
+/// </summary>
+internal static class NumericMapLocalPromotionAnalyzer
+{
+    public static void Analyze(List<Stmt> program, TypeMap? typeMap, ClosureAnalyzer? closures)
+    {
+        if (typeMap == null)
+            return;
+
+        var visitor = new Visitor(typeMap);
+        foreach (var statement in program)
+            visitor.Visit(statement);
+
+        if (visitor.ContainsDirectEval || visitor.IntrinsicMapIsObservable)
+            return;
+
+        foreach (var (key, nameToken) in visitor.Candidates)
+        {
+            if (key.Scope == 0
+                || visitor.Disqualified.Contains(key)
+                || visitor.DeclarationCounts.GetValueOrDefault(key) != 1
+                || closures?.IsVariableCaptured(key.Name) == true)
+            {
+                continue;
+            }
+
+            typeMap.MarkPromotableNumericMapLocal(nameToken);
+        }
+    }
+
+    private static bool IsNumber(TypeInfo? type) =>
+        type is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER }
+            or TypeInfo.NumberLiteral;
+
+    private static bool IsExactNumericMap(TypeInfo? type) =>
+        type is TypeInfo.Map map
+        && IsNumber(map.KeyType)
+        && IsNumber(map.ValueType);
+
+    private sealed class Visitor(TypeMap typeMap) : AstVisitorBase
+    {
+        private readonly TypeMap _typeMap = typeMap;
+        private Expr.Call? _discardedCall;
+        private int _scope;
+        private int _nextScope;
+
+        public Dictionary<(int Scope, string Name), Token> Candidates { get; } = [];
+        public Dictionary<(int Scope, string Name), int> DeclarationCounts { get; } = [];
+        public HashSet<(int Scope, string Name)> Disqualified { get; } = [];
+        public bool ContainsDirectEval { get; private set; }
+        public bool IntrinsicMapIsObservable { get; private set; }
+
+        protected override void VisitFunction(Stmt.Function statement) =>
+            InScope(() => base.VisitFunction(statement));
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression) =>
+            InScope(() => base.VisitArrowFunction(expression));
+
+        private void InScope(Action visit)
+        {
+            int saved = _scope;
+            _scope = ++_nextScope;
+            visit();
+            _scope = saved;
+        }
+
+        protected override void VisitVar(Stmt.Var statement) =>
+            HandleDeclaration(statement.Name, statement.Initializer);
+
+        protected override void VisitConst(Stmt.Const statement) =>
+            HandleDeclaration(statement.Name, statement.Initializer);
+
+        private void HandleDeclaration(Token name, Expr? initializer)
+        {
+            var key = (_scope, name.Lexeme);
+            DeclarationCounts[key] = DeclarationCounts.GetValueOrDefault(key) + 1;
+
+            if (initializer is Expr.New
+                {
+                    Callee: Expr.Variable { Name.Lexeme: "Map" },
+                    Arguments.Count: 0
+                }
+                && IsExactNumericMap(_typeMap.Get(initializer)))
+            {
+                Candidates.TryAdd(key, name);
+            }
+
+            if (initializer != null)
+                Visit(initializer);
+        }
+
+        protected override void VisitNew(Expr.New expression)
+        {
+            // Constructing the intrinsic does not expose it. Skip only the
+            // callee token; entry arguments still participate in escape proof.
+            if (expression.Callee is Expr.Variable { Name.Lexeme: "Map" })
+            {
+                foreach (var argument in expression.Arguments)
+                    Visit(argument);
+                return;
+            }
+
+            base.VisitNew(expression);
+        }
+
+        protected override void VisitExpression(Stmt.Expression statement)
+        {
+            Expr.Call? saved = _discardedCall;
+            _discardedCall = statement.Expr as Expr.Call;
+            try
+            {
+                Visit(statement.Expr);
+            }
+            finally
+            {
+                _discardedCall = saved;
+            }
+        }
+
+        protected override void VisitCall(Expr.Call expression)
+        {
+            if (!expression.Optional
+                && expression.Callee is Expr.Variable { Name.Lexeme: "eval" })
+            {
+                ContainsDirectEval = true;
+            }
+
+            if (!expression.Optional
+                && expression.Callee is Expr.Get
+                {
+                    Object: Expr.Variable receiver,
+                    Optional: false
+                } method
+                && IsExactNumericMap(_typeMap.Get(receiver))
+                && IsPermittedCall(expression, method.Name.Lexeme))
+            {
+                foreach (var argument in expression.Arguments)
+                    Visit(argument);
+                return;
+            }
+
+            base.VisitCall(expression);
+        }
+
+        private bool IsPermittedCall(Expr.Call call, string methodName) => methodName switch
+        {
+            "set" => ReferenceEquals(call, _discardedCall)
+                && call.Arguments is [var key, var value]
+                && IsNumber(_typeMap.Get(key))
+                && IsNumber(_typeMap.Get(value)),
+            "get" or "has" or "delete" => call.Arguments is [var key]
+                && IsNumber(_typeMap.Get(key)),
+            "clear" => call.Arguments.Count == 0,
+            _ => false
+        };
+
+        protected override void VisitGet(Expr.Get expression)
+        {
+            if (!expression.Optional
+                && expression.Name.Lexeme == "size"
+                && expression.Object is Expr.Variable receiver
+                && IsExactNumericMap(_typeMap.Get(receiver)))
+            {
+                return;
+            }
+
+            base.VisitGet(expression);
+        }
+
+        protected override void VisitVariable(Expr.Variable expression)
+        {
+            if (expression.Name.Lexeme == "Map")
+                IntrinsicMapIsObservable = true;
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+        }
+
+        protected override void VisitAssign(Expr.Assign expression)
+        {
+            if (expression.Name.Lexeme == "Map")
+                IntrinsicMapIsObservable = true;
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+            base.VisitAssign(expression);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
+        {
+            if (expression.Name.Lexeme == "Map")
+                IntrinsicMapIsObservable = true;
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+            base.VisitCompoundAssign(expression);
+        }
+
+        protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
+        {
+            if (expression.Name.Lexeme == "Map")
+                IntrinsicMapIsObservable = true;
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+            base.VisitLogicalAssign(expression);
+        }
+
+        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expression)
+        {
+            if (expression.Operand is Expr.Variable variable)
+                Disqualified.Add((_scope, variable.Name.Lexeme));
+            base.VisitPrefixIncrement(expression);
+        }
+
+        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expression)
+        {
+            if (expression.Operand is Expr.Variable variable)
+                Disqualified.Add((_scope, variable.Name.Lexeme));
+            base.VisitPostfixIncrement(expression);
+        }
+    }
+}

--- a/src/SharpTS/Compilation/RuntimeEmitter.Maps.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Maps.cs
@@ -259,12 +259,12 @@ public partial class RuntimeEmitter
         var dictType = _types.DictionaryObjectObject;
         var valueLocal = il.DeclareLocal(_types.Object);
 
-        var returnNullLabel = il.DefineLabel();
+        var returnUndefinedLabel = il.DefineLabel();
 
-        // if (map is not Dictionary<object, object?> dict) return null;
+        // if (map is not Dictionary<object, object?> dict) return undefined;
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, dictType);
-        il.Emit(OpCodes.Brfalse, returnNullLabel);
+        il.Emit(OpCodes.Brfalse, returnUndefinedLabel);
 
         // if (dict.TryGetValue(NormalizeMapKey(key), out var value)) return value;
         il.Emit(OpCodes.Ldarg_0);
@@ -273,14 +273,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.NormalizeMapKey);
         il.Emit(OpCodes.Ldloca, valueLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(dictType, "TryGetValue")!);
-        il.Emit(OpCodes.Brfalse, returnNullLabel);
+        il.Emit(OpCodes.Brfalse, returnUndefinedLabel);
 
         il.Emit(OpCodes.Ldloc, valueLocal);
         il.Emit(OpCodes.Ret);
 
-        // return null;
-        il.MarkLabel(returnNullLabel);
-        il.Emit(OpCodes.Ldnull);
+        // Missing Map keys produce JavaScript undefined, not null.
+        il.MarkLabel(returnUndefinedLabel);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/TypeProvider.cs
+++ b/src/SharpTS/Compilation/TypeProvider.cs
@@ -284,14 +284,18 @@ public class TypeProvider
     public Type ConcurrentQueueOpen => Resolve("System.Collections.Concurrent.ConcurrentQueue`1");
     public Type ConcurrentQueueOfObject => MakeGenericType(ConcurrentQueueOpen, Object);
     public Type IEqualityComparerOpen => Resolve("System.Collections.Generic.IEqualityComparer`1");
+    public Type EqualityComparerOpen => Resolve("System.Collections.Generic.EqualityComparer`1");
     public Type RuntimeHelpers => Resolve("System.Runtime.CompilerServices.RuntimeHelpers");
 
     public Type ListOfObject => MakeGenericType(ListOpen, Object);
     public Type ListOfObjectNullable => typeof(List<object?>);
     public Type IEqualityComparerOfObject => MakeGenericType(IEqualityComparerOpen, Object);
     public Type IEqualityComparerOfString => MakeGenericType(IEqualityComparerOpen, String);
+    public Type IEqualityComparerOfDouble => MakeGenericType(IEqualityComparerOpen, Double);
+    public Type EqualityComparerOfDouble => MakeGenericType(EqualityComparerOpen, Double);
     public Type StringComparer => Resolve("System.StringComparer");
     public Type DictionaryObjectObject => MakeGenericType(DictionaryOpen, Object, Object);
+    public Type DictionaryDoubleDouble => MakeGenericType(DictionaryOpen, Double, Double);
     public Type DictionaryStringObject => MakeGenericType(DictionaryOpen, String, Object);
     public Type IEnumerableOfObject => MakeGenericType(IEnumerableOpen, Object);
     public Type IEnumeratorOfObject => MakeGenericType(IEnumeratorOpen, Object);

--- a/src/SharpTS/Runtime/BuiltIns/MapBuiltIns.cs
+++ b/src/SharpTS/Runtime/BuiltIns/MapBuiltIns.cs
@@ -39,7 +39,12 @@ public static class MapBuiltIns
         => _lookup.GetMember(receiver, name);
 
     private static RuntimeValue GetV2(Interpreter _, SharpTSMap map, ReadOnlySpan<RuntimeValue> args)
-        => RuntimeValue.FromBoxed(map.Get(args[0].ToObject()));
+    {
+        object? key = args[0].ToObject();
+        return map.Has(key)
+            ? RuntimeValue.FromBoxed(map.Get(key))
+            : RuntimeValue.Undefined;
+    }
 
     private static RuntimeValue SetV2(Interpreter _, SharpTSMap map, ReadOnlySpan<RuntimeValue> args)
         => RuntimeValue.FromObject(map.Set(args[0].ToObject(), args[1].ToObject()));

--- a/src/SharpTS/TypeSystem/TypeMap.cs
+++ b/src/SharpTS/TypeSystem/TypeMap.cs
@@ -21,6 +21,7 @@ public class TypeMap
     private readonly HashSet<object> _undefinedReachableNumericLocals = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Stmt.Parameter> _undefinedReachableNumericParams = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<Token, TokenType> _promotableArrayLocals = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Token> _promotableNumericMapLocals = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Token> _promotableStringAccumulators = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<Token, ObjectShapeInfo> _promotableObjectLocals = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<Token, ClassScalarReplacementInfo> _scalarReplaceableClassLocals =
@@ -153,6 +154,19 @@ public class TypeMap
     /// </summary>
     public bool IsPromotableArrayLocal(Token nameToken, out TokenType elementToken) =>
         _promotableArrayLocals.TryGetValue(nameToken, out elementToken);
+
+    /// <summary>
+    /// Marks a fresh, exact, non-escaping <c>Map&lt;number, number&gt;</c> function local
+    /// whose complete lifetime is limited to direct numeric operations. The IL
+    /// compiler may represent it as <c>Dictionary&lt;double, double&gt;</c>. Keyed by
+    /// the declaration name token so a synthetic <see cref="Stmt.Var"/> emitted
+    /// for <see cref="Stmt.Const"/> retains the proof.
+    /// </summary>
+    public void MarkPromotableNumericMapLocal(Token nameToken) =>
+        _promotableNumericMapLocals.Add(nameToken);
+
+    public bool IsPromotableNumericMapLocal(Token nameToken) =>
+        _promotableNumericMapLocals.Contains(nameToken);
 
     /// <summary>
     /// Flags a <c>const</c>/<c>let</c> string local with a string-literal initializer that is provably

--- a/tests/SharpTS.Tests/CompilerTests/NumericMapPromotionTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/NumericMapPromotionTests.cs
@@ -1,0 +1,313 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class NumericMapPromotionTests
+{
+    [Fact]
+    public void ExactLocal_UsesTypedDictionaryAndDirectCallsWithoutNumericBoxing()
+    {
+        Assembly assembly = Compile(EligibleSource);
+        MethodInfo method = FindFunction(assembly, "exercise");
+        var instructions = ReadInstructions(method).ToArray();
+
+        Assert.Contains(method.GetMethodBody()!.LocalVariables, local =>
+            local.LocalType == typeof(Dictionary<double, double>));
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "set_Item" }
+            && IsDoubleDictionary(instruction.Operand.DeclaringType));
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "ContainsKey" }
+            && IsDoubleDictionary(instruction.Operand.DeclaringType));
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "Remove" }
+            && IsDoubleDictionary(instruction.Operand.DeclaringType));
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "Clear" }
+            && IsDoubleDictionary(instruction.Operand.DeclaringType));
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "get_Count" }
+            && IsDoubleDictionary(instruction.Operand.DeclaringType));
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.OpCode == OpCodes.Box && instruction.Operand == typeof(double));
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "MapSet" or "MapHas" or "MapDelete" or "MapClear" or "MapSize"
+            });
+    }
+
+    [Fact]
+    public void ExactLocal_PreservesResultAndVerifiesIl()
+    {
+        var diagnostics = TestHarness.CompileAndVerifyOnly(EligibleSource);
+        Assert.True(diagnostics.Count == 0, string.Join("\n", diagnostics));
+        Assert.Equal("3\n", TestHarness.RunCompiled(EligibleSource));
+        Assert.Equal("3\n", TestHarness.RunCompiledStandalone(EligibleSource));
+    }
+
+    [Fact]
+    public void CountedNumericFill_ReservesTypedDictionaryCapacityOnce()
+    {
+        Assembly assembly = Compile(CountedFillSource);
+        MethodInfo method = FindFunction(assembly, "fill");
+        var instructions = ReadInstructions(method).ToArray();
+
+        Assert.Single(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "EnsureCapacity" }
+            && IsDoubleDictionary(instruction.Operand.DeclaringType));
+        var diagnostics = TestHarness.CompileAndVerifyOnly(CountedFillSource);
+        Assert.True(diagnostics.Count == 0, string.Join("\n", diagnostics));
+        Assert.Equal("10000\n", TestHarness.RunCompiled(CountedFillSource));
+    }
+
+    [Theory]
+    [MemberData(nameof(BailoutSources))]
+    public void ObservableOrWidenedLifetime_RetainsObjectMap(string source)
+    {
+        Assembly assembly = Compile(source);
+        MethodInfo method = FindFunction(assembly, "read");
+        var instructions = ReadInstructions(method).ToArray();
+
+        Assert.DoesNotContain(method.GetMethodBody()!.LocalVariables, local =>
+            local.LocalType == typeof(Dictionary<double, double>));
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "MapSet" });
+    }
+
+    public static TheoryData<string> BailoutSources => new()
+    {
+        // Iteration observes insertion order and entry identity.
+        """
+        function read(): number {
+            const map = new Map<number, number>();
+            map.set(1, 2);
+            let sum: number = 0;
+            for (const entry of map) sum = sum + entry[0] + entry[1];
+            return sum;
+        }
+        """,
+        // forEach observes order, callback arguments, and receiver identity.
+        """
+        function read(): number {
+            const map = new Map<number, number>();
+            map.set(1, 2);
+            let sum: number = 0;
+            map.forEach((value: number): void => { sum = sum + value; });
+            return sum;
+        }
+        """,
+        // Constructor entry iterables are outside the empty-intrinsic proof.
+        """
+        function read(): number {
+            const map = new Map<number, number>([[1, 2]]);
+            map.set(2, 3);
+            return map.size;
+        }
+        """,
+        // Identity observations require the ordinary JavaScript object.
+        """
+        function read(): number {
+            const map = new Map<number, number>();
+            map.set(1, 2);
+            return map === map ? 1 : 0;
+        }
+        """,
+        // A direct alias escapes the specialized slot.
+        """
+        function read(): number {
+            const map = new Map<number, number>();
+            map.set(1, 2);
+            const alias: Map<number, number> = map;
+            return alias.size;
+        }
+        """,
+        // The result of set is the receiver and therefore an alias.
+        """
+        function read(): number {
+            const map = new Map<number, number>();
+            const alias: Map<number, number> = map.set(1, 2);
+            return alias.size;
+        }
+        """,
+        // Captures require an object-valued display-class field.
+        """
+        function read(): number {
+            const map = new Map<number, number>();
+            map.set(1, 2);
+            const size = (): number => map.size;
+            return size();
+        }
+        """,
+        // Returning the Map exposes its representation and identity.
+        """
+        function read(): any {
+            const map = new Map<number, number>();
+            map.set(1, 2);
+            return map;
+        }
+        """,
+        // Unknown calls may retain or mutate the Map.
+        """
+        function consume(value: any): void {}
+        function read(): number {
+            const map = new Map<number, number>();
+            map.set(1, 2);
+            consume(map);
+            return map.size;
+        }
+        """,
+        // Computed method extraction can observe a replaced member and receiver.
+        """
+        function read(): number {
+            const map = new Map<number, number>();
+            map.set(1, 2);
+            const get: any = (map as any)["get"];
+            return get.call(map, 1);
+        }
+        """,
+        // Intrinsic prototype mutation invalidates direct method dispatch globally.
+        """
+        function read(): number {
+            const map = new Map<number, number>();
+            const proto: any = Map.prototype;
+            proto.set = null;
+            map.set(1, 2);
+            return map.size;
+        }
+        """,
+        // A widened key can carry non-number JavaScript values.
+        """
+        function read(): number {
+            const map = new Map<number, number>();
+            const key: any = 1;
+            map.set(key, 2);
+            return map.size;
+        }
+        """,
+        // A widened value cannot be stored in a native double slot.
+        """
+        function read(): number {
+            const map = new Map<number, number>();
+            const value: any = 2;
+            map.set(1, value);
+            return map.size;
+        }
+        """,
+        // Direct eval can obtain and mutate bindings or intrinsic prototypes.
+        """
+        function read(): number {
+            const map = new Map<number, number>();
+            map.set(1, 2);
+            eval("void 0");
+            return map.size;
+        }
+        """
+    };
+
+    private const string EligibleSource = """
+        function exercise(n: number): number {
+            const map = new Map<number, number>();
+            map.set(0, n);
+            let score: number = 0;
+            if (map.has(0)) score = score + 1;
+            if (map.delete(0)) score = score + 1;
+            map.set(2, 3);
+            score = score + map.size;
+            map.clear();
+            return score + map.size;
+        }
+        console.log(exercise(7));
+        """;
+
+    private const string CountedFillSource = """
+        function fill(n: number): number {
+            const map = new Map<number, number>();
+            for (let i: number = 0; i < n; i++) {
+                map.set(i, i * 3 + 1);
+            }
+            return map.size;
+        }
+        console.log(fill(10000));
+        """;
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"issue_1482_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static bool IsDoubleDictionary(Type? type) =>
+        type?.IsGenericType == true
+        && type.GetGenericTypeDefinition() == typeof(Dictionary<,>)
+        && type.GetGenericArguments() is [var key, var value]
+        && key == typeof(double)
+        && value == typeof(double);
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token)
+                    : module.ResolveType(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}

--- a/tests/SharpTS.Tests/SharedTests/NumericMapPromotionSemanticsTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/NumericMapPromotionSemanticsTests.cs
@@ -1,0 +1,71 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+public sealed class NumericMapPromotionSemanticsTests
+{
+    [Theory, ModeData]
+    public void NumericMapOperations_PreserveSameValueZeroAndMissingGet(ExecutionMode mode)
+    {
+        const string source = """
+            function run(): void {
+                const map = new Map<number, number>();
+                const nan: number = 0 / 0;
+
+                map.set(nan, 1);
+                map.set(nan, 2);
+                console.log(map.get(nan));
+                console.log(map.has(nan));
+                console.log(map.size);
+
+                map.set(-0, 3);
+                map.set(+0, 4);
+                console.log(map.get(-0));
+                console.log(map.size);
+
+                map.set(1, 10);
+                map.set(2, 20);
+                map.set(1, 11);
+                console.log(map.size);
+                console.log(map.get(1));
+
+                console.log(map.delete(1));
+                console.log(map.size);
+                map.set(1, 12);
+                console.log(map.get(1));
+                console.log(map.get(999) === undefined);
+
+                map.clear();
+                console.log(map.size);
+            }
+            run();
+            """;
+
+        Assert.Equal(
+            "2\ntrue\n1\n4\n2\n4\n11\ntrue\n3\n12\ntrue\n0\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void RepeatedSetAndDeleteReinsert_PreserveOrderValueAndSize(ExecutionMode mode)
+    {
+        const string source = """
+            function order(): string {
+                const map = new Map<number, number>();
+                map.set(1, 10);
+                map.set(2, 20);
+                map.set(1, 11);
+                let before: string = "";
+                for (const entry of map) before = before + entry[0];
+
+                map.delete(1);
+                map.set(1, 12);
+                return before + ":" + map.size + ":" + map.get(1);
+            }
+            console.log(order());
+            """;
+
+        Assert.Equal("12:2:12\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
## Summary

- conservatively promote fresh, exact, non-escaping function-local Map<number, number> instances to Dictionary<double, double>
- emit direct typed set/get/has/delete/clear/size operations and reserve capacity for proven counted fill loops
- preserve SameValueZero behavior, return undefined for missing Map.get calls, and bail out for observable or widened lifetimes
- add IL, dual-mode semantic, capacity, and bailout coverage

## Performance

At N=10,000:

- Windows BenchmarkDotNet: 1,516.1 us / 2,326.35 KB to 360.5 us / 979.56 KB (76.2% faster, 57.9% less allocation)
- Windows cross-runtime median: 1.0116 ms to 0.3403 ms (66.4% faster)
- WSL Ubuntu cross-runtime median: 0.9163 ms to 0.3935 ms (57.1% faster)
- Map iteration and Set operation/iteration controls remained neutral or improved on both hosts

## Validation

- Windows core suite: 17,335 passed, 3 skipped, 0 failed
- WSL Ubuntu 26.04 core suite: 17,338 passed, 0 failed
- 21 focused promotion/IL/bailout tests passed
- emitted IL verification passed
- AOT/trim/single-file analyzer ratchet: zero warnings, baseline matched
- linux-x64 Native AOT publish and execution passed (AotCompileGate output: 42)
- performance harness smoke tests and diff checks passed

Closes #1482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved performance for eligible numeric maps by using optimized storage and direct operations.
  * Added capacity reservation for supported counted loops that populate numeric maps.

* **Bug Fixes**
  * Missing map keys now consistently return `undefined`.
  * Preserved numeric map behavior for `NaN`, signed zero, deletion, reinsertion, ordering, and size tracking.

* **Compatibility**
  * Maps automatically retain standard behavior when usage includes unsupported or observable patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->