### PR TITLE
Fix scoped child process cleanup

### DIFF
--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -2357,6 +2357,12 @@ public class EmittedRuntime
     public MethodBuilder ChildProcessExecFileSync { get; set; } = null!;
     public MethodBuilder ChildProcessExecFile { get; set; } = null!;
     public MethodBuilder ChildProcessFork { get; set; } = null!;
+    public FieldBuilder ChildProcessOwnedProcessesField { get; set; } = null!;
+    public FieldBuilder ChildProcessOwnershipStoppingField { get; set; } = null!;
+    public MethodBuilder ChildProcessRegisterOwned { get; set; } = null!;
+    public MethodBuilder ChildProcessUnregisterOwned { get; set; } = null!;
+    public MethodBuilder ChildProcessReleaseOwned { get; set; } = null!;
+    public MethodBuilder ChildProcessTerminateOwned { get; set; } = null!;
 
     // Querystring module methods
 

--- a/src/SharpTS/Compilation/ILCompiler.Functions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Functions.cs
@@ -1215,6 +1215,12 @@ public partial class ILCompiler
             System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!);
     }
 
+    private void EmitTerminateOwnedChildProcesses(ILGenerator il)
+    {
+        if (_runtime.ChildProcessTerminateOwned is not null)
+            il.Emit(OpCodes.Call, _runtime.ChildProcessTerminateOwned);
+    }
+
     /// <summary>
     /// Emits the default entry point where top-level statements run as the program.
     /// Used for DLL target or EXE without user-defined main().
@@ -1232,6 +1238,8 @@ public partial class ILCompiler
 
         var il = mainMethod.GetILGenerator();
         EmitInstallEventLoopSyncContext(il);
+        var returnLabel = il.DefineLabel();
+        il.BeginExceptionBlock();
 
         if (_hosted)
         {
@@ -1252,7 +1260,12 @@ public partial class ILCompiler
         // Node process lifecycle at natural drain: 'beforeExit' (re-entering
         // the loop when a listener schedules work), then 'exit' (#1080).
         il.Emit(OpCodes.Call, _runtime.ProcessRunLifecycle);
-
+        il.Emit(OpCodes.Leave, returnLabel);
+        il.BeginFinallyBlock();
+        EmitTerminateOwnedChildProcesses(il);
+        il.Emit(OpCodes.Endfinally);
+        il.EndExceptionBlock();
+        il.MarkLabel(returnLabel);
         il.Emit(OpCodes.Ret);
     }
 
@@ -1412,6 +1425,8 @@ public partial class ILCompiler
 
         var il = mainMethod.GetILGenerator();
         EmitInstallEventLoopSyncContext(il);
+        var returnLabel = il.DefineLabel();
+        il.BeginExceptionBlock();
         var ctx = CreateEntryPointTopLevelContext(il, mainMethod);
 
         // Create entry-point display class instance if there are captured top-level variables
@@ -1550,6 +1565,7 @@ public partial class ILCompiler
                 // Unbox double, convert to int, call Environment.Exit
                 il.Emit(OpCodes.Unbox_Any, _types.Double);
                 il.Emit(OpCodes.Conv_I4);
+                EmitTerminateOwnedChildProcesses(il);
                 il.Emit(OpCodes.Call, _types.GetMethod(_types.Environment, "Exit", _types.Int32));
             }
             else
@@ -1563,7 +1579,7 @@ public partial class ILCompiler
             // Node process lifecycle at natural drain: 'beforeExit' (re-entering
             // the loop when a listener schedules work), then 'exit' (#1080).
             il.Emit(OpCodes.Call, _runtime.ProcessRunLifecycle);
-            il.Emit(OpCodes.Ret);
+            il.Emit(OpCodes.Leave, returnLabel);
         }
         else
         {
@@ -1572,6 +1588,7 @@ public partial class ILCompiler
                 // Unbox double, convert to int, call Environment.Exit
                 il.Emit(OpCodes.Unbox_Any, _types.Double);
                 il.Emit(OpCodes.Conv_I4);
+                EmitTerminateOwnedChildProcesses(il);
                 il.Emit(OpCodes.Call, _types.GetMethod(_types.Environment, "Exit", _types.Int32));
             }
             else
@@ -1585,8 +1602,15 @@ public partial class ILCompiler
             // Node process lifecycle at natural drain: 'beforeExit' (re-entering
             // the loop when a listener schedules work), then 'exit' (#1080).
             il.Emit(OpCodes.Call, _runtime.ProcessRunLifecycle);
-            il.Emit(OpCodes.Ret);
+            il.Emit(OpCodes.Leave, returnLabel);
         }
+
+        il.BeginFinallyBlock();
+        EmitTerminateOwnedChildProcesses(il);
+        il.Emit(OpCodes.Endfinally);
+        il.EndExceptionBlock();
+        il.MarkLabel(returnLabel);
+        il.Emit(OpCodes.Ret);
 
     }
 

--- a/src/SharpTS/Compilation/ILCompiler.Hosting.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Hosting.cs
@@ -95,6 +95,8 @@ public partial class ILCompiler
             hookIl =>
             {
                 hookIl.Emit(OpCodes.Call, _runtime.CancelAllTimers);
+                if (_runtime.ChildProcessTerminateOwned is not null)
+                    hookIl.Emit(OpCodes.Call, _runtime.ChildProcessTerminateOwned);
                 hookIl.Emit(OpCodes.Call, _runtime.EventLoopGetInstance);
                 hookIl.Emit(OpCodes.Callvirt, _runtime.EventLoopClearHosted);
             });

--- a/src/SharpTS/Compilation/ILCompiler.Modules.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Modules.cs
@@ -826,6 +826,8 @@ public partial class ILCompiler
         // hold the first top-level awaits, so the context must be current before the
         // first $Initialize call captures an awaiter.
         EmitInstallEventLoopSyncContext(il);
+        var returnLabel = il.DefineLabel();
+        il.BeginExceptionBlock();
 
         if (hostedInitialize == null)
         {
@@ -838,7 +840,12 @@ public partial class ILCompiler
         // Node process lifecycle at natural drain: 'beforeExit' (re-entering
         // the loop when a listener schedules work), then 'exit' (#1080).
         il.Emit(OpCodes.Call, _runtime.ProcessRunLifecycle);
-
+        il.Emit(OpCodes.Leave, returnLabel);
+        il.BeginFinallyBlock();
+        EmitTerminateOwnedChildProcesses(il);
+        il.Emit(OpCodes.Endfinally);
+        il.EndExceptionBlock();
+        il.MarkLabel(returnLabel);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.ChildProcessAsync.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.ChildProcessAsync.cs
@@ -682,6 +682,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldfld, _childCtxProc);
         il.Emit(OpCodes.Callvirt, _miProcStart);
         il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxProc);
+        il.Emit(OpCodes.Call, runtime.ChildProcessRegisterOwned);
 
         EmitDictSetFromCtx(il, "pid", () =>
         {
@@ -805,6 +808,9 @@ public partial class RuntimeEmitter
         il.EndExceptionBlock();
 
         il.MarkLabel(afterTry);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxProc);
+        il.Emit(OpCodes.Call, runtime.ChildProcessReleaseOwned);
         // EventLoop.GetInstance().Schedule(new Action(this.EmitCaptured));
         EmitScheduleOnLoop(il, runtime, _childCtxEmitCaptured);
         il.Emit(OpCodes.Ldnull);
@@ -1051,6 +1057,9 @@ public partial class RuntimeEmitter
         il.EndExceptionBlock();
 
         il.MarkLabel(afterTry);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _childCtxProc);
+        il.Emit(OpCodes.Call, runtime.ChildProcessReleaseOwned);
         EmitScheduleOnLoop(il, runtime, _childCtxEmitStreamClose);
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ret);
@@ -1538,6 +1547,8 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldloc, processLocal);
             il.Emit(OpCodes.Callvirt, _miProcStart);
             il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ldloc, processLocal);
+            il.Emit(OpCodes.Call, runtime.ChildProcessRegisterOwned);
             EmitDictSet(il, dictLocal, "pid", () =>
             {
                 il.Emit(OpCodes.Ldloc, processLocal);
@@ -1550,6 +1561,8 @@ public partial class RuntimeEmitter
             il.BeginCatchBlock(_types.Exception);
             var exLocal = il.DeclareLocal(_types.Exception);
             il.Emit(OpCodes.Stloc, exLocal);
+            il.Emit(OpCodes.Ldloc, processLocal);
+            il.Emit(OpCodes.Call, runtime.ChildProcessReleaseOwned);
             StoreCtxField(il, ctxLocal, _childCtxResKind, () => il.Emit(OpCodes.Ldc_I4_2));
             StoreCtxField(il, ctxLocal, _childCtxResError, () =>
             {

--- a/src/SharpTS/Compilation/RuntimeEmitter.ChildProcessHelpers.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.ChildProcessHelpers.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.InteropServices;
@@ -12,6 +13,7 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitChildProcessMethods(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
+        EmitOwnedChildProcessLifecycle(typeBuilder, runtime);
         EmitChildProcessNoOp(typeBuilder);
         EmitChildProcessAsyncInfra(typeBuilder, runtime);
         EmitChildProcessExecSync(typeBuilder, runtime);
@@ -21,6 +23,215 @@ public partial class RuntimeEmitter
         EmitChildProcessExecFileSync(typeBuilder, runtime);
         EmitChildProcessExecFile(typeBuilder, runtime);
         EmitChildProcessFork(typeBuilder, runtime);
+    }
+
+    /// <summary>
+    /// Emits the generated runtime's private child-process ownership registry. The emitted
+    /// assembly remains standalone: every operation is expressed using BCL types and IL.
+    /// </summary>
+    private void EmitOwnedChildProcessLifecycle(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        Type registryType = typeof(ConcurrentDictionary<int, Process>);
+        MethodInfo volatileRead = typeof(Volatile).GetMethod(nameof(Volatile.Read), [typeof(int).MakeByRefType()])!;
+        MethodInfo exchange = typeof(Interlocked).GetMethod(nameof(Interlocked.Exchange), [typeof(int).MakeByRefType(), typeof(int)])!;
+        MethodInfo processId = _types.GetProperty(_types.Process, "Id")!.GetGetMethod()!;
+        MethodInfo setItem = registryType.GetProperty("Item")!.GetSetMethod()!;
+        MethodInfo tryRemove = registryType.GetMethod("TryRemove", [typeof(int), typeof(Process).MakeByRefType()])!;
+
+        runtime.ChildProcessUnregisterOwned = DefineChildProcessUnregisterOwned(
+            typeBuilder, runtime, processId, tryRemove);
+
+        var terminateOne = typeBuilder.DefineMethod(
+            "ChildProcessTerminateOne",
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.Void,
+            [_types.Process]);
+        {
+            var il = terminateOne.GetILGenerator();
+            var afterKill = il.DefineLabel();
+            il.BeginExceptionBlock();
+            var skipKill = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Brfalse, skipKill);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Process, "HasExited")!.GetGetMethod()!);
+            il.Emit(OpCodes.Brtrue, skipKill);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Process, "Kill", [_types.Boolean])!);
+            il.MarkLabel(skipKill);
+            il.Emit(OpCodes.Leave, afterKill);
+            il.BeginCatchBlock(_types.Exception);
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Leave, afterKill);
+            il.EndExceptionBlock();
+            il.MarkLabel(afterKill);
+
+            var afterWait = il.DefineLabel();
+            il.BeginExceptionBlock();
+            var skipWait = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Brfalse, skipWait);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldc_I4, 5000);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Process, "WaitForExit", [_types.Int32])!);
+            il.Emit(OpCodes.Pop);
+            il.MarkLabel(skipWait);
+            il.Emit(OpCodes.Leave, afterWait);
+            il.BeginCatchBlock(_types.Exception);
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Leave, afterWait);
+            il.EndExceptionBlock();
+            il.MarkLabel(afterWait);
+            il.Emit(OpCodes.Ret);
+        }
+
+        runtime.ChildProcessRegisterOwned = typeBuilder.DefineMethod(
+            "ChildProcessRegisterOwned",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            [_types.Process]);
+        {
+            var il = runtime.ChildProcessRegisterOwned.GetILGenerator();
+            var register = il.DefineLabel();
+            var done = il.DefineLabel();
+
+            il.Emit(OpCodes.Ldsflda, runtime.ChildProcessOwnershipStoppingField);
+            il.Emit(OpCodes.Call, volatileRead);
+            il.Emit(OpCodes.Brfalse, register);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, terminateOne);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(register);
+            il.Emit(OpCodes.Ldsfld, runtime.ChildProcessOwnedProcessesField);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, processId);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, setItem);
+
+            il.Emit(OpCodes.Ldsflda, runtime.ChildProcessOwnershipStoppingField);
+            il.Emit(OpCodes.Call, volatileRead);
+            il.Emit(OpCodes.Brfalse, done);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, runtime.ChildProcessUnregisterOwned);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, terminateOne);
+            il.MarkLabel(done);
+            il.Emit(OpCodes.Ret);
+        }
+
+        runtime.ChildProcessReleaseOwned = typeBuilder.DefineMethod(
+            "ChildProcessReleaseOwned",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            [_types.Process]);
+        {
+            var il = runtime.ChildProcessReleaseOwned.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, runtime.ChildProcessUnregisterOwned);
+            var done = il.DefineLabel();
+            var dispose = il.DefineLabel();
+            il.BeginExceptionBlock();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Brtrue, dispose);
+            il.Emit(OpCodes.Leave, done);
+            il.MarkLabel(dispose);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.IDisposable, "Dispose")!);
+            il.Emit(OpCodes.Leave, done);
+            il.BeginCatchBlock(_types.Exception);
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Leave, done);
+            il.EndExceptionBlock();
+            il.MarkLabel(done);
+            il.Emit(OpCodes.Ret);
+        }
+
+        runtime.ChildProcessTerminateOwned = typeBuilder.DefineMethod(
+            "ChildProcessTerminateOwned",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            Type.EmptyTypes);
+        {
+            var il = runtime.ChildProcessTerminateOwned.GetILGenerator();
+            Type collectionType = typeof(ICollection<Process>);
+            var processes = il.DeclareLocal(typeof(Process[]));
+            var values = il.DeclareLocal(collectionType);
+            var index = il.DeclareLocal(_types.Int32);
+
+            il.Emit(OpCodes.Ldsflda, runtime.ChildProcessOwnershipStoppingField);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Call, exchange);
+            il.Emit(OpCodes.Pop);
+
+            il.Emit(OpCodes.Ldsfld, runtime.ChildProcessOwnedProcessesField);
+            il.Emit(OpCodes.Callvirt, registryType.GetProperty("Values")!.GetGetMethod()!);
+            il.Emit(OpCodes.Stloc, values);
+            il.Emit(OpCodes.Ldloc, values);
+            il.Emit(OpCodes.Callvirt, collectionType.GetProperty("Count")!.GetGetMethod()!);
+            il.Emit(OpCodes.Newarr, _types.Process);
+            il.Emit(OpCodes.Stloc, processes);
+            il.Emit(OpCodes.Ldloc, values);
+            il.Emit(OpCodes.Ldloc, processes);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Callvirt, collectionType.GetMethod("CopyTo")!);
+
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Stloc, index);
+            var loop = il.DefineLabel();
+            var loopTest = il.DefineLabel();
+            il.Emit(OpCodes.Br, loopTest);
+            il.MarkLabel(loop);
+            il.Emit(OpCodes.Ldloc, processes);
+            il.Emit(OpCodes.Ldloc, index);
+            il.Emit(OpCodes.Ldelem_Ref);
+            il.Emit(OpCodes.Call, terminateOne);
+            il.Emit(OpCodes.Ldloc, index);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, index);
+            il.MarkLabel(loopTest);
+            il.Emit(OpCodes.Ldloc, index);
+            il.Emit(OpCodes.Ldloc, processes);
+            il.Emit(OpCodes.Ldlen);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Blt, loop);
+            il.Emit(OpCodes.Ldsfld, runtime.ChildProcessOwnedProcessesField);
+            il.Emit(OpCodes.Callvirt, registryType.GetMethod("Clear", Type.EmptyTypes)!);
+            il.Emit(OpCodes.Ret);
+        }
+    }
+
+    private MethodBuilder DefineChildProcessUnregisterOwned(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime,
+        MethodInfo processId,
+        MethodInfo tryRemove)
+    {
+        var method = typeBuilder.DefineMethod(
+            "ChildProcessUnregisterOwned",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Void,
+            [_types.Process]);
+        var il = method.GetILGenerator();
+        var removed = il.DeclareLocal(_types.Process);
+        var done = il.DefineLabel();
+        il.BeginExceptionBlock();
+        il.Emit(OpCodes.Ldsfld, runtime.ChildProcessOwnedProcessesField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, processId);
+        il.Emit(OpCodes.Ldloca, removed);
+        il.Emit(OpCodes.Callvirt, tryRemove);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Leave, done);
+        il.BeginCatchBlock(_types.Exception);
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Leave, done);
+        il.EndExceptionBlock();
+        il.MarkLabel(done);
+        il.Emit(OpCodes.Ret);
+        return method;
     }
 
     /// <summary>
@@ -284,6 +495,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, processLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Process, "Start", Type.EmptyTypes)!);
         il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Call, runtime.ChildProcessRegisterOwned);
         EmitSyncInputWrite(il, processLocal, __inputES);
 
         // stdout = process.StandardOutput.ReadToEnd()
@@ -309,14 +522,10 @@ public partial class RuntimeEmitter
 
         il.Emit(OpCodes.Leave, afterTryLabel);
 
-        // finally { process?.Dispose() }
+        // finally { unregister + dispose the process owned by this generated runtime }
         il.BeginFinallyBlock();
-        var skipDisposeLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, processLocal);
-        il.Emit(OpCodes.Brfalse, skipDisposeLabel);
-        il.Emit(OpCodes.Ldloc, processLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.IDisposable, "Dispose")!);
-        il.MarkLabel(skipDisposeLabel);
+        il.Emit(OpCodes.Call, runtime.ChildProcessReleaseOwned);
         il.Emit(OpCodes.Endfinally);
 
         il.EndExceptionBlock();
@@ -535,6 +744,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, processLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Process, "Start", Type.EmptyTypes)!);
         il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Call, runtime.ChildProcessRegisterOwned);
 
         // if (input != null) { process.StandardInput.Write(input); process.StandardInput.Close(); }  (#1021)
         var noInputWrite = il.DefineLabel();
@@ -567,14 +778,19 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Process, "ExitCode")!.GetGetMethod()!);
         il.Emit(OpCodes.Stloc, exitCodeLocal);
 
-        // Dispose process
+        // Release ownership and dispose process
         il.Emit(OpCodes.Ldloc, processLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.IDisposable, "Dispose")!);
+        il.Emit(OpCodes.Call, runtime.ChildProcessReleaseOwned);
 
         il.Emit(OpCodes.Leave, afterProcessLabel);
 
         // catch (Exception ex) { errorMsg = ex.Message; exitCode = -1; }
         il.BeginCatchBlock(_types.Exception);
+        var spawnSyncException = il.DeclareLocal(_types.Exception);
+        il.Emit(OpCodes.Stloc, spawnSyncException);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Call, runtime.ChildProcessReleaseOwned);
+        il.Emit(OpCodes.Ldloc, spawnSyncException);
         il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Exception, "Message")!.GetGetMethod()!);
         il.Emit(OpCodes.Stloc, errorMsgLocal);
         il.Emit(OpCodes.Ldc_I4_M1);
@@ -998,6 +1214,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, processLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Process, "Start", Type.EmptyTypes)!);
         il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ldloc, processLocal);
+        il.Emit(OpCodes.Call, runtime.ChildProcessRegisterOwned);
         EmitSyncInputWrite(il, processLocal, __inputEFS);
 
         il.Emit(OpCodes.Ldloc, processLocal);
@@ -1019,14 +1237,10 @@ public partial class RuntimeEmitter
 
         il.Emit(OpCodes.Leave, afterTryLabel);
 
-        // finally { process?.Dispose() }
+        // finally { unregister + dispose the process owned by this generated runtime }
         il.BeginFinallyBlock();
-        var skipDisposeLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, processLocal);
-        il.Emit(OpCodes.Brfalse, skipDisposeLabel);
-        il.Emit(OpCodes.Ldloc, processLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.IDisposable, "Dispose")!);
-        il.MarkLabel(skipDisposeLabel);
+        il.Emit(OpCodes.Call, runtime.ChildProcessReleaseOwned);
         il.Emit(OpCodes.Endfinally);
 
         il.EndExceptionBlock();
@@ -1187,9 +1401,12 @@ public partial class RuntimeEmitter
         var refLocal = il.DeclareLocal(typeof(Action));
         var unrefLocal = il.DeclareLocal(typeof(Action));
         var scheduleLocal = il.DeclareLocal(typeof(Action<Action>));
+        var registerLocal = il.DeclareLocal(typeof(Action<Process>));
+        var unregisterLocal = il.DeclareLocal(typeof(Action<Process>));
         var argsLocal = il.DeclareLocal(_types.ObjectArray);
         var actionCtor = typeof(Action).GetConstructor([_types.Object, typeof(IntPtr)])!;
         var actionOfActionCtor = typeof(Action<Action>).GetConstructor([_types.Object, typeof(IntPtr)])!;
+        var actionOfProcessCtor = typeof(Action<Process>).GetConstructor([_types.Object, typeof(IntPtr)])!;
 
         // Type t = Type.GetType("SharpTS.Runtime.BuiltIns.Modules.Interpreter.ChildProcessModuleInterpreter, SharpTS");
         il.Emit(OpCodes.Ldstr, "SharpTS.Runtime.BuiltIns.Modules.Interpreter.ChildProcessModuleInterpreter, SharpTS");
@@ -1221,9 +1438,17 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldftn, runtime.EventLoopSchedule);
         il.Emit(OpCodes.Newobj, actionOfActionCtor);
         il.Emit(OpCodes.Stloc, scheduleLocal);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldftn, runtime.ChildProcessRegisterOwned);
+        il.Emit(OpCodes.Newobj, actionOfProcessCtor);
+        il.Emit(OpCodes.Stloc, registerLocal);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldftn, runtime.ChildProcessUnregisterOwned);
+        il.Emit(OpCodes.Newobj, actionOfProcessCtor);
+        il.Emit(OpCodes.Stloc, unregisterLocal);
 
-        // object[] args = { modulePath, argsObj, optionsObj, ref, unref, schedule };
-        il.Emit(OpCodes.Ldc_I4_6);
+        // object[] args = { modulePath, argsObj, optionsObj, ref, unref, schedule, register, unregister };
+        il.Emit(OpCodes.Ldc_I4_8);
         il.Emit(OpCodes.Newarr, _types.Object);
         il.Emit(OpCodes.Stloc, argsLocal);
         void SetArg(int i, OpCode ld) { il.Emit(OpCodes.Ldloc, argsLocal); il.Emit(OpCodes.Ldc_I4, i); il.Emit(ld); il.Emit(OpCodes.Stelem_Ref); }
@@ -1233,6 +1458,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, argsLocal); il.Emit(OpCodes.Ldc_I4_3); il.Emit(OpCodes.Ldloc, refLocal); il.Emit(OpCodes.Stelem_Ref);
         il.Emit(OpCodes.Ldloc, argsLocal); il.Emit(OpCodes.Ldc_I4_4); il.Emit(OpCodes.Ldloc, unrefLocal); il.Emit(OpCodes.Stelem_Ref);
         il.Emit(OpCodes.Ldloc, argsLocal); il.Emit(OpCodes.Ldc_I4_5); il.Emit(OpCodes.Ldloc, scheduleLocal); il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Ldloc, argsLocal); il.Emit(OpCodes.Ldc_I4_6); il.Emit(OpCodes.Ldloc, registerLocal); il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Ldloc, argsLocal); il.Emit(OpCodes.Ldc_I4_7); il.Emit(OpCodes.Ldloc, unregisterLocal); il.Emit(OpCodes.Stelem_Ref);
 
         // return t.GetMethod("ForkForCompiledLoop").Invoke(null, args);
         il.Emit(OpCodes.Ldloc, typeLocal);

--- a/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -481,6 +481,21 @@ public partial class RuntimeEmitter
         );
         runtime.ConsoleGroupLevelField = consoleGroupLevelField;
 
+        // A generated program owns only the child processes it starts. This registry is
+        // private to the generated $Runtime type, so parallel worktrees/processes cannot
+        // observe or terminate one another's children.
+        if (_features.UsesChildProcess)
+        {
+            runtime.ChildProcessOwnedProcessesField = typeBuilder.DefineField(
+                "_ownedChildProcesses",
+                typeof(System.Collections.Concurrent.ConcurrentDictionary<int, System.Diagnostics.Process>),
+                FieldAttributes.Private | FieldAttributes.Static);
+            runtime.ChildProcessOwnershipStoppingField = typeBuilder.DefineField(
+                "_childProcessOwnershipStopping",
+                _types.Int32,
+                FieldAttributes.Private | FieldAttributes.Static);
+        }
+
         // Pre-define populate-method shells before the cctor IL is generated
         // so the cctor can `Call` each populate to eagerly fill the
         // singletons. Without eager-population, `delete Number.prototype.toString;
@@ -530,6 +545,13 @@ public partial class RuntimeEmitter
         // Initialize _random = new Random()
         cctorIL.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.Random));
         cctorIL.Emit(OpCodes.Stsfld, randomField);
+
+        if (_features.UsesChildProcess)
+        {
+            cctorIL.Emit(OpCodes.Newobj, typeof(System.Collections.Concurrent.ConcurrentDictionary<int, System.Diagnostics.Process>)
+                .GetConstructor(Type.EmptyTypes)!);
+            cctorIL.Emit(OpCodes.Stsfld, runtime.ChildProcessOwnedProcessesField);
+        }
 
         // Initialize _mathSingleton = new Dictionary<string, object>()
         cctorIL.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.DictionaryStringObject));

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSProcess.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSProcess.cs
@@ -1702,6 +1702,9 @@ public partial class RuntimeEmitter
         il.MarkLabel(haveCode);
         il.Emit(OpCodes.Stloc, codeLocal);
 
+        if (runtime.ChildProcessTerminateOwned is not null)
+            il.Emit(OpCodes.Call, runtime.ChildProcessTerminateOwned);
+
         // Hosted output emits exit synchronously but transfers termination to
         // the host lifetime. It never mutates Environment.ExitCode or calls
         // Environment.Exit on this path.

--- a/src/SharpTS/Execution/Interpreter.cs
+++ b/src/SharpTS/Execution/Interpreter.cs
@@ -206,6 +206,7 @@ public partial class Interpreter : IDisposable
     // SynchronizationContext routes async/await continuations back to the main thread
     private readonly System.Collections.Concurrent.BlockingCollection<Action> _callbackQueue = new();
     private readonly CancellationTokenSource _shutdownCts = new();
+    private readonly OwnedProcessRegistry _ownedProcesses = new();
     private InterpreterSynchronizationContext? _eventLoopSyncContext;
 
     // VM timeout support — checked during statement execution to enforce script timeout
@@ -635,7 +636,19 @@ public partial class Interpreter : IDisposable
     {
         try { _shutdownCts.Cancel(); }
         catch (ObjectDisposedException) { }
+        _ownedProcesses.TerminateAll();
     }
+
+    /// <summary>
+    /// Registers a successfully started OS process as owned by this interpreter.
+    /// No other interpreter, test host, worktree, or build-server process is visible here.
+    /// </summary>
+    internal void RegisterOwnedProcess(System.Diagnostics.Process process) => _ownedProcesses.Register(process);
+
+    /// <summary>Releases ownership after the child has exited and its streams have drained.</summary>
+    internal void UnregisterOwnedProcess(System.Diagnostics.Process process) => _ownedProcesses.Unregister(process);
+
+    internal int OwnedProcessCount => _ownedProcesses.Count;
 
     /// <summary>
     /// Allows runtime resources to stop pending asynchronous I/O when their owning interpreter
@@ -1090,6 +1103,10 @@ public partial class Interpreter : IDisposable
         // Signal the event loop to exit via cooperative cancellation
         try { _shutdownCts.Cancel(); }
         catch (ObjectDisposedException) { }
+
+        // Child processes are external resources: cancellation alone cannot stop them.
+        // Terminate only the processes explicitly registered by this interpreter.
+        _ownedProcesses.TerminateAll();
 
         // Complete the callback queue to unblock any waiting TryTake
         try { _callbackQueue.CompleteAdding(); }

--- a/src/SharpTS/References/NuGetRestorer.cs
+++ b/src/SharpTS/References/NuGetRestorer.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Security;
 using System.Security.Cryptography;
 using System.Text;
+using SharpTS.Runtime;
 
 namespace SharpTS.References;
 
@@ -107,14 +108,18 @@ internal static class NuGetRestorer
                 $"sharpts.json packages ('{manifest.ManifestPath}').");
         }
 
-        string stdout = process.StandardOutput.ReadToEnd();
-        string stderr = process.StandardError.ReadToEnd();
+        using var processLifetime = process;
+        Task<string> stdoutTask = process.StandardOutput.ReadToEndAsync();
+        Task<string> stderrTask = process.StandardError.ReadToEndAsync();
         if (!process.WaitForExit(TimeSpan.FromMinutes(10)))
         {
-            try { process.Kill(entireProcessTree: true); } catch { }
+            ProcessTreeTermination.Terminate(process);
             throw new Exception(
                 $"Error: NuGet restore for sharpts.json ('{manifest.ManifestPath}') timed out after 10 minutes.");
         }
+
+        string stdout = stdoutTask.GetAwaiter().GetResult();
+        string stderr = stderrTask.GetAwaiter().GetResult();
 
         if (process.ExitCode != 0)
         {

--- a/src/SharpTS/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
+++ b/src/SharpTS/Runtime/BuiltIns/Modules/Interpreter/ChildProcessModuleInterpreter.cs
@@ -68,34 +68,42 @@ public static class ChildProcessModuleInterpreter
 
         using var process = new Process { StartInfo = startInfo };
         process.Start();
-        if (input != null)
+        interpreter.RegisterOwnedProcess(process);
+        try
         {
-            process.StandardInput.Write(input);
-            process.StandardInput.Close();
-        }
-
-        var stdout = process.StandardOutput.ReadToEnd();
-
-        if (timeout > 0)
-        {
-            if (!process.WaitForExit((int)timeout))
+            if (input != null)
             {
-                process.Kill();
-                throw new Exception("Command timed out");
+                process.StandardInput.Write(input);
+                process.StandardInput.Close();
             }
-        }
-        else
-        {
-            process.WaitForExit();
-        }
 
-        if (process.ExitCode != 0)
-        {
-            var stderr = process.StandardError.ReadToEnd();
-            throw new Exception($"Command failed with exit code {process.ExitCode}: {stderr}");
-        }
+            var stdout = process.StandardOutput.ReadToEnd();
 
-        return RuntimeValue.FromString(stdout);
+            if (timeout > 0)
+            {
+                if (!process.WaitForExit((int)timeout))
+                {
+                    ProcessTreeTermination.Terminate(process);
+                    throw new Exception("Command timed out");
+                }
+            }
+            else
+            {
+                process.WaitForExit();
+            }
+
+            if (process.ExitCode != 0)
+            {
+                var stderr = process.StandardError.ReadToEnd();
+                throw new Exception($"Command failed with exit code {process.ExitCode}: {stderr}");
+            }
+
+            return RuntimeValue.FromString(stdout);
+        }
+        finally
+        {
+            interpreter.UnregisterOwnedProcess(process);
+        }
     }
 
     private static RuntimeValue SpawnSync(Interp interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
@@ -145,16 +153,24 @@ public static class ChildProcessModuleInterpreter
         {
             using var process = new Process { StartInfo = startInfo };
             process.Start();
-            if (input != null)
+            interpreter.RegisterOwnedProcess(process);
+            try
             {
-                // Feed the synchronous stdin, then close so the child sees EOF.
-                process.StandardInput.Write(input);
-                process.StandardInput.Close();
+                if (input != null)
+                {
+                    // Feed the synchronous stdin, then close so the child sees EOF.
+                    process.StandardInput.Write(input);
+                    process.StandardInput.Close();
+                }
+                stdout = process.StandardOutput.ReadToEnd();
+                stderr = process.StandardError.ReadToEnd();
+                process.WaitForExit();
+                exitCode = process.ExitCode;
             }
-            stdout = process.StandardOutput.ReadToEnd();
-            stderr = process.StandardError.ReadToEnd();
-            process.WaitForExit();
-            exitCode = process.ExitCode;
+            finally
+            {
+                interpreter.UnregisterOwnedProcess(process);
+            }
         }
         catch (Exception ex)
         {
@@ -250,42 +266,50 @@ public static class ChildProcessModuleInterpreter
 
                 using var process = new Process { StartInfo = startInfo };
                 process.Start();
+                interpreter.RegisterOwnedProcess(process);
                 childProcess.SetPid(process.Id);
                 childProcess.SetProcess(process);
-
-                var maxBuffer = (int)GetDoubleOption(options, "maxBuffer", 1024 * 1024);
-                var (asBuffer, encoding) = GetOutputEncoding(options);
-                var outBytes = ReadCappedBytes(process.StandardOutput.BaseStream, maxBuffer, out var oOver);
-                var errBytes = ReadCappedBytes(process.StandardError.BaseStream, maxBuffer, out var eOver);
-                stdout = asBuffer ? new SharpTSBuffer(outBytes) : BufferEncoding.Decode(outBytes, encoding);
-                stderr = asBuffer ? new SharpTSBuffer(errBytes) : BufferEncoding.Decode(errBytes, encoding);
-                if (oOver || eOver)
+                try
                 {
-                    try { process.Kill(); } catch { }
-                    error = MaxBufferError();
-                }
-
-                if (timeout > 0)
-                {
-                    if (!process.WaitForExit((int)timeout))
+                    var maxBuffer = (int)GetDoubleOption(options, "maxBuffer", 1024 * 1024);
+                    var (asBuffer, encoding) = GetOutputEncoding(options);
+                    var outBytes = ReadCappedBytes(process.StandardOutput.BaseStream, maxBuffer, out var oOver);
+                    var errBytes = ReadCappedBytes(process.StandardError.BaseStream, maxBuffer, out var eOver);
+                    stdout = asBuffer ? new SharpTSBuffer(outBytes) : BufferEncoding.Decode(outBytes, encoding);
+                    stderr = asBuffer ? new SharpTSBuffer(errBytes) : BufferEncoding.Decode(errBytes, encoding);
+                    if (oOver || eOver)
                     {
-                        process.Kill();
-                        kind = 1;
+                        ProcessTreeTermination.Terminate(process);
+                        error = MaxBufferError();
                     }
-                    else { code = process.ExitCode; }
-                }
-                else
-                {
-                    process.WaitForExit();
-                    code = process.ExitCode;
-                }
 
-                if (kind == 0 && error == null && code != 0)
-                    error = new SharpTSObject(new Dictionary<string, object?>
+                    if (timeout > 0)
                     {
-                        ["message"] = $"Command failed with exit code {code}",
-                        ["code"] = (double)code
-                    });
+                        if (!process.WaitForExit((int)timeout))
+                        {
+                            ProcessTreeTermination.Terminate(process);
+                            kind = 1;
+                        }
+                        else { code = process.ExitCode; }
+                    }
+                    else
+                    {
+                        process.WaitForExit();
+                        code = process.ExitCode;
+                    }
+
+                    if (kind == 0 && error == null && code != 0)
+                        error = new SharpTSObject(new Dictionary<string, object?>
+                        {
+                            ["message"] = $"Command failed with exit code {code}",
+                            ["code"] = (double)code
+                        });
+                }
+                finally
+                {
+                    interpreter.UnregisterOwnedProcess(process);
+                    childProcess.ClearProcess(process);
+                }
             }
             catch (Exception ex)
             {
@@ -366,7 +390,7 @@ public static class ChildProcessModuleInterpreter
 
         // Start synchronously so child.stdin.write()/.end() on the same tick reach a live
         // StandardInput; a spawn failure is surfaced as an async 'error' event.
-        Process process;
+        Process? process = null;
         try
         {
             var startInfo = new ProcessStartInfo
@@ -402,6 +426,7 @@ public static class ChildProcessModuleInterpreter
 
             process = new Process { StartInfo = startInfo };
             process.Start();
+            interpreter.RegisterOwnedProcess(process);
             childProcess.SetPid(process.Id);
             childProcess.SetProcess(process);
 
@@ -447,6 +472,13 @@ public static class ChildProcessModuleInterpreter
         }
         catch (Exception ex)
         {
+            if (process != null)
+            {
+                ProcessTreeTermination.Terminate(process);
+                interpreter.UnregisterOwnedProcess(process);
+                childProcess.ClearProcess(process);
+                process.Dispose();
+            }
             var spawnErr = SpawnError(ex, command, "spawn");
             interpreter.Ref();
             interpreter.EnqueueCallback(() =>
@@ -460,7 +492,7 @@ public static class ChildProcessModuleInterpreter
         // Keep the loop alive while the child runs; stream chunks and lifecycle events are
         // marshalled onto the loop thread (PushFromHost / EmitWith) so they run with a real
         // interpreter and after the synchronous script has attached its listeners.
-        var startedProcess = process;
+        var startedProcess = process!;
         interpreter.Ref();
         Task.Run(() =>
         {
@@ -530,6 +562,12 @@ public static class ChildProcessModuleInterpreter
                     finally { interpreter.Unref(); }
                 });
             }
+            finally
+            {
+                interpreter.UnregisterOwnedProcess(startedProcess);
+                childProcess.ClearProcess(startedProcess);
+                startedProcess.Dispose();
+            }
         });
 
         return RuntimeValue.FromObject(childProcess);
@@ -583,34 +621,42 @@ public static class ChildProcessModuleInterpreter
 
         using var process = new Process { StartInfo = startInfo };
         process.Start();
-        if (input != null)
+        interpreter.RegisterOwnedProcess(process);
+        try
         {
-            process.StandardInput.Write(input);
-            process.StandardInput.Close();
-        }
-
-        var stdout = process.StandardOutput.ReadToEnd();
-
-        if (timeout > 0)
-        {
-            if (!process.WaitForExit((int)timeout))
+            if (input != null)
             {
-                process.Kill();
-                throw new Exception("Command timed out");
+                process.StandardInput.Write(input);
+                process.StandardInput.Close();
             }
-        }
-        else
-        {
-            process.WaitForExit();
-        }
 
-        if (process.ExitCode != 0)
-        {
-            var stderr = process.StandardError.ReadToEnd();
-            throw new Exception($"Command failed with exit code {process.ExitCode}: {stderr}");
-        }
+            var stdout = process.StandardOutput.ReadToEnd();
 
-        return RuntimeValue.FromString(stdout);
+            if (timeout > 0)
+            {
+                if (!process.WaitForExit((int)timeout))
+                {
+                    ProcessTreeTermination.Terminate(process);
+                    throw new Exception("Command timed out");
+                }
+            }
+            else
+            {
+                process.WaitForExit();
+            }
+
+            if (process.ExitCode != 0)
+            {
+                var stderr = process.StandardError.ReadToEnd();
+                throw new Exception($"Command failed with exit code {process.ExitCode}: {stderr}");
+            }
+
+            return RuntimeValue.FromString(stdout);
+        }
+        finally
+        {
+            interpreter.UnregisterOwnedProcess(process);
+        }
     }
 
     /// <summary>
@@ -682,42 +728,50 @@ public static class ChildProcessModuleInterpreter
 
                 using var process = new Process { StartInfo = startInfo };
                 process.Start();
+                interpreter.RegisterOwnedProcess(process);
                 childProcess.SetPid(process.Id);
                 childProcess.SetProcess(process);
-
-                var maxBuffer = (int)GetDoubleOption(options, "maxBuffer", 1024 * 1024);
-                var (asBuffer, encoding) = GetOutputEncoding(options);
-                var outBytes = ReadCappedBytes(process.StandardOutput.BaseStream, maxBuffer, out var oOver);
-                var errBytes = ReadCappedBytes(process.StandardError.BaseStream, maxBuffer, out var eOver);
-                stdout = asBuffer ? new SharpTSBuffer(outBytes) : BufferEncoding.Decode(outBytes, encoding);
-                stderr = asBuffer ? new SharpTSBuffer(errBytes) : BufferEncoding.Decode(errBytes, encoding);
-                if (oOver || eOver)
+                try
                 {
-                    try { process.Kill(); } catch { }
-                    error = MaxBufferError();
-                }
-
-                if (timeout > 0)
-                {
-                    if (!process.WaitForExit((int)timeout))
+                    var maxBuffer = (int)GetDoubleOption(options, "maxBuffer", 1024 * 1024);
+                    var (asBuffer, encoding) = GetOutputEncoding(options);
+                    var outBytes = ReadCappedBytes(process.StandardOutput.BaseStream, maxBuffer, out var oOver);
+                    var errBytes = ReadCappedBytes(process.StandardError.BaseStream, maxBuffer, out var eOver);
+                    stdout = asBuffer ? new SharpTSBuffer(outBytes) : BufferEncoding.Decode(outBytes, encoding);
+                    stderr = asBuffer ? new SharpTSBuffer(errBytes) : BufferEncoding.Decode(errBytes, encoding);
+                    if (oOver || eOver)
                     {
-                        process.Kill();
-                        kind = 1;
+                        ProcessTreeTermination.Terminate(process);
+                        error = MaxBufferError();
                     }
-                    else { code = process.ExitCode; }
-                }
-                else
-                {
-                    process.WaitForExit();
-                    code = process.ExitCode;
-                }
 
-                if (kind == 0 && error == null && code != 0)
-                    error = new SharpTSObject(new Dictionary<string, object?>
+                    if (timeout > 0)
                     {
-                        ["message"] = $"Command failed with exit code {code}",
-                        ["code"] = (double)code
-                    });
+                        if (!process.WaitForExit((int)timeout))
+                        {
+                            ProcessTreeTermination.Terminate(process);
+                            kind = 1;
+                        }
+                        else { code = process.ExitCode; }
+                    }
+                    else
+                    {
+                        process.WaitForExit();
+                        code = process.ExitCode;
+                    }
+
+                    if (kind == 0 && error == null && code != 0)
+                        error = new SharpTSObject(new Dictionary<string, object?>
+                        {
+                            ["message"] = $"Command failed with exit code {code}",
+                            ["code"] = (double)code
+                        });
+                }
+                finally
+                {
+                    interpreter.UnregisterOwnedProcess(process);
+                    childProcess.ClearProcess(process);
+                }
             }
             catch (Exception ex)
             {
@@ -783,7 +837,8 @@ public static class ChildProcessModuleInterpreter
         var cwd = GetStringOption(options, "cwd");
         var childProcess = RunFork(modulePath, forkArgs, options, cwd, interpreter,
             interpreter.Ref, interpreter.Unref, interpreter.EnqueueCallback,
-            (cp, ev, arg) => cp.EmitWith(interpreter, ev, arg));
+            (cp, ev, arg) => cp.EmitWith(interpreter, ev, arg),
+            interpreter.RegisterOwnedProcess, interpreter.UnregisterOwnedProcess);
         return RuntimeValue.FromObject(childProcess);
     }
 
@@ -795,7 +850,8 @@ public static class ChildProcessModuleInterpreter
     /// </summary>
     public static SharpTSChildProcess ForkForCompiledLoop(
         string modulePath, object? argsObj, object? optionsObj,
-        Action eventLoopRef, Action eventLoopUnref, Action<Action> eventLoopSchedule)
+        Action eventLoopRef, Action eventLoopUnref, Action<Action> eventLoopSchedule,
+        Action<Process> registerProcess, Action<Process> unregisterProcess)
     {
         var forkArgs = new List<string>();
         if (argsObj is SharpTSArray a)
@@ -806,7 +862,7 @@ public static class ChildProcessModuleInterpreter
 
         return RunFork(modulePath, forkArgs, options, cwd, interp: null,
             eventLoopRef, eventLoopUnref, eventLoopSchedule,
-            (cp, ev, arg) => cp.EmitDirect(ev, arg));
+            (cp, ev, arg) => cp.EmitDirect(ev, arg), registerProcess, unregisterProcess);
     }
 
     /// <summary>
@@ -823,7 +879,8 @@ public static class ChildProcessModuleInterpreter
     private static SharpTSChildProcess RunFork(
         string modulePath, List<string> forkArgs, SharpTSObject? options, string? cwd,
         Interp? interp, Action refLoop, Action unrefLoop, Action<Action> post,
-        Action<SharpTSChildProcess, string, object?> emit)
+        Action<SharpTSChildProcess, string, object?> emit,
+        Action<Process> registerProcess, Action<Process> unregisterProcess)
     {
         var resolvedModule = modulePath;
         if (!Path.IsPathRooted(resolvedModule))
@@ -903,10 +960,12 @@ public static class ChildProcessModuleInterpreter
         refLoop();
         Task.Run(() =>
         {
+            Process? process = null;
             try
             {
-                var process = new Process { StartInfo = startInfo };
+                process = new Process { StartInfo = startInfo };
                 process.Start();
+                registerProcess(process);
                 childProcess.SetPid(process.Id);
                 childProcess.SetProcess(process);
 
@@ -992,6 +1051,7 @@ public static class ChildProcessModuleInterpreter
             }
             catch (Exception ex)
             {
+                ProcessTreeTermination.Terminate(process);
                 post(() =>
                 {
                     try
@@ -1003,6 +1063,16 @@ public static class ChildProcessModuleInterpreter
                     }
                     finally { unrefLoop(); }
                 });
+            }
+            finally
+            {
+                cts.Cancel();
+                if (process != null)
+                {
+                    unregisterProcess(process);
+                    childProcess.ClearProcess(process);
+                    process.Dispose();
+                }
             }
         });
 

--- a/src/SharpTS/Runtime/OwnedProcessRegistry.cs
+++ b/src/SharpTS/Runtime/OwnedProcessRegistry.cs
@@ -1,0 +1,167 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace SharpTS.Runtime;
+
+/// <summary>
+/// Best-effort, cross-platform termination for a process and every descendant it owns.
+/// The caller remains responsible for disposing the <see cref="Process"/> instance.
+/// </summary>
+internal static class ProcessTreeTermination
+{
+    internal static bool TryKill(Process? process)
+    {
+        if (process == null)
+            return false;
+
+        try
+        {
+            if (process.HasExited)
+                return false;
+
+            process.Kill(entireProcessTree: true);
+            return true;
+        }
+        catch (ObjectDisposedException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            // The process was never started or exited between HasExited and Kill.
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            // A remote Process is not expected here, but cleanup must remain best effort.
+            return false;
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            // The process may have exited or become inaccessible concurrently.
+            return false;
+        }
+        catch (NullReferenceException)
+        {
+            // Process is not thread-safe: a concurrent Dispose can clear its native
+            // handle between the public state checks and the framework's kill core.
+            return false;
+        }
+    }
+
+    internal static bool TryWaitForExit(Process? process, TimeSpan timeout)
+    {
+        if (process == null)
+            return true;
+
+        try
+        {
+            int milliseconds = timeout <= TimeSpan.Zero
+                ? 0
+                : (int)Math.Min(int.MaxValue, Math.Ceiling(timeout.TotalMilliseconds));
+            return process.WaitForExit(milliseconds);
+        }
+        catch (ObjectDisposedException)
+        {
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return true;
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            return true;
+        }
+        catch (NullReferenceException)
+        {
+            // Process.WaitForExitCore can dereference a handle cleared by a concurrent
+            // Dispose. Cleanup has already signalled the process, so treat it as reaped.
+            return true;
+        }
+    }
+
+    internal static void Terminate(Process? process, TimeSpan? timeout = null)
+    {
+        TryKill(process);
+        TryWaitForExit(process, timeout ?? TimeSpan.FromSeconds(5));
+    }
+}
+
+/// <summary>
+/// Tracks only processes created by one SharpTS runtime. Once shutdown begins, a process
+/// racing with shutdown is killed during registration rather than escaping the snapshot.
+/// </summary>
+internal sealed class OwnedProcessRegistry
+{
+    private static readonly TimeSpan DefaultShutdownTimeout = TimeSpan.FromSeconds(5);
+    private readonly ConcurrentDictionary<int, Process> _processes = new();
+    private int _stopping;
+
+    internal int Count => _processes.Count;
+
+    internal void Register(Process process)
+    {
+        ArgumentNullException.ThrowIfNull(process);
+
+        if (Volatile.Read(ref _stopping) != 0)
+        {
+            ProcessTreeTermination.Terminate(process, DefaultShutdownTimeout);
+            return;
+        }
+
+        int pid = process.Id;
+        _processes[pid] = process;
+
+        // Close the race where shutdown took its snapshot between the first stopping
+        // check and this insertion. Only remove the exact Process instance we inserted.
+        if (Volatile.Read(ref _stopping) != 0 &&
+            _processes.TryGetValue(pid, out Process? current) &&
+            ReferenceEquals(current, process))
+        {
+            _processes.TryRemove(pid, out _);
+            ProcessTreeTermination.Terminate(process, DefaultShutdownTimeout);
+        }
+    }
+
+    internal void Unregister(Process process)
+    {
+        ArgumentNullException.ThrowIfNull(process);
+
+        try
+        {
+            int pid = process.Id;
+            if (_processes.TryGetValue(pid, out Process? current) && ReferenceEquals(current, process))
+                _processes.TryRemove(pid, out _);
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        catch (InvalidOperationException)
+        {
+            // The Process was never started.
+        }
+    }
+
+    internal void TerminateAll(TimeSpan? timeout = null)
+    {
+        Interlocked.Exchange(ref _stopping, 1);
+
+        KeyValuePair<int, Process>[] snapshot = _processes.ToArray();
+
+        // Signal every tree first so many children terminate concurrently.
+        foreach ((_, Process process) in snapshot)
+            ProcessTreeTermination.TryKill(process);
+
+        TimeSpan budget = timeout ?? DefaultShutdownTimeout;
+        long started = Stopwatch.GetTimestamp();
+        foreach ((int pid, Process process) in snapshot)
+        {
+            TimeSpan remaining = budget - Stopwatch.GetElapsedTime(started);
+            ProcessTreeTermination.TryWaitForExit(process, remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero);
+
+            if (_processes.TryGetValue(pid, out Process? current) && ReferenceEquals(current, process))
+                _processes.TryRemove(pid, out _);
+        }
+    }
+}

--- a/src/SharpTS/Runtime/Types/SharpTSChildProcess.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSChildProcess.cs
@@ -30,7 +30,12 @@ public class SharpTSChildProcess : SharpTSEventEmitter
     /// <summary>
     /// Sets the underlying OS process for kill() support.
     /// </summary>
-    public void SetProcess(Process process) => _process = process;
+    public void SetProcess(Process process) => Volatile.Write(ref _process, process);
+
+    /// <summary>
+    /// Drops the Process handle after its owner has observed exit and disposed it.
+    /// </summary>
+    public void ClearProcess(Process process) => Interlocked.CompareExchange(ref _process, null, process);
 
     /// <summary>
     /// Sets the PID of the spawned process.
@@ -123,9 +128,10 @@ public class SharpTSChildProcess : SharpTSEventEmitter
 
         try
         {
-            if (_process != null && !_process.HasExited)
+            var process = Volatile.Read(ref _process);
+            if (process != null && !process.HasExited)
             {
-                _process.Kill(entireProcessTree: true);
+                ProcessTreeTermination.TryKill(process);
                 return RuntimeValue.True;
             }
         }

--- a/tests/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using SharpTS.Compilation;
 using SharpTS.Modules;
 using SharpTS.Parsing;
+using SharpTS.Runtime;
 using SharpTS.Tests.Infrastructure;
 using SharpTS.TypeSystem;
 using Xunit;
@@ -1560,14 +1561,7 @@ public class StandaloneDllTests
 
     private static void TryTerminateProcessTree(Process process)
     {
-        try
-        {
-            process.Kill(entireProcessTree: true);
-        }
-        catch (InvalidOperationException)
-        {
-            // The process exited between the timeout and Kill().
-        }
+        ProcessTreeTermination.Terminate(process);
     }
 
     private static List<string> GetAssemblyReferences(string dllPath)

--- a/tests/SharpTS.Tests/DebugAdapter/DapProtocolHarness.cs
+++ b/tests/SharpTS.Tests/DebugAdapter/DapProtocolHarness.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using SharpTS.DebugAdapter.Adapter;
+using SharpTS.Runtime;
 
 namespace SharpTS.Tests.DebugAdapter;
 
@@ -163,8 +164,7 @@ internal sealed class DapProtocolHarness : IAsyncDisposable
         }
         catch
         {
-            if (!_process.HasExited)
-                _process.Kill(entireProcessTree: true);
+            ProcessTreeTermination.Terminate(_process);
         }
         finally
         {

--- a/tests/SharpTS.Tests/Infrastructure/ExternalAssemblyFixture.cs
+++ b/tests/SharpTS.Tests/Infrastructure/ExternalAssemblyFixture.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using SharpTS.Runtime;
 using Xunit;
 
 namespace SharpTS.Tests.Infrastructure;
@@ -149,7 +150,7 @@ public sealed class ExternalAssemblyFixture : IDisposable
         string stderr = process.StandardError.ReadToEnd();
         if (!process.WaitForExit(TimeSpan.FromMinutes(5)))
         {
-            try { process.Kill(entireProcessTree: true); } catch { }
+            ProcessTreeTermination.Terminate(process);
             throw new TimeoutException($"'dotnet {arguments}' timed out in {workingDirectory}");
         }
         if (process.ExitCode != 0)

--- a/tests/SharpTS.Tests/Infrastructure/TestHarness.cs
+++ b/tests/SharpTS.Tests/Infrastructure/TestHarness.cs
@@ -6,6 +6,7 @@ using SharpTS.Diagnostics;
 using SharpTS.Execution;
 using SharpTS.Modules;
 using SharpTS.Parsing;
+using SharpTS.Runtime;
 using SharpTS.Runtime.BuiltIns;
 using SharpTS.TypeSystem;
 
@@ -549,7 +550,7 @@ public static class TestHarness
             // Use timeout to catch infinite loop bugs
             if (!process.WaitForExit((int)timeout.TotalMilliseconds))
             {
-                process.Kill();
+                ProcessTreeTermination.Terminate(process);
                 throw new TimeoutException(
                     $"Compiled program execution exceeded {timeout.TotalSeconds}s timeout. " +
                     "This likely indicates an infinite loop bug (e.g., Promise double-wrapping in async iterators).");
@@ -732,7 +733,7 @@ public static class TestHarness
 
         if (!process.WaitForExit((int)DefaultTimeout.TotalMilliseconds))
         {
-            process.Kill();
+            ProcessTreeTermination.Terminate(process);
             throw new TimeoutException(
                 $"Compiled DLL execution exceeded {DefaultTimeout.TotalSeconds}s timeout.");
         }
@@ -1187,7 +1188,7 @@ public static class TestHarness
             {
                 var partialOut = outputTask.IsCompleted ? outputTask.Result : "(reading)";
                 var partialErr = errorTask.IsCompleted ? errorTask.Result : "(reading)";
-                process.Kill();
+                ProcessTreeTermination.Terminate(process);
                 throw new TimeoutException(
                     $"Compiled module execution exceeded {DefaultTimeout.TotalSeconds}s timeout. " +
                     $"Stdout: [{partialOut}] Stderr: [{partialErr}]");

--- a/tests/SharpTS.Tests/IntegrationTests/CliManifestTests.cs
+++ b/tests/SharpTS.Tests/IntegrationTests/CliManifestTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using SharpTS.Runtime;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using SharpTS.Modules;
@@ -216,7 +217,7 @@ public class CliManifestTests(ExternalAssemblyFixture fixture)
         var stderr = process.StandardError.ReadToEnd();
         if (!process.WaitForExit(TimeSpan.FromSeconds(60)))
         {
-            try { process.Kill(entireProcessTree: true); } catch { }
+            ProcessTreeTermination.Terminate(process);
             throw new TimeoutException($"Compiled program timed out: {dllPath}");
         }
         return new CliTestHelper.CliResult(

--- a/tests/SharpTS.Tests/IntegrationTests/CliShebangTests.cs
+++ b/tests/SharpTS.Tests/IntegrationTests/CliShebangTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using SharpTS.Runtime;
 using Xunit;
 
 namespace SharpTS.Tests.IntegrationTests;
@@ -141,7 +142,7 @@ public class CliShebangTests
         var stderrTask = process.StandardError.ReadToEndAsync();
         if (!process.WaitForExit((int)CliTestHelper.DefaultTimeout.TotalMilliseconds))
         {
-            process.Kill(entireProcessTree: true);
+            ProcessTreeTermination.Terminate(process);
             throw new TimeoutException("Executable shebang example did not exit within 30 seconds.");
         }
 
@@ -166,7 +167,7 @@ public class CliShebangTests
         var stderrTask = process.StandardError.ReadToEndAsync();
         if (!process.WaitForExit((int)CliTestHelper.DefaultTimeout.TotalMilliseconds))
         {
-            process.Kill(entireProcessTree: true);
+            ProcessTreeTermination.Terminate(process);
             throw new TimeoutException("Compiled shebang script did not exit within 30 seconds.");
         }
 

--- a/tests/SharpTS.Tests/IntegrationTests/CliSourceExecutionTests.cs
+++ b/tests/SharpTS.Tests/IntegrationTests/CliSourceExecutionTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using SharpTS.Runtime;
 using Xunit;
 
 namespace SharpTS.Tests.IntegrationTests;
@@ -58,7 +59,7 @@ public class CliSourceExecutionTests
         var stderrTask = process.StandardError.ReadToEndAsync();
         if (!process.WaitForExit(60_000))
         {
-            process.Kill(entireProcessTree: true);
+            ProcessTreeTermination.Terminate(process);
             throw new TimeoutException("Compiled source-execution host did not exit within 60 seconds.");
         }
 

--- a/tests/SharpTS.Tests/IntegrationTests/CliTestHelper.cs
+++ b/tests/SharpTS.Tests/IntegrationTests/CliTestHelper.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Reflection;
+using SharpTS.Runtime;
 
 namespace SharpTS.Tests.IntegrationTests;
 
@@ -46,7 +47,7 @@ public static class CliTestHelper
 
         if (!process.WaitForExit((int)effectiveTimeout.TotalMilliseconds))
         {
-            process.Kill();
+            ProcessTreeTermination.Terminate(process);
             throw new TimeoutException(
                 $"CLI execution exceeded {effectiveTimeout.TotalSeconds}s timeout. " +
                 $"Arguments: {arguments}");

--- a/tests/SharpTS.Tests/IntegrationTests/RealPackageSmokeTests.cs
+++ b/tests/SharpTS.Tests/IntegrationTests/RealPackageSmokeTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using SharpTS.Runtime;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -109,7 +110,7 @@ public class NpmFixture : IDisposable
 
         if (!process.WaitForExit(timeoutMs))
         {
-            process.Kill();
+            ProcessTreeTermination.Terminate(process);
             throw new TimeoutException($"{fileName} {arguments} exceeded {timeoutMs}ms");
         }
 

--- a/tests/SharpTS.Tests/RuntimeTests/OwnedProcessRegistryTests.cs
+++ b/tests/SharpTS.Tests/RuntimeTests/OwnedProcessRegistryTests.cs
@@ -1,0 +1,188 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using SharpTS.Execution;
+using SharpTS.Runtime;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.RuntimeTests;
+
+public sealed class OwnedProcessRegistryTests
+{
+    private static readonly TimeSpan ExitTimeout = TimeSpan.FromSeconds(10);
+
+    [Fact]
+    public void InterpreterDispose_TerminatesOnlyItsOwnProcesses()
+    {
+        using var firstInterpreter = new Interpreter(TextWriter.Null, TextWriter.Null);
+        using var secondInterpreter = new Interpreter(TextWriter.Null, TextWriter.Null);
+        using Process firstProcess = StartLongRunningProcess();
+        using Process secondProcess = StartLongRunningProcess();
+
+        try
+        {
+            firstInterpreter.RegisterOwnedProcess(firstProcess);
+            secondInterpreter.RegisterOwnedProcess(secondProcess);
+
+            Assert.Equal(1, firstInterpreter.OwnedProcessCount);
+            Assert.Equal(1, secondInterpreter.OwnedProcessCount);
+
+            firstInterpreter.Dispose();
+
+            Assert.True(WaitUntilExited(firstProcess), "The first interpreter did not terminate its child process.");
+            Assert.False(secondProcess.HasExited);
+            Assert.Equal(1, secondInterpreter.OwnedProcessCount);
+
+            secondInterpreter.Dispose();
+            Assert.True(WaitUntilExited(secondProcess), "The second interpreter did not terminate its child process.");
+        }
+        finally
+        {
+            ProcessTreeTermination.Terminate(firstProcess);
+            ProcessTreeTermination.Terminate(secondProcess);
+        }
+    }
+
+    [Fact]
+    public async Task ProcessTreeTermination_TerminatesDescendants()
+    {
+        using Process parent = StartParentThatReportsChildPid();
+        Process? child = null;
+
+        try
+        {
+            string? line = await parent.StandardOutput.ReadLineAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.True(int.TryParse(line, out int childPid), $"Parent did not report a child PID. Output: {line ?? "<null>"}");
+
+            child = Process.GetProcessById(childPid);
+            Assert.False(child.HasExited);
+
+            ProcessTreeTermination.Terminate(parent);
+
+            Assert.True(WaitUntilExited(parent), "The parent process did not exit.");
+            Assert.True(WaitUntilExited(child), "The descendant process survived process-tree termination.");
+        }
+        finally
+        {
+            ProcessTreeTermination.Terminate(parent);
+            ProcessTreeTermination.Terminate(child);
+            child?.Dispose();
+        }
+    }
+
+    [Theory, ModeData]
+    public void ExecutionTimeout_TerminatesSpawnedProcess(ExecutionMode mode)
+    {
+        string pidPath = Path.Combine(Path.GetTempPath(), $"sharpts-owned-process-{Guid.NewGuid():N}.pid");
+        string sourcePath = pidPath.Replace("\\", "\\\\").Replace("'", "\\'");
+        (string command, string arguments) = LongRunningGuestCommand();
+        Process? child = null;
+
+        string source = $$"""
+            import { spawn } from 'child_process';
+            import { writeFileSync } from 'fs';
+
+            const child = spawn('{{command}}', {{arguments}});
+            writeFileSync('{{sourcePath}}', '' + child.pid);
+            while (true) {}
+            """;
+
+        try
+        {
+            var files = new Dictionary<string, string> { ["main.ts"] = source };
+            Assert.Throws<TimeoutException>(() =>
+                TestHarness.RunModules(files, "main.ts", mode, TimeSpan.FromSeconds(1)));
+
+            Assert.True(File.Exists(pidPath), "The guest did not record the spawned child PID before timing out.");
+            Assert.True(int.TryParse(File.ReadAllText(pidPath), out int childPid), "The guest recorded an invalid child PID.");
+
+            child = TryGetProcess(childPid);
+            Assert.True(child is null || WaitUntilExited(child), $"{mode} timeout left child PID {childPid} running.");
+        }
+        finally
+        {
+            ProcessTreeTermination.Terminate(child);
+            child?.Dispose();
+            try { File.Delete(pidPath); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+
+    private static Process StartLongRunningProcess()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "powershell.exe" : "/bin/sh",
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            startInfo.ArgumentList.Add("-NoProfile");
+            startInfo.ArgumentList.Add("-NonInteractive");
+            startInfo.ArgumentList.Add("-Command");
+            startInfo.ArgumentList.Add("Start-Sleep -Seconds 120");
+        }
+        else
+        {
+            startInfo.ArgumentList.Add("-c");
+            startInfo.ArgumentList.Add("sleep 120");
+        }
+
+        return Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start long-running test process.");
+    }
+
+    private static Process StartParentThatReportsChildPid()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "powershell.exe" : "/bin/sh",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            startInfo.ArgumentList.Add("-NoProfile");
+            startInfo.ArgumentList.Add("-NonInteractive");
+            startInfo.ArgumentList.Add("-Command");
+            startInfo.ArgumentList.Add(
+                "$child = Start-Process powershell.exe -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 120' " +
+                "-PassThru -WindowStyle Hidden; [Console]::Out.WriteLine($child.Id); $child.WaitForExit()");
+        }
+        else
+        {
+            startInfo.ArgumentList.Add("-c");
+            startInfo.ArgumentList.Add("sleep 120 & echo $!; wait");
+        }
+
+        return Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start process-tree test parent.");
+    }
+
+    private static (string Command, string Arguments) LongRunningGuestCommand()
+    {
+        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? ("powershell.exe", "['-NoProfile', '-NonInteractive', '-Command', 'Start-Sleep -Seconds 120']")
+            : ("/bin/sh", "['-c', 'sleep 120']");
+    }
+
+    private static bool WaitUntilExited(Process process)
+    {
+        return SpinWait.SpinUntil(() =>
+        {
+            try { return process.HasExited; }
+            catch (ObjectDisposedException) { return true; }
+            catch (InvalidOperationException) { return true; }
+        }, ExitTimeout);
+    }
+
+    private static Process? TryGetProcess(int processId)
+    {
+        try { return Process.GetProcessById(processId); }
+        catch (ArgumentException) { return null; }
+    }
+}


### PR DESCRIPTION
## Summary
- track child processes per interpreter and per emitted compiled runtime
- terminate only owned process trees during shutdown, cancellation, and runtime exit
- harden test, CLI, debug-adapter, standalone, and NuGet timeout cleanup
- add isolation, descendant-tree, and interpreted/compiled timeout regression tests

## Investigation
The hundreds of background processes observed during the investigation were MSBuild worker nodes (`dotnet ... MSBuild.dll /nodemode:1`) whose build parents had already exited. SharpTS also had a separate ownership gap: guest child processes were not centrally tracked and several timeout paths did not wait for full process-tree termination. This PR fixes the SharpTS-owned portion without globally shutting down .NET build servers or reducing parallelism.

## Validation
- `dotnet build tests/SharpTS.Tests/SharpTS.Tests.csproj -c Release --no-restore -m:1 -nr:false --nologo`
- full Windows suite: 17,342 passed, 0 failed, 3 skipped
- child-process suite: 79/79 passed
- four concurrent scoped stress runs: 332/332 passed
- emitted IL verification enabled for ownership regressions: 4/4 passed
- final process snapshot: 0 dotnet, MSBuild worker, testhost, or ownership-test child processes

## Platform note
Ubuntu 26.04 WSL is installed on the test machine, but no .NET SDK is installed inside that distribution, so the WSL execution pass could not be run locally. The regression helpers include Unix `/bin/sh`/`sleep` paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Child processes are now tracked and cleaned up reliably when programs exit, fail, time out, or are disposed.
  * Process trees are terminated across supported platforms, reducing orphaned subprocesses.
  * Improved cleanup for synchronous, asynchronous, streamed, and forked child-process operations.
  * NuGet restore processes now drain output safely and terminate descendants on timeout.

* **Tests**
  * Added coverage for process ownership isolation, descendant termination, and timeout cleanup across execution modes and platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->