### PR TITLE
Perf: hoist exact TypedArray backing storage into numeric loops

### DIFF
--- a/scripts/perf-local.ps1
+++ b/scripts/perf-local.ps1
@@ -156,6 +156,7 @@ function Invoke-WslChecked {
     )
 
     $scriptText = if ($WithoutToolchain) { "set -euo pipefail`n$Command" } else { "$(Get-WslEnvironmentPrefix)`n$Command" }
+    $scriptText = $scriptText.Replace("`r`n", "`n").Replace("`r", "`n")
     if ($Capture) {
         $output = @(& wsl.exe -d $WslDistro --exec bash -c $scriptText 2>&1)
     } else {

--- a/src/SharpTS/Compilation/CompilationContext.cs
+++ b/src/SharpTS/Compilation/CompilationContext.cs
@@ -35,7 +35,17 @@ public record struct HoistedArrayEntry(LocalBuilder TypedLocal, ArrayElementsDes
 /// index fast paths load <see cref="TypedLocal"/> directly instead of re-emitting
 /// <c>ldloc; castclass $XArray</c> on every access.
 /// </summary>
-public record struct HoistedTypedArrayEntry(LocalBuilder TypedLocal, Type XArrayType, string ElementType);
+public readonly record struct HoistedTypedArrayBacking(
+    LocalBuilder BufferLocal,
+    LocalBuilder ByteOffsetLocal,
+    LocalBuilder LengthLocal,
+    TypedArrayElementLayout Layout);
+
+public record struct HoistedTypedArrayEntry(
+    LocalBuilder TypedLocal,
+    Type XArrayType,
+    string ElementType,
+    HoistedTypedArrayBacking? Backing);
 
 public record struct HoistedCompactRecordEntry(
     LocalBuilder TypedLocal,

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -667,6 +667,7 @@ public partial class ILCompiler
             statements, _typeMap, _closures.Analyzer, _features);
         _classes.CompactStorageClasses.UnionWith(
             CompactClassStorageAnalyzer.Analyze(statements, _typeMap, _features));
+        TypedArrayHoistAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         ArrayLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         StringAccumulatorPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         ObjectLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);

--- a/src/SharpTS/Compilation/ILEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Operators.cs
@@ -1201,6 +1201,98 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Castclass, xArrayType);
     }
 
+    private bool TryGetDirectTypedArrayBacking(
+        Expr receiver,
+        string elementType,
+        out HoistedTypedArrayBacking backing)
+    {
+        if (receiver is Expr.Variable variable
+            && _ctx.TryGetHoistedTypedArray(variable.Name.Lexeme) is
+                { ElementType: var hoistedElement, Backing: { } direct }
+            && hoistedElement == elementType)
+        {
+            backing = direct;
+            return true;
+        }
+
+        backing = default;
+        return false;
+    }
+
+    private void EmitDirectTypedArrayRead(
+        HoistedTypedArrayBacking backing,
+        LocalBuilder indexLocal)
+    {
+        if (backing.Layout.BytesPerElement == 1)
+        {
+            EmitDirectTypedArrayArrayAndIndex(backing, indexLocal);
+            IL.Emit(backing.Layout.Signed ? OpCodes.Ldelem_I1 : OpCodes.Ldelem_U1);
+            IL.Emit(OpCodes.Conv_R8);
+            return;
+        }
+
+        EmitDirectTypedArrayElementReference(backing, indexLocal);
+        RuntimeEmitter.EmitReadElementAsDouble(
+            IL,
+            backing.Layout.BytesPerElement,
+            backing.Layout.Signed,
+            backing.Layout.IsFloat);
+    }
+
+    private void EmitDirectTypedArrayWrite(
+        HoistedTypedArrayBacking backing,
+        LocalBuilder indexLocal,
+        LocalBuilder valueLocal)
+    {
+        if (backing.Layout.BytesPerElement == 1)
+        {
+            EmitDirectTypedArrayArrayAndIndex(backing, indexLocal);
+            IL.Emit(OpCodes.Ldloc, valueLocal);
+            IL.Emit(OpCodes.Conv_I4);
+            IL.Emit(backing.Layout.Signed ? OpCodes.Conv_I1 : OpCodes.Conv_U1);
+            IL.Emit(OpCodes.Stelem_I1);
+            return;
+        }
+
+        EmitDirectTypedArrayElementReference(backing, indexLocal);
+        IL.Emit(OpCodes.Ldloc, valueLocal);
+        RuntimeEmitter.EmitNarrowDoubleAndWrite(
+            IL,
+            backing.Layout.BytesPerElement,
+            backing.Layout.Signed,
+            backing.Layout.IsFloat);
+    }
+
+    private void EmitDirectTypedArrayArrayAndIndex(
+        HoistedTypedArrayBacking backing,
+        LocalBuilder indexLocal)
+    {
+        IL.Emit(OpCodes.Ldloc, backing.BufferLocal);
+        EmitDirectTypedArrayByteIndex(backing, indexLocal);
+    }
+
+    private void EmitDirectTypedArrayElementReference(
+        HoistedTypedArrayBacking backing,
+        LocalBuilder indexLocal)
+    {
+        EmitDirectTypedArrayArrayAndIndex(backing, indexLocal);
+        IL.Emit(OpCodes.Ldelema, typeof(byte));
+    }
+
+    private void EmitDirectTypedArrayByteIndex(
+        HoistedTypedArrayBacking backing,
+        LocalBuilder indexLocal)
+    {
+        IL.Emit(OpCodes.Ldloc, backing.ByteOffsetLocal);
+        IL.Emit(OpCodes.Ldloc, indexLocal);
+        if (backing.Layout.BytesPerElement != 1)
+        {
+            IL.Emit(OpCodes.Ldc_I4, backing.Layout.BytesPerElement);
+            IL.Emit(OpCodes.Mul);
+        }
+        IL.Emit(OpCodes.Add);
+    }
+
     private bool TryEmitIntegerCounterIndexI4(Expr index)
     {
         switch (index)
@@ -2448,20 +2540,29 @@ public partial class ILEmitter
             && _ctx.TypeMap?.Get(csi.Value) is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral
             && IsArithmeticOrBitwiseCompound(csi.Operator.Type))
         {
-            // recv = (TAType)a  — side-effect-free variable, loaded once. Reuse the loop-hoisted
-            // typed local directly when available (#928), else cast once into a fresh recvLocal.
-            LocalBuilder recvLocal;
-            if (csi.Object is Expr.Variable cv && _ctx.TryGetHoistedTypedArray(cv.Name.Lexeme) is { } choist)
+            HoistedTypedArrayBacking? directBacking =
+                TryGetDirectTypedArrayBacking(csi.Object, cta.ElementType, out var backing)
+                    ? backing
+                    : null;
+
+            // The concrete receiver remains the fallback when the whole-program backing proof
+            // does not hold. Keep its existing cast-only hoist intact.
+            LocalBuilder? recvLocal = null;
+            if (directBacking == null)
             {
-                recvLocal = choist.TypedLocal;
-            }
-            else
-            {
-                EmitExpression(csi.Object);
-                EnsureBoxed();
-                IL.Emit(OpCodes.Castclass, ctaType);
-                recvLocal = IL.DeclareLocal(ctaType);
-                IL.Emit(OpCodes.Stloc, recvLocal);
+                if (csi.Object is Expr.Variable cv
+                    && _ctx.TryGetHoistedTypedArray(cv.Name.Lexeme) is { } choist)
+                {
+                    recvLocal = choist.TypedLocal;
+                }
+                else
+                {
+                    EmitExpression(csi.Object);
+                    EnsureBoxed();
+                    IL.Emit(OpCodes.Castclass, ctaType);
+                    recvLocal = IL.DeclareLocal(ctaType);
+                    IL.Emit(OpCodes.Stloc, recvLocal);
+                }
             }
 
             // idx = (int)i  (native-int fast path when the index is an integer loop counter, #928)
@@ -2469,21 +2570,34 @@ public partial class ILEmitter
             var idxLocal = IL.DeclareLocal(_ctx.Types.Int32);
             IL.Emit(OpCodes.Stloc, idxLocal);
 
-            // cur = recv.GetUnboxed(idx)  → double
-            IL.Emit(OpCodes.Ldloc, recvLocal);
-            IL.Emit(OpCodes.Ldloc, idxLocal);
-            IL.Emit(OpCodes.Call, ctaGet);
+            // cur = direct backing read, or recv.GetUnboxed(idx) on the fallback path.
+            if (directBacking is { } directRead)
+            {
+                EmitDirectTypedArrayRead(directRead, idxLocal);
+            }
+            else
+            {
+                IL.Emit(OpCodes.Ldloc, recvLocal!);
+                IL.Emit(OpCodes.Ldloc, idxLocal);
+                IL.Emit(OpCodes.Call, ctaGet);
+            }
 
             // result = cur OP v  (double)
             EmitCompoundArithmeticDoubleOnStack(csi.Operator.Type, csi.Value);
             var resLocal = IL.DeclareLocal(_ctx.Types.Double);
             IL.Emit(OpCodes.Stloc, resLocal);
 
-            // recv.SetUnboxed(idx, result)
-            IL.Emit(OpCodes.Ldloc, recvLocal);
-            IL.Emit(OpCodes.Ldloc, idxLocal);
-            IL.Emit(OpCodes.Ldloc, resLocal);
-            IL.Emit(OpCodes.Call, ctaSet);
+            if (directBacking is { } directWrite)
+            {
+                EmitDirectTypedArrayWrite(directWrite, idxLocal, resLocal);
+            }
+            else
+            {
+                IL.Emit(OpCodes.Ldloc, recvLocal!);
+                IL.Emit(OpCodes.Ldloc, idxLocal);
+                IL.Emit(OpCodes.Ldloc, resLocal);
+                IL.Emit(OpCodes.Call, ctaSet);
+            }
 
             // The compound-assignment expression evaluates to the stored numeric result.
             IL.Emit(OpCodes.Ldloc, resLocal);

--- a/src/SharpTS/Compilation/ILEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Operators.cs
@@ -1283,14 +1283,15 @@ public partial class ILEmitter
         HoistedTypedArrayBacking backing,
         LocalBuilder indexLocal)
     {
-        IL.Emit(OpCodes.Ldloc, backing.ByteOffsetLocal);
+        // Stable-backing candidates are created only by the exact length constructor, whose
+        // backing always starts at byte zero. Keep the captured offset in the preheader as part
+        // of the guarded storage facts, but do not reload and add that known zero at every access.
         IL.Emit(OpCodes.Ldloc, indexLocal);
         if (backing.Layout.BytesPerElement != 1)
         {
             IL.Emit(OpCodes.Ldc_I4, backing.Layout.BytesPerElement);
             IL.Emit(OpCodes.Mul);
         }
-        IL.Emit(OpCodes.Add);
     }
 
     private bool TryEmitIntegerCounterIndexI4(Expr index)

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -28,6 +28,18 @@ public partial class ILEmitter
             return;
         }
 
+        if (!g.Optional
+            && g.Name.Lexeme == "length"
+            && g.Object is Expr.Variable typedArrayLength
+            && _ctx.TryGetHoistedTypedArray(typedArrayLength.Name.Lexeme) is
+                { Backing: { } backing })
+        {
+            IL.Emit(OpCodes.Ldloc, backing.LengthLocal);
+            IL.Emit(OpCodes.Conv_R8);
+            SetStackType(StackType.Double);
+            return;
+        }
+
         // CommonJS: `module.exports` reads → ldsfld $exports
         if (TryEmitCjsGet(g)) return;
 
@@ -1146,6 +1158,16 @@ public partial class ILEmitter
             && _ctx.Runtime!.GetTypedArrayType(gta.ElementType) is { } gtaType
             && _ctx.Runtime!.TypedArrayGetUnboxedByElement.TryGetValue(gta.ElementType, out var taGetU))
         {
+            if (TryGetDirectTypedArrayBacking(gi.Object, gta.ElementType, out var backing))
+            {
+                EmitIndexAsInt32(gi.Index);
+                var indexLocal = IL.DeclareLocal(_ctx.Types.Int32);
+                IL.Emit(OpCodes.Stloc, indexLocal);
+                EmitDirectTypedArrayRead(backing, indexLocal);
+                SetStackType(StackType.Double);
+                return;
+            }
+
             // Receiver: hoisted loop-invariant cast when available, else per-access cast (#928).
             EmitTypedArrayReceiver(gi.Object, gtaType);
             // Native-int fast path when the index is an integer loop counter (#928).
@@ -1651,6 +1673,14 @@ public partial class ILEmitter
             EnsureDouble();
             var valLocal = IL.DeclareLocal(_ctx.Types.Double);
             IL.Emit(OpCodes.Stloc, valLocal);
+
+            if (TryGetDirectTypedArrayBacking(si.Object, sta.ElementType, out var backing))
+            {
+                EmitDirectTypedArrayWrite(backing, idxLocal, valLocal);
+                IL.Emit(OpCodes.Ldloc, valLocal);
+                SetStackType(StackType.Double);
+                return;
+            }
 
             // Receiver: hoisted loop-invariant cast when available, else per-access cast (#928).
             EmitTypedArrayReceiver(si.Object, staType);

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -1032,8 +1032,9 @@ public partial class ILEmitter
         if (candidates.Count == 0) return false;
 
         Dictionary<string, HoistedTypedArrayEntry>? cache = null;
-        foreach (var (varName, elementType) in candidates)
+        foreach (var (varName, candidate) in candidates)
         {
+            string elementType = candidate.ElementType;
             // Skip variables already hoisted by an outer loop.
             if (_ctx.TryGetHoistedTypedArray(varName) != null) continue;
             // Only numeric typed arrays with unboxed accessors take the fast path (BigInt /
@@ -1051,8 +1052,35 @@ public partial class ILEmitter
             IL.Emit(OpCodes.Castclass, xArrayType);
             IL.Emit(OpCodes.Stloc, typedLocal);
 
+            HoistedTypedArrayBacking? backing = null;
+            if (candidate.CanHoistBacking
+                && TypedArrayElementLayout.TryGet(elementType, out var layout))
+            {
+                // The whole-program proof guarantees a fresh length-constructed array whose
+                // binding and backing identity never escape. Capture all storage facts before the
+                // loop so the hot body need not reload fields through GetUnboxed/SetUnboxed.
+                var bufferLocal = IL.DeclareLocal(typeof(byte[]));
+                IL.Emit(OpCodes.Ldloc, typedLocal);
+                IL.Emit(OpCodes.Call, _ctx.Runtime.TypedArrayGetBuffer);
+                IL.Emit(OpCodes.Stloc, bufferLocal);
+
+                var byteOffsetLocal = IL.DeclareLocal(_ctx.Types.Int32);
+                IL.Emit(OpCodes.Ldloc, typedLocal);
+                IL.Emit(OpCodes.Call, _ctx.Runtime.TypedArrayByteOffsetGetter);
+                IL.Emit(OpCodes.Stloc, byteOffsetLocal);
+
+                var lengthLocal = IL.DeclareLocal(_ctx.Types.Int32);
+                IL.Emit(OpCodes.Ldloc, typedLocal);
+                IL.Emit(OpCodes.Call, _ctx.Runtime.TypedArrayLengthGetter);
+                IL.Emit(OpCodes.Stloc, lengthLocal);
+
+                backing = new HoistedTypedArrayBacking(
+                    bufferLocal, byteOffsetLocal, lengthLocal, layout);
+            }
+
             cache ??= new Dictionary<string, HoistedTypedArrayEntry>();
-            cache[varName] = new HoistedTypedArrayEntry(typedLocal, xArrayType, elementType);
+            cache[varName] = new HoistedTypedArrayEntry(
+                typedLocal, xArrayType, elementType, backing);
         }
 
         if (cache == null) return false;

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSTypedArray.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSTypedArray.cs
@@ -851,7 +851,7 @@ public partial class RuntimeEmitter
     }
 
     // Stack in: [ref byte]. Stack out: [double]. Reads the element and widens to double.
-    private static void EmitReadElementAsDouble(ILGenerator il, int bytesPerElement, bool signed, bool isFloat)
+    internal static void EmitReadElementAsDouble(ILGenerator il, int bytesPerElement, bool signed, bool isFloat)
     {
         if (bytesPerElement == 1)
         {
@@ -887,7 +887,7 @@ public partial class RuntimeEmitter
 
     // Stack in: [ref byte, double value]. Narrows the double to the element type and stores it.
     // Conv opcodes mirror the boxed Set so the fast path and boxed fallback agree exactly.
-    private static void EmitNarrowDoubleAndWrite(ILGenerator il, int bytesPerElement, bool signed, bool isFloat)
+    internal static void EmitNarrowDoubleAndWrite(ILGenerator il, int bytesPerElement, bool signed, bool isFloat)
     {
         if (bytesPerElement == 1)
         {

--- a/src/SharpTS/Compilation/TypedArrayHoistAnalyzer.cs
+++ b/src/SharpTS/Compilation/TypedArrayHoistAnalyzer.cs
@@ -4,20 +4,78 @@ using SharpTS.TypeSystem;
 
 namespace SharpTS.Compilation;
 
+public readonly record struct TypedArrayElementLayout(
+    int BytesPerElement,
+    bool Signed,
+    bool IsFloat)
+{
+    public static bool TryGet(string elementType, out TypedArrayElementLayout layout)
+    {
+        layout = elementType switch
+        {
+            "Int8" => new(1, Signed: true, IsFloat: false),
+            "Uint8" => new(1, Signed: false, IsFloat: false),
+            "Int16" => new(2, Signed: true, IsFloat: false),
+            "Uint16" => new(2, Signed: false, IsFloat: false),
+            "Int32" => new(4, Signed: true, IsFloat: false),
+            "Uint32" => new(4, Signed: false, IsFloat: false),
+            "Float32" => new(4, Signed: false, IsFloat: true),
+            "Float64" => new(8, Signed: false, IsFloat: true),
+            _ => default
+        };
+        return layout.BytesPerElement != 0;
+    }
+
+    public static bool IsSupportedConstructor(string name) =>
+        name.EndsWith("Array", StringComparison.Ordinal)
+        && TryGet(name[..^5], out _);
+}
+
+public readonly record struct TypedArrayHoistCandidate(
+    string ElementType,
+    bool CanHoistBacking);
+
 /// <summary>
-/// Analyzes a loop for numeric TypedArray variables whose <c>castclass $XArray</c> can be hoisted
-/// out of the loop (#928). A variable qualifies when it is the receiver of an index get / set /
-/// compound-set, is statically typed as a <see cref="TypeInfo.TypedArray"/>, and is not reassigned
-/// or re-declared anywhere in the loop (so the cast stays valid for every iteration).
-///
-/// Returns <c>varName → element-type name</c> (e.g. <c>"Int32"</c>); the emit site resolves the
-/// concrete <c>$XArray</c> type and skips element types without unboxed accessors (BigInt /
-/// Uint8Clamped), whose index sites do not take the unboxed fast path. Mirrors
-/// <see cref="ArrayHoistAnalyzer"/>, which performs the equivalent hoist for ordinary arrays.
+/// Proves the exact local lifetime needed to cache a numeric TypedArray's backing storage, and
+/// separately finds loop-invariant receivers whose concrete cast can still be hoisted (#1481).
+/// Backing hoisting is deliberately narrower: the receiver must be a function-local value created
+/// from a numeric length and used only through numeric index operations or <c>.length</c>. Any escape,
+/// alias/view exposure, capture, reassignment, dynamic access, direct eval, or observable constructor
+/// use keeps the existing concrete-accessor path.
 /// </summary>
 public static class TypedArrayHoistAnalyzer
 {
-    public static Dictionary<string, string> AnalyzeFor(
+    /// <summary>
+    /// Marks receiver expressions belonging to exact, locally constructed, non-escaping numeric
+    /// TypedArrays. This whole-program proof runs after closure analysis and before IL emission.
+    /// </summary>
+    public static void Analyze(List<Stmt> program, TypeMap? typeMap, ClosureAnalyzer? closures)
+    {
+        if (typeMap == null) return;
+
+        var visitor = new StableBackingVisitor(typeMap);
+        foreach (var statement in program)
+            visitor.Visit(statement);
+
+        if (visitor.ContainsDirectEval || visitor.IntrinsicConstructorIsObservable)
+            return;
+
+        foreach (var (key, candidate) in visitor.Candidates)
+        {
+            if (key.Scope == 0
+                || visitor.Disqualified.Contains(key)
+                || visitor.DeclarationCounts.GetValueOrDefault(key) != 1
+                || closures?.IsVariableCaptured(key.Name) == true)
+            {
+                continue;
+            }
+
+            foreach (var receiver in candidate.PermittedReceivers)
+                typeMap.MarkStableTypedArrayBackingReceiver(receiver);
+        }
+    }
+
+    public static Dictionary<string, TypedArrayHoistCandidate> AnalyzeFor(
         Stmt body, Expr? condition, Expr? increment, TypeMap? typeMap)
     {
         if (typeMap == null) return new();
@@ -27,23 +85,247 @@ public static class TypedArrayHoistAnalyzer
         if (condition != null) visitor.VisitExpr(condition);
         if (increment != null) visitor.VisitExpr(increment);
 
+        // eval can replace a lexical binding without an Assign node in this AST.
+        if (visitor.ContainsDirectEval)
+            return new();
+
         foreach (var reassigned in visitor.Reassigned)
             visitor.Candidates.Remove(reassigned);
 
         return visitor.Candidates;
     }
 
-    private sealed class TypedArrayAccessVisitor : AstVisitorBase
+    private static bool IsNumber(TypeInfo? type) =>
+        type is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER }
+            or TypeInfo.NumberLiteral;
+
+    private sealed class StableBackingCandidate(string elementType)
     {
-        private readonly TypeMap _typeMap;
+        public string ElementType { get; } = elementType;
+        public HashSet<Expr.Variable> PermittedReceivers { get; } =
+            new(ReferenceEqualityComparer.Instance);
+    }
 
-        /// <summary>Variable name → TypedArray element-type name (e.g. "Int32").</summary>
-        public Dictionary<string, string> Candidates { get; } = new();
+    private sealed class StableBackingVisitor(TypeMap typeMap) : AstVisitorBase
+    {
+        private readonly TypeMap _typeMap = typeMap;
+        private int _scope;
+        private int _nextScope;
 
-        /// <summary>Variables reassigned/re-declared within the loop (disqualified).</summary>
-        public HashSet<string> Reassigned { get; } = new();
+        public Dictionary<(int Scope, string Name), StableBackingCandidate> Candidates { get; } = [];
+        public Dictionary<(int Scope, string Name), int> DeclarationCounts { get; } = [];
+        public HashSet<(int Scope, string Name)> Disqualified { get; } = [];
+        public bool ContainsDirectEval { get; private set; }
+        public bool IntrinsicConstructorIsObservable { get; private set; }
 
-        public TypedArrayAccessVisitor(TypeMap typeMap) => _typeMap = typeMap;
+        protected override void VisitFunction(Stmt.Function statement)
+        {
+            if (TypedArrayElementLayout.IsSupportedConstructor(statement.Name.Lexeme))
+                IntrinsicConstructorIsObservable = true;
+            InScope(() => base.VisitFunction(statement));
+        }
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression) =>
+            InScope(() => base.VisitArrowFunction(expression));
+
+        private void InScope(Action visit)
+        {
+            int saved = _scope;
+            _scope = ++_nextScope;
+            visit();
+            _scope = saved;
+        }
+
+        protected override void VisitVar(Stmt.Var statement) =>
+            HandleDeclaration(statement.Name, statement.Initializer);
+
+        protected override void VisitConst(Stmt.Const statement) =>
+            HandleDeclaration(statement.Name, statement.Initializer);
+
+        private void HandleDeclaration(Token name, Expr? initializer)
+        {
+            var key = (_scope, name.Lexeme);
+            DeclarationCounts[key] = DeclarationCounts.GetValueOrDefault(key) + 1;
+
+            if (TypedArrayElementLayout.IsSupportedConstructor(name.Lexeme))
+                IntrinsicConstructorIsObservable = true;
+
+            if (initializer is Expr.New
+                {
+                    Callee: Expr.Variable constructor,
+                    Arguments: [var length]
+                }
+                && _typeMap.Get(initializer) is TypeInfo.TypedArray typedArray
+                && TypedArrayElementLayout.TryGet(typedArray.ElementType, out _)
+                && constructor.Name.Lexeme == typedArray.ElementType + "Array"
+                && IsNumber(_typeMap.Get(length)))
+            {
+                Candidates.TryAdd(key, new StableBackingCandidate(typedArray.ElementType));
+            }
+
+            if (initializer != null)
+                Visit(initializer);
+        }
+
+        protected override void VisitNew(Expr.New expression)
+        {
+            // Constructing an intrinsic is not itself an observation of the constructor binding.
+            if (expression.Callee is Expr.Variable constructor
+                && TypedArrayElementLayout.IsSupportedConstructor(constructor.Name.Lexeme))
+            {
+                foreach (var argument in expression.Arguments)
+                    Visit(argument);
+                return;
+            }
+
+            base.VisitNew(expression);
+        }
+
+        protected override void VisitGetIndex(Expr.GetIndex expression)
+        {
+            if (!expression.Optional
+                && expression.Object is Expr.Variable receiver
+                && IsNumber(_typeMap.Get(expression.Index))
+                && TryPermitReceiver(receiver))
+            {
+                Visit(expression.Index);
+                return;
+            }
+
+            base.VisitGetIndex(expression);
+        }
+
+        protected override void VisitSetIndex(Expr.SetIndex expression)
+        {
+            if (expression.Object is Expr.Variable receiver
+                && IsNumber(_typeMap.Get(expression.Index))
+                && IsNumber(_typeMap.Get(expression.Value))
+                && TryPermitReceiver(receiver))
+            {
+                Visit(expression.Index);
+                Visit(expression.Value);
+                return;
+            }
+
+            base.VisitSetIndex(expression);
+        }
+
+        protected override void VisitCompoundSetIndex(Expr.CompoundSetIndex expression)
+        {
+            if (expression.Object is Expr.Variable receiver
+                && IsNumber(_typeMap.Get(expression.Index))
+                && IsNumber(_typeMap.Get(expression.Value))
+                && IsDirectCompoundOperator(expression.Operator.Type)
+                && TryPermitReceiver(receiver))
+            {
+                Visit(expression.Index);
+                Visit(expression.Value);
+                return;
+            }
+
+            base.VisitCompoundSetIndex(expression);
+        }
+
+        protected override void VisitGet(Expr.Get expression)
+        {
+            if (!expression.Optional
+                && expression.Name.Lexeme == "length"
+                && expression.Object is Expr.Variable receiver
+                && TryPermitReceiver(receiver))
+            {
+                return;
+            }
+
+            base.VisitGet(expression);
+        }
+
+        protected override void VisitCall(Expr.Call expression)
+        {
+            if (!expression.Optional
+                && expression.Callee is Expr.Variable { Name.Lexeme: "eval" })
+            {
+                ContainsDirectEval = true;
+            }
+            base.VisitCall(expression);
+        }
+
+        private bool TryPermitReceiver(Expr.Variable receiver)
+        {
+            if (_typeMap.Get(receiver) is not TypeInfo.TypedArray typedArray
+                || !TypedArrayElementLayout.TryGet(typedArray.ElementType, out _))
+            {
+                return false;
+            }
+
+            var key = (_scope, receiver.Name.Lexeme);
+            if (Candidates.TryGetValue(key, out var candidate)
+                && candidate.ElementType == typedArray.ElementType)
+            {
+                candidate.PermittedReceivers.Add(receiver);
+            }
+            return true;
+        }
+
+        protected override void VisitVariable(Expr.Variable expression)
+        {
+            if (TypedArrayElementLayout.IsSupportedConstructor(expression.Name.Lexeme))
+                IntrinsicConstructorIsObservable = true;
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+        }
+
+        protected override void VisitAssign(Expr.Assign expression)
+        {
+            NoteAssignment(expression.Name.Lexeme);
+            base.VisitAssign(expression);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
+        {
+            NoteAssignment(expression.Name.Lexeme);
+            base.VisitCompoundAssign(expression);
+        }
+
+        protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
+        {
+            NoteAssignment(expression.Name.Lexeme);
+            base.VisitLogicalAssign(expression);
+        }
+
+        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expression)
+        {
+            if (expression.Operand is Expr.Variable variable)
+                NoteAssignment(variable.Name.Lexeme);
+            base.VisitPrefixIncrement(expression);
+        }
+
+        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expression)
+        {
+            if (expression.Operand is Expr.Variable variable)
+                NoteAssignment(variable.Name.Lexeme);
+            base.VisitPostfixIncrement(expression);
+        }
+
+        private void NoteAssignment(string name)
+        {
+            if (TypedArrayElementLayout.IsSupportedConstructor(name))
+                IntrinsicConstructorIsObservable = true;
+            Disqualified.Add((_scope, name));
+        }
+
+        private static bool IsDirectCompoundOperator(TokenType op) => op is
+            TokenType.PLUS_EQUAL or TokenType.MINUS_EQUAL or TokenType.STAR_EQUAL or
+            TokenType.SLASH_EQUAL or TokenType.PERCENT_EQUAL or TokenType.AMPERSAND_EQUAL or
+            TokenType.PIPE_EQUAL or TokenType.CARET_EQUAL or TokenType.LESS_LESS_EQUAL or
+            TokenType.GREATER_GREATER_EQUAL;
+    }
+
+    private sealed class TypedArrayAccessVisitor(TypeMap typeMap) : AstVisitorBase
+    {
+        private readonly TypeMap _typeMap = typeMap;
+
+        public Dictionary<string, TypedArrayHoistCandidate> Candidates { get; } = [];
+        public HashSet<string> Reassigned { get; } = [];
+        public bool ContainsDirectEval { get; private set; }
 
         public void VisitExpr(Expr expr) => Visit(expr);
 
@@ -77,19 +359,65 @@ public static class TypedArrayHoistAnalyzer
             base.VisitCompoundAssign(expr);
         }
 
+        protected override void VisitLogicalAssign(Expr.LogicalAssign expr)
+        {
+            Reassigned.Add(expr.Name.Lexeme);
+            base.VisitLogicalAssign(expr);
+        }
+
+        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expr)
+        {
+            if (expr.Operand is Expr.Variable variable)
+                Reassigned.Add(variable.Name.Lexeme);
+            base.VisitPrefixIncrement(expr);
+        }
+
+        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expr)
+        {
+            if (expr.Operand is Expr.Variable variable)
+                Reassigned.Add(variable.Name.Lexeme);
+            base.VisitPostfixIncrement(expr);
+        }
+
+        protected override void VisitCall(Expr.Call expr)
+        {
+            if (!expr.Optional && expr.Callee is Expr.Variable { Name.Lexeme: "eval" })
+                ContainsDirectEval = true;
+            base.VisitCall(expr);
+        }
+
         protected override void VisitVar(Stmt.Var stmt)
         {
-            // Variable shadowing — treat as reassignment, matching ArrayHoistAnalyzer.
             Reassigned.Add(stmt.Name.Lexeme);
             base.VisitVar(stmt);
         }
 
+        protected override void VisitConst(Stmt.Const stmt)
+        {
+            Reassigned.Add(stmt.Name.Lexeme);
+            base.VisitConst(stmt);
+        }
+
         private void TryRegister(Expr receiver)
         {
-            if (receiver is not Expr.Variable v) return;
-            if (Candidates.ContainsKey(v.Name.Lexeme)) return;
-            if (_typeMap.Get(receiver) is TypeInfo.TypedArray ta)
-                Candidates[v.Name.Lexeme] = ta.ElementType;
+            if (receiver is not Expr.Variable variable
+                || _typeMap.Get(receiver) is not TypeInfo.TypedArray typedArray)
+            {
+                return;
+            }
+
+            bool stableBacking = _typeMap.IsStableTypedArrayBackingReceiver(variable);
+            if (Candidates.TryGetValue(variable.Name.Lexeme, out var current))
+            {
+                // Every access in the loop must belong to the same whole-program proof.
+                Candidates[variable.Name.Lexeme] = current with
+                {
+                    CanHoistBacking = current.CanHoistBacking && stableBacking
+                };
+                return;
+            }
+
+            Candidates[variable.Name.Lexeme] = new(typedArray.ElementType, stableBacking);
         }
     }
 }

--- a/src/SharpTS/TypeSystem/TypeMap.cs
+++ b/src/SharpTS/TypeSystem/TypeMap.cs
@@ -37,6 +37,7 @@ public class TypeMap
     private readonly HashSet<Expr.Variable> _stablePrimitivePromiseAllPushReceivers = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr> _stablePrimitivePromiseAllSeedValues = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.Variable> _stablePrimitivePromiseAllResultUses = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Expr.Variable> _stableTypedArrayBackingReceivers = new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
     /// Associates an expression with its resolved type.
@@ -154,6 +155,17 @@ public class TypeMap
     /// </summary>
     public bool IsPromotableArrayLocal(Token nameToken, out TokenType elementToken) =>
         _promotableArrayLocals.TryGetValue(nameToken, out elementToken);
+
+    /// <summary>
+    /// Marks an indexed receiver use whose binding belongs to a fresh, exact, non-escaping numeric
+    /// TypedArray local. The IL compiler may cache that receiver's backing storage around a loop.
+    /// Keying the actual receiver node keeps the whole-program proof scope-correct under shadowing.
+    /// </summary>
+    public void MarkStableTypedArrayBackingReceiver(Expr.Variable receiver) =>
+        _stableTypedArrayBackingReceivers.Add(receiver);
+
+    public bool IsStableTypedArrayBackingReceiver(Expr.Variable receiver) =>
+        _stableTypedArrayBackingReceivers.Contains(receiver);
 
     /// <summary>
     /// Marks a fresh, exact, non-escaping <c>Map&lt;number, number&gt;</c> function local

--- a/tests/SharpTS.Tests/CompilerTests/TypedArrayBackingHoistTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/TypedArrayBackingHoistTests.cs
@@ -1,0 +1,235 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>Structural proof and fallback coverage for #1481.</summary>
+public sealed class TypedArrayBackingHoistTests
+{
+    [Fact]
+    public void ExactInt32Loop_LoadsBackingBeforeBodyAndSkipsAccessors()
+    {
+        MethodInfo hot = CompileFunction("""
+            function hot(n: number): number {
+                const data = new Int32Array(n);
+                for (let i: number = 0; i < n; i++) {
+                    data[i] = data[i] + 1;
+                }
+                return n;
+            }
+            """, "hot");
+
+        var instructions = ReadInstructions(hot).ToArray();
+        int getBuffer = FindCall(instructions, "GetBuffer");
+        int getOffset = FindCall(instructions, "get_ByteOffset");
+        int getLength = FindCall(instructions, "get_Length");
+        int read = FindCall(instructions, "ReadUnaligned");
+        int write = FindCall(instructions, "WriteUnaligned");
+
+        Assert.True(getBuffer >= 0 && getBuffer < read);
+        Assert.True(getOffset >= 0 && getOffset < read);
+        Assert.True(getLength >= 0 && getLength < read);
+        Assert.True(write > read);
+        Assert.DoesNotContain(instructions, IsUnboxedAccessorCall);
+    }
+
+    [Fact]
+    public void ExactUint8Loop_UsesDirectByteElementOperations()
+    {
+        MethodInfo hot = CompileFunction("""
+            function hot(n: number): number {
+                const data = new Uint8Array(n);
+                for (let i: number = 0; i < n; i++) {
+                    data[i] = data[i] + 1;
+                }
+                return n;
+            }
+            """, "hot");
+
+        var instructions = ReadInstructions(hot).ToArray();
+        Assert.Contains(instructions, instruction => instruction.OpCode == OpCodes.Ldelem_U1);
+        Assert.Contains(instructions, instruction => instruction.OpCode == OpCodes.Stelem_I1);
+        Assert.DoesNotContain(instructions, IsUnboxedAccessorCall);
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "ReadUnaligned" or "WriteUnaligned" });
+    }
+
+    [Theory]
+    [MemberData(nameof(FallbackPrograms))]
+    public void UnsafeLifetime_RetainsConcreteAccessorFallback(string source)
+    {
+        var instructions = ReadInstructions(CompileFunction(source, "hot")).ToArray();
+
+        Assert.Contains(instructions, IsUnboxedAccessorCall);
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "GetBuffer" });
+    }
+
+    [Fact]
+    public void UnsupportedClampedKind_DoesNotHoistBacking()
+    {
+        var instructions = ReadInstructions(CompileFunction("""
+            function hot(n: number): number {
+                const data = new Uint8ClampedArray(n);
+                for (let i: number = 0; i < n; i++) data[i] = i;
+                return n;
+            }
+            """, "hot")).ToArray();
+
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "GetBuffer" or "ReadUnaligned" or "WriteUnaligned" });
+    }
+
+    [Fact]
+    public void ExactBackingLoop_PassesIlVerification()
+    {
+        const string source = """
+            function hot(n: number): number {
+                const data = new Float64Array(n);
+                for (let i: number = 0; i < n; i++) data[i] += i * 0.5;
+                return n;
+            }
+            console.log(hot(8));
+            """;
+
+        Assert.Empty(Infrastructure.TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    public static TheoryData<string> FallbackPrograms => new()
+    {
+        """
+        function observe(value: Int32Array): void {}
+        function hot(n: number): number {
+            const data = new Int32Array(n);
+            observe(data);
+            for (let i: number = 0; i < n; i++) data[i] = i;
+            return n;
+        }
+        """,
+        """
+        function hot(n: number): number {
+            let data = new Int32Array(n);
+            for (let i: number = 0; i < n; i++) {
+                if (i === 1) data = new Int32Array(n);
+                data[i] = i;
+            }
+            return n;
+        }
+        """,
+        """
+        function hot(n: number): number {
+            const data = new Int32Array(n);
+            const alias = data.subarray(0);
+            for (let i: number = 0; i < n; i++) data[i] = i;
+            return alias.length;
+        }
+        """,
+        """
+        function hot(n: number): number {
+            const data = new Int32Array(n);
+            const backing = data.buffer;
+            for (let i: number = 0; i < n; i++) data[i] = i;
+            return backing.byteLength;
+        }
+        """,
+        """
+        function hot(n: number): number {
+            const data = new Int32Array(n);
+            const index: any = 0;
+            for (let i: number = 0; i < n; i++) data[index] = i;
+            return n;
+        }
+        """,
+        """
+        function hot(n: number): number {
+            const buffer = new ArrayBuffer(n * 4);
+            const data = new Int32Array(buffer);
+            for (let i: number = 0; i < n; i++) data[i] = i;
+            return n;
+        }
+        """,
+        """
+        function hot(n: number): number {
+            const data = new Int32Array(n);
+            const read = (): number => data[0];
+            for (let i: number = 0; i < n; i++) data[i] = i;
+            return read();
+        }
+        """
+    };
+
+    private static MethodInfo CompileFunction(string source, string name)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"issue_1481_typed_array_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        Assembly assembly = Assembly.Load(compiler.SaveToBytes());
+        return assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+    }
+
+    private static int FindCall(
+        (OpCode OpCode, MemberInfo? Operand)[] instructions,
+        string methodName) =>
+        Array.FindIndex(instructions, instruction =>
+            instruction.Operand is MethodBase method && method.Name == methodName);
+
+    private static bool IsUnboxedAccessorCall((OpCode OpCode, MemberInfo? Operand) instruction) =>
+        instruction.Operand is MethodBase { Name: "GetUnboxed" or "SetUnboxed" };
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineField or OperandType.InlineMethod
+                or OperandType.InlineTok or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = module.ResolveMember(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch => 4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}

--- a/tests/SharpTS.Tests/SharedTests/TypedArrayBackingHoistParityTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/TypedArrayBackingHoistParityTests.cs
@@ -1,0 +1,48 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>Observable parity coverage for the #1481 compiled backing-storage specialization.</summary>
+public sealed class TypedArrayBackingHoistParityTests
+{
+    [Theory, ModeData]
+    public void ExactNumericLoops_PreserveNarrowingAndAccumulation(ExecutionMode mode)
+    {
+        const string source = """
+            function exercise(n: number): number {
+                const ints = new Int32Array(n);
+                const floats = new Float64Array(n);
+                for (let i: number = 0; i < n; i++) {
+                    ints[i] = i * 3.75;
+                    floats[i] = i * 0.5;
+                }
+                for (let i: number = 0; i < n; i++) floats[i] += ints[i];
+                let sum: number = 0;
+                for (let i: number = 0; i < ints.length; i++) {
+                    sum = sum + ints[i] + floats[i];
+                }
+                return sum;
+            }
+            console.log(exercise(6));
+            """;
+
+        Assert.Equal("115.5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void AliasedView_RemainsObservableThroughFallback(ExecutionMode mode)
+    {
+        const string source = """
+            const original = new Uint8Array(4);
+            const alias = original.subarray(1, 3);
+            for (let i: number = 0; i < original.length; i++) original[i] = i * 10 + 1;
+            console.log(alias[0]);
+            console.log(alias[1]);
+            alias[0] = 99;
+            console.log(original[1]);
+            """;
+
+        Assert.Equal("11\n21\n99\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
## Summary

- prove fresh, exact, non-escaping numeric TypedArray locals with a conservative whole-program analysis
- hoist the concrete receiver, backing buffer, byte offset, and length before eligible numeric loops
- emit direct byte-array access or `Unsafe.Read/WriteUnaligned` in hot loop bodies while retaining accessor fallbacks
- fold the statically-zero byte offset for exact length constructors
- add structural IL, parity, zero-allocation, and negative fallback coverage
- normalize the local performance harness command text for WSL

Refs #1481

## Performance

Five-launch paired medians at 1,000,000 elements:

| Platform | Kernel | Baseline | Candidate | Change | Candidate/Node |
|---|---|---:|---:|---:|---:|
| Windows | Float64 accumulate | 6.7277 ms | 5.2262 ms | -22.32% | 0.693x |
| Windows | Int32 kernel | 4.0638 ms | 3.8053 ms | -7.24% | 1.158x |
| WSL Ubuntu | Float64 accumulate | 9.0284 ms | 7.4415 ms | -17.56% | 0.961x |
| WSL Ubuntu | Int32 kernel | 4.6696 ms | 4.2445 ms | -7.86% | 1.184x |

Float64 clears the 10% target on both hosts and Windows has no material regressions. The WSL 1M Int32 kernel improves, but remains 2.14 percentage points short of the issue's 10% target; this PR intentionally does not auto-close the issue.

The broader Windows control run classified Brainfuck and count-primes as neutral.

## Validation

- final commit: Windows Release build, IL verification, performance/micro smoke checks, and 807/807 compiler-focused tests
- final commit: WSL Ubuntu Release build, IL verification, performance/micro smoke checks, and 807/807 compiler-focused tests
- focused TypedArray/parity/regression suite: 39/39
- full WSL gate: 17,383/17,383 core tests, 106/106 GUI conformance tests, conformance builds, packaging helpers, zero-warning AOT analyzer baseline, and Linux Native AOT execution
- full Windows gate: 17,370 passed and 3 skipped; four parallel resource-sensitive failures all passed in isolated reruns, followed by 106/106 GUI conformance tests, packaging helpers, and the zero-warning AOT analyzer baseline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved numeric typed-array loops by directly accessing backing storage when safe.
  - Accelerated indexed reads, writes, compound assignments, and length checks for eligible arrays.
  - Preserved existing behavior for aliased, dynamically accessed, unsupported, or otherwise unsafe arrays.

- **Bug Fixes**
  - Ensured typed-array numeric narrowing, accumulation, and aliased-view behavior remain consistent across execution modes.
  - Improved compatibility for generated scripts executed through WSL.

- **Tests**
  - Added coverage for optimized typed-array operations, fallback behavior, and generated-code verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->