### PR TITLE
Perf: specialize stable radix-10 parseInt calls

### DIFF
--- a/benchmarks/cross-runtime/scripts/language-hot-paths.ts
+++ b/benchmarks/cross-runtime/scripts/language-hot-paths.ts
@@ -58,6 +58,9 @@ function generatorRange(n: number): number {
     return sum;
 }
 
+// Permanent cross-runtime guard for the stable decimal parser. Keep the
+// numeric toString producer here so this tracks the real #1480 workload while
+// the BenchmarkDotNet companion isolates parser-only attribution.
 function parseIntegers(n: number): number {
     let sum: number = 0;
     for (let i: number = 0; i < n; i++) {

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ParseIntDecimalBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ParseIntDecimalBenchmarks.cs
@@ -1,0 +1,64 @@
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using SharpTS.Microbenchmarks.Infrastructure;
+
+namespace SharpTS.Microbenchmarks.Benchmarks;
+
+/// <summary>
+/// Parser-only attribution for stable parseInt(string, 10). Delegates target
+/// the emitted runtime helpers directly so generated wrapper and TypeScript
+/// loop costs do not obscure the decimal scanner.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class ParseIntDecimalBenchmarks
+{
+    private Func<string, double> _decimal = null!;
+    private Func<string, int, double> _general = null!;
+
+    [Params(
+        "123456789012345",
+        "  -12345suffix",
+        "\u00A0+9007199254740991tail")]
+    public string Input { get; set; } = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Assembly assembly = typeof(ParseIntDecimalBenchmarks).Assembly;
+        using Stream stream = assembly.GetManifestResourceStream(
+            "SharpTS.Microbenchmarks.TypeScriptSources.ParseIntDecimal.ts")
+            ?? throw new InvalidOperationException(
+                "Could not find embedded resource ParseIntDecimal.ts");
+        using var reader = new StreamReader(stream);
+        string dllPath = CompilationCache.GetOrCompile(
+            reader.ReadToEnd(), "ParseIntDecimal");
+        Assembly compiled = BenchmarkHarness.LoadCompiledAssembly(
+            dllPath, "parse-int-decimal");
+        BenchmarkHarness.InitializeCompiledModules(compiled);
+
+        Type runtime = compiled.GetType("$Runtime")
+            ?? throw new InvalidOperationException(
+                "Compiled parseInt benchmark has no $Runtime type");
+        _decimal = runtime.GetMethod(
+                "NumberParseIntDecimalString",
+                BindingFlags.Public | BindingFlags.Static)
+            ?.CreateDelegate<Func<string, double>>()
+            ?? throw new InvalidOperationException(
+                "Compiled runtime has no decimal parseInt helper");
+        _general = runtime.GetMethod(
+                "NumberParseIntString",
+                BindingFlags.Public | BindingFlags.Static)
+            ?.CreateDelegate<Func<string, int, double>>()
+            ?? throw new InvalidOperationException(
+                "Compiled runtime has no general typed parseInt helper");
+    }
+
+    [Benchmark]
+    public double DecimalScanner() => _decimal(Input);
+
+    [Benchmark(Baseline = true)]
+    public double GeneralRadixParser() => _general(Input, 10);
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ParseIntDecimal.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ParseIntDecimal.ts
@@ -1,0 +1,9 @@
+// Keep both runtime parse helpers rooted so the C# benchmark can call them
+// directly without measuring a generated TypeScript wrapper.
+export function parseDecimal(value: string): number {
+    return parseInt(value, 10);
+}
+
+export function parseGeneral(value: string, radix: number): number {
+    return parseInt(value, radix);
+}

--- a/src/SharpTS/Compilation/CallHandlers/GlobalFunctionHandler.cs
+++ b/src/SharpTS/Compilation/CallHandlers/GlobalFunctionHandler.cs
@@ -186,6 +186,28 @@ public class GlobalFunctionHandler : ICallHandler
 
     private static bool EmitParseInt(IEmitterContext emitter, System.Reflection.Emit.ILGenerator il, CompilationContext ctx, Expr.Call call)
     {
+        if (call.Arguments.Count == 2
+            && ExpressionEmitterBase.TryGetInt32Literal(call.Arguments[1], out int decimalRadix)
+            && decimalRadix == 10)
+        {
+            if (emitter is ExpressionEmitterBase expressionEmitter
+                && expressionEmitter.TryEmitStableIntegerCounterParseInt(
+                    call.Arguments[0]))
+            {
+                return true;
+            }
+
+            if (IsStaticallyString(ctx.TypeMap?.Get(call.Arguments[0])))
+            {
+                emitter.EmitExpression(call.Arguments[0]);
+                il.Emit(System.Reflection.Emit.OpCodes.Castclass, ctx.Types.String);
+                il.Emit(System.Reflection.Emit.OpCodes.Call,
+                    ctx.Runtime!.NumberParseIntDecimalString);
+                emitter.SetStackType(StackType.Double);
+                return true;
+            }
+        }
+
         if (call.Arguments.Count is 1 or 2
             && IsStaticallyString(ctx.TypeMap?.Get(call.Arguments[0]))
             && (call.Arguments.Count == 1

--- a/src/SharpTS/Compilation/CallHandlers/GlobalThisChainHandler.cs
+++ b/src/SharpTS/Compilation/CallHandlers/GlobalThisChainHandler.cs
@@ -28,6 +28,12 @@ public class GlobalThisChainHandler : ICallHandler
         string namespaceName = innerGet.Name.Lexeme;
         string methodName = chainedGet.Name.Lexeme;
 
+        if (namespaceName == "Number"
+            && ctx.RuntimeFeatures?.UsesNumberConstructorMutation == true)
+        {
+            return false;
+        }
+
         // Handle globalThis.console.log() etc.
         if (namespaceName == "console")
         {
@@ -45,7 +51,17 @@ public class GlobalThisChainHandler : ICallHandler
         var staticStrategy = ctx.TypeEmitterRegistry.GetStaticStrategy(namespaceName);
         if (staticStrategy != null && staticStrategy.TryEmitStaticCall(emitter, methodName, call.Arguments))
         {
-            emitter.SetStackUnknown();
+            if (namespaceName == "Number"
+                && methodName == "parseInt"
+                && NumberStaticEmitter.EmitsUnboxedDecimalParseInt(
+                    emitter, call.Arguments))
+            {
+                emitter.SetStackType(StackType.Double);
+            }
+            else
+            {
+                emitter.SetStackUnknown();
+            }
             return true;
         }
 

--- a/src/SharpTS/Compilation/CallHandlers/StaticTypeHandler.cs
+++ b/src/SharpTS/Compilation/CallHandlers/StaticTypeHandler.cs
@@ -24,6 +24,13 @@ public class StaticTypeHandler : ICallHandler
         if (ctx.TypeEmitterRegistry == null)
             return false;
 
+        if (staticVar.Name.Lexeme == "Number"
+            && (emitter.HasVariable("Number")
+                || ctx.RuntimeFeatures?.UsesNumberConstructorMutation == true))
+        {
+            return false;
+        }
+
         var staticStrategy = ctx.TypeEmitterRegistry.GetStaticStrategy(staticVar.Name.Lexeme);
         if (staticStrategy == null)
             return false;
@@ -31,7 +38,14 @@ public class StaticTypeHandler : ICallHandler
         if (!staticStrategy.TryEmitStaticCall(emitter, staticGet.Name.Lexeme, call.Arguments))
             return false;
 
-        if (staticVar.Name.Lexeme == "Promise"
+        if (staticVar.Name.Lexeme == "Number"
+            && staticGet.Name.Lexeme == "parseInt"
+            && NumberStaticEmitter.EmitsUnboxedDecimalParseInt(
+                emitter, call.Arguments))
+        {
+            emitter.SetStackType(StackType.Double);
+        }
+        else if (staticVar.Name.Lexeme == "Promise"
             && staticGet.Name.Lexeme == "resolve"
             && call.Arguments is [var resolvedValue]
             && ctx.TypeMap?.IsStablePrimitivePromiseAllSeedValue(resolvedValue) == true)

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -1150,6 +1150,8 @@ public class EmittedRuntime
     public MethodBuilder NumberParseInt { get; set; } = null!;
     /// <summary>Typed intrinsic parse path: already-coerced string plus native radix.</summary>
     public MethodBuilder NumberParseIntString { get; set; } = null!;
+    /// <summary>Allocation-free decimal parser for a stable string and literal radix 10.</summary>
+    public MethodBuilder NumberParseIntDecimalString { get; set; } = null!;
     public MethodBuilder NumberParseFloat { get; set; } = null!;
     public MethodBuilder NumberIsNaN { get; set; } = null!;
     public MethodBuilder NumberIsFinite { get; set; } = null!;

--- a/src/SharpTS/Compilation/Emitters/NumberStaticEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/NumberStaticEmitter.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using System.Reflection.Emit;
 using SharpTS.Parsing;
+using TypeInfo = SharpTS.TypeSystem.TypeInfo;
 
 namespace SharpTS.Compilation.Emitters;
 
@@ -22,7 +23,8 @@ public sealed class NumberStaticEmitter : IStaticTypeEmitterStrategy
         switch (methodName)
         {
             case "parseInt":
-                EmitParseInt(emitter, arguments);
+                EmitParseInt(emitter, arguments,
+                    EmitsUnboxedDecimalParseInt(emitter, arguments));
                 return true;
             case "parseFloat":
                 EmitParseFloat(emitter, arguments);
@@ -164,10 +166,50 @@ public sealed class NumberStaticEmitter : IStaticTypeEmitterStrategy
         }
     }
 
-    private static void EmitParseInt(IEmitterContext emitter, List<Expr> arguments)
+    internal static bool EmitsUnboxedDecimalParseInt(
+        IEmitterContext emitter,
+        IReadOnlyList<Expr> arguments)
+        => emitter.Context.RuntimeFeatures?.UsesNumberConstructorMutation != true
+            && !emitter.HasVariable("Number")
+            && arguments.Count == 2
+            && (IsStaticallyString(emitter.Context.TypeMap?.Get(arguments[0]))
+                || emitter is ExpressionEmitterBase expressionEmitter
+                    && expressionEmitter.CanEmitStableIntegerCounterParseInt(
+                        arguments[0]))
+            && ExpressionEmitterBase.TryGetInt32Literal(arguments[1], out int radix)
+            && radix == 10;
+
+    private static bool IsStaticallyString(TypeInfo? type) => type switch
+    {
+        TypeInfo.String => true,
+        TypeInfo.StringLiteral => true,
+        TypeInfo.Union union => union.Types.Count > 0
+            && union.Types.All(IsStaticallyString),
+        _ => false
+    };
+
+    private static void EmitParseInt(
+        IEmitterContext emitter,
+        List<Expr> arguments,
+        bool emitDecimalFastPath)
     {
         var ctx = emitter.Context;
         var il = ctx.IL;
+
+        if (emitDecimalFastPath)
+        {
+            if (emitter is ExpressionEmitterBase expressionEmitter
+                && expressionEmitter.TryEmitStableIntegerCounterParseInt(
+                    arguments[0]))
+            {
+                return;
+            }
+
+            emitter.EmitExpression(arguments[0]);
+            il.Emit(OpCodes.Castclass, ctx.Types.String);
+            il.Emit(OpCodes.Call, ctx.Runtime!.NumberParseIntDecimalString);
+            return;
+        }
 
         // Emit string argument
         if (arguments.Count > 0)

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.NumberConversions.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.NumberConversions.cs
@@ -73,6 +73,59 @@ public abstract partial class ExpressionEmitterBase
     /// </summary>
     protected virtual bool TryEmitIntegerCounterDecimalString(Expr expression) => false;
 
+    /// <summary>
+    /// Folds <c>parseInt(counter.toString(), 10)</c> only when the receiver is a
+    /// native Int64 loop-counter expression. Every Int64 is below JavaScript's
+    /// 1e21 exponential-format threshold, so parsing its stable decimal spelling
+    /// is exactly the original numeric value and neither intermediate operation
+    /// is observable.
+    /// </summary>
+    internal bool TryEmitStableIntegerCounterParseInt(Expr expression)
+    {
+        if (!CanEmitStableIntegerCounterParseInt(expression))
+            return false;
+
+        var toStringCall = (Expr.Call)expression;
+        var methodGet = (Expr.Get)toStringCall.Callee;
+        return TryEmitIntegerCounterDecimalValue(methodGet.Object);
+    }
+
+    /// <summary>
+    /// Non-emitting companion used while a call handler selects its stack ABI.
+    /// </summary>
+    internal bool CanEmitStableIntegerCounterParseInt(Expr expression)
+    {
+        if (Ctx.RuntimeFeatures?.UsesNumberPrototypeMutation == true
+            || expression is not Expr.Call
+            {
+                Optional: false,
+                Callee: Expr.Get
+                {
+                    Optional: false,
+                    Name.Lexeme: "toString"
+                } methodGet
+            } toStringCall
+            || toStringCall.Arguments.Count > 1
+            || (toStringCall.Arguments.Count == 1
+                && (!TryGetInt32Literal(toStringCall.Arguments[0], out int radix)
+                    || radix != 10))
+            || !IsStaticallyNumber(Ctx.TypeMap?.Get(methodGet.Object)))
+        {
+            return false;
+        }
+
+        return IsIntegerCounterDecimalValue(methodGet.Object);
+    }
+
+    /// <summary>
+    /// Sync ILEmitter overrides this for its native Int64 for-loop counters.
+    /// Other emitters conservatively retain the string-and-scan path.
+    /// </summary>
+    protected virtual bool TryEmitIntegerCounterDecimalValue(Expr expression) => false;
+
+    /// <summary>Non-emitting probe paired with the value emitter.</summary>
+    protected virtual bool IsIntegerCounterDecimalValue(Expr expression) => false;
+
     private static bool IsStaticallyNumber(TypeInfo? type) => type switch
     {
         TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } => true,

--- a/src/SharpTS/Compilation/ILEmitter.Calls.NumberMethods.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.NumberMethods.cs
@@ -21,6 +21,20 @@ public partial class ILEmitter
         return true;
     }
 
+    protected override bool TryEmitIntegerCounterDecimalValue(Expr expression)
+    {
+        if (!IsIntegerCounterValueI8(expression))
+            return false;
+
+        _ = TryEmitIntegerCounterValueI8(expression);
+        IL.Emit(OpCodes.Conv_R8);
+        SetStackType(StackType.Double);
+        return true;
+    }
+
+    protected override bool IsIntegerCounterDecimalValue(Expr expression) =>
+        IsIntegerCounterValueI8(expression);
+
     /// <summary>
     /// Emits a BigInt instance-method call (receiver statically bigint). toString takes
     /// an optional radix (ECMA-262 21.2.3.3); toLocaleString is the decimal form;

--- a/src/SharpTS/Compilation/RuntimeEmitter.Number.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Number.cs
@@ -150,6 +150,7 @@ public partial class RuntimeEmitter
     {
         // Emit helper methods first (they're used by other methods)
         EmitGetDigitValue(typeBuilder, runtime);
+        EmitParseIntDecimalStringHelper(typeBuilder, runtime);
         EmitParseIntStringHelper(typeBuilder, runtime);
         EmitParseIntHelper(typeBuilder, runtime);
         EmitConvertIntToRadix(typeBuilder, runtime);
@@ -168,6 +169,167 @@ public partial class RuntimeEmitter
         EmitNumberToPrecision(typeBuilder, runtime);
         EmitNumberToExponential(typeBuilder, runtime);
         EmitNumberToStringRadix(typeBuilder, runtime);
+    }
+
+    /// <summary>
+    /// Emits the literal-radix-10 parse core. The caller has already proved that
+    /// ToString/ToInt32 coercion and intrinsic lookup are unobservable, so this
+    /// helper can scan the existing string directly without trimming or boxing.
+    /// </summary>
+    private void EmitParseIntDecimalStringHelper(
+        TypeBuilder typeBuilder,
+        EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "NumberParseIntDecimalString",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Double,
+            [_types.String]);
+        method.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
+        runtime.NumberParseIntDecimalString = method;
+
+        var il = method.GetILGenerator();
+        var length = il.DeclareLocal(_types.Int32);
+        var index = il.DeclareLocal(_types.Int32);
+        var digitStart = il.DeclareLocal(_types.Int32);
+        var sign = il.DeclareLocal(_types.Int32);
+        var digit = il.DeclareLocal(_types.Int32);
+        var current = il.DeclareLocal(_types.Char);
+        var result = il.DeclareLocal(_types.Double);
+
+        var whitespaceLoop = il.DefineLabel();
+        var aboveAsciiWhitespace = il.DefineLabel();
+        var consumeWhitespace = il.DefineLabel();
+        var afterWhitespace = il.DefineLabel();
+        var notMinus = il.DefineLabel();
+        var afterSign = il.DefineLabel();
+        var digitLoop = il.DefineLabel();
+        var endDigits = il.DefineLabel();
+        var noDigits = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt,
+            _types.GetProperty(_types.String, "Length")!.GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, length);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, index);
+
+        // Skip exactly the ECMAScript WhiteSpace and LineTerminator set. The
+        // ASCII check is first so the common digit-leading input reaches the
+        // parser after two comparisons. U+0085 is intentionally not accepted;
+        // char.IsWhiteSpace includes it even though ECMAScript does not.
+        il.MarkLabel(whitespaceLoop);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldloc, length);
+        il.Emit(OpCodes.Bge, noDigits);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Callvirt,
+            _types.GetMethod(_types.String, "get_Chars", [_types.Int32])!);
+        il.Emit(OpCodes.Stloc, current);
+
+        il.Emit(OpCodes.Ldloc, current);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)' ');
+        il.Emit(OpCodes.Bgt_Un, aboveAsciiWhitespace);
+        il.Emit(OpCodes.Ldloc, current);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)' ');
+        il.Emit(OpCodes.Beq, consumeWhitespace);
+        il.Emit(OpCodes.Ldloc, current);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)'\t');
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Ldc_I4_4);
+        il.Emit(OpCodes.Ble_Un, consumeWhitespace);
+        il.Emit(OpCodes.Br, afterWhitespace);
+
+        il.MarkLabel(aboveAsciiWhitespace);
+        il.Emit(OpCodes.Ldloc, current);
+        il.Emit(OpCodes.Ldc_I4, 0x00A0);
+        il.Emit(OpCodes.Blt_Un, afterWhitespace);
+        il.Emit(OpCodes.Ldloc, current);
+        il.Emit(OpCodes.Ldc_I4, 0xFEFF);
+        il.Emit(OpCodes.Beq, consumeWhitespace);
+        il.Emit(OpCodes.Ldloc, current);
+        il.Emit(OpCodes.Call,
+            _types.GetMethod(_types.Char, "IsWhiteSpace", _types.Char));
+        il.Emit(OpCodes.Brfalse, afterWhitespace);
+
+        il.MarkLabel(consumeWhitespace);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, index);
+        il.Emit(OpCodes.Br, whitespaceLoop);
+
+        il.MarkLabel(afterWhitespace);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, sign);
+        il.Emit(OpCodes.Ldloc, current);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)'-');
+        il.Emit(OpCodes.Bne_Un, notMinus);
+        il.Emit(OpCodes.Ldc_I4_M1);
+        il.Emit(OpCodes.Stloc, sign);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, index);
+        il.Emit(OpCodes.Br, afterSign);
+
+        il.MarkLabel(notMinus);
+        il.Emit(OpCodes.Ldloc, current);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)'+');
+        il.Emit(OpCodes.Bne_Un, afterSign);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, index);
+
+        il.MarkLabel(afterSign);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Stloc, digitStart);
+        il.Emit(OpCodes.Ldc_R8, 0.0);
+        il.Emit(OpCodes.Stloc, result);
+
+        il.MarkLabel(digitLoop);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldloc, length);
+        il.Emit(OpCodes.Bge, endDigits);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Callvirt,
+            _types.GetMethod(_types.String, "get_Chars", [_types.Int32])!);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)'0');
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Stloc, digit);
+        il.Emit(OpCodes.Ldloc, digit);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)9);
+        il.Emit(OpCodes.Bgt_Un, endDigits);
+
+        il.Emit(OpCodes.Ldloc, result);
+        il.Emit(OpCodes.Ldc_R8, 10.0);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ldloc, digit);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, result);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, index);
+        il.Emit(OpCodes.Br, digitLoop);
+
+        il.MarkLabel(endDigits);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldloc, digitStart);
+        il.Emit(OpCodes.Beq, noDigits);
+        il.Emit(OpCodes.Ldloc, sign);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Ldloc, result);
+        il.Emit(OpCodes.Mul);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(noDigits);
+        il.Emit(OpCodes.Ldc_R8, double.NaN);
+        il.Emit(OpCodes.Ret);
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -98,6 +98,7 @@ public sealed class RuntimeFeatureDetector
             UsesPromisePrototypeMutation = false,
             UsesArrayPrototypeMutation = false,
             UsesNumberPrototypeMutation = false,
+            UsesNumberConstructorMutation = false,
             UsesRegExpPrototypeMutation = false,
             UsesGlobalParseIntMutation = false,
             PotentiallyMaterializesUnknownCompactObjectRecordShape = false,
@@ -881,8 +882,11 @@ public sealed class RuntimeFeatureDetector
                 if (IsPromiseMutationTarget(s.Object)
                     || s.Name.Lexeme is "then" or "constructor" or "__proto__")
                     _set.UsesPromisePrototypeMutation = true;
-                if (IsNumberMutationTarget(s.Object))
+                if (IsNumberMutationTarget(s.Object)
+                    || (IsGlobalObject(s.Object) && s.Name.Lexeme == "Number"))
                     _set.UsesNumberPrototypeMutation = true;
+                if (IsNumberConstructorMutationTarget(s.Object, s.Name.Lexeme))
+                    _set.UsesNumberConstructorMutation = true;
                 if (IsRegExpMutationTarget(s.Object)
                     || (IsGlobalObject(s.Object) && s.Name.Lexeme == "RegExp"))
                     _set.UsesRegExpPrototypeMutation = true;
@@ -938,8 +942,14 @@ public sealed class RuntimeFeatureDetector
                         Value: "then" or "constructor" or "__proto__"
                     })
                     _set.UsesPromisePrototypeMutation = true;
-                if (IsNumberMutationTarget(si.Object))
+                if (IsNumberMutationTarget(si.Object)
+                    || (IsGlobalObject(si.Object)
+                        && si.Index is Expr.Literal { Value: "Number" }))
                     _set.UsesNumberPrototypeMutation = true;
+                if (si.Index is Expr.Literal { Value: string setIndexNumberProperty }
+                    && IsNumberConstructorMutationTarget(
+                        si.Object, setIndexNumberProperty))
+                    _set.UsesNumberConstructorMutation = true;
                 if (IsRegExpMutationTarget(si.Object)
                     || (IsGlobalObject(si.Object)
                         && si.Index is Expr.Literal { Value: "RegExp" }))
@@ -962,6 +972,7 @@ public sealed class RuntimeFeatureDetector
                 {
                     _set.UsesPromisePrototypeMutation = true;
                     _set.UsesNumberPrototypeMutation = true;
+                    _set.UsesNumberConstructorMutation = true;
                     _set.UsesRegExpPrototypeMutation = true;
                     _set.UsesGlobalParseIntMutation = true;
                 }
@@ -988,6 +999,7 @@ public sealed class RuntimeFeatureDetector
                     // value dispatch is conservative and preserves observability.
                     _set.UsesPromisePrototypeMutation = true;
                     _set.UsesNumberPrototypeMutation = true;
+                    _set.UsesNumberConstructorMutation = true;
                     _set.UsesRegExpPrototypeMutation = true;
                 }
                 if (c.Callee is not Expr.Variable directSourceCall ||
@@ -1075,7 +1087,10 @@ public sealed class RuntimeFeatureDetector
                 if (asg.Name.Lexeme == "Promise")
                     _set.UsesPromisePrototypeMutation = true;
                 if (asg.Name.Lexeme == "Number")
+                {
                     _set.UsesNumberPrototypeMutation = true;
+                    _set.UsesNumberConstructorMutation = true;
+                }
                 if (asg.Name.Lexeme == "RegExp")
                     _set.UsesRegExpPrototypeMutation = true;
                 if (asg.Name.Lexeme == "parseInt")
@@ -1086,7 +1101,10 @@ public sealed class RuntimeFeatureDetector
                 break;
             case Expr.CompoundAssign ca:
                 if (ca.Name.Lexeme == "Number")
+                {
                     _set.UsesNumberPrototypeMutation = true;
+                    _set.UsesNumberConstructorMutation = true;
+                }
                 if (ca.Name.Lexeme == "RegExp")
                     _set.UsesRegExpPrototypeMutation = true;
                 if (ca.Name.Lexeme == "parseInt")
@@ -1098,8 +1116,11 @@ public sealed class RuntimeFeatureDetector
                 if (IsPromiseMutationTarget(cs.Object)
                     || cs.Name.Lexeme is "then" or "constructor" or "__proto__")
                     _set.UsesPromisePrototypeMutation = true;
-                if (IsNumberMutationTarget(cs.Object))
+                if (IsNumberMutationTarget(cs.Object)
+                    || (IsGlobalObject(cs.Object) && cs.Name.Lexeme == "Number"))
                     _set.UsesNumberPrototypeMutation = true;
+                if (IsNumberConstructorMutationTarget(cs.Object, cs.Name.Lexeme))
+                    _set.UsesNumberConstructorMutation = true;
                 if (IsRegExpMutationTarget(cs.Object))
                     _set.UsesRegExpPrototypeMutation = true;
                 if (IsGlobalObject(cs.Object) && cs.Name.Lexeme == "parseInt")
@@ -1117,8 +1138,14 @@ public sealed class RuntimeFeatureDetector
                         Value: "then" or "constructor" or "__proto__"
                     })
                     _set.UsesPromisePrototypeMutation = true;
-                if (IsNumberMutationTarget(csi.Object))
+                if (IsNumberMutationTarget(csi.Object)
+                    || (IsGlobalObject(csi.Object)
+                        && csi.Index is Expr.Literal { Value: "Number" }))
                     _set.UsesNumberPrototypeMutation = true;
+                if (csi.Index is Expr.Literal { Value: string compoundNumberProperty }
+                    && IsNumberConstructorMutationTarget(
+                        csi.Object, compoundNumberProperty))
+                    _set.UsesNumberConstructorMutation = true;
                 if (IsRegExpMutationTarget(csi.Object))
                     _set.UsesRegExpPrototypeMutation = true;
                 if (IsGlobalObject(csi.Object)
@@ -1133,7 +1160,10 @@ public sealed class RuntimeFeatureDetector
                 break;
             case Expr.LogicalAssign la:
                 if (la.Name.Lexeme == "Number")
+                {
                     _set.UsesNumberPrototypeMutation = true;
+                    _set.UsesNumberConstructorMutation = true;
+                }
                 if (la.Name.Lexeme == "RegExp")
                     _set.UsesRegExpPrototypeMutation = true;
                 if (la.Name.Lexeme == "parseInt")
@@ -1145,8 +1175,11 @@ public sealed class RuntimeFeatureDetector
                 if (IsPromiseMutationTarget(ls.Object)
                     || ls.Name.Lexeme is "then" or "constructor" or "__proto__")
                     _set.UsesPromisePrototypeMutation = true;
-                if (IsNumberMutationTarget(ls.Object))
+                if (IsNumberMutationTarget(ls.Object)
+                    || (IsGlobalObject(ls.Object) && ls.Name.Lexeme == "Number"))
                     _set.UsesNumberPrototypeMutation = true;
+                if (IsNumberConstructorMutationTarget(ls.Object, ls.Name.Lexeme))
+                    _set.UsesNumberConstructorMutation = true;
                 if (IsRegExpMutationTarget(ls.Object))
                     _set.UsesRegExpPrototypeMutation = true;
                 if (IsGlobalObject(ls.Object) && ls.Name.Lexeme == "parseInt")
@@ -1164,8 +1197,14 @@ public sealed class RuntimeFeatureDetector
                         Value: "then" or "constructor" or "__proto__"
                     })
                     _set.UsesPromisePrototypeMutation = true;
-                if (IsNumberMutationTarget(lsi.Object))
+                if (IsNumberMutationTarget(lsi.Object)
+                    || (IsGlobalObject(lsi.Object)
+                        && lsi.Index is Expr.Literal { Value: "Number" }))
                     _set.UsesNumberPrototypeMutation = true;
+                if (lsi.Index is Expr.Literal { Value: string logicalNumberProperty }
+                    && IsNumberConstructorMutationTarget(
+                        lsi.Object, logicalNumberProperty))
+                    _set.UsesNumberConstructorMutation = true;
                 if (IsRegExpMutationTarget(lsi.Object))
                     _set.UsesRegExpPrototypeMutation = true;
                 if (IsGlobalObject(lsi.Object)
@@ -1220,8 +1259,13 @@ public sealed class RuntimeFeatureDetector
                     if (IsPromiseMutationTarget(deletedProperty.Object)
                         || deletedProperty.Name.Lexeme is "then" or "constructor" or "__proto__")
                         _set.UsesPromisePrototypeMutation = true;
-                    if (IsNumberMutationTarget(deletedProperty.Object))
+                    if (IsNumberMutationTarget(deletedProperty.Object)
+                        || (IsGlobalObject(deletedProperty.Object)
+                            && deletedProperty.Name.Lexeme == "Number"))
                         _set.UsesNumberPrototypeMutation = true;
+                    if (IsNumberConstructorMutationTarget(
+                            deletedProperty.Object, deletedProperty.Name.Lexeme))
+                        _set.UsesNumberConstructorMutation = true;
                     if (IsRegExpMutationTarget(deletedProperty.Object))
                         _set.UsesRegExpPrototypeMutation = true;
                     if (IsGlobalObject(deletedProperty.Object)
@@ -1240,8 +1284,15 @@ public sealed class RuntimeFeatureDetector
                             Value: "then" or "constructor" or "__proto__"
                         })
                         _set.UsesPromisePrototypeMutation = true;
-                    if (IsNumberMutationTarget(deletedIndex.Object))
+                    if (IsNumberMutationTarget(deletedIndex.Object)
+                        || (IsGlobalObject(deletedIndex.Object)
+                            && deletedIndex.Index is Expr.Literal { Value: "Number" }))
                         _set.UsesNumberPrototypeMutation = true;
+                    if (deletedIndex.Index is Expr.Literal
+                        { Value: string deletedNumberProperty }
+                        && IsNumberConstructorMutationTarget(
+                            deletedIndex.Object, deletedNumberProperty))
+                        _set.UsesNumberConstructorMutation = true;
                     if (IsRegExpMutationTarget(deletedIndex.Object))
                         _set.UsesRegExpPrototypeMutation = true;
                     if (IsGlobalObject(deletedIndex.Object)
@@ -1484,6 +1535,10 @@ public sealed class RuntimeFeatureDetector
     private bool IsNumberMutationTarget(Expr expr) =>
         IsNumberConstructor(expr) || IsNumberPrototype(expr);
 
+    private bool IsNumberConstructorMutationTarget(Expr owner, string propertyName) =>
+        IsNumberConstructor(owner)
+        || (IsGlobalObject(owner) && propertyName == "Number");
+
     private void TrackNumberAlias(string name, Expr initializer)
     {
         if (IsNumberConstructor(initializer))
@@ -1629,9 +1684,32 @@ public sealed class RuntimeFeatureDetector
     private void MarkMutationOperand(Expr operand)
     {
         if (operand is Expr.Get property)
+        {
             MarkMutationTarget(property.Object);
+            if (IsNumberMutationTarget(property.Object)
+                || (IsGlobalObject(property.Object)
+                    && property.Name.Lexeme == "Number"))
+            {
+                _set.UsesNumberPrototypeMutation = true;
+            }
+            if (IsNumberConstructorMutationTarget(
+                    property.Object, property.Name.Lexeme))
+                _set.UsesNumberConstructorMutation = true;
+        }
         else if (operand is Expr.GetIndex index)
+        {
             MarkMutationTarget(index.Object);
+            if (IsNumberMutationTarget(index.Object)
+                || (IsGlobalObject(index.Object)
+                    && index.Index is Expr.Literal { Value: "Number" }))
+            {
+                _set.UsesNumberPrototypeMutation = true;
+            }
+            if (index.Index is Expr.Literal { Value: string incrementNumberProperty }
+                && IsNumberConstructorMutationTarget(
+                    index.Object, incrementNumberProperty))
+                _set.UsesNumberConstructorMutation = true;
+        }
     }
 
     private void CollectStableSourceFunctionNames(IReadOnlyList<Stmt> statements)

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -154,9 +154,12 @@ public sealed class RuntimeFeatureSet
     // prototype-chain mutation API, or __proto__ access makes a backing-list-only
     // array append unsafe. The discarded-result push fast path requires this false.
     public bool UsesArrayPrototypeMutation { get; set; } = true;
-    // Number prototype/static mutation makes typed number method calls observable
+    // Number prototype mutation makes typed number instance methods observable
     // through ordinary property lookup. Direct formatting requires this false.
     public bool UsesNumberPrototypeMutation { get; set; } = true;
+    // Replacing Number or mutating its static properties requires live lookup of
+    // Number.parseInt and the other constructor-owned built-ins.
+    public bool UsesNumberConstructorMutation { get; set; } = true;
     // Any observable access to RegExp.prototype, replacement of the global
     // constructor, dynamic evaluation, or opaque descriptor/prototype mutation
     // can replace the intrinsic test/exec bindings. The allocation-free literal

--- a/src/SharpTS/Runtime/BuiltIns/GlobalFunctionHandlers.cs
+++ b/src/SharpTS/Runtime/BuiltIns/GlobalFunctionHandlers.cs
@@ -159,7 +159,9 @@ internal static class GlobalFunctionHandlers
             throw new InterpreterException($"{BuiltInNames.ParseInt}() requires at least one argument.");
 
         var strRV = await evaluateArg(arguments[0]);
-        var str = strRV.ToObject()?.ToString() ?? "";
+        var str = strRV.IsString
+            ? strRV.AsString()
+            : interpreter.ToStringForBuiltInArgument(strRV.ToObject());
         int radix = 10;
         if (arguments.Count > 1)
         {

--- a/src/SharpTS/Runtime/BuiltIns/NumberBuiltIns.cs
+++ b/src/SharpTS/Runtime/BuiltIns/NumberBuiltIns.cs
@@ -133,11 +133,14 @@ public static class NumberBuiltIns
         => _instanceLookup.GetMethod(name);
 
     // Static method implementations (V2)
-    private static RuntimeValue ParseIntV2(Interpreter _, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
+    private static RuntimeValue ParseIntV2(
+        Interpreter interpreter,
+        RuntimeValue receiver,
+        ReadOnlySpan<RuntimeValue> args)
     {
         var str = args[0].Kind == ValueKind.String
             ? args[0].AsString()
-            : args[0].ToObject()?.ToString() ?? "";
+            : interpreter.ToStringForBuiltInArgument(args[0].ToObject());
         var radix = args.Length > 1 && args[1].Kind == ValueKind.Number
             ? (int)Interpreter.ToNumber(args[1])
             : 10;
@@ -303,6 +306,9 @@ public static class NumberBuiltIns
     /// </summary>
     public static double ParseInt(string str, int radix)
     {
+        if (radix == 10)
+            return ParseIntDecimal(str);
+
         str = str.Trim();
         if (string.IsNullOrEmpty(str)) return double.NaN;
 
@@ -340,6 +346,53 @@ public static class NumberBuiltIns
         {
             return double.NaN;
         }
+    }
+
+    /// <summary>
+    /// Parses an already-coerced string with radix 10 without allocating a
+    /// trimmed string or digit buffer.
+    /// </summary>
+    public static double ParseIntDecimal(string str)
+    {
+        int index = 0;
+        while (index < str.Length && IsEcmaParseWhitespace(str[index]))
+            index++;
+
+        int sign = 1;
+        if (index < str.Length)
+        {
+            if (str[index] == '-')
+            {
+                sign = -1;
+                index++;
+            }
+            else if (str[index] == '+')
+            {
+                index++;
+            }
+        }
+
+        int digitStart = index;
+        double result = 0;
+        while (index < str.Length)
+        {
+            int digit = str[index] - '0';
+            if ((uint)digit > 9)
+                break;
+            result = result * 10 + digit;
+            index++;
+        }
+
+        return index == digitStart ? double.NaN : sign * result;
+    }
+
+    private static bool IsEcmaParseWhitespace(char value)
+    {
+        if (value <= ' ')
+            return value == ' ' || (uint)(value - '\t') <= 4;
+        if (value < '\u00A0')
+            return false;
+        return value == '\uFEFF' || char.IsWhiteSpace(value);
     }
 
     /// <summary>

--- a/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
@@ -181,6 +181,9 @@ public class RuntimeFeatureDetectorTests
     [InlineData("Number.prototype['toFixed'] = function() { return 'x'; };", true)]
     [InlineData("const N = Number; N.prototype.toString = function() { return 'x'; };", true)]
     [InlineData("const p = Number.prototype; p.toFixed = function() { return 'x'; };", true)]
+    [InlineData("Number.parseInt = function() { return 0; };", true)]
+    [InlineData("globalThis.Number = Number;", true)]
+    [InlineData("globalThis['Number'] = Number;", true)]
     [InlineData("Object.defineProperty(Number.prototype, 'x', { value: 1 });", true)]
     [InlineData("eval('void 0');", true)]
     public void DetectsNumberPrototypeMutationRisk(string source, bool expected)
@@ -190,6 +193,20 @@ public class RuntimeFeatureDetectorTests
         var features = new RuntimeFeatureDetector().Detect(statements, typeMap);
 
         Assert.Equal(expected, features.UsesNumberPrototypeMutation);
+    }
+
+    [Theory]
+    [InlineData("Number.prototype.toString = function() { return 'x'; };", false)]
+    [InlineData("Number.parseInt = function() { return 0; };", true)]
+    [InlineData("globalThis.Number = Number;", true)]
+    [InlineData("globalThis['Number'] = Number;", true)]
+    [InlineData("eval('void 0');", true)]
+    public void DetectsNumberConstructorMutationRisk(string source, bool expected)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var features = new RuntimeFeatureDetector().Detect(statements);
+
+        Assert.Equal(expected, features.UsesNumberConstructorMutation);
     }
 
     [Theory]

--- a/tests/SharpTS.Tests/CompilerTests/StableNumericStringConversionTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableNumericStringConversionTests.cs
@@ -107,35 +107,73 @@ public sealed class StableNumericStringConversionTests
             function render(value: number): string { return value.toString(10); }
             function fixed(value: number): string { return value.toFixed(2); }
             function read(value: string): number { return parseInt(value, 10); }
+            function readStatic(value: string): number {
+                return Number.parseInt(value, 10);
+            }
+            function parseCounter(n: number): number {
+                let total: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    total += parseInt(i.toString(), 10);
+                }
+                return total;
+            }
+            function parseCounterStatic(n: number): number {
+                let total: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    total += Number.parseInt(i.toString(), 10);
+                }
+                return total;
+            }
             """);
 
         AssertCalls(assembly, "counterLengths", "ConcatStringInt64");
         AssertCalls(assembly, "render", "FormatNumber");
         AssertCalls(assembly, "fixed", "NumberToFixedDouble");
-        AssertCalls(assembly, "read", "NumberParseIntString");
+        AssertCalls(assembly, "read", "NumberParseIntDecimalString");
+        AssertCalls(assembly, "readStatic", "NumberParseIntDecimalString");
 
-        foreach (string function in new[] { "counterLengths", "render", "fixed", "read" })
+        foreach (string function in new[]
+                 {
+                     "counterLengths", "render", "fixed", "read", "readStatic",
+                     "parseCounter", "parseCounterStatic"
+                 })
+        {
+            MethodInfo method = FindFunction(assembly, function);
+            MethodBase? unexpected = CalledMethods(method).FirstOrDefault(called =>
+                called.Name is "NumberToStringRadix" or "NumberToFixed" or
+                    "NumberParseIntString" or "NumberParseInt" or
+                    "ParseIntHelper" or "InvokeMethodValue");
+            Assert.True(unexpected == null,
+                $"{function} unexpectedly calls {unexpected?.Name}.");
+        }
+
+        foreach (string function in new[] { "parseCounter", "parseCounterStatic" })
         {
             MethodInfo method = FindFunction(assembly, function);
             Assert.DoesNotContain(CalledMethods(method), called =>
-                called.Name is "NumberToStringRadix" or "NumberToFixed" or
-                    "NumberParseInt" or "InvokeMethodValue");
+                called.Name is "NumberParseIntDecimalString" or "FormatNumber" or
+                    "ConcatStringInt64");
+            Assert.Contains(Instructions(method), instruction =>
+                instruction.OpCode == OpCodes.Conv_R8);
         }
 
         Assert.DoesNotContain(Instructions(FindFunction(assembly, "read")), instruction =>
             instruction.OpCode == OpCodes.Box);
+        Assert.DoesNotContain(
+            Instructions(FindFunction(assembly, "readStatic")),
+            instruction => instruction.OpCode == OpCodes.Box);
         Assert.DoesNotContain(Instructions(FindFunction(assembly, "fixed")), instruction =>
             instruction.OpCode == OpCodes.Box);
     }
 
     [Fact]
-    public void TypedParseIntLoop_DoesNotAllocatePerIteration()
+    public void TypedDecimalParseIntLoop_DoesNotAllocatePerIteration()
     {
         Assembly assembly = Compile("""
             function run(n: number): number {
                 let total: number = 0;
                 for (let i: number = 0; i < n; i++) {
-                    total += parseInt("12345", 10);
+                    total += parseInt(" \uFEFF12345suffix", 10);
                 }
                 return total;
             }
@@ -149,7 +187,7 @@ public sealed class StableNumericStringConversionTests
 
         Assert.Equal(1_234_500_000, result);
         Assert.True(allocated <= 256,
-            $"Typed parseInt allocated {allocated:N0} bytes in the hot loop.");
+            $"Typed decimal parseInt allocated {allocated:N0} bytes in the hot loop.");
     }
 
     [Fact]
@@ -181,16 +219,27 @@ public sealed class StableNumericStringConversionTests
         const string source = """
             const originalToString: any = Number.prototype.toString;
             const originalToFixed: any = Number.prototype.toFixed;
+            function parseCounters(n: number): number {
+                let total: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    total += parseInt(i.toString(), 10);
+                    total += Number.parseInt(i.toString(), 10);
+                }
+                return total;
+            }
 
             (Number.prototype as any).toString = function(): string { return "patched-string"; };
             (Number.prototype as any).toFixed = function(): string { return "patched-fixed"; };
             console.log((5).toString(), (5).toFixed(2));
+            console.log(parseCounters(3));
 
             (Number.prototype as any).toString = originalToString;
             (Number.prototype as any).toFixed = originalToFixed;
             """;
 
-        Assert.Equal("patched-string patched-fixed\n", TestHarness.Run(source, mode));
+        Assert.Equal(
+            "patched-string patched-fixed\nNaN\n",
+            TestHarness.Run(source, mode));
     }
 
     [Fact]
@@ -204,6 +253,19 @@ public sealed class StableNumericStringConversionTests
             """;
 
         Assert.Equal("77\n", TestHarness.Run(source, ExecutionMode.Compiled));
+    }
+
+    [Fact]
+    public void ReassignedNumberParseInt_RetainsLiveDispatch()
+    {
+        const string source = """
+            const originalParseInt: any = Number.parseInt;
+            (Number as any).parseInt = function(): number { return 88; };
+            console.log(Number.parseInt("10", 10));
+            (Number as any).parseInt = originalParseInt;
+            """;
+
+        Assert.Equal("88\n", TestHarness.Run(source, ExecutionMode.Compiled));
     }
 
     [Theory, ModeData]
@@ -246,10 +308,30 @@ public sealed class StableNumericStringConversionTests
             function fixed(value: number, digits: number): string {
                 return value.toFixed(digits);
             }
+            function dynamicRadix(value: string, radix: number): number {
+                return parseInt(value, radix);
+            }
+            function dynamicInput(value: any): number {
+                return parseInt(value, 10);
+            }
+            function hexadecimal(value: string): number {
+                return parseInt(value, 16);
+            }
             """);
 
         AssertCalls(assembly, "render", "NumberToStringRadix");
         AssertCalls(assembly, "fixed", "NumberToFixed");
+        AssertCalls(assembly, "dynamicRadix", "NumberParseInt");
+        AssertCalls(assembly, "dynamicInput", "NumberParseInt");
+        AssertCalls(assembly, "hexadecimal", "NumberParseIntString");
+        foreach (string function in new[]
+                 {
+                     "dynamicRadix", "dynamicInput", "hexadecimal"
+                 })
+        {
+            Assert.DoesNotContain(CalledMethods(FindFunction(assembly, function)),
+                called => called.Name == "NumberParseIntDecimalString");
+        }
     }
 
     private static Assembly Compile(string source)

--- a/tests/SharpTS.Tests/SharedTests/NumberTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/NumberTests.cs
@@ -119,6 +119,45 @@ public class NumberTests
     }
 
     [Theory, ModeData]
+    public void RadixTenParseInt_PreservesScannerBoundaries(ExecutionMode mode)
+    {
+        var source = """
+            const whitespace: string =
+                "\u0009\u000A\u000B\u000C\u000D\u0020\u00A0\u1680" +
+                "\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007" +
+                "\u2008\u2009\u200A\u2028\u2029\u202F\u205F\u3000\uFEFF";
+
+            console.log(
+                parseInt(whitespace + "+42tail", 10),
+                Number.parseInt(whitespace + "+42tail", 10));
+            console.log(
+                Object.is(parseInt("-000suffix", 10), -0),
+                Object.is(Number.parseInt("-0.5", 10), -0));
+            console.log(
+                Number.isNaN(parseInt("", 10)),
+                Number.isNaN(parseInt("+", 10)),
+                Number.isNaN(Number.parseInt("-x", 10)));
+            console.log(
+                parseInt("123.75", 10),
+                Number.parseInt("0x10", 10));
+            console.log(
+                parseInt("9".repeat(400), 10) === Infinity,
+                Number.parseInt("9".repeat(400), 10) === Infinity);
+            console.log(Number.isNaN(parseInt("\u008512", 10)));
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal(
+            "42 42\n" +
+            "true true\n" +
+            "true true true\n" +
+            "123 0\n" +
+            "true true\n" +
+            "true\n",
+            output);
+    }
+
+    [Theory, ModeData]
     public void Number_parseFloat_ParsesFloats(ExecutionMode mode)
     {
         var source = """


### PR DESCRIPTION
## Summary

- add an allocation-free decimal scanner for stable `parseInt(value, 10)` and `Number.parseInt(value, 10)` calls
- fold the proven Int64 `counter.toString()` hot-path shape while retaining coercion and mutation fallbacks
- add semantic, IL, and allocation coverage plus BenchmarkDotNet and permanent cross-runtime performance guards

Closes #1480

## Performance

Cross-runtime issue workload (`N = 100,000`):

| Platform | Baseline median | Candidate median | Improvement |
| --- | ---: | ---: | ---: |
| Windows | 1.7028 ms | 0.0543 ms | 96.81% |
| WSL Ubuntu | 2.2869 ms | 0.0529 ms | 97.69% |

The scanner microbenchmark is 3-4x faster and allocates zero bytes for whitespace inputs.

## Validation

- WSL Ubuntu core suite: 17,412/17,412 passed; GUI suite: 106/106 passed
- Windows focused suites: 107/107 passed; GUI suite: 106/106 passed
- Windows final core run: 17,393 passed, 3 skipped; one unrelated load-sensitive process-tree race failed and then passed immediately in isolation
- IL verification, allocation checks, performance harness, and microbenchmark smoke test passed
- AOT analyzer reported zero warnings; Linux NativeAOT publish and execution gate completed with output `42`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved radix-10 `parseInt` performance, including optimized handling for string inputs and numeric loop counters.
  * Reduced allocations in repeated decimal parsing scenarios.

* **Bug Fixes**
  * Improved conversion of non-string values passed to `parseInt`.
  * Preserved correct behavior for whitespace, signs, prefixes, invalid inputs, overflow, and negative zero.
  * Maintained live behavior when the global `Number` constructor or its methods are modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->