### PR TITLE
Keep stable Date numeric results unboxed

### DIFF
--- a/benchmarks/cross-runtime/scripts/date-numeric.ts
+++ b/benchmarks/cross-runtime/scripts/date-numeric.ts
@@ -1,0 +1,20 @@
+import { bench } from "./lib/bench.ts";
+
+// Stable Date numeric getter/setter workload (#1487). The Date instance remains
+// local and no intrinsic method binding is exposed or mutated, so compiled
+// SharpTS can keep both helper results as native doubles.
+function dateNumericLoop(n: number): number {
+    const date = new Date(0);
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        date.setTime(i);
+        sum = sum + date.getTime();
+    }
+    return sum;
+}
+
+const params: number[] = [100, 10000, 100000];
+for (let p: number = 0; p < params.length; p++) {
+    const n: number = params[p];
+    bench("date-numeric", n, () => dateNumericLoop(n));
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/DateNumericBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/DateNumericBenchmarks.cs
@@ -1,0 +1,39 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using SharpTS.Microbenchmarks.Infrastructure;
+
+namespace SharpTS.Microbenchmarks.Benchmarks;
+
+/// <summary>
+/// Allocation coverage for stable numeric Date getter/setter calls. The TypeScript
+/// body creates one Date per benchmark operation, while the measured loop must not
+/// allocate boxed results per iteration.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class DateNumericBenchmarks
+{
+    private Func<double, double> _dateNumericLoop = null!;
+
+    [Params(100_000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var assembly = typeof(DateNumericBenchmarks).Assembly;
+        using var stream = assembly.GetManifestResourceStream(
+            "SharpTS.Microbenchmarks.TypeScriptSources.DateNumeric.ts")
+            ?? throw new InvalidOperationException("Could not find embedded resource DateNumeric.ts");
+        using var reader = new StreamReader(stream);
+        string source = reader.ReadToEnd();
+
+        string dllPath = CompilationCache.GetOrCompile(source, "DateNumeric");
+        var compiled = BenchmarkHarness.LoadCompiledAssembly(dllPath, "date-numeric");
+        _dateNumericLoop = BenchmarkHarness.GetCompiledNumberFunc(compiled, "dateNumericLoop");
+    }
+
+    [Benchmark]
+    public double SharpTS_GetTimeSetTime() => _dateNumericLoop(N);
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/DateNumeric.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/DateNumeric.ts
@@ -1,0 +1,12 @@
+// Stable Date numeric getter/setter workload (#1487). One Date allocation is
+// intentionally outside the loop; Date helper results must not allocate per
+// iteration.
+function dateNumericLoop(n: number): number {
+    const date = new Date(0);
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        date.setTime(i);
+        sum = sum + date.getTime();
+    }
+    return sum;
+}

--- a/src/SharpTS/Compilation/Emitters/DateEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/DateEmitter.cs
@@ -30,13 +30,11 @@ public sealed class DateEmitter : ITypeEmitterStrategy
         emitter.EmitExpression(receiver);
         emitter.EmitBoxIfNeeded(receiver);
 
-        // Every handled method leaves a reference on the stack: a boxed double for the
-        // numeric getters/setters/valueOf (and a string|null object for toJSON), or a
-        // string for the conversion methods. We record the resulting StackType so the
-        // caller's EnsureBoxed() does not box an already-boxed value a second time —
-        // emitting `box Double` twice is the StackUnexpected ILVerify failure in #537.
-        // (The numeric arg emitted via EmitExpressionAsDouble would otherwise leave the
-        // tracked type as Double, tricking EnsureBoxed into re-boxing the boxed result.)
+        // Direct numeric getters and the single-double-argument setters keep the helper's
+        // native double result on the stack. Consumers that need object/any will box it at
+        // their actual boundary; numeric consumers and discarded results avoid the former
+        // box/unbox pair entirely (#1487). Multi-argument setters still use the object[]
+        // path and deliberately retain their boxed result for now.
         StackType resultType = StackType.Unknown;
 
         switch (methodName)
@@ -44,136 +42,136 @@ public sealed class DateEmitter : ITypeEmitterStrategy
             // Getters (no arguments, return double)
             case "getTime":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetTime);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getFullYear":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetFullYear);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getMonth":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetMonth);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getDate":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetDate);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getDay":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetDay);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getHours":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetHours);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getMinutes":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetMinutes);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getSeconds":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetSeconds);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getMilliseconds":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetMilliseconds);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getTimezoneOffset":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetTimezoneOffset);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             // UTC getters + legacy getYear (no arguments, return double)
             case "getUTCFullYear":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetUTCFullYear);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getUTCMonth":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetUTCMonth);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getUTCDate":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetUTCDate);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getUTCDay":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetUTCDay);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getUTCHours":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetUTCHours);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getUTCMinutes":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetUTCMinutes);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getUTCSeconds":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetUTCSeconds);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getUTCMilliseconds":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetUTCMilliseconds);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "getYear":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateGetYear);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             // Simple setters (single argument, return double)
             case "setTime":
                 EmitSingleDoubleArgOrNaN(emitter, arguments);
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateSetTime);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "setDate":
                 EmitSingleDoubleArgOrNaN(emitter, arguments);
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateSetDate);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "setMilliseconds":
                 EmitSingleDoubleArgOrNaN(emitter, arguments);
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateSetMilliseconds);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             // UTC simple setters + legacy setYear (single argument, return double)
             case "setUTCDate":
                 EmitSingleDoubleArgOrNaN(emitter, arguments);
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateSetUTCDate);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "setUTCMilliseconds":
                 EmitSingleDoubleArgOrNaN(emitter, arguments);
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateSetUTCMilliseconds);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             case "setYear":
                 EmitSingleDoubleArgOrNaN(emitter, arguments);
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateSetYear);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             // Multi-argument setters (variadic, packaged as object[]). The $Runtime
@@ -285,7 +283,7 @@ public sealed class DateEmitter : ITypeEmitterStrategy
             // valueOf (no arguments, returns double)
             case "valueOf":
                 il.Emit(OpCodes.Call, ctx.Runtime!.DateValueOf);
-                il.Emit(OpCodes.Box, ctx.Types.Double);
+                resultType = StackType.Double;
                 break;
 
             // toString (no arguments, returns string)

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -37,6 +37,12 @@ public sealed class RuntimeFeatureDetector
         "Number"
     };
     private readonly HashSet<string> _numberPrototypeAliases = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _dateConstructorAliases = new(StringComparer.Ordinal)
+    {
+        "Date"
+    };
+    private readonly HashSet<string> _datePrototypeAliases = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _dateInstanceAliases = new(StringComparer.Ordinal);
     private readonly HashSet<(string Fingerprint, int Index)> _invalidCompactRecordSelfFields = [];
     private readonly Dictionary<string, JsonSerializationShape.Record> _canonicalCompactRecordShapes = [];
     private TypeMap? _typeMap;
@@ -299,7 +305,10 @@ public sealed class RuntimeFeatureDetector
             case "Function":
                 _set.UsesObjectIntegrityMutation = true;
                 if (name is "eval" or "Function")
+                {
+                    _set.UsesDatePrototypeMutation = true;
                     _set.UsesRegExpPrototypeMutation = true;
+                }
                 break;
 
             // Fetch family
@@ -635,6 +644,7 @@ public sealed class RuntimeFeatureDetector
                 if (var.Initializer is not null)
                 {
                     TrackNumberAlias(var.Name.Lexeme, var.Initializer);
+                    TrackDateAlias(var.Name.Lexeme, var.Initializer);
                     if (_opaqueValueBindings.Contains(var.Name.Lexeme))
                         MarkPotentiallyMaterialized(var.Initializer);
                     VisitExpr(var.Initializer);
@@ -643,6 +653,7 @@ public sealed class RuntimeFeatureDetector
 
             case Stmt.Const cst:
                 TrackNumberAlias(cst.Name.Lexeme, cst.Initializer);
+                TrackDateAlias(cst.Name.Lexeme, cst.Initializer);
                 if (_opaqueValueBindings.Contains(cst.Name.Lexeme))
                     MarkPotentiallyMaterialized(cst.Initializer);
                 VisitExpr(cst.Initializer);
@@ -789,6 +800,12 @@ public sealed class RuntimeFeatureDetector
                 break;
 
             case Expr.Get g:
+                // A Date-typed parameter may be the only Date value in the source.
+                // Preserve its runtime helpers without treating ubiquitous method
+                // spellings such as toString/valueOf as Date usage on other types.
+                if (CouldTargetDateInstance(g.Object)
+                    && IsDateInstanceMethodName(g.Name.Lexeme))
+                    _set.UsesDate = true;
                 if (g.Name.Lexeme is "Object" or "Reflect")
                     _set.UsesObjectIntegrityMutation = true;
                 if (g.Name.Lexeme is "prototype" or "__proto__")
@@ -801,6 +818,9 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesNumberPrototypeMutation = true;
                 if (IsRegExpPrototype(g))
                     _set.UsesRegExpPrototypeMutation = true;
+                if (IsDatePrototype(g)
+                    || (g.Name.Lexeme == "__proto__" && CouldTargetDateInstance(g.Object)))
+                    _set.UsesDatePrototypeMutation = true;
                 if (g.Name.Lexeme == "__proto__")
                     _set.UsesRegExpPrototypeMutation = true;
                 if (g.Object is Expr.Variable ov)
@@ -876,7 +896,10 @@ public sealed class RuntimeFeatureDetector
                 MarkMutationTarget(s.Object);
                 if (CouldTargetClassMethod(s.Object, s.Name.Lexeme))
                     _set.UsesClassPrototypeMutation = true;
-                if (IsDatePrototype(s.Object))
+                if (IsDatePrototype(s.Object)
+                    || (IsDateInstanceMethodName(s.Name.Lexeme)
+                        && CouldTargetDateInstance(s.Object))
+                    || (s.Name.Lexeme == "prototype" && IsDateConstructor(s.Object)))
                     _set.UsesDatePrototypeMutation = true;
                 if (IsPromiseMutationTarget(s.Object)
                     || s.Name.Lexeme is "then" or "constructor" or "__proto__")
@@ -899,6 +922,8 @@ public sealed class RuntimeFeatureDetector
                 break;
 
             case Expr.GetIndex gi:
+                if (IsDatePrototype(gi))
+                    _set.UsesDatePrototypeMutation = true;
                 if (gi.Index is Expr.Literal { Value: string computedGlobalName })
                 {
                     // Computed global-object constructor access, e.g.
@@ -930,7 +955,10 @@ public sealed class RuntimeFeatureDetector
                         ? CouldTargetClassMethod(si.Object, methodName)
                         : IsClassInstance(si.Object))
                     _set.UsesClassPrototypeMutation = true;
-                if (IsDatePrototype(si.Object))
+                if (IsDatePrototype(si.Object)
+                    || (CouldTargetDateInstance(si.Object)
+                        && (si.Index is not Expr.Literal { Value: string dateSetIndexMember }
+                            || IsDateInstanceMethodName(dateSetIndexMember))))
                     _set.UsesDatePrototypeMutation = true;
                 if (IsPromiseMutationTarget(si.Object)
                     || si.Index is Expr.Literal
@@ -960,6 +988,7 @@ public sealed class RuntimeFeatureDetector
             case Expr.Call c:
                 if (c.Callee is Expr.Variable { Name.Lexeme: "eval" })
                 {
+                    _set.UsesDatePrototypeMutation = true;
                     _set.UsesPromisePrototypeMutation = true;
                     _set.UsesNumberPrototypeMutation = true;
                     _set.UsesRegExpPrototypeMutation = true;
@@ -1025,10 +1054,22 @@ public sealed class RuntimeFeatureDetector
                 if (c.Arguments.Count > 0
                     && c.Callee is Expr.Get
                     {
-                        Object: Expr.Variable { Name.Lexeme: "Object" },
-                        Name.Lexeme: "defineProperty" or "defineProperties"
+                        Object: Expr.Variable { Name.Lexeme: "Object" or "Reflect" },
+                        Name.Lexeme: "assign" or "defineProperty" or "defineProperties"
+                            or "set" or "deleteProperty" or "setPrototypeOf"
                     }
-                    && IsDatePrototype(c.Arguments[0]))
+                    && (IsDatePrototype(c.Arguments[0])
+                        || CouldTargetDateInstance(c.Arguments[0])))
+                {
+                    _set.UsesDatePrototypeMutation = true;
+                }
+                if (c.Arguments.Count > 0
+                    && c.Callee is Expr.Get
+                    {
+                        Object: Expr.Variable { Name.Lexeme: "Object" or "Reflect" },
+                        Name.Lexeme: "getPrototypeOf"
+                    }
+                    && CouldTargetDateInstance(c.Arguments[0]))
                 {
                     _set.UsesDatePrototypeMutation = true;
                 }
@@ -1072,6 +1113,7 @@ public sealed class RuntimeFeatureDetector
                 break;
 
             case Expr.Assign asg:
+                TrackDateAlias(asg.Name.Lexeme, asg.Value);
                 if (asg.Name.Lexeme == "Promise")
                     _set.UsesPromisePrototypeMutation = true;
                 if (asg.Name.Lexeme == "Number")
@@ -1102,6 +1144,10 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesNumberPrototypeMutation = true;
                 if (IsRegExpMutationTarget(cs.Object))
                     _set.UsesRegExpPrototypeMutation = true;
+                if (IsDatePrototype(cs.Object)
+                    || (IsDateInstanceMethodName(cs.Name.Lexeme)
+                        && CouldTargetDateInstance(cs.Object)))
+                    _set.UsesDatePrototypeMutation = true;
                 if (IsGlobalObject(cs.Object) && cs.Name.Lexeme == "parseInt")
                     _set.UsesGlobalParseIntMutation = true;
                 if (cs.Name.Lexeme == "push" && CouldTargetArray(cs.Object))
@@ -1121,6 +1167,11 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesNumberPrototypeMutation = true;
                 if (IsRegExpMutationTarget(csi.Object))
                     _set.UsesRegExpPrototypeMutation = true;
+                if (IsDatePrototype(csi.Object)
+                    || (CouldTargetDateInstance(csi.Object)
+                        && (csi.Index is not Expr.Literal { Value: string dateCompoundIndexMember }
+                            || IsDateInstanceMethodName(dateCompoundIndexMember))))
+                    _set.UsesDatePrototypeMutation = true;
                 if (IsGlobalObject(csi.Object)
                     && csi.Index is Expr.Literal { Value: "parseInt" })
                     _set.UsesGlobalParseIntMutation = true;
@@ -1149,6 +1200,10 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesNumberPrototypeMutation = true;
                 if (IsRegExpMutationTarget(ls.Object))
                     _set.UsesRegExpPrototypeMutation = true;
+                if (IsDatePrototype(ls.Object)
+                    || (IsDateInstanceMethodName(ls.Name.Lexeme)
+                        && CouldTargetDateInstance(ls.Object)))
+                    _set.UsesDatePrototypeMutation = true;
                 if (IsGlobalObject(ls.Object) && ls.Name.Lexeme == "parseInt")
                     _set.UsesGlobalParseIntMutation = true;
                 if (ls.Name.Lexeme == "push" && CouldTargetArray(ls.Object))
@@ -1168,6 +1223,11 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesNumberPrototypeMutation = true;
                 if (IsRegExpMutationTarget(lsi.Object))
                     _set.UsesRegExpPrototypeMutation = true;
+                if (IsDatePrototype(lsi.Object)
+                    || (CouldTargetDateInstance(lsi.Object)
+                        && (lsi.Index is not Expr.Literal { Value: string dateLogicalIndexMember }
+                            || IsDateInstanceMethodName(dateLogicalIndexMember))))
+                    _set.UsesDatePrototypeMutation = true;
                 if (IsGlobalObject(lsi.Object)
                     && lsi.Index is Expr.Literal { Value: "parseInt" })
                     _set.UsesGlobalParseIntMutation = true;
@@ -1224,6 +1284,10 @@ public sealed class RuntimeFeatureDetector
                         _set.UsesNumberPrototypeMutation = true;
                     if (IsRegExpMutationTarget(deletedProperty.Object))
                         _set.UsesRegExpPrototypeMutation = true;
+                    if (IsDatePrototype(deletedProperty.Object)
+                        || (IsDateInstanceMethodName(deletedProperty.Name.Lexeme)
+                            && CouldTargetDateInstance(deletedProperty.Object)))
+                        _set.UsesDatePrototypeMutation = true;
                     if (IsGlobalObject(deletedProperty.Object)
                         && deletedProperty.Name.Lexeme == "parseInt")
                         _set.UsesGlobalParseIntMutation = true;
@@ -1244,6 +1308,11 @@ public sealed class RuntimeFeatureDetector
                         _set.UsesNumberPrototypeMutation = true;
                     if (IsRegExpMutationTarget(deletedIndex.Object))
                         _set.UsesRegExpPrototypeMutation = true;
+                    if (IsDatePrototype(deletedIndex.Object)
+                        || (CouldTargetDateInstance(deletedIndex.Object)
+                            && (deletedIndex.Index is not Expr.Literal { Value: string dateDeletedIndexMember }
+                                || IsDateInstanceMethodName(dateDeletedIndexMember))))
+                        _set.UsesDatePrototypeMutation = true;
                     if (IsGlobalObject(deletedIndex.Object)
                         && deletedIndex.Index is Expr.Literal { Value: "parseInt" })
                         _set.UsesGlobalParseIntMutation = true;
@@ -1438,11 +1507,89 @@ public sealed class RuntimeFeatureDetector
         }
     }
 
-    private static bool IsDatePrototype(Expr expr) => expr is Expr.Get
+    private bool IsDateConstructor(Expr expr) => expr switch
     {
-        Object: Expr.Variable { Name.Lexeme: "Date" },
-        Name.Lexeme: "prototype"
+        Expr.Variable variable => _dateConstructorAliases.Contains(variable.Name.Lexeme),
+        Expr.Get
+        {
+            Object: Expr.Variable { Name.Lexeme: "globalThis" or "global" },
+            Name.Lexeme: "Date"
+        } => true,
+        Expr.GetIndex
+        {
+            Object: Expr.Variable { Name.Lexeme: "globalThis" or "global" },
+            Index: Expr.Literal { Value: "Date" }
+        } => true,
+        Expr.Grouping grouping => IsDateConstructor(grouping.Expression),
+        Expr.TypeAssertion assertion => IsDateConstructor(assertion.Expression),
+        Expr.Satisfies satisfies => IsDateConstructor(satisfies.Expression),
+        Expr.NonNullAssertion nonNull => IsDateConstructor(nonNull.Expression),
+        _ => false
     };
+
+    private bool IsDatePrototype(Expr expr) => expr switch
+    {
+        Expr.Variable variable => _datePrototypeAliases.Contains(variable.Name.Lexeme),
+        Expr.Get { Name.Lexeme: "prototype" } get => IsDateConstructor(get.Object),
+        Expr.GetIndex { Index: Expr.Literal { Value: "prototype" } } get =>
+            IsDateConstructor(get.Object),
+        Expr.Grouping grouping => IsDatePrototype(grouping.Expression),
+        Expr.TypeAssertion assertion => IsDatePrototype(assertion.Expression),
+        Expr.Satisfies satisfies => IsDatePrototype(satisfies.Expression),
+        Expr.NonNullAssertion nonNull => IsDatePrototype(nonNull.Expression),
+        _ => false
+    };
+
+    private bool CouldTargetDateInstance(Expr expr)
+    {
+        while (true)
+        {
+            switch (expr)
+            {
+                case Expr.Grouping grouping:
+                    expr = grouping.Expression;
+                    continue;
+                case Expr.TypeAssertion assertion:
+                    expr = assertion.Expression;
+                    continue;
+                case Expr.Satisfies satisfies:
+                    expr = satisfies.Expression;
+                    continue;
+                case Expr.NonNullAssertion nonNull:
+                    expr = nonNull.Expression;
+                    continue;
+            }
+
+            break;
+        }
+
+        return (expr is Expr.Variable variable
+                && _dateInstanceAliases.Contains(variable.Name.Lexeme))
+            || _typeMap?.Get(expr) is TypeInfo.Date;
+    }
+
+    private void TrackDateAlias(string name, Expr initializer)
+    {
+        if (IsDateConstructor(initializer))
+            _dateConstructorAliases.Add(name);
+        if (IsDatePrototype(initializer))
+            _datePrototypeAliases.Add(name);
+        if (CouldTargetDateInstance(initializer))
+            _dateInstanceAliases.Add(name);
+    }
+
+    private static bool IsDateInstanceMethodName(string name) => name is
+        "getTime" or "getFullYear" or "getMonth" or "getDate" or "getDay" or
+        "getHours" or "getMinutes" or "getSeconds" or "getMilliseconds" or
+        "getTimezoneOffset" or "getUTCFullYear" or "getUTCMonth" or "getUTCDate" or
+        "getUTCDay" or "getUTCHours" or "getUTCMinutes" or "getUTCSeconds" or
+        "getUTCMilliseconds" or "getYear" or "setTime" or "setDate" or
+        "setMilliseconds" or "setUTCDate" or "setUTCMilliseconds" or "setYear" or
+        "setFullYear" or "setMonth" or "setHours" or "setMinutes" or "setSeconds" or
+        "setUTCFullYear" or "setUTCMonth" or "setUTCHours" or "setUTCMinutes" or
+        "setUTCSeconds" or "toISOString" or "toDateString" or "toTimeString" or
+        "toUTCString" or "toLocaleDateString" or "toLocaleTimeString" or
+        "toLocaleString" or "toJSON" or "valueOf" or "toString" or "__proto__";
 
     private static bool IsGlobalObject(Expr expr) => expr switch
     {

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -143,8 +143,10 @@ public sealed class RuntimeFeatureSet
     // Function route checked alongside this flag) can replace a method binding.
     // Exact-instance typed companion calls require this to remain false.
     public bool UsesClassPrototypeMutation { get; set; } = true;
-    // A Date.prototype write makes statically typed Date method calls observable
-    // through the prototype object, so the direct DateEmitter fast path is unsafe.
+    // Date method binding mutation (prototype aliases, own overrides/accessors,
+    // prototype-chain mutation, or opaque evaluation) makes statically typed Date
+    // calls observable, so the direct DateEmitter fast path is unsafe. The historical
+    // property name is retained because it is part of the emitted-runtime feature API.
     public bool UsesDatePrototypeMutation { get; set; } = true;
     // Promise method/constructor/species mutation makes direct then lowering
     // observable through ordinary property lookup. Such programs must retain

--- a/tests/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -1475,10 +1475,10 @@ public class ILVerificationTests
         Assert.Equal(output, TestHarness.RunInterpreted(source));
     }
 
-    // #537: single-double-argument Date setters (setTime/setDate/setMilliseconds/setUTCDate/
-    // setUTCMilliseconds/setYear) used as a bare statement or assigned to a number previously left
-    // the tracked stack type as Double, so the caller boxed the already-boxed result a second time
-    // (StackUnexpected). The DateEmitter now records the boxed result as a reference type.
+    // #537 / #1487: single-double-argument Date setters (setTime/setDate/setMilliseconds/
+    // setUTCDate/setUTCMilliseconds/setYear) must leave a correctly tracked result. They now keep
+    // the helper's native double on the stack, so both bare statements and numeric assignment avoid
+    // boxing while continuing to pass strict IL verification.
     [Fact]
     public void DateSingleArgSetters_PassILVerification()
     {

--- a/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
@@ -129,13 +129,32 @@ public class RuntimeFeatureDetectorTests
     [InlineData("Date.prototype.toString = Object.prototype.toString;", true)]
     [InlineData("Date.prototype['valueOf'] = function() { return 0; };", true)]
     [InlineData("Object.defineProperty(Date.prototype, 'x', { value: 1 });", true)]
+    [InlineData("const prototype = Date.prototype;", true)]
+    [InlineData("const d = new Date(0); (d as any).getTime = function() { return 1; };", true)]
+    [InlineData("const d = new Date(0); const alias: any = d; alias.setTime = function() { return 1; };", true)]
+    [InlineData("const d = new Date(0); Object.defineProperty(d, 'getTime', { value: function() { return 1; } });", true)]
+    [InlineData("const d = new Date(0); Object.getPrototypeOf(d);", true)]
     [InlineData("new Date().toString();", false)]
-    public void DetectsDatePrototypeMutation(string source, bool expected)
+    public void DetectsDateMethodMutationRisk(string source, bool expected)
     {
         var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
-        var features = new RuntimeFeatureDetector().Detect(statements);
+        var typeMap = new TypeChecker().Check(statements);
+        var features = new RuntimeFeatureDetector().Detect(statements, typeMap);
 
         Assert.Equal(expected, features.UsesDatePrototypeMutation);
+    }
+
+    [Fact]
+    public void DateTypedParameterMethodRequiresDateRuntimeWithoutDisablingFastPath()
+    {
+        const string source = "function read(d: Date): number { return d.getTime(); }";
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+
+        var features = new RuntimeFeatureDetector().Detect(statements, typeMap);
+
+        Assert.True(features.UsesDate);
+        Assert.False(features.UsesDatePrototypeMutation);
     }
 
     [Theory]

--- a/tests/SharpTS.Tests/CompilerTests/StableDateNumericTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableDateNumericTests.cs
@@ -1,0 +1,318 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class StableDateNumericTests
+{
+    private static readonly string[] NumericGetterHelpers =
+    [
+        "DateGetTime",
+        "DateGetFullYear",
+        "DateGetMonth",
+        "DateGetDate",
+        "DateGetDay",
+        "DateGetHours",
+        "DateGetMinutes",
+        "DateGetSeconds",
+        "DateGetMilliseconds",
+        "DateGetTimezoneOffset",
+        "DateGetUTCFullYear",
+        "DateGetUTCMonth",
+        "DateGetUTCDate",
+        "DateGetUTCDay",
+        "DateGetUTCHours",
+        "DateGetUTCMinutes",
+        "DateGetUTCSeconds",
+        "DateGetUTCMilliseconds",
+        "DateGetYear",
+        "DateValueOf",
+    ];
+
+    private static readonly string[] SimpleSetterHelpers =
+    [
+        "DateSetTime",
+        "DateSetDate",
+        "DateSetMilliseconds",
+        "DateSetUTCDate",
+        "DateSetUTCMilliseconds",
+        "DateSetYear",
+    ];
+
+    [Fact]
+    public void NumericGettersAndValueOfStayUnboxed()
+    {
+        const string source = """
+            function readAll(d: Date): number {
+                return d.getTime()
+                    + d.getFullYear() + d.getMonth() + d.getDate() + d.getDay()
+                    + d.getHours() + d.getMinutes() + d.getSeconds() + d.getMilliseconds()
+                    + d.getTimezoneOffset()
+                    + d.getUTCFullYear() + d.getUTCMonth() + d.getUTCDate() + d.getUTCDay()
+                    + d.getUTCHours() + d.getUTCMinutes() + d.getUTCSeconds()
+                    + d.getUTCMilliseconds() + d.getYear() + d.valueOf();
+            }
+            """;
+
+        MethodInfo method = FindFunction(Compile(source), "readAll");
+        var instructions = ReadInstructions(method).ToArray();
+        string[] calls = DateHelperCalls(instructions).ToArray();
+
+        Assert.Equal(NumericGetterHelpers, calls);
+        Assert.DoesNotContain(instructions, IsDoubleBox);
+        Assert.DoesNotContain(instructions, IsDoubleUnbox);
+    }
+
+    [Fact]
+    public void DiscardedSimpleSetterResultsArePoppedWithoutBoxing()
+    {
+        const string source = """
+            function discard(d: Date, value: number): void {
+                d.setTime(value);
+                d.setDate(value);
+                d.setMilliseconds(value);
+                d.setUTCDate(value);
+                d.setUTCMilliseconds(value);
+                d.setYear(value);
+            }
+            """;
+
+        MethodInfo method = FindFunction(Compile(source), "discard");
+        var instructions = ReadInstructions(method).ToArray();
+        var setterIndexes = instructions
+            .Select((instruction, index) => (instruction, index))
+            .Where(entry => entry.instruction.Operand is MethodBase called
+                && SimpleSetterHelpers.Contains(called.Name, StringComparer.Ordinal))
+            .ToArray();
+
+        Assert.Equal(SimpleSetterHelpers, setterIndexes
+            .Select(entry => ((MethodBase)entry.instruction.Operand!).Name));
+        Assert.All(setterIndexes, entry =>
+            Assert.Equal(OpCodes.Pop, instructions[entry.index + 1].OpCode));
+        Assert.DoesNotContain(instructions, IsDoubleBox);
+        Assert.DoesNotContain(instructions, IsDoubleUnbox);
+    }
+
+    [Fact]
+    public void AnyResultContextsBoxAtTheActualBoundary()
+    {
+        const string source = """
+            function getterAny(d: Date): any {
+                return d.getTime();
+            }
+            function setterAny(d: Date): any {
+                return d.setTime(1);
+            }
+            """;
+
+        Assembly assembly = Compile(source);
+        AssertCallIsFollowedByDoubleBox(FindFunction(assembly, "getterAny"), "DateGetTime");
+        AssertCallIsFollowedByDoubleBox(FindFunction(assembly, "setterAny"), "DateSetTime");
+    }
+
+    [Fact]
+    public void NumericDateLoopDoesNotAllocatePerIteration()
+    {
+        const string source = """
+            function dateLoop(n: number): number {
+                const date = new Date(0);
+                let sum: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    date.setTime(i);
+                    sum = sum + date.getTime();
+                }
+                return sum;
+            }
+            """;
+
+        MethodInfo method = FindFunction(Compile(source), "dateLoop");
+        var dateLoop = method.CreateDelegate<Func<double, double>>();
+
+        Assert.Equal(45, dateLoop(10));
+        _ = dateLoop(100_000);
+
+        long smallBefore = GC.GetAllocatedBytesForCurrentThread();
+        Assert.Equal(499_500, dateLoop(1_000));
+        long smallAllocated = GC.GetAllocatedBytesForCurrentThread() - smallBefore;
+
+        long largeBefore = GC.GetAllocatedBytesForCurrentThread();
+        double result = dateLoop(100_000);
+        long largeAllocated = GC.GetAllocatedBytesForCurrentThread() - largeBefore;
+
+        Assert.Equal(4_999_950_000, result);
+        Assert.True(largeAllocated <= smallAllocated + 8_192,
+            $"Stable Date numeric allocations scaled with the loop: "
+            + $"{smallAllocated:N0} bytes for 1,000 iterations and "
+            + $"{largeAllocated:N0} bytes for 100,000 iterations.");
+    }
+
+    [Fact]
+    public void PrototypeMutationRetainsDynamicDispatch()
+    {
+        const string source = """
+            function read(d: Date): number {
+                return d.getTime();
+            }
+            Date.prototype.getTime = function(): number { return 77; };
+            console.log(read(new Date(0)));
+            """;
+
+        Assembly assembly = Compile(source);
+        var instructions = ReadInstructions(FindFunction(assembly, "read")).ToArray();
+
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "InvokeMethodValue" });
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "DateGetTime" });
+        Assert.Equal("77\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void OwnOverridesAccessorsAliasesAndAmbiguousReceiversRemainObservable()
+    {
+        const string source = """
+            const own = new Date(0);
+            (own as any).getTime = function(): number { return 11; };
+            console.log(own.getTime());
+
+            const accessor = new Date(0);
+            Object.defineProperty(accessor, "getTime", {
+                configurable: true,
+                get: function(): any {
+                    console.log("lookup");
+                    return function(): number { return 22; };
+                }
+            });
+            console.log(accessor.getTime());
+
+            const borrowedDate = new Date(33);
+            const borrowed: any = borrowedDate.getTime;
+            console.log(borrowed.call(borrowedDate));
+
+            const ambiguous: any = new Date(44);
+            ambiguous.getTime = function(): number { return 55; };
+            console.log(ambiguous.getTime());
+            """;
+
+        Assert.Equal("11\nlookup\n22\n33\n55\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void StableAndFallbackShapesPassIlVerification()
+    {
+        const string source = """
+            function stable(d: Date, n: number): number {
+                d.setTime(n);
+                return d.getTime() + d.valueOf();
+            }
+            function ambiguous(d: any): any {
+                return d.getTime();
+            }
+            console.log(stable(new Date(0), 5), ambiguous(new Date(7)));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("10 7\n", output);
+    }
+
+    private static void AssertCallIsFollowedByDoubleBox(MethodInfo method, string helperName)
+    {
+        var instructions = ReadInstructions(method).ToArray();
+        int callIndex = Array.FindIndex(instructions, instruction =>
+            instruction.Operand is MethodBase called && called.Name == helperName);
+
+        Assert.True(callIndex >= 0, $"No call to {helperName} was emitted.");
+        Assert.True(IsDoubleBox(instructions[callIndex + 1]),
+            $"The {helperName} result was not boxed at the any boundary.");
+        Assert.DoesNotContain(instructions, IsDoubleUnbox);
+    }
+
+    private static IEnumerable<string> DateHelperCalls(
+        IEnumerable<(OpCode OpCode, MemberInfo? Operand)> instructions) =>
+        instructions
+            .Select(instruction => instruction.Operand)
+            .OfType<MethodBase>()
+            .Select(method => method.Name)
+            .Where(name => name.StartsWith("DateGet", StringComparison.Ordinal)
+                || name == "DateValueOf");
+
+    private static bool IsDoubleBox((OpCode OpCode, MemberInfo? Operand) instruction) =>
+        instruction.OpCode == OpCodes.Box && instruction.Operand == typeof(double);
+
+    private static bool IsDoubleUnbox((OpCode OpCode, MemberInfo? Operand) instruction) =>
+        instruction.OpCode == OpCodes.Unbox_Any && instruction.Operand == typeof(double);
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        TypeMap typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"stable_date_numeric_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token)
+                    : module.ResolveType(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}


### PR DESCRIPTION
## Summary

- keep stable Date numeric getters, valueOf, and simple setter results as native doubles in compiled IL
- box only when a value crosses into an object or any context
- retain dynamic method dispatch when Date prototype or instance bindings may have been mutated
- add IL, semantic fallback, allocation-scaling, cross-runtime, and BenchmarkDotNet coverage

## Performance

100,000 iterations of date.setTime(i) followed by sum += date.getTime(), median of three process launches:

| Platform | SharpTS | Node | SharpTS / Node |
| --- | ---: | ---: | ---: |
| Windows | 0.5920 ms | 1.5719 ms | 0.38x |
| WSL Ubuntu | 0.5957 ms | 1.2118 ms | 0.49x |

BenchmarkDotNet reports 33 B per complete 100,000-iteration operation on both platforms. This is the single Date instance; allocation-scaling and IL assertions verify that no result boxing occurs per iteration.

## Validation

- Windows Release solution build, strict IL verification, local performance gate, benchmark smoke, and conformance-project builds passed
- Windows Date and feature-detector coverage: 178/178 passed
- WSL Release solution build, strict IL verification, local performance gate, benchmark smoke, and conformance-project builds passed
- WSL compiler suite: 809/809 passed
- WSL broad suite reached 10,914 passed and 0 failed before an unrelated asynchronous teardown callback aborted the test host
- Windows broad testing was stopped after machine-level HttpListener handle errors, certificate-access failures, and IPC contention appeared in both interpreted and compiled paths

Closes #1487

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved performance and reduced allocations for numeric `Date` getters and single-argument setters, especially in repeated date-processing loops.
  * Added benchmark coverage for numeric date operations across multiple workload sizes.

* **Bug Fixes**
  * Preserved correct dynamic behavior when Date methods or prototypes are overridden, aliased, or accessed through dynamic values.
  * Expanded validation for Date runtime feature detection and compiler-generated output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->