### PR TITLE
test: stabilize process tree termination

### DIFF
--- a/tests/SharpTS.Tests/RuntimeTests/OwnedProcessRegistryTests.cs
+++ b/tests/SharpTS.Tests/RuntimeTests/OwnedProcessRegistryTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using SharpTS.Execution;
 using SharpTS.Runtime;
@@ -44,14 +45,28 @@ public sealed class OwnedProcessRegistryTests
     }
 
     [Fact]
-    public async Task ProcessTreeTermination_TerminatesDescendants()
+    public void ProcessTreeTermination_TerminatesDescendants()
     {
         using Process parent = StartParentThatReportsChildPid();
         Process? child = null;
 
         try
         {
-            string? line = await parent.StandardOutput.ReadLineAsync().WaitAsync(TimeSpan.FromSeconds(10));
+            // Keep the PID handshake off the ThreadPool: under the suite's aggressive
+            // parallelism, an awaited continuation can be delayed past the child's lifetime.
+            string? line = null;
+            Exception? readException = null;
+            var reader = new Thread(() =>
+            {
+                try { line = parent.StandardOutput.ReadLine(); }
+                catch (Exception exception) { readException = exception; }
+            }) { IsBackground = true };
+            reader.Start();
+
+            Assert.True(reader.Join(TimeSpan.FromSeconds(10)), "Timed out waiting for the parent to report a child PID.");
+            if (readException is not null)
+                ExceptionDispatchInfo.Capture(readException).Throw();
+
             Assert.True(int.TryParse(line, out int childPid), $"Parent did not report a child PID. Output: {line ?? "<null>"}");
 
             child = Process.GetProcessById(childPid);


### PR DESCRIPTION
## Summary
- keep the descendant PID handshake off the ThreadPool to avoid delayed xUnit continuations
- retain the 10-second handshake timeout and all process-tree assertions
- preserve aggressive suite parallelism and focused-test runtime

## Validation
- focused test: 1 passed in 105 ms
- OwnedProcessRegistryTests: 4 passed in 3 s
- SharpTS.Tests: 17,386 passed in 5m12s
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of process termination coverage.
  * Added timeout handling for descendant-process monitoring.
  * Test failures now report background read errors directly, making diagnostic results clearer and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->