### PR TITLE
Perf: keep stable numeric arrays packed through slice and sort

### DIFF
--- a/src/SharpTS/Compilation/ArrayLocalPromotionAnalyzer.cs
+++ b/src/SharpTS/Compilation/ArrayLocalPromotionAnalyzer.cs
@@ -50,6 +50,8 @@ public static class ArrayLocalPromotionAnalyzer
             if (!visitor.ElementToken.TryGetValue(key, out var token)) continue; // no Double/Bool use seen
             if (closures?.IsVariableCaptured(key.Name) == true) continue;
             typeMap.MarkPromotableArrayLocal(nameToken, token);
+            if (visitor.NumericSliceSortReceivers.TryGetValue(key, out var receiverToken))
+                typeMap.MarkStableNumericSliceSortReceiver(receiverToken);
         }
     }
 
@@ -68,6 +70,20 @@ public static class ArrayLocalPromotionAnalyzer
 
         /// <summary>(scope, name) → candidate declaration's name token (empty-array-literal local).</summary>
         public Dictionary<(int Scope, string Name), Token> Candidates { get; } = new();
+
+        /// <summary>
+        /// Fresh zero-argument numeric slice candidates. Unlike the older
+        /// List&lt;T&gt; promotions, these keep an object slot but reuse the same
+        /// non-escape proof to admit a representation-preserving sort kernel.
+        /// </summary>
+        private HashSet<(int Scope, string Name)> NumericSliceCandidates { get; } = new();
+
+        /// <summary>
+        /// Candidate key to the exact receiver token of its one admitted sort.
+        /// The token is published to TypeMap only if the candidate survives all
+        /// later escape, alias, capture, and redeclaration checks.
+        /// </summary>
+        public Dictionary<(int Scope, string Name), Token> NumericSliceSortReceivers { get; } = new();
 
         /// <summary>How many times each (scope, name) is declared.</summary>
         public Dictionary<(int Scope, string Name), int> DeclCount { get; } = new();
@@ -113,6 +129,8 @@ public static class ArrayLocalPromotionAnalyzer
                 // own uses. (Empty-literal candidates get their element kind from their uses instead.)
                 if (initializer is Expr.Call)
                     ElementToken[key] = TokenType.TYPE_NUMBER;
+                if (IsNumericSliceInitializer(initializer))
+                    NumericSliceCandidates.Add(key);
             }
 
             // Visit the initializer for completeness: `[]` has no sub-uses, but a `src.map(cb)` init
@@ -124,10 +142,80 @@ public static class ArrayLocalPromotionAnalyzer
 
         private bool IsPromotableArrayInitializer(Expr? init) =>
             init is Expr.ArrayLiteral { Elements.Count: 0 }
+            || IsNumericSliceInitializer(init)
             || (init is Expr.Call { Callee: Expr.Get { Object: Expr.Variable, Name.Lexeme: "map", Optional: false } } mc
                 && IsTypedNonCapturingNumericMapper(mc.Arguments))
             || (init is Expr.Call { Callee: Expr.Get { Object: Expr.Variable, Name.Lexeme: "filter", Optional: false } } fc
                 && IsTypedNonCapturingNumericPredicate(fc.Arguments));
+
+        private bool IsNumericSliceInitializer(Expr? init) =>
+            init is Expr.Call
+            {
+                Optional: false,
+                Callee: Expr.Get
+                {
+                    Object: Expr.Variable source,
+                    Name.Lexeme: "slice",
+                    Optional: false
+                },
+                Arguments.Count: 0
+            }
+            && IsNumberArrayReceiver(source);
+
+        protected override void VisitExpression(Stmt.Expression stmt)
+        {
+            // Only a discarded `copy.sort((a,b)=>a-b)` may consume a fresh
+            // numeric-slice candidate. Using sort's receiver result (alias,
+            // return, comparison, argument pass) falls through VisitCall and
+            // disqualifies the local through the ordinary bare-variable rule.
+            if (stmt.Expr is Expr.Call
+                {
+                    Optional: false,
+                    Callee: Expr.Get
+                    {
+                        Object: Expr.Variable receiver,
+                        Name.Lexeme: "sort",
+                        Optional: false
+                    },
+                    Arguments: [Expr.ArrowFunction comparator]
+                }
+                && NumericSliceCandidates.Contains((_scope, receiver.Name.Lexeme))
+                && IsPureNumericDifference(comparator))
+            {
+                NotePermittedReceiver(receiver);
+                NumericSliceSortReceivers[(_scope, receiver.Name.Lexeme)] = receiver.Name;
+                Visit(comparator);
+                return;
+            }
+
+            base.VisitExpression(stmt);
+        }
+
+        private bool IsPureNumericDifference(Expr.ArrowFunction comparator)
+        {
+            if (comparator.HasOwnThis
+                || comparator.IsAsync
+                || comparator.IsGenerator
+                || comparator.Parameters.Count != 2
+                || comparator.Parameters.Any(parameter =>
+                    parameter.IsRest || parameter.IsOptional || parameter.DefaultValue != null)
+                || comparator.Parameters[0].Type != "number"
+                || comparator.Parameters[1].Type != "number"
+                || comparator.ReturnType != null && comparator.ReturnType != "number"
+                || _closures?.GetCaptures(comparator).Count > 0
+                || comparator.ExpressionBody is not Expr.Binary
+                {
+                    Operator.Type: TokenType.MINUS,
+                    Left: Expr.Variable left,
+                    Right: Expr.Variable right
+                })
+            {
+                return false;
+            }
+
+            return left.Name.Lexeme == comparator.Parameters[0].Name.Lexeme
+                && right.Name.Lexeme == comparator.Parameters[1].Name.Lexeme;
+        }
 
         protected override void VisitGetIndex(Expr.GetIndex expr)
         {

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -252,6 +252,7 @@ public class EmittedRuntime
     public MethodBuilder ArrayShiftProto { get; set; } = null!;
     public MethodBuilder ArrayUnshift { get; set; } = null!;
     public MethodBuilder ArraySlice { get; set; } = null!;
+    public MethodBuilder ArraySliceNumber { get; set; } = null!;
     public MethodBuilder ArrayMap { get; set; } = null!;
     public MethodBuilder ArrayMapDirect { get; set; } = null!;
     public MethodBuilder ArrayMapDouble { get; set; } = null!;
@@ -296,6 +297,7 @@ public class EmittedRuntime
     public MethodBuilder ArraySort { get; set; } = null!;
     public MethodBuilder ArraySortDirect { get; set; } = null!;
     public MethodBuilder ArraySortDirectNumber { get; set; } = null!;
+    public MethodBuilder ArraySortNumeric { get; set; } = null!;
     public MethodBuilder ArraySortProto { get; set; } = null!;
     public MethodBuilder ArraySortCanUseDenseFastPath { get; set; } = null!;
     public MethodBuilder ArrayToSorted { get; set; } = null!;
@@ -1550,6 +1552,10 @@ public class EmittedRuntime
     public MethodBuilder TSArraySetDouble { get; set; } = null!;
     public MethodBuilder TSArrayPushDouble { get; set; } = null!;
     public MethodBuilder TSArrayEnsureBoxed { get; set; } = null!;
+    public MethodBuilder TSArrayIsNumericGetter { get; set; } = null!;
+    public MethodBuilder TSArrayNumericCountGetter { get; set; } = null!;
+    public MethodBuilder TSArrayCloneNumeric { get; set; } = null!;
+    public MethodBuilder TSArraySortNumeric { get; set; } = null!;
     // Flips an empty $Array into numeric (unboxed double[]) mode — emitted at
     // statically-number[] array-creation sites so escaping number[] arrays start
     // unboxed. No-op on a non-empty / sparse array (stays boxed).

--- a/src/SharpTS/Compilation/Emitters/ArrayEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/ArrayEmitter.cs
@@ -26,6 +26,11 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         var ctx = emitter.Context;
         var il = ctx.IL;
 
+        if (methodName == "slice" && TryEmitNumericSliceCall(emitter, receiver, arguments))
+            return true;
+        if (methodName == "sort" && TryEmitNumericSortCall(emitter, receiver, arguments))
+            return true;
+
         if (methodName == "push"
             && receiver is Expr.Variable stableReceiver
             && ctx.TypeMap?.IsStablePrimitivePromiseAllPushReceiver(stableReceiver) == true
@@ -909,6 +914,117 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
             return bound;
         }
         return null;
+    }
+
+    /// <summary>
+    /// Keeps a zero-argument slice of a statically numeric array in the
+    /// packed-double $Array representation. The runtime helper repeats the
+    /// dense ordinary-array proof and falls back to observable generic slice.
+    /// </summary>
+    private static bool TryEmitNumericSliceCall(
+        IEmitterContext emitter,
+        Expr receiver,
+        List<Expr> arguments)
+    {
+        var ctx = emitter.Context;
+        if (arguments.Count != 0
+            || ArrayElements.Resolve(ctx.TypeMap?.Get(receiver)) is not
+                { Kind: ArrayElementsKind.Double }
+            || ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors != false
+            || ctx.RuntimeFeatures.UsesArrayPrototypeMutation)
+        {
+            return false;
+        }
+
+        emitter.EmitExpression(receiver);
+        emitter.EmitBoxIfNeeded(receiver);
+        ctx.IL.Emit(OpCodes.Call, ctx.Runtime!.ArraySliceNumber);
+        emitter.SetStackUnknown();
+        return true;
+    }
+
+    /// <summary>
+    /// Routes the closed, non-throwing numeric comparator <c>(a,b) =&gt; a-b</c>
+    /// to the packed stable merge kernel. Captures, calls, property reads,
+    /// statements, and every other comparator shape retain the observable sort
+    /// path, including comparator-driven mutation and abrupt completion.
+    /// </summary>
+    private static bool TryEmitNumericSortCall(
+        IEmitterContext emitter,
+        Expr receiver,
+        List<Expr> arguments)
+    {
+        var ctx = emitter.Context;
+        if (receiver is not Expr.Variable stableSlice
+            || ctx.TypeMap?.IsStableNumericSliceSortReceiver(stableSlice.Name) != true
+            || arguments.Count != 1
+            || ArrayElements.Resolve(ctx.TypeMap?.Get(receiver)) is not
+                { Kind: ArrayElementsKind.Double }
+            || ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors != false
+            || ctx.RuntimeFeatures.UsesArrayPrototypeMutation)
+        {
+            return false;
+        }
+
+        var af = ResolveCallbackArrow(emitter, arguments[0]);
+        if (af is null
+            || af.HasOwnThis
+            || af.IsAsync
+            || af.IsGenerator
+            || af.Parameters.Count != 2
+            || af.Parameters.Any(parameter =>
+                parameter.IsRest || parameter.IsOptional || parameter.DefaultValue != null)
+            || !IsPureNumericDifference(af)
+            || ctx.DisplayClasses.ContainsKey(af)
+            || !ctx.ArrowMethods.TryGetValue(af, out var arrowMethod)
+            || arrowMethod.ReturnType != ctx.Types.Double
+            || arrowMethod.GetParameters() is not { Length: 2 } parameters
+            || parameters[0].ParameterType != ctx.Types.Double
+            || parameters[1].ParameterType != ctx.Types.Double
+            || arrowMethod.DeclaringType is not TypeBuilder programType)
+        {
+            return false;
+        }
+
+        var typedComparator = typeof(Func<double, double, double>);
+        var boxedComparator = typeof(Func<object, object, double>);
+        var boxedAdapter = ctx.ArrowBoxedAdapters.GetOrEmit(
+            programType,
+            arrowMethod,
+            funcArity: 2,
+            instance: false,
+            boolReturn: false,
+            numberReturn: true);
+
+        emitter.EmitExpression(receiver);
+        emitter.EmitBoxIfNeeded(receiver);
+        ctx.IL.Emit(OpCodes.Ldnull);
+        ctx.IL.Emit(OpCodes.Ldftn, arrowMethod);
+        ctx.IL.Emit(OpCodes.Newobj,
+            typedComparator.GetConstructor([typeof(object), typeof(IntPtr)])!);
+        ctx.IL.Emit(OpCodes.Ldnull);
+        ctx.IL.Emit(OpCodes.Ldftn, boxedAdapter);
+        ctx.IL.Emit(OpCodes.Newobj,
+            boxedComparator.GetConstructor([typeof(object), typeof(IntPtr)])!);
+        ctx.IL.Emit(OpCodes.Call, ctx.Runtime!.ArraySortNumeric);
+        emitter.SetStackUnknown();
+        return true;
+    }
+
+    private static bool IsPureNumericDifference(Expr.ArrowFunction af)
+    {
+        if (af.ExpressionBody is not Expr.Binary
+            {
+                Operator.Type: TokenType.MINUS,
+                Left: Expr.Variable left,
+                Right: Expr.Variable right
+            })
+        {
+            return false;
+        }
+
+        return left.Name.Lexeme == af.Parameters[0].Name.Lexeme
+            && right.Name.Lexeme == af.Parameters[1].Name.Lexeme;
     }
 
     private static bool TryEmitDirectDelegateCall(IEmitterContext emitter, List<Expr> arguments, System.Reflection.Emit.MethodBuilder helperMethod, System.Reflection.Emit.MethodBuilder? boolHelper = null)

--- a/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Mutators.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Mutators.cs
@@ -1779,6 +1779,126 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
+    /// Zero-argument numeric slice entry point. A packed dense ordinary array
+    /// clones its double[] store directly; every observable or boxed shape
+    /// delegates to the existing generic slice and is wrapped normally.
+    /// </summary>
+    private void EmitArraySliceNumber(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "ArraySliceNumber",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object]);
+        runtime.ArraySliceNumber = method;
+
+        var il = method.GetILGenerator();
+        var array = il.DeclareLocal(runtime.TSArrayType);
+        var count = il.DeclareLocal(_types.Int32);
+        var fallback = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Stloc, array);
+        il.Emit(OpCodes.Ldloc, array);
+        il.Emit(OpCodes.Brfalse, fallback);
+        il.Emit(OpCodes.Ldloc, array);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayIsNumericGetter);
+        il.Emit(OpCodes.Brfalse, fallback);
+        il.Emit(OpCodes.Ldloc, array);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayNumericCountGetter);
+        il.Emit(OpCodes.Stloc, count);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, count);
+        il.Emit(OpCodes.Call, runtime.ArraySortCanUseDenseFastPath);
+        il.Emit(OpCodes.Brfalse, fallback);
+        il.Emit(OpCodes.Ldloc, array);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayCloneNumeric);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(fallback);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Call, runtime.ArraySlice);
+        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Guarded packed-double sort entry point for a proven pure numeric
+    /// comparator. The boxed adapter is carried only for the fallback branch;
+    /// the hot branch invokes the typed comparator and merge kernel without
+    /// object snapshots or per-comparison boxing.
+    /// </summary>
+    private void EmitArraySortNumeric(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var typedComparator = typeof(Func<double, double, double>);
+        var boxedComparator = typeof(Func<object, object, double>);
+        var method = typeBuilder.DefineMethod(
+            "ArraySortNumeric",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, typedComparator, boxedComparator]);
+        runtime.ArraySortNumeric = method;
+
+        var il = method.GetILGenerator();
+        var array = il.DeclareLocal(runtime.TSArrayType);
+        var count = il.DeclareLocal(_types.Int32);
+        var frozenMarker = il.DeclareLocal(_types.Object);
+        var fallback = il.DefineLabel();
+        var fallbackReady = il.DefineLabel();
+        var returnReceiver = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Stloc, array);
+        il.Emit(OpCodes.Ldloc, array);
+        il.Emit(OpCodes.Brfalse, fallbackReady);
+        il.Emit(OpCodes.Ldloc, array);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayIsNumericGetter);
+        il.Emit(OpCodes.Brfalse, fallback);
+
+        // Preserve the existing frozen-array behavior without materializing a
+        // packed receiver merely to discover that sort returns it unchanged.
+        il.Emit(OpCodes.Ldsfld, runtime.FrozenObjectsField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloca, frozenMarker);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.ConditionalWeakTable,
+            "TryGetValue",
+            _types.Object,
+            _types.Object.MakeByRefType()));
+        il.Emit(OpCodes.Brtrue, returnReceiver);
+
+        il.Emit(OpCodes.Ldloc, array);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayNumericCountGetter);
+        il.Emit(OpCodes.Stloc, count);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, count);
+        il.Emit(OpCodes.Call, runtime.ArraySortCanUseDenseFastPath);
+        il.Emit(OpCodes.Brfalse, fallback);
+        il.Emit(OpCodes.Ldloc, array);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, runtime.TSArraySortNumeric);
+        il.Emit(OpCodes.Br, returnReceiver);
+
+        il.MarkLabel(fallback);
+        il.Emit(OpCodes.Ldloc, array);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayEnsureBoxed);
+        il.MarkLabel(fallbackReady);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, _types.ListOfObject);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Call, runtime.ArraySortDirectNumber);
+        il.Emit(OpCodes.Pop);
+
+        il.MarkLabel(returnReceiver);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
     /// Emits the shape guard shared by sort's snapshot and write-back phases.
     /// It performs no indexed Get/Set/Delete operations and invokes no guest
     /// code, so a failed check can safely fall through to the observable path.
@@ -1821,12 +1941,29 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.PDSHasIndexedOwnProperty);
         il.Emit(OpCodes.Brtrue, returnFalse);
 
-        // The raw backing must still represent every snapshotted index.
+        // The raw backing must still represent every snapshotted index. A
+        // packed-double $Array deliberately has an empty inherited List, so a
+        // Count mismatch gets one representation-aware retry before bailing.
+        var backingLengthReady = il.DefineLabel();
+        var numericArray = il.DeclareLocal(runtime.TSArrayType);
         il.Emit(OpCodes.Ldloc, receiverList);
         il.Emit(OpCodes.Callvirt,
             _types.GetProperty(_types.ListOfObject, "Count").GetGetMethod()!);
         il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Beq, backingLengthReady);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Stloc, numericArray);
+        il.Emit(OpCodes.Ldloc, numericArray);
+        il.Emit(OpCodes.Brfalse, returnFalse);
+        il.Emit(OpCodes.Ldloc, numericArray);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayIsNumericGetter);
+        il.Emit(OpCodes.Brfalse, returnFalse);
+        il.Emit(OpCodes.Ldloc, numericArray);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayNumericCountGetter);
+        il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Bne_Un, returnFalse);
+        il.MarkLabel(backingLengthReady);
 
         var notTSArray = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);

--- a/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -1210,6 +1210,8 @@ public partial class RuntimeEmitter
         // MethodBuilder is available to InvokeValue's Type-callee dispatch.
         EmitArraySort(typeBuilder, runtime);
         EmitArraySortDirect(typeBuilder, runtime);
+        EmitArraySliceNumber(typeBuilder, runtime);
+        EmitArraySortNumeric(typeBuilder, runtime);
         EmitArraySortProto(typeBuilder, runtime);
         EmitArrayToSorted(typeBuilder, runtime);
         EmitArrayToSortedGeneric(typeBuilder, runtime);

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSArray.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSArray.cs
@@ -309,6 +309,334 @@ public partial class RuntimeEmitter
         var markNonExtensible = typeBuilder.DefineMethod("MarkNonExtensible",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, System.Type.EmptyTypes);
         runtime.TSArrayMarkNonExtensible = markNonExtensible;
+        var isNumericGetter = typeBuilder.DefineMethod("get_IsNumeric",
+            MethodAttributes.Assembly | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+            _types.Boolean, Type.EmptyTypes);
+        runtime.TSArrayIsNumericGetter = isNumericGetter;
+        var numericCountGetter = typeBuilder.DefineMethod("get_NumericCount",
+            MethodAttributes.Assembly | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+            _types.Int32, Type.EmptyTypes);
+        runtime.TSArrayNumericCountGetter = numericCountGetter;
+        var cloneNumeric = typeBuilder.DefineMethod("CloneNumeric",
+            MethodAttributes.Assembly | MethodAttributes.HideBySig,
+            typeBuilder, Type.EmptyTypes);
+        runtime.TSArrayCloneNumeric = cloneNumeric;
+        var numericComparatorType = typeof(Func<double, double, double>);
+        var sortNumeric = typeBuilder.DefineMethod("SortNumeric",
+            MethodAttributes.Assembly | MethodAttributes.HideBySig,
+            _types.Void, [numericComparatorType]);
+        sortNumeric.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
+        runtime.TSArraySortNumeric = sortNumeric;
+
+        // These representation probes are consumed only by guarded emitted-runtime
+        // helpers. They expose no backing storage and do not force materialization.
+        {
+            var il = isNumericGetter.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayIsNumericField);
+            il.Emit(OpCodes.Ret);
+        }
+        {
+            var il = numericCountGetter.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // CloneNumeric() preserves the packed-double representation for a fresh
+        // zero-argument slice. The caller proves numeric mode plus ordinary dense
+        // array observability before entering, so one exact-sized double[] is the
+        // complete slice storage and no element is boxed.
+        {
+            var il = cloneNumeric.GetILGenerator();
+            var result = il.DeclareLocal(typeBuilder);
+            var index = il.DeclareLocal(_types.Int32);
+            var loop = il.DefineLabel();
+            var done = il.DefineLabel();
+
+            il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.ListOfObject));
+            il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+            il.Emit(OpCodes.Stloc, result);
+            il.Emit(OpCodes.Ldloc, result);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Stfld, _tsArrayIsNumericField);
+            il.Emit(OpCodes.Ldloc, result);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Stfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Ldloc, result);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Conv_I8);
+            il.Emit(OpCodes.Stfld, _tsArrayLengthField);
+            il.Emit(OpCodes.Ldloc, result);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Newarr, _types.Double);
+            il.Emit(OpCodes.Stfld, _tsArrayNumStoreField);
+
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Stloc, index);
+            il.MarkLabel(loop);
+            il.Emit(OpCodes.Ldloc, index);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Bge, done);
+            il.Emit(OpCodes.Ldloc, result);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldloc, index);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldloc, index);
+            il.Emit(OpCodes.Ldelem_R8);
+            il.Emit(OpCodes.Stelem_R8);
+            il.Emit(OpCodes.Ldloc, index);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, index);
+            il.Emit(OpCodes.Br, loop);
+            il.MarkLabel(done);
+            il.Emit(OpCodes.Ldloc, result);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // Stable bottom-up merge sort over the packed store. The persistent
+        // slice buffer is one side of the merge and a single double[] is the
+        // scratch side; after the last pass the sorted buffer becomes the store.
+        // The proven comparator has signature double(double,double), so neither
+        // elements nor comparison results cross an object boundary. A bgt on the
+        // result treats NaN like zero and takes the left run, preserving stability.
+        {
+            var il = sortNumeric.GetILGenerator();
+            var n = il.DeclareLocal(_types.Int32);
+            var src = il.DeclareLocal(_types.DoubleArray);
+            var dst = il.DeclareLocal(_types.DoubleArray);
+            var swap = il.DeclareLocal(_types.DoubleArray);
+            var width = il.DeclareLocal(_types.Int32);
+            var lo = il.DeclareLocal(_types.Int32);
+            var mid = il.DeclareLocal(_types.Int32);
+            var hi = il.DeclareLocal(_types.Int32);
+            var i = il.DeclareLocal(_types.Int32);
+            var j = il.DeclareLocal(_types.Int32);
+            var k = il.DeclareLocal(_types.Int32);
+
+            var done = il.DefineLabel();
+            var widthCond = il.DefineLabel();
+            var widthBody = il.DefineLabel();
+            var loCond = il.DefineLabel();
+            var loBody = il.DefineLabel();
+            var loNext = il.DefineLabel();
+            var midAdd = il.DefineLabel();
+            var midDone = il.DefineLabel();
+            var hiAdd = il.DefineLabel();
+            var hiDone = il.DefineLabel();
+            var widthDouble = il.DefineLabel();
+            var mergeCond = il.DefineLabel();
+            var mergeBody = il.DefineLabel();
+            var takeLeft = il.DefineLabel();
+            var takeRight = il.DefineLabel();
+            var afterTake = il.DefineLabel();
+            var drainLeftCond = il.DefineLabel();
+            var drainLeftBody = il.DefineLabel();
+            var drainRightCond = il.DefineLabel();
+            var drainRightBody = il.DefineLabel();
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Stloc, n);
+            il.Emit(OpCodes.Ldloc, n);
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Blt, done);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Stloc, src);
+            il.Emit(OpCodes.Ldloc, n);
+            il.Emit(OpCodes.Newarr, _types.Double);
+            il.Emit(OpCodes.Stloc, dst);
+
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Stloc, width);
+            il.Emit(OpCodes.Br, widthCond);
+            il.MarkLabel(widthBody);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Stloc, lo);
+            il.Emit(OpCodes.Br, loCond);
+            il.MarkLabel(loBody);
+
+            il.Emit(OpCodes.Ldloc, width);
+            il.Emit(OpCodes.Ldloc, n);
+            il.Emit(OpCodes.Ldloc, lo);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Blt, midAdd);
+            il.Emit(OpCodes.Ldloc, n);
+            il.Emit(OpCodes.Stloc, mid);
+            il.Emit(OpCodes.Br, midDone);
+            il.MarkLabel(midAdd);
+            il.Emit(OpCodes.Ldloc, lo);
+            il.Emit(OpCodes.Ldloc, width);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, mid);
+            il.MarkLabel(midDone);
+
+            il.Emit(OpCodes.Ldloc, width);
+            il.Emit(OpCodes.Ldloc, n);
+            il.Emit(OpCodes.Ldloc, mid);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Blt, hiAdd);
+            il.Emit(OpCodes.Ldloc, n);
+            il.Emit(OpCodes.Stloc, hi);
+            il.Emit(OpCodes.Br, hiDone);
+            il.MarkLabel(hiAdd);
+            il.Emit(OpCodes.Ldloc, mid);
+            il.Emit(OpCodes.Ldloc, width);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, hi);
+            il.MarkLabel(hiDone);
+
+            il.Emit(OpCodes.Ldloc, lo);
+            il.Emit(OpCodes.Stloc, i);
+            il.Emit(OpCodes.Ldloc, mid);
+            il.Emit(OpCodes.Stloc, j);
+            il.Emit(OpCodes.Ldloc, lo);
+            il.Emit(OpCodes.Stloc, k);
+            il.Emit(OpCodes.Br, mergeCond);
+
+            il.MarkLabel(mergeBody);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldloc, src);
+            il.Emit(OpCodes.Ldloc, i);
+            il.Emit(OpCodes.Ldelem_R8);
+            il.Emit(OpCodes.Ldloc, src);
+            il.Emit(OpCodes.Ldloc, j);
+            il.Emit(OpCodes.Ldelem_R8);
+            il.Emit(OpCodes.Callvirt, numericComparatorType.GetMethod("Invoke")!);
+            il.Emit(OpCodes.Ldc_R8, 0.0);
+            il.Emit(OpCodes.Bgt, takeRight);
+
+            il.MarkLabel(takeLeft);
+            il.Emit(OpCodes.Ldloc, dst);
+            il.Emit(OpCodes.Ldloc, k);
+            il.Emit(OpCodes.Ldloc, src);
+            il.Emit(OpCodes.Ldloc, i);
+            il.Emit(OpCodes.Ldelem_R8);
+            il.Emit(OpCodes.Stelem_R8);
+            il.Emit(OpCodes.Ldloc, i);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, i);
+            il.Emit(OpCodes.Br, afterTake);
+
+            il.MarkLabel(takeRight);
+            il.Emit(OpCodes.Ldloc, dst);
+            il.Emit(OpCodes.Ldloc, k);
+            il.Emit(OpCodes.Ldloc, src);
+            il.Emit(OpCodes.Ldloc, j);
+            il.Emit(OpCodes.Ldelem_R8);
+            il.Emit(OpCodes.Stelem_R8);
+            il.Emit(OpCodes.Ldloc, j);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, j);
+
+            il.MarkLabel(afterTake);
+            il.Emit(OpCodes.Ldloc, k);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, k);
+            il.MarkLabel(mergeCond);
+            il.Emit(OpCodes.Ldloc, i);
+            il.Emit(OpCodes.Ldloc, mid);
+            il.Emit(OpCodes.Bge, drainLeftCond);
+            il.Emit(OpCodes.Ldloc, j);
+            il.Emit(OpCodes.Ldloc, hi);
+            il.Emit(OpCodes.Blt, mergeBody);
+
+            il.MarkLabel(drainLeftCond);
+            il.Emit(OpCodes.Ldloc, i);
+            il.Emit(OpCodes.Ldloc, mid);
+            il.Emit(OpCodes.Bge, drainRightCond);
+            il.MarkLabel(drainLeftBody);
+            il.Emit(OpCodes.Ldloc, dst);
+            il.Emit(OpCodes.Ldloc, k);
+            il.Emit(OpCodes.Ldloc, src);
+            il.Emit(OpCodes.Ldloc, i);
+            il.Emit(OpCodes.Ldelem_R8);
+            il.Emit(OpCodes.Stelem_R8);
+            il.Emit(OpCodes.Ldloc, i);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, i);
+            il.Emit(OpCodes.Ldloc, k);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, k);
+            il.Emit(OpCodes.Ldloc, i);
+            il.Emit(OpCodes.Ldloc, mid);
+            il.Emit(OpCodes.Blt, drainLeftBody);
+
+            il.MarkLabel(drainRightCond);
+            il.Emit(OpCodes.Ldloc, j);
+            il.Emit(OpCodes.Ldloc, hi);
+            il.Emit(OpCodes.Bge, loNext);
+            il.MarkLabel(drainRightBody);
+            il.Emit(OpCodes.Ldloc, dst);
+            il.Emit(OpCodes.Ldloc, k);
+            il.Emit(OpCodes.Ldloc, src);
+            il.Emit(OpCodes.Ldloc, j);
+            il.Emit(OpCodes.Ldelem_R8);
+            il.Emit(OpCodes.Stelem_R8);
+            il.Emit(OpCodes.Ldloc, j);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, j);
+            il.Emit(OpCodes.Ldloc, k);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, k);
+            il.Emit(OpCodes.Ldloc, j);
+            il.Emit(OpCodes.Ldloc, hi);
+            il.Emit(OpCodes.Blt, drainRightBody);
+
+            il.MarkLabel(loNext);
+            il.Emit(OpCodes.Ldloc, hi);
+            il.Emit(OpCodes.Stloc, lo);
+            il.MarkLabel(loCond);
+            il.Emit(OpCodes.Ldloc, lo);
+            il.Emit(OpCodes.Ldloc, n);
+            il.Emit(OpCodes.Blt, loBody);
+
+            il.Emit(OpCodes.Ldloc, src);
+            il.Emit(OpCodes.Stloc, swap);
+            il.Emit(OpCodes.Ldloc, dst);
+            il.Emit(OpCodes.Stloc, src);
+            il.Emit(OpCodes.Ldloc, swap);
+            il.Emit(OpCodes.Stloc, dst);
+            il.Emit(OpCodes.Ldloc, width);
+            il.Emit(OpCodes.Ldc_I4, int.MaxValue / 2);
+            il.Emit(OpCodes.Ble, widthDouble);
+            il.Emit(OpCodes.Ldc_I4, int.MaxValue);
+            il.Emit(OpCodes.Stloc, width);
+            il.Emit(OpCodes.Br, widthCond);
+            il.MarkLabel(widthDouble);
+            il.Emit(OpCodes.Ldloc, width);
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Mul);
+            il.Emit(OpCodes.Stloc, width);
+            il.MarkLabel(widthCond);
+            il.Emit(OpCodes.Ldloc, width);
+            il.Emit(OpCodes.Ldloc, n);
+            il.Emit(OpCodes.Blt, widthBody);
+
+            il.Emit(OpCodes.Ldloc, src);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Beq, done);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, src);
+            il.Emit(OpCodes.Stfld, _tsArrayNumStoreField);
+            il.MarkLabel(done);
+            il.Emit(OpCodes.Ret);
+        }
 
         // ── void EnsureBoxed() ── numeric -> boxed: box each _numStore[i] into
         // the (empty) base list, then clear the numeric mode.

--- a/src/SharpTS/TypeSystem/TypeMap.cs
+++ b/src/SharpTS/TypeSystem/TypeMap.cs
@@ -156,6 +156,21 @@ public class TypeMap
     public bool IsPromotableArrayLocal(Token nameToken, out TokenType elementToken) =>
         _promotableArrayLocals.TryGetValue(nameToken, out elementToken);
 
+    private readonly HashSet<Token> _stableNumericSliceSortReceivers =
+        new(ReferenceEqualityComparer.Instance);
+
+    /// <summary>
+    /// Records the exact receiver occurrence of a discarded
+    /// <c>freshNumericSlice.sort((a, b) =&gt; a - b)</c> call after whole-function
+    /// analysis proves that the slice local neither escapes nor aliases.
+    /// </summary>
+    public void MarkStableNumericSliceSortReceiver(Token receiverToken) =>
+        _stableNumericSliceSortReceivers.Add(receiverToken);
+
+    /// <summary>True only for the receiver occurrence approved by the analyzer.</summary>
+    public bool IsStableNumericSliceSortReceiver(Token receiverToken) =>
+        _stableNumericSliceSortReceivers.Contains(receiverToken);
+
     /// <summary>
     /// Marks an indexed receiver use whose binding belongs to a fresh, exact, non-escaping numeric
     /// TypedArray local. The IL compiler may cache that receiver's backing storage around a loop.

--- a/tests/SharpTS.Tests/CompilerTests/ArraySortDirectComparatorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/ArraySortDirectComparatorTests.cs
@@ -206,6 +206,134 @@ public sealed class ArraySortDirectComparatorTests
             $"Stable numeric sort allocated {allocated:N0} bytes; comparator results may be boxed.");
     }
 
+    [Fact]
+    public void FreshNumericSliceSort_UsesTypedStableKernel()
+    {
+        Assembly assembly = Compile("""
+            function makeNumbers(n: number): number[] {
+                const values: number[] = [];
+                let state: number = 123456789;
+                for (let i: number = 0; i < n; i++) {
+                    state = (state * 48271) % 2147483647;
+                    values.push(state);
+                }
+                return values;
+            }
+
+            function sortNumbers(source: number[]): number {
+                const copy: number[] = source.slice();
+                copy.sort((left: number, right: number): number => left - right);
+                return copy[0] + copy[copy.length - 1];
+            }
+
+            function stableSignedZeros(): boolean {
+                const source: number[] = [2, 0, -0, 1];
+                const copy: number[] = source.slice();
+                copy.sort((left: number, right: number): number => left - right);
+                return 1 / copy[0] === Infinity
+                    && 1 / copy[1] === -Infinity
+                    && copy[2] === 1
+                    && copy[3] === 2
+                    && source[0] === 2;
+            }
+            """);
+
+        MethodInfo sortNumbers = FindFunction(assembly, "sortNumbers");
+        MethodBase[] calls = CalledMethods(sortNumbers).ToArray();
+        Assert.Contains(calls, method => method.Name == "ArraySliceNumber");
+        Assert.Contains(calls, method => method.Name == "ArraySortNumeric");
+        Assert.DoesNotContain(calls, method => method.Name == "ArraySortDirectNumber");
+        Assert.DoesNotContain(calls, method => method.Name == "EnsureBoxed");
+
+        MethodInfo kernel = assembly.GetType("$Array")!.GetMethod(
+            "SortNumeric",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Missing packed numeric sort kernel.");
+        var kernelInstructions = Instructions(kernel).ToArray();
+        Assert.Contains(kernelInstructions, instruction =>
+            instruction.OpCode == OpCodes.Newarr
+            && instruction.Operand is Type type
+            && type == typeof(double));
+        Assert.DoesNotContain(kernelInstructions, instruction =>
+            instruction.OpCode == OpCodes.Newarr
+            && instruction.Operand is Type type
+            && type == typeof(object));
+        Assert.DoesNotContain(kernelInstructions, instruction =>
+            instruction.OpCode == OpCodes.Box
+            && instruction.Operand is Type type
+            && type == typeof(double));
+        Assert.Contains(CalledMethods(kernel), method =>
+            method.DeclaringType == typeof(Func<double, double, double>)
+            && method.Name == "Invoke");
+        Assert.DoesNotContain(
+            kernel.GetMethodBody()!.LocalVariables,
+            local => local.LocalType == typeof(object[]));
+
+        var numbers = Assert.IsAssignableFrom<List<object>>(
+            FindFunction(assembly, "makeNumbers").Invoke(null, [1_000.0]));
+        double checksum = Assert.IsType<double>(sortNumbers.Invoke(null, [numbers]));
+        Assert.True(checksum > 0);
+        MethodInfo stableSignedZeros = FindFunction(assembly, "stableSignedZeros");
+        Assert.Contains(CalledMethods(stableSignedZeros), method =>
+            method.Name == "ArraySortNumeric");
+        Assert.True(Assert.IsType<bool>(stableSignedZeros.Invoke(null, [])));
+    }
+
+    [Fact]
+    public void FreshNumericSliceSort_HolesAndUndefinedUseRuntimeFallback()
+    {
+        Assembly assembly = Compile("""
+            function makeHoley(): number[] {
+                const values: number[] = [];
+                values[0] = 3;
+                values[2] = 1;
+                return values;
+            }
+
+            function makeUndefined(): number[] {
+                return [3, undefined as any, 1];
+            }
+
+            function sortFirst(source: number[]): number {
+                const copy: number[] = source.slice();
+                copy.sort((left: number, right: number): number => left - right);
+                return copy[0];
+            }
+            """);
+
+        MethodInfo sortFirst = FindFunction(assembly, "sortFirst");
+        Assert.Contains(CalledMethods(sortFirst), method => method.Name == "ArraySortNumeric");
+
+        var holey = Assert.IsAssignableFrom<List<object>>(
+            FindFunction(assembly, "makeHoley").Invoke(null, []));
+        var undefined = Assert.IsAssignableFrom<List<object>>(
+            FindFunction(assembly, "makeUndefined").Invoke(null, []));
+        Assert.Equal(1.0, Assert.IsType<double>(sortFirst.Invoke(null, [holey])));
+        Assert.Equal(1.0, Assert.IsType<double>(sortFirst.Invoke(null, [undefined])));
+    }
+
+    [Theory]
+    [InlineData("const alias: number[] = copy; copy.sort((a: number, b: number): number => a - b); return alias[0];")]
+    [InlineData("copy.sort((a: number, b: number): number => a - b); return copy.sort((a: number, b: number): number => a - b)[0];")]
+    [InlineData("Object.freeze(copy); copy.sort((a: number, b: number): number => a - b); return copy[0];")]
+    [InlineData("Object.defineProperty(copy, '0', { value: 4 }); copy.sort((a: number, b: number): number => a - b); return copy[0];")]
+    [InlineData("Object.setPrototypeOf(copy, Array.prototype); copy.sort((a: number, b: number): number => a - b); return copy[0];")]
+    [InlineData("copy.sort((a: number, b: number): number => { copy.push(0); return a - b; }); return copy[0];")]
+    [InlineData("copy.sort((a: number, b: number): number => { throw new Error('stop'); }); return copy[0];")]
+    public void ObservableNumericSliceSortShapes_RetainGeneralPath(string body)
+    {
+        Assembly assembly = Compile($$"""
+            function sortObserved(source: number[]): number {
+                const copy: number[] = source.slice();
+                {{body}}
+            }
+            """);
+
+        MethodInfo method = FindFunction(assembly, "sortObserved");
+        Assert.DoesNotContain(CalledMethods(method), called =>
+            called.Name == "ArraySortNumeric");
+    }
+
     private static Assembly Compile(string source)
     {
         var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();


### PR DESCRIPTION
## Summary

- preserve the packed double-array representation through safe zero-argument numeric slice calls
- route proven fresh, nonescaping numeric slice temporaries with an exact `(a, b) => a - b` comparator through a stable typed merge-sort kernel
- retain observable fallbacks for holes, undefined, aliases, descriptors, prototypes, frozen arrays, and effectful or throwing comparators
- add semantic and structural IL coverage that rejects object arrays and numeric boxing on the fast path

## Performance

Windows, N=10,000:

- numeric sort: 2.259 ms -> 0.673 ms (-70.2%)
- numeric sort allocation: 1,284.93 KB -> 156.54 KB (-87.8%)
- combined numeric/record workload: 4.988 ms -> 2.679 ms (-46.3%)

WSL Ubuntu compiled combined sort, N=10,000:

- 4.317 ms -> 3.045 ms (-29.5%)

## Validation

- focused compiler/IL tests: 13/13 on Windows and WSL
- WSL full suite: 17,371/17,371
- Windows full run: 17,366 passed, 3 skipped; both unrelated contention flakes passed in isolation
- GUI conformance: 106/106 on Windows and WSL
- emitted IL verification passed
- AOT/trim analyzer baseline passed with zero warnings on Windows and WSL
- Linux x64 Native AOT publish and compile gate passed with output 42
- Windows package/SDK smoke and conformance builds passed

Closes #1483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved performance for zero-argument numeric array `slice()` and pure comparator-based `sort()` operations.
  - Numeric arrays can be cloned and sorted efficiently while preserving stable ordering and special numeric behavior.
  - General-purpose behavior remains available for arrays with mutations, aliases, holes, frozen state, or observable side effects.

- **Bug Fixes**
  - Preserved correct handling of signed zero, `undefined`, comparator results, and exceptions during numeric sorting.

- **Tests**
  - Added coverage for optimized sorting and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->