### PR TITLE
Perf: optimize locally caught primitive throws

### DIFF
--- a/benchmarks/cross-runtime/scripts/exceptions.ts
+++ b/benchmarks/cross-runtime/scripts/exceptions.ts
@@ -1,0 +1,65 @@
+import { bench } from "./lib/bench.ts";
+
+function branchControl(n: number): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        if ((i & 1023) === 0) {
+            sum = sum + i;
+        } else {
+            sum = sum + 1;
+        }
+    }
+    return sum;
+}
+
+function tryCatchNoThrow(n: number): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        try {
+            if ((i & 1023) === 0) {
+                sum = sum + i;
+            } else {
+                sum = sum + 1;
+            }
+        } catch (error) {
+            sum = sum - 1;
+        }
+    }
+    return sum;
+}
+
+function primitiveThrow(n: number): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        try {
+            if ((i & 1023) === 0) {
+                throw i;
+            }
+            sum = sum + 1;
+        } catch (error: any) {
+            sum = sum + (error === i ? i : -1);
+        }
+    }
+    return sum;
+}
+
+function errorThrow(n: number): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        try {
+            if ((i & 1023) === 0) {
+                throw new Error("sparse");
+            }
+            sum = sum + 1;
+        } catch (error: any) {
+            sum = sum + (error instanceof Error ? i : -1);
+        }
+    }
+    return sum;
+}
+
+const n: number = 100000;
+bench("throw-branch-control", n, () => branchControl(n));
+bench("throw-try-catch-no-throw", n, () => tryCatchNoThrow(n));
+bench("throw-primitive", n, () => primitiveThrow(n));
+bench("throw-error", n, () => errorThrow(n));

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ExceptionThrowBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ExceptionThrowBenchmarks.cs
@@ -1,0 +1,60 @@
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using SharpTS.Microbenchmarks.Infrastructure;
+
+namespace SharpTS.Microbenchmarks.Benchmarks;
+
+/// <summary>
+/// Sparse guest-throw timing and allocation comparisons. The branch-only and
+/// no-throw protected-region controls separate loop/try overhead from the
+/// primitive wrapper and JavaScript Error allocations.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class ExceptionThrowBenchmarks
+{
+    private Func<double, double> _branchControl = null!;
+    private Func<double, double> _tryCatchNoThrow = null!;
+    private Func<double, double> _primitiveThrow = null!;
+    private Func<double, double> _errorThrow = null!;
+
+    [Params(100_000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Assembly assembly = typeof(ExceptionThrowBenchmarks).Assembly;
+        using Stream stream = assembly.GetManifestResourceStream(
+            "SharpTS.Microbenchmarks.TypeScriptSources.ExceptionThrows.ts")
+            ?? throw new InvalidOperationException(
+                "Could not find embedded resource ExceptionThrows.ts");
+        using var reader = new StreamReader(stream);
+        string dllPath = CompilationCache.GetOrCompile(
+            reader.ReadToEnd(), "ExceptionThrows");
+        Assembly compiled = BenchmarkHarness.LoadCompiledAssembly(
+            dllPath, "exception-throws");
+        _branchControl = BenchmarkHarness.GetCompiledNumberFunc(
+            compiled, "throwBranchControl");
+        _tryCatchNoThrow = BenchmarkHarness.GetCompiledNumberFunc(
+            compiled, "throwTryCatchNoThrow");
+        _primitiveThrow = BenchmarkHarness.GetCompiledNumberFunc(
+            compiled, "throwPrimitiveSparse");
+        _errorThrow = BenchmarkHarness.GetCompiledNumberFunc(
+            compiled, "throwErrorSparse");
+    }
+
+    [Benchmark(Baseline = true)]
+    public double BranchOnlyControl() => _branchControl(N);
+
+    [Benchmark]
+    public double TryCatchNoThrow() => _tryCatchNoThrow(N);
+
+    [Benchmark]
+    public double PrimitiveThrow() => _primitiveThrow(N);
+
+    [Benchmark]
+    public double ErrorThrow() => _errorThrow(N);
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ExceptionThrows.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ExceptionThrows.ts
@@ -1,0 +1,57 @@
+function throwBranchControl(n: number): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        if ((i & 1023) === 0) {
+            sum = sum + i;
+        } else {
+            sum = sum + 1;
+        }
+    }
+    return sum;
+}
+
+function throwTryCatchNoThrow(n: number): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        try {
+            if ((i & 1023) === 0) {
+                sum = sum + i;
+            } else {
+                sum = sum + 1;
+            }
+        } catch (error) {
+            sum = sum - 1;
+        }
+    }
+    return sum;
+}
+
+function throwPrimitiveSparse(n: number): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        try {
+            if ((i & 1023) === 0) {
+                throw i;
+            }
+            sum = sum + 1;
+        } catch (error: any) {
+            sum = sum + (error === i ? i : -1);
+        }
+    }
+    return sum;
+}
+
+function throwErrorSparse(n: number): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        try {
+            if ((i & 1023) === 0) {
+                throw new Error("sparse");
+            }
+            sum = sum + 1;
+        } catch (error: any) {
+            sum = sum + (error instanceof Error ? i : -1);
+        }
+    }
+    return sum;
+}

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -1490,6 +1490,12 @@ public class EmittedRuntime
     public MethodBuilder ErrorIsError { get; set; } = null!;
     public MethodBuilder AggregateErrorGetErrors { get; set; } = null!;
 
+    // $ThrownValueException : Exception — the allocation-light carrier for a
+    // guest `throw` value. Message is derived lazily at a host boundary.
+    public Type ThrownValueExceptionType { get; set; } = null!;
+    public ConstructorBuilder ThrownValueExceptionCtor { get; set; } = null!;
+    public MethodBuilder ThrownValueExceptionValueGetter { get; set; } = null!;
+
     // Promise type - emitted for standalone assemblies
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSPromise
     public Type TSPromiseType { get; set; } = null!;

--- a/src/SharpTS/Compilation/GeneratorStateMachineBuilder.cs
+++ b/src/SharpTS/Compilation/GeneratorStateMachineBuilder.cs
@@ -667,7 +667,7 @@ public class GeneratorStateMachineBuilder : StateMachineBuilderBase, IIteratorSt
         throwIL.Emit(OpCodes.Stfld, StateField);
 
         // If error is already an Exception, rethrow it directly
-        // Otherwise, use CreateException to properly wrap the value with __tsValue
+        // Otherwise, use CreateException to carry the exact guest value.
         var isExceptionLabel = throwIL.DefineLabel();
         var createExceptionLabel = throwIL.DefineLabel();
 
@@ -676,7 +676,7 @@ public class GeneratorStateMachineBuilder : StateMachineBuilderBase, IIteratorSt
         throwIL.Emit(OpCodes.Dup);
         throwIL.Emit(OpCodes.Brtrue, isExceptionLabel);
 
-        // Not an exception - use CreateException to wrap with __tsValue
+        // Not an exception - use CreateException to carry the exact guest value.
         throwIL.Emit(OpCodes.Pop);
         throwIL.Emit(OpCodes.Ldarg_1);
         throwIL.Emit(OpCodes.Call, _runtime!.CreateException);

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -2623,55 +2623,67 @@ public partial class ILEmitter
             return;
         }
 
-        // Use ValidatedILBuilder for exception block operations - it tracks depth automatically
-        // and validates proper Begin/End pairing
+        if (t.CatchBlock == null)
+            throw new InvalidOperationException("A try statement requires a catch or finally block.");
+
+        // Keep a real CLR handler for exceptions crossing calls/reflection, but
+        // route syntactically local guest throws directly to the JavaScript catch
+        // body. CLR unwind dominates sparse local-throw time even after removing
+        // wrapper metadata; a typed value local preserves the same catch identity
+        // without allocating or unwinding.
         var builder = _ctx.ILBuilder;
+        var catchValue = IL.DeclareLocal(_ctx.Types.Object);
+        var catchBody = builder.DefineLabel("js_local_catch");
+        var afterCatch = builder.DefineLabel("js_local_catch_done");
 
         _ctx.ExceptionBlockDepth++;
         builder.BeginExceptionBlock();
 
-        foreach (var stmt in t.TryBlock)
+        _localThrowScopes.Push(new LocalThrowScope(
+            catchValue,
+            catchBody,
+            _abruptCompletionScopes.Count,
+            _iteratorLoopCompletionScopes.Count));
+        try
         {
-            EmitStatement(stmt);
-        }
-
-        if (t.CatchBlock != null)
-        {
-            builder.BeginCatchBlock(_ctx.Types.Exception);
-            _ctx.Locals.EnterScope();
-            try
-            {
-                if (t.CatchParam != null)
-                {
-                    var exLocal = _ctx.Locals.DeclareLocal(t.CatchParam.Lexeme, _ctx.Types.Object);
-                    IL.Emit(OpCodes.Call, _ctx.Runtime!.WrapException);
-                    IL.Emit(OpCodes.Stloc, exLocal);
-                }
-                else
-                {
-                    IL.Emit(OpCodes.Pop);
-                }
-
-                foreach (var stmt in t.CatchBlock)
-                    EmitStatement(stmt);
-            }
-            finally
-            {
-                _ctx.Locals.ExitScope();
-            }
-        }
-
-        if (t.FinallyBlock != null)
-        {
-            builder.BeginFinallyBlock();
-            foreach (var stmt in t.FinallyBlock)
-            {
+            foreach (var stmt in t.TryBlock)
                 EmitStatement(stmt);
-            }
         }
+        finally
+        {
+            _localThrowScopes.Pop();
+        }
+        builder.Emit_Leave(afterCatch);
+
+        builder.BeginCatchBlock(_ctx.Types.Exception);
+        if (t.CatchParam != null)
+        {
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.WrapException);
+            IL.Emit(OpCodes.Stloc, catchValue);
+        }
+        else
+        {
+            IL.Emit(OpCodes.Pop);
+        }
+        builder.Emit_Leave(catchBody);
 
         builder.EndExceptionBlock();
         _ctx.ExceptionBlockDepth--;
+
+        builder.MarkLabel(catchBody);
+        _ctx.Locals.EnterScope();
+        try
+        {
+            if (t.CatchParam != null)
+                _ctx.Locals.RegisterLocal(t.CatchParam.Lexeme, catchValue);
+            foreach (var stmt in t.CatchBlock)
+                EmitStatement(stmt);
+        }
+        finally
+        {
+            _ctx.Locals.ExitScope();
+        }
+        builder.MarkLabel(afterCatch);
     }
 
     /// <summary>
@@ -2815,6 +2827,18 @@ public partial class ILEmitter
 
     protected override void EmitThrow(Stmt.Throw t)
     {
+        if (_localThrowScopes.TryPeek(out var localThrow) &&
+            localThrow.AbruptCompletionDepth == _abruptCompletionScopes.Count &&
+            localThrow.IteratorCompletionDepth == _iteratorLoopCompletionScopes.Count)
+        {
+            EmitExpression(t.Value);
+            EmitBoxIfNeeded(t.Value);
+            IL.Emit(OpCodes.Stloc, localThrow.Value);
+            SetStackUnknown();
+            _ctx.ILBuilder.Emit_Leave(localThrow.CatchBody);
+            return;
+        }
+
         EmitExpression(t.Value);
         EmitBoxIfNeeded(t.Value);
         IL.Emit(OpCodes.Call, _ctx.Runtime!.CreateException);

--- a/src/SharpTS/Compilation/ILEmitter.cs
+++ b/src/SharpTS/Compilation/ILEmitter.cs
@@ -36,6 +36,7 @@ public partial class ILEmitter : StatementEmitterBase, IEmitterContext
     private readonly LocalVariableResolver _resolver;
     private readonly Stack<AbruptCompletionScope> _abruptCompletionScopes = [];
     private readonly Stack<IteratorLoopCompletionScope> _iteratorLoopCompletionScopes = [];
+    private readonly Stack<LocalThrowScope> _localThrowScopes = [];
 
     private sealed class AbruptCompletionScope
     {
@@ -60,6 +61,12 @@ public partial class ILEmitter : StatementEmitterBase, IEmitterContext
         LocalBuilder CloseNeeded,
         Label ContinueTarget,
         HashSet<Label> EscapingTargets);
+
+    private sealed record LocalThrowScope(
+        LocalBuilder Value,
+        Label CatchBody,
+        int AbruptCompletionDepth,
+        int IteratorCompletionDepth);
 
     // Abstract property implementations for ExpressionEmitterBase
     protected override ILGenerator IL => _ctx.IL;

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.Parse.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.Parse.cs
@@ -21,7 +21,7 @@ public partial class RuntimeEmitter
 
         // try { return JsonParseHelper(arg); }
         // catch (Exception ex) {
-        //   if (ex.Data.Contains("__tsValue")) rethrow;
+        //   if (ex is $ThrownValueException || ex.Data.Contains("__tsValue")) rethrow;
         //   throw $SyntaxError(ex.Message); // ECMA-262 24.5.1.1: parse failures throw SyntaxError
         // }
         il.BeginExceptionBlock();
@@ -34,6 +34,13 @@ public partial class RuntimeEmitter
         var exLocal = il.DeclareLocal(_types.Exception);
         il.Emit(OpCodes.Stloc, exLocal);
         var rethrowLabel = il.DefineLabel();
+        var checkMetadataLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, exLocal);
+        il.Emit(OpCodes.Isinst, runtime.ThrownValueExceptionType);
+        il.Emit(OpCodes.Brfalse, checkMetadataLabel);
+        il.Emit(OpCodes.Br, rethrowLabel);
+
+        il.MarkLabel(checkMetadataLabel);
         il.Emit(OpCodes.Ldloc, exLocal);
         il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Exception, "Data").GetGetMethod()!);
         il.Emit(OpCodes.Ldstr, "__tsValue");

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Exceptions.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Exceptions.cs
@@ -12,23 +12,8 @@ public partial class RuntimeEmitter
         var method = (MethodBuilder)runtime.CreateException;
 
         var il = method.GetILGenerator();
-        var exLocal = il.DeclareLocal(_types.Exception);
-
-        // var ex = new Exception(value?.ToString() ?? "null")
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.Stringify);
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String));
-        il.Emit(OpCodes.Stloc, exLocal);
-
-        // ex.Data["__tsValue"] = value;  (preserve original value)
-        il.Emit(OpCodes.Ldloc, exLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Exception, "Data").GetGetMethod()!);
-        il.Emit(OpCodes.Ldstr, "__tsValue");
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.IDictionary, "set_Item"));
-
-        // return ex;
-        il.Emit(OpCodes.Ldloc, exLocal);
+        il.Emit(OpCodes.Newobj, runtime.ThrownValueExceptionCtor);
         il.Emit(OpCodes.Ret);
     }
 
@@ -44,6 +29,7 @@ public partial class RuntimeEmitter
 
         var il = method.GetILGenerator();
         var fallbackLabel = il.DefineLabel();
+        var checkMetadataLabel = il.DefineLabel();
         var checkTsValueLabel = il.DefineLabel();
         var unwrapLoopLabel = il.DefineLabel();
         var tsValueLocal = il.DeclareLocal(_types.Object);
@@ -75,6 +61,18 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(checkTsValueLabel);
 
+        // The normal guest-throw path stores the value directly on a dedicated
+        // exception. Check it before touching Exception.Data so a local catch
+        // never creates or probes the dictionary-backed metadata store.
+        il.Emit(OpCodes.Ldloc, exLocal);
+        il.Emit(OpCodes.Isinst, runtime.ThrownValueExceptionType);
+        il.Emit(OpCodes.Brfalse, checkMetadataLabel);
+        il.Emit(OpCodes.Ldloc, exLocal);
+        il.Emit(OpCodes.Castclass, runtime.ThrownValueExceptionType);
+        il.Emit(OpCodes.Call, runtime.ThrownValueExceptionValueGetter);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(checkMetadataLabel);
         // Check if ex.Data contains "__tsValue" (TypeScript throw value)
         // if (ex.Data.Contains("__tsValue")) return ex.Data["__tsValue"];
         il.Emit(OpCodes.Ldloc, exLocal);
@@ -253,7 +251,7 @@ public partial class RuntimeEmitter
         // Create new $ReferenceError(message)
         il.Emit(OpCodes.Newobj, runtime.TSReferenceErrorCtor);
 
-        // Wrap as System.Exception using CreateException helper (stores original value in Data["__tsValue"])
+        // Wrap as System.Exception using the dedicated guest-value carrier.
         il.Emit(OpCodes.Call, runtime.CreateException);
         il.Emit(OpCodes.Throw);
     }

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Iteration.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Iteration.cs
@@ -1524,7 +1524,7 @@ public partial class RuntimeEmitter
 
         // ECMA-262 §20.1.2.7 Object.fromEntries step 1:
         // RequireObjectCoercible — throws TypeError on null/undefined.
-        // Use TSTypeError + CreateException so __tsValue carries through to
+        // Use TSTypeError + CreateException so the exact value carries through to
         // catch/then handlers as a real TypeError instance.
         var requireOcThrowLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.Any.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.Any.cs
@@ -230,8 +230,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, afterExceptionLabel);
 
         // Unwrap the AggregateException Task.Exception always wraps faults in;
-        // WrapException then yields the guest value (__tsValue / rejection
-        // Reason / message dictionary fallback).
+        // WrapException then yields the guest value (dedicated carrier / rejection
+        // Reason / legacy metadata / message fallback).
         il.MarkLabel(hasExceptionLabel);
         il.Emit(OpCodes.Stloc, aggExLocal);
         il.Emit(OpCodes.Ldloc, aggExLocal);
@@ -269,7 +269,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldfld, anyState.RejectionReasonsField);  // errors list
         il.Emit(OpCodes.Ldnull);  // message (use default)
         il.Emit(OpCodes.Newobj, runtime.TSAggregateErrorCtor);
-        // Wrap with CreateException to store in Data["__tsValue"]
+        // Wrap with CreateException to preserve the exact AggregateError value.
         il.Emit(OpCodes.Call, runtime.CreateException);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.TaskCompletionSourceOfObject, "TrySetException", [_types.Exception]));
         il.Emit(OpCodes.Pop);  // discard bool result

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSEventEmitter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSEventEmitter.cs
@@ -451,8 +451,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, innerLocal);
 
         // object reason: a $Promise rejection carries it in .Reason; a raw
-        // Task faulted by a guest `throw` carries the guest value in the
-        // exception's __tsValue (recovered by WrapException).
+        // Task faulted by a guest `throw` carries the guest value in a
+        // $ThrownValueException (or legacy __tsValue metadata).
         var reasonLocal = il.DeclareLocal(_types.Object);
         var notRejected = il.DefineLabel();
         var haveReason = il.DefineLabel();
@@ -465,6 +465,16 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, reasonLocal);
         il.Emit(OpCodes.Br, haveReason);
         il.MarkLabel(notRejected);
+        var checkMetadata = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, innerLocal);
+        il.Emit(OpCodes.Isinst, runtime.ThrownValueExceptionType);
+        il.Emit(OpCodes.Brfalse, checkMetadata);
+        il.Emit(OpCodes.Ldloc, innerLocal);
+        il.Emit(OpCodes.Castclass, runtime.ThrownValueExceptionType);
+        il.Emit(OpCodes.Call, runtime.ThrownValueExceptionValueGetter);
+        il.Emit(OpCodes.Stloc, reasonLocal);
+        il.Emit(OpCodes.Br, haveReason);
+        il.MarkLabel(checkMetadata);
         // reason = inner.Data.Contains("__tsValue") ? inner.Data["__tsValue"] : inner
         var dataGetter = typeof(Exception).GetProperty("Data")!.GetGetMethod()!;
         var dataContains = typeof(System.Collections.IDictionary).GetMethod("Contains", [_types.Object])!;

--- a/src/SharpTS/Compilation/RuntimeEmitter.ThrownValueException.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.ThrownValueException.cs
@@ -1,0 +1,88 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    /// <summary>
+    /// Emits the allocation-light carrier used for guest <c>throw</c> values.
+    /// The value stays typed and <see cref="Exception.Message"/> is computed only
+    /// when a host boundary observes it, so local catches avoid stringification
+    /// and the dictionary-backed <see cref="Exception.Data"/> store.
+    /// </summary>
+    private void EmitThrownValueExceptionType(
+        ModuleBuilder moduleBuilder,
+        EmittedRuntime runtime)
+    {
+        var typeBuilder = EmitTypeDefinitions.DefineType(
+            moduleBuilder,
+            "$ThrownValueException",
+            TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.Sealed |
+                TypeAttributes.BeforeFieldInit,
+            _types.Exception);
+        runtime.ThrownValueExceptionType = typeBuilder;
+
+        var valueField = typeBuilder.DefineField(
+            "_value",
+            _types.Object,
+            FieldAttributes.Private | FieldAttributes.InitOnly);
+
+        var ctor = typeBuilder.DefineConstructor(
+            MethodAttributes.Public,
+            CallingConventions.Standard,
+            [_types.Object]);
+        runtime.ThrownValueExceptionCtor = ctor;
+
+        var ctorIl = ctor.GetILGenerator();
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Call, _types.GetDefaultConstructor(_types.Exception));
+        ctorIl.Emit(OpCodes.Ldarg_0);
+        ctorIl.Emit(OpCodes.Ldarg_1);
+        ctorIl.Emit(OpCodes.Stfld, valueField);
+        ctorIl.Emit(OpCodes.Ret);
+
+        var valueProperty = typeBuilder.DefineProperty(
+            "Value",
+            PropertyAttributes.None,
+            _types.Object,
+            null);
+        var valueGetter = typeBuilder.DefineMethod(
+            "get_Value",
+            MethodAttributes.Public | MethodAttributes.SpecialName |
+                MethodAttributes.HideBySig,
+            _types.Object,
+            Type.EmptyTypes);
+        runtime.ThrownValueExceptionValueGetter = valueGetter;
+
+        var valueIl = valueGetter.GetILGenerator();
+        valueIl.Emit(OpCodes.Ldarg_0);
+        valueIl.Emit(OpCodes.Ldfld, valueField);
+        valueIl.Emit(OpCodes.Ret);
+        valueProperty.SetGetMethod(valueGetter);
+
+        var messageProperty = typeBuilder.DefineProperty(
+            "Message",
+            PropertyAttributes.None,
+            _types.String,
+            null);
+        var messageGetter = typeBuilder.DefineMethod(
+            "get_Message",
+            MethodAttributes.Public | MethodAttributes.Virtual |
+                MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+            _types.String,
+            Type.EmptyTypes);
+
+        var messageIl = messageGetter.GetILGenerator();
+        messageIl.Emit(OpCodes.Ldarg_0);
+        messageIl.Emit(OpCodes.Ldfld, valueField);
+        messageIl.Emit(OpCodes.Call, runtime.Stringify);
+        messageIl.Emit(OpCodes.Ret);
+        messageProperty.SetGetMethod(messageGetter);
+        typeBuilder.DefineMethodOverride(
+            messageGetter,
+            _types.GetProperty(_types.Exception, "Message").GetGetMethod()!);
+
+        typeBuilder.CreateType();
+    }
+}

--- a/src/SharpTS/Compilation/RuntimeEmitter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.cs
@@ -55,6 +55,11 @@ public partial class RuntimeEmitter
         // re-use the pre-allocated TypeBuilder + MethodBuilders.
         DefineRuntimeClassPhase1(moduleBuilder, runtime);
 
+        // Guest throws use a dedicated exception carrying the original value.
+        // Define it immediately after the phase-1 runtime signatures because its
+        // lazy Message getter calls the forward-declared Stringify helper.
+        EmitThrownValueExceptionType(moduleBuilder, runtime);
+
         // Emit IUnionType marker interface first (union types need to implement this)
         EmitIUnionTypeInterface(moduleBuilder, runtime);
 

--- a/src/SharpTS/Compilation/RuntimeTypes.Exceptions.cs
+++ b/src/SharpTS/Compilation/RuntimeTypes.Exceptions.cs
@@ -16,6 +16,17 @@ public static partial class RuntimeTypes
         while (ex is System.Reflection.TargetInvocationException && ex.InnerException is not null)
             ex = ex.InnerException;
 
+        var type = ex.GetType();
+        if (ManagedEmittedShapeReflection.IsShape(
+                type, ManagedEmittedShape.ThrownValueException))
+        {
+            var valueProperty = ManagedEmittedShapeReflection.GetPublicProperty(
+                type, ManagedEmittedShape.ThrownValueException, "Value")
+                ?? throw new InvalidOperationException(
+                    "Compiler-emitted $ThrownValueException has no Value property.");
+            return valueProperty.GetValue(ex)!;
+        }
+
         // Promise rejection exceptions carry the original rejection value
         // (for example, a raw string from Promise.reject("msg")).
         if (ex is SharpTSPromiseRejectedException runtimeRejection)
@@ -23,7 +34,6 @@ public static partial class RuntimeTypes
             return runtimeRejection.Reason ?? new SharpTSError(ex.Message);
         }
 
-        var type = ex.GetType();
         if (ManagedEmittedShapeReflection.IsShape(
                 type, ManagedEmittedShape.PromiseRejectedException))
         {

--- a/src/SharpTS/Runtime/Types/ManagedEmittedShapeReflection.cs
+++ b/src/SharpTS/Runtime/Types/ManagedEmittedShapeReflection.cs
@@ -45,6 +45,8 @@ internal static class ManagedEmittedShapeReflection
             ManagedEmittedShape.Date => type.Name == "$TSDate",
             ManagedEmittedShape.PromiseRejectedException =>
                 type.Name == "$PromiseRejectedException",
+            ManagedEmittedShape.ThrownValueException =>
+                type.Name == "$ThrownValueException",
             ManagedEmittedShape.HasFields => HasAssemblyLocalFieldsContract(type),
             _ => false
         };
@@ -156,6 +158,7 @@ internal static class ManagedEmittedShapeReflection
         ManagedEmittedShape.ArrayBuffer => "$ArrayBuffer",
         ManagedEmittedShape.Date => "$TSDate",
         ManagedEmittedShape.PromiseRejectedException => "$PromiseRejectedException",
+        ManagedEmittedShape.ThrownValueException => "$ThrownValueException",
         ManagedEmittedShape.HasFields => "$IHasFields object",
         _ => shape.ToString()
     };
@@ -170,5 +173,6 @@ internal enum ManagedEmittedShape
     ArrayBuffer,
     Date,
     PromiseRejectedException,
+    ThrownValueException,
     HasFields
 }

--- a/tests/SharpTS.Tests/Compilation/CompilationServiceTests.cs
+++ b/tests/SharpTS.Tests/Compilation/CompilationServiceTests.cs
@@ -184,6 +184,25 @@ public class CompilationServiceTests
         Assert.Contains("boom", run.Error);
     }
 
+    [Theory]
+    [InlineData("throw 42;", "42")]
+    [InlineData("throw true;", "true")]
+    [InlineData("throw null;", "null")]
+    [InlineData("throw undefined;", "undefined")]
+    [InlineData("throw \"plain\";", "plain")]
+    public void Execute_GuestPrimitiveThrow_ReportsLazyGuestMessage(
+        string source,
+        string expected)
+    {
+        var result = CompilationService.Compile(source);
+        Assert.True(result.Success);
+
+        var run = CompilationService.Execute(result.AssemblyBytes!, new StringWriter());
+
+        Assert.False(run.Success);
+        Assert.Equal(expected, run.Error);
+    }
+
     [Fact]
     public void Execute_InvalidAssembly_ReportsFailedLoadAndAggregateTime()
     {

--- a/tests/SharpTS.Tests/CompilerTests/Issue1486ThrowWrapperTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/Issue1486ThrowWrapperTests.cs
@@ -1,0 +1,72 @@
+using System.Reflection;
+using SharpTS.Compilation;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public class Issue1486ThrowWrapperTests
+{
+    [Fact]
+    public void CreateException_UsesDedicatedCarrierWithoutEagerMessageOrMetadata()
+    {
+        Assembly assembly = Compile("function noop(): void { }");
+        MethodInfo createException = assembly.GetType("$Runtime")!
+            .GetMethod("CreateException", BindingFlags.Public | BindingFlags.Static)!;
+        var probe = new ToStringProbe();
+
+        var exception = Assert.IsAssignableFrom<Exception>(
+            createException.Invoke(null, [probe]));
+
+        Assert.Equal("$ThrownValueException", exception.GetType().Name);
+        Assert.Same(probe, exception.GetType().GetProperty("Value")!.GetValue(exception));
+        Assert.Equal(0, probe.CallCount);
+        Assert.Empty(exception.Data);
+        Assert.Equal("probe", exception.Message);
+        Assert.Equal(1, probe.CallCount);
+    }
+
+    [Fact]
+    public void ReflectionAndManagedHostUnwrapping_PreserveExactGuestValue()
+    {
+        Assembly assembly = Compile("""
+            const marker: any = {};
+            function getMarker(): any { return marker; }
+            function fail(): void { throw marker; }
+            """);
+        Type program = assembly.GetType("$Program")!;
+        program.GetMethod("Main", BindingFlags.Public | BindingFlags.Static)!.Invoke(null, null);
+        MethodInfo getMarker = FindFunction(program, "getMarker");
+        MethodInfo fail = FindFunction(program, "fail");
+        object marker = getMarker.Invoke(null, null)!;
+        var reflectionException = Assert.Throws<TargetInvocationException>(
+            () => fail.Invoke(null, null));
+
+        MethodInfo emittedWrap = assembly.GetType("$Runtime")!
+            .GetMethod("WrapException", BindingFlags.Public | BindingFlags.Static)!;
+        Assert.Same(marker, emittedWrap.Invoke(null, [reflectionException]));
+        Assert.Same(marker, RuntimeTypes.WrapException(reflectionException));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var result = CompilationService.Compile(source);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return Assembly.Load(result.AssemblyBytes!);
+    }
+
+    private static MethodInfo FindFunction(Type program, string name) =>
+        program.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name == name ||
+                method.Name.EndsWith("_" + name, StringComparison.Ordinal));
+
+    private sealed class ToStringProbe
+    {
+        public int CallCount { get; private set; }
+
+        public override string ToString()
+        {
+            CallCount++;
+            return "probe";
+        }
+    }
+}

--- a/tests/SharpTS.Tests/SharedTests/BuiltInModules/EventsRejectionMonitorTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/BuiltInModules/EventsRejectionMonitorTests.cs
@@ -37,6 +37,30 @@ public class EventsRejectionMonitorTests
     }
 
     [Theory, ModeData]
+    public void CaptureRejections_PreservesRawGuestReason(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { EventEmitter } from 'events';
+                async function main(): Promise<void> {
+                    const marker: any = {};
+                    const ee = new EventEmitter({ captureRejections: true });
+                    let same = false;
+                    ee.on('error', (reason: any) => { same = reason === marker; });
+                    ee.on('go', async () => { throw marker; });
+                    ee.emit('go');
+                    await new Promise((resolve: any) => setTimeout(resolve, 10));
+                    console.log(same);
+                }
+                main();
+                """
+        };
+
+        Assert.Equal("true\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory, ModeData]
     public void CaptureRejections_Off_DoesNotRouteToError(ExecutionMode mode)
     {
         var files = new Dictionary<string, string>

--- a/tests/SharpTS.Tests/SharedTests/Issue1486ThrowValueTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/Issue1486ThrowValueTests.cs
@@ -1,0 +1,97 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>Semantic coverage for the allocation-light guest-throw carrier.</summary>
+public class Issue1486ThrowValueTests
+{
+    [Theory, ModeData]
+    public void GuestThrows_PreserveEveryValueKind(ExecutionMode mode)
+    {
+        var source = """
+            class CustomError extends Error { }
+            const symbolValue = Symbol("marker");
+            const objectValue: any = { marker: true };
+            const errorValue = new CustomError("custom");
+            const values: any[] = [
+                42, "text", true, false, null, undefined,
+                symbolValue, objectValue, errorValue
+            ];
+            function fail(value: any): void { throw value; }
+
+            for (const expected of values) {
+                try {
+                    throw expected;
+                } catch (actual) {
+                    console.log(actual === expected);
+                }
+
+                try {
+                    fail(expected);
+                } catch (actual) {
+                    console.log(actual === expected);
+                }
+            }
+            """;
+
+        var output = TestHarness.Run(source, mode);
+        Assert.Equal(string.Concat(Enumerable.Repeat("true\n", 18)), output);
+    }
+
+    [Theory, ModeData]
+    public void GuestThrow_CrossesAsyncGeneratorAndPromiseBoundaries(ExecutionMode mode)
+    {
+        var source = """
+            const marker: any = { kind: "marker" };
+
+            async function failAsync(): Promise<void> { throw marker; }
+            function* failGenerator(): Generator<number> { yield 1; throw marker; }
+            async function* failAsyncGenerator(): AsyncGenerator<number> { yield 1; throw marker; }
+
+            async function main(): Promise<void> {
+                try { await failAsync(); }
+                catch (error) { console.log(error === marker); }
+
+                const generator = failGenerator();
+                generator.next();
+                try { generator.next(); }
+                catch (error) { console.log(error === marker); }
+
+                const asyncGenerator = failAsyncGenerator();
+                await asyncGenerator.next();
+                try { await asyncGenerator.next(); }
+                catch (error) { console.log(error === marker); }
+
+                try {
+                    await Promise.resolve(0).then(() => { throw marker; });
+                } catch (error) {
+                    console.log(error === marker);
+                }
+            }
+            main();
+            """;
+
+        Assert.Equal("true\ntrue\ntrue\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void GuestThrow_RunsNestedFinallyBeforePreservingValue(ExecutionMode mode)
+    {
+        var source = """
+            const marker: any = {};
+            try {
+                try {
+                    try { throw marker; }
+                    finally { console.log("inner"); }
+                } finally {
+                    console.log("outer");
+                }
+            } catch (error) {
+                console.log(error === marker);
+            }
+            """;
+
+        Assert.Equal("inner\nouter\ntrue\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
## Summary

- emit a dedicated `$ThrownValueException` that carries the exact guest value without eagerly stringifying it or allocating `Exception.Data`
- route syntactically local throws directly into plain catch bodies when no pending finally/iterator cleanup must run, avoiding CLR exception allocation and unwinding
- preserve exact thrown values across reflection, async functions, generators, async generators, promises, JSON callbacks, EventEmitter rejection capture, and uncaught host reporting
- add BenchmarkDotNet allocation coverage, cross-runtime timing workloads, and dual-mode semantic tests

## Performance

The primitive benchmark throws sparsely while processing 100,000 iterations. Medians use three cross-runtime launches.

| Environment | Primitive allocation | Incremental throw time vs Node |
| --- | ---: | ---: |
| Windows | 7,056 B | 0.52x |
| WSL Ubuntu | 7,056 B | 0.94x |

The final local-catch path reduces primitive allocation from a conservative in-turn typed-wrapper baseline of 29,008 B to 7,056 B (75.7%). Both branch-only and try/catch no-throw controls allocate 0 B.

## Validation

- Windows Release solution build: 0 warnings, 0 errors; IL verification passed
- Windows focused #1486 tests with compiled IL verification: 31 passed
- Windows core suite: 17,436 passed, 3 skipped; one interpreter-only generator timeout passed both modes when rerun alone
- Test262 subset: 3,219 passed
- TypeScript conformance subset: 65 passed
- WSL Ubuntu isolated Release build: 0 errors
- WSL focused IL-verified suite: 289 passed; strengthened value-identity rerun: 6 passed
- `git diff --check`

Closes #1486


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Guest-thrown values now preserve their exact type and identity, including primitives, objects, `null`, and `undefined`.
  * Improved propagation of thrown values across async, generator, promise, and nested cleanup flows.
  * Non-Error promise rejections are forwarded unchanged to rejection handlers.
  * Error messages are generated only when needed, improving handling of thrown values.

* **Tests**
  * Added coverage for exception propagation, wrapping, unwrapping, rejection monitoring, and performance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->