### PR TITLE
perf: specialize exact Int32Array stencil loops

### DIFF
--- a/src/SharpTS/Compilation/ILEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Operators.cs
@@ -27,6 +27,9 @@ public partial class ILEmitter
         if (TryEmitExternalBinaryOperator(b))
             return;
 
+        if (TryEmitDirectInt32TypedArrayStencil(b))
+            return;
+
         // instanceof/in are valid with any operand type — bypass bigint-arithmetic path
         // so a bigint LHS gets boxed and flows through the normal InstanceOf/HasIn runtime call.
         if (IsBigIntOperation(b) && b.Operator.Type is not (TokenType.IN or TokenType.INSTANCEOF))
@@ -1217,6 +1220,340 @@ public partial class ILEmitter
 
         backing = default;
         return false;
+    }
+
+    /// <summary>
+    /// Emits the common three-point Int32 stencil with one element-range guard and unchecked
+    /// neighboring reads. The ordinary lowering independently checks <c>i - 1</c>, <c>i</c>, and
+    /// <c>i + 1</c> against the byte array. For an exact non-escaping backing all three indexes and
+    /// reads are pure, so one unsigned center/range check preserves the same first-fault behavior
+    /// while letting RyuJIT use a single base-plus-scaled-index address in the hot body.
+    /// </summary>
+    private bool TryEmitDirectInt32TypedArrayStencil(Expr.Binary expression)
+    {
+        if (expression.Operator.Type != TokenType.PLUS
+            || expression.Left is not Expr.Binary
+            {
+                Operator.Type: TokenType.MINUS,
+                Left: Expr.GetIndex left,
+                Right: Expr.Binary { Operator.Type: TokenType.STAR } scaledCenter
+            }
+            || expression.Right is not Expr.GetIndex right
+            || !TryMatchTimesTwoGetIndex(scaledCenter, out var center)
+            || center.Index is not Expr.Variable counter
+            || !IsIntegerCounterLocal(counter.Name.Lexeme)
+            || !MatchesCounterOffset(left.Index, counter.Name.Lexeme, -1)
+            || !MatchesCounterOffset(right.Index, counter.Name.Lexeme, 1)
+            || !TryMatchExactInt32Receiver(left, out var receiverName)
+            || !TryMatchExactInt32Receiver(center, out var centerReceiver)
+            || !TryMatchExactInt32Receiver(right, out var rightReceiver)
+            || centerReceiver != receiverName
+            || rightReceiver != receiverName
+            || !TryGetDirectTypedArrayBacking(left.Object, "Int32", out var backing)
+            || backing.Layout is not
+                { BytesPerElement: 4, Signed: true, IsFloat: false })
+        {
+            return false;
+        }
+
+        EmitIndexAsInt32(center.Index);
+        var centerIndex = IL.DeclareLocal(_ctx.Types.Int32);
+        IL.Emit(OpCodes.Stloc, centerIndex);
+
+        // (uint)(center - 1) < (uint)(length - 2) proves both neighboring indexes.
+        // The unsigned form also rejects negative centers and lengths below three.
+        var inRange = IL.DefineLabel();
+        IL.Emit(OpCodes.Ldloc, centerIndex);
+        IL.Emit(OpCodes.Ldc_I4_1);
+        IL.Emit(OpCodes.Sub);
+        IL.Emit(OpCodes.Ldloc, backing.LengthLocal);
+        IL.Emit(OpCodes.Ldc_I4_2);
+        IL.Emit(OpCodes.Sub);
+        IL.Emit(OpCodes.Blt_Un, inRange);
+        IL.Emit(OpCodes.Newobj, _ctx.Types.GetDefaultConstructor(typeof(IndexOutOfRangeException)));
+        IL.Emit(OpCodes.Throw);
+        IL.MarkLabel(inRange);
+
+        var centerReference = IL.DeclareLocal(_ctx.Types.Byte.MakeByRefType());
+        IL.Emit(OpCodes.Ldloc, backing.BufferLocal);
+        IL.Emit(OpCodes.Call, RuntimeEmitter.GetByteArrayDataReference());
+        IL.Emit(OpCodes.Ldloc, centerIndex);
+        IL.Emit(OpCodes.Ldc_I4_4);
+        IL.Emit(OpCodes.Mul);
+        IL.Emit(OpCodes.Call, RuntimeEmitter.UnsafeAddByteOffset());
+        IL.Emit(OpCodes.Stloc, centerReference);
+
+        EmitDirectInt32Read(centerReference, -4);
+        EmitDirectInt32Read(centerReference, 0);
+        IL.Emit(OpCodes.Ldc_R8, 2d);
+        IL.Emit(OpCodes.Mul);
+        IL.Emit(OpCodes.Sub);
+        EmitDirectInt32Read(centerReference, 4);
+        IL.Emit(OpCodes.Add);
+        SetStackType(StackType.Double);
+        return true;
+    }
+
+    private bool TryMatchExactInt32Receiver(Expr.GetIndex access, out string receiverName)
+    {
+        if (!access.Optional
+            && access.Object is Expr.Variable receiver
+            && _ctx.TypeMap?.Get(access.Object) is TypeInfo.TypedArray { ElementType: "Int32" })
+        {
+            receiverName = receiver.Name.Lexeme;
+            return true;
+        }
+
+        receiverName = "";
+        return false;
+    }
+
+    private static bool TryMatchTimesTwoGetIndex(
+        Expr.Binary multiplication,
+        out Expr.GetIndex access)
+    {
+        if (TryGetIntLiteralValue(multiplication.Left, out long left) && left == 2
+            && multiplication.Right is Expr.GetIndex right)
+        {
+            access = right;
+            return true;
+        }
+        if (TryGetIntLiteralValue(multiplication.Right, out long rightValue) && rightValue == 2
+            && multiplication.Left is Expr.GetIndex leftAccess)
+        {
+            access = leftAccess;
+            return true;
+        }
+
+        access = null!;
+        return false;
+    }
+
+    private static bool MatchesCounterOffset(Expr index, string counterName, long offset) =>
+        index is Expr.Binary
+        {
+            Operator.Type: TokenType.PLUS or TokenType.MINUS,
+            Left: Expr.Variable variable,
+            Right: var literal
+        }
+        && variable.Name.Lexeme == counterName
+        && TryGetIntLiteralValue(literal, out long value)
+        && (index is Expr.Binary { Operator.Type: TokenType.PLUS }
+            ? value
+            : -value) == offset;
+
+    private void EmitDirectInt32Read(LocalBuilder centerReference, int byteOffset)
+    {
+        IL.Emit(OpCodes.Ldloc, centerReference);
+        if (byteOffset != 0)
+        {
+            IL.Emit(OpCodes.Ldc_I4, byteOffset);
+            IL.Emit(OpCodes.Call, RuntimeEmitter.UnsafeAddByteOffset());
+        }
+        RuntimeEmitter.EmitReadElementAsDouble(
+            IL, bytesPerElement: 4, signed: true, isFloat: false);
+    }
+
+    /// <summary>
+    /// Keeps a pure, statically range-safe integer-counter expression native through an exact
+    /// Int32Array write. The counter round-trip guard preserves the existing behavior after an
+    /// Int64 counter leaves the Int32 range; the cold branch then evaluates and narrows the original
+    /// double expression. For an in-range array index, the range proof guarantees every arithmetic
+    /// intermediate and the assignment result are exactly representable as both Int32 and double.
+    /// </summary>
+    private bool TryEmitDirectInt32CounterWrite(
+        Expr index,
+        Expr value,
+        HoistedTypedArrayBacking backing,
+        LocalBuilder indexLocal)
+    {
+        if (backing.Layout is not { BytesPerElement: 4, Signed: true, IsFloat: false }
+            || index is not Expr.Variable counter
+            || !IsIntegerCounterLocal(counter.Name.Lexeme)
+            || !TryAnalyzeInt32CounterExpression(value, counter.Name.Lexeme, out _))
+        {
+            return false;
+        }
+
+        var slow = IL.DefineLabel();
+        var end = IL.DefineLabel();
+
+        // A native Int64 counter can exceed Int32 even though its typed-array index is Conv_I4.
+        // Take the specialized path only while that conversion is lossless.
+        IL.Emit(OpCodes.Ldloc, _ctx.Locals.GetLocal(counter.Name.Lexeme)!);
+        IL.Emit(OpCodes.Ldloc, indexLocal);
+        IL.Emit(OpCodes.Conv_I8);
+        IL.Emit(OpCodes.Bne_Un, slow);
+
+        EmitInt32CounterExpression(value, counter.Name.Lexeme, indexLocal);
+        var nativeValue = IL.DeclareLocal(_ctx.Types.Int32);
+        IL.Emit(OpCodes.Stloc, nativeValue);
+
+        EmitDirectTypedArrayElementReference(backing, indexLocal);
+        IL.Emit(OpCodes.Ldloc, nativeValue);
+        IL.Emit(OpCodes.Unaligned, (byte)1);
+        IL.Emit(OpCodes.Stind_I4);
+        IL.Emit(OpCodes.Ldloc, nativeValue);
+        IL.Emit(OpCodes.Conv_R8);
+        IL.Emit(OpCodes.Br, end);
+
+        IL.MarkLabel(slow);
+        EmitExpression(value);
+        EnsureDouble();
+        var doubleValue = IL.DeclareLocal(_ctx.Types.Double);
+        IL.Emit(OpCodes.Stloc, doubleValue);
+        EmitDirectTypedArrayWrite(backing, indexLocal, doubleValue);
+        IL.Emit(OpCodes.Ldloc, doubleValue);
+
+        IL.MarkLabel(end);
+        SetStackType(StackType.Double);
+        return true;
+    }
+
+    private readonly record struct Int32ExpressionRange(long Minimum, long Maximum);
+
+    private static bool TryAnalyzeInt32CounterExpression(
+        Expr expression,
+        string counterName,
+        out Int32ExpressionRange range)
+    {
+        // A byte[]-backed Int32Array cannot contain more than this many valid indexes.
+        const long maximumCounter = int.MaxValue / 4L - 1;
+
+        switch (expression)
+        {
+            case Expr.Grouping grouping:
+                return TryAnalyzeInt32CounterExpression(
+                    grouping.Expression, counterName, out range);
+
+            case Expr.Variable variable when variable.Name.Lexeme == counterName:
+                range = new(0, maximumCounter);
+                return true;
+
+            case var literal when !IsNegativeZeroLiteral(literal)
+                && TryGetIntLiteralValue(literal, out long value)
+                && value is >= int.MinValue and <= int.MaxValue:
+                range = new(value, value);
+                return true;
+
+            case Expr.Binary binary
+                when binary.Operator.Type is TokenType.PLUS or TokenType.MINUS or
+                    TokenType.STAR or TokenType.PERCENT
+                    && TryAnalyzeInt32CounterExpression(binary.Left, counterName, out var left)
+                    && TryAnalyzeInt32CounterExpression(binary.Right, counterName, out var right)
+                    && TryCombineInt32Ranges(binary.Operator.Type, left, right, out range):
+                return true;
+        }
+
+        range = default;
+        return false;
+    }
+
+    private static bool TryCombineInt32Ranges(
+        TokenType operation,
+        Int32ExpressionRange left,
+        Int32ExpressionRange right,
+        out Int32ExpressionRange range)
+    {
+        long minimum;
+        long maximum;
+        try
+        {
+            switch (operation)
+            {
+                case TokenType.PLUS:
+                    minimum = checked(left.Minimum + right.Minimum);
+                    maximum = checked(left.Maximum + right.Maximum);
+                    break;
+                case TokenType.MINUS:
+                    minimum = checked(left.Minimum - right.Maximum);
+                    maximum = checked(left.Maximum - right.Minimum);
+                    break;
+                case TokenType.STAR:
+                    long a = checked(left.Minimum * right.Minimum);
+                    long b = checked(left.Minimum * right.Maximum);
+                    long c = checked(left.Maximum * right.Minimum);
+                    long d = checked(left.Maximum * right.Maximum);
+                    minimum = Math.Min(Math.Min(a, b), Math.Min(c, d));
+                    maximum = Math.Max(Math.Max(a, b), Math.Max(c, d));
+                    break;
+                case TokenType.PERCENT
+                    when left.Minimum >= 0
+                        && right.Minimum == right.Maximum
+                        && right.Minimum > 0:
+                    minimum = 0;
+                    maximum = Math.Min(left.Maximum, right.Maximum - 1);
+                    break;
+                default:
+                    range = default;
+                    return false;
+            }
+        }
+        catch (OverflowException)
+        {
+            range = default;
+            return false;
+        }
+
+        if (minimum < int.MinValue || maximum > int.MaxValue)
+        {
+            range = default;
+            return false;
+        }
+
+        range = new(minimum, maximum);
+        return true;
+    }
+
+    private static bool IsNegativeZeroLiteral(Expr expression) => expression switch
+    {
+        Expr.Literal { Value: double value } =>
+            value == 0d && BitConverter.DoubleToInt64Bits(value) < 0,
+        Expr.Unary
+        {
+            Operator.Type: TokenType.MINUS,
+            Right: Expr.Literal { Value: double value }
+        } => value == 0d,
+        _ => false
+    };
+
+    private void EmitInt32CounterExpression(
+        Expr expression,
+        string counterName,
+        LocalBuilder indexLocal)
+    {
+        switch (expression)
+        {
+            case Expr.Grouping grouping:
+                EmitInt32CounterExpression(grouping.Expression, counterName, indexLocal);
+                return;
+
+            case Expr.Variable variable when variable.Name.Lexeme == counterName:
+                IL.Emit(OpCodes.Ldloc, indexLocal);
+                return;
+
+            case var literal when TryGetIntLiteralValue(literal, out long value):
+                IL.Emit(OpCodes.Ldc_I4, checked((int)value));
+                return;
+
+            case Expr.Binary binary:
+                EmitInt32CounterExpression(binary.Left, counterName, indexLocal);
+                EmitInt32CounterExpression(binary.Right, counterName, indexLocal);
+                IL.Emit(binary.Operator.Type switch
+                {
+                    TokenType.PLUS => OpCodes.Add,
+                    TokenType.MINUS => OpCodes.Sub,
+                    TokenType.STAR => OpCodes.Mul,
+                    TokenType.PERCENT => OpCodes.Rem,
+                    _ => throw new InvalidOperationException(
+                        $"Unsupported native Int32 expression operator {binary.Operator.Type}.")
+                });
+                return;
+
+            default:
+                throw new InvalidOperationException(
+                    "Native Int32 expression emission did not match its range proof.");
+        }
     }
 
     private void EmitDirectTypedArrayRead(

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -1669,12 +1669,20 @@ public partial class ILEmitter
             var idxLocal = IL.DeclareLocal(_ctx.Types.Int32);
             IL.Emit(OpCodes.Stloc, idxLocal);
 
+            bool hasDirectBacking =
+                TryGetDirectTypedArrayBacking(si.Object, sta.ElementType, out var backing);
+            if (hasDirectBacking
+                && TryEmitDirectInt32CounterWrite(si.Index, si.Value, backing, idxLocal))
+            {
+                return;
+            }
+
             EmitExpression(si.Value);
             EnsureDouble();
             var valLocal = IL.DeclareLocal(_ctx.Types.Double);
             IL.Emit(OpCodes.Stloc, valLocal);
 
-            if (TryGetDirectTypedArrayBacking(si.Object, sta.ElementType, out var backing))
+            if (hasDirectBacking)
             {
                 EmitDirectTypedArrayWrite(backing, idxLocal, valLocal);
                 IL.Emit(OpCodes.Ldloc, valLocal);

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSTypedArray.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSTypedArray.cs
@@ -940,4 +940,27 @@ public partial class RuntimeEmitter
             && m.GetParameters()[0].ParameterType == typeof(byte).MakeByRefType())!;
         return EmitGenerics.MakeGenericMethod(open, elementType);
     }
+
+    internal static MethodInfo GetByteArrayDataReference()
+    {
+        var methods = typeof(System.Runtime.InteropServices.MemoryMarshal).GetMethods();
+        var open = Array.Find(methods, m => m.Name == "GetArrayDataReference"
+            && m.IsGenericMethodDefinition
+            && m.GetParameters() is [{ ParameterType.IsArray: true }])!;
+        return EmitGenerics.MakeGenericMethod(open, typeof(byte));
+    }
+
+    internal static MethodInfo UnsafeAddByteOffset()
+    {
+        var methods = typeof(System.Runtime.CompilerServices.Unsafe).GetMethods();
+        var open = Array.Find(methods, m => m.Name == "Add"
+            && m.IsGenericMethodDefinition
+            && m.GetParameters() is
+            [
+                { ParameterType.IsByRef: true },
+                { ParameterType: var offsetType }
+            ]
+            && offsetType == typeof(int))!;
+        return EmitGenerics.MakeGenericMethod(open, typeof(byte));
+    }
 }

--- a/tests/SharpTS.Tests/CompilerTests/TypedArrayBackingHoistTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/TypedArrayBackingHoistTests.cs
@@ -58,6 +58,105 @@ public sealed class TypedArrayBackingHoistTests
             instruction.Operand is MethodBase { Name: "ReadUnaligned" or "WriteUnaligned" });
     }
 
+    [Fact]
+    public void ExactInt32Stencil_CoalescesNeighborBoundsChecks()
+    {
+        MethodInfo hot = CompileFunction("""
+            function hot(n: number): number {
+                const data = new Int32Array(n);
+                let sum: number = 0;
+                for (let i: number = 1; i < n - 1; i++) {
+                    sum = sum + (data[i - 1] - 2 * data[i] + data[i + 1]);
+                }
+                return sum;
+            }
+            """, "hot");
+
+        var instructions = ReadInstructions(hot).ToArray();
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "GetArrayDataReference" });
+        Assert.Equal(3, instructions.Count(instruction =>
+            instruction.Operand is MethodBase { Name: "ReadUnaligned" }));
+        Assert.DoesNotContain(instructions, IsUnboxedAccessorCall);
+    }
+
+    [Fact]
+    public void ExactInt32Stencil_OutOfRangeStillFaults()
+    {
+        MethodInfo hot = CompileFunction("""
+            function hot(n: number): number {
+                const data = new Int32Array(n);
+                let sum: number = 0;
+                for (let i: number = 0; i < 1; i++) {
+                    sum = sum + (data[i - 1] - 2 * data[i] + data[i + 1]);
+                }
+                return sum;
+            }
+            """, "hot");
+
+        var exception = Assert.Throws<TargetInvocationException>(() => hot.Invoke(null, [3d]));
+        Assert.IsType<IndexOutOfRangeException>(exception.InnerException);
+    }
+
+    [Fact]
+    public void ExactInt32CounterWrite_KeepsRangeSafeArithmeticNative()
+    {
+        MethodInfo hot = CompileFunction("""
+            function hot(n: number): number {
+                const data = new Int32Array(n);
+                for (let i: number = 0; i < n; i++) {
+                    data[i] = i * 3 - (i % 7);
+                }
+                return n;
+            }
+            """, "hot");
+
+        var instructions = ReadInstructions(hot).ToArray();
+        Assert.Contains(instructions, instruction => instruction.OpCode == OpCodes.Stind_I4);
+        Assert.Contains(instructions, instruction => instruction.OpCode == OpCodes.Rem);
+        Assert.DoesNotContain(instructions, IsUnboxedAccessorCall);
+    }
+
+    [Fact]
+    public void Int32CounterWrite_UnsafeRangeRetainsDoubleNarrowing()
+    {
+        MethodInfo hot = CompileFunction("""
+            function hot(n: number): number {
+                const data = new Int32Array(n);
+                for (let i: number = 0; i < n; i++) {
+                    data[i] = i * 100000;
+                }
+                return n;
+            }
+            """, "hot");
+
+        var instructions = ReadInstructions(hot).ToArray();
+        Assert.DoesNotContain(instructions, instruction => instruction.OpCode == OpCodes.Stind_I4);
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "WriteUnaligned" });
+    }
+
+    [Fact]
+    public void Int32CounterWrite_NegativeZeroRetainsDoubleSemantics()
+    {
+        MethodInfo hot = CompileFunction("""
+            function hot(n: number): number {
+                const data = new Int32Array(n);
+                let result: number = 1;
+                for (let i: number = 0; i < n; i++) {
+                    result = (data[i] = i * -0);
+                }
+                return 1 / result;
+            }
+            """, "hot");
+
+        var instructions = ReadInstructions(hot).ToArray();
+        Assert.DoesNotContain(instructions, instruction => instruction.OpCode == OpCodes.Stind_I4);
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "WriteUnaligned" });
+        Assert.Equal(double.NegativeInfinity, (double)hot.Invoke(null, [1d])!);
+    }
+
     [Theory]
     [MemberData(nameof(FallbackPrograms))]
     public void UnsafeLifetime_RetainsConcreteAccessorFallback(string source)
@@ -93,7 +192,16 @@ public sealed class TypedArrayBackingHoistTests
                 for (let i: number = 0; i < n; i++) data[i] += i * 0.5;
                 return n;
             }
-            console.log(hot(8));
+            function stencil(n: number): number {
+                const data = new Int32Array(n);
+                for (let i: number = 0; i < n; i++) data[i] = i * 3 - (i % 7);
+                let sum: number = 0;
+                for (let i: number = 1; i < n - 1; i++) {
+                    sum = sum + (data[i - 1] - 2 * data[i] + data[i + 1]);
+                }
+                return sum;
+            }
+            console.log(hot(8), stencil(8));
             """;
 
         Assert.Empty(Infrastructure.TestHarness.CompileAndVerifyOnly(source));

--- a/tests/SharpTS.Tests/SharedTests/TypedArrayBackingHoistParityTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/TypedArrayBackingHoistParityTests.cs
@@ -45,4 +45,23 @@ public sealed class TypedArrayBackingHoistParityTests
 
         Assert.Equal("11\n21\n99\n", TestHarness.Run(source, mode));
     }
+
+    [Theory, ModeData]
+    public void ExactInt32Stencil_PreservesIntegralWriteAndReadSemantics(ExecutionMode mode)
+    {
+        const string source = """
+            function stencil(n: number): number {
+                const data = new Int32Array(n);
+                for (let i: number = 0; i < n; i++) data[i] = i * 3 - (i % 7);
+                let sum: number = 0;
+                for (let i: number = 1; i < n - 1; i++) {
+                    sum = sum + (data[i - 1] - 2 * data[i] + data[i + 1]);
+                }
+                return sum;
+            }
+            console.log(stencil(8));
+            """;
+
+        Assert.Equal("7\n", TestHarness.Run(source, mode));
+    }
 }


### PR DESCRIPTION
Closes #1481

## Summary

- coalesce the exact Int32Array three-point stencil into one unsigned range guard plus direct neighboring backing-storage reads
- keep statically range-safe integer-counter fill expressions native through Int32Array stores, with a cold double fallback for counter wrap, unsafe ranges, and negative zero
- add structural IL, out-of-range, fallback, negative-zero, parity, and IL-verification coverage

## Performance

Five alternating baseline/candidate launches; changes are medians of paired launch changes.

### WSL Ubuntu vs #1481 frozen baseline (`d861d8f9`)

| Benchmark (1M) | Baseline | Candidate | Change |
|---|---:|---:|---:|
| Int32 kernel | 3.4507 ms | 2.9872 ms | **-13.43%** |
| Float64 accumulate | 6.7405 ms | 5.5581 ms | **-17.54%** |
| Typed-array control | 3.5153 ms | 3.3364 ms | -5.93% |
| Brainfuck control | 29.3793 ms | 29.5572 ms | +0.10% (neutral) |

### Windows vs current main (`53f6c91e`)

| Benchmark (1M) | Baseline | Candidate | Change |
|---|---:|---:|---:|
| Int32 kernel | 2.8852 ms | 2.3951 ms | **-16.99%** |
| Float64 accumulate | 4.1174 ms | 4.1313 ms | -0.84% (neutral paired change) |
| Typed-array control | 2.4357 ms | 2.4770 ms | +1.78% (neutral) |
| Brainfuck control | 22.4790 ms | 23.8022 ms | +7.18% (neutral) |

## Validation

- focused backing-hoist tests: 22/22 on Windows and WSL
- WSL compiler tests: 843/843
- WSL full core: 17,416/17,416 plus the allocation gate passed twice in isolation after a 72-byte suite-order miss; unchanged main also passed it twice
- GUI conformance: 106/106 on both Windows and WSL
- cross-runtime and microbenchmark smoke inventories passed on both platforms
- conformance projects and packaging helpers passed in WSL; conformance projects built on Windows
- analyzer ratchet: zero AOT/trim/single-file warnings
- Linux Native AOT publish/execute gate returned `42`

The Windows machine was concurrently running other performance work and accumulated persistent MSBuild nodes. Three standalone compiler tests failed identically on unchanged main, and the later broad suite encountered host-wide `HttpListener` invalid-handle/IPC failures. No shared processes or worktrees were terminated or modified; clean-environment CI should provide the definitive Windows full-suite result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved `Int32Array` calculations by reducing repeated bounds checks and using optimized integer arithmetic where safe.
  * Improved counter-based typed-array writes while preserving existing behavior for unsafe or out-of-range calculations.

* **Bug Fixes**
  * Maintained correct fault handling for out-of-range indexed access.
  * Preserved expected behavior for negative zero and non-integer arithmetic.

* **Tests**
  * Added coverage for optimized stencil calculations, integer writes, bounds checking, fallback behavior, and execution-mode consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->