### PR TITLE
Perf: optimize hot paths across #1501-#1510

### DIFF
--- a/benchmarks/cross-runtime/scripts/array-destructure.ts
+++ b/benchmarks/cross-runtime/scripts/array-destructure.ts
@@ -1,0 +1,17 @@
+import { bench } from "./lib/bench.ts";
+
+function destructureArray(n: number): number {
+    const pair: number[] = [1, 2];
+    let checksum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const [left, right] = pair;
+        checksum = checksum + left + right;
+    }
+    return checksum;
+}
+
+const sizes: number[] = [10000, 100000];
+for (let i: number = 0; i < sizes.length; i++) {
+    const n: number = sizes[i];
+    bench("array-destructure", n, () => destructureArray(n));
+}

--- a/benchmarks/cross-runtime/scripts/array-includes.ts
+++ b/benchmarks/cross-runtime/scripts/array-includes.ts
@@ -1,0 +1,32 @@
+import { bench } from "./lib/bench.ts";
+
+function scanIncludes(n: number): number {
+    const values: number[] = [];
+    for (let i: number = 0; i < n; i++) values.push(i);
+
+    let checksum: number = 0;
+    for (let pass: number = 0; pass < 100; pass++) {
+        if (values.includes(-1)) checksum = checksum + 1;
+    }
+
+    if (values.includes(n - 1)) checksum = checksum + 1;       // hit
+    if (!values.includes(n + 1)) checksum = checksum + 2;      // miss
+    if (values.includes(n - 1, n - 1)) checksum = checksum + 4;
+    if (!values.includes(0, 1)) checksum = checksum + 8;       // positive fromIndex
+    if (values.includes(n - 1, -1)) checksum = checksum + 16;  // negative fromIndex
+
+    const special: number[] = [];
+    special.push(-0, NaN);
+    if (special.includes(+0)) checksum = checksum + 32;        // signed zero
+    if (special.includes(NaN)) checksum = checksum + 64;       // SameValueZero NaN
+
+    const empty: number[] = [];
+    if (!empty.includes(0)) checksum = checksum + 128;
+    return checksum;
+}
+
+const sizes: number[] = [1000, 10000];
+for (let i: number = 0; i < sizes.length; i++) {
+    const n: number = sizes[i];
+    bench("array-includes", n, () => scanIncludes(n));
+}

--- a/benchmarks/cross-runtime/scripts/array-queue.ts
+++ b/benchmarks/cross-runtime/scripts/array-queue.ts
@@ -1,0 +1,29 @@
+import { bench } from "./lib/bench.ts";
+
+function shiftDrain(n: number): number {
+    const values: number[] = [];
+    for (let i: number = 0; i < n; i++) {
+        values.push(i);
+    }
+
+    let checksum: number = 0;
+    while (values.length > 0) {
+        checksum = checksum + values.shift();
+    }
+    return checksum;
+}
+
+function unshiftBuild(n: number): number {
+    const values: number[] = [];
+    for (let i: number = 0; i < n; i++) {
+        values.unshift(i);
+    }
+    return values.length + values[0] + values[n - 1];
+}
+
+const sizes: number[] = [1000, 10000];
+for (let i: number = 0; i < sizes.length; i++) {
+    const n: number = sizes[i];
+    bench("array-shift-drain", n, () => shiftDrain(n));
+    bench("array-unshift-build", n, () => unshiftBuild(n));
+}

--- a/benchmarks/cross-runtime/scripts/custom-iterator-dynamic-control.ts
+++ b/benchmarks/cross-runtime/scripts/custom-iterator-dynamic-control.ts
@@ -1,0 +1,30 @@
+import { bench } from "./lib/bench.ts";
+
+function mutatedCustomIterator(n: number): number {
+    let current: number = 0;
+    const iterable: any = {
+        [Symbol.iterator]() { return this; },
+        next() {
+            if (current < n) {
+                const value: number = current;
+                current = current + 1;
+                return { value, done: false };
+            }
+            return { value: 0, done: true };
+        }
+    };
+
+    // Observable alias + protocol write: this must retain the generic path.
+    const alias: any = iterable;
+    alias.next = alias.next;
+
+    let checksum: number = 0;
+    for (const value of iterable) checksum = checksum + value;
+    return checksum;
+}
+
+const sizes: number[] = [10000, 100000];
+for (let i: number = 0; i < sizes.length; i++) {
+    const n: number = sizes[i];
+    bench("custom-iterator-dynamic-control", n, () => mutatedCustomIterator(n));
+}

--- a/benchmarks/cross-runtime/scripts/custom-iterator.ts
+++ b/benchmarks/cross-runtime/scripts/custom-iterator.ts
@@ -1,0 +1,26 @@
+import { bench } from "./lib/bench.ts";
+
+function stableCustomIterator(n: number): number {
+    let current: number = 0;
+    const iterable = {
+        [Symbol.iterator]() { return this; },
+        next() {
+            if (current < n) {
+                const value: number = current;
+                current = current + 1;
+                return { value, done: false };
+            }
+            return { value: 0, done: true };
+        }
+    };
+
+    let checksum: number = 0;
+    for (const value of iterable) checksum = checksum + value;
+    return checksum;
+}
+
+const sizes: number[] = [10000, 100000];
+for (let i: number = 0; i < sizes.length; i++) {
+    const n: number = sizes[i];
+    bench("custom-iterator", n, () => stableCustomIterator(n));
+}

--- a/benchmarks/cross-runtime/scripts/exceptions.ts
+++ b/benchmarks/cross-runtime/scripts/exceptions.ts
@@ -58,8 +58,45 @@ function errorThrow(n: number): number {
     return sum;
 }
 
+function errorConstruction(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        if ((i & 1023) === 0) {
+            const error = new Error("sparse");
+            total = total + error.message.length;
+        }
+    }
+    return total;
+}
+
+function errorFirstStackRead(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        if ((i & 1023) === 0) {
+            total = total + new Error("sparse").stack!.length;
+        }
+    }
+    return total;
+}
+
+function errorRepeatedStackRead(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        if ((i & 1023) === 0) {
+            const error = new Error("sparse");
+            const first = error.stack!;
+            const second = error.stack!;
+            total = total + (first === second ? second.length : -1);
+        }
+    }
+    return total;
+}
+
 const n: number = 100000;
 bench("throw-branch-control", n, () => branchControl(n));
 bench("throw-try-catch-no-throw", n, () => tryCatchNoThrow(n));
 bench("throw-primitive", n, () => primitiveThrow(n));
 bench("throw-error", n, () => errorThrow(n));
+bench("error-construct-no-stack", n, () => errorConstruction(n));
+bench("error-first-stack-read", n, () => errorFirstStackRead(n));
+bench("error-repeated-stack-read", n, () => errorRepeatedStackRead(n));

--- a/benchmarks/cross-runtime/scripts/math-min-max.ts
+++ b/benchmarks/cross-runtime/scripts/math-min-max.ts
@@ -1,0 +1,75 @@
+import { bench } from "./lib/bench.ts";
+
+function mathMinZero(n: number): number {
+    let result: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        result = Math.min();
+    }
+    return result;
+}
+
+function mathMaxOne(a: number, n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        total = total + Math.max(a);
+    }
+    return total;
+}
+
+function mathMinTwo(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        // Both operands vary non-linearly so neither host can hoist or
+        // constant-fold the intrinsic out of the loop.
+        total = total + Math.min(i % 97, i % 89);
+    }
+    return total;
+}
+
+function mathMaxSeveral(
+    a: number, b: number, c: number, d: number, n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        total = total + Math.max(a, b, c, d);
+    }
+    return total;
+}
+
+function mathMinDynamic(a: any, b: any, n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        total = total + Math.min(a, b);
+    }
+    return total;
+}
+
+function mathMaxSpread(values: number[], n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        total = total + Math.max(...values);
+    }
+    return total;
+}
+
+// Make the values unknown to the host optimizer while keeping their TypeScript
+// types precise enough for SharpTS's fixed-arity path.
+const seed: number = Date.now() & 1;
+const a: number = 3 + seed;
+const b: number = 4 + seed;
+const c: number = 2 + seed;
+const d: number = 7 + seed;
+const dynamicA: any = a;
+const dynamicB: any = b;
+const spreadValues: number[] = [a, b, c, d];
+const params: number[] = [100, 10000, 100000];
+
+for (let p: number = 0; p < params.length; p++) {
+    const n: number = params[p];
+
+    bench("math-min-zero", n, () => mathMinZero(n));
+    bench("math-max-one", n, () => mathMaxOne(a, n));
+    bench("math-min-two", n, () => mathMinTwo(n));
+    bench("math-max-several", n, () => mathMaxSeveral(a, b, c, d, n));
+    bench("math-min-dynamic", n, () => mathMinDynamic(dynamicA, dynamicB, n));
+    bench("math-max-spread", n, () => mathMaxSpread(spreadValues, n));
+}

--- a/benchmarks/cross-runtime/scripts/object-destructure.ts
+++ b/benchmarks/cross-runtime/scripts/object-destructure.ts
@@ -1,0 +1,19 @@
+import { bench } from "./lib/bench.ts";
+
+type Point = { x: number; y: number };
+
+function destructureObject(n: number): number {
+    const point: Point = { x: 1, y: 2 };
+    let checksum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const { x, y } = point;
+        checksum = checksum + x + y;
+    }
+    return checksum;
+}
+
+const sizes: number[] = [10000, 100000];
+for (let i: number = 0; i < sizes.length; i++) {
+    const n: number = sizes[i];
+    bench("object-destructure", n, () => destructureObject(n));
+}

--- a/benchmarks/cross-runtime/scripts/object-keys.ts
+++ b/benchmarks/cross-runtime/scripts/object-keys.ts
@@ -1,0 +1,72 @@
+import { bench } from "./lib/bench.ts";
+
+function exactRecordKeys(n: number): number {
+    const exactKeysRecord = { alpha: 1, beta: 2, gamma: 3, delta: 4 };
+    let checksum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const exactKeys: string[] = Object.keys(exactKeysRecord);
+        checksum = checksum + exactKeys.length;
+    }
+    return checksum;
+}
+
+function numericRecordKeys(n: number): number {
+    const numericKeysRecord: any = { 10: "ten", first: "a", 2: "two", 1: "one" };
+    let checksum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const numericKeys: string[] = Object.keys(numericKeysRecord);
+        if (numericKeys.join(",") === "1,2,10,first") checksum = checksum + 1;
+    }
+    return checksum;
+}
+
+function mutatedRecordKeys(n: number): number {
+    const mutatedKeysRecord: any = { first: 1, second: 2 };
+    mutatedKeysRecord.third = 3;
+    let checksum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const mutatedKeys: string[] = Object.keys(mutatedKeysRecord);
+        checksum = checksum + mutatedKeys.length;
+    }
+    return checksum;
+}
+
+function accessorRecordKeys(n: number): number {
+    let getterCalls: number = 0;
+    const accessorKeysRecord: any = {
+        first: 1,
+        get second(): number { getterCalls = getterCalls + 1; return 2; }
+    };
+    let checksum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const accessorKeys: string[] = Object.keys(accessorKeysRecord);
+        checksum = checksum + accessorKeys.length;
+    }
+    return checksum + getterCalls;
+}
+
+function proxyRecordKeys(n: number): number {
+    let ownKeysCalls: number = 0;
+    const proxyKeysRecord: any = new Proxy({ first: 1, second: 2 }, {
+        ownKeys(target: any): any[] {
+            ownKeysCalls = ownKeysCalls + 1;
+            return Reflect.ownKeys(target);
+        }
+    });
+    let checksum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const proxyKeys: string[] = Object.keys(proxyKeysRecord);
+        checksum = checksum + proxyKeys.length;
+    }
+    return checksum + ownKeysCalls;
+}
+
+const sizes: number[] = [10000, 100000];
+for (let i: number = 0; i < sizes.length; i++) {
+    const n: number = sizes[i];
+    bench("object-keys-exact", n, () => exactRecordKeys(n));
+    bench("object-keys-numeric", n, () => numericRecordKeys(n));
+    bench("object-keys-mutated", n, () => mutatedRecordKeys(n));
+    bench("object-keys-accessor", n, () => accessorRecordKeys(n));
+    bench("object-keys-proxy", n, () => proxyRecordKeys(n));
+}

--- a/benchmarks/cross-runtime/scripts/object-spread.ts
+++ b/benchmarks/cross-runtime/scripts/object-spread.ts
@@ -1,0 +1,46 @@
+import { bench } from "./lib/bench.ts";
+
+function spreadOneSource(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const oneSource = { a: i, b: i + 1, c: i + 2 };
+        const oneResult = { ...oneSource, d: i + 3 };
+        total = total + oneResult.a + oneResult.d;
+    }
+    return total;
+}
+
+function spreadMultipleOverwrite(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const overwriteFirst = { a: i, b: i + 1, c: i + 2 };
+        const overwriteSecond = { b: i + 3, c: i + 4, d: i + 5 };
+        const overwriteResult = { ...overwriteFirst, b: i + 6, ...overwriteSecond, c: i + 7 };
+        total = total + overwriteResult.a + overwriteResult.b + overwriteResult.c + overwriteResult.d;
+    }
+    return total;
+}
+
+function consumeSpreadResult(value: any): number {
+    value.d = value.d + 1;
+    return value.a + value.d;
+}
+
+function spreadMutationEscape(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const escapeSource = { a: i, b: i + 1, c: i + 2 };
+        const escapeResult = { ...escapeSource, d: i + 3 };
+        escapeResult.b = escapeResult.b + 1;
+        total = total + consumeSpreadResult(escapeResult);
+    }
+    return total;
+}
+
+const sizes: number[] = [10000, 100000];
+for (let i: number = 0; i < sizes.length; i++) {
+    const n: number = sizes[i];
+    bench("object-spread-one", n, () => spreadOneSource(n));
+    bench("object-spread-overwrite", n, () => spreadMultipleOverwrite(n));
+    bench("object-spread-escape", n, () => spreadMutationEscape(n));
+}

--- a/benchmarks/cross-runtime/scripts/regex-replace.ts
+++ b/benchmarks/cross-runtime/scripts/regex-replace.ts
@@ -1,0 +1,15 @@
+import { bench } from "./lib/bench.ts";
+
+const input: string = "foo bar foo baz foo qux";
+const params: number[] = [100, 10000, 100000];
+
+for (let p: number = 0; p < params.length; p++) {
+    const n: number = params[p];
+    bench("regex-replace", n, () => {
+        let total: number = 0;
+        for (let i: number = 0; i < n; i++) {
+            total = total + input.replace(/foo/g, "bar").length;
+        }
+        return total;
+    });
+}

--- a/benchmarks/cross-runtime/scripts/string-intrinsics.ts
+++ b/benchmarks/cross-runtime/scripts/string-intrinsics.ts
@@ -1,0 +1,54 @@
+import { bench } from "./lib/bench.ts";
+
+const input: string = "alpha-beta-gamma-delta";
+const needle: string = "gamma";
+const position: number = 2;
+const start: number = 3;
+const end: number = 18;
+const params: number[] = [100, 10000, 100000];
+
+for (let p: number = 0; p < params.length; p++) {
+    const n: number = params[p];
+
+    bench("string-indexof", n, () => {
+        let total: number = 0;
+        let currentPosition: number = position;
+        for (let i: number = 0; i < n; i++) {
+            total = total + input.indexOf(needle, currentPosition);
+            currentPosition = currentPosition === position ? 12 : position;
+        }
+        return total;
+    });
+
+    bench("string-includes", n, () => {
+        let total: number = 0;
+        let currentPosition: number = position;
+        for (let i: number = 0; i < n; i++) {
+            if (input.includes(needle, currentPosition)) {
+                total = total + 1;
+            }
+            currentPosition = currentPosition === position ? 12 : position;
+        }
+        return total;
+    });
+
+    bench("string-slice", n, () => {
+        let total: number = 0;
+        let currentStart: number = start;
+        for (let i: number = 0; i < n; i++) {
+            total = total + input.slice(currentStart, end).length;
+            currentStart = currentStart === start ? start + 1 : start;
+        }
+        return total;
+    });
+
+    bench("string-substring", n, () => {
+        let total: number = 0;
+        let currentStart: number = start;
+        for (let i: number = 0; i < n; i++) {
+            total = total + input.substring(currentStart, end).length;
+            currentStart = currentStart === start ? start + 1 : start;
+        }
+        return total;
+    });
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Baselines/ArrayQueueBaselines.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Baselines/ArrayQueueBaselines.cs
@@ -1,0 +1,24 @@
+namespace SharpTS.Microbenchmarks.Baselines;
+
+public static class ArrayQueueBaselines
+{
+    public static double ShiftDrain(int n)
+    {
+        var values = new List<double>(n);
+        for (int i = 0; i < n; i++) values.Add(i);
+        double checksum = 0;
+        while (values.Count > 0)
+        {
+            checksum += values[0];
+            values.RemoveAt(0);
+        }
+        return checksum;
+    }
+
+    public static double UnshiftBuild(int n)
+    {
+        var values = new List<double>(n);
+        for (int i = 0; i < n; i++) values.Insert(0, i);
+        return values.Count + values[0] + values[n - 1];
+    }
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ArrayQueueBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ArrayQueueBenchmarks.cs
@@ -1,0 +1,53 @@
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Order;
+using SharpTS.Microbenchmarks.Baselines;
+using SharpTS.Microbenchmarks.Infrastructure;
+
+namespace SharpTS.Microbenchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+[RankColumn]
+[CategoriesColumn]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class ArrayQueueBenchmarks
+{
+    private Func<double, double> _shift = null!;
+    private Func<double, double> _unshift = null!;
+
+    [Params(1_000, 10_000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Assembly assembly = typeof(ArrayQueueBenchmarks).Assembly;
+        using Stream stream = assembly.GetManifestResourceStream(
+            "SharpTS.Microbenchmarks.TypeScriptSources.ArrayQueue.ts")
+            ?? throw new InvalidOperationException("Could not find embedded resource ArrayQueue.ts");
+        using var reader = new StreamReader(stream);
+        string dllPath = CompilationCache.GetOrCompile(reader.ReadToEnd(), "ArrayQueue");
+        Assembly compiled = BenchmarkHarness.LoadCompiledAssembly(dllPath, "array-queue");
+        BenchmarkHarness.InitializeCompiledModules(compiled);
+        _shift = BenchmarkHarness.GetCompiledNumberFunc(compiled, "arrayShiftDrain");
+        _unshift = BenchmarkHarness.GetCompiledNumberFunc(compiled, "arrayUnshiftBuild");
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("Shift")]
+    public double SharpTS_Shift() => _shift(N);
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("Shift")]
+    public double CSharp_Shift() => ArrayQueueBaselines.ShiftDrain(N);
+
+    [Benchmark]
+    [BenchmarkCategory("Unshift")]
+    public double SharpTS_Unshift() => _unshift(N);
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("Unshift")]
+    public double CSharp_Unshift() => ArrayQueueBaselines.UnshiftBuild(N);
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ExceptionThrowBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ExceptionThrowBenchmarks.cs
@@ -19,6 +19,9 @@ public class ExceptionThrowBenchmarks
     private Func<double, double> _tryCatchNoThrow = null!;
     private Func<double, double> _primitiveThrow = null!;
     private Func<double, double> _errorThrow = null!;
+    private Func<double, double> _errorConstruction = null!;
+    private Func<double, double> _firstStackRead = null!;
+    private Func<double, double> _repeatedStackRead = null!;
 
     [Params(100_000)]
     public int N { get; set; }
@@ -44,6 +47,12 @@ public class ExceptionThrowBenchmarks
             compiled, "throwPrimitiveSparse");
         _errorThrow = BenchmarkHarness.GetCompiledNumberFunc(
             compiled, "throwErrorSparse");
+        _errorConstruction = BenchmarkHarness.GetCompiledNumberFunc(
+            compiled, "constructErrorSparse");
+        _firstStackRead = BenchmarkHarness.GetCompiledNumberFunc(
+            compiled, "firstErrorStackRead");
+        _repeatedStackRead = BenchmarkHarness.GetCompiledNumberFunc(
+            compiled, "repeatedErrorStackRead");
     }
 
     [Benchmark(Baseline = true)]
@@ -57,4 +66,13 @@ public class ExceptionThrowBenchmarks
 
     [Benchmark]
     public double ErrorThrow() => _errorThrow(N);
+
+    [Benchmark]
+    public double ErrorConstructionNoStackRead() => _errorConstruction(N);
+
+    [Benchmark]
+    public double ErrorFirstStackRead() => _firstStackRead(N);
+
+    [Benchmark]
+    public double ErrorRepeatedStackRead() => _repeatedStackRead(N);
 }

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/MathMinMaxBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/MathMinMaxBenchmarks.cs
@@ -1,0 +1,73 @@
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using SharpTS.Microbenchmarks.Infrastructure;
+
+namespace SharpTS.Microbenchmarks.Benchmarks;
+
+/// <summary>
+/// Fixed-arity typed Math.min/max workloads, plus a dynamic control that must
+/// retain JavaScript argument coercion.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class MathMinMaxBenchmarks
+{
+    private Func<double, double> _zero = null!;
+    private Func<double, double, double> _one = null!;
+    private Func<double, double, double, double> _two = null!;
+    private Func<double, double, double, double, double, double> _several = null!;
+    private Func<object, object, double, double> _dynamic = null!;
+
+    [Params(100, 10_000, 100_000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var assembly = typeof(MathMinMaxBenchmarks).Assembly;
+        using var stream = assembly.GetManifestResourceStream(
+            "SharpTS.Microbenchmarks.TypeScriptSources.MathMinMax.ts")
+            ?? throw new InvalidOperationException("Could not find embedded resource MathMinMax.ts");
+        using var reader = new StreamReader(stream);
+        string source = reader.ReadToEnd();
+
+        string dllPath = CompilationCache.GetOrCompile(source, "MathMinMax");
+        Assembly compiled = BenchmarkHarness.LoadCompiledAssembly(dllPath, "math-min-max");
+        _zero = BenchmarkHarness.GetCompiledMethod(compiled, "mathMinZeroLoop")
+            .CreateDelegate<Func<double, double>>();
+        _one = BenchmarkHarness.GetCompiledMethod(compiled, "mathMaxOneLoop")
+            .CreateDelegate<Func<double, double, double>>();
+        _two = BenchmarkHarness.GetCompiledMethod(compiled, "mathMinTwoLoop")
+            .CreateDelegate<Func<double, double, double, double>>();
+        _several = BenchmarkHarness.GetCompiledMethod(compiled, "mathMaxSeveralLoop")
+            .CreateDelegate<Func<double, double, double, double, double, double>>();
+        _dynamic = BenchmarkHarness.GetCompiledMethod(compiled, "mathMinDynamicLoop")
+            .CreateDelegate<Func<object, object, double, double>>();
+    }
+
+    [Benchmark]
+    public double SharpTS_Zero() => _zero(N);
+
+    [Benchmark]
+    public double SharpTS_One() => _one(3, N);
+
+    [Benchmark]
+    public double SharpTS_Two() => _two(3, 4, N);
+
+    [Benchmark]
+    public double NativeCSharp_Two()
+    {
+        double total = 0;
+        for (int i = 0; i < N; i++)
+            total += Math.Min(3, 4);
+        return total;
+    }
+
+    [Benchmark]
+    public double SharpTS_Several() => _several(1, 7, 3, 5, N);
+
+    [Benchmark]
+    public double SharpTS_DynamicControl() => _dynamic(3d, 4d, N);
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ObjectLiteralsBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ObjectLiteralsBenchmarks.cs
@@ -6,10 +6,9 @@ using SharpTS.Microbenchmarks.Infrastructure;
 namespace SharpTS.Microbenchmarks.Benchmarks;
 
 /// <summary>
-/// Object-literal allocation benchmarks. Each <c>{ ... }</c> in TS source
-/// emits <c>new Dictionary&lt;string, object&gt;()</c> + N <c>set_Item</c>
-/// calls + a no-op <c>CreateObject</c> helper call. Measures the per-iter
-/// cost in tight loops — return values, options bags, tree builders.
+/// Object-literal allocation benchmarks. Measures fixed records, nested/dynamic
+/// objects, stable exact spread, overwrite order, and an escaping spread control
+/// in tight loops such as options-bag and tree-building workloads.
 /// </summary>
 [MemoryDiagnoser]
 [RankColumn]
@@ -20,6 +19,9 @@ public class ObjectLiteralsBenchmarks
     private MethodInfo _tsSmall = null!;
     private MethodInfo _tsMedium = null!;
     private MethodInfo _tsNested = null!;
+    private MethodInfo _tsSpreadOne = null!;
+    private MethodInfo _tsSpreadMultiple = null!;
+    private MethodInfo _tsSpreadEscape = null!;
 
     [Params(100, 10_000, 1_000_000)]
     public int N { get; set; }
@@ -40,6 +42,9 @@ public class ObjectLiteralsBenchmarks
         _tsSmall = BenchmarkHarness.GetCompiledMethod(_tsAssembly, "smallLiteralLoop");
         _tsMedium = BenchmarkHarness.GetCompiledMethod(_tsAssembly, "mediumLiteralLoop");
         _tsNested = BenchmarkHarness.GetCompiledMethod(_tsAssembly, "nestedLiteralLoop");
+        _tsSpreadOne = BenchmarkHarness.GetCompiledMethod(_tsAssembly, "spreadOneSourceLoop");
+        _tsSpreadMultiple = BenchmarkHarness.GetCompiledMethod(_tsAssembly, "spreadMultipleOverwriteLoop");
+        _tsSpreadEscape = BenchmarkHarness.GetCompiledMethod(_tsAssembly, "spreadMutationEscapeLoop");
     }
 
     [Benchmark]
@@ -56,4 +61,19 @@ public class ObjectLiteralsBenchmarks
     [BenchmarkCategory("NestedLiteral")]
     public object? SharpTS_NestedLiteralLoop()
         => BenchmarkHarness.InvokeCompiled(_tsNested, (double)N);
+
+    [Benchmark]
+    [BenchmarkCategory("SpreadOneSource")]
+    public object? SharpTS_SpreadOneSourceLoop()
+        => BenchmarkHarness.InvokeCompiled(_tsSpreadOne, (double)N);
+
+    [Benchmark]
+    [BenchmarkCategory("SpreadMultipleOverwrite")]
+    public object? SharpTS_SpreadMultipleOverwriteLoop()
+        => BenchmarkHarness.InvokeCompiled(_tsSpreadMultiple, (double)N);
+
+    [Benchmark]
+    [BenchmarkCategory("SpreadMutationEscape")]
+    public object? SharpTS_SpreadMutationEscapeLoop()
+        => BenchmarkHarness.InvokeCompiled(_tsSpreadEscape, (double)N);
 }

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ObjectLiteralsBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ObjectLiteralsBenchmarks.cs
@@ -22,6 +22,8 @@ public class ObjectLiteralsBenchmarks
     private MethodInfo _tsSpreadOne = null!;
     private MethodInfo _tsSpreadMultiple = null!;
     private MethodInfo _tsSpreadEscape = null!;
+    private MethodInfo _tsObjectKeysExact = null!;
+    private MethodInfo _tsObjectKeysMutation = null!;
 
     [Params(100, 10_000, 1_000_000)]
     public int N { get; set; }
@@ -45,6 +47,8 @@ public class ObjectLiteralsBenchmarks
         _tsSpreadOne = BenchmarkHarness.GetCompiledMethod(_tsAssembly, "spreadOneSourceLoop");
         _tsSpreadMultiple = BenchmarkHarness.GetCompiledMethod(_tsAssembly, "spreadMultipleOverwriteLoop");
         _tsSpreadEscape = BenchmarkHarness.GetCompiledMethod(_tsAssembly, "spreadMutationEscapeLoop");
+        _tsObjectKeysExact = BenchmarkHarness.GetCompiledMethod(_tsAssembly, "objectKeysExactLoop");
+        _tsObjectKeysMutation = BenchmarkHarness.GetCompiledMethod(_tsAssembly, "objectKeysMutationLoop");
     }
 
     [Benchmark]
@@ -76,4 +80,14 @@ public class ObjectLiteralsBenchmarks
     [BenchmarkCategory("SpreadMutationEscape")]
     public object? SharpTS_SpreadMutationEscapeLoop()
         => BenchmarkHarness.InvokeCompiled(_tsSpreadEscape, (double)N);
+
+    [Benchmark]
+    [BenchmarkCategory("ObjectKeysExact")]
+    public object? SharpTS_ObjectKeysExactLoop()
+        => BenchmarkHarness.InvokeCompiled(_tsObjectKeysExact, (double)N);
+
+    [Benchmark]
+    [BenchmarkCategory("ObjectKeysMutation")]
+    public object? SharpTS_ObjectKeysMutationLoop()
+        => BenchmarkHarness.InvokeCompiled(_tsObjectKeysMutation, (double)N);
 }

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/PrimitiveStringIntrinsicBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/PrimitiveStringIntrinsicBenchmarks.cs
@@ -1,0 +1,112 @@
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using SharpTS.Microbenchmarks.Infrastructure;
+
+namespace SharpTS.Microbenchmarks.Benchmarks;
+
+/// <summary>
+/// Dynamic-input coverage for the fixed-arity primitive string intrinsics.
+/// Search operations should allocate nothing in the measured loop; slicing
+/// should allocate only the observable result strings.
+/// </summary>
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class PrimitiveStringIntrinsicBenchmarks
+{
+    private const string Input = "alpha-beta-gamma-delta";
+    private const string Needle = "gamma";
+    private const int Position = 2;
+    private const int Start = 3;
+    private const int End = 18;
+
+    private Func<string, string, double, double, double> _indexOf = null!;
+    private Func<string, string, double, double, double> _includes = null!;
+    private Func<string, double, double, double, double> _slice = null!;
+    private Func<string, double, double, double, double> _substring = null!;
+
+    [Params(100, 10_000, 100_000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var assembly = typeof(PrimitiveStringIntrinsicBenchmarks).Assembly;
+        using var stream = assembly.GetManifestResourceStream(
+            "SharpTS.Microbenchmarks.TypeScriptSources.PrimitiveStringIntrinsics.ts")
+            ?? throw new InvalidOperationException(
+                "Could not find embedded resource PrimitiveStringIntrinsics.ts");
+        using var reader = new StreamReader(stream);
+        string source = reader.ReadToEnd();
+
+        string dllPath = CompilationCache.GetOrCompile(source, "PrimitiveStringIntrinsics");
+        Assembly compiled = BenchmarkHarness.LoadCompiledAssembly(
+            dllPath, "primitive-string-intrinsics");
+        _indexOf = BenchmarkHarness.GetCompiledMethod(compiled, "stringIndexOfLoop")
+            .CreateDelegate<Func<string, string, double, double, double>>();
+        _includes = BenchmarkHarness.GetCompiledMethod(compiled, "stringIncludesLoop")
+            .CreateDelegate<Func<string, string, double, double, double>>();
+        _slice = BenchmarkHarness.GetCompiledMethod(compiled, "stringSliceLoop")
+            .CreateDelegate<Func<string, double, double, double, double>>();
+        _substring = BenchmarkHarness.GetCompiledMethod(compiled, "stringSubstringLoop")
+            .CreateDelegate<Func<string, double, double, double, double>>();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("StringIndexOf")]
+    public double SharpTS_IndexOf() => _indexOf(Input, Needle, Position, N);
+
+    [Benchmark]
+    [BenchmarkCategory("StringIndexOf")]
+    public int NativeCSharp_IndexOf()
+    {
+        int total = 0;
+        for (int i = 0; i < N; i++)
+            total += Input.IndexOf(Needle, Position, StringComparison.Ordinal);
+        return total;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("StringIncludes")]
+    public double SharpTS_Includes() => _includes(Input, Needle, Position, N);
+
+    [Benchmark]
+    [BenchmarkCategory("StringIncludes")]
+    public int NativeCSharp_Includes()
+    {
+        int total = 0;
+        for (int i = 0; i < N; i++)
+            if (Input.IndexOf(Needle, Position, StringComparison.Ordinal) >= 0)
+                total++;
+        return total;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("StringSlice")]
+    public double SharpTS_Slice() => _slice(Input, Start, End, N);
+
+    [Benchmark]
+    [BenchmarkCategory("StringSlice")]
+    public int NativeCSharp_Slice()
+    {
+        int total = 0;
+        for (int i = 0; i < N; i++)
+            total += Input.Substring(Start, End - Start).Length;
+        return total;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("StringSubstring")]
+    public double SharpTS_Substring() => _substring(Input, Start, End, N);
+
+    [Benchmark]
+    [BenchmarkCategory("StringSubstring")]
+    public int NativeCSharp_Substring()
+    {
+        int total = 0;
+        for (int i = 0; i < N; i++)
+            total += Input.Substring(Start, End - Start).Length;
+        return total;
+    }
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/RegexBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/RegexBenchmarks.cs
@@ -28,6 +28,8 @@ public class RegexBenchmarks
     // comparison.
     private readonly Regex _nativeValidator = new(
         "^[a-z]+$", RegexOptions.ECMAScript | RegexOptions.Compiled);
+    private readonly Regex _nativeReplace = new(
+        "foo", RegexOptions.ECMAScript | RegexOptions.Compiled);
 
     [Params(100, 10_000, 100_000)]
     public int N { get; set; }
@@ -58,6 +60,16 @@ public class RegexBenchmarks
     [BenchmarkCategory("RegexLiteral")]
     public object? SharpTS_RegexLiteralLoop()
         => BenchmarkHarness.InvokeCompiled(_tsLiteral, ReplaceInput, (double)N);
+
+    [Benchmark]
+    [BenchmarkCategory("RegexLiteral")]
+    public int NativeCSharp_RegexReplaceLoop()
+    {
+        int total = 0;
+        for (int i = 0; i < N; i++)
+            total += _nativeReplace.Replace(ReplaceInput, "bar").Length;
+        return total;
+    }
 
     [Benchmark]
     [BenchmarkCategory("RegexValidator")]

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ArrayQueue.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ArrayQueue.ts
@@ -1,0 +1,19 @@
+function arrayShiftDrain(n: number): number {
+    const values: number[] = [];
+    for (let i: number = 0; i < n; i++) {
+        values.push(i);
+    }
+    let checksum: number = 0;
+    while (values.length > 0) {
+        checksum = checksum + values.shift();
+    }
+    return checksum;
+}
+
+function arrayUnshiftBuild(n: number): number {
+    const values: number[] = [];
+    for (let i: number = 0; i < n; i++) {
+        values.unshift(i);
+    }
+    return values.length + values[0] + values[n - 1];
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ExceptionThrows.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ExceptionThrows.ts
@@ -55,3 +55,38 @@ function throwErrorSparse(n: number): number {
     }
     return sum;
 }
+
+function constructErrorSparse(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        if ((i & 1023) === 0) {
+            const error = new Error("sparse");
+            total = total + error.message.length;
+        }
+    }
+    return total;
+}
+
+function firstErrorStackRead(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        if ((i & 1023) === 0) {
+            const error = new Error("sparse");
+            total = total + error.stack!.length;
+        }
+    }
+    return total;
+}
+
+function repeatedErrorStackRead(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        if ((i & 1023) === 0) {
+            const error = new Error("sparse");
+            const first = error.stack!;
+            const second = error.stack!;
+            total = total + (first === second ? second.length : -1);
+        }
+    }
+    return total;
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/MathMinMax.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/MathMinMax.ts
@@ -1,0 +1,40 @@
+function mathMinZeroLoop(n: number): number {
+    let result: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        result = Math.min();
+    }
+    return result;
+}
+
+function mathMaxOneLoop(a: number, n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        total = total + Math.max(a);
+    }
+    return total;
+}
+
+function mathMinTwoLoop(a: number, b: number, n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        total = total + Math.min(a, b);
+    }
+    return total;
+}
+
+function mathMaxSeveralLoop(
+    a: number, b: number, c: number, d: number, n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        total = total + Math.max(a, b, c, d);
+    }
+    return total;
+}
+
+function mathMinDynamicLoop(a: any, b: any, n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        total = total + Math.min(a, b);
+    }
+    return total;
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ObjectLiterals.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ObjectLiterals.ts
@@ -70,3 +70,24 @@ function spreadMutationEscapeLoop(n: number): number {
     }
     return total;
 }
+
+function objectKeysExactLoop(n: number): number {
+    const bdnExactKeysRecord = { alpha: 1, beta: 2, gamma: 3, delta: 4 };
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const bdnExactKeys: string[] = Object.keys(bdnExactKeysRecord);
+        total = total + bdnExactKeys.length;
+    }
+    return total;
+}
+
+function objectKeysMutationLoop(n: number): number {
+    const bdnMutatedKeysRecord: any = { alpha: 1, beta: 2, gamma: 3 };
+    bdnMutatedKeysRecord.delta = 4;
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const bdnMutatedKeys: string[] = Object.keys(bdnMutatedKeysRecord);
+        total = total + bdnMutatedKeys.length;
+    }
+    return total;
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ObjectLiterals.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ObjectLiterals.ts
@@ -33,3 +33,40 @@ function nestedLiteralLoop(n: number): number {
     }
     return total;
 }
+
+function spreadOneSourceLoop(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const oneSource = { a: i, b: i + 1, c: i + 2 };
+        const oneResult = { ...oneSource, d: i + 3 };
+        total = total + oneResult.a + oneResult.d;
+    }
+    return total;
+}
+
+function spreadMultipleOverwriteLoop(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const overwriteFirst = { a: i, b: i + 1, c: i + 2 };
+        const overwriteSecond = { b: i + 3, c: i + 4, d: i + 5 };
+        const overwriteResult = { ...overwriteFirst, b: i + 6, ...overwriteSecond, c: i + 7 };
+        total = total + overwriteResult.a + overwriteResult.b + overwriteResult.c + overwriteResult.d;
+    }
+    return total;
+}
+
+function consumeSpreadResult(value: any): number {
+    value.d = value.d + 1;
+    return value.a + value.d;
+}
+
+function spreadMutationEscapeLoop(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const escapeSource = { a: i, b: i + 1, c: i + 2 };
+        const escapeResult = { ...escapeSource, d: i + 3 };
+        escapeResult.b = escapeResult.b + 1;
+        total = total + consumeSpreadResult(escapeResult);
+    }
+    return total;
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/PrimitiveStringIntrinsics.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/PrimitiveStringIntrinsics.ts
@@ -1,0 +1,37 @@
+function stringIndexOfLoop(
+    input: string, needle: string, position: number, n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        total = total + input.indexOf(needle, position);
+    }
+    return total;
+}
+
+function stringIncludesLoop(
+    input: string, needle: string, position: number, n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        if (input.includes(needle, position)) {
+            total = total + 1;
+        }
+    }
+    return total;
+}
+
+function stringSliceLoop(
+    input: string, start: number, end: number, n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        total = total + input.slice(start, end).length;
+    }
+    return total;
+}
+
+function stringSubstringLoop(
+    input: string, start: number, end: number, n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        total = total + input.substring(start, end).length;
+    }
+    return total;
+}

--- a/src/SharpTS/Compilation/ArrayLocalPromotionAnalyzer.cs
+++ b/src/SharpTS/Compilation/ArrayLocalPromotionAnalyzer.cs
@@ -18,8 +18,9 @@ namespace SharpTS.Compilation;
 /// <list type="number">
 ///   <item>declared <c>const</c>/<c>let</c> with an empty array-literal initializer (<c>[]</c>);</item>
 ///   <item>every use resolves the array element type to <c>number</c> or <c>boolean</c>;</item>
-///   <item>the ONLY uses are <c>x[i]</c> read, <c>x[i] = v</c> write, <c>x.length</c>, and
-///         the dense mutators <c>x.push(...)</c>, <c>x.shift()</c>, and <c>x.unshift(...)</c> — any
+///   <item>the ONLY uses are <c>x[i]</c> read, <c>x[i] = v</c> write, <c>x.length</c>,
+///         stable numeric <c>x.includes(value, fromIndex?)</c>, and the dense mutators
+///         <c>x.push(...)</c>, <c>x.shift()</c>, and <c>x.unshift(...)</c> — any
 ///         other appearance of the bare variable (argument pass, return, store,
 ///         spread, <c>for…of</c>, <c>===</c>, reassignment, <c>delete x[i]</c>, <c>pop</c>/any other
 ///         method or property) disqualifies it;</item>
@@ -270,6 +271,26 @@ public static class ArrayLocalPromotionAnalyzer
 
         protected override void VisitCall(Expr.Call expr)
         {
+            // A stable intrinsic includes call over a number[] can scan the promoted
+            // List<double> directly. Restrict both arguments to statically numeric
+            // values so no ToNumber coercion (and therefore no user code or mutation)
+            // is skipped. Omitted search arguments and all non-numeric shapes retain
+            // the generic Array.prototype algorithm.
+            if (expr.Callee is Expr.Get
+                {
+                    Object: Expr.Variable includesReceiver,
+                    Optional: false,
+                    Name.Lexeme: "includes"
+                }
+                && expr.Arguments.Count is 1 or 2
+                && IsNumberArrayReceiver(includesReceiver)
+                && expr.Arguments.All(IsNumberExpression))
+            {
+                NotePermittedReceiver(includesReceiver);
+                foreach (var arg in expr.Arguments) Visit(arg);
+                return;
+            }
+
             // Dense shift/unshift are representable directly by the promoted List<T>.
             // Evaluate every unshift argument before mutation in the emitter; here we
             // apply the same undefined-sentinel guard as push/index writes.
@@ -360,6 +381,10 @@ public static class ArrayLocalPromotionAnalyzer
             }
             base.VisitCall(expr);
         }
+
+        private bool IsNumberExpression(Expr expression) =>
+            _typeMap.Get(expression) is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER }
+                or TypeInfo.NumberLiteral;
 
         /// <summary>
         /// True if <paramref name="arguments"/> is a single inline, non-capturing arrow with one

--- a/src/SharpTS/Compilation/ArrayLocalPromotionAnalyzer.cs
+++ b/src/SharpTS/Compilation/ArrayLocalPromotionAnalyzer.cs
@@ -19,7 +19,8 @@ namespace SharpTS.Compilation;
 ///   <item>declared <c>const</c>/<c>let</c> with an empty array-literal initializer (<c>[]</c>);</item>
 ///   <item>every use resolves the array element type to <c>number</c> or <c>boolean</c>;</item>
 ///   <item>the ONLY uses are <c>x[i]</c> read, <c>x[i] = v</c> write, <c>x.length</c>, and
-///         <c>x.push(...)</c> — any other appearance of the bare variable (argument pass, return, store,
+///         the dense mutators <c>x.push(...)</c>, <c>x.shift()</c>, and <c>x.unshift(...)</c> — any
+///         other appearance of the bare variable (argument pass, return, store,
 ///         spread, <c>for…of</c>, <c>===</c>, reassignment, <c>delete x[i]</c>, <c>pop</c>/any other
 ///         method or property) disqualifies it;</item>
 ///   <item>the name is declared exactly once within its function scope (conservative guard against
@@ -35,9 +36,16 @@ namespace SharpTS.Compilation;
 /// </summary>
 public static class ArrayLocalPromotionAnalyzer
 {
-    public static void Analyze(List<Stmt> program, TypeMap? typeMap, ClosureAnalyzer? closures)
+    public static void Analyze(
+        List<Stmt> program,
+        TypeMap? typeMap,
+        ClosureAnalyzer? closures,
+        RuntimeFeatureSet? features = null)
     {
-        if (typeMap == null) return;
+        if (typeMap == null
+            || features?.UsesDynamicPropertyDescriptors == true
+            || features?.UsesArrayPrototypeMutation == true)
+            return;
 
         var visitor = new Visitor(typeMap, closures);
         foreach (var stmt in program)
@@ -262,6 +270,30 @@ public static class ArrayLocalPromotionAnalyzer
 
         protected override void VisitCall(Expr.Call expr)
         {
+            // Dense shift/unshift are representable directly by the promoted List<T>.
+            // Evaluate every unshift argument before mutation in the emitter; here we
+            // apply the same undefined-sentinel guard as push/index writes.
+            if (expr.Callee is Expr.Get { Object: Expr.Variable dense, Optional: false } denseGet
+                && denseGet.Name.Lexeme == "shift"
+                && expr.Arguments.Count == 0)
+            {
+                NotePermittedReceiver(dense);
+                return;
+            }
+
+            if (expr.Callee is Expr.Get { Object: Expr.Variable unshiftDense, Optional: false } unshiftGet
+                && unshiftGet.Name.Lexeme == "unshift")
+            {
+                NotePermittedReceiver(unshiftDense);
+                foreach (var arg in expr.Arguments)
+                {
+                    if (ValueAdmitsUndefinedSentinel(arg))
+                        Disqualified.Add((_scope, unshiftDense.Name.Lexeme));
+                    Visit(arg);
+                }
+                return;
+            }
+
             // `x.push(args)` — permitted; visit the args but skip the receiver
             // variable. Every other call shape recurses normally, so a receiver
             // passed as an argument, or any non-push method, is caught. (pop is

--- a/src/SharpTS/Compilation/CallHandlers/ArrayDestructureHandler.cs
+++ b/src/SharpTS/Compilation/CallHandlers/ArrayDestructureHandler.cs
@@ -42,7 +42,21 @@ public class ArrayDestructureHandler : ICallHandler
         // array/tuple/string the index access reads directly — and tuple positional element types
         // stay intact.
         if (IsIndexAddressable(ctx.TypeMap?.Get(arg)))
+        {
+            if (ctx.RuntimeFeatures?.UsesArrayPrototypeMutation != true &&
+                ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors != true)
+                return true;
+
+            // An own/prototype Symbol.iterator replacement makes positional reads observably
+            // wrong even for a statically typed array. Materialize through the iterator protocol
+            // when whole-program analysis cannot prove the built-in iterator remains intact.
+            il.Emit(OpCodes.Ldsfld, ctx.Runtime!.SymbolIterator);
+            il.Emit(OpCodes.Ldtoken, ctx.Runtime.RuntimeType);
+            il.Emit(OpCodes.Call, ctx.Types.GetMethod(ctx.Types.Type, "GetTypeFromHandle"));
+            il.Emit(OpCodes.Call, ctx.Runtime.IterateToList);
+            il.Emit(OpCodes.Newobj, ctx.Runtime.TSArrayCtor);
             return true;
+        }
 
         // Otherwise normalize at runtime:
         //   ArrayDestructureSource(value, Symbol.iterator, runtimeType)

--- a/src/SharpTS/Compilation/CallHandlers/BuiltInConstructorHandler.cs
+++ b/src/SharpTS/Compilation/CallHandlers/BuiltInConstructorHandler.cs
@@ -237,6 +237,13 @@ public class BuiltInConstructorHandler : ICallHandler
 
         // Call runtime CreateError(errorTypeName, args)
         il.Emit(OpCodes.Call, ctx.Runtime!.CreateError);
+        var createdError = il.DeclareLocal(ctx.Types.Object);
+        il.Emit(OpCodes.Stloc, createdError);
+        il.Emit(OpCodes.Ldloc, createdError);
+        il.Emit(OpCodes.Castclass, ctx.Runtime.TSErrorType);
+        il.Emit(OpCodes.Ldstr, ctx.CurrentMethod?.Name ?? "Main");
+        il.Emit(OpCodes.Callvirt, ctx.Runtime.TSErrorCapturedStackSetter);
+        il.Emit(OpCodes.Ldloc, createdError);
         return true;
     }
 }

--- a/src/SharpTS/Compilation/CallHandlers/GlobalThisChainHandler.cs
+++ b/src/SharpTS/Compilation/CallHandlers/GlobalThisChainHandler.cs
@@ -33,6 +33,11 @@ public class GlobalThisChainHandler : ICallHandler
         {
             return false;
         }
+        if (namespaceName == "Math"
+            && ctx.RuntimeFeatures?.UsesMathMutation == true)
+        {
+            return false;
+        }
 
         // Handle globalThis.console.log() etc.
         if (namespaceName == "console")
@@ -55,6 +60,12 @@ public class GlobalThisChainHandler : ICallHandler
                 && methodName == "parseInt"
                 && NumberStaticEmitter.EmitsUnboxedDecimalParseInt(
                     emitter, call.Arguments))
+            {
+                emitter.SetStackType(StackType.Double);
+            }
+            else if (namespaceName == "Math"
+                && MathStaticEmitter.EmitsUnboxedFixedArityMinMax(
+                    emitter, methodName, call.Arguments))
             {
                 emitter.SetStackType(StackType.Double);
             }

--- a/src/SharpTS/Compilation/CallHandlers/StaticTypeHandler.cs
+++ b/src/SharpTS/Compilation/CallHandlers/StaticTypeHandler.cs
@@ -30,6 +30,12 @@ public class StaticTypeHandler : ICallHandler
         {
             return false;
         }
+        if (staticVar.Name.Lexeme == "Math"
+            && (emitter.HasVariable("Math")
+                || ctx.RuntimeFeatures?.UsesMathMutation == true))
+        {
+            return false;
+        }
 
         var staticStrategy = ctx.TypeEmitterRegistry.GetStaticStrategy(staticVar.Name.Lexeme);
         if (staticStrategy == null)
@@ -42,6 +48,12 @@ public class StaticTypeHandler : ICallHandler
             && staticGet.Name.Lexeme == "parseInt"
             && NumberStaticEmitter.EmitsUnboxedDecimalParseInt(
                 emitter, call.Arguments))
+        {
+            emitter.SetStackType(StackType.Double);
+        }
+        else if (staticVar.Name.Lexeme == "Math"
+            && MathStaticEmitter.EmitsUnboxedFixedArityMinMax(
+                emitter, staticGet.Name.Lexeme, call.Arguments))
         {
             emitter.SetStackType(StackType.Double);
         }

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -83,6 +83,11 @@ public class EmittedRuntime
     public ConstructorBuilder TSFunctionCtorWithCache { get; set; } = null!;
     public MethodBuilder TSFunctionInvoke { get; set; } = null!;
     public MethodBuilder TSFunctionInvokeWithThis { get; set; } = null!;
+    public MethodBuilder TSFunctionGetTarget { get; set; } = null!;
+    public Type StableNumberIteratorResultType { get; set; } = null!;
+    public ConstructorInfo StableNumberIteratorResultCtor { get; set; } = null!;
+    public FieldInfo StableNumberIteratorResultValueField { get; set; } = null!;
+    public FieldInfo StableNumberIteratorResultDoneField { get; set; } = null!;
     public MethodBuilder TSFunctionBindThis { get; set; } = null!;
     public MethodBuilder TSFunctionLengthGetter { get; set; } = null!;
     public MethodBuilder TSFunctionNameGetter { get; set; } = null!;

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -296,6 +296,8 @@ public class EmittedRuntime
     public MethodBuilder ArrayReduceDouble { get; set; } = null!;
     public MethodBuilder ArrayReduceRight { get; set; } = null!;
     public MethodBuilder ArrayIncludes { get; set; } = null!;
+    public MethodBuilder ArrayIncludesProto { get; set; } = null!;
+    public MethodBuilder ArrayIncludesDouble { get; set; } = null!;
     public MethodBuilder ArrayIndexOf { get; set; } = null!;
     public MethodBuilder ArrayLastIndexOf { get; set; } = null!;
     public MethodBuilder ArrayJoin { get; set; } = null!;

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -1374,6 +1374,7 @@ public class EmittedRuntime
     public MethodBuilder RegExpSetLastIndex { get; set; } = null!;
     public MethodBuilder StringMatchRegExp { get; set; } = null!;
     public MethodBuilder StringTryInvokeSymbolMethod { get; set; } = null!;
+    public MethodBuilder StableRegExpReplace { get; set; } = null!;
     public MethodBuilder StringReplaceRegExp { get; set; } = null!;
     public MethodBuilder StringReplaceAllRegExp { get; set; } = null!;
     public MethodBuilder StringSearchRegExp { get; set; } = null!;
@@ -1419,6 +1420,7 @@ public class EmittedRuntime
     public MethodBuilder TSRegExpTestMethod { get; set; } = null!;
     public MethodBuilder TSRegExpExecMethod { get; set; } = null!;
     public MethodBuilder TSRegExpToStringMethod { get; set; } = null!;
+    public MethodBuilder TSRegExpReplaceMethod { get; set; } = null!;
     // ECMA-262 (ES2025) RegExp.escape static — emitted standalone on $RegExp.
     public MethodBuilder TSRegExpEscapeMethod { get; set; } = null!;
     public MethodBuilder BuildNamedGroups { get; set; } = null!;

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -249,8 +249,14 @@ public class EmittedRuntime
     public MethodBuilder ArrayPop { get; set; } = null!;
     public MethodBuilder ArrayPopProto { get; set; } = null!;
     public MethodBuilder ArrayShift { get; set; } = null!;
+    public MethodBuilder ArrayShiftDouble { get; set; } = null!;
+    public MethodBuilder ArrayShiftBool { get; set; } = null!;
     public MethodBuilder ArrayShiftProto { get; set; } = null!;
+    public MethodBuilder ArrayShiftNumber { get; set; } = null!;
     public MethodBuilder ArrayUnshift { get; set; } = null!;
+    public MethodBuilder ArrayUnshiftDouble { get; set; } = null!;
+    public MethodBuilder ArrayUnshiftBool { get; set; } = null!;
+    public MethodBuilder ArrayUnshiftNumber { get; set; } = null!;
     public MethodBuilder ArraySlice { get; set; } = null!;
     public MethodBuilder ArraySliceNumber { get; set; } = null!;
     public MethodBuilder ArrayMap { get; set; } = null!;
@@ -1560,6 +1566,9 @@ public class EmittedRuntime
     public MethodBuilder TSArrayEnsureBoxed { get; set; } = null!;
     public MethodBuilder TSArrayIsNumericGetter { get; set; } = null!;
     public MethodBuilder TSArrayNumericCountGetter { get; set; } = null!;
+    public MethodBuilder TSArrayCanMutateNumericGetter { get; set; } = null!;
+    public MethodBuilder TSArrayShiftNumeric { get; set; } = null!;
+    public MethodBuilder TSArrayUnshiftNumeric { get; set; } = null!;
     public MethodBuilder TSArrayCloneNumeric { get; set; } = null!;
     public MethodBuilder TSArraySortNumeric { get; set; } = null!;
     // Flips an empty $Array into numeric (unboxed double[]) mode — emitted at

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -1456,6 +1456,7 @@ public class EmittedRuntime
     public MethodBuilder TSErrorMessageSetter { get; set; } = null!;
     public MethodBuilder TSErrorStackGetter { get; set; } = null!;
     public MethodBuilder TSErrorStackSetter { get; set; } = null!;
+    public MethodBuilder TSErrorCapturedStackSetter { get; set; } = null!;
     public MethodBuilder TSErrorCauseGetter { get; set; } = null!;
     public MethodBuilder TSErrorCauseSetter { get; set; } = null!;
     public MethodBuilder TSErrorHasCauseGetter { get; set; } = null!;
@@ -1463,7 +1464,6 @@ public class EmittedRuntime
     public MethodBuilder TSErrorCodeSetter { get; set; } = null!;
     public MethodBuilder TSErrorSyscallGetter { get; set; } = null!;
     public MethodBuilder TSErrorSyscallSetter { get; set; } = null!;
-    public MethodBuilder TSErrorCaptureStackTrace { get; set; } = null!;
 
     // $TypeError
     public Type TSTypeErrorType { get; set; } = null!;

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -404,6 +404,10 @@ public class EmittedRuntime
     public MethodBuilder StringSubstr { get; set; } = null!;
     public MethodBuilder StringIndexOf { get; set; } = null!;
     public MethodBuilder StringIndexOfFrom { get; set; } = null!;
+    public MethodBuilder StringIndexOfPrimitive { get; set; } = null!;
+    public MethodBuilder StringIncludesPrimitive { get; set; } = null!;
+    public MethodBuilder StringSlicePrimitive { get; set; } = null!;
+    public MethodBuilder StringSubstringPrimitive { get; set; } = null!;
     public MethodBuilder StringToUpperCase { get; set; } = null!;
     public MethodBuilder StringToLowerCase { get; set; } = null!;
     public MethodBuilder StringTrim { get; set; } = null!;

--- a/src/SharpTS/Compilation/Emitters/ArrayEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/ArrayEmitter.cs
@@ -31,6 +31,14 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
                 || ctx.RuntimeFeatures.UsesArrayPrototypeMutation))
             return false;
 
+        // includes may observe holes through inherited indexed properties and
+        // its prototype binding is writable/deletable. Programs that touch
+        // either surface must resolve and invoke the live method value.
+        if (methodName == "includes"
+            && (ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors != false
+                || ctx.RuntimeFeatures.UsesArrayPrototypeMutation))
+            return false;
+
         if (methodName == "slice" && TryEmitNumericSliceCall(emitter, receiver, arguments))
             return true;
         if (methodName == "sort" && TryEmitNumericSortCall(emitter, receiver, arguments))

--- a/src/SharpTS/Compilation/Emitters/ArrayEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/ArrayEmitter.cs
@@ -26,6 +26,11 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         var ctx = emitter.Context;
         var il = ctx.IL;
 
+        if (methodName is "shift" or "unshift"
+            && (ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors != false
+                || ctx.RuntimeFeatures.UsesArrayPrototypeMutation))
+            return false;
+
         if (methodName == "slice" && TryEmitNumericSliceCall(emitter, receiver, arguments))
             return true;
         if (methodName == "sort" && TryEmitNumericSortCall(emitter, receiver, arguments))

--- a/src/SharpTS/Compilation/Emitters/MathStaticEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/MathStaticEmitter.cs
@@ -46,6 +46,18 @@ public sealed class MathStaticEmitter : IStaticTypeEmitterStrategy
         // Handle variadic min/max (JavaScript allows any number of arguments)
         if (methodName is "min" or "max")
         {
+            // A replaced Math binding/property must be obtained and invoked as
+            // an ordinary live property. Returning false leaves that work to
+            // the generic call emitter.
+            if (ctx.RuntimeFeatures?.UsesMathMutation != false)
+                return false;
+
+            if (EmitsUnboxedFixedArityMinMax(emitter, methodName, arguments))
+            {
+                EmitUnboxedFixedArityMinMax(emitter, methodName, arguments);
+                return true;
+            }
+
             // Spread args (\`Math.max(...arr)\`) have a runtime-unknown count, so the
             // inline per-arg loop below can't expand them. Route to the variadic
             // \`object[]\`-taking adapter, feeding a spread-expanded args array — the
@@ -421,6 +433,60 @@ public sealed class MathStaticEmitter : IStaticTypeEmitterStrategy
         return false;
     }
 
+    internal static bool EmitsUnboxedFixedArityMinMax(
+        IEmitterContext emitter, string methodName, IReadOnlyList<Expr> arguments)
+    {
+        if (methodName is not ("min" or "max")
+            || emitter.Context.RuntimeFeatures?.UsesMathMutation != false
+            || arguments.Any(argument => argument is Expr.Spread))
+            return false;
+
+        return arguments.All(argument =>
+            emitter.Context.TypeMap?.Get(argument) is
+                TypeSystem.TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER }
+                or TypeSystem.TypeInfo.NumberLiteral
+                or TypeSystem.TypeInfo.Enum { Kind: TypeSystem.EnumKind.Numeric });
+    }
+
+    private static void EmitUnboxedFixedArityMinMax(
+        IEmitterContext emitter, string methodName, IReadOnlyList<Expr> arguments)
+    {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+        if (arguments.Count == 0)
+        {
+            il.Emit(OpCodes.Ldc_R8,
+                methodName == "min"
+                    ? double.PositiveInfinity
+                    : double.NegativeInfinity);
+            emitter.SetStackType(StackType.Double);
+            return;
+        }
+
+        // Evaluate every argument exactly once and in source order with a
+        // clear evaluation stack. The locals remain native doubles, so this
+        // also handles suspending/effectful numeric expressions without an
+        // object spill or a ToNumber boundary.
+        var values = new LocalBuilder[arguments.Count];
+        for (int i = 0; i < arguments.Count; i++)
+        {
+            values[i] = il.DeclareLocal(ctx.Types.Double);
+            emitter.EmitExpressionAsDouble(arguments[i]);
+            il.Emit(OpCodes.Stloc, values[i]);
+        }
+
+        MethodInfo fold = methodName == "min"
+            ? ctx.Types.GetMethod(ctx.Types.Math, "Min", ctx.Types.Double, ctx.Types.Double)
+            : ctx.Types.GetMethod(ctx.Types.Math, "Max", ctx.Types.Double, ctx.Types.Double);
+        il.Emit(OpCodes.Ldloc, values[0]);
+        for (int i = 1; i < values.Length; i++)
+        {
+            il.Emit(OpCodes.Ldloc, values[i]);
+            il.Emit(OpCodes.Call, fold);
+        }
+        emitter.SetStackType(StackType.Double);
+    }
+
     /// <summary>
     /// Attempts to emit IL for bare access to a Math static member without
     /// a call — data constants (<c>PI</c>, <c>E</c>) and method references
@@ -434,6 +500,11 @@ public sealed class MathStaticEmitter : IStaticTypeEmitterStrategy
     {
         var ctx = emitter.Context;
         var il = ctx.IL;
+
+        // Property replacement also affects value-form reads (`const f =
+        // Math.min`) and numeric constants. Let ordinary live lookup observe it.
+        if (ctx.RuntimeFeatures?.UsesMathMutation == true)
+            return false;
 
         // ECMA-262 21.3.1: numeric constants on the Math object.
         switch (propertyName)

--- a/src/SharpTS/Compilation/Emitters/ObjectStaticEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/ObjectStaticEmitter.cs
@@ -17,6 +17,18 @@ public sealed class ObjectStaticEmitter : IStaticTypeEmitterStrategy
         var ctx = emitter.Context;
         var il = ctx.IL;
 
+        // Closed non-escaping record (#1506): Object.keys(o) needs a fresh mutable result, but it
+        // does not need to box/materialize o or enter GetKeys' descriptor/reflection dispatch. Shape
+        // field order is the proven enumerable string-key order for this restricted record domain.
+        if (methodName == "keys" && arguments is [Expr.Variable receiver]
+            && ctx.TryGetPromotedObjectLocal(receiver.Name.Lexeme) is { } promoted)
+        {
+            il.Emit(OpCodes.Ldsfld, promoted.Shape.KeyMetadataField);
+            il.Emit(OpCodes.Newobj, ctx.Types.GetConstructor(
+                ctx.Types.ListOfObject, ctx.Types.IEnumerableOfObject));
+            return true;
+        }
+
         // Object methods take exactly one argument. The first arg is pushed
         // by the shared prologue below. Object.is is the exception — missing
         // arg1 should default to undefined (not null) so Object.is() returns

--- a/src/SharpTS/Compilation/Emitters/StringEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/StringEmitter.cs
@@ -422,7 +422,9 @@ public sealed class StringEmitter : ITypeEmitterStrategy
                 return false;
 
             emitter.EmitExpression(receiver);
+            emitter.EmitConversionForParameter(receiver, ctx.Types.String);
             emitter.EmitExpression(arguments[0]);
+            emitter.EmitConversionForParameter(arguments[0], ctx.Types.String);
             if (arguments.Count == 2)
                 emitter.EmitExpressionAsDouble(arguments[1]);
             else
@@ -447,6 +449,7 @@ public sealed class StringEmitter : ITypeEmitterStrategy
             return false;
 
         emitter.EmitExpression(receiver);
+        emitter.EmitConversionForParameter(receiver, ctx.Types.String);
         if (arguments.Count > 0)
             emitter.EmitExpressionAsDouble(arguments[0]);
         else

--- a/src/SharpTS/Compilation/Emitters/StringEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/StringEmitter.cs
@@ -71,6 +71,8 @@ public sealed class StringEmitter : ITypeEmitterStrategy
                 return true;
 
             case "replace":
+                if (TryEmitStableRegExpReplace(emitter, receiver, arguments))
+                    return true;
                 EmitReplace(emitter, arguments);
                 return true;
 
@@ -322,6 +324,66 @@ public sealed class StringEmitter : ITypeEmitterStrategy
         // The helper performs @@replace dispatch before deciding whether the
         // original replacement is callable or needs ToString coercion.
         il.Emit(OpCodes.Call, ctx.Runtime!.StringReplaceRegExp);
+    }
+
+    private static bool TryEmitStableRegExpReplace(
+        IEmitterContext emitter, Expr receiver, List<Expr> arguments)
+    {
+        var ctx = emitter.Context;
+        if (ctx.RuntimeFeatures?.UsesRegExpPrototypeMutation != false
+            || arguments.Count != 2
+            || arguments[0] is not Expr.RegexLiteral literal
+            || literal.Flags.IndexOfAny(['u', 'v', 'y']) >= 0
+            || ctx.Runtime?.RegexHoistFields?.ContainsKey(literal) != true
+            || !IsSideEffectFreePrimitiveString(receiver, ctx)
+            || !IsSideEffectFreePrimitiveString(arguments[1], ctx))
+            return false;
+
+        // The ordinary method prologue has already left the unwrapped receiver
+        // string on the stack. Spill it so the instance regex can be loaded
+        // first for the typed helper call.
+        var inputLocal = ctx.IL.DeclareLocal(ctx.Types.String);
+        ctx.IL.Emit(OpCodes.Stloc, inputLocal);
+
+        ctx.IL.Emit(OpCodes.Ldloc, inputLocal);
+        emitter.EmitExpression(literal);
+        emitter.EmitBoxIfNeeded(literal);
+        ctx.IL.Emit(OpCodes.Castclass, ctx.Runtime.TSRegExpType);
+        emitter.EmitExpression(arguments[1]);
+        ctx.IL.Emit(literal.Flags.Contains('g') ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
+        ctx.IL.Emit(OpCodes.Call, ctx.Runtime.StableRegExpReplace);
+        emitter.SetStackType(StackType.String);
+        return true;
+    }
+
+    private static bool IsSideEffectFreePrimitiveString(Expr expression, CompilationContext ctx)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case Expr.Grouping grouping:
+                    expression = grouping.Expression;
+                    continue;
+                case Expr.TypeAssertion assertion:
+                    expression = assertion.Expression;
+                    continue;
+                case Expr.Satisfies satisfies:
+                    expression = satisfies.Expression;
+                    continue;
+                case Expr.NonNullAssertion nonNull:
+                    expression = nonNull.Expression;
+                    continue;
+            }
+
+            break;
+        }
+
+        if (expression is not Expr.Variable and not Expr.Literal { Value: string })
+            return false;
+
+        return ctx.TypeMap?.Get(expression) is TypeSystem.TypeInfo.String
+            or TypeSystem.TypeInfo.StringLiteral;
     }
 
     private static void EmitSplit(IEmitterContext emitter, List<Expr> arguments)

--- a/src/SharpTS/Compilation/Emitters/StringEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/StringEmitter.cs
@@ -17,6 +17,22 @@ public sealed class StringEmitter : ITypeEmitterStrategy
         var ctx = emitter.Context;
         var il = ctx.IL;
 
+        if (methodName is "indexOf" or "includes" or "slice" or "substring")
+        {
+            // A live String prototype/constructor makes the method binding
+            // observable. Resolve it before evaluating arguments, exactly like
+            // an ordinary JavaScript method call.
+            if (ctx.RuntimeFeatures?.UsesStringPrototypeMutation != false)
+            {
+                EmitDynamicMethodCall(emitter, receiver, methodName, arguments);
+                return true;
+            }
+
+            if (TryEmitPrimitiveStringIntrinsic(
+                    emitter, receiver, methodName, arguments))
+                return true;
+        }
+
         // replaceAll performs observable @@replace dispatch before ToString(this).
         // Preserve a boxed String receiver until the runtime helper has offered
         // the custom protocol method the original value.
@@ -384,6 +400,136 @@ public sealed class StringEmitter : ITypeEmitterStrategy
 
         return ctx.TypeMap?.Get(expression) is TypeSystem.TypeInfo.String
             or TypeSystem.TypeInfo.StringLiteral;
+    }
+
+    private static bool TryEmitPrimitiveStringIntrinsic(
+        IEmitterContext emitter,
+        Expr receiver,
+        string methodName,
+        List<Expr> arguments)
+    {
+        var ctx = emitter.Context;
+        if (!IsSideEffectFreePrimitiveString(receiver, ctx))
+            return false;
+
+        bool isSearch = methodName is "indexOf" or "includes";
+        if (isSearch)
+        {
+            if (arguments.Count is < 1 or > 2
+                || !IsSideEffectFreePrimitiveString(arguments[0], ctx)
+                || (arguments.Count == 2
+                    && !IsSideEffectFreePrimitiveNumber(arguments[1], ctx)))
+                return false;
+
+            emitter.EmitExpression(receiver);
+            emitter.EmitExpression(arguments[0]);
+            if (arguments.Count == 2)
+                emitter.EmitExpressionAsDouble(arguments[1]);
+            else
+                ctx.IL.Emit(OpCodes.Ldc_R8, 0.0);
+
+            if (methodName == "indexOf")
+            {
+                ctx.IL.Emit(OpCodes.Call, ctx.Runtime!.StringIndexOfPrimitive);
+                emitter.SetStackType(StackType.Double);
+            }
+            else
+            {
+                ctx.IL.Emit(OpCodes.Call, ctx.Runtime!.StringIncludesPrimitive);
+                emitter.SetStackType(StackType.Boolean);
+            }
+            return true;
+        }
+
+        if (arguments.Count > 2
+            || arguments.Any(argument =>
+                !IsSideEffectFreePrimitiveNumber(argument, ctx)))
+            return false;
+
+        emitter.EmitExpression(receiver);
+        if (arguments.Count > 0)
+            emitter.EmitExpressionAsDouble(arguments[0]);
+        else
+            ctx.IL.Emit(OpCodes.Ldc_R8, 0.0);
+        if (arguments.Count > 1)
+            emitter.EmitExpressionAsDouble(arguments[1]);
+        else
+            ctx.IL.Emit(OpCodes.Ldc_R8, 0.0);
+        ctx.IL.Emit(arguments.Count > 1 ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
+        ctx.IL.Emit(
+            OpCodes.Call,
+            methodName == "slice"
+                ? ctx.Runtime!.StringSlicePrimitive
+                : ctx.Runtime!.StringSubstringPrimitive);
+        emitter.SetStackType(StackType.String);
+        return true;
+    }
+
+    private static bool IsSideEffectFreePrimitiveNumber(
+        Expr expression, CompilationContext ctx)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case Expr.Grouping grouping:
+                    expression = grouping.Expression;
+                    continue;
+                case Expr.TypeAssertion assertion:
+                    expression = assertion.Expression;
+                    continue;
+                case Expr.Satisfies satisfies:
+                    expression = satisfies.Expression;
+                    continue;
+                case Expr.NonNullAssertion nonNull:
+                    expression = nonNull.Expression;
+                    continue;
+            }
+
+            break;
+        }
+
+        bool sideEffectFree = expression is Expr.Variable
+            or Expr.Literal { Value: double }
+            || expression is Expr.Unary unary
+                && IsSideEffectFreePrimitiveNumber(unary.Right, ctx);
+        return sideEffectFree
+            && ctx.TypeMap?.Get(expression) is TypeSystem.TypeInfo.Primitive
+                { Type: TokenType.TYPE_NUMBER }
+                or TypeSystem.TypeInfo.NumberLiteral;
+    }
+
+    private static void EmitDynamicMethodCall(
+        IEmitterContext emitter,
+        Expr receiver,
+        string methodName,
+        List<Expr> arguments)
+    {
+        var ctx = emitter.Context;
+        var il = ctx.IL;
+
+        emitter.EmitExpression(receiver);
+        emitter.EmitBoxIfNeeded(receiver);
+        var receiverLocal = emitter.SpillStackToObjectLocal();
+
+        // GetValue precedes ArgumentListEvaluation for a method call.
+        il.Emit(OpCodes.Ldloc, receiverLocal);
+        il.Emit(OpCodes.Ldstr, methodName);
+        il.Emit(OpCodes.Call, ctx.Runtime!.GetProperty);
+        var functionLocal = emitter.SpillStackToObjectLocal();
+
+        if (arguments.Any(argument => argument is Expr.Spread))
+            emitter.EmitArgsArrayWithSpread(arguments);
+        else
+            emitter.EmitArgsArray(arguments);
+        var argumentsLocal = emitter.SpillStackToObjectLocal();
+
+        il.Emit(OpCodes.Ldloc, receiverLocal);
+        il.Emit(OpCodes.Ldloc, functionLocal);
+        il.Emit(OpCodes.Ldloc, argumentsLocal);
+        il.Emit(OpCodes.Castclass, ctx.Types.ObjectArray);
+        il.Emit(OpCodes.Call, ctx.Runtime.InvokeMethodValue);
+        emitter.SetStackUnknown();
     }
 
     private static void EmitSplit(IEmitterContext emitter, List<Expr> arguments)

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -1574,6 +1574,14 @@ public abstract partial class ExpressionEmitterBase
 
         // Type-first dispatch via TypeEmitterRegistry
         var objType = Ctx.TypeMap?.Get(methodGet.Object);
+        if (objType is TypeSystem.TypeInfo.Array
+            && methodName == "includes"
+            && (Ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors != false
+                || Ctx.RuntimeFeatures.UsesArrayPrototypeMutation))
+        {
+            EmitDynamicMethodCallPreservingThis(methodGet.Object, methodName, c.Arguments);
+            return true;
+        }
         if (objType != null && Ctx.TypeEmitterRegistry != null)
         {
             var strategy = Ctx.TypeEmitterRegistry.GetStrategy(objType);

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.Constructors.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.Constructors.cs
@@ -816,6 +816,13 @@ public abstract partial class ExpressionEmitterBase
             IL.Emit(OpCodes.Stelem_Ref);
         }
         IL.Emit(OpCodes.Call, Ctx.Runtime!.CreateError);
+        var createdError = IL.DeclareLocal(Ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, createdError);
+        IL.Emit(OpCodes.Ldloc, createdError);
+        IL.Emit(OpCodes.Castclass, Ctx.Runtime.TSErrorType);
+        IL.Emit(OpCodes.Ldstr, Ctx.CurrentMethod?.Name ?? "Main");
+        IL.Emit(OpCodes.Callvirt, Ctx.Runtime.TSErrorCapturedStackSetter);
+        IL.Emit(OpCodes.Ldloc, createdError);
         SetStackUnknown();
     }
 

--- a/src/SharpTS/Compilation/ILCompiler.ArrowFunctions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.ArrowFunctions.cs
@@ -230,6 +230,11 @@ public partial class ILCompiler
                     }
                 }
             }
+            if (_typeMap?.TryGetStableCustomIteratorNext(arrow, out var stableIterator) == true &&
+                _runtime.StableNumberIteratorResultType is { } iteratorResultType)
+            {
+                returnType = iteratorResultType;
+            }
             _closures.ArrowReturnTypes[arrow] = returnType;
 
             // For object methods, add __this as the first parameter

--- a/src/SharpTS/Compilation/ILCompiler.Functions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Functions.cs
@@ -388,7 +388,7 @@ public partial class ILCompiler
             capturedLocals = renameAware;
         }
 
-        RegisterFunctionDisplayClass(qualifiedFunctionName, capturedLocals);
+        RegisterFunctionDisplayClass(qualifiedFunctionName, capturedLocals, funcStmt);
     }
 
     /// <summary>
@@ -398,7 +398,10 @@ public partial class ILCompiler
     /// async-method / standalone-arrow path (only the promoted async-written captures, #682). The caller
     /// decides membership; this only builds the type.
     /// </summary>
-    private void RegisterFunctionDisplayClass(string qualifiedFunctionName, IEnumerable<string> capturedLocals)
+    private void RegisterFunctionDisplayClass(
+        string qualifiedFunctionName,
+        IEnumerable<string> capturedLocals,
+        object? callable = null)
     {
         // Create display class type. The counter guarantees a unique type name; '.' and ':' in the key
         // (async-method keys are "<Class>::<method>") are sanitized to valid identifier characters.
@@ -412,7 +415,11 @@ public partial class ILCompiler
         var fieldMap = new Dictionary<string, FieldBuilder>();
         foreach (var varName in capturedLocals)
         {
-            var field = displayClass.DefineField(varName, _types.Object, FieldAttributes.Public);
+            Type fieldType = callable is not null &&
+                _typeMap?.IsStableNumericFunctionCaptureField(callable, varName) == true
+                ? _types.Double
+                : _types.Object;
+            var field = displayClass.DefineField(varName, fieldType, FieldAttributes.Public);
             fieldMap[varName] = field;
         }
 
@@ -589,9 +596,15 @@ public partial class ILCompiler
                 {
                     il.Emit(OpCodes.Ldloc, displayLocal);
                     il.Emit(OpCodes.Ldarg, i);
-                    // Box if the parameter is a value type (numbers are double)
+                    // Box value-type parameters only for the general object ABI.
                     Type paramType = i < methodParams.Length ? methodParams[i].ParameterType : typeof(object);
-                    if (paramType.IsValueType)
+                    if (field.FieldType == _types.Double && paramType != _types.Double)
+                    {
+                        if (paramType.IsValueType)
+                            il.Emit(OpCodes.Box, paramType);
+                        il.Emit(OpCodes.Call, _runtime!.ConvertToNumber);
+                    }
+                    else if (field.FieldType == _types.Object && paramType.IsValueType)
                     {
                         il.Emit(OpCodes.Box, paramType);
                     }

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -668,7 +668,7 @@ public partial class ILCompiler
         _classes.CompactStorageClasses.UnionWith(
             CompactClassStorageAnalyzer.Analyze(statements, _typeMap, _features));
         TypedArrayHoistAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
-        ArrayLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
+        ArrayLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer, _features);
         StringAccumulatorPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         ObjectLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
     }

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -646,6 +646,9 @@ public partial class ILCompiler
         statements = NestedFunctionLifter.Lift(statements, _entryPointDebugScope?.Spans);
         _lexicalBindingNames = LexicalBindingNameCollector.Collect(statements);
         _features ??= new RuntimeFeatureDetector().Detect(statements, _typeMap);
+        // The stable iterator result shape must be known before Phase 1 emits its
+        // result carrier. Closure-based eligibility is rechecked later.
+        StableCustomIteratorAnalyzer.Analyze(statements, _typeMap, null, _features);
         return statements;
     }
 
@@ -653,6 +656,8 @@ public partial class ILCompiler
     {
         Phase2_AnalyzeClosures(statements);
         StableMapIterationAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
+        StableCustomIteratorAnalyzer.Analyze(
+            statements, _typeMap, _closures.Analyzer, _features);
         NumericMapLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         StablePrimitivePromiseThenAnalyzer.Analyze(
             statements, _typeMap, _closures.Analyzer);
@@ -1324,6 +1329,12 @@ public partial class ILCompiler
             if (modules.Any(module => module.IsCommonJs))
                 _features.UsesCjsRequire = true;
         }
+
+        // As in the single-file path, discover the result ABI before Phase 1
+        // emits runtime types; closure-based eligibility is rechecked after the
+        // combined module closure analysis.
+        StableCustomIteratorAnalyzer.Analyze(
+            allStatements, _typeMap, null, _features);
 
         return allStatements;
     }

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -1014,11 +1014,28 @@ public partial class ILCompiler
                 fieldBuilders[name] = structType.DefineField(name, clr, FieldAttributes.Public);
             }
 
+            var keyMetadataField = structType.DefineField(
+                "$Keys", _types.ObjectArray,
+                FieldAttributes.Assembly | FieldAttributes.Static | FieldAttributes.InitOnly);
+            var shapeInitializer = structType.DefineTypeInitializer().GetILGenerator();
+            shapeInitializer.Emit(OpCodes.Ldc_I4, shape.Fields.Count);
+            shapeInitializer.Emit(OpCodes.Newarr, _types.Object);
+            for (int index = 0; index < shape.Fields.Count; index++)
+            {
+                shapeInitializer.Emit(OpCodes.Dup);
+                shapeInitializer.Emit(OpCodes.Ldc_I4, index);
+                shapeInitializer.Emit(OpCodes.Ldstr, shape.Fields[index].Name);
+                shapeInitializer.Emit(OpCodes.Stelem_Ref);
+            }
+            shapeInitializer.Emit(OpCodes.Stsfld, keyMetadataField);
+            shapeInitializer.Emit(OpCodes.Ret);
+
             var info = new ObjectShapeTypeInfo
             {
                 ClrType = structType,
                 Fields = shape.Fields.Select(f => (f.Name, f.Kind)).ToList(),
                 FieldBuilders = fieldBuilders,
+                KeyMetadataField = keyMetadataField,
             };
             _closures.ObjectShapes.ByKey[shape.CanonicalKey] = info;
             _closures.ObjectShapes.ByClrType[structType] = info;

--- a/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -102,6 +102,29 @@ public partial class ILEmitter
         if (TryEmitStableNumberConversionCall(methodGet, arguments))
             return;
 
+        // Proven dense numeric includes: ArrayLocalPromotionAnalyzer admits this
+        // call only while the receiver remains a non-escaping List<double> and the
+        // intrinsic Array.prototype binding is globally stable. Both arguments are
+        // native doubles and the helper returns native bool, so the million-element
+        // scan has no per-element or result boxing.
+        if (methodName == "includes" && !methodGet.Optional
+            && methodGet.Object is Expr.Variable includesVariable
+            && _ctx.TryGetPromotedArrayLocal(includesVariable.Name.Lexeme) is
+                { Descriptor.Kind: ArrayElementsKind.Double } includesPromotion
+            && arguments.Count is 1 or 2
+            && arguments.All(argument => IsNumericType(_ctx.TypeMap?.Get(argument))))
+        {
+            IL.Emit(OpCodes.Ldloc, includesPromotion.Local);
+            EmitExpressionAsDouble(arguments[0]);
+            if (arguments.Count == 2)
+                EmitExpressionAsDouble(arguments[1]);
+            else
+                IL.Emit(OpCodes.Ldc_R8, 0.0);
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.ArrayIncludesDouble);
+            SetStackType(StackType.Boolean);
+            return;
+        }
+
         // Promoted typed-array local push (#857/#860): append unboxed elements directly to the
         // bare List<T> via the typed helper — bypassing ArrayEmitter's $Array unwrap/copy and the
         // per-element boxing. Handled here (not in ArrayEmitter) because EnsureDouble/EnsureBoolean
@@ -296,7 +319,7 @@ public partial class ILEmitter
         }
 
         if (objType is TypeSystem.TypeInfo.Array
-            && methodName is ("shift" or "unshift")
+            && methodName is ("shift" or "unshift" or "includes")
             && (_ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors != false
                 || _ctx.RuntimeFeatures.UsesArrayPrototypeMutation))
         {

--- a/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -113,6 +113,22 @@ public partial class ILEmitter
             return;
         }
 
+        if (methodName == "shift" && !methodGet.Optional && arguments.Count == 0
+            && methodGet.Object is Expr.Variable shiftVar
+            && _ctx.TryGetPromotedArrayLocal(shiftVar.Name.Lexeme) is { } shiftProm)
+        {
+            EmitPromotedArrayShift(shiftProm.Local, shiftProm.Descriptor);
+            return;
+        }
+
+        if (methodName == "unshift" && !methodGet.Optional
+            && methodGet.Object is Expr.Variable unshiftVar
+            && _ctx.TryGetPromotedArrayLocal(unshiftVar.Name.Lexeme) is { } unshiftProm)
+        {
+            EmitPromotedArrayUnshift(unshiftProm.Local, unshiftProm.Descriptor, arguments);
+            return;
+        }
+
         // Escaping number[] push (number[] unboxing): the receiver is a statically `number[]`
         // expression that is NOT a promoted local — so its runtime value is a $Array (numeric or boxed,
         // never List<double>: the promoted-local branch above + the escape analyzer guarantee that).
@@ -130,6 +146,49 @@ public partial class ILEmitter
             && arguments.All(a => IsNumericType(_ctx.TypeMap?.Get(a))))
         {
             EmitEscapingNumberArrayPush(methodGet.Object, arguments);
+            return;
+        }
+
+        // Escaping number[] receivers retain their packed-double $Array storage.
+        // Whole-program feature gates prove the direct intrinsic is unmodified;
+        // the emitted helper repeats exact-type/numeric-mode guards and falls back
+        // for holes, boxed arrays, subclasses, and non-extensible receivers.
+        if (methodName == "shift" && !methodGet.Optional && arguments.Count == 0
+            && _ctx.TypeMap?.Get(methodGet.Object) is TypeSystem.TypeInfo.Array
+            && ArrayElements.Resolve(_ctx.TypeMap.Get(methodGet.Object)) is
+                { Kind: ArrayElementsKind.Double }
+            && _ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == false
+            && !_ctx.RuntimeFeatures.UsesArrayPrototypeMutation)
+        {
+            EmitExpression(methodGet.Object);
+            EmitBoxIfNeeded(methodGet.Object);
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.ArrayShiftNumber);
+            SetStackUnknown();
+            return;
+        }
+
+        if (methodName == "unshift" && !methodGet.Optional
+            && _ctx.TypeMap?.Get(methodGet.Object) is TypeSystem.TypeInfo.Array
+            && ArrayElements.Resolve(_ctx.TypeMap.Get(methodGet.Object)) is
+                { Kind: ArrayElementsKind.Double }
+            && arguments.All(argument => argument is not Expr.Spread
+                && IsNumericType(_ctx.TypeMap.Get(argument)))
+            && _ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == false
+            && !_ctx.RuntimeFeatures.UsesArrayPrototypeMutation)
+        {
+            EmitExpression(methodGet.Object);
+            EmitBoxIfNeeded(methodGet.Object);
+            IL.Emit(OpCodes.Ldc_I4, arguments.Count);
+            IL.Emit(OpCodes.Newarr, _ctx.Types.Double);
+            for (int i = 0; i < arguments.Count; i++)
+            {
+                IL.Emit(OpCodes.Dup);
+                IL.Emit(OpCodes.Ldc_I4, i);
+                EmitExpressionAsDouble(arguments[i]);
+                IL.Emit(OpCodes.Stelem_R8);
+            }
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.ArrayUnshiftNumber);
+            SetStackType(StackType.Double);
             return;
         }
 
@@ -234,6 +293,15 @@ public partial class ILEmitter
                 EmitPromiseInstanceMethodCall(methodGet, methodName, arguments);
                 return;
             }
+        }
+
+        if (objType is TypeSystem.TypeInfo.Array
+            && methodName is ("shift" or "unshift")
+            && (_ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors != false
+                || _ctx.RuntimeFeatures.UsesArrayPrototypeMutation))
+        {
+            EmitDynamicMethodCallPreservingThis(methodGet.Object, methodName, arguments);
+            return;
         }
 
         // Type-first dispatch: Use TypeEmitterRegistry if we have type information

--- a/src/SharpTS/Compilation/ILEmitter.Destructuring.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Destructuring.cs
@@ -1,0 +1,275 @@
+using System.Reflection.Emit;
+using SharpTS.Compilation.Emitters;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Stable destructuring-source caches. The parser marks only the synthetic source
+/// temporary, allowing positional/property binding reads to reuse one guarded typed
+/// receiver and to keep numeric values native through their consuming local.
+/// </summary>
+public partial class ILEmitter
+{
+    private sealed record StableArrayDestructureBinding(
+        LocalBuilder ObjectLocal,
+        LocalBuilder ArrayLocal);
+
+    private sealed record StableRecordDestructureBinding(
+        LocalBuilder ObjectLocal,
+        LocalBuilder TypedLocal,
+        string Fingerprint,
+        JsonSerializationShape.Record Shape,
+        bool IsExact);
+
+    private readonly Dictionary<string, StableArrayDestructureBinding>
+        _stableArrayDestructureBindings = [];
+    private readonly Dictionary<string, StableRecordDestructureBinding>
+        _stableRecordDestructureBindings = [];
+
+    private void RegisterStableDestructuringSource(Stmt.Var declaration, LocalBuilder objectLocal)
+    {
+        if (objectLocal.LocalType != _ctx.Types.Object || declaration.Initializer is null)
+            return;
+
+        switch (declaration.DestructuringSource)
+        {
+            case DestructuringSourceKind.Array:
+                RegisterStableArrayDestructuringSource(declaration, objectLocal);
+                break;
+            case DestructuringSourceKind.Object:
+                RegisterStableRecordDestructuringSource(declaration, objectLocal);
+                break;
+        }
+    }
+
+    private void RegisterStableArrayDestructuringSource(
+        Stmt.Var declaration, LocalBuilder objectLocal)
+    {
+        if (_ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == true ||
+            _ctx.RuntimeFeatures?.UsesArrayPrototypeMutation == true ||
+            declaration.Initializer is not Expr.Call
+            {
+                Callee: Expr.Variable { Name.Lexeme: "__arrayDestructure" },
+                Arguments.Count: 1
+            } call ||
+            _ctx.TypeMap?.Get(call.Arguments[0]) is not (TypeInfo.Array or TypeInfo.Tuple))
+            return;
+
+        var arrayLocal = IL.DeclareLocal(_ctx.Runtime!.TSArrayType);
+        IL.Emit(OpCodes.Ldloc, objectLocal);
+        IL.Emit(OpCodes.Isinst, _ctx.Runtime.TSArrayType);
+        IL.Emit(OpCodes.Stloc, arrayLocal);
+        _stableArrayDestructureBindings[declaration.Name.Lexeme] =
+            new StableArrayDestructureBinding(objectLocal, arrayLocal);
+    }
+
+    private void RegisterStableRecordDestructuringSource(
+        Stmt.Var declaration, LocalBuilder objectLocal)
+    {
+        if (_ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == true ||
+            _ctx.RuntimeFeatures is not { } features ||
+            _ctx.TypeMap?.Get(declaration.Initializer!) is not { } sourceType ||
+            !ILCompiler.TryGetCompactRecordShape(sourceType, out var shape))
+            return;
+
+        string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(shape);
+        if (!features.CanAssumeCompactObjectRecordIsUnmaterialized(fingerprint) ||
+            !_ctx.Runtime!.CompactObjectRecordTypes.TryGetValue(fingerprint, out var carrierType))
+            return;
+
+        LocalBuilder typedLocal;
+        bool isExact = false;
+        if (declaration.Initializer is Expr.Variable sourceVariable &&
+            _ctx.HoistedCompactRecordParameters.TryGetValue(
+                sourceVariable.Name.Lexeme, out var hoisted) &&
+            hoisted.Fingerprint == fingerprint)
+        {
+            typedLocal = hoisted.TypedLocal;
+            isExact = hoisted.IsExact;
+        }
+        else
+        {
+            typedLocal = IL.DeclareLocal(carrierType);
+            IL.Emit(OpCodes.Ldloc, objectLocal);
+            IL.Emit(OpCodes.Isinst, carrierType);
+            IL.Emit(OpCodes.Stloc, typedLocal);
+        }
+
+        _stableRecordDestructureBindings[declaration.Name.Lexeme] =
+            new StableRecordDestructureBinding(
+                objectLocal, typedLocal, fingerprint, shape, isExact);
+    }
+
+    private bool TryEmitStableArrayDestructureGet(Expr.GetIndex expression)
+    {
+        if (expression.Optional ||
+            expression.Object is not Expr.Variable source ||
+            expression.Index is not Expr.Literal { Value: double index } ||
+            index < 0 || index != Math.Truncate(index) ||
+            !_stableArrayDestructureBindings.TryGetValue(
+                source.Name.Lexeme, out var binding))
+            return false;
+
+        var fallback = IL.DefineLabel();
+        var end = IL.DefineLabel();
+        IL.Emit(OpCodes.Ldloc, binding.ArrayLocal);
+        IL.Emit(OpCodes.Brfalse, fallback);
+        IL.Emit(OpCodes.Ldloc, binding.ArrayLocal);
+        IL.Emit(OpCodes.Ldc_I8, checked((long)index));
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArrayGetLong);
+        IL.Emit(OpCodes.Br, end);
+
+        IL.MarkLabel(fallback);
+        IL.Emit(OpCodes.Ldloc, binding.ObjectLocal);
+        EmitDoubleConstant(index);
+        IL.Emit(OpCodes.Box, _ctx.Types.Double);
+        IL.Emit(OpCodes.Call, _ctx.Runtime.GetIndex);
+        IL.MarkLabel(end);
+        SetStackUnknown();
+        return true;
+    }
+
+    private bool TryEmitStableArrayDestructureGetAsDouble(Expr.GetIndex expression)
+    {
+        if (expression.Optional ||
+            expression.Object is not Expr.Variable source ||
+            expression.Index is not Expr.Literal { Value: double index } ||
+            index < 0 || index != Math.Truncate(index) || index > int.MaxValue ||
+            !_stableArrayDestructureBindings.TryGetValue(
+                source.Name.Lexeme, out var binding))
+            return false;
+
+        int intIndex = (int)index;
+        var genericReceiver = IL.DefineLabel();
+        var boxedArrayValue = IL.DefineLabel();
+        var end = IL.DefineLabel();
+        var result = IL.DeclareLocal(_ctx.Types.Double);
+
+        IL.Emit(OpCodes.Ldloc, binding.ArrayLocal);
+        IL.Emit(OpCodes.Brfalse, genericReceiver);
+        IL.Emit(OpCodes.Ldloc, binding.ArrayLocal);
+        IL.Emit(OpCodes.Ldc_I4, intIndex);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArrayCanGetDouble);
+        IL.Emit(OpCodes.Brfalse, boxedArrayValue);
+        IL.Emit(OpCodes.Ldloc, binding.ArrayLocal);
+        IL.Emit(OpCodes.Ldc_I4, intIndex);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime.TSArrayGetDouble);
+        IL.Emit(OpCodes.Stloc, result);
+        IL.Emit(OpCodes.Br, end);
+
+        // Holes and non-numeric backing modes still avoid boxing the literal key.
+        IL.MarkLabel(boxedArrayValue);
+        IL.Emit(OpCodes.Ldloc, binding.ArrayLocal);
+        IL.Emit(OpCodes.Ldc_I8, (long)intIndex);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime.TSArrayGetLong);
+        IL.Emit(OpCodes.Call, _ctx.Runtime.ConvertToNumber);
+        IL.Emit(OpCodes.Stloc, result);
+        IL.Emit(OpCodes.Br, end);
+
+        IL.MarkLabel(genericReceiver);
+        IL.Emit(OpCodes.Ldloc, binding.ObjectLocal);
+        EmitDoubleConstant(index);
+        IL.Emit(OpCodes.Box, _ctx.Types.Double);
+        IL.Emit(OpCodes.Call, _ctx.Runtime.GetIndex);
+        IL.Emit(OpCodes.Call, _ctx.Runtime.ConvertToNumber);
+        IL.Emit(OpCodes.Stloc, result);
+
+        IL.MarkLabel(end);
+        IL.Emit(OpCodes.Ldloc, result);
+        SetStackType(StackType.Double);
+        return true;
+    }
+
+    private bool TryEmitStableRecordDestructureGet(Expr.Get expression)
+    {
+        if (expression.Optional ||
+            expression.Object is not Expr.Variable source ||
+            !_stableRecordDestructureBindings.TryGetValue(
+                source.Name.Lexeme, out var binding) ||
+            !TryGetStableRecordField(binding, expression.Name.Lexeme, out var field))
+            return false;
+
+        if (binding.IsExact)
+        {
+            IL.Emit(OpCodes.Ldloc, binding.TypedLocal);
+            IL.Emit(OpCodes.Ldfld, field);
+            SetStackTypeForFieldType(field.FieldType);
+            return true;
+        }
+
+        var fallback = IL.DefineLabel();
+        var end = IL.DefineLabel();
+        IL.Emit(OpCodes.Ldloc, binding.TypedLocal);
+        IL.Emit(OpCodes.Brfalse, fallback);
+        IL.Emit(OpCodes.Ldloc, binding.TypedLocal);
+        IL.Emit(OpCodes.Ldfld, field);
+        if (field.FieldType.IsValueType)
+            IL.Emit(OpCodes.Box, field.FieldType);
+        IL.Emit(OpCodes.Br, end);
+        IL.MarkLabel(fallback);
+        IL.Emit(OpCodes.Ldloc, binding.ObjectLocal);
+        IL.Emit(OpCodes.Ldstr, expression.Name.Lexeme);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.GetProperty);
+        IL.MarkLabel(end);
+        SetStackUnknown();
+        return true;
+    }
+
+    private bool TryEmitStableRecordDestructureGetAsDouble(Expr.Get expression)
+    {
+        if (expression.Optional ||
+            expression.Object is not Expr.Variable source ||
+            !_stableRecordDestructureBindings.TryGetValue(
+                source.Name.Lexeme, out var binding) ||
+            !TryGetStableRecordField(binding, expression.Name.Lexeme, out var field) ||
+            field.FieldType != _ctx.Types.Double)
+            return false;
+
+        if (binding.IsExact)
+        {
+            IL.Emit(OpCodes.Ldloc, binding.TypedLocal);
+            IL.Emit(OpCodes.Ldfld, field);
+            SetStackType(StackType.Double);
+            return true;
+        }
+
+        var fallback = IL.DefineLabel();
+        var end = IL.DefineLabel();
+        var result = IL.DeclareLocal(_ctx.Types.Double);
+        IL.Emit(OpCodes.Ldloc, binding.TypedLocal);
+        IL.Emit(OpCodes.Brfalse, fallback);
+        IL.Emit(OpCodes.Ldloc, binding.TypedLocal);
+        IL.Emit(OpCodes.Ldfld, field);
+        IL.Emit(OpCodes.Stloc, result);
+        IL.Emit(OpCodes.Br, end);
+        IL.MarkLabel(fallback);
+        IL.Emit(OpCodes.Ldloc, binding.ObjectLocal);
+        IL.Emit(OpCodes.Ldstr, expression.Name.Lexeme);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.GetProperty);
+        IL.Emit(OpCodes.Call, _ctx.Runtime.ConvertToNumber);
+        IL.Emit(OpCodes.Stloc, result);
+        IL.MarkLabel(end);
+        IL.Emit(OpCodes.Ldloc, result);
+        SetStackType(StackType.Double);
+        return true;
+    }
+
+    private bool TryGetStableRecordField(
+        StableRecordDestructureBinding binding,
+        string property,
+        out FieldBuilder field)
+    {
+        for (int index = 0; index < binding.Shape.Fields.Count; index++)
+        {
+            if (binding.Shape.Fields[index].Key != property)
+                continue;
+            return _ctx.Runtime!.CompactObjectRecordValueFields.TryGetValue(
+                (binding.Fingerprint, index), out field!);
+        }
+
+        field = null!;
+        return false;
+    }
+}

--- a/src/SharpTS/Compilation/ILEmitter.Expressions.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Expressions.cs
@@ -415,13 +415,19 @@ public partial class ILEmitter
             return;
         }
 
-        // Direct numeric locals already coerce their RHS to double below. Ask the
+        var assignmentDCName = _ctx.ResolveFunctionDCFieldName(a.Name.Lexeme);
+        FieldBuilder? assignmentDCField = null;
+        if (_ctx.CapturedFunctionLocals?.Contains(assignmentDCName) == true)
+            _ctx.FunctionDisplayClassFields?.TryGetValue(assignmentDCName, out assignmentDCField);
+
+        // Direct numeric locals and proven numeric function-capture slots coerce
+        // their RHS to double up front, avoiding a box/unbox round trip.
         // expression emitter for that representation up front for number[] reads,
         // allowing the guarded GetDouble arm to avoid a box/unbox round trip.
         var assignmentLocal = _ctx.Locals.GetLocal(a.Name.Lexeme);
-        if (a.Value is Expr.GetIndex
-            && assignmentLocal != null
-            && _ctx.Types.IsDouble(assignmentLocal.LocalType))
+        if ((assignmentDCField?.FieldType == _ctx.Types.Double) ||
+            (a.Value is Expr.GetIndex && assignmentLocal != null &&
+             _ctx.Types.IsDouble(assignmentLocal.LocalType)))
         {
             EmitExpressionAsDouble(a.Value);
         }
@@ -462,10 +468,41 @@ public partial class ILEmitter
         // 1. Function display class fields (captured function-local vars)
         // Check this BEFORE regular locals to ensure we use the shared storage.
         // #838: remap a write-captured block-scope shadow to its renamed DC storage key in an arrow body.
-        var assignDCName = _ctx.ResolveFunctionDCFieldName(a.Name.Lexeme);
-        if (_ctx.CapturedFunctionLocals?.Contains(assignDCName) == true &&
-            _ctx.FunctionDisplayClassFields?.TryGetValue(assignDCName, out var funcDCField) == true)
+        if (assignmentDCField is { } funcDCField)
         {
+            if (funcDCField.FieldType == _ctx.Types.Double)
+            {
+                EnsureDouble();
+                IL.Emit(OpCodes.Dup);
+                var numericTemp = IL.DeclareLocal(_ctx.Types.Double);
+                IL.Emit(OpCodes.Stloc, numericTemp);
+                if (_ctx.FunctionDisplayClassLocal != null)
+                {
+                    IL.Emit(OpCodes.Ldloc, _ctx.FunctionDisplayClassLocal);
+                }
+                else if (_ctx.CurrentArrowFunctionDCField != null)
+                {
+                    IL.Emit(OpCodes.Ldarg_0);
+                    IL.Emit(OpCodes.Ldfld, _ctx.CurrentArrowFunctionDCField);
+                }
+                else
+                {
+                    IL.Emit(OpCodes.Pop);
+                    SetStackType(StackType.Double);
+                    return;
+                }
+                IL.Emit(OpCodes.Ldloc, numericTemp);
+                IL.Emit(OpCodes.Stfld, funcDCField);
+                if (_ctx.FunctionDisplayClassLocal != null &&
+                    _ctx.TryGetParameter(a.Name.Lexeme, out var numericParamSync))
+                {
+                    IL.Emit(OpCodes.Ldloc, numericTemp);
+                    IL.Emit(OpCodes.Starg, numericParamSync);
+                }
+                SetStackType(StackType.Double);
+                return;
+            }
+
             EmitBoxIfNeeded(a.Value);
             IL.Emit(OpCodes.Dup);
             // Store to field: need temp since value is on top of stack

--- a/src/SharpTS/Compilation/ILEmitter.Helpers.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Helpers.cs
@@ -322,6 +322,14 @@ public partial class ILEmitter
 
     public override void EmitExpressionAsDouble(Expr expr)
     {
+        if (expr is Expr.Get stableRecordGet
+            && TryEmitStableRecordDestructureGetAsDouble(stableRecordGet))
+            return;
+
+        if (expr is Expr.GetIndex stableArrayGet
+            && TryEmitStableArrayDestructureGetAsDouble(stableArrayGet))
+            return;
+
         if (expr is Expr.GetIndex flattenedRestIndex
             && TryEmitFlattenedNumericRestIndex(flattenedRestIndex))
             return;

--- a/src/SharpTS/Compilation/ILEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Operators.cs
@@ -1819,9 +1819,9 @@ public partial class ILEmitter
         if (_ctx.CapturedFunctionLocals?.Contains(incDCName) == true &&
             _ctx.FunctionDisplayClassFields?.TryGetValue(incDCName, out var funcDCField) == true)
         {
-            // Store to function display class field (always boxed).
-            if (isTypedDouble) IL.Emit(OpCodes.Box, _ctx.Types.Double);
-            var temp = IL.DeclareLocal(_ctx.Types.Object);
+            bool numericField = funcDCField.FieldType == _ctx.Types.Double;
+            if (isTypedDouble && !numericField) IL.Emit(OpCodes.Box, _ctx.Types.Double);
+            var temp = IL.DeclareLocal(funcDCField.FieldType);
             IL.Emit(OpCodes.Stloc, temp);
             if (_ctx.FunctionDisplayClassLocal != null)
             {
@@ -1843,8 +1843,11 @@ public partial class ILEmitter
                 _ctx.EmitConvertForParamSlot(IL, name);
                 IL.Emit(OpCodes.Starg, funcParamSync);
             }
-            if (resultIsUnboxedDouble) IL.Emit(OpCodes.Box, _ctx.Types.Double);
-            SetStackUnknown();
+            if (resultIsUnboxedDouble && !numericField) IL.Emit(OpCodes.Box, _ctx.Types.Double);
+            if (numericField)
+                SetStackType(StackType.Double);
+            else
+                SetStackUnknown();
             return;
         }
 
@@ -2002,6 +2005,10 @@ public partial class ILEmitter
             // Check if this is a typed double local
             var localType = _ctx.Locals.GetLocalType(v.Name.Lexeme);
             bool isTypedDouble = localType != null && _ctx.Types.IsDouble(localType);
+            string prefixDCName = _ctx.ResolveFunctionDCFieldName(v.Name.Lexeme);
+            if (!isTypedDouble &&
+                _ctx.FunctionDisplayClassFields?.TryGetValue(prefixDCName, out var prefixDCField) == true)
+                isTypedDouble = prefixDCField.FieldType == _ctx.Types.Double;
 
             if (!isTypedDouble)
             {
@@ -2198,6 +2205,10 @@ public partial class ILEmitter
             // Check if this is a typed double local
             var localType = _ctx.Locals.GetLocalType(v.Name.Lexeme);
             bool isTypedDouble = localType != null && _ctx.Types.IsDouble(localType);
+            string postfixDCName = _ctx.ResolveFunctionDCFieldName(v.Name.Lexeme);
+            if (!isTypedDouble &&
+                _ctx.FunctionDisplayClassFields?.TryGetValue(postfixDCName, out var postfixDCField) == true)
+                isTypedDouble = postfixDCField.FieldType == _ctx.Types.Double;
 
             if (!isTypedDouble)
             {
@@ -3056,7 +3067,17 @@ public partial class ILEmitter
         var leftType = _ctx.TypeMap.Get(b.Left);
         var rightType = _ctx.TypeMap.Get(b.Right);
 
-        return IsNumericType(leftType) && IsNumericType(rightType);
+        return IsNumericOperand(b.Left, leftType) && IsNumericOperand(b.Right, rightType);
+    }
+
+    private bool IsNumericOperand(Expr expression, TypeSystem.TypeInfo? type)
+    {
+        if (IsNumericType(type))
+            return true;
+        while (expression is Expr.Grouping grouping)
+            expression = grouping.Expression;
+        return expression is Expr.Variable variable &&
+            _ctx.Locals.GetLocal(variable.Name.Lexeme)?.LocalType == _ctx.Types.Double;
     }
 
     private bool IsStringPlusOperation(Expr.Binary b)

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -17,6 +17,9 @@ public partial class ILEmitter
 {
     protected override void EmitGet(Expr.Get g)
     {
+        if (TryEmitStableRecordDestructureGet(g))
+            return;
+
         if (!g.Optional
             && g.Name.Lexeme == "length"
             && g.Object is Expr.Variable restLength
@@ -988,6 +991,9 @@ public partial class ILEmitter
 
     protected override void EmitGetIndex(Expr.GetIndex gi)
     {
+        if (TryEmitStableArrayDestructureGet(gi))
+            return;
+
         if (TryEmitFlattenedNumericRestIndex(gi))
             return;
 

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -1940,6 +1940,58 @@ public partial class ILEmitter
         SetStackType(StackType.Double);
     }
 
+    private void EmitPromotedArrayShift(LocalBuilder list, ArrayElementsDescriptor desc)
+    {
+        IL.Emit(OpCodes.Ldloc, list);
+        IL.Emit(OpCodes.Call, desc.Kind == ArrayElementsKind.Double
+            ? _ctx.Runtime!.ArrayShiftDouble
+            : _ctx.Runtime!.ArrayShiftBool);
+        SetStackUnknown();
+    }
+
+    private void EmitPromotedArrayUnshift(
+        LocalBuilder list,
+        ArrayElementsDescriptor desc,
+        List<Expr> arguments)
+    {
+        var listType = desc.GetListType(_ctx.Types);
+        if (arguments.Count == 0)
+        {
+            IL.Emit(OpCodes.Ldloc, list);
+            IL.Emit(OpCodes.Callvirt, _ctx.Types.GetProperty(listType, "Count").GetGetMethod()!);
+            IL.Emit(OpCodes.Conv_R8);
+            SetStackType(StackType.Double);
+            return;
+        }
+
+        // ECMAScript evaluates every argument before moving any element. Spill
+        // them in source order, then prepend in reverse order so the final array
+        // preserves the original argument order without an object[] pack.
+        var elementType = desc.GetElementType(_ctx.Types);
+        var values = new LocalBuilder[arguments.Count];
+        for (int i = 0; i < arguments.Count; i++)
+        {
+            EmitExpression(arguments[i]);
+            if (desc.Kind == ArrayElementsKind.Double) EnsureDouble();
+            else EnsureBoolean();
+            values[i] = IL.DeclareLocal(elementType);
+            IL.Emit(OpCodes.Stloc, values[i]);
+        }
+
+        var helper = desc.Kind == ArrayElementsKind.Double
+            ? _ctx.Runtime!.ArrayUnshiftDouble
+            : _ctx.Runtime!.ArrayUnshiftBool;
+        for (int i = arguments.Count - 1; i >= 0; i--)
+        {
+            IL.Emit(OpCodes.Ldloc, list);
+            IL.Emit(OpCodes.Ldloc, values[i]);
+            IL.Emit(OpCodes.Call, helper);
+            if (i != 0)
+                IL.Emit(OpCodes.Pop);
+        }
+        SetStackType(StackType.Double);
+    }
+
     /// <summary>
     /// Emits <c>x.push(args)</c> for an ESCAPING <c>number[]</c> whose runtime value is a <c>$Array</c>
     /// (number[] unboxing project): append each (unboxed) <c>double</c> argument via the mode-checked

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -149,14 +149,20 @@ public partial class ILEmitter
 
             if (v.Initializer != null)
             {
-                EmitExpression(v.Initializer);
-                EmitBoxIfNeeded(v.Initializer);
+                if (funcDisplayField.FieldType == _ctx.Types.Double)
+                    EmitExpressionAsDouble(v.Initializer);
+                else
+                {
+                    EmitExpression(v.Initializer);
+                    EmitBoxIfNeeded(v.Initializer);
+                }
             }
             else if (v.TypeAnnotation == "number")
             {
                 // Typed number without initializer defaults to 0
                 IL.Emit(OpCodes.Ldc_R8, 0.0);
-                IL.Emit(OpCodes.Box, _ctx.Types.Double);
+                if (funcDisplayField.FieldType == _ctx.Types.Object)
+                    IL.Emit(OpCodes.Box, _ctx.Types.Double);
             }
             else
             {
@@ -569,6 +575,12 @@ public partial class ILEmitter
     /// </summary>
     private bool CanUseUnboxedLocal(Stmt.Var v)
     {
+        // Stable custom iteration proves its value binding is numeric. For the
+        // exact `acc = acc + value` loop shape, that proof also removes the
+        // checker's conservative any/undefined flow from the accumulator.
+        if (_ctx.TypeMap?.IsStableCustomIteratorNumericAccumulator(v.Name) == true)
+            return true;
+
         // #367: a number-typed local that an `any`/`undefined` value may have (transitively) been
         // assigned must use an object slot — an unboxed double slot would coerce the runtime
         // `undefined` sentinel to NaN at the store. The type checker flags such declarations (and,
@@ -1128,6 +1140,15 @@ public partial class ILEmitter
         TypeInfo? iterableType = _ctx.TypeMap?.Get(f.Iterable);
         EmitExpression(f.Iterable);
 
+        if (_ctx.TypeMap?.TryGetStableCustomIterator(f, out var stableIterator) == true)
+        {
+            EmitBoxIfNeeded(f.Iterable);
+            var stableIterable = IL.DeclareLocal(_ctx.Types.Object);
+            IL.Emit(OpCodes.Stloc, stableIterable);
+            EmitStableCustomIterator(f, stableIterable, stableIterator, labelNames);
+            return;
+        }
+
         if (iterableType is TypeInfo.Map
             && _ctx.TypeMap?.IsStableNumericMapIteration(f) == true)
         {
@@ -1507,6 +1528,139 @@ public partial class ILEmitter
         builder.MarkLabel(endLabel);
         IL.Emit(OpCodes.Ldloca, enumeratorLocal);
         IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(enumeratorType, "Dispose")!);
+        _ctx.ExitLoop();
+        _ctx.Locals.ExitScope();
+    }
+
+    private void EmitStableCustomIterator(
+        Stmt.ForOf loop,
+        LocalBuilder iterableLocal,
+        StableCustomIteratorInfo info,
+        IReadOnlyList<string>? labelNames)
+    {
+        _ctx.ArrowMethods.TryGetValue(info.NextMethod, out var nextMethod);
+        Type resultType = _ctx.Runtime!.StableNumberIteratorResultType;
+        var valueField = _ctx.Runtime.StableNumberIteratorResultValueField;
+        var doneField = _ctx.Runtime.StableNumberIteratorResultDoneField;
+        if (nextMethod is null ||
+            nextMethod.ReturnType != resultType)
+        {
+            throw new InvalidOperationException(
+                $"Stable custom iterator proof did not match emitted result shape " +
+                $"(method={nextMethod?.ReturnType}, result={resultType}, " +
+                $"value={valueField?.FieldType}, done={doneField?.FieldType}).");
+        }
+
+        var builder = _ctx.ILBuilder;
+
+        // GetIteratorFromMethod, once: preserve observable iterator acquisition and this binding.
+        IL.Emit(OpCodes.Ldloc, iterableLocal);
+        IL.Emit(OpCodes.Ldsfld, _ctx.Runtime.SymbolIterator);
+        IL.Emit(OpCodes.Call, _ctx.Runtime.GetIteratorFunction);
+        var iteratorFunction = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, iteratorFunction);
+        IL.Emit(OpCodes.Ldloc, iterableLocal);
+        IL.Emit(OpCodes.Ldloc, iteratorFunction);
+        IL.Emit(OpCodes.Ldc_I4_0);
+        IL.Emit(OpCodes.Newarr, _ctx.Types.Object);
+        IL.Emit(OpCodes.Call, _ctx.Runtime.InvokeMethodValue);
+        var iteratorObject = IL.DeclareLocal(_ctx.Types.Object);
+        IL.Emit(OpCodes.Stloc, iteratorObject);
+
+        // Get(iterator, "next"), once. The analyzer proved this exact data method cannot
+        // be reassigned or observed through an alias, so subsequent steps call it directly.
+        IL.Emit(OpCodes.Ldloc, iteratorObject);
+        IL.Emit(OpCodes.Ldstr, "next");
+        IL.Emit(OpCodes.Call, _ctx.Runtime.GetProperty);
+        IL.Emit(OpCodes.Castclass, _ctx.Runtime.TSFunctionType);
+        var nextFunction = IL.DeclareLocal(_ctx.Runtime.TSFunctionType);
+        IL.Emit(OpCodes.Stloc, nextFunction);
+
+        LocalBuilder? nextTarget = null;
+        bool capturing = _ctx.DisplayClasses.TryGetValue(
+            info.NextMethod, out var displayClass);
+        if (capturing)
+        {
+            nextTarget = IL.DeclareLocal(displayClass!);
+            IL.Emit(OpCodes.Ldloc, nextFunction);
+            IL.Emit(OpCodes.Callvirt, _ctx.Runtime.TSFunctionGetTarget);
+            IL.Emit(OpCodes.Castclass, displayClass!);
+            IL.Emit(OpCodes.Stloc, nextTarget);
+        }
+
+        var start = builder.DefineLabel("forof_stable_iterator_start");
+        var end = builder.DefineLabel("forof_stable_iterator_end");
+        var body = builder.DefineLabel("forof_stable_iterator_body");
+        var cont = builder.DefineLabel("forof_stable_iterator_continue");
+        var result = IL.DeclareLocal(resultType);
+        var loopVar = _ctx.Locals.DeclareLocal(
+            loop.Variable.Lexeme, _ctx.Types.Double);
+        var closeNeeded = IL.DeclareLocal(_ctx.Types.Boolean);
+        var throwing = IL.DeclareLocal(_ctx.Types.Boolean);
+
+        _ctx.EnterLoop(end, cont, labelNames ?? CompilationContext.NoLabels);
+        builder.MarkLabel(start);
+        EmitCancellationCheck();
+
+        if (nextTarget is not null)
+            IL.Emit(OpCodes.Ldloc, nextTarget);
+        if (info.NextMethod.HasOwnThis)
+            IL.Emit(OpCodes.Ldloc, iteratorObject);
+        IL.Emit(capturing ? OpCodes.Callvirt : OpCodes.Call, nextMethod);
+        IL.Emit(OpCodes.Stloc, result);
+        IL.Emit(OpCodes.Ldloc, result);
+        IL.Emit(OpCodes.Ldfld, doneField);
+        builder.Emit_Brfalse(body);
+        builder.Emit_Br(end);
+
+        builder.MarkLabel(body);
+        IL.Emit(OpCodes.Ldc_I4_1);
+        IL.Emit(OpCodes.Stloc, closeNeeded);
+        IL.Emit(OpCodes.Ldc_I4_0);
+        IL.Emit(OpCodes.Stloc, throwing);
+
+        var escapingTargets = new HashSet<Label>();
+        foreach (var enclosing in _ctx.LoopLabels)
+        {
+            escapingTargets.Add(enclosing.BreakLabel);
+            escapingTargets.Add(enclosing.ContinueLabel);
+        }
+
+        _ctx.ExceptionBlockDepth++;
+        builder.BeginExceptionBlock();
+        IL.Emit(OpCodes.Ldloc, result);
+        IL.Emit(OpCodes.Ldfld, valueField);
+        IL.Emit(OpCodes.Stloc, loopVar);
+
+        _iteratorLoopCompletionScopes.Push(new IteratorLoopCompletionScope(
+            closeNeeded, cont, escapingTargets));
+        EmitStatement(loop.Body);
+        _iteratorLoopCompletionScopes.Pop();
+
+        IL.Emit(OpCodes.Ldc_I4_0);
+        IL.Emit(OpCodes.Stloc, closeNeeded);
+        builder.Emit_Leave(cont);
+
+        builder.BeginCatchBlock(_ctx.Types.Exception);
+        IL.Emit(OpCodes.Pop);
+        IL.Emit(OpCodes.Ldc_I4_1);
+        IL.Emit(OpCodes.Stloc, throwing);
+        IL.Emit(OpCodes.Rethrow);
+
+        builder.BeginFinallyBlock();
+        var skipClose = builder.DefineLabel("forof_stable_iterator_skip_close");
+        IL.Emit(OpCodes.Ldloc, closeNeeded);
+        builder.Emit_Brfalse(skipClose);
+        IL.Emit(OpCodes.Ldloc, iteratorObject);
+        IL.Emit(OpCodes.Ldloc, throwing);
+        IL.Emit(OpCodes.Call, _ctx.Runtime.IteratorClose);
+        builder.MarkLabel(skipClose);
+        builder.EndExceptionBlock();
+        _ctx.ExceptionBlockDepth--;
+
+        builder.MarkLabel(cont);
+        builder.Emit_Br(start);
+        builder.MarkLabel(end);
         _ctx.ExitLoop();
         _ctx.Locals.ExitScope();
     }
@@ -2036,6 +2190,11 @@ public partial class ILEmitter
                 && _ctx.FunctionDisplayClassFields?.TryGetValue(name, out var functionField) == true
                 && _ctx.FunctionDisplayClassLocal != null)
             {
+                // A value-type slot is emitted only after proving initialization
+                // precedes creation of its sole iterator closure, so it cannot be
+                // observed in TDZ and cannot hold the sentinel.
+                if (functionField.FieldType.IsValueType)
+                    continue;
                 IL.Emit(OpCodes.Ldloc, _ctx.FunctionDisplayClassLocal);
                 IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.LexicalUninitializedInstance);
                 IL.Emit(OpCodes.Stfld, functionField);
@@ -2305,6 +2464,9 @@ public partial class ILEmitter
 
         if (r.Value != null)
         {
+            if (TryEmitStableIteratorResultReturn(returnType, r.Value))
+                goto emit_return;
+
             if (_ctx.Types.IsDouble(returnType) && r.Value is Expr.GetIndex)
                 EmitExpressionAsDouble(r.Value);
             else
@@ -2399,6 +2561,7 @@ public partial class ILEmitter
             }
         }
 
+    emit_return:
         if (_abruptCompletionScopes.TryPeek(out var completion))
         {
             if (_ctx.ReturnValueLocal == null && !_ctx.HasDeferredVoidReturn)
@@ -2444,6 +2607,51 @@ public partial class ILEmitter
         // EmitBoxIfNeeded, it sees StackType.Double and incorrectly boxes the
         // next value (e.g., an array reference) as a Double.
         SetStackUnknown();
+    }
+
+    private bool TryEmitStableIteratorResultReturn(Type returnType, Expr expression)
+    {
+        if (_ctx.Runtime?.StableNumberIteratorResultType != returnType)
+            return false;
+
+        while (true)
+        {
+            switch (expression)
+            {
+                case Expr.Grouping grouping:
+                    expression = grouping.Expression;
+                    continue;
+                case Expr.TypeAssertion assertion:
+                    expression = assertion.Expression;
+                    continue;
+                case Expr.Satisfies satisfies:
+                    expression = satisfies.Expression;
+                    continue;
+                case Expr.NonNullAssertion nonNull:
+                    expression = nonNull.Expression;
+                    continue;
+            }
+            break;
+        }
+
+        if (expression is not Expr.ObjectLiteral
+            {
+                Properties:
+                [
+                    { IsSpread: false, Kind: Expr.ObjectPropertyKind.Value, Key: var valueKey, Value: var value },
+                    { IsSpread: false, Kind: Expr.ObjectPropertyKind.Value, Key: var doneKey, Value: var done }
+                ]
+            } ||
+            GetPropertyKeyString(valueKey!) != "value" ||
+            GetPropertyKeyString(doneKey!) != "done")
+            return false;
+
+        EmitExpressionAsDouble(value);
+        EmitExpression(done);
+        EnsureBoolean();
+        IL.Emit(OpCodes.Newobj, _ctx.Runtime.StableNumberIteratorResultCtor);
+        SetStackUnknown();
+        return true;
     }
 
     protected override void EmitBreak(Stmt.Break b)

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -11,6 +11,15 @@ public partial class ILEmitter
 {
     private readonly Stack<(string Name, LocalBuilder Key, LocalBuilder Value)> _stableMapEntryBindings = new();
 
+    private Type PromotedObjectValueClrType(TypeInfo? type) => type switch
+    {
+        TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } => _ctx.Types.Double,
+        TypeInfo.Primitive { Type: TokenType.TYPE_BOOLEAN } => _ctx.Types.Boolean,
+        TypeInfo.String => _ctx.Types.String,
+        _ => throw new InvalidOperationException(
+            $"Promoted object field has unsupported static type '{type}'")
+    };
+
     protected override void EmitConditionCheck(Expr condition)
     {
         EmitExpression(condition);
@@ -325,6 +334,54 @@ public partial class ILEmitter
             var structLocal = _ctx.Locals.DeclareLocal(v.Name.Lexeme, shapeType.ClrType);
             IL.Emit(OpCodes.Ldloca, structLocal);
             IL.Emit(OpCodes.Initobj, shapeType.ClrType);
+
+            if (shapeLit.Properties.Any(p => p.IsSpread))
+            {
+                // Stable exact object spread (#1505). Snapshot each source field at the precise
+                // spread position: an explicit initializer between two spreads may mutate a source,
+                // so loading only the final source state would violate CopyDataProperties order.
+                // Explicit values also go through temporaries so overwritten initializers still run.
+                var finalValues = new Dictionary<string, LocalBuilder>(StringComparer.Ordinal);
+                foreach (var prop in shapeLit.Properties)
+                {
+                    if (prop.IsSpread)
+                    {
+                        var spreadVar = (Expr.Variable)prop.Value;
+                        var source = _ctx.TryGetPromotedObjectLocal(spreadVar.Name.Lexeme)
+                            ?? throw new InvalidOperationException(
+                                $"Promoted object spread source '{spreadVar.Name.Lexeme}' has no shape local");
+
+                        foreach (var sourceField in source.Shape.Fields)
+                        {
+                            var sourceBuilder = source.Shape.FieldBuilders[sourceField.Name];
+                            var snapshot = IL.DeclareLocal(sourceBuilder.FieldType);
+                            IL.Emit(OpCodes.Ldloca, source.Local);
+                            IL.Emit(OpCodes.Ldfld, sourceBuilder);
+                            IL.Emit(OpCodes.Stloc, snapshot);
+                            finalValues[sourceField.Name] = snapshot;
+                        }
+                        continue;
+                    }
+
+                    var fieldName = ((Expr.IdentifierKey)prop.Key!).Name.Lexeme;
+                    Type valueType = PromotedObjectValueClrType(_ctx.TypeMap.Get(prop.Value));
+                    var value = IL.DeclareLocal(valueType);
+                    EmitExpression(prop.Value);
+                    EnsureForFieldType(valueType);
+                    IL.Emit(OpCodes.Stloc, value);
+                    finalValues[fieldName] = value;
+                }
+
+                foreach (var field in shapeType.Fields)
+                {
+                    var fieldBuilder = shapeType.FieldBuilders[field.Name];
+                    IL.Emit(OpCodes.Ldloca, structLocal);
+                    IL.Emit(OpCodes.Ldloc, finalValues[field.Name]);
+                    IL.Emit(OpCodes.Stfld, fieldBuilder);
+                }
+                return;
+            }
+
             // Evaluate every field initializer in source order (preserving side effects), even a field
             // never read later, and store into its typed struct field.
             foreach (var prop in shapeLit.Properties)

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -462,7 +462,7 @@ public partial class ILEmitter
             // initializer is created as a NUMERIC $Array; otherwise emit the initializer normally.
             if (!TryEmitNumericEmptyArrayInit(v))
             {
-                if (_ctx.Types.IsDouble(localType) && v.Initializer is Expr.GetIndex)
+                if (_ctx.Types.IsDouble(localType))
                     EmitExpressionAsDouble(v.Initializer);
                 else
                     EmitExpression(v.Initializer);
@@ -479,6 +479,7 @@ public partial class ILEmitter
                 }
             }
             IL.Emit(OpCodes.Stloc, local);
+            RegisterStableDestructuringSource(v, local);
 
             foreach (var (dcInstance, field) in _ctx.SelfCaptureWriteBacks)
             {

--- a/src/SharpTS/Compilation/LocalVariableResolver.cs
+++ b/src/SharpTS/Compilation/LocalVariableResolver.cs
@@ -97,8 +97,9 @@ public class LocalVariableResolver : IVariableResolver
                 // Direct access from function body - use the local
                 _il.Emit(OpCodes.Ldloc, _ctx.FunctionDisplayClassLocal);
                 _il.Emit(OpCodes.Ldfld, funcDCField);
-                _ctx.EmitLexicalTdzValueCheck(_il, name);
-                return StackType.Unknown;
+                if (!funcDCField.FieldType.IsValueType)
+                    _ctx.EmitLexicalTdzValueCheck(_il, name);
+                return MapTypeToStackType(funcDCField.FieldType);
             }
 
             if (_ctx.CurrentArrowFunctionDCField != null)
@@ -133,8 +134,9 @@ public class LocalVariableResolver : IVariableResolver
                     _il.Emit(OpCodes.Ldfld, _ctx.CurrentArrowFunctionDCField);
                     _il.Emit(OpCodes.Ldfld, funcDCField);
                 }
-                _ctx.EmitLexicalTdzValueCheck(_il, name);
-                return StackType.Unknown;
+                if (!funcDCField.FieldType.IsValueType)
+                    _ctx.EmitLexicalTdzValueCheck(_il, name);
+                return MapTypeToStackType(funcDCField.FieldType);
             }
 
             // No DC access available — fall through to other checks
@@ -316,7 +318,9 @@ public class LocalVariableResolver : IVariableResolver
         if (_ctx.CapturedFunctionLocals?.Contains(dcName) == true &&
             _ctx.FunctionDisplayClassFields?.TryGetValue(dcName, out var funcDCField) == true)
         {
-            var temp = _il.DeclareLocal(_types.Object);
+            var temp = _il.DeclareLocal(funcDCField.FieldType);
+            if (funcDCField.FieldType == _types.Double)
+                _il.Emit(OpCodes.Call, _ctx.Runtime!.ConvertToNumber);
             _il.Emit(OpCodes.Stloc, temp);
 
             if (_ctx.FunctionDisplayClassLocal != null)

--- a/src/SharpTS/Compilation/ObjectLocalPromotionAnalyzer.cs
+++ b/src/SharpTS/Compilation/ObjectLocalPromotionAnalyzer.cs
@@ -10,19 +10,22 @@ namespace SharpTS.Compilation;
 /// typed fields (#862). Direct sibling of <see cref="ArrayLocalPromotionAnalyzer"/> and
 /// <see cref="NonEscapingArrowLocalAnalyzer"/>: a name qualifies only if it is provably non-escaping, so
 /// the promoted struct (which has no dynamic-object semantics — no descriptors, enumerability, prototype,
-/// <c>delete</c>, spread, freeze) is never observed anywhere those would be needed. A candidate <c>o</c>
+/// <c>delete</c>, freeze) is never observed anywhere those would be needed. Stable object spread is
+/// represented by direct copies between compatible shape structs; a connected source/result chain is
+/// promoted only when every member remains non-escaping. A candidate <c>o</c>
 /// qualifies iff ALL hold:
 /// <list type="number">
 ///   <item>declared <c>const</c>/<c>let</c> with an initializer that is a <em>simple</em> object literal —
-///         every property is a plain <c>key: value</c> (no spread, no computed/string-literal key, no
-///         method, no getter/setter, no <c>{ a = 5 }</c> cover-grammar shorthand-default), keys are
-///         unique, and every value's static type is a primitive <c>number</c>/<c>boolean</c>/<c>string</c>
+///         every property is either a plain <c>key: value</c> or a spread of an earlier candidate local
+///         (no computed/string-literal key, method, getter/setter, or <c>{ a = 5 }</c>
+///         cover-grammar shorthand-default), and every final value's static type is a primitive
+///         <c>number</c>/<c>boolean</c>/<c>string</c>
 ///         (which inherently excludes <c>any</c>/<c>undefined</c>-admitting fields a typed slot would
 ///         silently coerce);</item>
 ///   <item>the ONLY uses are constant-key field reads <c>o.KEY</c> and writes <c>o.KEY = v</c> where
 ///         <c>KEY</c> is one of the literal's own fields (and a write's value is the same primitive kind).
 ///         Any other appearance of the bare variable — argument pass, return, store to another binding,
-///         spread, <c>===</c>, <c>typeof</c>, <c>o[expr]</c>, <c>o.unknownKey</c>, <c>delete</c>,
+///         unstable spread, <c>===</c>, <c>typeof</c>, <c>o[expr]</c>, <c>o.unknownKey</c>, <c>delete</c>,
 ///         compound/logical member assign, reassignment — disqualifies it;</item>
 ///   <item>the name is declared exactly once in the whole program (conservative guard against scope
 ///         ambiguity / shadowing without full scope resolution);</item>
@@ -46,11 +49,33 @@ public static class ObjectLocalPromotionAnalyzer
         foreach (var stmt in program)
             visitor.Visit(stmt);
 
-        foreach (var (name, candidate) in visitor.Candidates)
+        var eligible = new HashSet<string>(visitor.Candidates.Keys, StringComparer.Ordinal);
+        foreach (var name in visitor.Candidates.Keys)
         {
-            if (visitor.Disqualified.Contains(name)) continue;
-            if (visitor.DeclCount.GetValueOrDefault(name) != 1) continue;
-            if (closures?.IsVariableCaptured(name) == true) continue;
+            if (visitor.Disqualified.Contains(name)
+                || visitor.DeclCount.GetValueOrDefault(name) != 1
+                || closures?.IsVariableCaptured(name) == true)
+                eligible.Remove(name);
+        }
+
+        // A generic object cannot consume a promoted struct as a spread source, and a promoted result
+        // cannot snapshot a generic source. Therefore an instability anywhere in a spread-connected
+        // component invalidates both endpoints, transitively.
+        bool changed;
+        do
+        {
+            changed = false;
+            foreach (var (source, target) in visitor.SpreadEdges)
+            {
+                if (eligible.Contains(source) && eligible.Contains(target)) continue;
+                changed |= eligible.Remove(source);
+                changed |= eligible.Remove(target);
+            }
+        } while (changed);
+
+        foreach (var name in eligible)
+        {
+            var candidate = visitor.Candidates[name];
             typeMap.MarkPromotableObjectLocal(candidate.NameToken, candidate.Shape);
         }
     }
@@ -59,8 +84,20 @@ public static class ObjectLocalPromotionAnalyzer
     {
         private readonly TypeMap _typeMap = typeMap;
 
-        /// <summary>name → its candidate declaration (name token, shape, and the field-name set for O(1) membership).</summary>
-        public Dictionary<string, (Token NameToken, ObjectShapeInfo Shape, HashSet<string> FieldNames)> Candidates { get; } = new();
+        public sealed record Candidate(
+            Token NameToken,
+            ObjectShapeInfo Shape,
+            HashSet<string> FieldNames);
+
+        /// <summary>name → its candidate declaration and final merged shape.</summary>
+        public Dictionary<string, Candidate> Candidates { get; } = new(StringComparer.Ordinal);
+
+        /// <summary>Stable spread dependency edges (source, result).</summary>
+        public List<(string Source, string Target)> SpreadEdges { get; } = [];
+
+        /// <summary>Spread-bearing candidate literal → its declaration, for specialized visitation.</summary>
+        private Dictionary<Expr.ObjectLiteral, string> SpreadLiteralOwners { get; } =
+            new(ReferenceEqualityComparer.Instance);
 
         /// <summary>How many times each name is declared anywhere (any kind of binding).</summary>
         public Dictionary<string, int> DeclCount { get; } = new();
@@ -80,8 +117,16 @@ public static class ObjectLocalPromotionAnalyzer
             DeclCount[lexeme] = DeclCount.GetValueOrDefault(lexeme) + 1;
 
             if (initializer is Expr.ObjectLiteral lit && !Candidates.ContainsKey(lexeme)
-                && TryBuildShape(lit, out var shape, out var fieldNames))
-                Candidates[lexeme] = (name, shape, fieldNames);
+                && TryBuildShape(lit, out var shape, out var fieldNames, out var spreadSources))
+            {
+                Candidates[lexeme] = new Candidate(name, shape, fieldNames);
+                if (spreadSources.Count != 0)
+                {
+                    SpreadLiteralOwners[lit] = lexeme;
+                    foreach (var source in spreadSources)
+                        SpreadEdges.Add((source, lexeme));
+                }
+            }
 
             // Visit the initializer so its sub-uses are accounted for. The literal's own property
             // values reference OTHER variables (e.g. `i` in `{ x: i }`), not `o`, so this never
@@ -119,6 +164,26 @@ public static class ObjectLocalPromotionAnalyzer
             base.VisitSet(expr);
         }
 
+        protected override void VisitObjectLiteral(Expr.ObjectLiteral expr)
+        {
+            if (!SpreadLiteralOwners.ContainsKey(expr))
+            {
+                base.VisitObjectLiteral(expr);
+                return;
+            }
+
+            // A spread source occurrence is the one additional permitted use of a stable candidate.
+            // Do not visit that bare variable (the dependency edge handles its eligibility); do visit
+            // every explicit initializer so reads, writes, and side effects are analyzed normally.
+            foreach (var prop in expr.Properties)
+            {
+                if (prop.IsSpread && prop.Value is Expr.Variable spreadVar
+                    && Candidates.ContainsKey(spreadVar.Name.Lexeme))
+                    continue;
+                Visit(prop.Value);
+            }
+        }
+
         protected override void VisitVariable(Expr.Variable expr)
         {
             // Catch-all: any bare variable occurrence not consumed by a permitted read/write override
@@ -131,32 +196,65 @@ public static class ObjectLocalPromotionAnalyzer
         /// Builds the shape for a candidate object literal, or returns false if the literal is not a
         /// simple fixed-shape primitive record. See the class summary for the rules.
         /// </summary>
-        private bool TryBuildShape(Expr.ObjectLiteral lit, out ObjectShapeInfo shape, out HashSet<string> fieldNames)
+        private bool TryBuildShape(
+            Expr.ObjectLiteral lit,
+            out ObjectShapeInfo shape,
+            out HashSet<string> fieldNames,
+            out List<string> spreadSources)
         {
             shape = null!;
             fieldNames = null!;
+            spreadSources = [];
             if (lit.Properties.Count == 0) return false;
 
             var fields = new List<ObjectShapeField>(lit.Properties.Count);
             var names = new HashSet<string>(StringComparer.Ordinal);
+            var fieldIndexes = new Dictionary<string, int>(StringComparer.Ordinal);
+            bool hasSpread = lit.Properties.Any(p => p.IsSpread);
             foreach (var prop in lit.Properties)
             {
-                if (prop.IsSpread || prop.Kind != Expr.ObjectPropertyKind.Value || prop.IsShorthandDefault)
+                if (prop.IsSpread)
+                {
+                    if (prop.Value is not Expr.Variable spreadVar
+                        || !Candidates.TryGetValue(spreadVar.Name.Lexeme, out var source))
+                        return false;
+
+                    spreadSources.Add(spreadVar.Name.Lexeme);
+                    foreach (var sourceField in source.Shape.Fields)
+                        UpsertField(sourceField.Name, sourceField.Kind);
+                    continue;
+                }
+
+                if (prop.Kind != Expr.ObjectPropertyKind.Value || prop.IsShorthandDefault)
                     return false;
                 if (prop.Key is not Expr.IdentifierKey idk)
                     return false; // computed / string-literal / numeric keys: not o.KEY-accessible
                 var fname = idk.Name.Lexeme;
-                if (!names.Add(fname))
-                    return false; // duplicate key
                 if (ClassifyKind(_typeMap.Get(prop.Value)) is not { } kind)
                     return false; // non-primitive / undefined-admitting field
-                fields.Add(new ObjectShapeField(fname, kind));
+                if (!hasSpread && names.Contains(fname))
+                    return false; // retain the original conservative rule for ordinary literals
+                UpsertField(fname, kind);
             }
 
             var key = string.Join(";", fields.Select(f => f.Name + ":" + f.Kind));
             shape = new ObjectShapeInfo(key, fields);
             fieldNames = names;
             return true;
+
+            void UpsertField(string name, TokenType kind)
+            {
+                if (fieldIndexes.TryGetValue(name, out int index))
+                {
+                    // Object spread overwrites without moving the key in enumeration order.
+                    fields[index] = new ObjectShapeField(name, kind);
+                    return;
+                }
+
+                fieldIndexes[name] = fields.Count;
+                names.Add(name);
+                fields.Add(new ObjectShapeField(name, kind));
+            }
         }
 
         private static TokenType FieldKind(ObjectShapeInfo shape, string name)

--- a/src/SharpTS/Compilation/ObjectLocalPromotionAnalyzer.cs
+++ b/src/SharpTS/Compilation/ObjectLocalPromotionAnalyzer.cs
@@ -22,8 +22,9 @@ namespace SharpTS.Compilation;
 ///         <c>number</c>/<c>boolean</c>/<c>string</c>
 ///         (which inherently excludes <c>any</c>/<c>undefined</c>-admitting fields a typed slot would
 ///         silently coerce);</item>
-///   <item>the ONLY uses are constant-key field reads <c>o.KEY</c> and writes <c>o.KEY = v</c> where
-///         <c>KEY</c> is one of the literal's own fields (and a write's value is the same primitive kind).
+///   <item>the ONLY uses are constant-key field reads <c>o.KEY</c>, same-kind writes
+///         <c>o.KEY = v</c>, stable spread, and direct <c>Object.keys(o)</c> calls. The latter can
+///         materialize the immutable key metadata without exposing the struct itself.
 ///         Any other appearance of the bare variable — argument pass, return, store to another binding,
 ///         unstable spread, <c>===</c>, <c>typeof</c>, <c>o[expr]</c>, <c>o.unknownKey</c>, <c>delete</c>,
 ///         compound/logical member assign, reassignment — disqualifies it;</item>
@@ -162,6 +163,23 @@ public static class ObjectLocalPromotionAnalyzer
                 return;
             }
             base.VisitSet(expr);
+        }
+
+        protected override void VisitCall(Expr.Call expr)
+        {
+            // Object.keys over a closed promoted shape (#1506) observes only a fresh array of the
+            // record's fixed enumerable string keys. The emitter does not load/box the struct.
+            if (!expr.Optional && expr.Arguments is [Expr.Variable receiver]
+                && expr.Callee is Expr.Get
+                {
+                    Optional: false,
+                    Object: Expr.Variable { Name.Lexeme: "Object" },
+                    Name.Lexeme: "keys"
+                }
+                && Candidates.ContainsKey(receiver.Name.Lexeme))
+                return;
+
+            base.VisitCall(expr);
         }
 
         protected override void VisitObjectLiteral(Expr.ObjectLiteral expr)

--- a/src/SharpTS/Compilation/ObjectShapeRegistry.cs
+++ b/src/SharpTS/Compilation/ObjectShapeRegistry.cs
@@ -38,4 +38,10 @@ public sealed class ObjectShapeTypeInfo
 
     /// <summary>Field name → its <see cref="FieldBuilder"/> on <see cref="ClrType"/>.</summary>
     public required Dictionary<string, FieldBuilder> FieldBuilders { get; init; }
+
+    /// <summary>
+    /// Cached ordered enumerable string keys for direct <c>Object.keys</c> materialization.
+    /// The emitted array is internal to the generated assembly and copied into every mutable result.
+    /// </summary>
+    public required FieldBuilder KeyMetadataField { get; init; }
 }

--- a/src/SharpTS/Compilation/RuntimeEmitter.ArrayPrototypePopulate.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.ArrayPrototypePopulate.cs
@@ -99,7 +99,7 @@ public partial class RuntimeEmitter
         Wire("every",          runtime.ArrayEvery,          1);
         Wire("reduce",         runtime.ArrayReduce,         1);
         Wire("reduceRight",    runtime.ArrayReduceRight,    1);
-        Wire("includes",       runtime.ArrayIncludes,       1);
+        Wire("includes",       runtime.ArrayIncludesProto,  1);
         Wire("indexOf",        runtime.ArrayIndexOf,        1);
         Wire("lastIndexOf",    runtime.ArrayLastIndexOf,    1);
         Wire("join",           runtime.ArrayJoin,           1);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Mutators.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Mutators.cs
@@ -475,6 +475,41 @@ public partial class RuntimeEmitter
         GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot modify a frozen or sealed array");
     }
 
+    private void EmitArrayShiftTyped(
+        TypeBuilder typeBuilder, EmittedRuntime runtime, ArrayElementsDescriptor desc)
+    {
+        var listType = desc.GetListType(_types);
+        var elementType = desc.GetElementType(_types);
+        var method = typeBuilder.DefineMethod(
+            $"ArrayShift{desc.Kind}",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [listType]);
+        if (desc.Kind == ArrayElementsKind.Double) runtime.ArrayShiftDouble = method;
+        else runtime.ArrayShiftBool = method;
+
+        var il = method.GetILGenerator();
+        var nonEmpty = il.DefineLabel();
+        var first = il.DeclareLocal(elementType);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(listType, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Brtrue, nonEmpty);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(nonEmpty);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(listType, "Item").GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, first);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(listType, "RemoveAt", _types.Int32));
+        il.Emit(OpCodes.Ldloc, first);
+        il.Emit(OpCodes.Box, elementType);
+        il.Emit(OpCodes.Ret);
+    }
+
     private void EmitArrayShiftProto(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         var method = typeBuilder.DefineMethod(
@@ -596,6 +631,47 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
+    /// <summary>
+    /// Guarded packed-number-array shift. Exact numeric $Array instances use the
+    /// unboxed store; every unusual receiver delegates to the complete prototype
+    /// algorithm without first materializing the numeric store.
+    /// </summary>
+    private void EmitArrayShiftNumber(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "ArrayShiftNumber",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object]);
+        runtime.ArrayShiftNumber = method;
+        var il = method.GetILGenerator();
+        var fallback = il.DefineLabel();
+        var array = il.DeclareLocal(runtime.TSArrayType);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Brfalse, fallback);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
+        il.Emit(OpCodes.Ldtoken, runtime.TSArrayType);
+        il.Emit(OpCodes.Call, _types.TypeGetTypeFromHandle);
+        il.Emit(OpCodes.Ceq);
+        il.Emit(OpCodes.Brfalse, fallback);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Stloc, array);
+        il.Emit(OpCodes.Ldloc, array);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayCanMutateNumericGetter);
+        il.Emit(OpCodes.Brfalse, fallback);
+        il.Emit(OpCodes.Ldloc, array);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayShiftNumeric);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(fallback);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.ArrayShiftProto);
+        il.Emit(OpCodes.Ret);
+    }
+
     private void EmitArrayUnshift(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         var method = typeBuilder.DefineMethod(
@@ -626,6 +702,103 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(frozenLabel);
         GuestErrorEmitter.ThrowTypeError(il, runtime, "Cannot modify a frozen or sealed array");
+    }
+
+    private void EmitArrayUnshiftTyped(
+        TypeBuilder typeBuilder, EmittedRuntime runtime, ArrayElementsDescriptor desc)
+    {
+        var listType = desc.GetListType(_types);
+        var elementType = desc.GetElementType(_types);
+        var method = typeBuilder.DefineMethod(
+            $"ArrayUnshift{desc.Kind}",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Double,
+            [listType, elementType]);
+        if (desc.Kind == ArrayElementsKind.Double) runtime.ArrayUnshiftDouble = method;
+        else runtime.ArrayUnshiftBool = method;
+
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(listType, "Insert", _types.Int32, elementType));
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(listType, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Guarded packed-number-array unshift. The typed double vector is allocated
+    /// only by the direct call site; fallback boxes it once for the generic
+    /// Array.prototype algorithm.
+    /// </summary>
+    private void EmitArrayUnshiftNumber(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "ArrayUnshiftNumber",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Double,
+            [_types.Object, _types.DoubleArray]);
+        runtime.ArrayUnshiftNumber = method;
+        var il = method.GetILGenerator();
+        var fallback = il.DefineLabel();
+        var array = il.DeclareLocal(runtime.TSArrayType);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Brfalse, fallback);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
+        il.Emit(OpCodes.Ldtoken, runtime.TSArrayType);
+        il.Emit(OpCodes.Call, _types.TypeGetTypeFromHandle);
+        il.Emit(OpCodes.Ceq);
+        il.Emit(OpCodes.Brfalse, fallback);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Stloc, array);
+        il.Emit(OpCodes.Ldloc, array);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayCanMutateNumericGetter);
+        il.Emit(OpCodes.Brfalse, fallback);
+        il.Emit(OpCodes.Ldloc, array);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, runtime.TSArrayUnshiftNumeric);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(fallback);
+        var boxed = il.DeclareLocal(_types.ObjectArray);
+        var index = il.DeclareLocal(_types.Int32);
+        var loop = il.DefineLabel();
+        var done = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Stloc, boxed);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, index);
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Bge, done);
+        il.Emit(OpCodes.Ldloc, boxed);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldelem_R8);
+        il.Emit(OpCodes.Box, _types.Double);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, index);
+        il.Emit(OpCodes.Br, loop);
+        il.MarkLabel(done);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, boxed);
+        il.Emit(OpCodes.Call, runtime.ArrayUnshiftProto);
+        il.Emit(OpCodes.Ret);
     }
 
     // Typed push for promoted number[]/boolean[] locals (#857/#860): appends an

--- a/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Search.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Search.cs
@@ -6,6 +6,174 @@ namespace SharpTS.Compilation;
 
 public partial class RuntimeEmitter
 {
+    /// <summary>
+    /// Variadic Array.prototype.includes entry point. Keeping the original
+    /// argument count distinguishes an omitted searchElement (undefined) from
+    /// an explicitly supplied null while still forwarding the optional
+    /// fromIndex to the complete boxed algorithm.
+    /// </summary>
+    private void EmitArrayIncludesProto(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "ArrayIncludesProto",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.ListOfObject, _types.ObjectArray]);
+        var paramArrayCtor = typeof(ParamArrayAttribute).GetConstructor(Type.EmptyTypes)!;
+        method.DefineParameter(2, ParameterAttributes.None, "args")
+            .SetCustomAttribute(paramArrayCtor, CustomAttributeEncoder.EmptyBlob);
+        runtime.ArrayIncludesProto = method;
+
+        var il = method.GetILGenerator();
+        var haveSearch = il.DefineLabel();
+        var afterSearch = il.DefineLabel();
+        var haveFromIndex = il.DefineLabel();
+        var afterFromIndex = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Brtrue, haveSearch);
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Br, afterSearch);
+        il.MarkLabel(haveSearch);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.MarkLabel(afterSearch);
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Bge, haveFromIndex);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Br, afterFromIndex);
+        il.MarkLabel(haveFromIndex);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.MarkLabel(afterFromIndex);
+        il.Emit(OpCodes.Call, runtime.ArrayIncludes);
+        il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Emits the allocation-free SameValueZero scan used only for a proven
+    /// dense, non-escaping <c>number[]</c> promoted to <c>List&lt;double&gt;</c>.
+    /// The caller supplies an already-numeric fromIndex (zero when omitted), so
+    /// ToIntegerOrInfinity can be implemented without boxing or observable
+    /// coercion. NaN matches NaN and CLR equality supplies signed-zero parity.
+    /// </summary>
+    private void EmitArrayIncludesDouble(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "ArrayIncludesDouble",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Boolean,
+            [_types.ListOfDouble, _types.Double, _types.Double]);
+        method.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
+        runtime.ArrayIncludesDouble = method;
+
+        var il = method.GetILGenerator();
+        var len = il.DeclareLocal(_types.Int32);
+        var n = il.DeclareLocal(_types.Double);
+        var index = il.DeclareLocal(_types.Int32);
+        var element = il.DeclareLocal(_types.Double);
+        var returnFalse = il.DefineLabel();
+        var normalizeFinite = il.DefineLabel();
+        var nonNegative = il.DefineLabel();
+        var startReady = il.DefineLabel();
+        var loop = il.DefineLabel();
+        var notEqual = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.ListOfDouble, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, len);
+        il.Emit(OpCodes.Ldloc, len);
+        il.Emit(OpCodes.Brfalse, returnFalse);
+
+        // n = Math.Truncate(fromIndex); NaN becomes +0 per ToIntegerOrInfinity.
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Truncate", _types.Double));
+        il.Emit(OpCodes.Stloc, n);
+        il.Emit(OpCodes.Ldloc, n);
+        il.Emit(OpCodes.Ldloc, n);
+        il.Emit(OpCodes.Ceq);
+        il.Emit(OpCodes.Brtrue, normalizeFinite);
+        il.Emit(OpCodes.Ldc_R8, 0.0);
+        il.Emit(OpCodes.Stloc, n);
+
+        il.MarkLabel(normalizeFinite);
+        // +Infinity and every finite n >= len cannot match.
+        il.Emit(OpCodes.Ldloc, n);
+        il.Emit(OpCodes.Ldloc, len);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Bge, returnFalse);
+        il.Emit(OpCodes.Ldloc, n);
+        il.Emit(OpCodes.Ldc_R8, 0.0);
+        il.Emit(OpCodes.Bge, nonNegative);
+
+        // Negative infinity and n <= -len both clamp to zero. Avoid conv.i4
+        // for infinity by comparing in double space before conversion.
+        il.Emit(OpCodes.Ldloc, n);
+        il.Emit(OpCodes.Ldloc, len);
+        il.Emit(OpCodes.Neg);
+        il.Emit(OpCodes.Conv_R8);
+        var negativeInRange = il.DefineLabel();
+        il.Emit(OpCodes.Bgt, negativeInRange);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, index);
+        il.Emit(OpCodes.Br, startReady);
+
+        il.MarkLabel(negativeInRange);
+        il.Emit(OpCodes.Ldloc, len);
+        il.Emit(OpCodes.Ldloc, n);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, index);
+        il.Emit(OpCodes.Br, startReady);
+
+        il.MarkLabel(nonNegative);
+        il.Emit(OpCodes.Ldloc, n);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Stloc, index);
+
+        il.MarkLabel(startReady);
+        il.MarkLabel(loop);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldloc, len);
+        il.Emit(OpCodes.Bge, returnFalse);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfDouble, "get_Item", _types.Int32));
+        il.Emit(OpCodes.Stloc, element);
+
+        il.Emit(OpCodes.Ldloc, element);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ceq);
+        var returnTrue = il.DefineLabel();
+        il.Emit(OpCodes.Brtrue, returnTrue);
+        il.Emit(OpCodes.Ldloc, element);
+        il.Emit(OpCodes.Call, _types.DoubleIsNaN);
+        il.Emit(OpCodes.Brfalse, notEqual);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, _types.DoubleIsNaN);
+        il.Emit(OpCodes.Brtrue, returnTrue);
+
+        il.MarkLabel(notEqual);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, index);
+        il.Emit(OpCodes.Br, loop);
+
+        il.MarkLabel(returnTrue);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(returnFalse);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+    }
+
     private void EmitArrayIncludes(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         var method = typeBuilder.DefineMethod(

--- a/src/SharpTS/Compilation/RuntimeEmitter.CompactObjectRecord.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.CompactObjectRecord.cs
@@ -33,7 +33,8 @@ public partial class RuntimeEmitter
             if (shape.Fields.Count is < 1 or > 4)
                 continue;
             bool specializeStablePushScalars =
-                _features.CompactObjectRecordStablePushShapes.Contains(fingerprint);
+                _features.CompactObjectRecordStablePushShapes.Contains(fingerprint) ||
+                _features.CompactObjectRecordStableIteratorShapes.Contains(fingerprint);
 
             var typeBuilder = EmitTypeDefinitions.DefineType(
                 moduleBuilder,

--- a/src/SharpTS/Compilation/RuntimeEmitter.Iterator.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Iterator.cs
@@ -1165,6 +1165,7 @@ public partial class RuntimeEmitter
         var collectDoneLabel = il.DefineLabel();
         var tryBufferLabel = il.DefineLabel();
         var throwLabel = il.DefineLabel();
+        var customArrayIteratorLabel = il.DefineLabel();
 
         // Create result list
         il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, _types.EmptyTypes));
@@ -1173,6 +1174,24 @@ public partial class RuntimeEmitter
         // Check for null input
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brfalse, throwLabel);
+
+        // An array can carry an own @@iterator. Only programs that can install one pay
+        // this probe; the stable majority retain the zero-dispatch backing-list path.
+        if (_features.UsesArrayPrototypeMutation)
+        {
+            var noCustomArrayIterator = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+            il.Emit(OpCodes.Brfalse, noCustomArrayIterator);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, runtime.GetIteratorFunction);
+            il.Emit(OpCodes.Stloc, iterFnLocal);
+            il.Emit(OpCodes.Ldloc, iterFnLocal);
+            il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+            il.Emit(OpCodes.Brfalse, customArrayIteratorLabel);
+            il.MarkLabel(noCustomArrayIterator);
+        }
 
         // 1a. Stage E.2: fast path for $Array — return its backing list directly.
         // Since `$Array` inherits List<object?> (M2 decision), Elements is just
@@ -1418,6 +1437,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_1);  // Symbol.iterator
         il.Emit(OpCodes.Call, runtime.GetIteratorFunction);
         il.Emit(OpCodes.Stloc, iterFnLocal);
+
+        if (_features.UsesArrayPrototypeMutation)
+            il.MarkLabel(customArrayIteratorLabel);
 
         // If no iterator function was found, try the CLR enumerable fallback.
         // Explicit null is not absence and flows to InvokeMethodValue, which

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.DeleteProperty.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.DeleteProperty.cs
@@ -635,6 +635,27 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldarg_1);
             il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
             il.Emit(OpCodes.Stloc, tsArrIndexDescLocal);
+
+            // Sealing makes every existing own indexed property non-configurable,
+            // including dense elements that do not have an explicit PDS entry.
+            // Missing numeric properties still delete successfully.
+            var tsArrIndexNotSealedLabel = il.DefineLabel();
+            var tsArrIndexSealedPropertyLabel = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Call, runtime.PDSIsSealed);
+            il.Emit(OpCodes.Brfalse, tsArrIndexNotSealedLabel);
+            il.Emit(OpCodes.Ldloc, tsArrIndexDescLocal);
+            il.Emit(OpCodes.Brtrue, tsArrIndexSealedPropertyLabel);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+            il.Emit(OpCodes.Ldloc, tsArrDelIndexLocal);
+            il.Emit(OpCodes.Callvirt, runtime.TSArrayHasIndex);
+            il.Emit(OpCodes.Brfalse, tsArrIndexNotSealedLabel);
+            il.MarkLabel(tsArrIndexSealedPropertyLabel);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(tsArrIndexNotSealedLabel);
+
             il.Emit(OpCodes.Ldloc, tsArrIndexDescLocal);
             il.Emit(OpCodes.Brfalse, tsArrIndexDescriptorConfigurableLabel);
             il.Emit(OpCodes.Ldloc, tsArrIndexDescLocal);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -869,7 +869,12 @@ public partial class RuntimeEmitter
             "toString", "toLocaleString"
         ];
 
-        foreach (var methodName in methodNames)
+        // When source code can replace array methods or install descriptors,
+        // resolve the live own/prototype slot below. The compact bound-method
+        // shortcut is valid only while those shapes are proven immutable.
+        foreach (var methodName in methodNames.Where(_ =>
+                     !_features.UsesArrayPrototypeMutation
+                     && !_features.UsesDynamicPropertyDescriptors))
         {
             var skipLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_1);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Utilities.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Utilities.cs
@@ -35,25 +35,57 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         var listType = _types.ListOfObject;
         var keysLocal = il.DeclareLocal(listType);
+        var symbolKeysLocal = il.DeclareLocal(listType);
         var indexLocal = il.DeclareLocal(_types.Int32);
-        var keyLocal = il.DeclareLocal(_types.String);
+        var keyLocal = il.DeclareLocal(_types.Object);
+        var descriptorLocal = il.DeclareLocal(_types.Object);
+        var sourceIsProxyLocal = il.DeclareLocal(_types.Boolean);
+        var proxySource = il.DefineLabel();
+        var ordinarySource = il.DefineLabel();
+        var keysReady = il.DefineLabel();
         var loopStart = il.DefineLabel();
-        var loopEnd = il.DefineLabel();
+        var nextKey = il.DefineLabel();
+        var returnLabel = il.DefineLabel();
+        var ordinaryEnumerableCheck = il.DefineLabel();
+        var enumerableCheckDone = il.DefineLabel();
 
         // CopyDataProperties silently ignores null and undefined sources.
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Brfalse, loopEnd);
+        il.Emit(OpCodes.Brfalse, returnLabel);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Isinst, runtime.UndefinedType);
-        il.Emit(OpCodes.Brtrue, loopEnd);
+        il.Emit(OpCodes.Brtrue, returnLabel);
 
-        // Snapshot enumerable own string keys, then perform a live [[Get]] for
-        // each key.  Besides matching CopyDataProperties semantics for
-        // accessors/descriptors, this supports every ordinary emitted carrier,
-        // including compact records whose slots live behind $IHasFields.
+        // Snapshot the complete mixed [[OwnPropertyKeys]] list once. Proxy ownKeys must be invoked
+        // exactly once; ordinary carriers reuse GetKeys' mature enumerable-string ordering and append
+        // Symbols for per-key descriptor filtering.
+        if (_features.UsesProxy)
+        {
+            EmitProxyTypeCheck(
+                il, () => il.Emit(OpCodes.Ldarg_1), proxySource, ordinarySource);
+            il.MarkLabel(proxySource);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Stloc, sourceIsProxyLocal);
+            EmitProxyOwnKeysCompiledCall(il, runtime, () => il.Emit(OpCodes.Ldarg_1));
+            il.Emit(OpCodes.Stloc, keysLocal);
+            il.Emit(OpCodes.Br, keysReady);
+        }
+
+        il.MarkLabel(ordinarySource);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, sourceIsProxyLocal);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Call, runtime.GetKeys);
         il.Emit(OpCodes.Stloc, keysLocal);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.GetOwnPropertySymbols);
+        il.Emit(OpCodes.Castclass, listType);
+        il.Emit(OpCodes.Stloc, symbolKeysLocal);
+        il.Emit(OpCodes.Ldloc, keysLocal);
+        il.Emit(OpCodes.Ldloc, symbolKeysLocal);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            listType, "AddRange", [_types.IEnumerableOfObject])!);
+        il.MarkLabel(keysReady);
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Stloc, indexLocal);
 
@@ -61,28 +93,57 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, indexLocal);
         il.Emit(OpCodes.Ldloc, keysLocal);
         il.Emit(OpCodes.Callvirt, _types.GetProperty(listType, "Count").GetGetMethod()!);
-        il.Emit(OpCodes.Bge, loopEnd);
+        il.Emit(OpCodes.Bge, returnLabel);
         il.Emit(OpCodes.Ldloc, keysLocal);
         il.Emit(OpCodes.Ldloc, indexLocal);
         il.Emit(OpCodes.Callvirt, _types.GetProperty(listType, "Item").GetGetMethod()!);
-        il.Emit(OpCodes.Castclass, _types.String);
         il.Emit(OpCodes.Stloc, keyLocal);
+
+        // Proxy [[GetOwnProperty]] is observable and may report that a snapshotted key disappeared.
+        il.Emit(OpCodes.Ldloc, sourceIsProxyLocal);
+        il.Emit(OpCodes.Brfalse, ordinaryEnumerableCheck);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Call, runtime.ObjectGetOwnPropertyDescriptor);
+        il.Emit(OpCodes.Stloc, descriptorLocal);
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Brfalse, nextKey);
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, nextKey);
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Ldstr, "enumerable");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Call, runtime.IsTruthy);
+        il.Emit(OpCodes.Brfalse, nextKey);
+        il.Emit(OpCodes.Br, enumerableCheckDone);
+
+        // GetKeys already filtered ordinary string keys. Symbols need their descriptor bit checked.
+        il.MarkLabel(ordinaryEnumerableCheck);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Call, runtime.IsSymbolMethod);
+        il.Emit(OpCodes.Brfalse, enumerableCheckDone);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldloc, keyLocal);
+        il.Emit(OpCodes.Call, runtime.PropertyIsEnumerableHelperMethod);
+        il.Emit(OpCodes.Brfalse, nextKey);
+        il.MarkLabel(enumerableCheckDone);
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldloc, keyLocal);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldloc, keyLocal);
-        il.Emit(OpCodes.Call, runtime.GetProperty);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(
-            _types.DictionaryStringObject, "set_Item", _types.String, _types.Object));
+        il.Emit(OpCodes.Call, runtime.GetIndex);
+        il.Emit(OpCodes.Call, runtime.SetIndex);
 
+        il.MarkLabel(nextKey);
         il.Emit(OpCodes.Ldloc, indexLocal);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Add);
         il.Emit(OpCodes.Stloc, indexLocal);
         il.Emit(OpCodes.Br, loopStart);
 
-        il.MarkLabel(loopEnd);
+        il.MarkLabel(returnLabel);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.RegExp.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RegExp.cs
@@ -68,11 +68,52 @@ public partial class RuntimeEmitter
         // WithFunction first: StringReplaceRegExp delegates to it for callable
         // replacements, so its MethodBuilder must be assigned beforehand.
         EmitStringReplaceWithFunction(typeBuilder, runtime);
+        EmitStableRegExpReplace(typeBuilder, runtime);
         EmitStringReplaceRegExp(typeBuilder, runtime);
         EmitStringReplaceAllRegExp(typeBuilder, runtime);
         EmitStringSearchRegExp(typeBuilder, runtime);
         EmitStringSplitRegExp(typeBuilder, runtime);
         EmitStringSplitProto(typeBuilder, runtime);
+    }
+
+    /// <summary>
+    /// Emits the allocation-light path for a stable intrinsic regex literal and
+    /// primitive replacement string. Substitution tokens retain the complete
+    /// RegExp @@replace algorithm; ordinary replacement text can call the typed
+    /// regex helper directly without symbol lookup or argument-array creation.
+    /// </summary>
+    private void EmitStableRegExpReplace(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "StableRegExpReplace",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.String,
+            [_types.String, runtime.TSRegExpType, _types.String, _types.Boolean]);
+        runtime.StableRegExpReplace = method;
+
+        var il = method.GetILGenerator();
+        var ordinaryReplacementLabel = il.DefineLabel();
+
+        // JavaScript substitution tokens need the spec path, particularly
+        // $<name>, whose spelling differs from .NET's ${name} syntax.
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldc_I4, (int)'$');
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "Contains", [_types.Char])!);
+        il.Emit(OpCodes.Brfalse, ordinaryReplacementLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Call, runtime.TSRegExpSymReplaceHelper);
+        il.Emit(OpCodes.Castclass, _types.String);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(ordinaryReplacementLabel);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldarg_3);
+        il.Emit(OpCodes.Call, runtime.TSRegExpReplaceMethod);
+        il.Emit(OpCodes.Ret);
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -1203,6 +1203,8 @@ public partial class RuntimeEmitter
         // Search helpers use ToIntegerOrInfinity for spec-compliant fromIndex clamping.
         EmitToIntegerOrInfinityHelper(typeBuilder, runtime);
         EmitArrayIncludes(typeBuilder, runtime);
+        EmitArrayIncludesProto(typeBuilder, runtime);
+        EmitArrayIncludesDouble(typeBuilder, runtime);
         EmitArrayIndexOf(typeBuilder, runtime);
         EmitArrayLastIndexOf(typeBuilder, runtime);
         // ECMA-262 Array.prototype.* accepts any array-like (length + indexed

--- a/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -1280,6 +1280,7 @@ public partial class RuntimeEmitter
         EmitStringSubstr(typeBuilder, runtime);
         EmitStringIndexOf(typeBuilder, runtime);
         EmitStringIndexOfFrom(typeBuilder, runtime);
+        EmitPrimitiveStringIntrinsics(typeBuilder, runtime);
         EmitStringReplace(typeBuilder, runtime);
         EmitStringIncludes(typeBuilder, runtime);
         EmitStringStartsWith(typeBuilder, runtime);

--- a/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -1157,9 +1157,15 @@ public partial class RuntimeEmitter
         EmitArrayPop(typeBuilder, runtime);
         EmitArrayPopProto(typeBuilder, runtime);
         EmitArrayShift(typeBuilder, runtime);
+        EmitArrayShiftTyped(typeBuilder, runtime, ArrayElements.Double);
+        EmitArrayShiftTyped(typeBuilder, runtime, ArrayElements.Bool);
         EmitArrayShiftProto(typeBuilder, runtime);
+        EmitArrayShiftNumber(typeBuilder, runtime);
         EmitArrayUnshift(typeBuilder, runtime);
+        EmitArrayUnshiftTyped(typeBuilder, runtime, ArrayElements.Double);
+        EmitArrayUnshiftTyped(typeBuilder, runtime, ArrayElements.Bool);
         EmitArrayUnshiftProto(typeBuilder, runtime);
+        EmitArrayUnshiftNumber(typeBuilder, runtime);
         EmitArraySlice(typeBuilder, runtime);
         // Array callback methods must come after InvokeValue and IsTruthy
         EmitArrayMap(typeBuilder, runtime);

--- a/src/SharpTS/Compilation/RuntimeEmitter.StableIteratorResult.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.StableIteratorResult.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    private void EmitStableNumberIteratorResult(
+        ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    {
+        var builder = EmitTypeDefinitions.DefineType(
+            moduleBuilder,
+            "$StableNumberIteratorResult",
+            TypeAttributes.Public | TypeAttributes.Sealed |
+            TypeAttributes.SequentialLayout | TypeAttributes.BeforeFieldInit,
+            _types.ValueType);
+        var value = builder.DefineField("Value", _types.Double, FieldAttributes.Public);
+        var done = builder.DefineField("Done", _types.Boolean, FieldAttributes.Public);
+        var ctor = builder.DefineConstructor(
+            MethodAttributes.Public,
+            CallingConventions.Standard,
+            [_types.Double, _types.Boolean]);
+        var il = ctor.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Initobj, builder);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Stfld, value);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Stfld, done);
+        il.Emit(OpCodes.Ret);
+
+        Type resultType = builder.CreateType()!;
+        runtime.StableNumberIteratorResultType = resultType;
+        runtime.StableNumberIteratorResultCtor = resultType.GetConstructor(
+            [_types.Double, _types.Boolean])!;
+        runtime.StableNumberIteratorResultValueField = resultType.GetField("Value")!;
+        runtime.StableNumberIteratorResultDoneField = resultType.GetField("Done")!;
+    }
+}

--- a/src/SharpTS/Compilation/RuntimeEmitter.Strings.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Strings.cs
@@ -383,6 +383,270 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
+    /// <summary>
+    /// Emits allocation-free overloads for the fixed-arity primitive string
+    /// intrinsics. Their signatures deliberately contain no <see cref="object"/>
+    /// or <c>object[]</c> slots, so a statically proven call stays in typed IL.
+    /// </summary>
+    private void EmitPrimitiveStringIntrinsics(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        MethodBuilder toInteger = EmitPrimitiveStringToInteger(typeBuilder);
+        MethodImplAttributes inlineAndOptimize =
+            MethodImplAttributes.AggressiveInlining |
+            MethodImplAttributes.AggressiveOptimization;
+        var lengthGetter = _types.GetProperty(_types.String, "Length").GetGetMethod()!;
+        var substring = _types.GetMethod(
+            _types.String, "Substring", _types.Int32, _types.Int32);
+        var indexOfOrdinal = _types.GetMethod(
+            _types.String, "IndexOf",
+            [_types.String, _types.Int32, typeof(StringComparison)])!;
+        var min = _types.GetMethod(_types.Math, "Min", _types.Int32, _types.Int32);
+        var max = _types.GetMethod(_types.Math, "Max", _types.Int32, _types.Int32);
+
+        var indexOf = typeBuilder.DefineMethod(
+            "StringIndexOfPrimitive",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Double,
+            [_types.String, _types.String, _types.Double]);
+        indexOf.SetImplementationFlags(inlineAndOptimize);
+        runtime.StringIndexOfPrimitive = indexOf;
+        {
+            var il = indexOf.GetILGenerator();
+            var start = il.DeclareLocal(_types.Int32);
+
+            // Clamp ToIntegerOrInfinity(position) to [0, string.length]. In
+            // particular, an empty needle at a position beyond the end must
+            // return length rather than -1.
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Call, toInteger);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Call, max);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, lengthGetter);
+            il.Emit(OpCodes.Call, min);
+            il.Emit(OpCodes.Stloc, start);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldloc, start);
+            il.Emit(OpCodes.Ldc_I4, (int)StringComparison.Ordinal);
+            il.Emit(OpCodes.Callvirt, indexOfOrdinal);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Ret);
+        }
+
+        var includes = typeBuilder.DefineMethod(
+            "StringIncludesPrimitive",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Boolean,
+            [_types.String, _types.String, _types.Double]);
+        includes.SetImplementationFlags(inlineAndOptimize);
+        runtime.StringIncludesPrimitive = includes;
+        {
+            var il = includes.GetILGenerator();
+            var found = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Call, indexOf);
+            il.Emit(OpCodes.Ldc_R8, 0.0);
+            il.Emit(OpCodes.Bge, found);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(found);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Ret);
+        }
+
+        var slice = typeBuilder.DefineMethod(
+            "StringSlicePrimitive",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.String,
+            [_types.String, _types.Double, _types.Double, _types.Boolean]);
+        slice.SetImplementationFlags(inlineAndOptimize);
+        runtime.StringSlicePrimitive = slice;
+        {
+            var il = slice.GetILGenerator();
+            var length = il.DeclareLocal(_types.Int32);
+            var from = il.DeclareLocal(_types.Int32);
+            var to = il.DeclareLocal(_types.Int32);
+            var nonNegativeStart = il.DefineLabel();
+            var startReady = il.DefineLabel();
+            var hasEnd = il.DefineLabel();
+            var nonNegativeEnd = il.DefineLabel();
+            var endReady = il.DefineLabel();
+            var returnSubstring = il.DefineLabel();
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, lengthGetter);
+            il.Emit(OpCodes.Stloc, length);
+
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, toInteger);
+            il.Emit(OpCodes.Stloc, from);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Bge, nonNegativeStart);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Call, max);
+            il.Emit(OpCodes.Stloc, from);
+            il.Emit(OpCodes.Br, startReady);
+            il.MarkLabel(nonNegativeStart);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Call, min);
+            il.Emit(OpCodes.Stloc, from);
+            il.MarkLabel(startReady);
+
+            il.Emit(OpCodes.Ldarg_3);
+            il.Emit(OpCodes.Brtrue, hasEnd);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Stloc, to);
+            il.Emit(OpCodes.Br, endReady);
+            il.MarkLabel(hasEnd);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Call, toInteger);
+            il.Emit(OpCodes.Stloc, to);
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Bge, nonNegativeEnd);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Call, max);
+            il.Emit(OpCodes.Stloc, to);
+            il.Emit(OpCodes.Br, endReady);
+            il.MarkLabel(nonNegativeEnd);
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Call, min);
+            il.Emit(OpCodes.Stloc, to);
+            il.MarkLabel(endReady);
+
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Bgt, returnSubstring);
+            il.Emit(OpCodes.Ldstr, "");
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(returnSubstring);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Callvirt, substring);
+            il.Emit(OpCodes.Ret);
+        }
+
+        var substringPrimitive = typeBuilder.DefineMethod(
+            "StringSubstringPrimitive",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.String,
+            [_types.String, _types.Double, _types.Double, _types.Boolean]);
+        substringPrimitive.SetImplementationFlags(inlineAndOptimize);
+        runtime.StringSubstringPrimitive = substringPrimitive;
+        {
+            var il = substringPrimitive.GetILGenerator();
+            var length = il.DeclareLocal(_types.Int32);
+            var start = il.DeclareLocal(_types.Int32);
+            var end = il.DeclareLocal(_types.Int32);
+            var from = il.DeclareLocal(_types.Int32);
+            var to = il.DeclareLocal(_types.Int32);
+            var hasEnd = il.DefineLabel();
+            var endReady = il.DefineLabel();
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, lengthGetter);
+            il.Emit(OpCodes.Stloc, length);
+
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, toInteger);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Call, max);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Call, min);
+            il.Emit(OpCodes.Stloc, start);
+
+            il.Emit(OpCodes.Ldarg_3);
+            il.Emit(OpCodes.Brtrue, hasEnd);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Stloc, end);
+            il.Emit(OpCodes.Br, endReady);
+            il.MarkLabel(hasEnd);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Call, toInteger);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Call, max);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Call, min);
+            il.Emit(OpCodes.Stloc, end);
+            il.MarkLabel(endReady);
+
+            il.Emit(OpCodes.Ldloc, start);
+            il.Emit(OpCodes.Ldloc, end);
+            il.Emit(OpCodes.Call, min);
+            il.Emit(OpCodes.Stloc, from);
+            il.Emit(OpCodes.Ldloc, start);
+            il.Emit(OpCodes.Ldloc, end);
+            il.Emit(OpCodes.Call, max);
+            il.Emit(OpCodes.Stloc, to);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Callvirt, substring);
+            il.Emit(OpCodes.Ret);
+        }
+    }
+
+    private MethodBuilder EmitPrimitiveStringToInteger(TypeBuilder typeBuilder)
+    {
+        var method = typeBuilder.DefineMethod(
+            "StringToIntegerOrInfinityPrimitive",
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.Int32,
+            [_types.Double]);
+        method.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
+
+        var il = method.GetILGenerator();
+        var notNaN = il.DefineLabel();
+        var belowMaximum = il.DefineLabel();
+        var aboveMinimum = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsNaN", _types.Double));
+        il.Emit(OpCodes.Brfalse, notNaN);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(notNaN);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_R8, (double)int.MaxValue);
+        il.Emit(OpCodes.Blt, belowMaximum);
+        il.Emit(OpCodes.Ldc_I4, int.MaxValue);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(belowMaximum);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_R8, (double)int.MinValue);
+        il.Emit(OpCodes.Bgt, aboveMinimum);
+        il.Emit(OpCodes.Ldc_I4, int.MinValue);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(aboveMinimum);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Truncate", _types.Double));
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Ret);
+        return method;
+    }
+
     private void EmitStringReplace(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         var method = typeBuilder.DefineMethod(

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSArray.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSArray.cs
@@ -317,6 +317,18 @@ public partial class RuntimeEmitter
             MethodAttributes.Assembly | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
             _types.Int32, Type.EmptyTypes);
         runtime.TSArrayNumericCountGetter = numericCountGetter;
+        var canMutateNumericGetter = typeBuilder.DefineMethod("get_CanMutateNumeric",
+            MethodAttributes.Assembly | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
+            _types.Boolean, Type.EmptyTypes);
+        runtime.TSArrayCanMutateNumericGetter = canMutateNumericGetter;
+        var shiftNumeric = typeBuilder.DefineMethod("ShiftNumeric",
+            MethodAttributes.Assembly | MethodAttributes.HideBySig,
+            _types.Object, Type.EmptyTypes);
+        runtime.TSArrayShiftNumeric = shiftNumeric;
+        var unshiftNumeric = typeBuilder.DefineMethod("UnshiftNumeric",
+            MethodAttributes.Assembly | MethodAttributes.HideBySig,
+            _types.Double, [_types.DoubleArray]);
+        runtime.TSArrayUnshiftNumeric = unshiftNumeric;
         var cloneNumeric = typeBuilder.DefineMethod("CloneNumeric",
             MethodAttributes.Assembly | MethodAttributes.HideBySig,
             typeBuilder, Type.EmptyTypes);
@@ -340,6 +352,175 @@ public partial class RuntimeEmitter
             var il = numericCountGetter.GetILGenerator();
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Ret);
+        }
+        {
+            var il = canMutateNumericGetter.GetILGenerator();
+            var unavailable = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayIsNumericField);
+            il.Emit(OpCodes.Brfalse, unavailable);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayIsFrozenField);
+            il.Emit(OpCodes.Brtrue, unavailable);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayIsSealedField);
+            il.Emit(OpCodes.Brtrue, unavailable);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNonExtensibleField);
+            il.Emit(OpCodes.Brtrue, unavailable);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(unavailable);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ret);
+        }
+
+        // Packed numeric shift/unshift kernels. Their callers require the exact
+        // $Array type and CanMutateNumeric; all observable or deoptimized shapes
+        // stay on ArrayShiftProto/ArrayUnshiftProto.
+        {
+            var il = shiftNumeric.GetILGenerator();
+            var nonEmpty = il.DefineLabel();
+            var skipCopy = il.DefineLabel();
+            var first = il.DeclareLocal(_types.Double);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Brtrue, nonEmpty);
+            il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(nonEmpty);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ldelem_R8);
+            il.Emit(OpCodes.Stloc, first);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Ble, skipCopy);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Call, _types.ArrayCopy5);
+
+            il.MarkLabel(skipCopy);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Ldc_I4_1);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Stfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Conv_I8);
+            il.Emit(OpCodes.Stfld, _tsArrayLengthField);
+            il.Emit(OpCodes.Ldloc, first);
+            il.Emit(OpCodes.Box, _types.Double);
+            il.Emit(OpCodes.Ret);
+        }
+        {
+            var il = unshiftNumeric.GetILGenerator();
+            var nonEmptyItems = il.DefineLabel();
+            var haveStore = il.DefineLabel();
+            var capacityReady = il.DefineLabel();
+            var required = il.DeclareLocal(_types.Int32);
+            var newCapacity = il.DeclareLocal(_types.Int32);
+
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldlen);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Brtrue, nonEmptyItems);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(nonEmptyItems);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldlen);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Stloc, required);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Brtrue, haveStore);
+            il.Emit(OpCodes.Ldc_I4_4);
+            il.Emit(OpCodes.Ldloc, required);
+            il.Emit(OpCodes.Call, _types.MathMaxInt32);
+            il.Emit(OpCodes.Stloc, newCapacity);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, newCapacity);
+            il.Emit(OpCodes.Newarr, _types.Double);
+            il.Emit(OpCodes.Stfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Br, capacityReady);
+
+            il.MarkLabel(haveStore);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldlen);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Ldloc, required);
+            il.Emit(OpCodes.Bge, capacityReady);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldlen);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Mul);
+            il.Emit(OpCodes.Ldloc, required);
+            il.Emit(OpCodes.Call, _types.MathMaxInt32);
+            il.Emit(OpCodes.Stloc, newCapacity);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldflda, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldloc, newCapacity);
+            il.Emit(OpCodes.Call, arrayResize);
+
+            il.MarkLabel(capacityReady);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldlen);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Call, _types.ArrayCopy5);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldlen);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Call, _types.ArrayCopy5);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, required);
+            il.Emit(OpCodes.Stfld, _tsArrayNumCountField);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldloc, required);
+            il.Emit(OpCodes.Conv_I8);
+            il.Emit(OpCodes.Stfld, _tsArrayLengthField);
+            il.Emit(OpCodes.Ldloc, required);
+            il.Emit(OpCodes.Conv_R8);
             il.Emit(OpCodes.Ret);
         }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSError.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSError.cs
@@ -13,6 +13,7 @@ public partial class RuntimeEmitter
     private FieldBuilder _tsErrorNameField = null!;
     private FieldBuilder _tsErrorMessageField = null!;
     private FieldBuilder _tsErrorStackField = null!;
+    private FieldBuilder _tsErrorCapturedStackField = null!;
     private FieldBuilder _tsErrorCauseField = null!;
     private FieldBuilder _tsErrorHasCauseField = null!;
     private FieldBuilder _tsErrorCodeField = null!;
@@ -52,13 +53,12 @@ public partial class RuntimeEmitter
         _tsErrorNameField = typeBuilder.DefineField("_name", _types.String, FieldAttributes.Private);
         _tsErrorMessageField = typeBuilder.DefineField("_message", _types.String, FieldAttributes.Private);
         _tsErrorStackField = typeBuilder.DefineField("_stack", _types.String, FieldAttributes.Private);
+        _tsErrorCapturedStackField = typeBuilder.DefineField(
+            "_capturedStack", _types.String, FieldAttributes.Private);
         _tsErrorCauseField = typeBuilder.DefineField("_cause", _types.Object, FieldAttributes.Private);
         _tsErrorHasCauseField = typeBuilder.DefineField("_hasCause", _types.Boolean, FieldAttributes.Private);
         _tsErrorCodeField = typeBuilder.DefineField("_code", _types.String, FieldAttributes.Private);
         _tsErrorSyscallField = typeBuilder.DefineField("_syscall", _types.String, FieldAttributes.Private);
-
-        // CaptureStackTrace helper - must be emitted first since the constructor calls it
-        EmitCaptureStackTrace(typeBuilder, runtime);
 
         // Protected constructor: protected $Error(string name, string? message)
         // Must be emitted before message constructor since it calls this one
@@ -71,6 +71,7 @@ public partial class RuntimeEmitter
         EmitTSErrorNameProperty(typeBuilder, runtime);
         EmitTSErrorMessageProperty(typeBuilder, runtime);
         EmitTSErrorStackProperty(typeBuilder, runtime);
+        EmitTSErrorCapturedStackSetter(typeBuilder, runtime);
         EmitTSErrorCauseProperty(typeBuilder, runtime);
         EmitTSErrorCodeProperty(typeBuilder, runtime);
         EmitTSErrorSyscallProperty(typeBuilder, runtime);
@@ -134,10 +135,11 @@ public partial class RuntimeEmitter
         il.MarkLabel(hasMessage);
         il.Emit(OpCodes.Stfld, _tsErrorMessageField);
 
-        // _stack = CaptureStackTrace()
+        // Runtime-created errors get a stable marker. Direct guest construction
+        // replaces it with the emitting method's interned creation-site token.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.TSErrorCaptureStackTrace);
-        il.Emit(OpCodes.Stfld, _tsErrorStackField);
+        il.Emit(OpCodes.Ldstr, "<runtime>");
+        il.Emit(OpCodes.Stfld, _tsErrorCapturedStackField);
 
         il.Emit(OpCodes.Ret);
     }
@@ -241,8 +243,45 @@ public partial class RuntimeEmitter
         );
         runtime.TSErrorStackGetter = getter;
         var getIL = getter.GetILGenerator();
+        var formatCapture = getIL.DefineLabel();
+
+        // Return an explicitly assigned or already-formatted value.
         getIL.Emit(OpCodes.Ldarg_0);
         getIL.Emit(OpCodes.Ldfld, _tsErrorStackField);
+        getIL.Emit(OpCodes.Dup);
+        getIL.Emit(OpCodes.Brtrue, formatCapture);
+        getIL.Emit(OpCodes.Pop);
+
+        // No capture can only occur after an explicit null assignment; expose
+        // the same string-shaped fallback as an empty captured trace.
+        var captured = getIL.DeclareLocal(_types.String);
+        var hasCapture = getIL.DefineLabel();
+        getIL.Emit(OpCodes.Ldarg_0);
+        getIL.Emit(OpCodes.Ldfld, _tsErrorCapturedStackField);
+        getIL.Emit(OpCodes.Stloc, captured);
+        getIL.Emit(OpCodes.Ldloc, captured);
+        getIL.Emit(OpCodes.Brtrue, hasCapture);
+        getIL.Emit(OpCodes.Ldstr, "");
+        getIL.Emit(OpCodes.Ret);
+
+        // Format once, cache the string, and release the captured frames.
+        getIL.MarkLabel(hasCapture);
+        var formatted = getIL.DeclareLocal(_types.String);
+        getIL.Emit(OpCodes.Ldstr, "    at ");
+        getIL.Emit(OpCodes.Ldloc, captured);
+        getIL.Emit(OpCodes.Call, _types.GetMethod(
+            _types.String, "Concat", [_types.String, _types.String])!);
+        getIL.Emit(OpCodes.Stloc, formatted);
+        getIL.Emit(OpCodes.Ldarg_0);
+        getIL.Emit(OpCodes.Ldloc, formatted);
+        getIL.Emit(OpCodes.Stfld, _tsErrorStackField);
+        getIL.Emit(OpCodes.Ldarg_0);
+        getIL.Emit(OpCodes.Ldnull);
+        getIL.Emit(OpCodes.Stfld, _tsErrorCapturedStackField);
+        getIL.Emit(OpCodes.Ldloc, formatted);
+        getIL.Emit(OpCodes.Ret);
+
+        getIL.MarkLabel(formatCapture);
         getIL.Emit(OpCodes.Ret);
         prop.SetGetMethod(getter);
 
@@ -258,8 +297,31 @@ public partial class RuntimeEmitter
         setIL.Emit(OpCodes.Ldarg_0);
         setIL.Emit(OpCodes.Ldarg_1);
         setIL.Emit(OpCodes.Stfld, _tsErrorStackField);
+        setIL.Emit(OpCodes.Ldarg_0);
+        setIL.Emit(OpCodes.Ldnull);
+        setIL.Emit(OpCodes.Stfld, _tsErrorCapturedStackField);
         setIL.Emit(OpCodes.Ret);
         prop.SetSetMethod(setter);
+    }
+
+    private void EmitTSErrorCapturedStackSetter(
+        TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "SetCapturedStackFrame",
+            MethodAttributes.Public | MethodAttributes.HideBySig,
+            _types.Void,
+            [_types.String]);
+        runtime.TSErrorCapturedStackSetter = method;
+
+        var il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Stfld, _tsErrorStackField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Stfld, _tsErrorCapturedStackField);
+        il.Emit(OpCodes.Ret);
     }
 
     private void EmitTSErrorCauseProperty(TypeBuilder typeBuilder, EmittedRuntime runtime)
@@ -417,190 +479,6 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, _tsErrorMessageField);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "Concat", [_types.String, _types.String, _types.String])!);
-        il.Emit(OpCodes.Ret);
-    }
-
-    private void EmitCaptureStackTrace(TypeBuilder typeBuilder, EmittedRuntime runtime)
-    {
-        // private static string CaptureStackTrace()
-        var method = typeBuilder.DefineMethod(
-            "CaptureStackTrace",
-            MethodAttributes.Private | MethodAttributes.Static,
-            _types.String,
-            Type.EmptyTypes
-        );
-        runtime.TSErrorCaptureStackTrace = method;
-
-        var il = method.GetILGenerator();
-
-        // var stackTrace = new StackTrace(skipFrames: 3, fNeedFileInfo: true);
-        var stackTraceLocal = il.DeclareLocal(_types.StackTrace);
-        il.Emit(OpCodes.Ldc_I4_3); // skipFrames
-        il.Emit(OpCodes.Ldc_I4_1); // fNeedFileInfo = true
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.StackTrace, [_types.Int32, _types.Boolean])!);
-        il.Emit(OpCodes.Stloc, stackTraceLocal);
-
-        // var frames = stackTrace.GetFrames();
-        var framesLocal = il.DeclareLocal(_types.MakeArrayType(_types.StackFrame));
-        il.Emit(OpCodes.Ldloc, stackTraceLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StackTrace, "GetFrames")!);
-        il.Emit(OpCodes.Stloc, framesLocal);
-
-        // if (frames == null || frames.Length == 0) return "";
-        var hasFramesLabel = il.DefineLabel();
-        var returnEmptyLabel = il.DefineLabel();
-
-        il.Emit(OpCodes.Ldloc, framesLocal);
-        il.Emit(OpCodes.Brfalse, returnEmptyLabel);
-        il.Emit(OpCodes.Ldloc, framesLocal);
-        il.Emit(OpCodes.Ldlen);
-        il.Emit(OpCodes.Conv_I4);
-        il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Bgt, hasFramesLabel);
-
-        il.MarkLabel(returnEmptyLabel);
-        il.Emit(OpCodes.Ldstr, "");
-        il.Emit(OpCodes.Ret);
-
-        il.MarkLabel(hasFramesLabel);
-
-        // var sb = new StringBuilder();
-        var sbLocal = il.DeclareLocal(_types.StringBuilder);
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.StringBuilder, Type.EmptyTypes)!);
-        il.Emit(OpCodes.Stloc, sbLocal);
-
-        // Loop through frames
-        var indexLocal = il.DeclareLocal(_types.Int32);
-        var loopStart = il.DefineLabel();
-        var loopEnd = il.DefineLabel();
-        var frameLocal = il.DeclareLocal(_types.StackFrame);
-        var methodLocal = il.DeclareLocal(_types.MethodBase);
-
-        il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Stloc, indexLocal);
-
-        il.MarkLabel(loopStart);
-        il.Emit(OpCodes.Ldloc, indexLocal);
-        il.Emit(OpCodes.Ldloc, framesLocal);
-        il.Emit(OpCodes.Ldlen);
-        il.Emit(OpCodes.Conv_I4);
-        il.Emit(OpCodes.Bge, loopEnd);
-
-        // frame = frames[index]
-        il.Emit(OpCodes.Ldloc, framesLocal);
-        il.Emit(OpCodes.Ldloc, indexLocal);
-        il.Emit(OpCodes.Ldelem_Ref);
-        il.Emit(OpCodes.Stloc, frameLocal);
-
-        // method = frame.GetMethod()
-        il.Emit(OpCodes.Ldloc, frameLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StackFrame, "GetMethod")!);
-        il.Emit(OpCodes.Stloc, methodLocal);
-
-        // if (method == null) continue
-        var processMethodLabel = il.DefineLabel();
-        il.Emit(OpCodes.Ldloc, methodLocal);
-        il.Emit(OpCodes.Brtrue, processMethodLabel);
-        il.Emit(OpCodes.Ldloc, indexLocal);
-        il.Emit(OpCodes.Ldc_I4_1);
-        il.Emit(OpCodes.Add);
-        il.Emit(OpCodes.Stloc, indexLocal);
-        il.Emit(OpCodes.Br, loopStart);
-
-        il.MarkLabel(processMethodLabel);
-
-        // sb.Append("    at ");
-        il.Emit(OpCodes.Ldloc, sbLocal);
-        il.Emit(OpCodes.Ldstr, "    at ");
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "Append", [_types.String])!);
-        il.Emit(OpCodes.Pop);
-
-        // Get type name
-        var typeNameLocal = il.DeclareLocal(_types.String);
-        var declaringTypeLocal = il.DeclareLocal(_types.Type);
-        var skipTypeLabel = il.DefineLabel();
-        var afterTypeLabel = il.DefineLabel();
-
-        il.Emit(OpCodes.Ldloc, methodLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.MethodBase, "DeclaringType")!.GetGetMethod()!);
-        il.Emit(OpCodes.Stloc, declaringTypeLocal);
-        il.Emit(OpCodes.Ldloc, declaringTypeLocal);
-        il.Emit(OpCodes.Brfalse, skipTypeLabel);
-
-        // sb.Append(typeName + ".")
-        il.Emit(OpCodes.Ldloc, sbLocal);
-        il.Emit(OpCodes.Ldloc, declaringTypeLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.Type, "Name")!.GetGetMethod()!);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "Append", [_types.String])!);
-        il.Emit(OpCodes.Pop);
-        il.Emit(OpCodes.Ldloc, sbLocal);
-        il.Emit(OpCodes.Ldstr, ".");
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "Append", [_types.String])!);
-        il.Emit(OpCodes.Pop);
-
-        il.MarkLabel(skipTypeLabel);
-
-        // sb.Append(method.Name)
-        il.Emit(OpCodes.Ldloc, sbLocal);
-        il.Emit(OpCodes.Ldloc, methodLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.MethodBase, "Name")!.GetGetMethod()!);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "Append", [_types.String])!);
-        il.Emit(OpCodes.Pop);
-
-        // Add file info if available
-        var fileNameLocal = il.DeclareLocal(_types.String);
-        var noFileLabel = il.DefineLabel();
-
-        il.Emit(OpCodes.Ldloc, frameLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StackFrame, "GetFileName")!);
-        il.Emit(OpCodes.Stloc, fileNameLocal);
-        il.Emit(OpCodes.Ldloc, fileNameLocal);
-        il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "IsNullOrEmpty")!);
-        il.Emit(OpCodes.Brtrue, noFileLabel);
-
-        // sb.Append(" (" + fileName + ":" + lineNumber + ")")
-        il.Emit(OpCodes.Ldloc, sbLocal);
-        il.Emit(OpCodes.Ldstr, " (");
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "Append", [_types.String])!);
-        il.Emit(OpCodes.Pop);
-        il.Emit(OpCodes.Ldloc, sbLocal);
-        il.Emit(OpCodes.Ldloc, fileNameLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "Append", [_types.String])!);
-        il.Emit(OpCodes.Pop);
-        il.Emit(OpCodes.Ldloc, sbLocal);
-        il.Emit(OpCodes.Ldstr, ":");
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "Append", [_types.String])!);
-        il.Emit(OpCodes.Pop);
-        il.Emit(OpCodes.Ldloc, sbLocal);
-        il.Emit(OpCodes.Ldloc, frameLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StackFrame, "GetFileLineNumber")!);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "Append", [_types.Int32])!);
-        il.Emit(OpCodes.Pop);
-        il.Emit(OpCodes.Ldloc, sbLocal);
-        il.Emit(OpCodes.Ldstr, ")");
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "Append", [_types.String])!);
-        il.Emit(OpCodes.Pop);
-
-        il.MarkLabel(noFileLabel);
-
-        // sb.AppendLine()
-        il.Emit(OpCodes.Ldloc, sbLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "AppendLine", Type.EmptyTypes)!);
-        il.Emit(OpCodes.Pop);
-
-        // index++
-        il.Emit(OpCodes.Ldloc, indexLocal);
-        il.Emit(OpCodes.Ldc_I4_1);
-        il.Emit(OpCodes.Add);
-        il.Emit(OpCodes.Stloc, indexLocal);
-        il.Emit(OpCodes.Br, loopStart);
-
-        il.MarkLabel(loopEnd);
-
-        // return sb.ToString().TrimEnd()
-        il.Emit(OpCodes.Ldloc, sbLocal);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.StringBuilder, "ToString", Type.EmptyTypes)!);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "TrimEnd", Type.EmptyTypes)!);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSFunction.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSFunction.cs
@@ -539,6 +539,17 @@ public partial class RuntimeEmitter
         gmIL.Emit(OpCodes.Ldfld, methodField);
         gmIL.Emit(OpCodes.Ret);
 
+        var getTargetBuilder = typeBuilder.DefineMethod(
+            "GetTarget",
+            MethodAttributes.Assembly | MethodAttributes.HideBySig,
+            _types.Object,
+            Type.EmptyTypes);
+        runtime.TSFunctionGetTarget = getTargetBuilder;
+        var gtIL = getTargetBuilder.GetILGenerator();
+        gtIL.Emit(OpCodes.Ldarg_0);
+        gtIL.Emit(OpCodes.Ldfld, targetField);
+        gtIL.Emit(OpCodes.Ret);
+
         // Helper method: private static object[] AdjustArgs(MethodInfo method, object[] args)
         var adjustArgsMethod = EmitTSFunctionAdjustArgsHelper(typeBuilder, runtime, paramCountField, hasListRestField, hasArrayRestField, padUndefinedMaskField);
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSRegExp.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSRegExp.cs
@@ -2653,16 +2653,27 @@ public partial class RuntimeEmitter
             [_types.String, _types.String, _types.Boolean]
         );
         _tsRegExpReplaceMethod = method;
+        runtime.TSRegExpReplaceMethod = method;
 
         var il = method.GetILGenerator();
         var globalLabel = il.DefineLabel();
-        var endLabel = il.DefineLabel();
+        var replacementReadyLabel = il.DefineLabel();
 
         // Preprocess replacement string: \`$0\` stays literal in JS (.NET would
         // expand to entire match) and \`$0N\` with N > captureCount is literal
         // (.NET-ECMAScript flag expands $0 greedily). Pass captureCount =
         // _regex.GetGroupNumbers().Length - 1 (group 0 is the match itself).
         var escapedLocal = il.DeclareLocal(_types.String);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Ldc_I4, (int)'$');
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "Contains", [_types.Char])!);
+        var preprocessLabel = il.DefineLabel();
+        il.Emit(OpCodes.Brtrue, preprocessLabel);
+        il.Emit(OpCodes.Ldarg_2);
+        il.Emit(OpCodes.Stloc, escapedLocal);
+        il.Emit(OpCodes.Br, replacementReadyLabel);
+
+        il.MarkLabel(preprocessLabel);
         il.Emit(OpCodes.Ldarg_2);
         // captureCount = _regex.GetGroupNumbers().Length - 1
         il.Emit(OpCodes.Ldarg_0);
@@ -2674,6 +2685,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Sub);
         il.Emit(OpCodes.Call, _tsRegExpEscapeJsReplacementMethod);
         il.Emit(OpCodes.Stloc, escapedLocal);
+        il.MarkLabel(replacementReadyLabel);
 
         // if (isGlobal)
         il.Emit(OpCodes.Ldarg_3);
@@ -3550,7 +3562,8 @@ public partial class RuntimeEmitter
             "ExpandReplacementSpec",
             MethodAttributes.Private | MethodAttributes.Static,
             _types.String,
-            [_types.String, _types.String, _types.String, _types.Int32, _types.ListOfObject]);
+            [_types.String, _types.String, _types.String, _types.Int32,
+                _types.ListOfObject, _types.Object]);
         _tsRegExpExpandReplacementSpecMethod = method;
 
         var il = method.GetILGenerator();
@@ -3561,6 +3574,8 @@ public partial class RuntimeEmitter
         var consumed = il.DeclareLocal(_types.Int32);
         var capture = il.DeclareLocal(_types.Object);
         var tailStart = il.DeclareLocal(_types.Int32);
+        var namedClose = il.DeclareLocal(_types.Int32);
+        var namedValue = il.DeclareLocal(_types.Object);
 
         var stringLength = _types.GetProperty(_types.String, "Length").GetGetMethod()!;
         var stringChars = _types.GetMethod(_types.String, "get_Chars", _types.Int32);
@@ -3661,9 +3676,65 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Br, tokenDone);
 
+        // $<name>. This syntax is active only when the match result exposes a
+        // named-captures object; without one it remains ordinary replacement
+        // text. Missing/unmatched named captures substitute the empty string.
+        il.MarkLabel(notSuffix);
+        var notNamedCapture = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, next);
+        il.Emit(OpCodes.Ldc_I4, (int)'<');
+        il.Emit(OpCodes.Bne_Un, notNamedCapture);
+        il.Emit(OpCodes.Ldarg_S, (byte)5);
+        il.Emit(OpCodes.Brfalse, notNamedCapture);
+        il.Emit(OpCodes.Ldarg_S, (byte)5);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, notNamedCapture);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4, (int)'>');
+        il.Emit(OpCodes.Ldloc, i);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.String, "IndexOf", _types.Char, _types.Int32));
+        il.Emit(OpCodes.Stloc, namedClose);
+        il.Emit(OpCodes.Ldloc, namedClose);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Blt, notNamedCapture);
+        il.Emit(OpCodes.Ldarg_S, (byte)5);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, i);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldloc, namedClose);
+        il.Emit(OpCodes.Ldloc, i);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Ldc_I4_2);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(
+            _types.String, "Substring", _types.Int32, _types.Int32));
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Stloc, namedValue);
+        var namedDone = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, namedValue);
+        il.Emit(OpCodes.Brfalse, namedDone);
+        il.Emit(OpCodes.Ldloc, namedValue);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, namedDone);
+        il.Emit(OpCodes.Ldloc, sb);
+        il.Emit(OpCodes.Ldloc, namedValue);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
+        il.Emit(OpCodes.Callvirt, appendString);
+        il.Emit(OpCodes.Pop);
+        il.MarkLabel(namedDone);
+        il.Emit(OpCodes.Ldloc, namedClose);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Stloc, i);
+        il.Emit(OpCodes.Br, loopTest);
+
         // $n / $nn. A nonexistent capture leaves '$' literal and lets the
         // following digit(s) be processed normally on subsequent iterations.
-        il.MarkLabel(notSuffix);
+        il.MarkLabel(notNamedCapture);
         il.Emit(OpCodes.Ldloc, next);
         il.Emit(OpCodes.Ldc_I4, (int)'0');
         il.Emit(OpCodes.Blt, ordinary);
@@ -4012,6 +4083,8 @@ public partial class RuntimeEmitter
         var captureValue = il.DeclareLocal(_types.Object);
         var replacement = il.DeclareLocal(_types.String);
         var currentIndex = il.DeclareLocal(_types.Int32);
+        var namedCaptures = il.DeclareLocal(_types.Object);
+        var hasNamedCaptures = il.DeclareLocal(_types.Boolean);
 
         var listAdd = _types.GetMethod(_types.ListOfObject, "Add", _types.Object);
         var listCountGet = _types.GetProperty(_types.ListOfObject, "Count").GetGetMethod()!;
@@ -4201,13 +4274,32 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, length);
         il.Emit(OpCodes.Blt, captureLoop);
 
-        // Functional replacement: [matched, ...captures, position, S].
+        il.Emit(OpCodes.Ldloc, execResult);
+        il.Emit(OpCodes.Ldstr, "groups");
+        il.Emit(OpCodes.Call, runtime.GetProperty);
+        il.Emit(OpCodes.Stloc, namedCaptures);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, hasNamedCaptures);
+        var namedCapturesReady = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, namedCaptures);
+        il.Emit(OpCodes.Brfalse, namedCapturesReady);
+        il.Emit(OpCodes.Ldloc, namedCaptures);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brtrue, namedCapturesReady);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, hasNamedCaptures);
+        il.MarkLabel(namedCapturesReady);
+
+        // Functional replacement: [matched, ...captures, position, S,
+        // groups?]. The final groups object is present only for named captures.
         il.Emit(OpCodes.Ldloc, replacementFunctionLocal);
         il.Emit(OpCodes.Brfalse, stringReplacement);
         var callArgs = il.DeclareLocal(_types.ObjectArray);
         il.Emit(OpCodes.Ldloc, captures);
         il.Emit(OpCodes.Callvirt, listCountGet);
         il.Emit(OpCodes.Ldc_I4_3);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldloc, hasNamedCaptures);
         il.Emit(OpCodes.Add);
         il.Emit(OpCodes.Newarr, _types.Object);
         il.Emit(OpCodes.Stloc, callArgs);
@@ -4254,6 +4346,17 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Add);
         il.Emit(OpCodes.Ldloc, sLocal);
         il.Emit(OpCodes.Stelem_Ref);
+        var callbackArgsReady = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, hasNamedCaptures);
+        il.Emit(OpCodes.Brfalse, callbackArgsReady);
+        il.Emit(OpCodes.Ldloc, callArgs);
+        il.Emit(OpCodes.Ldloc, captures);
+        il.Emit(OpCodes.Callvirt, listCountGet);
+        il.Emit(OpCodes.Ldc_I4_3);
+        il.Emit(OpCodes.Add);
+        il.Emit(OpCodes.Ldloc, namedCaptures);
+        il.Emit(OpCodes.Stelem_Ref);
+        il.MarkLabel(callbackArgsReady);
         il.Emit(OpCodes.Ldloc, replacementFunctionLocal);
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il.Emit(OpCodes.Ldloc, callArgs);
@@ -4268,6 +4371,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, matched);
         il.Emit(OpCodes.Ldloc, position);
         il.Emit(OpCodes.Ldloc, captures);
+        il.Emit(OpCodes.Ldloc, namedCaptures);
         il.Emit(OpCodes.Call, _tsRegExpExpandReplacementSpecMethod);
         il.Emit(OpCodes.Stloc, replacement);
         il.MarkLabel(haveReplacement);

--- a/src/SharpTS/Compilation/RuntimeEmitter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.cs
@@ -93,6 +93,9 @@ public partial class RuntimeEmitter
         // IsDefined read that backstops the (ref-asm-fragile) parameter-name check. (#738)
         EmitExpectsThisAttribute(moduleBuilder, runtime);
 
+        if (features.CompactObjectRecordStableIteratorShapes.Count > 0)
+            EmitStableNumberIteratorResult(moduleBuilder, runtime);
+
         // Emit TSFunction class first (other methods depend on it)
         EmitTSFunctionClass(moduleBuilder, runtime);
 

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -37,6 +37,10 @@ public sealed class RuntimeFeatureDetector
         "String"
     };
     private readonly HashSet<string> _stringPrototypeAliases = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _mathAliases = new(StringComparer.Ordinal)
+    {
+        "Math"
+    };
     private readonly HashSet<string> _dateConstructorAliases = new(StringComparer.Ordinal)
     {
         "Date"
@@ -106,6 +110,7 @@ public sealed class RuntimeFeatureDetector
             UsesArrayPrototypeMutation = false,
             UsesNumberPrototypeMutation = false,
             UsesStringPrototypeMutation = false,
+            UsesMathMutation = false,
             UsesNumberConstructorMutation = false,
             UsesRegExpPrototypeMutation = false,
             UsesGlobalParseIntMutation = false,
@@ -334,6 +339,7 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesDatePrototypeMutation = true;
                     _set.UsesRegExpPrototypeMutation = true;
                     _set.UsesStringPrototypeMutation = true;
+                    _set.UsesMathMutation = true;
                 }
                 break;
 
@@ -677,6 +683,7 @@ public sealed class RuntimeFeatureDetector
                 {
                     TrackNumberAlias(var.Name.Lexeme, var.Initializer);
                     TrackStringAlias(var.Name.Lexeme, var.Initializer);
+                    TrackMathAlias(var.Name.Lexeme, var.Initializer);
                     TrackDateAlias(var.Name.Lexeme, var.Initializer);
                     if (_opaqueValueBindings.Contains(var.Name.Lexeme))
                         MarkPotentiallyMaterialized(var.Initializer);
@@ -687,6 +694,7 @@ public sealed class RuntimeFeatureDetector
             case Stmt.Const cst:
                 TrackNumberAlias(cst.Name.Lexeme, cst.Initializer);
                 TrackStringAlias(cst.Name.Lexeme, cst.Initializer);
+                TrackMathAlias(cst.Name.Lexeme, cst.Initializer);
                 TrackDateAlias(cst.Name.Lexeme, cst.Initializer);
                 if (_opaqueValueBindings.Contains(cst.Name.Lexeme))
                     MarkPotentiallyMaterialized(cst.Initializer);
@@ -871,6 +879,8 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesNumberPrototypeMutation = true;
                 if (IsStringPrototype(g) || g.Name.Lexeme == "__proto__")
                     _set.UsesStringPrototypeMutation = true;
+                if (g.Name.Lexeme == "__proto__" && IsMathObject(g.Object))
+                    _set.UsesMathMutation = true;
                 if (IsRegExpPrototype(g))
                     _set.UsesRegExpPrototypeMutation = true;
                 if (IsDatePrototype(g)
@@ -893,6 +903,7 @@ public sealed class RuntimeFeatureDetector
                     {
                         _set.UsesRegExpPrototypeMutation = true;
                         _set.UsesStringPrototypeMutation = true;
+                        _set.UsesMathMutation = true;
                     }
                     if ((ov.Name.Lexeme == "Object"
                             && g.Name.Lexeme is "defineProperty" or "defineProperties" or "create")
@@ -968,6 +979,9 @@ public sealed class RuntimeFeatureDetector
                 if (IsStringMutationTarget(s.Object)
                     || (IsGlobalObject(s.Object) && s.Name.Lexeme == "String"))
                     _set.UsesStringPrototypeMutation = true;
+                if (IsMathObject(s.Object)
+                    || (IsGlobalObject(s.Object) && s.Name.Lexeme == "Math"))
+                    _set.UsesMathMutation = true;
                 if (IsNumberConstructorMutationTarget(s.Object, s.Name.Lexeme))
                     _set.UsesNumberConstructorMutation = true;
                 if (IsRegExpMutationTarget(s.Object)
@@ -1040,6 +1054,10 @@ public sealed class RuntimeFeatureDetector
                     || (IsGlobalObject(si.Object)
                         && si.Index is Expr.Literal { Value: "String" }))
                     _set.UsesStringPrototypeMutation = true;
+                if (IsMathObject(si.Object)
+                    || (IsGlobalObject(si.Object)
+                        && si.Index is Expr.Literal { Value: "Math" }))
+                    _set.UsesMathMutation = true;
                 if (si.Index is Expr.Literal { Value: string setIndexNumberProperty }
                     && IsNumberConstructorMutationTarget(
                         si.Object, setIndexNumberProperty))
@@ -1072,6 +1090,7 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesNumberConstructorMutation = true;
                     _set.UsesRegExpPrototypeMutation = true;
                     _set.UsesStringPrototypeMutation = true;
+                    _set.UsesMathMutation = true;
                     _set.UsesGlobalParseIntMutation = true;
                 }
                 if (c.Callee is Expr.Get
@@ -1100,6 +1119,7 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesNumberConstructorMutation = true;
                     _set.UsesRegExpPrototypeMutation = true;
                     _set.UsesStringPrototypeMutation = true;
+                    _set.UsesMathMutation = true;
                 }
                 if (c.Callee is not Expr.Variable directSourceCall ||
                     !_sourceFunctions.Contains(directSourceCall.Name.Lexeme))
@@ -1196,6 +1216,7 @@ public sealed class RuntimeFeatureDetector
 
             case Expr.Assign asg:
                 TrackStringAlias(asg.Name.Lexeme, asg.Value);
+                TrackMathAlias(asg.Name.Lexeme, asg.Value);
                 TrackDateAlias(asg.Name.Lexeme, asg.Value);
                 if (asg.Name.Lexeme == "Promise")
                     _set.UsesPromisePrototypeMutation = true;
@@ -1208,6 +1229,8 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesRegExpPrototypeMutation = true;
                 if (asg.Name.Lexeme == "String")
                     _set.UsesStringPrototypeMutation = true;
+                if (asg.Name.Lexeme == "Math")
+                    _set.UsesMathMutation = true;
                 if (asg.Name.Lexeme == "parseInt")
                     _set.UsesGlobalParseIntMutation = true;
                 if (_opaqueValueBindings.Contains(asg.Name.Lexeme))
@@ -1224,6 +1247,8 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesRegExpPrototypeMutation = true;
                 if (ca.Name.Lexeme == "String")
                     _set.UsesStringPrototypeMutation = true;
+                if (ca.Name.Lexeme == "Math")
+                    _set.UsesMathMutation = true;
                 if (ca.Name.Lexeme == "parseInt")
                     _set.UsesGlobalParseIntMutation = true;
                 VisitExpr(ca.Value);
@@ -1239,6 +1264,9 @@ public sealed class RuntimeFeatureDetector
                 if (IsStringMutationTarget(cs.Object)
                     || (IsGlobalObject(cs.Object) && cs.Name.Lexeme == "String"))
                     _set.UsesStringPrototypeMutation = true;
+                if (IsMathObject(cs.Object)
+                    || (IsGlobalObject(cs.Object) && cs.Name.Lexeme == "Math"))
+                    _set.UsesMathMutation = true;
                 if (IsNumberConstructorMutationTarget(cs.Object, cs.Name.Lexeme))
                     _set.UsesNumberConstructorMutation = true;
                 if (IsRegExpMutationTarget(cs.Object))
@@ -1270,6 +1298,10 @@ public sealed class RuntimeFeatureDetector
                     || (IsGlobalObject(csi.Object)
                         && csi.Index is Expr.Literal { Value: "String" }))
                     _set.UsesStringPrototypeMutation = true;
+                if (IsMathObject(csi.Object)
+                    || (IsGlobalObject(csi.Object)
+                        && csi.Index is Expr.Literal { Value: "Math" }))
+                    _set.UsesMathMutation = true;
                 if (csi.Index is Expr.Literal { Value: string compoundNumberProperty }
                     && IsNumberConstructorMutationTarget(
                         csi.Object, compoundNumberProperty))
@@ -1303,6 +1335,8 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesRegExpPrototypeMutation = true;
                 if (la.Name.Lexeme == "String")
                     _set.UsesStringPrototypeMutation = true;
+                if (la.Name.Lexeme == "Math")
+                    _set.UsesMathMutation = true;
                 if (la.Name.Lexeme == "parseInt")
                     _set.UsesGlobalParseIntMutation = true;
                 VisitExpr(la.Value);
@@ -1318,6 +1352,9 @@ public sealed class RuntimeFeatureDetector
                 if (IsStringMutationTarget(ls.Object)
                     || (IsGlobalObject(ls.Object) && ls.Name.Lexeme == "String"))
                     _set.UsesStringPrototypeMutation = true;
+                if (IsMathObject(ls.Object)
+                    || (IsGlobalObject(ls.Object) && ls.Name.Lexeme == "Math"))
+                    _set.UsesMathMutation = true;
                 if (IsNumberConstructorMutationTarget(ls.Object, ls.Name.Lexeme))
                     _set.UsesNumberConstructorMutation = true;
                 if (IsRegExpMutationTarget(ls.Object))
@@ -1349,6 +1386,10 @@ public sealed class RuntimeFeatureDetector
                     || (IsGlobalObject(lsi.Object)
                         && lsi.Index is Expr.Literal { Value: "String" }))
                     _set.UsesStringPrototypeMutation = true;
+                if (IsMathObject(lsi.Object)
+                    || (IsGlobalObject(lsi.Object)
+                        && lsi.Index is Expr.Literal { Value: "Math" }))
+                    _set.UsesMathMutation = true;
                 if (lsi.Index is Expr.Literal { Value: string logicalNumberProperty }
                     && IsNumberConstructorMutationTarget(
                         lsi.Object, logicalNumberProperty))
@@ -1845,6 +1886,32 @@ public sealed class RuntimeFeatureDetector
             _stringPrototypeAliases.Add(name);
     }
 
+    private bool IsMathObject(Expr expr) => expr switch
+    {
+        Expr.Variable variable => _mathAliases.Contains(variable.Name.Lexeme),
+        Expr.Get
+        {
+            Object: Expr.Variable { Name.Lexeme: "globalThis" or "global" },
+            Name.Lexeme: "Math"
+        } => true,
+        Expr.GetIndex
+        {
+            Object: Expr.Variable { Name.Lexeme: "globalThis" or "global" },
+            Index: Expr.Literal { Value: "Math" }
+        } => true,
+        Expr.Grouping grouping => IsMathObject(grouping.Expression),
+        Expr.TypeAssertion assertion => IsMathObject(assertion.Expression),
+        Expr.Satisfies satisfies => IsMathObject(satisfies.Expression),
+        Expr.NonNullAssertion nonNull => IsMathObject(nonNull.Expression),
+        _ => false
+    };
+
+    private void TrackMathAlias(string name, Expr initializer)
+    {
+        if (IsMathObject(initializer))
+            _mathAliases.Add(name);
+    }
+
     private static bool IsRegExpConstructor(Expr expr) => expr switch
     {
         Expr.Variable { Name.Lexeme: "RegExp" } => true,
@@ -2232,6 +2299,8 @@ public sealed class RuntimeFeatureDetector
     {
         if (IsStringMutationTarget(target))
             _set.UsesStringPrototypeMutation = true;
+        if (IsMathObject(target))
+            _set.UsesMathMutation = true;
         MarkObjectLiteralShape(target);
         TypeInfo? type = _typeMap?.Get(target);
         if (type is TypeInfo.Any or TypeInfo.Unknown)

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -32,6 +32,11 @@ public sealed class RuntimeFeatureDetector
         "Number"
     };
     private readonly HashSet<string> _numberPrototypeAliases = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _stringConstructorAliases = new(StringComparer.Ordinal)
+    {
+        "String"
+    };
+    private readonly HashSet<string> _stringPrototypeAliases = new(StringComparer.Ordinal);
     private readonly HashSet<string> _dateConstructorAliases = new(StringComparer.Ordinal)
     {
         "Date"
@@ -100,6 +105,7 @@ public sealed class RuntimeFeatureDetector
             UsesPromisePrototypeMutation = false,
             UsesArrayPrototypeMutation = false,
             UsesNumberPrototypeMutation = false,
+            UsesStringPrototypeMutation = false,
             UsesNumberConstructorMutation = false,
             UsesRegExpPrototypeMutation = false,
             UsesGlobalParseIntMutation = false,
@@ -327,6 +333,7 @@ public sealed class RuntimeFeatureDetector
                 {
                     _set.UsesDatePrototypeMutation = true;
                     _set.UsesRegExpPrototypeMutation = true;
+                    _set.UsesStringPrototypeMutation = true;
                 }
                 break;
 
@@ -669,6 +676,7 @@ public sealed class RuntimeFeatureDetector
                 if (var.Initializer is not null)
                 {
                     TrackNumberAlias(var.Name.Lexeme, var.Initializer);
+                    TrackStringAlias(var.Name.Lexeme, var.Initializer);
                     TrackDateAlias(var.Name.Lexeme, var.Initializer);
                     if (_opaqueValueBindings.Contains(var.Name.Lexeme))
                         MarkPotentiallyMaterialized(var.Initializer);
@@ -678,6 +686,7 @@ public sealed class RuntimeFeatureDetector
 
             case Stmt.Const cst:
                 TrackNumberAlias(cst.Name.Lexeme, cst.Initializer);
+                TrackStringAlias(cst.Name.Lexeme, cst.Initializer);
                 TrackDateAlias(cst.Name.Lexeme, cst.Initializer);
                 if (_opaqueValueBindings.Contains(cst.Name.Lexeme))
                     MarkPotentiallyMaterialized(cst.Initializer);
@@ -860,6 +869,8 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesPromisePrototypeMutation = true;
                 if (IsNumberPrototype(g))
                     _set.UsesNumberPrototypeMutation = true;
+                if (IsStringPrototype(g) || g.Name.Lexeme == "__proto__")
+                    _set.UsesStringPrototypeMutation = true;
                 if (IsRegExpPrototype(g))
                     _set.UsesRegExpPrototypeMutation = true;
                 if (IsDatePrototype(g)
@@ -879,7 +890,10 @@ public sealed class RuntimeFeatureDetector
                         _set.UsesArrayPrototypeMutation = true;
                     if (ov.Name.Lexeme is "Object" or "Reflect"
                         && g.Name.Lexeme == "getPrototypeOf")
+                    {
                         _set.UsesRegExpPrototypeMutation = true;
+                        _set.UsesStringPrototypeMutation = true;
+                    }
                     if ((ov.Name.Lexeme == "Object"
                             && g.Name.Lexeme is "defineProperty" or "defineProperties" or "create")
                         || (ov.Name.Lexeme == "Reflect" && g.Name.Lexeme == "defineProperty"))
@@ -951,6 +965,9 @@ public sealed class RuntimeFeatureDetector
                 if (IsNumberMutationTarget(s.Object)
                     || (IsGlobalObject(s.Object) && s.Name.Lexeme == "Number"))
                     _set.UsesNumberPrototypeMutation = true;
+                if (IsStringMutationTarget(s.Object)
+                    || (IsGlobalObject(s.Object) && s.Name.Lexeme == "String"))
+                    _set.UsesStringPrototypeMutation = true;
                 if (IsNumberConstructorMutationTarget(s.Object, s.Name.Lexeme))
                     _set.UsesNumberConstructorMutation = true;
                 if (IsRegExpMutationTarget(s.Object)
@@ -971,6 +988,8 @@ public sealed class RuntimeFeatureDetector
             case Expr.GetIndex gi:
                 if (IsDatePrototype(gi))
                     _set.UsesDatePrototypeMutation = true;
+                if (IsStringPrototype(gi))
+                    _set.UsesStringPrototypeMutation = true;
                 if (gi.Index is Expr.Literal { Value: string computedGlobalName })
                 {
                     // Computed global-object constructor access, e.g.
@@ -1017,6 +1036,10 @@ public sealed class RuntimeFeatureDetector
                     || (IsGlobalObject(si.Object)
                         && si.Index is Expr.Literal { Value: "Number" }))
                     _set.UsesNumberPrototypeMutation = true;
+                if (IsStringMutationTarget(si.Object)
+                    || (IsGlobalObject(si.Object)
+                        && si.Index is Expr.Literal { Value: "String" }))
+                    _set.UsesStringPrototypeMutation = true;
                 if (si.Index is Expr.Literal { Value: string setIndexNumberProperty }
                     && IsNumberConstructorMutationTarget(
                         si.Object, setIndexNumberProperty))
@@ -1048,6 +1071,7 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesNumberPrototypeMutation = true;
                     _set.UsesNumberConstructorMutation = true;
                     _set.UsesRegExpPrototypeMutation = true;
+                    _set.UsesStringPrototypeMutation = true;
                     _set.UsesGlobalParseIntMutation = true;
                 }
                 if (c.Callee is Expr.Get
@@ -1075,6 +1099,7 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesNumberPrototypeMutation = true;
                     _set.UsesNumberConstructorMutation = true;
                     _set.UsesRegExpPrototypeMutation = true;
+                    _set.UsesStringPrototypeMutation = true;
                 }
                 if (c.Callee is not Expr.Variable directSourceCall ||
                     !_sourceFunctions.Contains(directSourceCall.Name.Lexeme))
@@ -1170,6 +1195,7 @@ public sealed class RuntimeFeatureDetector
                 break;
 
             case Expr.Assign asg:
+                TrackStringAlias(asg.Name.Lexeme, asg.Value);
                 TrackDateAlias(asg.Name.Lexeme, asg.Value);
                 if (asg.Name.Lexeme == "Promise")
                     _set.UsesPromisePrototypeMutation = true;
@@ -1180,6 +1206,8 @@ public sealed class RuntimeFeatureDetector
                 }
                 if (asg.Name.Lexeme == "RegExp")
                     _set.UsesRegExpPrototypeMutation = true;
+                if (asg.Name.Lexeme == "String")
+                    _set.UsesStringPrototypeMutation = true;
                 if (asg.Name.Lexeme == "parseInt")
                     _set.UsesGlobalParseIntMutation = true;
                 if (_opaqueValueBindings.Contains(asg.Name.Lexeme))
@@ -1194,6 +1222,8 @@ public sealed class RuntimeFeatureDetector
                 }
                 if (ca.Name.Lexeme == "RegExp")
                     _set.UsesRegExpPrototypeMutation = true;
+                if (ca.Name.Lexeme == "String")
+                    _set.UsesStringPrototypeMutation = true;
                 if (ca.Name.Lexeme == "parseInt")
                     _set.UsesGlobalParseIntMutation = true;
                 VisitExpr(ca.Value);
@@ -1206,6 +1236,9 @@ public sealed class RuntimeFeatureDetector
                 if (IsNumberMutationTarget(cs.Object)
                     || (IsGlobalObject(cs.Object) && cs.Name.Lexeme == "Number"))
                     _set.UsesNumberPrototypeMutation = true;
+                if (IsStringMutationTarget(cs.Object)
+                    || (IsGlobalObject(cs.Object) && cs.Name.Lexeme == "String"))
+                    _set.UsesStringPrototypeMutation = true;
                 if (IsNumberConstructorMutationTarget(cs.Object, cs.Name.Lexeme))
                     _set.UsesNumberConstructorMutation = true;
                 if (IsRegExpMutationTarget(cs.Object))
@@ -1233,6 +1266,10 @@ public sealed class RuntimeFeatureDetector
                     || (IsGlobalObject(csi.Object)
                         && csi.Index is Expr.Literal { Value: "Number" }))
                     _set.UsesNumberPrototypeMutation = true;
+                if (IsStringMutationTarget(csi.Object)
+                    || (IsGlobalObject(csi.Object)
+                        && csi.Index is Expr.Literal { Value: "String" }))
+                    _set.UsesStringPrototypeMutation = true;
                 if (csi.Index is Expr.Literal { Value: string compoundNumberProperty }
                     && IsNumberConstructorMutationTarget(
                         csi.Object, compoundNumberProperty))
@@ -1264,6 +1301,8 @@ public sealed class RuntimeFeatureDetector
                 }
                 if (la.Name.Lexeme == "RegExp")
                     _set.UsesRegExpPrototypeMutation = true;
+                if (la.Name.Lexeme == "String")
+                    _set.UsesStringPrototypeMutation = true;
                 if (la.Name.Lexeme == "parseInt")
                     _set.UsesGlobalParseIntMutation = true;
                 VisitExpr(la.Value);
@@ -1276,6 +1315,9 @@ public sealed class RuntimeFeatureDetector
                 if (IsNumberMutationTarget(ls.Object)
                     || (IsGlobalObject(ls.Object) && ls.Name.Lexeme == "Number"))
                     _set.UsesNumberPrototypeMutation = true;
+                if (IsStringMutationTarget(ls.Object)
+                    || (IsGlobalObject(ls.Object) && ls.Name.Lexeme == "String"))
+                    _set.UsesStringPrototypeMutation = true;
                 if (IsNumberConstructorMutationTarget(ls.Object, ls.Name.Lexeme))
                     _set.UsesNumberConstructorMutation = true;
                 if (IsRegExpMutationTarget(ls.Object))
@@ -1303,6 +1345,10 @@ public sealed class RuntimeFeatureDetector
                     || (IsGlobalObject(lsi.Object)
                         && lsi.Index is Expr.Literal { Value: "Number" }))
                     _set.UsesNumberPrototypeMutation = true;
+                if (IsStringMutationTarget(lsi.Object)
+                    || (IsGlobalObject(lsi.Object)
+                        && lsi.Index is Expr.Literal { Value: "String" }))
+                    _set.UsesStringPrototypeMutation = true;
                 if (lsi.Index is Expr.Literal { Value: string logicalNumberProperty }
                     && IsNumberConstructorMutationTarget(
                         lsi.Object, logicalNumberProperty))
@@ -1755,6 +1801,50 @@ public sealed class RuntimeFeatureDetector
             _numberPrototypeAliases.Add(name);
     }
 
+    private bool IsStringConstructor(Expr expr) => expr switch
+    {
+        Expr.Variable variable => _stringConstructorAliases.Contains(variable.Name.Lexeme),
+        Expr.Get
+        {
+            Object: Expr.Variable { Name.Lexeme: "globalThis" or "global" },
+            Name.Lexeme: "String"
+        } => true,
+        Expr.GetIndex
+        {
+            Object: Expr.Variable { Name.Lexeme: "globalThis" or "global" },
+            Index: Expr.Literal { Value: "String" }
+        } => true,
+        Expr.Grouping grouping => IsStringConstructor(grouping.Expression),
+        Expr.TypeAssertion assertion => IsStringConstructor(assertion.Expression),
+        Expr.Satisfies satisfies => IsStringConstructor(satisfies.Expression),
+        Expr.NonNullAssertion nonNull => IsStringConstructor(nonNull.Expression),
+        _ => false
+    };
+
+    private bool IsStringPrototype(Expr expr) => expr switch
+    {
+        Expr.Variable variable => _stringPrototypeAliases.Contains(variable.Name.Lexeme),
+        Expr.Get { Name.Lexeme: "prototype" } get => IsStringConstructor(get.Object),
+        Expr.GetIndex { Index: Expr.Literal { Value: "prototype" } } get =>
+            IsStringConstructor(get.Object),
+        Expr.Grouping grouping => IsStringPrototype(grouping.Expression),
+        Expr.TypeAssertion assertion => IsStringPrototype(assertion.Expression),
+        Expr.Satisfies satisfies => IsStringPrototype(satisfies.Expression),
+        Expr.NonNullAssertion nonNull => IsStringPrototype(nonNull.Expression),
+        _ => false
+    };
+
+    private bool IsStringMutationTarget(Expr expr) =>
+        IsStringConstructor(expr) || IsStringPrototype(expr);
+
+    private void TrackStringAlias(string name, Expr initializer)
+    {
+        if (IsStringConstructor(initializer))
+            _stringConstructorAliases.Add(name);
+        if (IsStringPrototype(initializer))
+            _stringPrototypeAliases.Add(name);
+    }
+
     private static bool IsRegExpConstructor(Expr expr) => expr switch
     {
         Expr.Variable { Name.Lexeme: "RegExp" } => true,
@@ -2140,6 +2230,8 @@ public sealed class RuntimeFeatureDetector
 
     private void MarkMutationTarget(Expr target)
     {
+        if (IsStringMutationTarget(target))
+            _set.UsesStringPrototypeMutation = true;
         MarkObjectLiteralShape(target);
         TypeInfo? type = _typeMap?.Get(target);
         if (type is TypeInfo.Any or TypeInfo.Unknown)

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -960,7 +960,7 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesGlobalParseIntMutation = true;
                 if (IsArrayPrototype(s.Object)
                     || s.Name.Lexeme == "__proto__"
-                    || (s.Name.Lexeme == "push" && CouldTargetArray(s.Object)))
+                    || (IsArrayMutatorName(s.Name.Lexeme) && CouldTargetArray(s.Object)))
                     _set.UsesArrayPrototypeMutation = true;
                 if (s.Object is Expr.Variable osv)
                     HandleMemberAccess(osv.Name.Lexeme, s.Name.Lexeme);
@@ -1030,7 +1030,8 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesGlobalParseIntMutation = true;
                 if (IsArrayPrototype(si.Object)
                     || si.Index is Expr.Literal { Value: "__proto__" }
-                    || (si.Index is Expr.Literal { Value: "push" }
+                    || (si.Index is Expr.Literal { Value: string arrayMethod }
+                        && IsArrayMutatorName(arrayMethod)
                         && CouldTargetArray(si.Object)))
                     _set.UsesArrayPrototypeMutation = true;
                 VisitExpr(si.Object);
@@ -1214,7 +1215,7 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesDatePrototypeMutation = true;
                 if (IsGlobalObject(cs.Object) && cs.Name.Lexeme == "parseInt")
                     _set.UsesGlobalParseIntMutation = true;
-                if (cs.Name.Lexeme == "push" && CouldTargetArray(cs.Object))
+                if (IsArrayMutatorName(cs.Name.Lexeme) && CouldTargetArray(cs.Object))
                     _set.UsesArrayPrototypeMutation = true;
                 VisitExpr(cs.Object);
                 VisitExpr(cs.Value);
@@ -1245,7 +1246,8 @@ public sealed class RuntimeFeatureDetector
                 if (IsGlobalObject(csi.Object)
                     && csi.Index is Expr.Literal { Value: "parseInt" })
                     _set.UsesGlobalParseIntMutation = true;
-                if (csi.Index is Expr.Literal { Value: "push" }
+                if (csi.Index is Expr.Literal { Value: string compoundArrayMethod }
+                    && IsArrayMutatorName(compoundArrayMethod)
                     && CouldTargetArray(csi.Object))
                     _set.UsesArrayPrototypeMutation = true;
                 VisitExpr(csi.Object);
@@ -1282,7 +1284,7 @@ public sealed class RuntimeFeatureDetector
                     _set.UsesDatePrototypeMutation = true;
                 if (IsGlobalObject(ls.Object) && ls.Name.Lexeme == "parseInt")
                     _set.UsesGlobalParseIntMutation = true;
-                if (ls.Name.Lexeme == "push" && CouldTargetArray(ls.Object))
+                if (IsArrayMutatorName(ls.Name.Lexeme) && CouldTargetArray(ls.Object))
                     _set.UsesArrayPrototypeMutation = true;
                 VisitExpr(ls.Object);
                 VisitExpr(ls.Value);
@@ -1313,7 +1315,8 @@ public sealed class RuntimeFeatureDetector
                 if (IsGlobalObject(lsi.Object)
                     && lsi.Index is Expr.Literal { Value: "parseInt" })
                     _set.UsesGlobalParseIntMutation = true;
-                if (lsi.Index is Expr.Literal { Value: "push" }
+                if (lsi.Index is Expr.Literal { Value: string logicalArrayMethod }
+                    && IsArrayMutatorName(logicalArrayMethod)
                     && CouldTargetArray(lsi.Object))
                     _set.UsesArrayPrototypeMutation = true;
                 VisitExpr(lsi.Object);
@@ -1378,7 +1381,7 @@ public sealed class RuntimeFeatureDetector
                     if (IsGlobalObject(deletedProperty.Object)
                         && deletedProperty.Name.Lexeme == "parseInt")
                         _set.UsesGlobalParseIntMutation = true;
-                    if (deletedProperty.Name.Lexeme == "push"
+                    if (IsArrayMutatorName(deletedProperty.Name.Lexeme)
                         && CouldTargetArray(deletedProperty.Object))
                         _set.UsesArrayPrototypeMutation = true;
                 }
@@ -1410,7 +1413,8 @@ public sealed class RuntimeFeatureDetector
                     if (IsGlobalObject(deletedIndex.Object)
                         && deletedIndex.Index is Expr.Literal { Value: "parseInt" })
                         _set.UsesGlobalParseIntMutation = true;
-                    if (deletedIndex.Index is Expr.Literal { Value: "push" }
+                    if (deletedIndex.Index is Expr.Literal { Value: string deletedArrayMethod }
+                        && IsArrayMutatorName(deletedArrayMethod)
                         && CouldTargetArray(deletedIndex.Object))
                         _set.UsesArrayPrototypeMutation = true;
                 }
@@ -1827,11 +1831,22 @@ public sealed class RuntimeFeatureDetector
             || _typeMap?.Get(expr) is TypeInfo.Promise;
     }
 
-    private static bool IsArrayPrototype(Expr expr) => expr is Expr.Get
+    private static bool IsArrayPrototype(Expr expr) => expr switch
     {
-        Object: Expr.Variable { Name.Lexeme: "Array" },
-        Name.Lexeme: "prototype"
+        Expr.Get
+        {
+            Object: Expr.Variable { Name.Lexeme: "Array" },
+            Name.Lexeme: "prototype"
+        } => true,
+        Expr.Grouping grouping => IsArrayPrototype(grouping.Expression),
+        Expr.TypeAssertion assertion => IsArrayPrototype(assertion.Expression),
+        Expr.Satisfies satisfies => IsArrayPrototype(satisfies.Expression),
+        Expr.NonNullAssertion nonNull => IsArrayPrototype(nonNull.Expression),
+        _ => false
     };
+
+    private static bool IsArrayMutatorName(string name) =>
+        name is "push" or "shift" or "unshift";
 
     private bool CouldTargetArray(Expr expr)
     {

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -1029,6 +1029,7 @@ public sealed class RuntimeFeatureDetector
                     && si.Index is Expr.Literal { Value: "parseInt" })
                     _set.UsesGlobalParseIntMutation = true;
                 if (IsArrayPrototype(si.Object)
+                    || (CouldTargetArray(si.Object) && IsSymbolIterator(si.Index))
                     || si.Index is Expr.Literal { Value: "__proto__" }
                     || (si.Index is Expr.Literal { Value: string arrayMethod }
                         && IsArrayMutatorName(arrayMethod)
@@ -1246,7 +1247,8 @@ public sealed class RuntimeFeatureDetector
                 if (IsGlobalObject(csi.Object)
                     && csi.Index is Expr.Literal { Value: "parseInt" })
                     _set.UsesGlobalParseIntMutation = true;
-                if (csi.Index is Expr.Literal { Value: string compoundArrayMethod }
+                if ((CouldTargetArray(csi.Object) && IsSymbolIterator(csi.Index))
+                    || csi.Index is Expr.Literal { Value: string compoundArrayMethod }
                     && IsArrayMutatorName(compoundArrayMethod)
                     && CouldTargetArray(csi.Object))
                     _set.UsesArrayPrototypeMutation = true;
@@ -1315,7 +1317,8 @@ public sealed class RuntimeFeatureDetector
                 if (IsGlobalObject(lsi.Object)
                     && lsi.Index is Expr.Literal { Value: "parseInt" })
                     _set.UsesGlobalParseIntMutation = true;
-                if (lsi.Index is Expr.Literal { Value: string logicalArrayMethod }
+                if ((CouldTargetArray(lsi.Object) && IsSymbolIterator(lsi.Index))
+                    || lsi.Index is Expr.Literal { Value: string logicalArrayMethod }
                     && IsArrayMutatorName(logicalArrayMethod)
                     && CouldTargetArray(lsi.Object))
                     _set.UsesArrayPrototypeMutation = true;
@@ -1413,7 +1416,8 @@ public sealed class RuntimeFeatureDetector
                     if (IsGlobalObject(deletedIndex.Object)
                         && deletedIndex.Index is Expr.Literal { Value: "parseInt" })
                         _set.UsesGlobalParseIntMutation = true;
-                    if (deletedIndex.Index is Expr.Literal { Value: string deletedArrayMethod }
+                    if ((CouldTargetArray(deletedIndex.Object) && IsSymbolIterator(deletedIndex.Index))
+                        || deletedIndex.Index is Expr.Literal { Value: string deletedArrayMethod }
                         && IsArrayMutatorName(deletedArrayMethod)
                         && CouldTargetArray(deletedIndex.Object))
                         _set.UsesArrayPrototypeMutation = true;
@@ -1842,6 +1846,20 @@ public sealed class RuntimeFeatureDetector
         Expr.TypeAssertion assertion => IsArrayPrototype(assertion.Expression),
         Expr.Satisfies satisfies => IsArrayPrototype(satisfies.Expression),
         Expr.NonNullAssertion nonNull => IsArrayPrototype(nonNull.Expression),
+        _ => false
+    };
+
+    private static bool IsSymbolIterator(Expr expr) => expr switch
+    {
+        Expr.Get
+        {
+            Object: Expr.Variable { Name.Lexeme: "Symbol" },
+            Name.Lexeme: "iterator"
+        } => true,
+        Expr.Grouping grouping => IsSymbolIterator(grouping.Expression),
+        Expr.TypeAssertion assertion => IsSymbolIterator(assertion.Expression),
+        Expr.Satisfies satisfies => IsSymbolIterator(satisfies.Expression),
+        Expr.NonNullAssertion nonNull => IsSymbolIterator(nonNull.Expression),
         _ => false
     };
 

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -162,6 +162,10 @@ public sealed class RuntimeFeatureSet
     // Number prototype mutation makes typed number instance methods observable
     // through ordinary property lookup. Direct formatting requires this false.
     public bool UsesNumberPrototypeMutation { get; set; } = true;
+    // String prototype/constructor mutation makes primitive string method
+    // bindings observable through ordinary property lookup. Fixed-arity typed
+    // intrinsics require this to remain false.
+    public bool UsesStringPrototypeMutation { get; set; } = true;
     // Replacing Number or mutating its static properties requires live lookup of
     // Number.parseInt and the other constructor-owned built-ins.
     public bool UsesNumberConstructorMutation { get; set; } = true;

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -57,6 +57,8 @@ public sealed class RuntimeFeatureSet
     /// </summary>
     internal HashSet<string> CompactObjectRecordStablePushShapes { get; } =
         new(StringComparer.Ordinal);
+    internal HashSet<string> CompactObjectRecordStableIteratorShapes { get; } =
+        new(StringComparer.Ordinal);
 
     /// <summary>
     /// Generic-looking compact-record slots whose literal initializers prove that the

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -166,6 +166,9 @@ public sealed class RuntimeFeatureSet
     // bindings observable through ordinary property lookup. Fixed-arity typed
     // intrinsics require this to remain false.
     public bool UsesStringPrototypeMutation { get; set; } = true;
+    // Replacing the global Math object or one of its function properties makes
+    // direct Math.min/max interception observable. Typed folds require this false.
+    public bool UsesMathMutation { get; set; } = true;
     // Replacing Number or mutating its static properties requires live lookup of
     // Number.parseInt and the other constructor-owned built-ins.
     public bool UsesNumberConstructorMutation { get; set; } = true;

--- a/src/SharpTS/Compilation/StableCustomIteratorAnalyzer.cs
+++ b/src/SharpTS/Compilation/StableCustomIteratorAnalyzer.cs
@@ -1,0 +1,510 @@
+using SharpTS.Compilation.Emitters;
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Proves the narrow ordinary-object iterator shape used by the direct for-of path.
+/// The binding may only feed for-of, the iterator method must return its receiver,
+/// and every next return must be the same compact numeric result record.
+/// </summary>
+internal static class StableCustomIteratorAnalyzer
+{
+    public static void Analyze(
+        List<Stmt> program,
+        TypeMap? typeMap,
+        ClosureAnalyzer? closures,
+        RuntimeFeatureSet? features)
+    {
+        if (typeMap is null || features is null ||
+            features.UsesDynamicPropertyDescriptors ||
+            features.UsesClassPrototypeMutation)
+            return;
+
+        var visitor = new CandidateVisitor(typeMap, features);
+        foreach (var statement in program)
+            visitor.Visit(statement);
+        if (visitor.ContainsDirectEval)
+            return;
+
+        foreach (var (key, candidate) in visitor.Candidates)
+        {
+            if (visitor.Disqualified.Contains(key) ||
+                visitor.DeclarationCounts.GetValueOrDefault(key) != 1 ||
+                closures?.IsVariableCaptured(key.Name) == true ||
+                !visitor.Loops.TryGetValue(key, out var loops))
+                continue;
+
+            foreach (var loop in loops)
+            {
+                if (!loop.IsAsync && loop.Variable.Lexeme != key.Name)
+                {
+                    features.CompactObjectRecordStableIteratorShapes.Add(
+                        candidate.Info.ResultFingerprint);
+                    // The pre-runtime pass has no closure information and is
+                    // intentionally feature-only. Persist eligibility hints only
+                    // after the closure pass re-proves non-capture/non-escape.
+                    if (closures is not null)
+                    {
+                        typeMap.MarkStableCustomIterator(loop, candidate.Info);
+                        MarkStableNumericAccumulator(loop, candidate.Owner, typeMap);
+                    }
+                }
+            }
+
+            if (closures is not null)
+                MarkStableNumericFunctionCaptures(
+                    candidate.Info.NextMethod, candidate.Owner, closures, typeMap);
+        }
+    }
+
+    private static void MarkStableNumericAccumulator(
+        Stmt.ForOf loop, object? owner, TypeMap typeMap)
+    {
+        if (owner is not Stmt.Function { Body: { } body } ||
+            loop.Body is not Stmt.Expression
+            {
+                Expr: Expr.Assign assignment and
+                {
+                    Name: var accumulatorName,
+                    Value: Expr.Binary
+                    {
+                        Operator.Type: TokenType.PLUS,
+                        Left: Expr.Variable left,
+                        Right: Expr.Variable right
+                    }
+                }
+            } ||
+            left.Name.Lexeme != accumulatorName.Lexeme ||
+            right.Name.Lexeme != loop.Variable.Lexeme)
+            return;
+
+        int loopIndex = body.FindIndex(statement => ReferenceEquals(statement, loop));
+        if (loopIndex < 0)
+            return;
+
+        var writes = new NumericWriteVisitor(
+            accumulatorName.Lexeme, typeMap, assignment);
+        foreach (var statement in body)
+            writes.Visit(statement);
+        if (!writes.Valid)
+            return;
+
+        for (int index = 0; index < loopIndex; index++)
+        {
+            Token? declarationName = body[index] switch
+            {
+                Stmt.Var declaration when declaration.Name.Lexeme == accumulatorName.Lexeme &&
+                    declaration.TypeAnnotation == "number" &&
+                    declaration.Initializer is not null &&
+                    IsNumber(typeMap.Get(declaration.Initializer)) => declaration.Name,
+                Stmt.Const declaration when declaration.Name.Lexeme == accumulatorName.Lexeme &&
+                    declaration.TypeAnnotation == "number" &&
+                    IsNumber(typeMap.Get(declaration.Initializer)) => declaration.Name,
+                _ => null
+            };
+            if (declarationName is not null)
+            {
+                typeMap.MarkStableCustomIteratorNumericAccumulator(declarationName);
+                return;
+            }
+        }
+    }
+
+    private static void MarkStableNumericFunctionCaptures(
+        Expr.ArrowFunction next,
+        object? owner,
+        ClosureAnalyzer closures,
+        TypeMap typeMap)
+    {
+        if (owner is not Stmt.Function source || source.Body is null)
+            return;
+
+        int iteratorDeclaration = source.Body.FindIndex(statement => statement switch
+        {
+            Stmt.Var { Initializer: Expr.ObjectLiteral literal } =>
+                literal.Properties.Any(property => ReferenceEquals(property.Value, next)),
+            Stmt.Const { Initializer: Expr.ObjectLiteral literal } =>
+                literal.Properties.Any(property => ReferenceEquals(property.Value, next)),
+            _ => false
+        });
+        if (iteratorDeclaration < 0)
+            return;
+
+        foreach (string name in closures.GetCaptures(next))
+        {
+            if (!ReferenceEquals(closures.GetCaptureSource(next, name), source) ||
+                IsCapturedByAnotherCallable(source.Body, next, name, closures) ||
+                !HasStableNumericBinding(source, name, iteratorDeclaration, typeMap))
+                continue;
+
+            typeMap.MarkStableNumericFunctionCaptureField(source, name);
+        }
+    }
+
+    private static bool HasStableNumericBinding(
+        Stmt.Function source,
+        string name,
+        int iteratorDeclaration,
+        TypeMap typeMap)
+    {
+        bool initialized = source.Parameters.Any(parameter =>
+            parameter.Name.Lexeme == name && parameter.Type == "number" &&
+            !typeMap.IsUndefinedReachableNumericParam(parameter));
+
+        if (!initialized)
+        {
+            for (int index = 0; index < iteratorDeclaration; index++)
+            {
+                initialized = source.Body![index] switch
+                {
+                    Stmt.Var declaration when declaration.Name.Lexeme == name &&
+                        declaration.TypeAnnotation == "number" &&
+                        declaration.Initializer is not null &&
+                        !typeMap.IsUndefinedReachableNumericLocal(declaration) &&
+                        !typeMap.IsUndefinedReachableNumericLocal(declaration.Initializer) &&
+                        IsNumber(typeMap.Get(declaration.Initializer)) => true,
+                    Stmt.Const declaration when declaration.Name.Lexeme == name &&
+                        declaration.TypeAnnotation == "number" &&
+                        !typeMap.IsUndefinedReachableNumericLocal(declaration.Initializer) &&
+                        IsNumber(typeMap.Get(declaration.Initializer)) => true,
+                    _ => initialized
+                };
+            }
+        }
+
+        if (!initialized)
+            return false;
+
+        var writes = new NumericWriteVisitor(name, typeMap);
+        foreach (var statement in source.Body!)
+            writes.Visit(statement);
+        return writes.Valid;
+    }
+
+    private static bool IsCapturedByAnotherCallable(
+        IEnumerable<Stmt> body,
+        Expr.ArrowFunction next,
+        string name,
+        ClosureAnalyzer closures)
+    {
+        var visitor = new OtherCaptureVisitor(next, name, closures);
+        foreach (var statement in body)
+            visitor.Visit(statement);
+        return visitor.Found;
+    }
+
+    private static bool IsNumber(TypeInfo? type) => type is
+        TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral;
+
+    private sealed class NumericWriteVisitor(
+        string name,
+        TypeMap typeMap,
+        Expr.Assign? allowedUnknownAssignment = null) : AstVisitorBase
+    {
+        public bool Valid { get; private set; } = true;
+
+        protected override void VisitAssign(Expr.Assign expression)
+        {
+            if (expression.Name.Lexeme == name &&
+                !ReferenceEquals(expression, allowedUnknownAssignment) &&
+                !IsNumber(typeMap.Get(expression.Value)))
+                Valid = false;
+            base.VisitAssign(expression);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
+        {
+            if (expression.Name.Lexeme == name &&
+                (expression.Operator.Type is not (TokenType.PLUS_EQUAL or TokenType.MINUS_EQUAL or
+                    TokenType.STAR_EQUAL or TokenType.SLASH_EQUAL or TokenType.PERCENT_EQUAL) ||
+                 !IsNumber(typeMap.Get(expression.Value))))
+                Valid = false;
+            base.VisitCompoundAssign(expression);
+        }
+
+        protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
+        {
+            if (expression.Name.Lexeme == name)
+                Valid = false;
+            base.VisitLogicalAssign(expression);
+        }
+
+        protected override void VisitForOf(Stmt.ForOf statement)
+        {
+            if (statement.Variable.Lexeme == name)
+                Valid = false;
+            base.VisitForOf(statement);
+        }
+
+        protected override void VisitForIn(Stmt.ForIn statement)
+        {
+            if (statement.Variable.Lexeme == name)
+                Valid = false;
+            base.VisitForIn(statement);
+        }
+    }
+
+    private sealed class OtherCaptureVisitor(
+        Expr.ArrowFunction next, string name, ClosureAnalyzer closures) : AstVisitorBase
+    {
+        public bool Found { get; private set; }
+
+        protected override void VisitFunction(Stmt.Function statement)
+        {
+            if (closures.GetCaptures(statement).Contains(name))
+                Found = true;
+            base.VisitFunction(statement);
+        }
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression)
+        {
+            if (!ReferenceEquals(expression, next) &&
+                closures.GetCaptures(expression).Contains(name))
+                Found = true;
+            base.VisitArrowFunction(expression);
+        }
+    }
+
+    private sealed class CandidateVisitor(
+        TypeMap typeMap, RuntimeFeatureSet features) : AstVisitorBase
+    {
+        private int _scope;
+        private int _nextScope;
+
+        public Dictionary<(int Scope, string Name), Candidate> Candidates { get; } = [];
+        public HashSet<(int Scope, string Name)> Disqualified { get; } = [];
+        public Dictionary<(int Scope, string Name), int> DeclarationCounts { get; } = [];
+        public Dictionary<(int Scope, string Name), List<Stmt.ForOf>> Loops { get; } = [];
+        public bool ContainsDirectEval { get; private set; }
+
+        private object? _currentCallable;
+
+        protected override void VisitFunction(Stmt.Function statement) =>
+            InCallableScope(statement, () => base.VisitFunction(statement));
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression) =>
+            InCallableScope(expression, () => base.VisitArrowFunction(expression));
+
+        private void InCallableScope(object callable, Action visit)
+        {
+            int saved = _scope;
+            object? savedCallable = _currentCallable;
+            _scope = ++_nextScope;
+            _currentCallable = callable;
+            visit();
+            _scope = saved;
+            _currentCallable = savedCallable;
+        }
+
+        protected override void VisitVar(Stmt.Var statement) =>
+            HandleDeclaration(statement.Name, statement.Initializer);
+
+        protected override void VisitConst(Stmt.Const statement) =>
+            HandleDeclaration(statement.Name, statement.Initializer);
+
+        private void HandleDeclaration(Token name, Expr? initializer)
+        {
+            var key = (_scope, name.Lexeme);
+            DeclarationCounts[key] = DeclarationCounts.GetValueOrDefault(key) + 1;
+            if (initializer is Expr.ObjectLiteral literal &&
+                TryAnalyzeLiteral(literal, typeMap, features, out var info))
+                Candidates[key] = new Candidate(info, _currentCallable);
+            if (initializer is not null)
+                Visit(initializer);
+        }
+
+        protected override void VisitForOf(Stmt.ForOf statement)
+        {
+            if (statement.Iterable is Expr.Variable receiver)
+            {
+                var key = (_scope, receiver.Name.Lexeme);
+                if (!Loops.TryGetValue(key, out var loops))
+                    Loops[key] = loops = [];
+                loops.Add(statement);
+                Visit(statement.Body);
+                return;
+            }
+            base.VisitForOf(statement);
+        }
+
+        protected override void VisitCall(Expr.Call expression)
+        {
+            if (!expression.Optional &&
+                expression.Callee is Expr.Variable { Name.Lexeme: "eval" })
+                ContainsDirectEval = true;
+            base.VisitCall(expression);
+        }
+
+        protected override void VisitVariable(Expr.Variable expression) =>
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+
+        protected override void VisitAssign(Expr.Assign expression)
+        {
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+            base.VisitAssign(expression);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
+        {
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+            base.VisitCompoundAssign(expression);
+        }
+
+        protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
+        {
+            Disqualified.Add((_scope, expression.Name.Lexeme));
+            base.VisitLogicalAssign(expression);
+        }
+    }
+
+    private sealed record Candidate(StableCustomIteratorInfo Info, object? Owner);
+
+    private static bool TryAnalyzeLiteral(
+        Expr.ObjectLiteral literal,
+        TypeMap typeMap,
+        RuntimeFeatureSet features,
+        out StableCustomIteratorInfo info)
+    {
+        info = null!;
+        if (literal.Properties.Any(property => property.IsSpread ||
+            property.Kind is Expr.ObjectPropertyKind.Getter or Expr.ObjectPropertyKind.Setter))
+            return false;
+
+        Expr.ArrowFunction? iterator = null;
+        Expr.ArrowFunction? next = null;
+        foreach (var property in literal.Properties)
+        {
+            if (property.Value is not Expr.ArrowFunction method)
+                continue;
+            if (property.Key is Expr.IdentifierKey { Name.Lexeme: "next" })
+                next = method;
+            else if (property.Key is Expr.ComputedKey { Expression: var key } &&
+                IsSymbolIterator(key))
+                iterator = method;
+        }
+
+        if (iterator is null || next is null ||
+            iterator.IsAsync || iterator.IsGenerator || iterator.Parameters.Count != 0 ||
+            !iterator.HasOwnThis ||
+            next.IsAsync || next.IsGenerator || next.Parameters.Count != 0 ||
+            !ReturnsOnlyThis(iterator) ||
+            !TryGetResultShape(next, typeMap, out var fingerprint,
+                out int valueIndex, out int doneIndex) ||
+            !features.CanAssumeCompactObjectRecordIsUnmaterialized(fingerprint))
+            return false;
+
+        info = new StableCustomIteratorInfo(
+            iterator, next, fingerprint, valueIndex, doneIndex);
+        return true;
+    }
+
+    private static bool IsSymbolIterator(Expr expression) => expression switch
+    {
+        Expr.Get
+        {
+            Object: Expr.Variable { Name.Lexeme: "Symbol" },
+            Name.Lexeme: "iterator"
+        } => true,
+        Expr.Grouping grouping => IsSymbolIterator(grouping.Expression),
+        Expr.TypeAssertion assertion => IsSymbolIterator(assertion.Expression),
+        Expr.Satisfies satisfies => IsSymbolIterator(satisfies.Expression),
+        Expr.NonNullAssertion nonNull => IsSymbolIterator(nonNull.Expression),
+        _ => false
+    };
+
+    private static bool ReturnsOnlyThis(Expr.ArrowFunction method)
+    {
+        if (method.ExpressionBody is Expr.This)
+            return true;
+        return method.BlockBody is [Stmt.Return { Value: Expr.This }];
+    }
+
+    private static bool TryGetResultShape(
+        Expr.ArrowFunction next,
+        TypeMap typeMap,
+        out string fingerprint,
+        out int valueIndex,
+        out int doneIndex)
+    {
+        var returns = new ResultReturnVisitor();
+        if (next.ExpressionBody is not null)
+            returns.Add(next.ExpressionBody);
+        else if (next.BlockBody is not null)
+        {
+            // A typed value-result ABI has no `undefined` representation. Require
+            // an unconditional trailing result return so falling off the method
+            // cannot change from a protocol TypeError into a default struct value.
+            if (next.BlockBody.Count == 0 ||
+                next.BlockBody[^1] is not Stmt.Return { Value: Expr.ObjectLiteral })
+            {
+                fingerprint = "";
+                valueIndex = -1;
+                doneIndex = -1;
+                return false;
+            }
+            foreach (var statement in next.BlockBody)
+                returns.Visit(statement);
+        }
+
+        fingerprint = "";
+        valueIndex = -1;
+        doneIndex = -1;
+        if (!returns.Valid || returns.Values.Count == 0)
+            return false;
+
+        foreach (var value in returns.Values)
+        {
+            if (value is not Expr.ObjectLiteral literal ||
+                !JsonSerializationShapeAnalyzer.TryAnalyze(
+                    typeMap.Get(literal), out var analyzed) ||
+                analyzed is not JsonSerializationShape.Record shape ||
+                shape.Fields.Count != 2)
+                return false;
+
+            string current = JsonSerializationShapeAnalyzer.Fingerprint(shape);
+            if (fingerprint.Length == 0)
+            {
+                fingerprint = current;
+                for (int index = 0; index < shape.Fields.Count; index++)
+                {
+                    if (shape.Fields[index].Key == "value" &&
+                        shape.Fields[index].Value is JsonSerializationShape.Number)
+                        valueIndex = index;
+                    if (shape.Fields[index].Key == "done" &&
+                        shape.Fields[index].Value is JsonSerializationShape.Boolean)
+                        doneIndex = index;
+                }
+            }
+            else if (current != fingerprint)
+            {
+                return false;
+            }
+        }
+
+        // The specialized return ABI evaluates value then done. Restrict the proof
+        // to that source order so object-literal evaluation order is unchanged.
+        return valueIndex == 0 && doneIndex == 1;
+    }
+
+    private sealed class ResultReturnVisitor : AstVisitorBase
+    {
+        public List<Expr> Values { get; } = [];
+        public bool Valid { get; private set; } = true;
+
+        public void Add(Expr value) => Values.Add(value);
+
+        protected override void VisitReturn(Stmt.Return statement)
+        {
+            if (statement.Value is null)
+                Valid = false;
+            else
+                Values.Add(statement.Value);
+        }
+
+        protected override void VisitFunction(Stmt.Function statement) { }
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression) { }
+    }
+}

--- a/src/SharpTS/Execution/Interpreter.Expressions.cs
+++ b/src/SharpTS/Execution/Interpreter.Expressions.cs
@@ -622,7 +622,7 @@ public partial class Interpreter
             if (prop.IsSpread)
             {
                 object? spreadValue = (await ctx.EvaluateExprAsync(prop.Value)).ToObject();
-                ApplySpreadToFields(spreadValue, stringFields);
+                symbolFields = ApplySpreadToFields(spreadValue, stringFields, symbolFields);
             }
             else if (prop.Kind == Expr.ObjectPropertyKind.Getter)
             {
@@ -701,7 +701,7 @@ public partial class Interpreter
             if (prop.IsSpread)
             {
                 object? spreadValue = Evaluate(prop.Value);
-                ApplySpreadToFields(spreadValue, stringFields);
+                symbolFields = ApplySpreadToFields(spreadValue, stringFields, symbolFields);
             }
             else if (prop.Kind == Expr.ObjectPropertyKind.Getter)
             {
@@ -790,35 +790,71 @@ public partial class Interpreter
     /// Applies a spread value's properties to the target fields dictionary.
     /// Shared between sync and async object evaluation paths.
     /// </summary>
-    private static void ApplySpreadToFields(object? spreadValue, Dictionary<string, object?> stringFields)
+    private Dictionary<SharpTSSymbol, object?>? ApplySpreadToFields(
+        object? spreadValue,
+        Dictionary<string, object?> stringFields,
+        Dictionary<SharpTSSymbol, object?>? symbolFields)
     {
         // CopyDataProperties skips null/undefined. Other primitives are
         // ToObject-coerced: only strings contribute enumerable index keys;
         // number/boolean/symbol/bigint wrappers have none.
         if (spreadValue is null or SharpTSUndefined)
-            return;
+            return symbolFields;
         if (spreadValue is string text)
         {
             for (int i = 0; i < text.Length; i++)
                 stringFields[i.ToString()] = text[i].ToString();
-            return;
+            return symbolFields;
         }
         if (spreadValue is bool or double or int or long or float or decimal
             or SharpTSSymbol or SharpTSBigInt or System.Numerics.BigInteger)
-            return;
+            return symbolFields;
 
         if (spreadValue is SharpTSObject spreadObj)
         {
-            foreach (var kv in spreadObj.Fields)
+            // CopyDataProperties snapshots own keys, filters enumerability, then performs a live
+            // [[Get]]. This invokes getters exactly once and includes enumerable Symbols after the
+            // string-key section of OrdinaryOwnPropertyKeys.
+            foreach (string key in spreadObj.OwnEnumerableKeys())
             {
-                stringFields[kv.Key] = kv.Value;
+                stringFields[key] = GetPropertyValue(spreadObj, key);
+            }
+            foreach (SharpTSSymbol symbol in spreadObj.GetSymbolPropertyNames())
+            {
+                if (spreadObj.GetOwnPropertyDescriptor(symbol)?.Enumerable != true)
+                    continue;
+                (symbolFields ??= [])[symbol] = GetSymbolPropertyValue(spreadObj, symbol);
             }
         }
         else if (spreadValue is SharpTSInstance inst)
         {
-            foreach (var key in inst.GetFieldNames())
+            foreach (string key in inst.OwnEnumerableKeys())
             {
-                stringFields[key] = inst.GetRawField(key);
+                stringFields[key] = GetPropertyValue(inst, key);
+            }
+            foreach (SharpTSSymbol symbol in inst.GetSymbolPropertyNames())
+                (symbolFields ??= [])[symbol] = GetSymbolPropertyValue(inst, symbol);
+        }
+        else if (spreadValue is SharpTSProxy proxy)
+        {
+            // Keep the Proxy algorithm unified: one mixed [[OwnPropertyKeys]] snapshot, then an
+            // observable descriptor query and [[Get]] for each still-enumerable key.
+            foreach (object? key in proxy.TrapOwnPropertyKeys(this))
+            {
+                object? descriptor = key switch
+                {
+                    string name => proxy.TrapGetOwnPropertyDescriptor(name, this),
+                    SharpTSSymbol symbol => proxy.TrapGetOwnPropertyDescriptor(symbol, this),
+                    _ => null
+                };
+                if (descriptor is null or SharpTSUndefined
+                    || !SharpTSPropertyDescriptor.FromAnyObject(descriptor).Enumerable)
+                    continue;
+
+                if (key is SharpTSSymbol symbolKey)
+                    (symbolFields ??= [])[symbolKey] = proxy.TrapGet(symbolKey, this);
+                else
+                    stringFields[(string)key!] = proxy.TrapGet((string)key!, this);
             }
         }
         // Plain Dictionary<string, object?> — used by runtime helpers like
@@ -835,6 +871,7 @@ public partial class Interpreter
         {
             throw new InterpreterException("Spread in object literal requires an object.");
         }
+        return symbolFields;
     }
 
     /// <summary>

--- a/src/SharpTS/Execution/Interpreter.Statements.cs
+++ b/src/SharpTS/Execution/Interpreter.Statements.cs
@@ -1265,7 +1265,7 @@ public partial class Interpreter
     {
         switch (value)
         {
-            case SharpTSArray:
+            case SharpTSArray array when !array.HasSymbolProperty(SharpTSSymbol.Iterator):
                 return value;
             // Typed arrays / buffers expose index access but no [Symbol.iterator] in this runtime, so
             // GetIterableElements would throw; read their elements directly into a fresh Array (#781).

--- a/src/SharpTS/Parsing/AST.cs
+++ b/src/SharpTS/Parsing/AST.cs
@@ -309,6 +309,13 @@ public record Decorator(Token AtToken, Expr Expression);
 /// or compiled by <see cref="ILCompiler"/>.
 /// </remarks>
 /// <seealso cref="Expr"/>
+public enum DestructuringSourceKind
+{
+    None,
+    Array,
+    Object
+}
+
 public abstract record Stmt
 {
     public record Expression(Expr Expr) : Stmt;
@@ -327,7 +334,7 @@ public abstract record Stmt
     /// inferred type is still kept). Set by the destructuring desugarer to carry the binding pattern's
     /// shape so a mixed array literal source infers as a tuple instead of an array (#783). Erased at
     /// runtime (interpreter and IL compiler ignore it).</param>
-    public record Var(Token Name, string? TypeAnnotation, Expr? Initializer, bool HasDefiniteAssignmentAssertion = false, bool IsVar = false, TypeNode? TypeAnnotationNode = null, Expr? HoistTypeInferenceInitializer = null, TypeNode? InitializerContext = null, bool IsDeclare = false) : Stmt;
+    public record Var(Token Name, string? TypeAnnotation, Expr? Initializer, bool HasDefiniteAssignmentAssertion = false, bool IsVar = false, TypeNode? TypeAnnotationNode = null, Expr? HoistTypeInferenceInitializer = null, TypeNode? InitializerContext = null, bool IsDeclare = false, DestructuringSourceKind DestructuringSource = DestructuringSourceKind.None) : Stmt;
     /// <summary>
     /// Const variable declaration. Separate from Var for cleaner const-specific handling (e.g., unique symbol).
     /// Initializer is non-nullable since const always requires initialization.

--- a/src/SharpTS/Parsing/Parser.Destructuring.cs
+++ b/src/SharpTS/Parsing/Parser.Destructuring.cs
@@ -164,7 +164,9 @@ public partial class Parser
         // Carry the pattern's shape as a contextual type so a mixed array-literal source (`[[7], 8]`)
         // infers as a tuple instead of an array — otherwise `_dest[0]` is a non-indexable union and a
         // nested pattern (`[m]`) fails to type-check (#783). Erased at runtime.
-        statements.Add(new Stmt.Var(temp, null, normalizedInit, InitializerContext: BuildArrayPatternShape(pattern)));
+        statements.Add(new Stmt.Var(temp, null, normalizedInit,
+            InitializerContext: BuildArrayPatternShape(pattern),
+            DestructuringSource: DestructuringSourceKind.Array));
 
         int index = 0;
         foreach (var element in pattern.Elements)
@@ -228,7 +230,8 @@ public partial class Parser
 
         // const _dest0 = initializer;
         Token temp = GenerateTempVar(pattern.Line);
-        statements.Add(new Stmt.Var(temp, null, initializer));
+        statements.Add(new Stmt.Var(temp, null, initializer,
+            DestructuringSource: DestructuringSourceKind.Object));
 
         foreach (var prop in pattern.Properties)
         {
@@ -389,7 +392,8 @@ public partial class Parser
     {
         // _srcN = __arrayDestructure(source) — normalize any iterable to an indexable array (#685).
         Token srcTemp = GenerateTempVar(line);
-        stmts.Add(new Stmt.Var(srcTemp, null, MakeArrayDestructureCall(source, line)));
+        stmts.Add(new Stmt.Var(srcTemp, null, MakeArrayDestructureCall(source, line),
+            DestructuringSource: DestructuringSourceKind.Array));
         Expr src = new Expr.Variable(srcTemp);
 
         for (int i = 0; i < arr.Elements.Count; i++)
@@ -412,7 +416,8 @@ public partial class Parser
     {
         // _srcN = source — object patterns read properties directly (no iterator normalization).
         Token srcTemp = GenerateTempVar(line);
-        stmts.Add(new Stmt.Var(srcTemp, null, source));
+        stmts.Add(new Stmt.Var(srcTemp, null, source,
+            DestructuringSource: DestructuringSourceKind.Object));
         Expr src = new Expr.Variable(srcTemp);
         var usedKeys = new List<Expr>();
 

--- a/src/SharpTS/Runtime/BuiltIns/BuiltInTypes.cs
+++ b/src/SharpTS/Runtime/BuiltIns/BuiltInTypes.cs
@@ -142,7 +142,7 @@ public static class BuiltInTypes
             "reduceRight" => new TypeInfo.Function(
                 [new TypeInfo.Function([AnyType, elementType, NumberType, new TypeInfo.Array(elementType)], AnyType, RequiredParams: 2), AnyType],
                 AnyType, RequiredParams: 1), // initialValue is optional
-            "includes" => new TypeInfo.Function([elementType], BooleanType),
+            "includes" => new TypeInfo.Function([elementType, AnyType], BooleanType, RequiredParams: 1),
             // ECMA-262 23.1.3.17 / 23.1.3.18: fromIndex is coerced via
             // ToIntegerOrInfinity — accepts objects (with valueOf/toString),
             // strings ("Infinity"), booleans, etc. Signature widened to Any so

--- a/src/SharpTS/Runtime/BuiltIns/ObjectBuiltIns.cs
+++ b/src/SharpTS/Runtime/BuiltIns/ObjectBuiltIns.cs
@@ -64,7 +64,7 @@ public static partial class ObjectBuiltIns
     /// Throws for non-object receivers; <paramref name="apiName"/> qualifies the message.
     /// </summary>
     private static IEnumerable<KeyValuePair<string, object?>> EnumerateOwnEnumerable(
-        Interpreter interpreter, object? arg, string apiName)
+        Interpreter interpreter, object? arg, string apiName, bool includeValues = true)
     {
         switch (arg)
         {
@@ -95,7 +95,8 @@ public static partial class ObjectBuiltIns
                     if (!Compilation.RuntimeTypes.IsTruthy(enumerable))
                         continue;
 
-                    yield return new(key, proxy.TrapGet(key, interpreter));
+                    yield return new(key,
+                        includeValues ? proxy.TrapGet(key, interpreter) : null);
                 }
                 yield break;
             case SharpTSObject obj:
@@ -103,47 +104,53 @@ public static partial class ObjectBuiltIns
                 // reading values. A getter may add or delete siblings without
                 // changing the key list being traversed by entries()/values().
                 foreach (var k in obj.OwnEnumerableKeys().ToList())
-                    yield return new(k, interpreter.GetProperty(obj, k));
+                    yield return new(k,
+                        includeValues ? interpreter.GetProperty(obj, k) : null);
                 yield break;
             case SharpTSArray arr:
                 foreach (var key in arr.OwnEnumerableKeys())
-                    yield return new(key, interpreter.GetProperty(arr, key));
+                    yield return new(key,
+                        includeValues ? interpreter.GetProperty(arr, key) : null);
                 yield break;
             case SharpTSInstance inst:
                 foreach (var n in inst.GetFieldNames())
-                    yield return new(n, inst.GetRawField(n));
+                    yield return new(n, includeValues ? inst.GetRawField(n) : null);
                 yield break;
             case IDictionary<string, object?> dict:
                 foreach (var kv in dict)
-                    yield return kv;
+                    yield return includeValues ? kv : new(kv.Key, null);
                 yield break;
             case SharpTSMath math:
                 foreach (var kv in math.OwnEnumerableProperties)
-                    yield return new(kv.Key, kv.Value);
+                    yield return new(kv.Key, includeValues ? kv.Value : null);
                 yield break;
             case SharpTSJSON json:
                 foreach (var key in json.OwnEnumerableKeys())
-                    yield return new(key, json.TryGetExtra(key));
+                    yield return new(key, includeValues ? json.TryGetExtra(key) : null);
                 yield break;
             case SharpTSDate date:
                 foreach (var key in date.OwnEnumerableKeys())
-                    yield return new(key, date.TryGetExtra(key));
+                    yield return new(key, includeValues ? date.TryGetExtra(key) : null);
                 yield break;
             case SharpTSRegExp regex:
                 foreach (var key in regex.OwnEnumerableKeys())
-                    yield return new(key, regex.TryGetProperty(key, out var value) ? value : null);
+                    yield return new(key,
+                        includeValues && regex.TryGetProperty(key, out var value) ? value : null);
                 yield break;
             case SharpTSError error:
                 foreach (var key in error.OwnEnumerableKeys())
-                    yield return new(key, interpreter.GetProperty(error, key));
+                    yield return new(key,
+                        includeValues ? interpreter.GetProperty(error, key) : null);
                 yield break;
             case SharpTSFunction fn:
                 foreach (var k in fn.PropertyKeys)
-                    yield return new(k, fn.TryGetProperty(k, out var v) ? v : null);
+                    yield return new(k,
+                        includeValues && fn.TryGetProperty(k, out var v) ? v : null);
                 yield break;
             case SharpTSArrowFunction arrowFn:
                 foreach (var k in arrowFn.PropertyKeys)
-                    yield return new(k, arrowFn.TryGetProperty(k, out var av) ? av : null);
+                    yield return new(k,
+                        includeValues && arrowFn.TryGetProperty(k, out var av) ? av : null);
                 yield break;
             case ISharpTSCallable:
                 yield break;
@@ -154,7 +161,10 @@ public static partial class ObjectBuiltIns
 
     private static RuntimeValue KeysV2(Interpreter interpreter, RuntimeValue receiver, ReadOnlySpan<RuntimeValue> args)
     {
-        var keys = EnumerateOwnEnumerable(interpreter, args[0].ToObject(), "Object.keys()")
+        // Object.keys performs key/descriptor discovery only; unlike values/entries, it must never
+        // perform [[Get]] or invoke accessors/proxy get traps.
+        var keys = EnumerateOwnEnumerable(
+                interpreter, args[0].ToObject(), "Object.keys()", includeValues: false)
             .Select(kv => (object?)kv.Key).ToList();
         return RuntimeValue.FromObject(new SharpTSArray(keys));
     }

--- a/src/SharpTS/Runtime/BuiltIns/RegExpBuiltIns.cs
+++ b/src/SharpTS/Runtime/BuiltIns/RegExpBuiltIns.cs
@@ -1010,6 +1010,9 @@ public static class RegExpBuiltIns
                     : ToStr(interp, capture));
             }
 
+            object? namedCaptures = interp.GetProperty(match, "groups");
+            bool hasNamedCaptures = namedCaptures is not (null or SharpTSUndefined);
+
             string replacement;
             if (isCallable)
             {
@@ -1018,6 +1021,8 @@ public static class RegExpBuiltIns
                 callArgs.AddRange(captures);
                 callArgs.Add((double)position);
                 callArgs.Add(s);
+                if (hasNamedCaptures)
+                    callArgs.Add(namedCaptures);
                 var fnResult = FunctionBuiltIns.CallWithThis(
                     interp, (ISharpTSCallable)replaceValue!,
                     SharpTSUndefined.Instance, callArgs);
@@ -1026,7 +1031,8 @@ public static class RegExpBuiltIns
             else
             {
                 replacement = ExpandReplacement(
-                    interp, replaceStr, s, matchStr, position, captures);
+                    interp, replaceStr, s, matchStr, position, captures,
+                    hasNamedCaptures ? namedCaptures : null);
             }
 
             // Append the un-modified slice + replacement.
@@ -1048,7 +1054,8 @@ public static class RegExpBuiltIns
         string input,
         string matched,
         int position,
-        List<object?> captures)
+        List<object?> captures,
+        object? namedCaptures)
     {
         var result = new System.Text.StringBuilder(replacement.Length);
         for (int i = 0; i < replacement.Length; i++)
@@ -1079,6 +1086,20 @@ public static class RegExpBuiltIns
                     result.Append(input, tailStart, input.Length - tailStart);
                     i++;
                     continue;
+            }
+
+            if (next == '<' && namedCaptures is not null)
+            {
+                int close = replacement.IndexOf('>', i + 2);
+                if (close >= 0)
+                {
+                    string name = replacement.Substring(i + 2, close - i - 2);
+                    object? namedValue = interp.GetProperty(namedCaptures, name);
+                    if (namedValue is not (null or SharpTSUndefined))
+                        result.Append(ToStr(interp, namedValue));
+                    i = close;
+                    continue;
+                }
             }
 
             if (next == '0'

--- a/src/SharpTS/Runtime/Types/SharpTSError.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSError.cs
@@ -12,6 +12,8 @@ namespace SharpTS.Runtime.Types;
 public class SharpTSError : ITypeCategorized
 {
     private readonly SharpTSObject _properties = new([]);
+    private string? _stack;
+    private System.Diagnostics.StackTrace? _capturedStack;
 
     /// <inheritdoc />
     public TypeCategory RuntimeCategory => TypeCategory.Error;
@@ -36,7 +38,27 @@ public class SharpTSError : ITypeCategorized
     /// <summary>
     /// The stack trace at the point the error was created.
     /// </summary>
-    public string Stack { get; set; }
+    public string Stack
+    {
+        get
+        {
+            if (_stack is not null)
+                return _stack;
+
+            var captured = _capturedStack;
+            if (captured is null)
+                return "";
+
+            _stack = FormatStackTrace(captured);
+            _capturedStack = null;
+            return _stack;
+        }
+        set
+        {
+            _stack = value;
+            _capturedStack = null;
+        }
+    }
 
     /// <summary>
     /// The Node.js error code (e.g., "ENOENT", "ECONNREFUSED").
@@ -98,7 +120,7 @@ public class SharpTSError : ITypeCategorized
         ErrorTypeName = name;
         Name = name;
         Message = message ?? "";
-        Stack = CaptureStackTrace();
+        _capturedStack = CaptureStackTrace();
     }
 
     /// <summary>
@@ -116,16 +138,18 @@ public class SharpTSError : ITypeCategorized
     /// <summary>
     /// Captures a stack trace at the current point.
     /// </summary>
-    private static string CaptureStackTrace()
+    private static System.Diagnostics.StackTrace CaptureStackTrace()
     {
-        // Get the stack trace, skipping the Error constructor frames
-        var stackTrace = new System.Diagnostics.StackTrace(skipFrames: 3, fNeedFileInfo: true);
-        var frames = stackTrace.GetFrames();
+        // Preserve the creation-time call chain but leave its public string
+        // representation unbuilt until Stack is observed.
+        return new System.Diagnostics.StackTrace(skipFrames: 3, fNeedFileInfo: true);
+    }
 
+    private static string FormatStackTrace(System.Diagnostics.StackTrace captured)
+    {
+        var frames = captured.GetFrames();
         if (frames == null || frames.Length == 0)
-        {
             return "";
-        }
 
         var sb = new System.Text.StringBuilder();
         foreach (var frame in frames)
@@ -137,18 +161,12 @@ public class SharpTSError : ITypeCategorized
             var (typeName, methodName) = displayName;
 
             if (!string.IsNullOrEmpty(typeName))
-            {
                 sb.Append($"    at {typeName}.{methodName}");
-            }
             else
-            {
                 sb.Append($"    at {methodName}");
-            }
 
             if (!string.IsNullOrEmpty(fileName))
-            {
                 sb.Append($" ({fileName}:{lineNumber})");
-            }
             sb.AppendLine();
         }
 

--- a/src/SharpTS/TypeSystem/StableCustomIteratorInfo.cs
+++ b/src/SharpTS/TypeSystem/StableCustomIteratorInfo.cs
@@ -1,0 +1,11 @@
+using SharpTS.Parsing;
+
+namespace SharpTS.TypeSystem;
+
+/// <summary>Compiler-only proof for an exact non-escaping custom iterator.</summary>
+public sealed record StableCustomIteratorInfo(
+    Expr.ArrowFunction IteratorMethod,
+    Expr.ArrowFunction NextMethod,
+    string ResultFingerprint,
+    int ValueFieldIndex,
+    int DoneFieldIndex);

--- a/src/SharpTS/TypeSystem/TypeChecker.Calls.cs
+++ b/src/SharpTS/TypeSystem/TypeChecker.Calls.cs
@@ -557,6 +557,22 @@ public partial class TypeChecker
             { result = new TypeInfo.Error(errorVar.Name.Lexeme); return true; }
         }
 
+        // Math.min/max always produce a Number (or throw while coercing an
+        // argument).  Math itself is otherwise modeled as `any`, but retaining
+        // this result type lets annotated numeric callers keep their native
+        // double return slot.  A lexical Math binding is user code and must go
+        // through ordinary callable resolution instead.
+        if (call.Callee is Expr.Get mathGet &&
+            mathGet.Object is Expr.Variable mathVar &&
+            mathVar.Name.Lexeme == "Math" &&
+            _environment.Get("Math") is null &&
+            mathGet.Name.Lexeme is "min" or "max")
+        {
+            foreach (var arg in call.Arguments)
+                CheckExpr(arg is Expr.Spread spread ? spread.Expression : arg);
+            { result = TypeInfo.Primitive.Number; return true; }
+        }
+
         // Handle Object.keys(), Object.values(), Object.entries()
         if (call.Callee is Expr.Get get &&
             get.Object is Expr.Variable objVar &&

--- a/src/SharpTS/TypeSystem/TypeMap.cs
+++ b/src/SharpTS/TypeSystem/TypeMap.cs
@@ -27,8 +27,14 @@ public class TypeMap
     private readonly Dictionary<Token, ClassScalarReplacementInfo> _scalarReplaceableClassLocals =
         new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Stmt.ForOf> _stableNumericMapIterations = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<Stmt.ForOf, StableCustomIteratorInfo> _stableCustomIteratorLoops =
+        new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<Expr.ArrowFunction, StableCustomIteratorInfo> _stableCustomIteratorNextMethods =
+        new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.Get> _stablePrimitivePromiseThenCalls = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<Expr.ArrowFunction, HashSet<string>> _stableNumericCaptureFields = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<object, HashSet<string>> _stableNumericFunctionCaptureFields = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<Token> _stableCustomIteratorNumericAccumulators = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Stmt.Var> _stableNumericStateMachineLocals = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Stmt.Parameter> _stableNumericStateMachineParameters = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Expr.Get> _stableExactPrimitiveMethodCalls = new(ReferenceEqualityComparer.Instance);
@@ -276,6 +282,21 @@ public class TypeMap
     public bool IsStableNumericMapIteration(Stmt.ForOf loop) =>
         _stableNumericMapIterations.Contains(loop);
 
+    public void MarkStableCustomIterator(
+        Stmt.ForOf loop, StableCustomIteratorInfo info)
+    {
+        _stableCustomIteratorLoops[loop] = info;
+        _stableCustomIteratorNextMethods[info.NextMethod] = info;
+    }
+
+    public bool TryGetStableCustomIterator(
+        Stmt.ForOf loop, out StableCustomIteratorInfo info) =>
+        _stableCustomIteratorLoops.TryGetValue(loop, out info!);
+
+    public bool TryGetStableCustomIteratorNext(
+        Expr.ArrowFunction method, out StableCustomIteratorInfo info) =>
+        _stableCustomIteratorNextMethods.TryGetValue(method, out info!);
+
     /// <summary>
     /// Marks a direct <c>Promise.prototype.then</c> access whose receiver is a fresh,
     /// non-escaping intrinsic Promise binding and whose sole inline fulfillment
@@ -307,6 +328,29 @@ public class TypeMap
     public bool IsStableNumericCaptureField(Expr.ArrowFunction arrow, string name) =>
         _stableNumericCaptureFields.TryGetValue(arrow, out var names)
         && names.Contains(name);
+
+    /// <summary>
+    /// Marks a function-owned captured numeric binding whose shared display-class
+    /// slot can remain an unboxed <c>double</c>. The stable custom-iterator analyzer
+    /// only records bindings initialized before iterator creation, referenced by the
+    /// exact non-escaping <c>next</c> closure, and kept numeric by every write.
+    /// </summary>
+    public void MarkStableNumericFunctionCaptureField(object callable, string name)
+    {
+        if (!_stableNumericFunctionCaptureFields.TryGetValue(callable, out var names))
+            _stableNumericFunctionCaptureFields[callable] = names = [];
+        names.Add(name);
+    }
+
+    public bool IsStableNumericFunctionCaptureField(object callable, string name) =>
+        _stableNumericFunctionCaptureFields.TryGetValue(callable, out var names)
+        && names.Contains(name);
+
+    public void MarkStableCustomIteratorNumericAccumulator(Token name) =>
+        _stableCustomIteratorNumericAccumulators.Add(name);
+
+    public bool IsStableCustomIteratorNumericAccumulator(Token name) =>
+        _stableCustomIteratorNumericAccumulators.Contains(name);
 
     /// <summary>
     /// Marks an explicitly numeric local whose complete state-machine lifetime has

--- a/tests/SharpTS.Tests/CompilerTests/DenseArrayShiftUnshiftTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/DenseArrayShiftUnshiftTests.cs
@@ -1,0 +1,165 @@
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class DenseArrayShiftUnshiftTests
+{
+    [Fact]
+    public void PromotedPrimitiveArrays_PreserveValuesLengthAndEmptyResult()
+    {
+        const string source = """
+            function numbers(): void {
+                const values: number[] = [];
+                values.push(2, 3);
+                console.log(values.unshift(0, 1));
+                console.log(values.shift(), values.shift(), values.length);
+                values.shift();
+                values.shift();
+                console.log(values.shift() === undefined, values.length);
+            }
+
+            function booleans(): void {
+                const values: boolean[] = [];
+                values.push(false);
+                console.log(values.unshift(true), values.shift(), values.shift());
+                console.log(values.shift() === undefined);
+            }
+
+            numbers();
+            booleans();
+            """;
+
+        Assert.Equal(
+            "4\n0 1 2\ntrue 0\n2 true false\ntrue\n",
+            TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void PromotedUnshift_EvaluatesAllArgumentsBeforeMutation()
+    {
+        const string source = """
+            const values: number[] = [];
+            values.push(10);
+            console.log(values.unshift(values.length, values.length));
+            console.log(values[0], values[1], values[2]);
+            """;
+
+        Assert.Equal("3\n1 1 10\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void EscapingNumberArray_UsesPackedMutatorsWithoutChangingSemantics()
+    {
+        const string source = """
+            function edit(values: number[]): void {
+                console.log(values.unshift(-2, -1));
+                console.log(values.shift(), values.shift(), values.length);
+            }
+
+            const values: number[] = [];
+            values.push(0, 1, 2);
+            edit(values);
+            console.log(values[0], values[2]);
+
+            const boxed: number[] = [1, 2];
+            (boxed as any)[0] = "x";
+            console.log(boxed.unshift(9), boxed.shift(), boxed.shift(), boxed.length);
+            """;
+
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+        Assert.Equal("5\n-2 -1 3\n0 2\n3 9 x 1\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void ReplacedShiftAndUnshift_RemainObservable()
+    {
+        const string source = """
+            const originalShift: any = Array.prototype.shift;
+            const originalUnshift: any = Array.prototype.unshift;
+            Array.prototype.shift = function(): number { return 77; };
+            Array.prototype.unshift = function(...items: any[]): number {
+                return 80 + items.length;
+            };
+            console.log((Array.prototype as any).shift === originalShift);
+
+            const values: number[] = [];
+            values.push(1);
+            console.log(values.shift(), values.unshift(2, 3), values.length);
+
+            Array.prototype.shift = originalShift;
+            Array.prototype.unshift = originalUnshift;
+            """;
+
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        Assert.True(new RuntimeFeatureDetector()
+            .Detect(statements, typeMap).UsesArrayPrototypeMutation);
+        Assert.Equal("false\n77 82 1\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void HoleAccessorFrozenAndBorrowedCases_UseGenericSemantics()
+    {
+        const string source = """
+            const holey: any[] = [, 2];
+            console.log(holey.shift() === undefined, holey[0], holey.length);
+
+            const observed: any[] = [1, 2];
+            let getterCalls: number = 0;
+            Object.defineProperty(observed, 1, {
+                get(): number { getterCalls = getterCalls + 1; return 9; }
+            });
+            console.log(observed.shift(), observed[0], getterCalls);
+
+            const frozen: number[] = [];
+            Object.freeze(frozen);
+            try { frozen.unshift(1); } catch (error) {
+                console.log(error instanceof TypeError);
+            }
+
+            const sealed: number[] = [1, 2];
+            Object.seal(sealed);
+            try { sealed.shift(); } catch (error) {
+                console.log(error instanceof TypeError);
+            }
+
+            Object.defineProperty(Array.prototype, "0", {
+                configurable: true,
+                get(): number { return 41; }
+            });
+            const inherited: any[] = [];
+            inherited.length = 1;
+            console.log(inherited.shift(), inherited.length);
+            delete (Array.prototype as any)[0];
+
+            const generic: any = { 0: "tail", length: 1 };
+            console.log(Array.prototype.unshift.call(generic, "head"));
+            console.log(Array.prototype.shift.call(generic), generic[0], generic.length);
+            """;
+
+        Assert.Equal(
+            "true 2 1\n1 9 1\ntrue\ntrue\n41 0\n2\nhead tail 1\n",
+            TestHarness.RunCompiled(source));
+    }
+
+
+    [Fact]
+    public void DeletedShift_RemainsObservable()
+    {
+        const string source = """
+            const originalShift: any = Array.prototype.shift;
+            delete (Array.prototype as any).shift;
+            const values: number[] = [1];
+            try { values.shift(); } catch (error) {
+                console.log(error instanceof TypeError);
+            }
+            Array.prototype.shift = originalShift;
+            """;
+
+        Assert.Equal("true\n", TestHarness.RunCompiled(source));
+    }
+}

--- a/tests/SharpTS.Tests/CompilerTests/DenseNumericIncludesTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/DenseNumericIncludesTests.cs
@@ -1,0 +1,198 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class DenseNumericIncludesTests
+{
+    private const string StableSource = """
+        function scan(size: number, passes: number): number {
+            const values: number[] = [];
+            for (let i: number = 0; i < size; i++) values.push(i);
+            let found: number = 0;
+            for (let pass: number = 0; pass < passes; pass++) {
+                if (values.includes(-1)) found = found + 1;
+            }
+            return found;
+        }
+        """;
+
+    [Theory, ModeData]
+    public void DenseNumericIncludes_PreservesSameValueZeroAndFromIndex(ExecutionMode mode)
+    {
+        const string source = """
+            const values: number[] = [];
+            values.push(-0, 1, NaN, 3);
+            console.log(values.includes(1), values.includes(2));
+            console.log(values.includes(NaN), values.includes(+0));
+            console.log(values.includes(1, 1), values.includes(1, 2));
+            console.log(values.includes(1, -3), values.includes(1, -2));
+            console.log(values.includes(3, 3.9), values.includes(1, -3.9));
+            console.log(values.includes(0, Infinity), values.includes(0, -Infinity));
+            const empty: number[] = [];
+            console.log(empty.includes(0));
+            """;
+
+        Assert.Equal(
+            "true false\ntrue true\ntrue false\ntrue false\ntrue true\nfalse true\nfalse\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void DenseNumericIncludes_UsesTypedHelperWithoutBoxing()
+    {
+        Assembly assembly = Compile(StableSource);
+        MethodInfo scan = FindFunction(assembly, "scan");
+        var calls = ReadInstructions(scan)
+            .Where(instruction => instruction.Operand is MethodBase)
+            .Select(instruction => (MethodBase)instruction.Operand!)
+            .ToArray();
+
+        Assert.Contains(calls, method => method.Name == "ArrayIncludesDouble");
+        Assert.DoesNotContain(calls, method => method.Name == "ArrayIncludes");
+        MethodInfo helper = assembly.GetType("$Runtime")!.GetMethod("ArrayIncludesDouble")!;
+        Assert.DoesNotContain(ReadInstructions(helper), instruction => instruction.OpCode == OpCodes.Box);
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(StableSource));
+    }
+
+    [Fact]
+    public void DenseNumericIncludes_DoesNotAllocatePerScannedElement()
+    {
+        MethodInfo scan = FindFunction(Compile(StableSource), "scan");
+        double Invoke(double passes) => Convert.ToDouble(scan.Invoke(null, [10_000.0, passes]));
+        Assert.Equal(0, Invoke(2));
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        double small = Invoke(1);
+        long smallAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        before = GC.GetAllocatedBytesForCurrentThread();
+        double large = Invoke(100);
+        long largeAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(0, small);
+        Assert.Equal(0, large);
+        Assert.True(largeAllocated <= smallAllocated + 2_048,
+            $"Dense includes allocations scaled: {smallAllocated} vs {largeAllocated} bytes.");
+        Assert.True(largeAllocated < 1_544_500,
+            $"Dense includes allocated {largeAllocated} bytes; the 95% reduction gate is 1,544,500 bytes.");
+    }
+
+    [Fact]
+    public void ObservableIncludesCases_RetainGenericSemantics()
+    {
+        const string source = """
+            const holey: any[] = [,];
+            console.log(holey.includes(undefined));
+
+            Object.defineProperty(Array.prototype, "0", {
+                configurable: true,
+                get(): number { return 7; }
+            });
+            const inherited: any[] = [];
+            inherited.length = 1;
+            console.log(inherited.includes(7));
+            delete (Array.prototype as any)[0];
+
+            const omitted: any[] = [undefined];
+            console.log(omitted.includes());
+
+            let coercions: number = 0;
+            const fromIndex: any = {
+                valueOf(): number { coercions = coercions + 1; return 0; }
+            };
+            console.log(([3] as number[]).includes(3, fromIndex), coercions);
+            """;
+
+        Assert.Equal("true\ntrue\ntrue\ntrue 1\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void ReplacedAndDeletedIncludes_RemainObservable()
+    {
+        const string replaced = """
+            const original: any = Array.prototype.includes;
+            Array.prototype.includes = function(value: any): boolean { return false; };
+            const values: number[] = [];
+            values.push(1);
+            console.log(values.includes(1));
+            Array.prototype.includes = original;
+            """;
+        Assert.Equal("false\n", TestHarness.RunCompiled(replaced));
+
+        const string deleted = """
+            const original: any = Array.prototype.includes;
+            delete (Array.prototype as any).includes;
+            const values: number[] = [];
+            values.push(1);
+            try { values.includes(1); } catch (error) {
+                console.log(error instanceof TypeError);
+            }
+            Array.prototype.includes = original;
+            """;
+        Assert.Equal("true\n", TestHarness.RunCompiled(deleted));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        TypeMap typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"dense_numeric_includes_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe ? unchecked((short)(0xfe00 | il[offset++])) : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType or OperandType.InlineField)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType switch
+                {
+                    OperandType.InlineMethod => module.ResolveMethod(token),
+                    OperandType.InlineField => module.ResolveField(token),
+                    _ => module.ResolveType(token)
+                };
+            }
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or OperandType.InlineField or
+                    OperandType.InlineMethod or OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch => 4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException($"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes).GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}

--- a/tests/SharpTS.Tests/CompilerTests/LazyErrorStackTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/LazyErrorStackTests.cs
@@ -1,0 +1,115 @@
+using System.Reflection;
+using SharpTS.Compilation;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class LazyErrorStackTests
+{
+    private const string SparseThrowSource = """
+        function throwErrorSparse(n: number): number {
+            let sum: number = 0;
+            for (let i: number = 0; i < n; i++) {
+                try {
+                    if ((i & 1023) === 0) {
+                        throw new Error("sparse");
+                    }
+                    sum = sum + 1;
+                } catch (error: any) {
+                    sum = sum + (error instanceof Error ? i : -1);
+                }
+            }
+            return sum;
+        }
+        """;
+
+    [Fact]
+    public void SparseThrowWithoutStackRead_AvoidsEagerFormattingAllocation()
+    {
+        var run = FindFunction(Compile(SparseThrowSource), "throwErrorSparse")
+            .CreateDelegate<Func<double, double>>();
+
+        _ = run(10_000);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        Assert.Equal(4_966_974, run(100_000));
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        // The eager baseline allocated 1,318,715 bytes for this exact shape.
+        // Keep at least the issue's 70% reduction as a permanent gate.
+        Assert.True(allocated <= 395_615,
+            $"Sparse Error throws allocated {allocated:N0} bytes.");
+    }
+
+    [Fact]
+    public void FirstReadUsesCreationSiteAndRepeatedReadIsStable()
+    {
+        const string source = """
+            function createError(): Error { return new Error("boom"); }
+            function readLater(error: Error): string { return error.stack!; }
+            const error = createError();
+            const first = readLater(error);
+            const second = error.stack!;
+            console.log(first.includes("createError"));
+            console.log(first.includes("readLater"));
+            console.log(first === second);
+            """;
+
+        Assert.Equal("true\nfalse\ntrue\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void SubtypeCauseAndExplicitStackAssignmentRemainObservable()
+    {
+        const string source = """
+            const cause = new Error("root");
+            const error = new TypeError("outer", { cause });
+            console.log(error.name, error.message, error.cause === cause);
+            console.log(typeof error.stack, error.stack === error.stack);
+            error.stack = "manual stack";
+            console.log(error.stack);
+            """;
+
+        Assert.Equal(
+            "TypeError outer true\nstring true\nmanual stack\n",
+            TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void UncaughtErrorRetainsItsCreationSiteForHostReporting()
+    {
+        Assembly assembly = Compile("""
+            function explode(): void { throw new Error("uncaught"); }
+            """);
+        MethodInfo explode = FindFunction(assembly, "explode");
+        var reflectionException = Assert.Throws<TargetInvocationException>(
+            () => explode.Invoke(null, null));
+        MethodInfo wrapException = assembly.GetType("$Runtime")!
+            .GetMethod("WrapException", BindingFlags.Public | BindingFlags.Static)!;
+
+        object guestError = wrapException.Invoke(null, [reflectionException])!;
+        string stack = Assert.IsType<string>(guestError.GetType()
+            .GetProperty("Stack")!.GetValue(guestError));
+
+        Assert.Contains("explode", stack, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LazyStackAssemblyPassesIlVerification()
+    {
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(SparseThrowSource));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var result = CompilationService.Compile(source);
+        Assert.True(result.Success, string.Join(Environment.NewLine, result.Diagnostics));
+        return Assembly.Load(result.AssemblyBytes!);
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name == name ||
+                method.Name.EndsWith("_" + name, StringComparison.Ordinal));
+}

--- a/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
@@ -215,6 +215,26 @@ public class RuntimeFeatureDetectorTests
     }
 
     [Theory]
+    [InlineData("const value: string = 'abc'; value.indexOf('b');", false)]
+    [InlineData("const prototype = String.prototype;", true)]
+    [InlineData("String.prototype.indexOf = function() { return 0; };", true)]
+    [InlineData("String.prototype['slice'] = function() { return ''; };", true)]
+    [InlineData("const S = String; S.prototype.includes = function() { return false; };", true)]
+    [InlineData("const p = String.prototype; p.substring = function() { return ''; };", true)]
+    [InlineData("globalThis.String = String;", true)]
+    [InlineData("globalThis['String'] = String;", true)]
+    [InlineData("Object.defineProperty(String.prototype, 'indexOf', { value: null });", true)]
+    [InlineData("eval('void 0');", true)]
+    public void DetectsStringPrototypeMutationRisk(string source, bool expected)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var features = new RuntimeFeatureDetector().Detect(statements, typeMap);
+
+        Assert.Equal(expected, features.UsesStringPrototypeMutation);
+    }
+
+    [Theory]
     [InlineData("Number.prototype.toString = function() { return 'x'; };", false)]
     [InlineData("Number.parseInt = function() { return 0; };", true)]
     [InlineData("globalThis.Number = Number;", true)]

--- a/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/RuntimeFeatureDetectorTests.cs
@@ -235,6 +235,24 @@ public class RuntimeFeatureDetectorTests
     }
 
     [Theory]
+    [InlineData("Math.min(1, 2);", false)]
+    [InlineData("Math.min = function() { return 0; };", true)]
+    [InlineData("Math['max'] = function() { return 0; };", true)]
+    [InlineData("const M = Math; M.min = function() { return 0; };", true)]
+    [InlineData("globalThis.Math = Math;", true)]
+    [InlineData("globalThis['Math'] = Math;", true)]
+    [InlineData("Object.defineProperty(Math, 'min', { value: null });", true)]
+    [InlineData("eval('void 0');", true)]
+    public void DetectsMathMutationRisk(string source, bool expected)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var features = new RuntimeFeatureDetector().Detect(statements, typeMap);
+
+        Assert.Equal(expected, features.UsesMathMutation);
+    }
+
+    [Theory]
     [InlineData("Number.prototype.toString = function() { return 'x'; };", false)]
     [InlineData("Number.parseInt = function() { return 0; };", true)]
     [InlineData("globalThis.Number = Number;", true)]

--- a/tests/SharpTS.Tests/CompilerTests/StableCustomIteratorTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableCustomIteratorTests.cs
@@ -1,0 +1,246 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class StableCustomIteratorTests
+{
+    private const string StableSource = """
+        function iterate(n: number): number {
+            let current: number = 0;
+            const iterable = {
+                [Symbol.iterator]() { return this; },
+                next() {
+                    if (current < n) {
+                        const value: number = current;
+                        current = current + 1;
+                        return { value, done: false };
+                    }
+                    return { value: 0, done: true };
+                }
+            };
+            let total: number = 0;
+            for (const value of iterable) total = total + value;
+            return total;
+        }
+        """;
+
+    [Theory, ModeData]
+    public void StableCustomIterator_ReturnsExpectedValues(ExecutionMode mode)
+    {
+        Assert.Equal("499500\n", TestHarness.Run(
+            StableSource + "\nconsole.log(iterate(1000));", mode));
+    }
+
+    [Fact]
+    public void StableCustomIterator_UsesDirectNextAndCompactResultSlots()
+    {
+        Assembly assembly = Compile(StableSource);
+        MethodInfo iterate = FindFunction(assembly, "iterate");
+        var instructions = ReadInstructions(iterate).ToArray();
+
+        Assert.Contains(instructions, instruction =>
+            instruction.OpCode is var op && (op == OpCodes.Call || op == OpCodes.Callvirt) &&
+            instruction.Operand is MethodBase { Name: "Invoke" } method &&
+            method.DeclaringType?.Name.StartsWith("<>c__DisplayClass", StringComparison.Ordinal) == true);
+        Assert.Contains(instructions, instruction => instruction.OpCode == OpCodes.Ldfld &&
+            instruction.Operand?.DeclaringType?.Name.StartsWith(
+                "$StableNumberIteratorResult", StringComparison.Ordinal) == true);
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "InvokeIteratorNext" or "GetIteratorDone" or "GetIteratorValue"
+            });
+        Assert.Contains(assembly.GetTypes().SelectMany(type => type.GetFields()), field =>
+            field.Name == "current" && field.FieldType == typeof(double));
+        MethodInfo next = assembly.GetTypes().SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance |
+                BindingFlags.Static))
+            .Single(method => method.ReturnType.Name == "$StableNumberIteratorResult");
+        Assert.DoesNotContain(ReadInstructions(next), instruction =>
+            instruction.OpCode == OpCodes.Box);
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(StableSource));
+    }
+
+    [Fact]
+    public void StableCustomIterator_DoesNotAllocatePerValue()
+    {
+        MethodInfo iterate = FindFunction(Compile(StableSource), "iterate");
+        double Invoke(double n) => Convert.ToDouble(iterate.Invoke(null, [n]));
+        Assert.Equal(4_999_950_000, Invoke(100_000));
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        double smallResult = Invoke(1_000);
+        long smallAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        before = GC.GetAllocatedBytesForCurrentThread();
+        double largeResult = Invoke(100_000);
+        long largeAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(499_500, smallResult);
+        Assert.Equal(4_999_950_000, largeResult);
+        Assert.True(largeAllocated <= smallAllocated + 2_048,
+            $"Stable iterator allocations scaled: {smallAllocated} vs {largeAllocated} bytes.");
+    }
+
+    [Theory, ModeData]
+    public void EscapedAndReassignedNext_RetainsGenericProtocol(ExecutionMode mode)
+    {
+        const string source = """
+            let current: number = 0;
+            const iterable: any = {
+                [Symbol.iterator]() { return this; },
+                next() { return { value: current++, done: current > 3 }; }
+            };
+            const alias: any = iterable;
+            alias.next = () => ({ value: 9, done: true });
+            let count: number = 0;
+            for (const value of iterable) count = count + value;
+            console.log(count);
+            """;
+
+        Assert.Equal("0\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void CapturedIteratorBinding_RetainsGenericProtocol(ExecutionMode mode)
+    {
+        const string source = """
+            function run(): number {
+                let current: number = 0;
+                const iterable = {
+                    [Symbol.iterator]() { return this; },
+                    next() {
+                        const value: number = current++;
+                        return { value, done: current > 3 };
+                    }
+                };
+                const retain = () => iterable;
+                let total: number = 0;
+                for (const value of iterable) total = total + value;
+                if (retain() !== iterable) return -1;
+                return total;
+            }
+            console.log(run());
+            """;
+
+        Assert.Equal("3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void Break_ClosesStableIteratorExactlyOnce(ExecutionMode mode)
+    {
+        const string source = """
+            let current: number = 0;
+            let closes: number = 0;
+            const iterable = {
+                [Symbol.iterator]() { return this; },
+                next() {
+                    const value: number = current++;
+                    return { value, done: false };
+                },
+                return() { closes = closes + 1; return { value: 0, done: true }; }
+            };
+            for (const value of iterable) { console.log(value); break; }
+            console.log("closes=" + closes);
+            """;
+
+        Assert.Equal("0\ncloses=1\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void ThrowFromStableNext_DoesNotCallReturn()
+    {
+        const string source = """
+            function run(): string {
+                let current: number = 0;
+                let closes: number = 0;
+                const iterable = {
+                    [Symbol.iterator]() { return this; },
+                    next() {
+                        current++;
+                        if (current === 2) throw new Error("next failed");
+                        return { value: current, done: false };
+                    },
+                    return() {
+                        closes++;
+                        return { value: 0, done: true };
+                    }
+                };
+                let message: string = "none";
+                try {
+                    for (const value of iterable) { }
+                } catch (error: any) {
+                    message = error.message;
+                }
+                return message + ":" + closes;
+            }
+            console.log(run());
+            """;
+
+        Assert.Equal("next failed:0\n", TestHarness.Run(source, ExecutionMode.Compiled));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        TypeMap typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"stable_custom_iterator_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe ? unchecked((short)(0xfe00 | il[offset++])) : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType or OperandType.InlineField)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType switch
+                {
+                    OperandType.InlineMethod => module.ResolveMethod(token),
+                    OperandType.InlineField => module.ResolveField(token),
+                    _ => module.ResolveType(token)
+                };
+            }
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or OperandType.InlineField or
+                    OperandType.InlineMethod or OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch => 4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException($"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes).GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}

--- a/tests/SharpTS.Tests/CompilerTests/StableDestructuringLoadTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableDestructuringLoadTests.cs
@@ -1,0 +1,131 @@
+using System.Reflection;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>Regression coverage for stable typed destructuring loads (#1502).</summary>
+public sealed class StableDestructuringLoadTests
+{
+    private const string HotSource = """
+        type Point = { x: number; y: number };
+
+        function arrayLoop(n: number): number {
+            const pair: number[] = [1, 2];
+            let total: number = 0;
+            for (let i: number = 0; i < n; i++) {
+                const [a, b] = pair;
+                total = total + a + b;
+            }
+            return total;
+        }
+
+        function objectLoop(n: number): number {
+            const point: Point = { x: 3, y: 4 };
+            let total: number = 0;
+            for (let i: number = 0; i < n; i++) {
+                const { x, y } = point;
+                total = total + x + y;
+            }
+            return total;
+        }
+        """;
+
+    [Fact]
+    public void StableArrayAndRecordBindings_AreAllocationFreePerIteration()
+    {
+        Assembly assembly = Compile(HotSource);
+        var arrayLoop = FindFunction(assembly, "arrayLoop")
+            .CreateDelegate<Func<double, double>>();
+        var objectLoop = FindFunction(assembly, "objectLoop")
+            .CreateDelegate<Func<double, double>>();
+
+        Assert.Equal(300_000, arrayLoop(100_000));
+        Assert.Equal(700_000, objectLoop(100_000));
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        double arraySmallResult = arrayLoop(1_000);
+        long arraySmallAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        before = GC.GetAllocatedBytesForCurrentThread();
+        double arrayLargeResult = arrayLoop(100_000);
+        long arrayLargeAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        before = GC.GetAllocatedBytesForCurrentThread();
+        double objectSmallResult = objectLoop(1_000);
+        long objectSmallAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        before = GC.GetAllocatedBytesForCurrentThread();
+        double objectLargeResult = objectLoop(100_000);
+        long objectLargeAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(3_000, arraySmallResult);
+        Assert.Equal(300_000, arrayLargeResult);
+        Assert.Equal(7_000, objectSmallResult);
+        Assert.Equal(700_000, objectLargeResult);
+        // Runtime/JIT bookkeeping varies by platform, but allocations must not scale
+        // with the 99,000 additional destructuring bindings.
+        Assert.True(arrayLargeAllocated <= arraySmallAllocated + 1_024,
+            $"Array destructuring allocations scaled: {arraySmallAllocated} vs {arrayLargeAllocated}.");
+        Assert.True(objectLargeAllocated <= objectSmallAllocated + 1_024,
+            $"Object destructuring allocations scaled: {objectSmallAllocated} vs {objectLargeAllocated}.");
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(HotSource));
+    }
+
+    [Theory, ModeData]
+    public void DefaultsElisionsNestedPatternsRestAndHoles_RetainSemantics(ExecutionMode mode)
+    {
+        const string source = """
+            const [first = 10, , [nested], ...rest] = [undefined, 2, [3], 4, 5];
+            console.log(first, nested, rest.length, rest[0], rest[1]);
+            """;
+
+        Assert.Equal("10 3 2 4 5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void ObjectGetters_RetainSourceOrderAndSingleEvaluation(ExecutionMode mode)
+    {
+        const string source = """
+            let trace: string = "";
+            const source = {
+                get x(): number { trace = trace + "x"; return 1; },
+                get y(): number { trace = trace + "y"; return 2; }
+            };
+            const { x, y } = source;
+            console.log(x, y, trace);
+            """;
+
+        Assert.Equal("1 2 xy\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void ReassignedArraySymbolIterator_UsesIteratorProtocol(ExecutionMode mode)
+    {
+        const string source = """
+            function* replacement(): Generator<number> { yield 9; yield 8; }
+            const values: number[] = [1, 2];
+            (values as any)[Symbol.iterator] = replacement;
+            const [a, b] = values;
+            console.log(a, b);
+            """;
+
+        Assert.Equal("9 8\n", TestHarness.Run(source, mode));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        TypeMap typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"stable_destructuring_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+}

--- a/tests/SharpTS.Tests/CompilerTests/StablePrimitiveStringIntrinsicTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StablePrimitiveStringIntrinsicTests.cs
@@ -193,16 +193,19 @@ public sealed class StablePrimitiveStringIntrinsicTests
     {
         const string source = IntrinsicFunctions + """
             const boxed: any = new String("abcdef");
+            const localized = new Date(Date.UTC(2024, 0, 15))
+                .toLocaleDateString("en-US", { timeZone: "UTC" });
             console.log(find("abcdef", "cd", 0));
             console.log(contains("abcdef", "cd", 0));
             console.log(takeSlice("abcdef", 1, 4));
             console.log(takeSubstring("abcdef", 4, 1));
             console.log(boxed.slice(1, 4));
+            console.log(localized.includes("2024"));
             """;
 
         var (errors, output) = TestHarness.CompileVerifyAndRun(source);
         Assert.Empty(errors);
-        Assert.Equal("2\ntrue\nbcd\nbcd\nbcd\n", output);
+        Assert.Equal("2\ntrue\nbcd\nbcd\nbcd\ntrue\n", output);
     }
 
     private static Assembly Compile(string source)

--- a/tests/SharpTS.Tests/CompilerTests/StablePrimitiveStringIntrinsicTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StablePrimitiveStringIntrinsicTests.cs
@@ -1,0 +1,274 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class StablePrimitiveStringIntrinsicTests
+{
+    private const string IntrinsicFunctions = """
+        function find(input: string, needle: string, position: number): number {
+            return input.indexOf(needle, position);
+        }
+        function contains(input: string, needle: string, position: number): boolean {
+            return input.includes(needle, position);
+        }
+        function takeSlice(input: string, start: number, end: number): string {
+            return input.slice(start, end);
+        }
+        function takeSubstring(input: string, start: number, end: number): string {
+            return input.substring(start, end);
+        }
+        """;
+
+    [Theory]
+    [InlineData("find", "StringIndexOfPrimitive")]
+    [InlineData("contains", "StringIncludesPrimitive")]
+    [InlineData("takeSlice", "StringSlicePrimitive")]
+    [InlineData("takeSubstring", "StringSubstringPrimitive")]
+    public void StablePrimitiveCall_UsesTypedFixedArityHelper(
+        string functionName, string helperName)
+    {
+        MethodInfo method = FindFunction(Compile(IntrinsicFunctions), functionName);
+        var instructions = ReadInstructions(method).ToArray();
+
+        Assert.Contains(instructions, instruction =>
+            instruction.OpCode == OpCodes.Call
+            && instruction.Operand is MethodBase { Name: var name }
+            && name == helperName);
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.OpCode is var opCode
+            && (opCode == OpCodes.Box || opCode == OpCodes.Newarr));
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "UnwrapStringReceiver" or "InvokeMethodValue"
+            });
+    }
+
+    [Fact]
+    public void StablePrimitiveSearch_DoesNotAllocatePerCall()
+    {
+        Assembly assembly = Compile(IntrinsicFunctions);
+        var find = FindFunction(assembly, "find")
+            .CreateDelegate<Func<string, string, double, double>>();
+        var contains = FindFunction(assembly, "contains")
+            .CreateDelegate<Func<string, string, double, bool>>();
+        const string input = "alpha-beta-gamma";
+        const string needle = "beta";
+
+        for (int i = 0; i < 10_000; i++)
+        {
+            _ = find(input, needle, 1);
+            _ = contains(input, needle, 1);
+        }
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        double total = 0;
+        for (int i = 0; i < 100_000; i++)
+        {
+            total += find(input, needle, i & 1);
+            if (contains(input, needle, i & 1))
+                total++;
+        }
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(700_000, total);
+        Assert.True(allocated <= 1_024,
+            $"Primitive string searches allocated {allocated:N0} bytes.");
+    }
+
+    [Theory, ModeData]
+    public void PrimitiveIntrinsics_PreservePositionsUtf16AndOmittedArguments(
+        ExecutionMode mode)
+    {
+        const string source = """
+            const unicode: string = "A😀BC😀D";
+            const ascii: string = "abcdef";
+            const zero: number = 0;
+            const two: number = 2;
+            const three: number = 3;
+            const five: number = 5;
+            const huge: number = 1e100;
+            const negativeHuge: number = -1e100;
+            const notNumber: number = NaN;
+            const positiveInfinity: number = Infinity;
+            const negativeInfinity: number = -Infinity;
+
+            console.log(unicode.indexOf("😀", zero));
+            console.log(unicode.indexOf("😀", two));
+            console.log(unicode.indexOf("😀"));
+            console.log(unicode.indexOf("", huge));
+            console.log(unicode.indexOf("", negativeInfinity));
+            console.log(unicode.includes("😀", two));
+            console.log(unicode.includes("😀", huge));
+            console.log(unicode.includes("A"));
+            console.log(unicode.includes("A", notNumber));
+
+            console.log(ascii.slice(zero));
+            console.log(ascii.slice(-three));
+            console.log(ascii.slice(negativeInfinity, positiveInfinity));
+            console.log(ascii.slice(notNumber, three));
+            console.log(ascii.slice(five, two));
+            console.log(ascii.slice(positiveInfinity));
+
+            console.log(ascii.substring(zero));
+            console.log(ascii.substring(-three));
+            console.log(ascii.substring(five, two));
+            console.log(ascii.substring(notNumber, positiveInfinity));
+            console.log(ascii.substring(positiveInfinity, negativeHuge));
+            """;
+
+        Assert.Equal(
+            "1\n5\n1\n8\n0\ntrue\nfalse\ntrue\ntrue\n" +
+            "abcdef\ndef\nabcdef\nabc\n\n\n" +
+            "abcdef\nabcdef\ncde\nabcdef\nabcdef\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void GenericFallback_PreservesBoxingCoercionAndRegExpRejection(
+        ExecutionMode mode)
+    {
+        const string source = """
+            const boxed: any = new String("abcdef");
+            console.log(boxed.indexOf("cd", 0));
+            console.log(boxed.includes("ef", 0));
+            console.log(boxed.slice(1, 4));
+            console.log(boxed.substring(4, 1));
+
+            const events: string[] = [];
+            const needle: any = {
+                toString: function(): string { events.push("needle"); return "cd"; }
+            };
+            const position: any = {
+                valueOf: function(): number { events.push("position"); return 1; }
+            };
+            console.log("abcdef".indexOf(needle, position));
+            console.log(events.join(","));
+
+            try {
+                console.log("abcdef".includes(/cd/ as any));
+            } catch (error) {
+                console.log(error instanceof TypeError);
+            }
+            """;
+
+        Assert.Equal(
+            "2\ntrue\nbcd\nbcd\n2\nneedle,position\ntrue\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void StringPrototypeReplacement_DisablesTypedHelperAndIsObservable()
+    {
+        const string source = """
+            (String.prototype as any).indexOf = function(
+                search: any, position: any): number {
+                console.log("custom", this, search, position);
+                return 41;
+            };
+            const input: string = "abcdef";
+            const needle: string = "cd";
+            const position: number = 2;
+            console.log(input.indexOf(needle, position));
+            """;
+
+        Assembly assembly = Compile(source);
+        MethodInfo main = assembly.GetType("$Program")!.GetMethod(
+            "Main", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;
+        Assert.DoesNotContain(ReadInstructions(main), instruction =>
+            instruction.Operand is MethodBase { Name: "StringIndexOfPrimitive" });
+        Assert.Contains(ReadInstructions(main), instruction =>
+            instruction.Operand is MethodBase { Name: "InvokeMethodValue" });
+        Assert.Equal("custom abcdef cd 2\n41\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void StableAndFallbackShapesPassIlVerification()
+    {
+        const string source = IntrinsicFunctions + """
+            const boxed: any = new String("abcdef");
+            console.log(find("abcdef", "cd", 0));
+            console.log(contains("abcdef", "cd", 0));
+            console.log(takeSlice("abcdef", 1, 4));
+            console.log(takeSubstring("abcdef", 4, 1));
+            console.log(boxed.slice(1, 4));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+        Assert.Empty(errors);
+        Assert.Equal("2\ntrue\nbcd\nbcd\nbcd\n", output);
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        TypeMap typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"stable_primitive_string_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token)
+                    : module.ResolveType(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}

--- a/tests/SharpTS.Tests/CompilerTests/StableRegExpReplaceTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableRegExpReplaceTests.cs
@@ -1,0 +1,198 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class StableRegExpReplaceTests
+{
+    private const string ReplaceLoopSource = """
+        function replaceLoop(input: string, n: number): number {
+            let total: number = 0;
+            for (let i: number = 0; i < n; i++) {
+                total = total + input.replace(/foo/g, "bar").length;
+            }
+            return total;
+        }
+        """;
+
+    [Fact]
+    public void StableLiteralReplace_UsesTypedHelperWithoutProtocolDispatch()
+    {
+        MethodInfo replaceLoop = FindFunction(Compile(ReplaceLoopSource), "replaceLoop");
+        var instructions = ReadInstructions(replaceLoop).ToArray();
+
+        Assert.Contains(instructions, instruction =>
+            instruction.OpCode == OpCodes.Call
+            && instruction.Operand is MethodBase { Name: "StableRegExpReplace" });
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "StringReplaceRegExp" or "StringTryInvokeSymbolMethod" or
+                    "InvokeMethodValue"
+            });
+    }
+
+    [Fact]
+    public void StableLiteralReplace_AllocatesOnlyNearTheResultStringCost()
+    {
+        MethodInfo replaceLoopMethod = FindFunction(Compile(ReplaceLoopSource), "replaceLoop");
+        var replaceLoop = replaceLoopMethod.CreateDelegate<Func<string, double, double>>();
+        const string input = "foo bar foo baz foo qux";
+
+        Assert.Equal(input.Length * 10, replaceLoop(input, 10));
+        _ = replaceLoop(input, 10_000);
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        Assert.Equal(input.Length * 100_000, replaceLoop(input, 100_000));
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.True(allocated <= 16_000_000,
+            $"Stable RegExp replace allocated {allocated:N0} bytes for 100,000 calls.");
+    }
+
+    [Theory, ModeData]
+    public void StableLiteralReplace_PreservesCapturesTokensAndMatchCardinality(
+        ExecutionMode mode)
+    {
+        const string source = """
+            console.log("aba".replace(/a/g, "x"));
+            console.log("aba".replace(/a/, "x"));
+            console.log("abc".replace(/(b)/, "[$$][$&][$1][$`][$']"));
+            console.log("ab".replace(/(?<letter>[a-z])/g, "<$<letter>>"));
+            console.log("ab".replace(/(?:)/g, "-"));
+            """;
+
+        Assert.Equal(
+            "xbx\nxba\na[$][b][b][a][c]c\n<a><b>\n-a-b-\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void CallbackReplacement_PreservesArgumentsAndNamedGroups(ExecutionMode mode)
+    {
+        const string source = """
+            const result: string = "ab".replace(
+                /(?<letter>[a-z])/g,
+                function(match: string, capture: string, index: number,
+                    input: string, groups: any): string {
+                    console.log(match, capture, index, input, groups.letter);
+                    return capture.toUpperCase();
+                });
+            console.log(result);
+            """;
+
+        Assert.Equal("a a 0 ab a\nb b 1 ab b\nAB\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void RegExpPrototypeMutation_DisablesStableHelperAndRemainsObservable()
+    {
+        const string source = """
+            RegExp.prototype[Symbol.replace] = function(
+                input: string, replacement: any): string {
+                console.log("custom", input, replacement);
+                return "mutated";
+            };
+            console.log("foo".replace(/foo/g, "bar"));
+            """;
+
+        Assembly assembly = Compile(source);
+        MethodInfo main = assembly.GetType("$Program")!.GetMethod(
+            "Main", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;
+        Assert.DoesNotContain(ReadInstructions(main), instruction =>
+            instruction.Operand is MethodBase { Name: "StableRegExpReplace" });
+        Assert.Equal("custom foo bar\nmutated\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void StableAndFallbackReplaceShapesPassIlVerification()
+    {
+        const string source = ReplaceLoopSource + """
+            const custom: any = {
+                [Symbol.replace]: function(input: string, replacement: any): string {
+                    return input + ":" + replacement;
+                }
+            };
+            const callback: any = function(match: string): string { return match; };
+            console.log(replaceLoop("foo", 2));
+            console.log("x".replace(custom, "y"));
+            console.log("x".replace(/x/, callback));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+        Assert.Empty(errors);
+        Assert.Equal("6\nx:y\nx\n", output);
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        TypeMap typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"stable_regexp_replace_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token)
+                    : module.ResolveType(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}

--- a/tests/SharpTS.Tests/CompilerTests/UnboxedMathMinMaxTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/UnboxedMathMinMaxTests.cs
@@ -1,0 +1,288 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed class UnboxedMathMinMaxTests
+{
+    private const string NumericLoopSource = """
+        function mathLoop(n: number): number {
+            const a: number = 3;
+            const b: number = 4;
+            let total: number = 0;
+            for (let i: number = 0; i < n; i++) {
+                total = total + Math.min(a, b) + Math.max(a, b);
+            }
+            return total;
+        }
+        """;
+
+    [Fact]
+    public void FixedArityNumericCalls_StayInNativeDoubleIl()
+    {
+        MethodInfo loop = FindFunction(Compile(NumericLoopSource), "mathLoop");
+        var instructions = ReadInstructions(loop).ToArray();
+
+        Assert.Contains(instructions, instruction =>
+            instruction.OpCode == OpCodes.Call
+            && instruction.Operand is MethodBase
+            {
+                DeclaringType: { } declaringType,
+                Name: "Min"
+            }
+            && declaringType == typeof(Math));
+        Assert.Contains(instructions, instruction =>
+            instruction.OpCode == OpCodes.Call
+            && instruction.Operand is MethodBase
+            {
+                DeclaringType: { } declaringType,
+                Name: "Max"
+            }
+            && declaringType == typeof(Math));
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "ToNumber" or "MathMinAdapter" or "MathMaxAdapter"
+            });
+    }
+
+    [Fact]
+    public void ZeroOneAndSeveralNumericArguments_AreAlsoUnboxed()
+    {
+        const string source = """
+            function emptyMin(): number { return Math.min(); }
+            function emptyMax(): number { return Math.max(); }
+            function one(a: number): number { return Math.min(a); }
+            function several(a: number, b: number, c: number): number {
+                return Math.max(a, b, c);
+            }
+            """;
+
+        Assembly assembly = Compile(source);
+        foreach (string name in new[] { "emptyMin", "emptyMax", "one", "several" })
+        {
+            var instructions = ReadInstructions(FindFunction(assembly, name)).ToArray();
+            Assert.DoesNotContain(instructions, instruction =>
+                instruction.OpCode == OpCodes.Box);
+            Assert.DoesNotContain(instructions, instruction =>
+                instruction.Operand is MethodBase { Name: "ToNumber" });
+        }
+
+        Assert.Equal(2, ReadInstructions(FindFunction(assembly, "several")).Count(instruction =>
+            instruction.OpCode == OpCodes.Call
+            && instruction.Operand is MethodBase { Name: "Min" or "Max" }));
+    }
+
+    [Fact]
+    public void TwoArgumentNumericLoop_HasNoSteadyStateAllocation()
+    {
+        var loop = FindFunction(Compile(NumericLoopSource), "mathLoop")
+            .CreateDelegate<Func<double, double>>();
+
+        Assert.Equal(70, loop(10));
+        _ = loop(10_000);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        Assert.Equal(7_000, loop(1_000));
+        long smallAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        before = GC.GetAllocatedBytesForCurrentThread();
+        Assert.Equal(700_000, loop(100_000));
+        long largeAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.True(largeAllocated <= smallAllocated + 1_024,
+            $"Typed Math.min/max allocations scaled: {smallAllocated:N0} vs {largeAllocated:N0} bytes.");
+    }
+
+    [Theory, ModeData]
+    public void NumericFastPath_PreservesEdgesAndEvaluationOrder(ExecutionMode mode)
+    {
+        const string source = """
+            const positiveZero: number = 0;
+            const negativeZero: number = -0;
+            const nan: number = NaN;
+            const positiveInfinity: number = Infinity;
+            const negativeInfinity: number = -Infinity;
+
+            console.log(Math.min() === positiveInfinity);
+            console.log(Math.max() === negativeInfinity);
+            console.log(Number.isNaN(Math.min(1, nan, 2)));
+            console.log(Number.isNaN(Math.max(nan, 1)));
+            console.log(Object.is(Math.min(positiveZero, negativeZero), negativeZero));
+            console.log(Object.is(Math.min(negativeZero, positiveZero), negativeZero));
+            console.log(Object.is(Math.max(positiveZero, negativeZero), positiveZero));
+            console.log(Object.is(Math.max(negativeZero, positiveZero), positiveZero));
+            console.log(Math.min(positiveInfinity, 9, negativeInfinity));
+            console.log(Math.max(negativeInfinity, 9, positiveInfinity));
+
+            const events: string[] = [];
+            function first(): number { events.push("first"); return 3; }
+            function second(): number { events.push("second"); return 1; }
+            function third(): number { events.push("third"); return 2; }
+            console.log(Math.min(first(), second(), third()));
+            console.log(events.join(","));
+            """;
+
+        Assert.Equal(
+            "true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n" +
+            "-Infinity\nInfinity\n1\nfirst,second,third\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void DynamicSpreadAndStoredCalls_KeepGenericSemantics(ExecutionMode mode)
+    {
+        const string source = """
+            const events: string[] = [];
+            const first: any = {
+                valueOf: function(): number { events.push("first"); return 4; }
+            };
+            const second: any = {
+                valueOf: function(): number { events.push("second"); return 2; }
+            };
+            console.log(Math.min(first, second));
+            console.log(events.join(","));
+            console.log(Math.max(...[1, 7, 3]));
+
+            const storedMin: any = Math.min;
+            const mathAlias: any = Math;
+            const storedMax: any = mathAlias.max;
+            console.log(storedMin("3", 2));
+            console.log(storedMax("3", 2));
+
+            try { Math.min(1n as any, 1); }
+            catch (error) { console.log(error instanceof TypeError); }
+            try { Math.max(Symbol("x") as any, 1); }
+            catch (error) { console.log(error instanceof TypeError); }
+            """;
+
+        Assert.Equal(
+            "2\nfirst,second\n7\n2\n3\ntrue\ntrue\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void ReplacedMathMethod_UsesLivePropertyDispatch()
+    {
+        const string source = """
+            (Math as any).min = function(a: any, b: any): number {
+                console.log("custom", a, b);
+                return 41;
+            };
+            console.log(Math.min(1, 2));
+            const stored: any = Math.min;
+            console.log(stored(3, 4));
+            """;
+
+        Assembly assembly = Compile(source);
+        MethodInfo main = assembly.GetType("$Program")!.GetMethod(
+            "Main", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;
+        Assert.DoesNotContain(ReadInstructions(main), instruction =>
+            instruction.Operand is MethodBase
+            {
+                DeclaringType: { } declaringType,
+                Name: "Min"
+            }
+            && declaringType == typeof(Math));
+        Assert.Contains(ReadInstructions(main), instruction =>
+            instruction.Operand is MethodBase { Name: "InvokeMethodValue" });
+        Assert.Equal(
+            "custom 1 2\n41\ncustom 3 4\n41\n",
+            TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
+    public void DynamicAndSpreadControlsUseGenericAdaptersAndVerify()
+    {
+        const string source = NumericLoopSource + """
+            function dynamicMin(a: any, b: any): number {
+                return Math.min(a, b);
+            }
+            function spreadMax(values: number[]): number {
+                return Math.max(...values);
+            }
+            console.log(mathLoop(2));
+            console.log(dynamicMin("3", 2));
+            console.log(spreadMax([1, 7, 3]));
+            """;
+
+        Assembly assembly = Compile(source);
+        Assert.Contains(ReadInstructions(FindFunction(assembly, "dynamicMin")), instruction =>
+            instruction.Operand is MethodBase { Name: "ToNumber" });
+        Assert.Contains(ReadInstructions(FindFunction(assembly, "spreadMax")), instruction =>
+            instruction.Operand is MethodBase { Name: "MathMaxAdapter" });
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+        Assert.Empty(errors);
+        Assert.Equal("14\n2\n7\n", output);
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        TypeMap typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"unboxed_math_min_max_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) =>
+        assembly.GetType("$Program")!
+            .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+            .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? operand = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                operand = opCode.OperandType == OperandType.InlineMethod
+                    ? module.ResolveMethod(token)
+                    : module.ResolveType(token);
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or
+                    OperandType.InlineField or OperandType.InlineMethod or
+                    OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or
+                    OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch =>
+                    4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, operand);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
+}

--- a/tests/SharpTS.Tests/SharedTests/ObjectLocalPromotionTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/ObjectLocalPromotionTests.cs
@@ -196,6 +196,25 @@ public class ObjectLocalPromotionTests
         Assert.Equal("9759\n", TestHarness.Run(source, mode));
     }
 
+    [Theory, ModeData]
+    public void Promoted_ObjectKeysIsFreshMutableAndKeepsClosedShape(ExecutionMode mode)
+    {
+        var source = """
+            function f(): string {
+                const record = { first: 1, second: 2 };
+                record.first = 3;
+                const firstKeys: string[] = Object.keys(record);
+                firstKeys[0] = "changed";
+                firstKeys.push("extra");
+                const secondKeys: string[] = Object.keys(record);
+                return firstKeys.join(",") + "|" + secondKeys.join(",") + "|" + record.first;
+            }
+            console.log(f());
+            """;
+
+        Assert.Equal("changed,second,extra|first,second|3\n", TestHarness.Run(source, mode));
+    }
+
     // ── Escape cases: must fall back, must stay correct ────────────────────
 
     [Theory, ModeData]
@@ -326,6 +345,51 @@ public class ObjectLocalPromotionTests
             """;
 
         Assert.Equal("1\n2\n1\n2\n2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void Escape_ObjectKeysNumericSymbolsAndShapeMutationUseGenericOrdering(ExecutionMode mode)
+    {
+        var source = """
+            const sym: symbol = Symbol("hidden");
+            const record: any = {
+                10: "ten",
+                first: "a",
+                2: "two",
+                1: "one",
+                [sym]: "symbol"
+            };
+            record.last = "z";
+            console.log(Object.keys(record).join(","));
+            """;
+
+        Assert.Equal("1,2,10,first,last\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void Escape_ObjectKeysAccessorAndProxyRemainObservable(ExecutionMode mode)
+    {
+        var source = """
+            let getterCalls: number = 0;
+            const accessor: any = {
+                a: 1,
+                get b(): number { getterCalls = getterCalls + 1; return 2; }
+            };
+            console.log(Object.keys(accessor).join(","));
+            console.log(getterCalls);
+
+            let ownKeysCalls: number = 0;
+            const proxy: any = new Proxy({ x: 1, y: 2 }, {
+                ownKeys(target: any): any[] {
+                    ownKeysCalls = ownKeysCalls + 1;
+                    return Reflect.ownKeys(target);
+                }
+            });
+            console.log(Object.keys(proxy).join(","));
+            console.log(ownKeysCalls);
+            """;
+
+        Assert.Equal("a,b\n0\nx,y\n1\n", TestHarness.Run(source, mode));
     }
 
     [Theory, ModeData]

--- a/tests/SharpTS.Tests/SharedTests/ObjectLocalPromotionTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/ObjectLocalPromotionTests.cs
@@ -11,9 +11,10 @@ namespace SharpTS.Tests.SharedTests;
 /// <c>Dictionary&lt;string, object&gt;</c> lookup with boxing.
 ///
 /// These run against BOTH the interpreter and the compiler. The positive cases exercise the promoted
-/// fast paths; the escape cases must NOT be promoted (they fall back to the general Dictionary path) and
-/// must still produce correct results — i.e. interpreter/compiled parity must hold even when the object
-/// is passed, returned, spread, enumerated, dynamically indexed, compared, captured, or compound-assigned.
+/// fast paths, including stable spread chains; the escape cases must NOT be promoted (they fall back to
+/// the general object path) and must still produce correct results — i.e. interpreter/compiled parity
+/// must hold even when the object is passed, returned, dynamically spread, enumerated, indexed,
+/// compared, captured, or compound-assigned.
 /// A wrong escape rule, or a miscompiled struct fast path, surfaces here as a compiled-mode mismatch.
 /// </summary>
 public class ObjectLocalPromotionTests
@@ -152,6 +153,49 @@ public class ObjectLocalPromotionTests
         Assert.Equal("21\n", TestHarness.Run(source, mode));
     }
 
+    [Theory, ModeData]
+    public void Promoted_StableSpreadCopiesPrimitiveShape(ExecutionMode mode)
+    {
+        var source = """
+            function f(n: number): number {
+                let total: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    const source = { x: i, y: i + 1 };
+                    const result = { ...source, z: i + 2 };
+                    total = total + result.x + result.y + result.z;
+                }
+                return total;
+            }
+            console.log(f(10));
+            """;
+
+        Assert.Equal("165\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void Promoted_MultipleSpreadsSnapshotAtEvaluationPosition(ExecutionMode mode)
+    {
+        // The first spread must observe x=1, while the second spread observes the intervening write.
+        // `changed` and the overwritten y initializer must still be evaluated in source order.
+        var source = """
+            function f(): number {
+                const source = { x: 1, y: 2 };
+                const other = { y: 4, z: 5 };
+                const result = {
+                    ...source,
+                    changed: (source.x = 9),
+                    ...other,
+                    ...source,
+                    y: 7
+                };
+                return result.x * 1000 + result.y * 100 + result.z * 10 + result.changed;
+            }
+            console.log(f());
+            """;
+
+        Assert.Equal("9759\n", TestHarness.Run(source, mode));
+    }
+
     // ── Escape cases: must fall back, must stay correct ────────────────────
 
     [Theory, ModeData]
@@ -197,6 +241,91 @@ public class ObjectLocalPromotionTests
             """;
 
         Assert.Equal("6\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void Escape_SpreadResultPassedAndMutatedFallsBackAsAComponent(ExecutionMode mode)
+    {
+        var source = """
+            function consume(value: any): number {
+                value.x = value.x + 10;
+                return value.x + value.y + value.z;
+            }
+            function f(): number {
+                const source = { x: 1, y: 2 };
+                const result = { ...source, z: 3 };
+                result.y = 20;
+                return consume(result) + source.x;
+            }
+            console.log(f());
+            """;
+
+        Assert.Equal("35\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void Escape_DynamicSpreadPreservesKeysSymbolsGettersAndNullishSources(ExecutionMode mode)
+    {
+        var source = """
+            let calls: number = 0;
+            const sym: symbol = Symbol("s");
+            const dynamic: any = {
+                2: "two",
+                first: "a",
+                get value(): number { calls = calls + 1; return calls; },
+                [sym]: "symbol"
+            };
+            const result: any = {
+                before: "b",
+                ...(null as any),
+                ...dynamic,
+                ...(undefined as any),
+                first: "overwritten",
+                after: "z"
+            };
+            console.log(Object.keys(result).join(","));
+            console.log(result.first);
+            console.log(result.value);
+            console.log(result[sym]);
+            console.log(calls);
+            """;
+
+        Assert.Equal(
+            "2,before,first,value,after\noverwritten\n1\nsymbol\n1\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void Escape_ProxySpreadUsesOneKeySnapshot(ExecutionMode mode)
+    {
+        var source = """
+            const target: any = { a: 1, b: 2 };
+            let ownKeysCount: number = 0;
+            let descriptorCount: number = 0;
+            let getCount: number = 0;
+            const proxy: any = new Proxy(target, {
+                ownKeys(inner: any): any[] {
+                    ownKeysCount = ownKeysCount + 1;
+                    return Reflect.ownKeys(inner);
+                },
+                getOwnPropertyDescriptor(inner: any, key: any): any {
+                    descriptorCount = descriptorCount + 1;
+                    return Reflect.getOwnPropertyDescriptor(inner, key);
+                },
+                get(inner: any, key: any): any {
+                    getCount = getCount + 1;
+                    return inner[key];
+                }
+            });
+            const result: any = { ...proxy };
+            console.log(result.a);
+            console.log(result.b);
+            console.log(ownKeysCount);
+            console.log(descriptorCount);
+            console.log(getCount);
+            """;
+
+        Assert.Equal("1\n2\n1\n2\n2\n", TestHarness.Run(source, mode));
     }
 
     [Theory, ModeData]


### PR DESCRIPTION
Closes #1501
Closes #1502
Closes #1503
Closes #1504
Closes #1505
Closes #1506
Closes #1507
Closes #1508
Closes #1509
Closes #1510

## Summary

- specialize dense array `shift`/`unshift` and numeric `includes` hot paths
- lower stable array/object destructuring to typed loads
- specialize stable custom iterators while preserving dynamic fallbacks
- retain closed object shapes through spread and materialize `Object.keys` directly
- specialize stable regex replacement and fixed-arity primitive string intrinsics
- emit unboxed fixed-arity `Math.min`/`Math.max`
- capture compact Error creation-site tokens and format/cache `.stack` lazily
- add microbenchmarks, cross-runtime workloads, allocation gates, semantic coverage, and IL verification for the optimized paths

Each issue is implemented in its own commit, in issue order.

## Validation

- Windows .NET 10: combined #1501-#1510 regression selection, 228/228 passed
- WSL .NET 10 (`/home/nick/.dotnet/dotnet`): same selection, 228/228 passed
- focused Windows and WSL tests were also run after each individual issue
- #1510 BenchmarkDotNet ShortRun: sparse Error throw 185.0 us and 44,753 B, down 96.6% from the reported 1,318,715 B baseline
- #1510 five-launch cross-runtime median: SharpTS 0.1899 ms vs Node 0.3757 ms (0.51x)

An additional unfiltered Windows test run was attempted. This host could not run its networking/process fixtures (`HttpListenerException: The handle is invalid`, IPC timeouts, and local TLS authentication failures); the affected optimization tests pass in isolated fresh testhosts on both Windows and WSL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved execution speed and reduced allocations for arrays, strings, math operations, destructuring, object keys/spreads, iterators, and regular-expression replacement.
  * Added expanded benchmark coverage for common language operations and exception handling.

* **Bug Fixes**
  * Preserved JavaScript behavior for mutable prototypes, custom iterators, accessors, proxies, symbols, sparse and sealed arrays, named regex groups, and error stack handling.
  * Improved `Array.includes()` support, including `fromIndex`, `NaN`, and signed-zero behavior.

* **Tests**
  * Added comprehensive coverage validating optimized and fallback execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->