### PR TITLE
Publish versioned cross-runtime performance snapshots

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -46,21 +46,31 @@ jobs:
 
       - name: Run benchmarks
         shell: pwsh
-        run: ./benchmarks/cross-runtime/run-benchmarks.ps1
+        run: |
+          $resultsDir = Join-Path ([System.IO.Path]::GetTempPath()) 'bench-results'
+          "BENCH_RESULTS_DIR=$resultsDir" >> $env:GITHUB_ENV
+          ./benchmarks/cross-runtime/run-benchmarks.ps1 -OutputDirectory $resultsDir
 
       - name: Publish results to job summary
         shell: pwsh
         run: |
-          $resultsDir = Join-Path ([System.IO.Path]::GetTempPath()) 'bench-results'
-          "BENCH_RESULTS_DIR=$resultsDir" >> $env:GITHUB_ENV
           ./benchmarks/cross-runtime/format-results.ps1 `
-            -ResultsFile (Join-Path $resultsDir 'results.txt') `
+            -ResultsFile (Join-Path $env:BENCH_RESULTS_DIR 'results.txt') `
             -DotNetVersion (dotnet --version) `
             -NodeVersion (node -v) `
             -BunVersion (bun --version) `
             >> $env:GITHUB_STEP_SUMMARY
 
-      - name: Upload raw results
+      - name: Validate structured results
+        shell: pwsh
+        run: |
+          ./benchmarks/cross-runtime/test-snapshot.ps1
+          ./benchmarks/cross-runtime/validate-snapshot.ps1 `
+            (Join-Path $env:BENCH_RESULTS_DIR 'snapshot.json'), `
+            benchmarks/cross-runtime/snapshots/latest.json
+
+      - name: Upload raw and structured results
+        if: always() && env.BENCH_RESULTS_DIR != ''
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: benchmark-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,9 @@ jobs:
         shell: pwsh
         run: |
           ./scripts/test-perf-local.ps1
+          ./benchmarks/cross-runtime/test-snapshot.ps1
+          ./benchmarks/cross-runtime/validate-snapshot.ps1 `
+            benchmarks/cross-runtime/snapshots/latest.json
           ./benchmarks/cross-runtime/run-benchmarks.ps1 -Smoke -NoBuild
           dotnet run --configuration Release --no-build `
             --project benchmarks/micro/SharpTS.Microbenchmarks -- --smoke

--- a/benchmarks/cross-runtime/README.md
+++ b/benchmarks/cross-runtime/README.md
@@ -4,16 +4,18 @@
 SharpTS compare to other JavaScript/TypeScript runtimes?* The bar is to **meet or
 exceed Node.js**.
 
-It runs the same TypeScript workloads across four runtimes and prints a
-side-by-side table:
+It runs the same TypeScript workloads across four runtimes and produces a
+side-by-side table plus a versioned JSON snapshot:
 
 - SharpTS **interpreter** (`dotnet run -- script.ts`)
 - SharpTS **compiled** (`dotnet run -- --compile script.ts` → run the DLL)
 - **Node.js** (with `--experimental-strip-types` on Node < 23)
 - **Bun** (if installed)
 
-Measurement is **whole-program, process-level** (includes startup + the full
-pipeline), so it reflects what a user actually experiences invoking each runtime.
+Published measurements are **in-process workload timings**. They include one
+invocation of the workload function and exclude process startup, script loading,
+SharpTS compilation, warmup, and batch calibration. Startup and compilation are
+important but are not mixed into the workload metric.
 
 > For the *internal* benchmarks — SharpTS-compiled vs the idiomatic-C#
 > performance ceiling, with allocation/GC profiling — see
@@ -24,8 +26,12 @@ pipeline), so it reflects what a user actually experiences invoking each runtime
 
 | Path | Purpose |
 |------|---------|
-| `run-benchmarks.ps1` | Builds SharpTS (Release), runs every `scripts/*.ts` on all runtimes, writes `results.txt`. |
+| `run-benchmarks.ps1` | Builds SharpTS (Release), runs every `scripts/*.ts` on all runtimes, writes `results.txt` and `snapshot.json`. |
 | `format-results.ps1` | Renders `results.txt` as a Markdown table (used for the CI job summary). |
+| `Snapshot.psm1` / `export-snapshot.ps1` | Parse raw diagnostics and deterministically export the public schema-v1 snapshot. |
+| `snapshot-v1.schema.json` | Checked-in, versioned JSON Schema for the public snapshot contract. |
+| `snapshots/latest.json` | Canonical reviewed snapshot consumed from a pinned SharpTS checkout. |
+| `validate-snapshot.ps1` / `test-snapshot.ps1` | Validate a snapshot and exercise exporter/contract failures without running timed work. |
 | `scripts/*.ts` | One workload per file (fibonacci, sort, json, regex, async/promises, …). |
 | `scripts/lib/bench.ts` | Shared synchronous and asynchronous timing harnesses (auto-batching, warmup, mean/min/stdev). |
 | `scripts/lib/algorithms.ts` | Algorithm bodies **shared byte-identical** with the microbenchmark suite (embedded there as a resource). |
@@ -33,7 +39,7 @@ pipeline), so it reflects what a user actually experiences invoking each runtime
 ## Running
 
 ```powershell
-# Run everything; results land in $TEMP/bench-results/results.txt
+# Run everything; results land in $TEMP/bench-results/{results.txt,snapshot.json}
 ./benchmarks/cross-runtime/run-benchmarks.ps1
 
 # Repeat only numeric-loop workloads, excluding the advisory Bun result
@@ -45,6 +51,9 @@ pipeline), so it reflects what a user actually experiences invoking each runtime
 
 # Render the table from a results file
 ./benchmarks/cross-runtime/format-results.ps1 -ResultsFile $env:TEMP/bench-results/results.txt
+
+# Validate a generated or checked-in public snapshot
+./benchmarks/cross-runtime/validate-snapshot.ps1 $env:TEMP/bench-results/snapshot.json
 ```
 
 To discover and compile every workload without running the timed loops (the
@@ -63,7 +72,8 @@ selected; Bun is skipped if not on `PATH`.
 the current runner compile and execute a frozen source worktree, so the baseline
 does not need to be modified when harness features are added later.
 `-NodeExecutable` selects a specific Node binary when more than one version is
-installed.
+installed. `-NoSnapshot` retains only `results.txt`; the paired local harness
+uses it because a historical baseline may predate the schema-v1 sampling fields.
 
 For repeatable candidate-vs-baseline runs on native Windows and WSL, see
 [`../local-perf/README.md`](../local-perf/README.md).
@@ -76,15 +86,49 @@ Each workload calls `bench(name, param, fn)` from `scripts/lib/bench.ts`, which:
    (honest for slow cases like the tree-walking interpreter on big inputs).
 2. Otherwise warms the JIT, calibrates an inner batch until a sample spans ≥ 1 ms
    (lifting fast cases above the timer noise floor), then samples to a budget.
-3. Emits one line per case, consumed by `format-results.ps1`:
+3. Emits one line per case, consumed by the PowerShell formatter and exporter:
 
    ```
-   BENCH:<name>:<param>:<meanMs>:<minMs>:<stdevMs>
+   BENCH:<name>:<param>:<meanMs>:<minMs>:<stdevMs>:<samples>:<inner>:<sampledMs>
    ```
 
 `performance.now()` (sub-microsecond, monotonic) is used everywhere so the
 methodology is identical across runtimes. A `guard` accumulator defeats
 dead-code elimination in both SharpTS modes and the JS engines.
+
+Each JSON measurement preserves the reported mean, minimum, sample standard
+deviation, sample count, calibrated inner-iteration count, sampled duration,
+and launch number in milliseconds. Multiple launches are kept as separate
+measurements inside one machine-bound run; the exporter never combines results
+from different machines. Cases are ordered by stable
+`<script-family>/<case-name>?n=<parameter>` IDs. Every case contains explicit
+records for interpreter, compiled, Node.js, and Bun; an unselected, unavailable,
+or failed runtime is represented as `missing` rather than removing the case.
+
+## Refreshing the public snapshot
+
+An intentional refresh should use a clean checkout and the pinned tool versions
+from `global.json`, `.node-version`, and `.bun-version`. Use multiple launches so
+reviewers can see run-to-run variation:
+
+```powershell
+./benchmarks/cross-runtime/run-benchmarks.ps1 `
+  -Launches 3 `
+  -OutputDirectory .perf-cross-runtime-refresh
+
+./benchmarks/cross-runtime/validate-snapshot.ps1 `
+  .perf-cross-runtime-refresh/snapshot.json
+
+Copy-Item .perf-cross-runtime-refresh/snapshot.json `
+  benchmarks/cross-runtime/snapshots/latest.json
+```
+
+Review the revision (including the `dirty` flag), environment/tool identity,
+case set, missing-runtime reasons, and per-launch variance along with the JSON
+diff. Do not hand-edit presentation values: consumers choose rounding and
+ratios from the canonical-unit measurements. A schema change requires a new
+`schemaVersion`, schema file, harness version/methodology identifier, and
+consumer opt-in; validators reject unknown versions.
 
 If a runtime produces no `BENCH:` line (crash, parse error, missing API),
 `run-benchmarks.ps1` warns loudly and echoes the tail of its output rather than
@@ -92,10 +136,13 @@ silently leaving a blank cell.
 
 ## CI
 
-`.github/workflows/benchmarks.yml` runs this suite on `workflow_dispatch` and
-publishes the formatted table to the job summary, with the raw `results.txt`
-uploaded as an artifact. It is **not** run on every push (timing on shared CI
-runners is noisy and the full sweep is slow).
+`.github/workflows/benchmarks.yml` runs this suite on `workflow_dispatch`,
+validates the generated and canonical snapshots, publishes the formatted table
+to the job summary, and uploads both `results.txt` and `snapshot.json` as
+diagnostic artifacts. It does not rewrite `snapshots/latest.json`; publication
+is an intentional reviewed source change. Ordinary CI runs the deterministic
+contract tests and validates the checked-in snapshot, but does not execute the
+timed sweep (shared-runner timing is noisy and the full sweep is slow).
 
 ## Why two benchmark suites?
 
@@ -104,7 +151,7 @@ runners is noisy and the full sweep is slow).
 | **Question** | Are we as fast as Node/Bun? | How close are we to the C# ceiling, and where's the overhead? |
 | **Compares against** | Node.js, Bun | Idiomatic C# (native types) + "equivalent" C# (`object?`/boxing) |
 | **Tool** | PowerShell + shared `bench.ts` | BenchmarkDotNet |
-| **Scope** | Whole-program, process-level | In-process, per-function (delegate-invoked) |
+| **Scope** | In-process workload function | In-process, per-function (delegate-invoked) |
 | **Profiling** | Wall-clock mean/min/stdev | + allocations/GC (`MemoryDiagnoser`) |
 
 They can't be merged: BenchmarkDotNet must run in-process against managed code

--- a/benchmarks/cross-runtime/Snapshot.psm1
+++ b/benchmarks/cross-runtime/Snapshot.psm1
@@ -1,0 +1,502 @@
+Set-StrictMode -Version Latest
+
+$script:InvariantCulture = [Globalization.CultureInfo]::InvariantCulture
+$script:RuntimeOrder = @('interpreter', 'compiled', 'node', 'bun')
+$script:SupportedUnits = @('milliseconds', 'bytes', 'operationsPerSecond')
+$script:SupportedDirections = @('lowerIsBetter', 'higherIsBetter')
+
+function Test-FiniteNumber {
+    param([object]$Value)
+
+    if ($null -eq $Value) { return $false }
+    try { $number = [double]$Value } catch { return $false }
+    return [double]::IsFinite($number)
+}
+
+function Get-RequiredProperty {
+    param([object]$Value, [string]$Name, [string]$Path)
+
+    if ($null -eq $Value -or $null -eq $Value.PSObject.Properties[$Name]) {
+        throw "$Path is missing required property '$Name'."
+    }
+    return $Value.$Name
+}
+
+function ConvertTo-ParameterText {
+    param([double]$Value)
+
+    return $Value.ToString('G17', $script:InvariantCulture)
+}
+
+function Get-CommandVersion {
+    param([string]$Command, [string[]]$Arguments = @())
+
+    $resolved = Get-Command $Command -ErrorAction SilentlyContinue
+    if ($null -eq $resolved) { return $null }
+    try {
+        $output = @(& $resolved.Source @Arguments 2>$null)
+        if ($LASTEXITCODE -ne 0 -or $output.Count -eq 0) { return $null }
+        return ([string]$output[0]).Trim()
+    } catch {
+        return $null
+    }
+}
+
+function Get-CpuIdentity {
+    if ($env:PROCESSOR_IDENTIFIER) { return $env:PROCESSOR_IDENTIFIER.Trim() }
+    if (Test-Path -LiteralPath '/proc/cpuinfo') {
+        $match = Select-String -LiteralPath '/proc/cpuinfo' -Pattern '^model name\s*:\s*(.+)$' |
+            Select-Object -First 1
+        if ($match) { return $match.Matches[0].Groups[1].Value.Trim() }
+    }
+    if ($IsMacOS) {
+        try {
+            $cpu = (& sysctl -n machdep.cpu.brand_string 2>$null | Select-Object -First 1)
+            if ($cpu) { return ([string]$cpu).Trim() }
+        } catch { }
+    }
+    return 'unknown'
+}
+
+function Get-GitMetadata {
+    param([Parameter(Mandatory)] [string]$RepositoryRoot)
+
+    $commit = @(& git -C $RepositoryRoot rev-parse HEAD 2>$null)
+    if ($LASTEXITCODE -ne 0 -or $commit.Count -ne 1 -or $commit[0] -notmatch '^[0-9a-f]{40}$') {
+        throw "Could not resolve the SharpTS revision from '$RepositoryRoot'."
+    }
+    $status = @(& git -C $RepositoryRoot status --porcelain --untracked-files=no 2>$null)
+    if ($LASTEXITCODE -ne 0) { throw "Could not inspect the SharpTS worktree at '$RepositoryRoot'." }
+    return [ordered]@{
+        commit = [string]$commit[0]
+        dirty = $status.Count -gt 0
+    }
+}
+
+function ConvertFrom-SharpTSRawBenchmarkResults {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$ResultsFile)
+
+    if (-not (Test-Path -LiteralPath $ResultsFile -PathType Leaf)) {
+        throw "Results file not found: $ResultsFile"
+    }
+
+    $observations = [Collections.Generic.List[object]]::new()
+    $seen = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    $lineNumber = 0
+    foreach ($line in Get-Content -LiteralPath $ResultsFile) {
+        $lineNumber++
+        if (-not $line.Trim()) { continue }
+
+        $runtimeAndPayload = $line -split '\|', 2
+        if ($runtimeAndPayload.Count -ne 2) {
+            throw "Malformed benchmark result at line ${lineNumber}: expected '<runtime>|<payload>'."
+        }
+        $runtime = $runtimeAndPayload[0]
+        if ($runtime -notin $script:RuntimeOrder) {
+            throw "Malformed benchmark result at line ${lineNumber}: unsupported runtime '$runtime'."
+        }
+
+        $fields = $runtimeAndPayload[1] -split ':'
+        if ($fields.Count -ne 10) {
+            throw "Malformed benchmark result at line ${lineNumber}: expected 10 payload fields, found $($fields.Count)."
+        }
+        $name = $fields[0]
+        $family = $fields[8]
+        if ($name -notmatch '^[a-z0-9][a-z0-9-]*$' -or $family -notmatch '^[a-z0-9][a-z0-9-]*$') {
+            throw "Malformed benchmark result at line ${lineNumber}: case name and family must be stable kebab-case identifiers."
+        }
+
+        try {
+            $parameter = [double]::Parse($fields[1], $script:InvariantCulture)
+            $mean = [double]::Parse($fields[2], $script:InvariantCulture)
+            $minimum = [double]::Parse($fields[3], $script:InvariantCulture)
+            $standardDeviation = [double]::Parse($fields[4], $script:InvariantCulture)
+            $sampleCount = [int]::Parse($fields[5], $script:InvariantCulture)
+            $innerIterations = [int]::Parse($fields[6], $script:InvariantCulture)
+            $sampledDuration = [double]::Parse($fields[7], $script:InvariantCulture)
+            $launch = [int]::Parse($fields[9], $script:InvariantCulture)
+        } catch {
+            throw "Malformed benchmark result at line ${lineNumber}: numeric field could not be parsed. $($_.Exception.Message)"
+        }
+
+        foreach ($number in @($parameter, $mean, $minimum, $standardDeviation, $sampledDuration)) {
+            if (-not (Test-FiniteNumber $number)) {
+                throw "Malformed benchmark result at line ${lineNumber}: numeric values must be finite."
+            }
+        }
+        if ($parameter -lt 0 -or $mean -lt 0 -or $minimum -lt 0 -or
+            $standardDeviation -lt 0 -or $sampledDuration -lt 0 -or
+            $sampleCount -lt 1 -or $innerIterations -lt 1 -or $launch -lt 1) {
+            throw "Malformed benchmark result at line ${lineNumber}: measurements and counters must be non-negative, with positive counts."
+        }
+        if ($minimum -gt $mean) {
+            throw "Malformed benchmark result at line ${lineNumber}: minimum exceeds mean."
+        }
+
+        $parameterText = ConvertTo-ParameterText $parameter
+        $caseId = '{0}/{1}?n={2}' -f $family, $name, $parameterText
+        $observationId = "$caseId|$runtime|$launch"
+        if (-not $seen.Add($observationId)) {
+            throw "Duplicate benchmark measurement '$observationId' at line $lineNumber."
+        }
+
+        $observations.Add([pscustomobject]@{
+            caseId = $caseId
+            family = $family
+            name = $name
+            parameter = $parameter
+            runtime = $runtime
+            launch = $launch
+            mean = $mean
+            minimum = $minimum
+            standardDeviation = $standardDeviation
+            sampleCount = $sampleCount
+            innerIterations = $innerIterations
+            sampledDuration = $sampledDuration
+        })
+    }
+
+    if ($observations.Count -eq 0) { throw 'Benchmark results contain no measurements.' }
+    return $observations.ToArray()
+}
+
+function Assert-SharpTSPublicBenchmarkSnapshot {
+    [CmdletBinding()]
+    param([Parameter(Mandatory, ValueFromPipeline)] [object]$Snapshot)
+
+    process {
+        $schema = Get-RequiredProperty $Snapshot '$schema' 'snapshot'
+        if ($schema -cne 'https://raw.githubusercontent.com/nickna/SharpTS/main/benchmarks/cross-runtime/snapshot-v1.schema.json') {
+            throw "Unsupported benchmark snapshot schema '$schema'."
+        }
+        $schemaVersion = Get-RequiredProperty $Snapshot 'schemaVersion' 'snapshot'
+        if ($schemaVersion -ne 1) { throw "Unsupported benchmark snapshot schema version '$schemaVersion'." }
+
+        $run = Get-RequiredProperty $Snapshot 'run' 'snapshot'
+        $revision = Get-RequiredProperty $run 'revision' 'snapshot.run'
+        $commit = Get-RequiredProperty $revision 'commit' 'snapshot.run.revision'
+        if ($commit -notmatch '^[0-9a-f]{40}$') { throw 'snapshot.run.revision.commit must be a 40-character lowercase Git SHA.' }
+        [void](Get-RequiredProperty $revision 'dirty' 'snapshot.run.revision')
+        $timestamp = Get-RequiredProperty $run 'timestampUtc' 'snapshot.run'
+        $parsedTimestamp = [DateTimeOffset]::MinValue
+        if (-not [DateTimeOffset]::TryParse([string]$timestamp, $script:InvariantCulture,
+            [Globalization.DateTimeStyles]::RoundtripKind, [ref]$parsedTimestamp)) {
+            throw 'snapshot.run.timestampUtc must be an ISO-8601 timestamp.'
+        }
+        $environment = Get-RequiredProperty $run 'environment' 'snapshot.run'
+        foreach ($field in @('operatingSystem', 'architecture', 'cpu', 'runner')) {
+            $value = Get-RequiredProperty $environment $field 'snapshot.run.environment'
+            if ([string]::IsNullOrWhiteSpace([string]$value)) { throw "snapshot.run.environment.$field cannot be empty." }
+        }
+        $tools = Get-RequiredProperty $run 'tools' 'snapshot.run'
+        if ([string]::IsNullOrWhiteSpace([string](Get-RequiredProperty $tools 'dotnet' 'snapshot.run.tools'))) {
+            throw 'snapshot.run.tools.dotnet cannot be empty.'
+        }
+        $runtimeTools = @(Get-RequiredProperty $tools 'runtimes' 'snapshot.run.tools')
+        if ($runtimeTools.Count -ne $script:RuntimeOrder.Count) {
+            throw 'snapshot.run.tools.runtimes must contain one record for every runtime.'
+        }
+        for ($runtimeIndex = 0; $runtimeIndex -lt $script:RuntimeOrder.Count; $runtimeIndex++) {
+            $tool = $runtimeTools[$runtimeIndex]
+            $runtimeId = [string](Get-RequiredProperty $tool 'id' 'snapshot.run.tools.runtimes[]')
+            if ($runtimeId -cne $script:RuntimeOrder[$runtimeIndex]) {
+                throw 'snapshot.run.tools.runtimes must use deterministic interpreter/compiled/node/bun ordering.'
+            }
+            $selectedValue = Get-RequiredProperty $tool 'selected' "snapshot.run.tools.runtimes[$runtimeId]"
+            $availableValue = Get-RequiredProperty $tool 'available' "snapshot.run.tools.runtimes[$runtimeId]"
+            if ($selectedValue -isnot [bool] -or $availableValue -isnot [bool]) {
+                throw "snapshot.run.tools.runtimes[$runtimeId] selected and available must be booleans."
+            }
+            $version = Get-RequiredProperty $tool 'version' "snapshot.run.tools.runtimes[$runtimeId]"
+            if ($availableValue -and [string]::IsNullOrWhiteSpace([string]$version)) {
+                throw "snapshot.run.tools.runtimes[$runtimeId] is available but has no version."
+            }
+            if (-not $availableValue -and $null -ne $version) {
+                throw "snapshot.run.tools.runtimes[$runtimeId] is unavailable but has a version."
+            }
+        }
+        [void](Get-RequiredProperty $Snapshot 'methodology' 'snapshot')
+
+        $cases = @(Get-RequiredProperty $Snapshot 'cases' 'snapshot')
+        if ($cases.Count -eq 0) { throw 'snapshot.cases must contain at least one case.' }
+        $caseIds = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+        $previousCaseId = $null
+        foreach ($case in $cases) {
+            $id = [string](Get-RequiredProperty $case 'id' 'snapshot.cases[]')
+            if (-not $caseIds.Add($id)) { throw "Duplicate benchmark case ID '$id'." }
+            if ($null -ne $previousCaseId -and [StringComparer]::Ordinal.Compare($previousCaseId, $id) -gt 0) {
+                throw 'snapshot.cases must use deterministic ordinal ordering by ID.'
+            }
+            $previousCaseId = $id
+
+            $family = [string](Get-RequiredProperty $case 'family' "snapshot.cases[$id]")
+            $name = [string](Get-RequiredProperty $case 'name' "snapshot.cases[$id]")
+            $parameters = Get-RequiredProperty $case 'parameters' "snapshot.cases[$id]"
+            $parameter = Get-RequiredProperty $parameters 'n' "snapshot.cases[$id].parameters"
+            if (-not (Test-FiniteNumber $parameter) -or [double]$parameter -lt 0) {
+                throw "Case '$id' has an invalid parameter."
+            }
+            $expectedId = '{0}/{1}?n={2}' -f $family, $name, (ConvertTo-ParameterText ([double]$parameter))
+            if ($id -cne $expectedId) { throw "Case ID '$id' does not match '$expectedId'." }
+
+            $unit = [string](Get-RequiredProperty $case 'unit' "snapshot.cases[$id]")
+            if ($unit -notin $script:SupportedUnits) { throw "Case '$id' has unsupported unit '$unit'." }
+            $direction = [string](Get-RequiredProperty $case 'direction' "snapshot.cases[$id]")
+            if ($direction -notin $script:SupportedDirections) { throw "Case '$id' has unsupported direction '$direction'." }
+
+            $runtimeRecords = @(Get-RequiredProperty $case 'runtimes' "snapshot.cases[$id]")
+            if ($runtimeRecords.Count -ne $script:RuntimeOrder.Count) {
+                throw "Case '$id' must contain one explicit record for every runtime."
+            }
+            for ($runtimeIndex = 0; $runtimeIndex -lt $script:RuntimeOrder.Count; $runtimeIndex++) {
+                $record = $runtimeRecords[$runtimeIndex]
+                $runtimeId = [string](Get-RequiredProperty $record 'id' "snapshot.cases[$id].runtimes[]")
+                if ($runtimeId -cne $script:RuntimeOrder[$runtimeIndex]) {
+                    throw "Case '$id' runtime records must use deterministic interpreter/compiled/node/bun ordering."
+                }
+                $status = [string](Get-RequiredProperty $record 'status' "snapshot.cases[$id].runtimes[$runtimeId]")
+                if ($status -eq 'missing') {
+                    $reason = [string](Get-RequiredProperty $record 'reason' "snapshot.cases[$id].runtimes[$runtimeId]")
+                    if ($reason -notin @('notSelected', 'unavailable', 'noMeasurement')) {
+                        throw "Case '$id' runtime '$runtimeId' has invalid missing reason '$reason'."
+                    }
+                    if ($null -ne $record.PSObject.Properties['measurements']) {
+                        throw "Case '$id' runtime '$runtimeId' cannot be missing and contain measurements."
+                    }
+                    continue
+                }
+                if ($status -ne 'measured') { throw "Case '$id' runtime '$runtimeId' has invalid status '$status'." }
+                $measurements = @(Get-RequiredProperty $record 'measurements' "snapshot.cases[$id].runtimes[$runtimeId]")
+                if ($measurements.Count -eq 0) { throw "Case '$id' runtime '$runtimeId' has no measurements." }
+                $previousLaunch = 0
+                foreach ($measurement in $measurements) {
+                    $launch = [int](Get-RequiredProperty $measurement 'launch' "snapshot.cases[$id].runtimes[$runtimeId].measurements[]")
+                    if ($launch -le $previousLaunch) { throw "Case '$id' runtime '$runtimeId' has duplicate or unordered launches." }
+                    $previousLaunch = $launch
+                    foreach ($field in @('mean', 'minimum', 'standardDeviation', 'sampledDuration')) {
+                        $number = Get-RequiredProperty $measurement $field "snapshot.cases[$id].runtimes[$runtimeId].measurements[$launch]"
+                        if (-not (Test-FiniteNumber $number) -or [double]$number -lt 0) {
+                            throw "Case '$id' runtime '$runtimeId' measurement '$field' must be finite and non-negative."
+                        }
+                    }
+                    if ([double]$measurement.minimum -gt [double]$measurement.mean) {
+                        throw "Case '$id' runtime '$runtimeId' minimum exceeds mean."
+                    }
+                    foreach ($field in @('sampleCount', 'innerIterations')) {
+                        $count = Get-RequiredProperty $measurement $field "snapshot.cases[$id].runtimes[$runtimeId].measurements[$launch]"
+                        if ($count -isnot [byte] -and $count -isnot [int16] -and $count -isnot [int32] -and $count -isnot [int64]) {
+                            throw "Case '$id' runtime '$runtimeId' measurement '$field' must be an integer."
+                        }
+                        if ([long]$count -lt 1) { throw "Case '$id' runtime '$runtimeId' measurement '$field' must be positive." }
+                    }
+                }
+            }
+        }
+        return $Snapshot
+    }
+}
+
+function New-SharpTSPublicBenchmarkSnapshot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$ResultsFile,
+        [Parameter(Mandatory)] [string]$RepositoryRoot,
+        [string[]]$SelectedRuntimes = @('interpreter', 'compiled', 'node', 'bun'),
+        [string]$TimestampUtc,
+        [string]$DotNetVersion,
+        [string]$NodeVersion,
+        [string]$BunVersion,
+        [string]$RunnerIdentity,
+        [string]$OperatingSystem,
+        [string]$Architecture,
+        [string]$Cpu,
+        [Collections.IDictionary]$Revision
+    )
+
+    $selected = @($SelectedRuntimes | ForEach-Object { $_.ToLowerInvariant() } | Sort-Object -Unique)
+    $unknown = @($selected | Where-Object { $_ -notin $script:RuntimeOrder })
+    if ($unknown.Count -gt 0) { throw "Unsupported selected runtime(s): $($unknown -join ', ')." }
+    if (-not $TimestampUtc) { $TimestampUtc = [DateTimeOffset]::UtcNow.ToString('o', $script:InvariantCulture) }
+    $timestampValue = [DateTimeOffset]::Parse($TimestampUtc, $script:InvariantCulture).ToUniversalTime().ToString('o', $script:InvariantCulture)
+    if (-not $PSBoundParameters.ContainsKey('DotNetVersion')) { $DotNetVersion = Get-CommandVersion 'dotnet' @('--version') }
+    if (-not $PSBoundParameters.ContainsKey('NodeVersion')) { $NodeVersion = Get-CommandVersion 'node' @('-v') }
+    if (-not $PSBoundParameters.ContainsKey('BunVersion')) { $BunVersion = Get-CommandVersion 'bun' @('--version') }
+    if (-not $RunnerIdentity) { $RunnerIdentity = if ($env:RUNNER_NAME) { $env:RUNNER_NAME } else { [Environment]::MachineName } }
+    if (-not $OperatingSystem) { $OperatingSystem = [Runtime.InteropServices.RuntimeInformation]::OSDescription.Trim() }
+    if (-not $Architecture) { $Architecture = [Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant() }
+    if (-not $Cpu) { $Cpu = Get-CpuIdentity }
+    if ($null -eq $Revision) { $Revision = Get-GitMetadata $RepositoryRoot }
+
+    $observations = @(ConvertFrom-SharpTSRawBenchmarkResults $ResultsFile)
+    $cases = [Collections.Generic.List[object]]::new()
+    foreach ($caseGroup in $observations | Group-Object caseId | Sort-Object Name) {
+        $first = $caseGroup.Group[0]
+        $runtimeRecords = [Collections.Generic.List[object]]::new()
+        foreach ($runtime in $script:RuntimeOrder) {
+            $runtimeMeasurements = @($caseGroup.Group | Where-Object runtime -ceq $runtime | Sort-Object launch)
+            if ($runtimeMeasurements.Count -eq 0) {
+                $reason = if ($runtime -notin $selected) {
+                    'notSelected'
+                } elseif (($runtime -eq 'node' -and -not $NodeVersion) -or ($runtime -eq 'bun' -and -not $BunVersion)) {
+                    'unavailable'
+                } else {
+                    'noMeasurement'
+                }
+                $runtimeRecords.Add([pscustomobject][ordered]@{
+                    id = $runtime
+                    status = 'missing'
+                    reason = $reason
+                })
+                continue
+            }
+
+            $measurements = @($runtimeMeasurements | ForEach-Object {
+                [pscustomobject][ordered]@{
+                    launch = [int]$_.launch
+                    mean = [double]$_.mean
+                    minimum = [double]$_.minimum
+                    standardDeviation = [double]$_.standardDeviation
+                    sampleCount = [int]$_.sampleCount
+                    innerIterations = [int]$_.innerIterations
+                    sampledDuration = [double]$_.sampledDuration
+                }
+            })
+            $runtimeRecords.Add([pscustomobject][ordered]@{
+                id = $runtime
+                status = 'measured'
+                measurements = $measurements
+            })
+        }
+
+        $cases.Add([pscustomobject][ordered]@{
+            id = $first.caseId
+            family = $first.family
+            name = $first.name
+            parameters = [pscustomobject][ordered]@{ n = [double]$first.parameter }
+            unit = 'milliseconds'
+            direction = 'lowerIsBetter'
+            runtimes = $runtimeRecords.ToArray()
+        })
+    }
+
+    $runtimeTools = [Collections.Generic.List[object]]::new()
+    foreach ($runtime in $script:RuntimeOrder) {
+        $version = $null
+        switch ($runtime) {
+            'interpreter' { $version = [string]$Revision.commit }
+            'compiled' { $version = [string]$Revision.commit }
+            'node' { $version = $NodeVersion }
+            'bun' { $version = $BunVersion }
+        }
+        $available = $runtime -in @('interpreter', 'compiled') -or -not [string]::IsNullOrWhiteSpace([string]$version)
+        $runtimeTools.Add([pscustomobject][ordered]@{
+            id = $runtime
+            selected = $runtime -in $selected
+            available = $available
+            version = if ($available) { [string]$version } else { $null }
+        })
+    }
+
+    $snapshot = [pscustomobject][ordered]@{
+        '$schema' = 'https://raw.githubusercontent.com/nickna/SharpTS/main/benchmarks/cross-runtime/snapshot-v1.schema.json'
+        schemaVersion = 1
+        run = [pscustomobject][ordered]@{
+            timestampUtc = $timestampValue
+            revision = [pscustomobject][ordered]@{
+                commit = [string]$Revision.commit
+                dirty = [bool]$Revision.dirty
+            }
+            environment = [pscustomobject][ordered]@{
+                operatingSystem = $OperatingSystem
+                architecture = $Architecture
+                cpu = $Cpu
+                runner = $RunnerIdentity
+            }
+            tools = [pscustomobject][ordered]@{
+                dotnet = $DotNetVersion
+                runtimes = $runtimeTools.ToArray()
+            }
+        }
+        methodology = [pscustomobject][ordered]@{
+            harnessVersion = 1
+            id = 'performance-now-auto-batched-v1'
+            timingScope = 'inProcessWorkload'
+            clock = 'performance.now'
+            includes = @('one workload function invocation')
+            excludes = @('process startup', 'script loading', 'SharpTS compilation', 'warmup', 'batch calibration')
+            sampling = [pscustomobject][ordered]@{
+                warmupCapMilliseconds = 100
+                minimumSampleDurationMilliseconds = 1
+                targetDurationMilliseconds = 300
+                minimumSamples = 8
+                hardCapMilliseconds = 2000
+                maximumSamples = 100000
+            }
+        }
+        cases = $cases.ToArray()
+    }
+
+    return Assert-SharpTSPublicBenchmarkSnapshot $snapshot
+}
+
+function Export-SharpTSPublicBenchmarkSnapshot {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string]$ResultsFile,
+        [Parameter(Mandatory)] [string]$OutputFile,
+        [Parameter(Mandatory)] [string]$RepositoryRoot,
+        [string[]]$SelectedRuntimes = @('interpreter', 'compiled', 'node', 'bun'),
+        [string]$TimestampUtc,
+        [string]$DotNetVersion,
+        [string]$NodeVersion,
+        [string]$BunVersion,
+        [string]$RunnerIdentity,
+        [string]$OperatingSystem,
+        [string]$Architecture,
+        [string]$Cpu,
+        [Collections.IDictionary]$Revision
+    )
+
+    $arguments = @{
+        ResultsFile = $ResultsFile
+        RepositoryRoot = $RepositoryRoot
+        SelectedRuntimes = $SelectedRuntimes
+    }
+    foreach ($name in @('TimestampUtc', 'DotNetVersion', 'NodeVersion', 'BunVersion', 'RunnerIdentity', 'OperatingSystem', 'Architecture', 'Cpu', 'Revision')) {
+        if ($PSBoundParameters.ContainsKey($name)) { $arguments[$name] = $PSBoundParameters[$name] }
+    }
+    $snapshot = New-SharpTSPublicBenchmarkSnapshot @arguments
+    $parent = Split-Path -Parent ([IO.Path]::GetFullPath($OutputFile))
+    if ($parent) { [IO.Directory]::CreateDirectory($parent) | Out-Null }
+    $json = $snapshot | ConvertTo-Json -Depth 12
+    [IO.File]::WriteAllText([IO.Path]::GetFullPath($OutputFile), $json + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+    return $snapshot
+}
+
+function Test-SharpTSPublicBenchmarkSnapshotFile {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { throw "Snapshot file not found: $Path" }
+    $raw = Get-Content -LiteralPath $Path -Raw
+    $schemaPath = Join-Path $PSScriptRoot 'snapshot-v1.schema.json'
+    try {
+        if (-not ($raw | Test-Json -SchemaFile $schemaPath -ErrorAction Stop)) {
+            throw 'JSON Schema validation returned false.'
+        }
+        $snapshot = $raw | ConvertFrom-Json
+    } catch {
+        throw "Snapshot is not valid schema-v1 JSON: $($_.Exception.Message)"
+    }
+    [void](Assert-SharpTSPublicBenchmarkSnapshot $snapshot)
+    return $true
+}
+
+Export-ModuleMember -Function @(
+    'Assert-SharpTSPublicBenchmarkSnapshot',
+    'ConvertFrom-SharpTSRawBenchmarkResults',
+    'Export-SharpTSPublicBenchmarkSnapshot',
+    'New-SharpTSPublicBenchmarkSnapshot',
+    'Test-SharpTSPublicBenchmarkSnapshotFile'
+)

--- a/benchmarks/cross-runtime/export-snapshot.ps1
+++ b/benchmarks/cross-runtime/export-snapshot.ps1
@@ -1,0 +1,31 @@
+[CmdletBinding()]
+param(
+    [string]$ResultsFile = (Join-Path ([System.IO.Path]::GetTempPath()) 'bench-results/results.txt'),
+    [string]$OutputFile = (Join-Path ([System.IO.Path]::GetTempPath()) 'bench-results/snapshot.json'),
+    [string]$RepositoryRoot,
+    [string[]]$SelectedRuntimes = @('interpreter', 'compiled', 'node', 'bun'),
+    [string]$TimestampUtc,
+    [string]$DotNetVersion,
+    [string]$NodeVersion,
+    [string]$BunVersion
+)
+
+$ErrorActionPreference = 'Stop'
+$harnessDirectory = Split-Path -Parent $MyInvocation.MyCommand.Definition
+if (-not $RepositoryRoot) {
+    $RepositoryRoot = (Resolve-Path (Join-Path $harnessDirectory '../..')).Path
+}
+Import-Module (Join-Path $harnessDirectory 'Snapshot.psm1') -Force
+
+$arguments = @{
+    ResultsFile = $ResultsFile
+    OutputFile = $OutputFile
+    RepositoryRoot = $RepositoryRoot
+    SelectedRuntimes = $SelectedRuntimes
+}
+foreach ($name in @('TimestampUtc', 'DotNetVersion', 'NodeVersion', 'BunVersion')) {
+    if ($PSBoundParameters.ContainsKey($name)) { $arguments[$name] = $PSBoundParameters[$name] }
+}
+
+[void](Export-SharpTSPublicBenchmarkSnapshot @arguments)
+Write-Host "Validated benchmark snapshot schema v1 and wrote $([IO.Path]::GetFullPath($OutputFile))"

--- a/benchmarks/cross-runtime/format-results.ps1
+++ b/benchmarks/cross-runtime/format-results.ps1
@@ -39,8 +39,9 @@ minimums are kept in the raw results artifact for deeper analysis.
 "@
 
 # Parse results into a dictionary keyed by "bench|param".
-# Each line is: <runtime>|<bench>:<param>:<mean>:<min>:<stdev>
-# (older <mean>-only lines are still accepted: min/stdev default to absent).
+# The first five payload fields remain
+# <bench>:<param>:<mean>:<min>:<stdev>. Newer harnesses append sampling,
+# workload-family, and launch metadata for the structured exporter.
 $data = [ordered]@{}
 foreach ($line in Get-Content $ResultsFile) {
     if (-not $line.Trim()) { continue }

--- a/benchmarks/cross-runtime/run-benchmarks.ps1
+++ b/benchmarks/cross-runtime/run-benchmarks.ps1
@@ -2,6 +2,7 @@
 param(
     [switch]$Smoke,
     [switch]$NoBuild,
+    [switch]$NoSnapshot,
 
     [string[]]$Workloads = @(),
 
@@ -123,12 +124,14 @@ if (-not $NoBuild) {
 # Detect Node.js version for --experimental-strip-types
 $node = $null
 $nodeFlags = @()
+$nodeVersionForSnapshot = $null
 if (-not $Smoke -and $Runtimes -contains 'node') {
     $node = Get-Command $NodeExecutable -ErrorAction SilentlyContinue
     if ($node) {
         $nodeVersion = Invoke-Captured { & $node.Source -v }
         if ($nodeVersion.ExitCode -eq 0) {
             $nodeVersionFull = ([string]$nodeVersion.Output[0]) -replace '^v', ''
+            $nodeVersionForSnapshot = "v$nodeVersionFull"
             $nodeMajor = [int]($nodeVersionFull -split '\.')[0]
             if ($nodeMajor -lt 23) {
                 $nodeFlags = @('--experimental-strip-types', '--no-warnings')
@@ -148,18 +151,33 @@ $bun = if (-not $Smoke -and $Runtimes -contains 'bun') {
 } else {
     $null
 }
+$bunVersionForSnapshot = if ($bun) {
+    $detectedBunVersion = Invoke-Captured { & $bun.Source --version }
+    if ($detectedBunVersion.ExitCode -eq 0) { [string]$detectedBunVersion.Output[0] } else { $null }
+} else {
+    $null
+}
 
 # Tag and persist a runtime's BENCH output. If none was produced (a crash, a
 # compile/parse error, a missing API), warn loudly and echo the tail of the
 # captured output instead of silently leaving a '-' in the results table.
 function Emit-Runtime {
-    param([string]$Runtime, [object]$Output, [string]$ResultsFile)
+    param(
+        [string]$Benchmark,
+        [string]$Runtime,
+        [int]$Launch,
+        [object]$Output,
+        [string]$ResultsFile
+    )
     $lines = @($Output)
     $benchLines = @($lines | Where-Object { $_ -match '^BENCH:' })
     if ($benchLines.Count -eq 0) {
         return $false
     }
-    $benchLines | ForEach-Object { "$Runtime|$($_ -replace '^BENCH:','')" } | Add-Content $ResultsFile
+    $benchLines | ForEach-Object {
+        $payload = $_ -replace '^BENCH:', ''
+        '{0}|{1}:{2}:{3}' -f $Runtime, $payload, $Benchmark, $Launch
+    } | Add-Content $ResultsFile
     return $true
 }
 
@@ -167,11 +185,12 @@ function Complete-Runtime {
     param(
         [string]$Benchmark,
         [string]$Runtime,
+        [int]$Launch,
         [object]$Result,
         [string]$ResultsFile
     )
 
-    $emitted = Emit-Runtime $Runtime $Result.Output $ResultsFile
+    $emitted = Emit-Runtime $Benchmark $Runtime $Launch $Result.Output $ResultsFile
     if ($Result.ExitCode -ne 0) {
         Add-Failure "$Benchmark [$Runtime] exited with code $($Result.ExitCode)"
         Show-Diagnostics $Runtime $Result.Output
@@ -256,19 +275,19 @@ try {
                         $result = Invoke-Captured {
                             dotnet run -c Release --no-build --project $SharpTSProject -- $script.FullName
                         }
-                        Complete-Runtime $benchName 'interpreter' $result $ResultsFile
+                        Complete-Runtime $benchName 'interpreter' $launch $result $ResultsFile
                     }
                     'compiled' {
                         if ($compiledReady) {
                             $result = Invoke-Captured { dotnet $dllPath }
-                            Complete-Runtime $benchName 'compiled' $result $ResultsFile
+                            Complete-Runtime $benchName 'compiled' $launch $result $ResultsFile
                         }
                     }
                     'node' {
                         if ($node) {
                             $nodeArgs = $nodeFlags + @($script.FullName)
                             $result = Invoke-Captured { & $node.Source @nodeArgs }
-                            Complete-Runtime $benchName 'node' $result $ResultsFile
+                            Complete-Runtime $benchName 'node' $launch $result $ResultsFile
                         } else {
                             Add-Failure "$benchName [node] could not run because Node.js is unavailable"
                         }
@@ -276,7 +295,7 @@ try {
                     'bun' {
                         if ($bun) {
                             $result = Invoke-Captured { & bun run $script.FullName }
-                            Complete-Runtime $benchName 'bun' $result $ResultsFile
+                            Complete-Runtime $benchName 'bun' $launch $result $ResultsFile
                         } else {
                             Write-Host '  [bun] not installed, skipping'
                         }
@@ -293,6 +312,17 @@ Write-Host ''
 if ($Smoke) {
     Write-Host "=== Smoke-compiled $($scripts.Count) benchmark workload(s) ==="
 } else {
+    if (-not $NoSnapshot) {
+        $SnapshotFile = Join-Path $OutputDir 'snapshot.json'
+        & (Join-Path $HarnessDir 'export-snapshot.ps1') `
+            -ResultsFile $ResultsFile `
+            -OutputFile $SnapshotFile `
+            -RepositoryRoot $RepoRoot `
+            -SelectedRuntimes $Runtimes `
+            -NodeVersion $nodeVersionForSnapshot `
+            -BunVersion $bunVersionForSnapshot
+        Write-Host "=== Structured snapshot written to $SnapshotFile ==="
+    }
     Write-Host "=== Results written to $ResultsFile ==="
     Get-Content $ResultsFile
 }

--- a/benchmarks/cross-runtime/scripts/lib/bench.ts
+++ b/benchmarks/cross-runtime/scripts/lib/bench.ts
@@ -10,8 +10,8 @@
 // noise floor), then collects samples until a time budget elapses and reports
 // the per-call mean, min, and sample standard deviation.
 //
-// Output line (consumed by benchmarks/cross-runtime/format-results.ps1):
-//   BENCH:<name>:<param>:<meanMs>:<minMs>:<stdevMs>
+// Output line (consumed by the cross-runtime PowerShell tools):
+//   BENCH:<name>:<param>:<meanMs>:<minMs>:<stdevMs>:<samples>:<inner>:<sampledMs>
 
 import { performance } from "perf_hooks";
 
@@ -33,6 +33,7 @@ export function bench(name: string, param: number, fn: () => number): void {
     let guard: number = 0;
     const samples: number[] = [];
     let total: number = 0;
+    let inner: number = 1;
 
     // One measured call up front. This both probes the cost and, when a single
     // call is already heavy (e.g. the tree-walking interpreter on a big input),
@@ -69,7 +70,6 @@ export function bench(name: string, param: number, fn: () => number): void {
             guard = guard + fn();
         }
 
-        let inner: number = 1;
         while (inner < MAX_INNER) {
             const c0: number = performance.now();
             for (let k: number = 0; k < inner; k++) {
@@ -123,7 +123,10 @@ export function bench(name: string, param: number, fn: () => number): void {
         console.log("guard:" + guard);
     }
 
-    console.log("BENCH:" + name + ":" + param + ":" + round(mean) + ":" + round(min) + ":" + round(stdev));
+    console.log(
+        "BENCH:" + name + ":" + param + ":" + round(mean) + ":" + round(min) + ":" +
+        round(stdev) + ":" + samples.length + ":" + inner + ":" + round(total),
+    );
 }
 
 // Async counterpart to `bench`. Each invocation is awaited inside the timed
@@ -139,6 +142,7 @@ export async function benchAsync(
     let guard: number = 0;
     const samples: number[] = [];
     let total: number = 0;
+    let inner: number = 1;
 
     const probeStart: number = performance.now();
     guard = guard + await fn();
@@ -166,7 +170,6 @@ export async function benchAsync(
             guard = guard + await fn();
         }
 
-        let inner: number = 1;
         while (inner < MAX_INNER) {
             const c0: number = performance.now();
             for (let k: number = 0; k < inner; k++) {
@@ -218,5 +221,8 @@ export async function benchAsync(
         console.log("guard:" + guard);
     }
 
-    console.log("BENCH:" + name + ":" + param + ":" + round(mean) + ":" + round(min) + ":" + round(stdev));
+    console.log(
+        "BENCH:" + name + ":" + param + ":" + round(mean) + ":" + round(min) + ":" +
+        round(stdev) + ":" + samples.length + ":" + inner + ":" + round(total),
+    );
 }

--- a/benchmarks/cross-runtime/snapshot-v1.schema.json
+++ b/benchmarks/cross-runtime/snapshot-v1.schema.json
@@ -1,0 +1,227 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/nickna/SharpTS/main/benchmarks/cross-runtime/snapshot-v1.schema.json",
+  "title": "SharpTS cross-runtime benchmark snapshot",
+  "description": "One machine-bound run of the SharpTS in-process workload benchmark suite.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schemaVersion", "run", "methodology", "cases"],
+  "properties": {
+    "$schema": {
+      "const": "https://raw.githubusercontent.com/nickna/SharpTS/main/benchmarks/cross-runtime/snapshot-v1.schema.json"
+    },
+    "schemaVersion": { "const": 1 },
+    "run": { "$ref": "#/$defs/run" },
+    "methodology": { "$ref": "#/$defs/methodology" },
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/case" }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["timestampUtc", "revision", "environment", "tools"],
+      "properties": {
+        "timestampUtc": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revision": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["commit", "dirty"],
+          "properties": {
+            "commit": {
+              "type": "string",
+              "pattern": "^[0-9a-f]{40}$"
+            },
+            "dirty": { "type": "boolean" }
+          }
+        },
+        "environment": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["operatingSystem", "architecture", "cpu", "runner"],
+          "properties": {
+            "operatingSystem": { "$ref": "#/$defs/nonEmptyString" },
+            "architecture": { "$ref": "#/$defs/nonEmptyString" },
+            "cpu": { "$ref": "#/$defs/nonEmptyString" },
+            "runner": { "$ref": "#/$defs/nonEmptyString" }
+          }
+        },
+        "tools": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["dotnet", "runtimes"],
+          "properties": {
+            "dotnet": { "$ref": "#/$defs/nonEmptyString" },
+            "runtimes": {
+              "type": "array",
+              "minItems": 4,
+              "maxItems": 4,
+              "items": { "$ref": "#/$defs/runtimeTool" }
+            }
+          }
+        }
+      }
+    },
+    "runtimeTool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "selected", "available", "version"],
+      "properties": {
+        "id": {
+          "enum": ["interpreter", "compiled", "node", "bun"]
+        },
+        "selected": { "type": "boolean" },
+        "available": { "type": "boolean" },
+        "version": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "methodology": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["harnessVersion", "id", "timingScope", "clock", "includes", "excludes", "sampling"],
+      "properties": {
+        "harnessVersion": { "const": 1 },
+        "id": { "const": "performance-now-auto-batched-v1" },
+        "timingScope": { "const": "inProcessWorkload" },
+        "clock": { "const": "performance.now" },
+        "includes": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/nonEmptyString" }
+        },
+        "excludes": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/nonEmptyString" }
+        },
+        "sampling": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "warmupCapMilliseconds",
+            "minimumSampleDurationMilliseconds",
+            "targetDurationMilliseconds",
+            "minimumSamples",
+            "hardCapMilliseconds",
+            "maximumSamples"
+          ],
+          "properties": {
+            "warmupCapMilliseconds": { "type": "number", "minimum": 0 },
+            "minimumSampleDurationMilliseconds": { "type": "number", "exclusiveMinimum": 0 },
+            "targetDurationMilliseconds": { "type": "number", "exclusiveMinimum": 0 },
+            "minimumSamples": { "type": "integer", "minimum": 1 },
+            "hardCapMilliseconds": { "type": "number", "exclusiveMinimum": 0 },
+            "maximumSamples": { "type": "integer", "minimum": 1 }
+          }
+        }
+      }
+    },
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "family", "name", "parameters", "unit", "direction", "runtimes"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*/[a-z0-9][a-z0-9-]*\\?n=[0-9.eE+-]+$"
+        },
+        "family": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        },
+        "name": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["n"],
+          "properties": {
+            "n": { "type": "number", "minimum": 0 }
+          }
+        },
+        "unit": {
+          "enum": ["milliseconds", "bytes", "operationsPerSecond"]
+        },
+        "direction": {
+          "enum": ["lowerIsBetter", "higherIsBetter"]
+        },
+        "runtimes": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "items": { "$ref": "#/$defs/runtimeRecord" }
+        }
+      }
+    },
+    "runtimeRecord": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "status", "measurements"],
+          "properties": {
+            "id": {
+              "enum": ["interpreter", "compiled", "node", "bun"]
+            },
+            "status": { "const": "measured" },
+            "measurements": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/measurement" }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "status", "reason"],
+          "properties": {
+            "id": {
+              "enum": ["interpreter", "compiled", "node", "bun"]
+            },
+            "status": { "const": "missing" },
+            "reason": {
+              "enum": ["notSelected", "unavailable", "noMeasurement"]
+            }
+          }
+        }
+      ]
+    },
+    "measurement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "launch",
+        "mean",
+        "minimum",
+        "standardDeviation",
+        "sampleCount",
+        "innerIterations",
+        "sampledDuration"
+      ],
+      "properties": {
+        "launch": { "type": "integer", "minimum": 1 },
+        "mean": { "type": "number", "minimum": 0 },
+        "minimum": { "type": "number", "minimum": 0 },
+        "standardDeviation": { "type": "number", "minimum": 0 },
+        "sampleCount": { "type": "integer", "minimum": 1 },
+        "innerIterations": { "type": "integer", "minimum": 1 },
+        "sampledDuration": { "type": "number", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/benchmarks/cross-runtime/snapshots/latest.json
+++ b/benchmarks/cross-runtime/snapshots/latest.json
@@ -1,0 +1,8008 @@
+{
+  "$schema": "https://raw.githubusercontent.com/nickna/SharpTS/main/benchmarks/cross-runtime/snapshot-v1.schema.json",
+  "schemaVersion": 1,
+  "run": {
+    "timestampUtc": "2026-08-26T17:41:38.9567174+00:00",
+    "revision": {
+      "commit": "7843dbe3128044f48fd6beae1f87e8acf8cabe75",
+      "dirty": true
+    },
+    "environment": {
+      "operatingSystem": "Microsoft Windows 10.0.29639",
+      "architecture": "x64",
+      "cpu": "Intel64 Family 6 Model 183 Stepping 1, GenuineIntel",
+      "runner": "DESKTOP-WC0X"
+    },
+    "tools": {
+      "dotnet": "10.0.400",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "selected": true,
+          "available": true,
+          "version": "7843dbe3128044f48fd6beae1f87e8acf8cabe75"
+        },
+        {
+          "id": "compiled",
+          "selected": true,
+          "available": true,
+          "version": "7843dbe3128044f48fd6beae1f87e8acf8cabe75"
+        },
+        {
+          "id": "node",
+          "selected": true,
+          "available": true,
+          "version": "v24.19.0"
+        },
+        {
+          "id": "bun",
+          "selected": true,
+          "available": false,
+          "version": null
+        }
+      ]
+    }
+  },
+  "methodology": {
+    "harnessVersion": 1,
+    "id": "performance-now-auto-batched-v1",
+    "timingScope": "inProcessWorkload",
+    "clock": "performance.now",
+    "includes": [
+      "one workload function invocation"
+    ],
+    "excludes": [
+      "process startup",
+      "script loading",
+      "SharpTS compilation",
+      "warmup",
+      "batch calibration"
+    ],
+    "sampling": {
+      "warmupCapMilliseconds": 100,
+      "minimumSampleDurationMilliseconds": 1,
+      "targetDurationMilliseconds": 300,
+      "minimumSamples": 8,
+      "hardCapMilliseconds": 2000,
+      "maximumSamples": 100000
+    }
+  },
+  "cases": [
+    {
+      "id": "array-methods/array-methods?n=1000",
+      "family": "array-methods",
+      "name": "array-methods",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 5.3928,
+              "minimum": 3.6098,
+              "standardDeviation": 2.2728,
+              "sampleCount": 56,
+              "innerIterations": 1,
+              "sampledDuration": 301.9961
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0168,
+              "minimum": 0.0094,
+              "standardDeviation": 0.0228,
+              "sampleCount": 17902,
+              "innerIterations": 1,
+              "sampledDuration": 300.003
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0133,
+              "minimum": 0.011,
+              "standardDeviation": 0.0016,
+              "sampleCount": 177,
+              "innerIterations": 128,
+              "sampledDuration": 301.5303
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "array-methods/array-methods?n=10000",
+      "family": "array-methods",
+      "name": "array-methods",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 25.2731,
+              "minimum": 10.2763,
+              "standardDeviation": 10.1293,
+              "sampleCount": 12,
+              "innerIterations": 1,
+              "sampledDuration": 303.2777
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1446,
+              "minimum": 0.1189,
+              "standardDeviation": 0.0146,
+              "sampleCount": 130,
+              "innerIterations": 16,
+              "sampledDuration": 300.6655
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1203,
+              "minimum": 0.112,
+              "standardDeviation": 0.0085,
+              "sampleCount": 156,
+              "innerIterations": 16,
+              "sampledDuration": 300.2704
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "array-methods/array-methods?n=100000",
+      "family": "array-methods",
+      "name": "array-methods",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 133.4962,
+              "minimum": 124.9969,
+              "standardDeviation": 8.3876,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 1067.9694
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.2773,
+              "minimum": 1.0842,
+              "standardDeviation": 0.1244,
+              "sampleCount": 235,
+              "innerIterations": 1,
+              "sampledDuration": 300.1568
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.2921,
+              "minimum": 1.8938,
+              "standardDeviation": 0.4583,
+              "sampleCount": 132,
+              "innerIterations": 1,
+              "sampledDuration": 302.5583
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "async-promises/async-function-calls?n=10",
+      "family": "async-promises",
+      "name": "async-function-calls",
+      "parameters": {
+        "n": 10.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0227,
+              "minimum": 0.0128,
+              "standardDeviation": 0.0106,
+              "sampleCount": 414,
+              "innerIterations": 32,
+              "sampledDuration": 300.2722
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0002,
+              "minimum": 0.0001,
+              "standardDeviation": 0.0001,
+              "sampleCount": 219,
+              "innerIterations": 8192,
+              "sampledDuration": 300.506
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0003,
+              "minimum": 0.0003,
+              "standardDeviation": 0.0,
+              "sampleCount": 212,
+              "innerIterations": 4096,
+              "sampledDuration": 300.3966
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "async-promises/async-function-calls?n=100",
+      "family": "async-promises",
+      "name": "async-function-calls",
+      "parameters": {
+        "n": 100.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1173,
+              "minimum": 0.1052,
+              "standardDeviation": 0.0141,
+              "sampleCount": 160,
+              "innerIterations": 16,
+              "sampledDuration": 300.2956
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0001,
+              "minimum": 0.0001,
+              "standardDeviation": 0.0,
+              "sampleCount": 289,
+              "innerIterations": 8192,
+              "sampledDuration": 300.4023
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0027,
+              "minimum": 0.0024,
+              "standardDeviation": 0.0002,
+              "sampleCount": 221,
+              "innerIterations": 512,
+              "sampledDuration": 300.9527
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "async-promises/async-function-calls?n=1000",
+      "family": "async-promises",
+      "name": "async-function-calls",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.1648,
+              "minimum": 1.0239,
+              "standardDeviation": 0.2347,
+              "sampleCount": 258,
+              "innerIterations": 1,
+              "sampledDuration": 300.5152
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0005,
+              "minimum": 0.0005,
+              "standardDeviation": 0.0001,
+              "sampleCount": 294,
+              "innerIterations": 2048,
+              "sampledDuration": 300.5497
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.026,
+              "minimum": 0.0226,
+              "standardDeviation": 0.0027,
+              "sampleCount": 181,
+              "innerIterations": 64,
+              "sampledDuration": 301.1727
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "async-promises/async-resolved-await?n=10",
+      "family": "async-promises",
+      "name": "async-resolved-await",
+      "parameters": {
+        "n": 10.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0793,
+              "minimum": 0.0441,
+              "standardDeviation": 0.3284,
+              "sampleCount": 3782,
+              "innerIterations": 1,
+              "sampledDuration": 300.002
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0005,
+              "minimum": 0.0003,
+              "standardDeviation": 0.0091,
+              "sampleCount": 100000,
+              "innerIterations": 1,
+              "sampledDuration": 54.9762
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0004,
+              "minimum": 0.0003,
+              "standardDeviation": 0.0,
+              "sampleCount": 202,
+              "innerIterations": 4096,
+              "sampledDuration": 300.247
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "async-promises/async-resolved-await?n=100",
+      "family": "async-promises",
+      "name": "async-resolved-await",
+      "parameters": {
+        "n": 100.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.2087,
+              "minimum": 0.1052,
+              "standardDeviation": 0.7441,
+              "sampleCount": 1473,
+              "innerIterations": 1,
+              "sampledDuration": 307.4867
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0001,
+              "minimum": 0.0001,
+              "standardDeviation": 0.0,
+              "sampleCount": 577,
+              "innerIterations": 4096,
+              "sampledDuration": 300.1028
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0027,
+              "minimum": 0.0025,
+              "standardDeviation": 0.0002,
+              "sampleCount": 220,
+              "innerIterations": 512,
+              "sampledDuration": 300.8931
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "async-promises/async-resolved-await?n=1000",
+      "family": "async-promises",
+      "name": "async-resolved-await",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.3703,
+              "minimum": 1.0619,
+              "standardDeviation": 4.3497,
+              "sampleCount": 127,
+              "innerIterations": 1,
+              "sampledDuration": 301.0273
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0005,
+              "minimum": 0.0005,
+              "standardDeviation": 0.0001,
+              "sampleCount": 141,
+              "innerIterations": 4096,
+              "sampledDuration": 302.1802
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0267,
+              "minimum": 0.0238,
+              "standardDeviation": 0.0022,
+              "sampleCount": 176,
+              "innerIterations": 64,
+              "sampledDuration": 300.9635
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "async-promises/promise-all?n=10",
+      "family": "async-promises",
+      "name": "promise-all",
+      "parameters": {
+        "n": 10.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0637,
+              "minimum": 0.032,
+              "standardDeviation": 0.3399,
+              "sampleCount": 4709,
+              "innerIterations": 1,
+              "sampledDuration": 300.0186
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0012,
+              "minimum": 0.0008,
+              "standardDeviation": 0.0185,
+              "sampleCount": 100000,
+              "innerIterations": 1,
+              "sampledDuration": 122.4676
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0005,
+              "minimum": 0.0004,
+              "standardDeviation": 0.0,
+              "sampleCount": 160,
+              "innerIterations": 4096,
+              "sampledDuration": 300.3775
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "async-promises/promise-all?n=100",
+      "family": "async-promises",
+      "name": "promise-all",
+      "parameters": {
+        "n": 100.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.4622,
+              "minimum": 0.2455,
+              "standardDeviation": 0.8357,
+              "sampleCount": 325,
+              "innerIterations": 2,
+              "sampledDuration": 300.4617
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.001,
+              "minimum": 0.0007,
+              "standardDeviation": 0.0003,
+              "sampleCount": 305,
+              "innerIterations": 1024,
+              "sampledDuration": 300.4802
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0033,
+              "minimum": 0.0028,
+              "standardDeviation": 0.0003,
+              "sampleCount": 180,
+              "innerIterations": 512,
+              "sampledDuration": 300.7992
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "async-promises/promise-all?n=1000",
+      "family": "async-promises",
+      "name": "promise-all",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 4.9848,
+              "minimum": 2.3318,
+              "standardDeviation": 5.9164,
+              "sampleCount": 61,
+              "innerIterations": 1,
+              "sampledDuration": 304.0709
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0052,
+              "minimum": 0.0043,
+              "standardDeviation": 0.001,
+              "sampleCount": 227,
+              "innerIterations": 256,
+              "sampledDuration": 301.0045
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0339,
+              "minimum": 0.0293,
+              "standardDeviation": 0.0035,
+              "sampleCount": 277,
+              "innerIterations": 32,
+              "sampledDuration": 300.7958
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "async-promises/promise-then-chain?n=10",
+      "family": "async-promises",
+      "name": "promise-then-chain",
+      "parameters": {
+        "n": 10.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0273,
+              "minimum": 0.0156,
+              "standardDeviation": 0.1811,
+              "sampleCount": 11006,
+              "innerIterations": 1,
+              "sampledDuration": 300.0043
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0017,
+              "minimum": 0.001,
+              "standardDeviation": 0.0225,
+              "sampleCount": 100000,
+              "innerIterations": 1,
+              "sampledDuration": 172.38
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0003,
+              "minimum": 0.0003,
+              "standardDeviation": 0.0,
+              "sampleCount": 221,
+              "innerIterations": 4096,
+              "sampledDuration": 300.5603
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "async-promises/promise-then-chain?n=100",
+      "family": "async-promises",
+      "name": "promise-then-chain",
+      "parameters": {
+        "n": 100.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1833,
+              "minimum": 0.1303,
+              "standardDeviation": 0.0933,
+              "sampleCount": 207,
+              "innerIterations": 8,
+              "sampledDuration": 303.4815
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0028,
+              "minimum": 0.0022,
+              "standardDeviation": 0.001,
+              "sampleCount": 425,
+              "innerIterations": 256,
+              "sampledDuration": 300.4416
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0026,
+              "minimum": 0.0021,
+              "standardDeviation": 0.0003,
+              "sampleCount": 230,
+              "innerIterations": 512,
+              "sampledDuration": 300.978
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "async-promises/promise-then-chain?n=1000",
+      "family": "async-promises",
+      "name": "promise-then-chain",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.7446,
+              "minimum": 1.2443,
+              "standardDeviation": 0.7651,
+              "sampleCount": 172,
+              "innerIterations": 1,
+              "sampledDuration": 300.0756
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0222,
+              "minimum": 0.0179,
+              "standardDeviation": 0.0039,
+              "sampleCount": 212,
+              "innerIterations": 64,
+              "sampledDuration": 300.5805
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0269,
+              "minimum": 0.0239,
+              "standardDeviation": 0.0028,
+              "sampleCount": 175,
+              "innerIterations": 64,
+              "sampledDuration": 300.9491
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "binary-trees/binary-trees?n=12",
+      "family": "binary-trees",
+      "name": "binary-trees",
+      "parameters": {
+        "n": 12.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 27.6822,
+              "minimum": 18.0664,
+              "standardDeviation": 5.4844,
+              "sampleCount": 11,
+              "innerIterations": 1,
+              "sampledDuration": 304.5043
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0676,
+              "minimum": 0.0558,
+              "standardDeviation": 0.0109,
+              "sampleCount": 278,
+              "innerIterations": 16,
+              "sampledDuration": 300.5648
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0736,
+              "minimum": 0.0616,
+              "standardDeviation": 0.0074,
+              "sampleCount": 255,
+              "innerIterations": 16,
+              "sampledDuration": 300.1636
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "binary-trees/binary-trees?n=16",
+      "family": "binary-trees",
+      "name": "binary-trees",
+      "parameters": {
+        "n": 16.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 333.1057,
+              "minimum": 270.8346,
+              "standardDeviation": 47.7161,
+              "sampleCount": 7,
+              "innerIterations": 1,
+              "sampledDuration": 2331.7401
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.4169,
+              "minimum": 0.7561,
+              "standardDeviation": 1.1862,
+              "sampleCount": 212,
+              "innerIterations": 1,
+              "sampledDuration": 300.3918
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.393,
+              "minimum": 1.0631,
+              "standardDeviation": 0.4329,
+              "sampleCount": 216,
+              "innerIterations": 1,
+              "sampledDuration": 300.895
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "binary-trees/binary-trees?n=8",
+      "family": "binary-trees",
+      "name": "binary-trees",
+      "parameters": {
+        "n": 8.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 4.0646,
+              "minimum": 2.1049,
+              "standardDeviation": 2.415,
+              "sampleCount": 74,
+              "innerIterations": 1,
+              "sampledDuration": 300.7834
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0051,
+              "minimum": 0.0034,
+              "standardDeviation": 0.0079,
+              "sampleCount": 58807,
+              "innerIterations": 1,
+              "sampledDuration": 300.0015
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.004,
+              "minimum": 0.0037,
+              "standardDeviation": 0.0003,
+              "sampleCount": 290,
+              "innerIterations": 256,
+              "sampledDuration": 300.5132
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "brainfuck/brainfuck?n=50",
+      "family": "brainfuck",
+      "name": "brainfuck",
+      "parameters": {
+        "n": 50.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 111.5413,
+              "minimum": 55.3918,
+              "standardDeviation": 98.6952,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 892.3305
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.2257,
+              "minimum": 0.2069,
+              "standardDeviation": 0.0899,
+              "sampleCount": 1330,
+              "innerIterations": 1,
+              "sampledDuration": 300.1259
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1685,
+              "minimum": 0.1271,
+              "standardDeviation": 0.0924,
+              "sampleCount": 1781,
+              "innerIterations": 1,
+              "sampledDuration": 300.0885
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "brainfuck/brainfuck?n=500",
+      "family": "brainfuck",
+      "name": "brainfuck",
+      "parameters": {
+        "n": 500.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 543.5528,
+              "minimum": 526.6538,
+              "standardDeviation": 12.8354,
+              "sampleCount": 4,
+              "innerIterations": 1,
+              "sampledDuration": 2174.2113
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.1359,
+              "minimum": 2.0647,
+              "standardDeviation": 0.0884,
+              "sampleCount": 141,
+              "innerIterations": 1,
+              "sampledDuration": 301.1567
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.74,
+              "minimum": 1.6551,
+              "standardDeviation": 0.1304,
+              "sampleCount": 173,
+              "innerIterations": 1,
+              "sampledDuration": 301.0271
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "brainfuck/brainfuck?n=5000",
+      "family": "brainfuck",
+      "name": "brainfuck",
+      "parameters": {
+        "n": 5000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 5343.5295,
+              "minimum": 5343.5295,
+              "standardDeviation": 0.0,
+              "sampleCount": 1,
+              "innerIterations": 1,
+              "sampledDuration": 5343.5295
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 21.9058,
+              "minimum": 21.1089,
+              "standardDeviation": 0.7682,
+              "sampleCount": 14,
+              "innerIterations": 1,
+              "sampledDuration": 306.6813
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 17.638,
+              "minimum": 17.2631,
+              "standardDeviation": 0.3557,
+              "sampleCount": 18,
+              "innerIterations": 1,
+              "sampledDuration": 317.4848
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-construction?n=1000",
+      "family": "classes",
+      "name": "class-construction",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.795,
+              "minimum": 1.2017,
+              "standardDeviation": 0.94,
+              "sampleCount": 169,
+              "innerIterations": 1,
+              "sampledDuration": 303.3608
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0007,
+              "minimum": 0.0005,
+              "standardDeviation": 0.0008,
+              "sampleCount": 813,
+              "innerIterations": 512,
+              "sampledDuration": 300.2138
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0003,
+              "minimum": 0.0003,
+              "standardDeviation": 0.0,
+              "sampleCount": 256,
+              "innerIterations": 4096,
+              "sampledDuration": 300.3203
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-construction?n=10000",
+      "family": "classes",
+      "name": "class-construction",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 23.8923,
+              "minimum": 18.7202,
+              "standardDeviation": 4.2635,
+              "sampleCount": 13,
+              "innerIterations": 1,
+              "sampledDuration": 310.5995
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0042,
+              "minimum": 0.004,
+              "standardDeviation": 0.0003,
+              "sampleCount": 278,
+              "innerIterations": 256,
+              "sampledDuration": 301.0676
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0051,
+              "minimum": 0.005,
+              "standardDeviation": 0.0003,
+              "sampleCount": 228,
+              "innerIterations": 256,
+              "sampledDuration": 300.3624
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-construction?n=100000",
+      "family": "classes",
+      "name": "class-construction",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 393.9719,
+              "minimum": 306.6882,
+              "standardDeviation": 70.7967,
+              "sampleCount": 6,
+              "innerIterations": 1,
+              "sampledDuration": 2363.8311
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0416,
+              "minimum": 0.0397,
+              "standardDeviation": 0.0032,
+              "sampleCount": 226,
+              "innerIterations": 32,
+              "sampledDuration": 300.7561
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.3451,
+              "minimum": 0.3119,
+              "standardDeviation": 0.0402,
+              "sampleCount": 218,
+              "innerIterations": 4,
+              "sampledDuration": 300.9309
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-field-reuse?n=1000",
+      "family": "classes",
+      "name": "class-field-reuse",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 3.0709,
+              "minimum": 1.3613,
+              "standardDeviation": 1.4847,
+              "sampleCount": 98,
+              "innerIterations": 1,
+              "sampledDuration": 300.9503
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0026,
+              "minimum": 0.0005,
+              "standardDeviation": 0.0107,
+              "sampleCount": 100000,
+              "innerIterations": 1,
+              "sampledDuration": 263.5771
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0004,
+              "minimum": 0.0003,
+              "standardDeviation": 0.0001,
+              "sampleCount": 201,
+              "innerIterations": 4096,
+              "sampledDuration": 301.1975
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-field-reuse?n=10000",
+      "family": "classes",
+      "name": "class-field-reuse",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 6.4067,
+              "minimum": 5.1055,
+              "standardDeviation": 0.9127,
+              "sampleCount": 47,
+              "innerIterations": 1,
+              "sampledDuration": 301.1144
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.005,
+              "minimum": 0.0047,
+              "standardDeviation": 0.0003,
+              "sampleCount": 236,
+              "innerIterations": 256,
+              "sampledDuration": 300.6053
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0063,
+              "minimum": 0.006,
+              "standardDeviation": 0.0005,
+              "sampleCount": 186,
+              "innerIterations": 256,
+              "sampledDuration": 301.4652
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-field-reuse?n=100000",
+      "family": "classes",
+      "name": "class-field-reuse",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 67.3117,
+              "minimum": 65.0498,
+              "standardDeviation": 1.5185,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 538.4939
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0546,
+              "minimum": 0.0485,
+              "standardDeviation": 0.0076,
+              "sampleCount": 172,
+              "innerIterations": 32,
+              "sampledDuration": 300.5021
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0879,
+              "minimum": 0.0819,
+              "standardDeviation": 0.0053,
+              "sampleCount": 214,
+              "innerIterations": 16,
+              "sampledDuration": 301.1121
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-method-inheritance-base?n=1000",
+      "family": "classes",
+      "name": "class-method-inheritance-base",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.1562,
+              "minimum": 0.8441,
+              "standardDeviation": 0.3393,
+              "sampleCount": 260,
+              "innerIterations": 1,
+              "sampledDuration": 300.6228
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0009,
+              "minimum": 0.0005,
+              "standardDeviation": 0.002,
+              "sampleCount": 2697,
+              "innerIterations": 128,
+              "sampledDuration": 300.0159
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0004,
+              "minimum": 0.0003,
+              "standardDeviation": 0.0,
+              "sampleCount": 205,
+              "innerIterations": 4096,
+              "sampledDuration": 301.3448
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-method-inheritance-base?n=10000",
+      "family": "classes",
+      "name": "class-method-inheritance-base",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 10.0058,
+              "minimum": 8.2842,
+              "standardDeviation": 0.8229,
+              "sampleCount": 31,
+              "innerIterations": 1,
+              "sampledDuration": 310.1788
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0053,
+              "minimum": 0.0047,
+              "standardDeviation": 0.0005,
+              "sampleCount": 223,
+              "innerIterations": 256,
+              "sampledDuration": 300.8752
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0062,
+              "minimum": 0.006,
+              "standardDeviation": 0.0002,
+              "sampleCount": 190,
+              "innerIterations": 256,
+              "sampledDuration": 300.3062
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-method-inheritance-base?n=100000",
+      "family": "classes",
+      "name": "class-method-inheritance-base",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 108.3974,
+              "minimum": 98.0616,
+              "standardDeviation": 6.4888,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 867.1794
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0531,
+              "minimum": 0.0485,
+              "standardDeviation": 0.0038,
+              "sampleCount": 177,
+              "innerIterations": 32,
+              "sampledDuration": 300.6573
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0971,
+              "minimum": 0.0925,
+              "standardDeviation": 0.0052,
+              "sampleCount": 194,
+              "innerIterations": 16,
+              "sampledDuration": 301.3239
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-method-inherited?n=1000",
+      "family": "classes",
+      "name": "class-method-inherited",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.916,
+              "minimum": 0.7997,
+              "standardDeviation": 0.0751,
+              "sampleCount": 328,
+              "innerIterations": 1,
+              "sampledDuration": 300.436
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0009,
+              "minimum": 0.0005,
+              "standardDeviation": 0.0019,
+              "sampleCount": 2609,
+              "innerIterations": 128,
+              "sampledDuration": 300.0505
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.001,
+              "minimum": 0.001,
+              "standardDeviation": 0.0001,
+              "sampleCount": 287,
+              "innerIterations": 1024,
+              "sampledDuration": 301.052
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-method-inherited?n=10000",
+      "family": "classes",
+      "name": "class-method-inherited",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 10.7893,
+              "minimum": 8.5977,
+              "standardDeviation": 1.0748,
+              "sampleCount": 28,
+              "innerIterations": 1,
+              "sampledDuration": 302.0996
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0054,
+              "minimum": 0.0049,
+              "standardDeviation": 0.0008,
+              "sampleCount": 219,
+              "innerIterations": 256,
+              "sampledDuration": 300.4839
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0106,
+              "minimum": 0.0098,
+              "standardDeviation": 0.001,
+              "sampleCount": 221,
+              "innerIterations": 128,
+              "sampledDuration": 300.5224
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-method-inherited?n=100000",
+      "family": "classes",
+      "name": "class-method-inherited",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 105.9738,
+              "minimum": 98.0993,
+              "standardDeviation": 5.8216,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 847.7906
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0527,
+              "minimum": 0.049,
+              "standardDeviation": 0.0035,
+              "sampleCount": 178,
+              "innerIterations": 32,
+              "sampledDuration": 300.1717
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0986,
+              "minimum": 0.0903,
+              "standardDeviation": 0.0067,
+              "sampleCount": 191,
+              "innerIterations": 16,
+              "sampledDuration": 301.3934
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-method-override?n=1000",
+      "family": "classes",
+      "name": "class-method-override",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.8838,
+              "minimum": 0.7672,
+              "standardDeviation": 0.0637,
+              "sampleCount": 170,
+              "innerIterations": 2,
+              "sampledDuration": 300.4848
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0009,
+              "minimum": 0.0005,
+              "standardDeviation": 0.0021,
+              "sampleCount": 2752,
+              "innerIterations": 128,
+              "sampledDuration": 300.0657
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.001,
+              "minimum": 0.001,
+              "standardDeviation": 0.0001,
+              "sampleCount": 295,
+              "innerIterations": 1024,
+              "sampledDuration": 300.8492
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-method-override?n=10000",
+      "family": "classes",
+      "name": "class-method-override",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 10.7542,
+              "minimum": 8.5048,
+              "standardDeviation": 1.7882,
+              "sampleCount": 28,
+              "innerIterations": 1,
+              "sampledDuration": 301.1165
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0049,
+              "minimum": 0.0047,
+              "standardDeviation": 0.0003,
+              "sampleCount": 238,
+              "innerIterations": 256,
+              "sampledDuration": 300.6046
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0107,
+              "minimum": 0.0102,
+              "standardDeviation": 0.0007,
+              "sampleCount": 220,
+              "innerIterations": 128,
+              "sampledDuration": 300.2118
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-method-override?n=100000",
+      "family": "classes",
+      "name": "class-method-override",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 118.1751,
+              "minimum": 109.5446,
+              "standardDeviation": 5.7556,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 945.401
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.052,
+              "minimum": 0.0485,
+              "standardDeviation": 0.0058,
+              "sampleCount": 181,
+              "innerIterations": 32,
+              "sampledDuration": 300.8974
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1017,
+              "minimum": 0.0926,
+              "standardDeviation": 0.006,
+              "sampleCount": 185,
+              "innerIterations": 16,
+              "sampledDuration": 300.907
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-method-reuse?n=1000",
+      "family": "classes",
+      "name": "class-method-reuse",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.0034,
+              "minimum": 1.5588,
+              "standardDeviation": 0.2157,
+              "sampleCount": 150,
+              "innerIterations": 1,
+              "sampledDuration": 300.5062
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0007,
+              "minimum": 0.0005,
+              "standardDeviation": 0.0013,
+              "sampleCount": 3367,
+              "innerIterations": 128,
+              "sampledDuration": 300.0269
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0004,
+              "minimum": 0.0003,
+              "standardDeviation": 0.0,
+              "sampleCount": 202,
+              "innerIterations": 4096,
+              "sampledDuration": 300.9268
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-method-reuse?n=10000",
+      "family": "classes",
+      "name": "class-method-reuse",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 10.0736,
+              "minimum": 7.9396,
+              "standardDeviation": 0.8651,
+              "sampleCount": 30,
+              "innerIterations": 1,
+              "sampledDuration": 302.2065
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0053,
+              "minimum": 0.0046,
+              "standardDeviation": 0.0008,
+              "sampleCount": 222,
+              "innerIterations": 256,
+              "sampledDuration": 300.4916
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0062,
+              "minimum": 0.006,
+              "standardDeviation": 0.0003,
+              "sampleCount": 191,
+              "innerIterations": 256,
+              "sampledDuration": 301.3131
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-method-reuse?n=100000",
+      "family": "classes",
+      "name": "class-method-reuse",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 99.2617,
+              "minimum": 95.1741,
+              "standardDeviation": 3.4006,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 794.0932
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0502,
+              "minimum": 0.0485,
+              "standardDeviation": 0.0026,
+              "sampleCount": 187,
+              "innerIterations": 32,
+              "sampledDuration": 300.1429
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0929,
+              "minimum": 0.0884,
+              "standardDeviation": 0.0058,
+              "sampleCount": 202,
+              "innerIterations": 16,
+              "sampledDuration": 300.0934
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-method-super?n=1000",
+      "family": "classes",
+      "name": "class-method-super",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.6198,
+              "minimum": 1.4386,
+              "standardDeviation": 0.107,
+              "sampleCount": 186,
+              "innerIterations": 1,
+              "sampledDuration": 301.2791
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.001,
+              "minimum": 0.0005,
+              "standardDeviation": 0.002,
+              "sampleCount": 4816,
+              "innerIterations": 64,
+              "sampledDuration": 300.0171
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.001,
+              "minimum": 0.001,
+              "standardDeviation": 0.0,
+              "sampleCount": 297,
+              "innerIterations": 1024,
+              "sampledDuration": 300.5015
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-method-super?n=10000",
+      "family": "classes",
+      "name": "class-method-super",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 18.3468,
+              "minimum": 17.1346,
+              "standardDeviation": 1.3587,
+              "sampleCount": 17,
+              "innerIterations": 1,
+              "sampledDuration": 311.896
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0054,
+              "minimum": 0.0049,
+              "standardDeviation": 0.0007,
+              "sampleCount": 436,
+              "innerIterations": 128,
+              "sampledDuration": 300.4125
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0102,
+              "minimum": 0.0098,
+              "standardDeviation": 0.0008,
+              "sampleCount": 231,
+              "innerIterations": 128,
+              "sampledDuration": 300.6087
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "classes/class-method-super?n=100000",
+      "family": "classes",
+      "name": "class-method-super",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 185.8481,
+              "minimum": 174.7893,
+              "standardDeviation": 8.1364,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 1486.7851
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0513,
+              "minimum": 0.0487,
+              "standardDeviation": 0.0033,
+              "sampleCount": 183,
+              "innerIterations": 32,
+              "sampledDuration": 300.2921
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1156,
+              "minimum": 0.1108,
+              "standardDeviation": 0.0054,
+              "sampleCount": 325,
+              "innerIterations": 8,
+              "sampledDuration": 300.4996
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "closures/closures?n=1000",
+      "family": "closures",
+      "name": "closures",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.9903,
+              "minimum": 0.5976,
+              "standardDeviation": 1.8019,
+              "sampleCount": 151,
+              "innerIterations": 1,
+              "sampledDuration": 300.529
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0035,
+              "minimum": 0.0015,
+              "standardDeviation": 0.007,
+              "sampleCount": 84816,
+              "innerIterations": 1,
+              "sampledDuration": 300.0009
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0097,
+              "minimum": 0.0076,
+              "standardDeviation": 0.0018,
+              "sampleCount": 121,
+              "innerIterations": 256,
+              "sampledDuration": 301.4998
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "closures/closures?n=10000",
+      "family": "closures",
+      "name": "closures",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 6.075,
+              "minimum": 5.7501,
+              "standardDeviation": 0.201,
+              "sampleCount": 50,
+              "innerIterations": 1,
+              "sampledDuration": 303.7486
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0181,
+              "minimum": 0.0158,
+              "standardDeviation": 0.003,
+              "sampleCount": 260,
+              "innerIterations": 64,
+              "sampledDuration": 300.68
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0806,
+              "minimum": 0.0684,
+              "standardDeviation": 0.0142,
+              "sampleCount": 233,
+              "innerIterations": 16,
+              "sampledDuration": 300.5369
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "closures/closures?n=100000",
+      "family": "closures",
+      "name": "closures",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 63.1812,
+              "minimum": 60.311,
+              "standardDeviation": 2.0221,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 505.4498
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1771,
+              "minimum": 0.158,
+              "standardDeviation": 0.0172,
+              "sampleCount": 212,
+              "innerIterations": 8,
+              "sampledDuration": 300.2783
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.8281,
+              "minimum": 0.7114,
+              "standardDeviation": 0.1177,
+              "sampleCount": 363,
+              "innerIterations": 1,
+              "sampledDuration": 300.5851
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "count-primes/count-primes?n=1000",
+      "family": "count-primes",
+      "name": "count-primes",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 8.5581,
+              "minimum": 6.2204,
+              "standardDeviation": 4.3922,
+              "sampleCount": 36,
+              "innerIterations": 1,
+              "sampledDuration": 308.0914
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0128,
+              "minimum": 0.0067,
+              "standardDeviation": 0.0174,
+              "sampleCount": 23353,
+              "innerIterations": 1,
+              "sampledDuration": 300.007
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0029,
+              "minimum": 0.0025,
+              "standardDeviation": 0.0003,
+              "sampleCount": 205,
+              "innerIterations": 512,
+              "sampledDuration": 300.6692
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "count-primes/count-primes?n=10000",
+      "family": "count-primes",
+      "name": "count-primes",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 55.3893,
+              "minimum": 21.5058,
+              "standardDeviation": 58.0787,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 443.1144
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0821,
+              "minimum": 0.074,
+              "standardDeviation": 0.0067,
+              "sampleCount": 229,
+              "innerIterations": 16,
+              "sampledDuration": 300.6351
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0419,
+              "minimum": 0.0367,
+              "standardDeviation": 0.0048,
+              "sampleCount": 224,
+              "innerIterations": 32,
+              "sampledDuration": 300.3659
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "count-primes/count-primes?n=100000",
+      "family": "count-primes",
+      "name": "count-primes",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 226.993,
+              "minimum": 211.1688,
+              "standardDeviation": 13.6597,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 1815.9438
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.0118,
+              "minimum": 0.785,
+              "standardDeviation": 0.2662,
+              "sampleCount": 149,
+              "innerIterations": 2,
+              "sampledDuration": 301.5128
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.8562,
+              "minimum": 0.6863,
+              "standardDeviation": 0.267,
+              "sampleCount": 351,
+              "innerIterations": 1,
+              "sampledDuration": 300.5207
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "date-numeric/date-numeric?n=100",
+      "family": "date-numeric",
+      "name": "date-numeric",
+      "parameters": {
+        "n": 100.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.4121,
+              "minimum": 0.2982,
+              "standardDeviation": 0.7271,
+              "sampleCount": 728,
+              "innerIterations": 1,
+              "sampledDuration": 300.0054
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0023,
+              "minimum": 0.0018,
+              "standardDeviation": 0.0055,
+              "sampleCount": 100000,
+              "innerIterations": 1,
+              "sampledDuration": 230.4859
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0007,
+              "minimum": 0.0006,
+              "standardDeviation": 0.0001,
+              "sampleCount": 208,
+              "innerIterations": 2048,
+              "sampledDuration": 300.7719
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "date-numeric/date-numeric?n=10000",
+      "family": "date-numeric",
+      "name": "date-numeric",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 25.0837,
+              "minimum": 6.0762,
+              "standardDeviation": 22.3835,
+              "sampleCount": 12,
+              "innerIterations": 1,
+              "sampledDuration": 301.0039
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.067,
+              "minimum": 0.0467,
+              "standardDeviation": 0.0332,
+              "sampleCount": 560,
+              "innerIterations": 8,
+              "sampledDuration": 300.0556
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0669,
+              "minimum": 0.0571,
+              "standardDeviation": 0.0056,
+              "sampleCount": 141,
+              "innerIterations": 32,
+              "sampledDuration": 301.6813
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "date-numeric/date-numeric?n=100000",
+      "family": "date-numeric",
+      "name": "date-numeric",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 54.114,
+              "minimum": 51.446,
+              "standardDeviation": 2.274,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 432.912
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.4556,
+              "minimum": 0.4335,
+              "standardDeviation": 0.0193,
+              "sampleCount": 165,
+              "innerIterations": 4,
+              "sampledDuration": 300.7112
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.6402,
+              "minimum": 0.536,
+              "standardDeviation": 0.1224,
+              "sampleCount": 469,
+              "innerIterations": 1,
+              "sampledDuration": 300.2495
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "exceptions/throw-branch-control?n=100000",
+      "family": "exceptions",
+      "name": "throw-branch-control",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 100.8883,
+              "minimum": 38.817,
+              "standardDeviation": 89.7259,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 807.1064
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.155,
+              "minimum": 0.1411,
+              "standardDeviation": 0.045,
+              "sampleCount": 1936,
+              "innerIterations": 1,
+              "sampledDuration": 300.0036
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.069,
+              "minimum": 0.0679,
+              "standardDeviation": 0.0022,
+              "sampleCount": 272,
+              "innerIterations": 16,
+              "sampledDuration": 300.2367
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "exceptions/throw-error?n=100000",
+      "family": "exceptions",
+      "name": "throw-error",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 40.3474,
+              "minimum": 38.8353,
+              "standardDeviation": 1.2247,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 322.7791
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.3885,
+              "minimum": 1.0341,
+              "standardDeviation": 2.033,
+              "sampleCount": 217,
+              "innerIterations": 1,
+              "sampledDuration": 301.3021
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.3971,
+              "minimum": 0.3309,
+              "standardDeviation": 0.0218,
+              "sampleCount": 189,
+              "innerIterations": 4,
+              "sampledDuration": 300.1747
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "exceptions/throw-primitive?n=100000",
+      "family": "exceptions",
+      "name": "throw-primitive",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 39.4917,
+              "minimum": 38.5246,
+              "standardDeviation": 0.9107,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 315.9338
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1944,
+              "minimum": 0.1546,
+              "standardDeviation": 0.0386,
+              "sampleCount": 1544,
+              "innerIterations": 1,
+              "sampledDuration": 300.1542
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.114,
+              "minimum": 0.1116,
+              "standardDeviation": 0.0038,
+              "sampleCount": 165,
+              "innerIterations": 16,
+              "sampledDuration": 300.873
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "exceptions/throw-try-catch-no-throw?n=100000",
+      "family": "exceptions",
+      "name": "throw-try-catch-no-throw",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 45.9121,
+              "minimum": 43.7309,
+              "standardDeviation": 1.8418,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 367.2964
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1514,
+              "minimum": 0.1441,
+              "standardDeviation": 0.0076,
+              "sampleCount": 248,
+              "innerIterations": 8,
+              "sampledDuration": 300.3459
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0689,
+              "minimum": 0.0679,
+              "standardDeviation": 0.0022,
+              "sampleCount": 273,
+              "innerIterations": 16,
+              "sampledDuration": 300.7404
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "factorial/factorial?n=100",
+      "family": "factorial",
+      "name": "factorial",
+      "parameters": {
+        "n": 100.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1107,
+              "minimum": 0.0272,
+              "standardDeviation": 0.4281,
+              "sampleCount": 2709,
+              "innerIterations": 1,
+              "sampledDuration": 300.0077
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0009,
+              "minimum": 0.0006,
+              "standardDeviation": 0.0047,
+              "sampleCount": 100000,
+              "innerIterations": 1,
+              "sampledDuration": 88.8106
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0,
+              "minimum": 0.0,
+              "standardDeviation": 0.0,
+              "sampleCount": 388,
+              "innerIterations": 16384,
+              "sampledDuration": 300.4863
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "factorial/factorial?n=1000",
+      "family": "factorial",
+      "name": "factorial",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.2617,
+              "minimum": 0.2386,
+              "standardDeviation": 0.0136,
+              "sampleCount": 144,
+              "innerIterations": 8,
+              "sampledDuration": 301.4825
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.001,
+              "minimum": 0.0008,
+              "standardDeviation": 0.0007,
+              "sampleCount": 583,
+              "innerIterations": 512,
+              "sampledDuration": 300.1226
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0008,
+              "minimum": 0.0008,
+              "standardDeviation": 0.0,
+              "sampleCount": 192,
+              "innerIterations": 2048,
+              "sampledDuration": 301.1519
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "factorial/factorial?n=10000",
+      "family": "factorial",
+      "name": "factorial",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.5029,
+              "minimum": 2.3665,
+              "standardDeviation": 0.1176,
+              "sampleCount": 120,
+              "innerIterations": 1,
+              "sampledDuration": 300.3457
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.008,
+              "minimum": 0.0078,
+              "standardDeviation": 0.0003,
+              "sampleCount": 293,
+              "innerIterations": 128,
+              "sampledDuration": 300.3198
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0079,
+              "minimum": 0.0078,
+              "standardDeviation": 0.0003,
+              "sampleCount": 296,
+              "innerIterations": 128,
+              "sampledDuration": 300.9077
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "fibonacci/fibonacci?n=10",
+      "family": "fibonacci",
+      "name": "fibonacci",
+      "parameters": {
+        "n": 10.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.2486,
+              "minimum": 0.0592,
+              "standardDeviation": 0.2411,
+              "sampleCount": 1207,
+              "innerIterations": 1,
+              "sampledDuration": 300.0552
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0008,
+              "minimum": 0.0006,
+              "standardDeviation": 0.005,
+              "sampleCount": 100000,
+              "innerIterations": 1,
+              "sampledDuration": 79.7618
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0004,
+              "minimum": 0.0003,
+              "standardDeviation": 0.0,
+              "sampleCount": 210,
+              "innerIterations": 4096,
+              "sampledDuration": 301.3437
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "fibonacci/fibonacci?n=20",
+      "family": "fibonacci",
+      "name": "fibonacci",
+      "parameters": {
+        "n": 20.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 7.2281,
+              "minimum": 6.8823,
+              "standardDeviation": 0.1644,
+              "sampleCount": 42,
+              "innerIterations": 1,
+              "sampledDuration": 303.5794
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.02,
+              "minimum": 0.0176,
+              "standardDeviation": 0.005,
+              "sampleCount": 235,
+              "innerIterations": 64,
+              "sampledDuration": 300.1318
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0435,
+              "minimum": 0.042,
+              "standardDeviation": 0.0025,
+              "sampleCount": 216,
+              "innerIterations": 32,
+              "sampledDuration": 300.4167
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "fibonacci/fibonacci?n=30",
+      "family": "fibonacci",
+      "name": "fibonacci",
+      "parameters": {
+        "n": 30.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 879.6726,
+              "minimum": 861.1476,
+              "standardDeviation": 19.2087,
+              "sampleCount": 3,
+              "innerIterations": 1,
+              "sampledDuration": 2639.0177
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.205,
+              "minimum": 2.1561,
+              "standardDeviation": 0.0515,
+              "sampleCount": 137,
+              "innerIterations": 1,
+              "sampledDuration": 302.0915
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 5.2632,
+              "minimum": 5.1703,
+              "standardDeviation": 0.2158,
+              "sampleCount": 58,
+              "innerIterations": 1,
+              "sampledDuration": 305.2659
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "fibonacci/fibonacci?n=35",
+      "family": "fibonacci",
+      "name": "fibonacci",
+      "parameters": {
+        "n": 35.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 9686.9027,
+              "minimum": 9686.9027,
+              "standardDeviation": 0.0,
+              "sampleCount": 1,
+              "innerIterations": 1,
+              "sampledDuration": 9686.9027
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 24.3767,
+              "minimum": 24.1287,
+              "standardDeviation": 0.1961,
+              "sampleCount": 13,
+              "innerIterations": 1,
+              "sampledDuration": 316.897
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 61.2812,
+              "minimum": 58.6655,
+              "standardDeviation": 2.1284,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 490.2498
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "int-arrays/accumulate?n=1000",
+      "family": "int-arrays",
+      "name": "accumulate",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 3.7663,
+              "minimum": 3.3156,
+              "standardDeviation": 0.334,
+              "sampleCount": 80,
+              "innerIterations": 1,
+              "sampledDuration": 301.301
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0042,
+              "minimum": 0.0034,
+              "standardDeviation": 0.0011,
+              "sampleCount": 278,
+              "innerIterations": 256,
+              "sampledDuration": 300.6925
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0049,
+              "minimum": 0.0032,
+              "standardDeviation": 0.0008,
+              "sampleCount": 238,
+              "innerIterations": 256,
+              "sampledDuration": 300.5046
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "int-arrays/accumulate?n=100000",
+      "family": "int-arrays",
+      "name": "accumulate",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 242.7848,
+              "minimum": 236.4177,
+              "standardDeviation": 11.9604,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 1942.2786
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.4825,
+              "minimum": 0.4537,
+              "standardDeviation": 0.0376,
+              "sampleCount": 156,
+              "innerIterations": 4,
+              "sampledDuration": 301.1104
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.446,
+              "minimum": 0.3658,
+              "standardDeviation": 0.3742,
+              "sampleCount": 673,
+              "innerIterations": 1,
+              "sampledDuration": 300.1851
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "int-arrays/accumulate?n=1000000",
+      "family": "int-arrays",
+      "name": "accumulate",
+      "parameters": {
+        "n": 1000000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2446.7923,
+              "minimum": 2446.7923,
+              "standardDeviation": 0.0,
+              "sampleCount": 1,
+              "innerIterations": 1,
+              "sampledDuration": 2446.7923
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 3.8893,
+              "minimum": 3.3842,
+              "standardDeviation": 0.4158,
+              "sampleCount": 78,
+              "innerIterations": 1,
+              "sampledDuration": 303.3665
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 3.6623,
+              "minimum": 3.3371,
+              "standardDeviation": 0.2454,
+              "sampleCount": 82,
+              "innerIterations": 1,
+              "sampledDuration": 300.3071
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "int-arrays/int32-kernel?n=1000",
+      "family": "int-arrays",
+      "name": "int32-kernel",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 3.7141,
+              "minimum": 1.2771,
+              "standardDeviation": 3.0751,
+              "sampleCount": 81,
+              "innerIterations": 1,
+              "sampledDuration": 300.8437
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0036,
+              "minimum": 0.002,
+              "standardDeviation": 0.0082,
+              "sampleCount": 83666,
+              "innerIterations": 1,
+              "sampledDuration": 300.1812
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0028,
+              "minimum": 0.0023,
+              "standardDeviation": 0.0004,
+              "sampleCount": 207,
+              "innerIterations": 512,
+              "sampledDuration": 301.0011
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "int-arrays/int32-kernel?n=100000",
+      "family": "int-arrays",
+      "name": "int32-kernel",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 121.3367,
+              "minimum": 110.7579,
+              "standardDeviation": 8.747,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 970.6934
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.277,
+              "minimum": 0.2327,
+              "standardDeviation": 0.042,
+              "sampleCount": 271,
+              "innerIterations": 4,
+              "sampledDuration": 300.2604
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.2672,
+              "minimum": 0.2244,
+              "standardDeviation": 0.1278,
+              "sampleCount": 141,
+              "innerIterations": 8,
+              "sampledDuration": 301.4233
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "int-arrays/int32-kernel?n=1000000",
+      "family": "int-arrays",
+      "name": "int32-kernel",
+      "parameters": {
+        "n": 1000000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1060.1627,
+              "minimum": 1059.1806,
+              "standardDeviation": 1.3889,
+              "sampleCount": 2,
+              "innerIterations": 1,
+              "sampledDuration": 2120.3254
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.2354,
+              "minimum": 2.0452,
+              "standardDeviation": 0.1872,
+              "sampleCount": 135,
+              "innerIterations": 1,
+              "sampledDuration": 301.7829
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.1043,
+              "minimum": 1.9452,
+              "standardDeviation": 0.2521,
+              "sampleCount": 143,
+              "innerIterations": 1,
+              "sampledDuration": 300.9135
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "json/json?n=100",
+      "family": "json",
+      "name": "json",
+      "parameters": {
+        "n": 100.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.9175,
+              "minimum": 0.7163,
+              "standardDeviation": 1.3944,
+              "sampleCount": 327,
+              "innerIterations": 1,
+              "sampledDuration": 300.0337
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0169,
+              "minimum": 0.0078,
+              "standardDeviation": 0.1904,
+              "sampleCount": 17752,
+              "innerIterations": 1,
+              "sampledDuration": 300.0016
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.02,
+              "minimum": 0.019,
+              "standardDeviation": 0.0011,
+              "sampleCount": 234,
+              "innerIterations": 64,
+              "sampledDuration": 300.1723
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "json/json?n=1000",
+      "family": "json",
+      "name": "json",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 7.5477,
+              "minimum": 6.9175,
+              "standardDeviation": 1.1818,
+              "sampleCount": 40,
+              "innerIterations": 1,
+              "sampledDuration": 301.9064
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0869,
+              "minimum": 0.0756,
+              "standardDeviation": 0.01,
+              "sampleCount": 216,
+              "innerIterations": 16,
+              "sampledDuration": 300.1874
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1822,
+              "minimum": 0.1752,
+              "standardDeviation": 0.0074,
+              "sampleCount": 206,
+              "innerIterations": 8,
+              "sampledDuration": 300.3263
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "json/json?n=10000",
+      "family": "json",
+      "name": "json",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 62.3703,
+              "minimum": 26.4455,
+              "standardDeviation": 30.9219,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 498.9627
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 4.0528,
+              "minimum": 0.8006,
+              "standardDeviation": 5.4417,
+              "sampleCount": 75,
+              "innerIterations": 1,
+              "sampledDuration": 303.963
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.1659,
+              "minimum": 1.9171,
+              "standardDeviation": 0.3215,
+              "sampleCount": 139,
+              "innerIterations": 1,
+              "sampledDuration": 301.0564
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/flattened-rest-control?n=1000",
+      "family": "language-hot-paths",
+      "name": "flattened-rest-control",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.3395,
+              "minimum": 0.3158,
+              "standardDeviation": 0.0144,
+              "sampleCount": 221,
+              "innerIterations": 4,
+              "sampledDuration": 300.099
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0021,
+              "minimum": 0.0015,
+              "standardDeviation": 0.0011,
+              "sampleCount": 554,
+              "innerIterations": 256,
+              "sampledDuration": 300.2321
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0004,
+              "minimum": 0.0004,
+              "standardDeviation": 0.0,
+              "sampleCount": 176,
+              "innerIterations": 4096,
+              "sampledDuration": 301.3967
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/flattened-rest-control?n=10000",
+      "family": "language-hot-paths",
+      "name": "flattened-rest-control",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 3.8431,
+              "minimum": 3.2824,
+              "standardDeviation": 0.2373,
+              "sampleCount": 79,
+              "innerIterations": 1,
+              "sampledDuration": 303.6018
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0159,
+              "minimum": 0.0155,
+              "standardDeviation": 0.0006,
+              "sampleCount": 296,
+              "innerIterations": 64,
+              "sampledDuration": 300.6024
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0048,
+              "minimum": 0.0046,
+              "standardDeviation": 0.0003,
+              "sampleCount": 244,
+              "innerIterations": 256,
+              "sampledDuration": 300.7741
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/flattened-rest-control?n=100000",
+      "family": "language-hot-paths",
+      "name": "flattened-rest-control",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 31.7673,
+              "minimum": 31.0433,
+              "standardDeviation": 0.6224,
+              "sampleCount": 10,
+              "innerIterations": 1,
+              "sampledDuration": 317.6731
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1607,
+              "minimum": 0.1549,
+              "standardDeviation": 0.0063,
+              "sampleCount": 234,
+              "innerIterations": 8,
+              "sampledDuration": 300.8016
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1585,
+              "minimum": 0.1562,
+              "standardDeviation": 0.0054,
+              "sampleCount": 237,
+              "innerIterations": 8,
+              "sampledDuration": 300.4369
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/format-fixed?n=1000",
+      "family": "language-hot-paths",
+      "name": "format-fixed",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.8609,
+              "minimum": 0.7242,
+              "standardDeviation": 0.1242,
+              "sampleCount": 349,
+              "innerIterations": 1,
+              "sampledDuration": 300.465
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1035,
+              "minimum": 0.0379,
+              "standardDeviation": 0.093,
+              "sampleCount": 2898,
+              "innerIterations": 1,
+              "sampledDuration": 300.0282
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0637,
+              "minimum": 0.0597,
+              "standardDeviation": 0.0052,
+              "sampleCount": 295,
+              "innerIterations": 16,
+              "sampledDuration": 300.8404
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/format-fixed?n=10000",
+      "family": "language-hot-paths",
+      "name": "format-fixed",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 7.5637,
+              "minimum": 7.0711,
+              "standardDeviation": 0.3331,
+              "sampleCount": 40,
+              "innerIterations": 1,
+              "sampledDuration": 302.5497
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.4346,
+              "minimum": 0.4122,
+              "standardDeviation": 0.0258,
+              "sampleCount": 173,
+              "innerIterations": 4,
+              "sampledDuration": 300.7718
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.6316,
+              "minimum": 0.5974,
+              "standardDeviation": 0.0386,
+              "sampleCount": 238,
+              "innerIterations": 2,
+              "sampledDuration": 300.626
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/format-fixed?n=100000",
+      "family": "language-hot-paths",
+      "name": "format-fixed",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 73.6962,
+              "minimum": 72.3429,
+              "standardDeviation": 0.6927,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 589.5697
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 4.467,
+              "minimum": 4.2391,
+              "standardDeviation": 0.166,
+              "sampleCount": 68,
+              "innerIterations": 1,
+              "sampledDuration": 303.7563
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 6.1808,
+              "minimum": 6.02,
+              "standardDeviation": 0.129,
+              "sampleCount": 49,
+              "innerIterations": 1,
+              "sampledDuration": 302.8614
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/generator-range?n=1000",
+      "family": "language-hot-paths",
+      "name": "generator-range",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.775,
+              "minimum": 1.3613,
+              "standardDeviation": 1.075,
+              "sampleCount": 170,
+              "innerIterations": 1,
+              "sampledDuration": 301.7432
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0034,
+              "minimum": 0.0019,
+              "standardDeviation": 0.0052,
+              "sampleCount": 1380,
+              "innerIterations": 64,
+              "sampledDuration": 300.0495
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.009,
+              "minimum": 0.0083,
+              "standardDeviation": 0.0007,
+              "sampleCount": 260,
+              "innerIterations": 128,
+              "sampledDuration": 300.3891
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/generator-range?n=10000",
+      "family": "language-hot-paths",
+      "name": "generator-range",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 14.0678,
+              "minimum": 12.8809,
+              "standardDeviation": 1.8389,
+              "sampleCount": 22,
+              "innerIterations": 1,
+              "sampledDuration": 309.4917
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0196,
+              "minimum": 0.0191,
+              "standardDeviation": 0.0009,
+              "sampleCount": 239,
+              "innerIterations": 64,
+              "sampledDuration": 300.4759
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.09,
+              "minimum": 0.0842,
+              "standardDeviation": 0.0068,
+              "sampleCount": 209,
+              "innerIterations": 16,
+              "sampledDuration": 301.0175
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/generator-range?n=100000",
+      "family": "language-hot-paths",
+      "name": "generator-range",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 121.0215,
+              "minimum": 115.2698,
+              "standardDeviation": 4.311,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 968.1721
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1967,
+              "minimum": 0.1901,
+              "standardDeviation": 0.0089,
+              "sampleCount": 191,
+              "innerIterations": 8,
+              "sampledDuration": 300.6004
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.901,
+              "minimum": 0.8115,
+              "standardDeviation": 0.0664,
+              "sampleCount": 333,
+              "innerIterations": 1,
+              "sampledDuration": 300.0396
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/numeric-assignment-control?n=1000",
+      "family": "language-hot-paths",
+      "name": "numeric-assignment-control",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.29,
+              "minimum": 0.2536,
+              "standardDeviation": 0.0259,
+              "sampleCount": 259,
+              "innerIterations": 4,
+              "sampledDuration": 300.4614
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0006,
+              "minimum": 0.0004,
+              "standardDeviation": 0.0006,
+              "sampleCount": 1039,
+              "innerIterations": 512,
+              "sampledDuration": 300.0802
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0003,
+              "minimum": 0.0003,
+              "standardDeviation": 0.0,
+              "sampleCount": 256,
+              "innerIterations": 4096,
+              "sampledDuration": 300.1624
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/numeric-assignment-control?n=10000",
+      "family": "language-hot-paths",
+      "name": "numeric-assignment-control",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.7018,
+              "minimum": 2.5763,
+              "standardDeviation": 0.0682,
+              "sampleCount": 112,
+              "innerIterations": 1,
+              "sampledDuration": 302.6007
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0041,
+              "minimum": 0.004,
+              "standardDeviation": 0.0002,
+              "sampleCount": 290,
+              "innerIterations": 256,
+              "sampledDuration": 300.7135
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0037,
+              "minimum": 0.0036,
+              "standardDeviation": 0.0002,
+              "sampleCount": 159,
+              "innerIterations": 512,
+              "sampledDuration": 300.2876
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/numeric-assignment-control?n=100000",
+      "family": "language-hot-paths",
+      "name": "numeric-assignment-control",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 26.3975,
+              "minimum": 25.4875,
+              "standardDeviation": 0.8401,
+              "sampleCount": 12,
+              "innerIterations": 1,
+              "sampledDuration": 316.7697
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0403,
+              "minimum": 0.0396,
+              "standardDeviation": 0.0014,
+              "sampleCount": 233,
+              "innerIterations": 32,
+              "sampledDuration": 300.7375
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0464,
+              "minimum": 0.0454,
+              "standardDeviation": 0.0016,
+              "sampleCount": 202,
+              "innerIterations": 32,
+              "sampledDuration": 300.184
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/numeric-compound?n=1000",
+      "family": "language-hot-paths",
+      "name": "numeric-compound",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.7145,
+              "minimum": 0.5183,
+              "standardDeviation": 1.4271,
+              "sampleCount": 175,
+              "innerIterations": 1,
+              "sampledDuration": 300.041
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0021,
+              "minimum": 0.0004,
+              "standardDeviation": 0.0049,
+              "sampleCount": 100000,
+              "innerIterations": 1,
+              "sampledDuration": 205.6388
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0003,
+              "minimum": 0.0003,
+              "standardDeviation": 0.0,
+              "sampleCount": 256,
+              "innerIterations": 4096,
+              "sampledDuration": 300.2695
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/numeric-compound?n=10000",
+      "family": "language-hot-paths",
+      "name": "numeric-compound",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 3.705,
+              "minimum": 3.4611,
+              "standardDeviation": 0.1283,
+              "sampleCount": 81,
+              "innerIterations": 1,
+              "sampledDuration": 300.1065
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.004,
+              "minimum": 0.004,
+              "standardDeviation": 0.0001,
+              "sampleCount": 290,
+              "innerIterations": 256,
+              "sampledDuration": 300.4181
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0037,
+              "minimum": 0.0036,
+              "standardDeviation": 0.0003,
+              "sampleCount": 159,
+              "innerIterations": 512,
+              "sampledDuration": 300.3484
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/numeric-compound?n=100000",
+      "family": "language-hot-paths",
+      "name": "numeric-compound",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 34.9135,
+              "minimum": 33.8107,
+              "standardDeviation": 0.9493,
+              "sampleCount": 9,
+              "innerIterations": 1,
+              "sampledDuration": 314.2214
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0406,
+              "minimum": 0.0396,
+              "standardDeviation": 0.0023,
+              "sampleCount": 231,
+              "innerIterations": 32,
+              "sampledDuration": 300.3401
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0464,
+              "minimum": 0.0454,
+              "standardDeviation": 0.0019,
+              "sampleCount": 202,
+              "innerIterations": 32,
+              "sampledDuration": 300.1632
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/parse-integers?n=1000",
+      "family": "language-hot-paths",
+      "name": "parse-integers",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.9166,
+              "minimum": 0.6486,
+              "standardDeviation": 0.2886,
+              "sampleCount": 328,
+              "innerIterations": 1,
+              "sampledDuration": 300.6357
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0007,
+              "minimum": 0.0004,
+              "standardDeviation": 0.0008,
+              "sampleCount": 860,
+              "innerIterations": 512,
+              "sampledDuration": 300.1139
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0046,
+              "minimum": 0.0044,
+              "standardDeviation": 0.0004,
+              "sampleCount": 257,
+              "innerIterations": 256,
+              "sampledDuration": 300.7918
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/parse-integers?n=10000",
+      "family": "language-hot-paths",
+      "name": "parse-integers",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 7.2207,
+              "minimum": 6.6194,
+              "standardDeviation": 0.2762,
+              "sampleCount": 42,
+              "innerIterations": 1,
+              "sampledDuration": 303.2687
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.004,
+              "minimum": 0.004,
+              "standardDeviation": 0.0001,
+              "sampleCount": 290,
+              "innerIterations": 256,
+              "sampledDuration": 300.0116
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0461,
+              "minimum": 0.044,
+              "standardDeviation": 0.0031,
+              "sampleCount": 204,
+              "innerIterations": 32,
+              "sampledDuration": 300.9947
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/parse-integers?n=100000",
+      "family": "language-hot-paths",
+      "name": "parse-integers",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 63.3323,
+              "minimum": 62.6766,
+              "standardDeviation": 0.5728,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 506.6584
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0406,
+              "minimum": 0.0396,
+              "standardDeviation": 0.002,
+              "sampleCount": 231,
+              "innerIterations": 32,
+              "sampledDuration": 300.2894
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.1559,
+              "minimum": 1.0372,
+              "standardDeviation": 0.1656,
+              "sampleCount": 260,
+              "innerIterations": 1,
+              "sampledDuration": 300.5452
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/stable-numeric-rest?n=1000",
+      "family": "language-hot-paths",
+      "name": "stable-numeric-rest",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.9887,
+              "minimum": 0.8835,
+              "standardDeviation": 0.0634,
+              "sampleCount": 304,
+              "innerIterations": 1,
+              "sampledDuration": 300.5673
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0009,
+              "minimum": 0.0006,
+              "standardDeviation": 0.0009,
+              "sampleCount": 662,
+              "innerIterations": 512,
+              "sampledDuration": 300.0185
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0003,
+              "minimum": 0.0003,
+              "standardDeviation": 0.0,
+              "sampleCount": 236,
+              "innerIterations": 4096,
+              "sampledDuration": 301.0924
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/stable-numeric-rest?n=10000",
+      "family": "language-hot-paths",
+      "name": "stable-numeric-rest",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 9.224,
+              "minimum": 8.4633,
+              "standardDeviation": 0.3776,
+              "sampleCount": 33,
+              "innerIterations": 1,
+              "sampledDuration": 304.3932
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0056,
+              "minimum": 0.0055,
+              "standardDeviation": 0.0002,
+              "sampleCount": 209,
+              "innerIterations": 256,
+              "sampledDuration": 300.9576
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0064,
+              "minimum": 0.006,
+              "standardDeviation": 0.0004,
+              "sampleCount": 184,
+              "innerIterations": 256,
+              "sampledDuration": 301.0208
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "language-hot-paths/stable-numeric-rest?n=100000",
+      "family": "language-hot-paths",
+      "name": "stable-numeric-rest",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 90.8636,
+              "minimum": 88.7645,
+              "standardDeviation": 1.1439,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 726.9085
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0562,
+              "minimum": 0.055,
+              "standardDeviation": 0.0023,
+              "sampleCount": 167,
+              "innerIterations": 32,
+              "sampledDuration": 300.5873
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.5082,
+              "minimum": 0.4765,
+              "standardDeviation": 0.0416,
+              "sampleCount": 296,
+              "innerIterations": 2,
+              "sampledDuration": 300.8724
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "map-set/map-iteration?n=100",
+      "family": "map-set",
+      "name": "map-iteration",
+      "parameters": {
+        "n": 100.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0959,
+              "minimum": 0.0774,
+              "standardDeviation": 0.0365,
+              "sampleCount": 3128,
+              "innerIterations": 1,
+              "sampledDuration": 300.0211
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0023,
+              "minimum": 0.0016,
+              "standardDeviation": 0.0011,
+              "sampleCount": 518,
+              "innerIterations": 256,
+              "sampledDuration": 300.2174
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0017,
+              "minimum": 0.0015,
+              "standardDeviation": 0.0001,
+              "sampleCount": 177,
+              "innerIterations": 1024,
+              "sampledDuration": 301.2305
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "map-set/map-iteration?n=1000",
+      "family": "map-set",
+      "name": "map-iteration",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.7647,
+              "minimum": 0.6745,
+              "standardDeviation": 0.1176,
+              "sampleCount": 197,
+              "innerIterations": 2,
+              "sampledDuration": 301.2888
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.02,
+              "minimum": 0.0158,
+              "standardDeviation": 0.0026,
+              "sampleCount": 234,
+              "innerIterations": 64,
+              "sampledDuration": 300.1874
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0139,
+              "minimum": 0.0134,
+              "standardDeviation": 0.0004,
+              "sampleCount": 169,
+              "innerIterations": 128,
+              "sampledDuration": 300.0456
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "map-set/map-iteration?n=10000",
+      "family": "map-set",
+      "name": "map-iteration",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 12.3329,
+              "minimum": 8.8527,
+              "standardDeviation": 4.1894,
+              "sampleCount": 25,
+              "innerIterations": 1,
+              "sampledDuration": 308.3236
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.4148,
+              "minimum": 0.2185,
+              "standardDeviation": 0.0842,
+              "sampleCount": 181,
+              "innerIterations": 4,
+              "sampledDuration": 300.298
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.4442,
+              "minimum": 0.3619,
+              "standardDeviation": 0.1173,
+              "sampleCount": 169,
+              "innerIterations": 4,
+              "sampledDuration": 300.283
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "map-set/map-operations?n=100",
+      "family": "map-set",
+      "name": "map-operations",
+      "parameters": {
+        "n": 100.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.7198,
+              "minimum": 0.2172,
+              "standardDeviation": 0.7743,
+              "sampleCount": 417,
+              "innerIterations": 1,
+              "sampledDuration": 300.1557
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0035,
+              "minimum": 0.0013,
+              "standardDeviation": 0.0111,
+              "sampleCount": 85713,
+              "innerIterations": 1,
+              "sampledDuration": 300.0001
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0018,
+              "minimum": 0.0016,
+              "standardDeviation": 0.0001,
+              "sampleCount": 328,
+              "innerIterations": 512,
+              "sampledDuration": 300.797
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "map-set/map-operations?n=1000",
+      "family": "map-set",
+      "name": "map-operations",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.4931,
+              "minimum": 1.3645,
+              "standardDeviation": 0.1677,
+              "sampleCount": 201,
+              "innerIterations": 1,
+              "sampledDuration": 300.1127
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0149,
+              "minimum": 0.0131,
+              "standardDeviation": 0.0015,
+              "sampleCount": 158,
+              "innerIterations": 128,
+              "sampledDuration": 301.0844
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0169,
+              "minimum": 0.0157,
+              "standardDeviation": 0.0009,
+              "sampleCount": 278,
+              "innerIterations": 64,
+              "sampledDuration": 300.9773
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "map-set/map-operations?n=10000",
+      "family": "map-set",
+      "name": "map-operations",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 17.6836,
+              "minimum": 16.1864,
+              "standardDeviation": 0.8082,
+              "sampleCount": 17,
+              "innerIterations": 1,
+              "sampledDuration": 300.6214
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.3568,
+              "minimum": 0.1757,
+              "standardDeviation": 0.1182,
+              "sampleCount": 106,
+              "innerIterations": 8,
+              "sampledDuration": 302.5452
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.5046,
+              "minimum": 0.4308,
+              "standardDeviation": 0.2248,
+              "sampleCount": 595,
+              "innerIterations": 1,
+              "sampledDuration": 300.2357
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "map-set/set-iteration?n=100",
+      "family": "map-set",
+      "name": "set-iteration",
+      "parameters": {
+        "n": 100.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0637,
+              "minimum": 0.0561,
+              "standardDeviation": 0.0067,
+              "sampleCount": 148,
+              "innerIterations": 32,
+              "sampledDuration": 301.7816
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.003,
+              "minimum": 0.0019,
+              "standardDeviation": 0.0016,
+              "sampleCount": 388,
+              "innerIterations": 256,
+              "sampledDuration": 300.5087
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0013,
+              "minimum": 0.0012,
+              "standardDeviation": 0.0001,
+              "sampleCount": 234,
+              "innerIterations": 1024,
+              "sampledDuration": 301.0893
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "map-set/set-iteration?n=1000",
+      "family": "map-set",
+      "name": "set-iteration",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.6043,
+              "minimum": 0.5366,
+              "standardDeviation": 0.1007,
+              "sampleCount": 249,
+              "innerIterations": 2,
+              "sampledDuration": 300.9415
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0243,
+              "minimum": 0.0185,
+              "standardDeviation": 0.0096,
+              "sampleCount": 194,
+              "innerIterations": 64,
+              "sampledDuration": 301.8323
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0115,
+              "minimum": 0.0104,
+              "standardDeviation": 0.0011,
+              "sampleCount": 204,
+              "innerIterations": 128,
+              "sampledDuration": 301.3565
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "map-set/set-iteration?n=10000",
+      "family": "map-set",
+      "name": "set-iteration",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 8.4227,
+              "minimum": 5.5506,
+              "standardDeviation": 4.0131,
+              "sampleCount": 36,
+              "innerIterations": 1,
+              "sampledDuration": 303.2158
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.3088,
+              "minimum": 0.2,
+              "standardDeviation": 0.0727,
+              "sampleCount": 244,
+              "innerIterations": 4,
+              "sampledDuration": 301.3738
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.3353,
+              "minimum": 0.2915,
+              "standardDeviation": 0.1118,
+              "sampleCount": 224,
+              "innerIterations": 4,
+              "sampledDuration": 300.4013
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "map-set/set-operations?n=100",
+      "family": "map-set",
+      "name": "set-operations",
+      "parameters": {
+        "n": 100.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.135,
+              "minimum": 0.1088,
+              "standardDeviation": 0.0716,
+              "sampleCount": 2223,
+              "innerIterations": 1,
+              "sampledDuration": 300.0811
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.003,
+              "minimum": 0.0019,
+              "standardDeviation": 0.002,
+              "sampleCount": 390,
+              "innerIterations": 256,
+              "sampledDuration": 300.0461
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0015,
+              "minimum": 0.0015,
+              "standardDeviation": 0.0001,
+              "sampleCount": 190,
+              "innerIterations": 1024,
+              "sampledDuration": 300.4389
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "map-set/set-operations?n=1000",
+      "family": "map-set",
+      "name": "set-operations",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.2055,
+              "minimum": 1.0965,
+              "standardDeviation": 0.1528,
+              "sampleCount": 249,
+              "innerIterations": 1,
+              "sampledDuration": 300.1619
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0272,
+              "minimum": 0.0186,
+              "standardDeviation": 0.0077,
+              "sampleCount": 346,
+              "innerIterations": 32,
+              "sampledDuration": 300.6951
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0175,
+              "minimum": 0.0154,
+              "standardDeviation": 0.0017,
+              "sampleCount": 268,
+              "innerIterations": 64,
+              "sampledDuration": 300.2468
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "map-set/set-operations?n=10000",
+      "family": "map-set",
+      "name": "set-operations",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 14.0581,
+              "minimum": 12.1953,
+              "standardDeviation": 1.3839,
+              "sampleCount": 22,
+              "innerIterations": 1,
+              "sampledDuration": 309.2787
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.459,
+              "minimum": 0.2371,
+              "standardDeviation": 0.2013,
+              "sampleCount": 164,
+              "innerIterations": 4,
+              "sampledDuration": 301.0756
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.484,
+              "minimum": 0.4196,
+              "standardDeviation": 0.1262,
+              "sampleCount": 155,
+              "innerIterations": 4,
+              "sampledDuration": 300.0521
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "num-arrays/num-push?n=1000",
+      "family": "num-arrays",
+      "name": "num-push",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.416,
+              "minimum": 0.7923,
+              "standardDeviation": 0.8891,
+              "sampleCount": 213,
+              "innerIterations": 1,
+              "sampledDuration": 301.6162
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.006,
+              "minimum": 0.0035,
+              "standardDeviation": 0.0056,
+              "sampleCount": 782,
+              "innerIterations": 64,
+              "sampledDuration": 300.2942
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0031,
+              "minimum": 0.0029,
+              "standardDeviation": 0.0002,
+              "sampleCount": 187,
+              "innerIterations": 512,
+              "sampledDuration": 300.7615
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "num-arrays/num-push?n=100000",
+      "family": "num-arrays",
+      "name": "num-push",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 106.827,
+              "minimum": 96.8946,
+              "standardDeviation": 10.7431,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 854.6162
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.941,
+              "minimum": 0.5783,
+              "standardDeviation": 0.3235,
+              "sampleCount": 319,
+              "innerIterations": 1,
+              "sampledDuration": 300.173
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.7145,
+              "minimum": 0.5705,
+              "standardDeviation": 0.513,
+              "sampleCount": 420,
+              "innerIterations": 1,
+              "sampledDuration": 300.0841
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "num-arrays/num-push?n=1000000",
+      "family": "num-arrays",
+      "name": "num-push",
+      "parameters": {
+        "n": 1000000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1119.6098,
+              "minimum": 1061.4447,
+              "standardDeviation": 82.2578,
+              "sampleCount": 2,
+              "innerIterations": 1,
+              "sampledDuration": 2239.2195
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 5.6433,
+              "minimum": 4.2495,
+              "standardDeviation": 1.5181,
+              "sampleCount": 54,
+              "innerIterations": 1,
+              "sampledDuration": 304.7407
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 8.2229,
+              "minimum": 6.6098,
+              "standardDeviation": 1.7559,
+              "sampleCount": 37,
+              "innerIterations": 1,
+              "sampledDuration": 304.2473
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "num-arrays/num-write?n=1000",
+      "family": "num-arrays",
+      "name": "num-write",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 3.373,
+              "minimum": 0.9311,
+              "standardDeviation": 2.4694,
+              "sampleCount": 89,
+              "innerIterations": 1,
+              "sampledDuration": 300.1975
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0295,
+              "minimum": 0.0234,
+              "standardDeviation": 0.0273,
+              "sampleCount": 10160,
+              "innerIterations": 1,
+              "sampledDuration": 300.0109
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0029,
+              "minimum": 0.0025,
+              "standardDeviation": 0.0003,
+              "sampleCount": 206,
+              "innerIterations": 512,
+              "sampledDuration": 300.8125
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "num-arrays/num-write?n=100000",
+      "family": "num-arrays",
+      "name": "num-write",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 85.4286,
+              "minimum": 75.8148,
+              "standardDeviation": 8.9105,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 683.4292
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.821,
+              "minimum": 0.7519,
+              "standardDeviation": 0.0905,
+              "sampleCount": 183,
+              "innerIterations": 2,
+              "sampledDuration": 300.4908
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.7491,
+              "minimum": 0.5742,
+              "standardDeviation": 0.3596,
+              "sampleCount": 401,
+              "innerIterations": 1,
+              "sampledDuration": 300.3737
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "num-arrays/num-write?n=1000000",
+      "family": "num-arrays",
+      "name": "num-write",
+      "parameters": {
+        "n": 1000000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 919.1889,
+              "minimum": 884.5314,
+              "standardDeviation": 42.3722,
+              "sampleCount": 3,
+              "innerIterations": 1,
+              "sampledDuration": 2757.5668
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 5.6766,
+              "minimum": 4.4858,
+              "standardDeviation": 1.5199,
+              "sampleCount": 53,
+              "innerIterations": 1,
+              "sampledDuration": 300.8575
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 8.363,
+              "minimum": 6.7966,
+              "standardDeviation": 1.6393,
+              "sampleCount": 36,
+              "innerIterations": 1,
+              "sampledDuration": 301.0681
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "objects/objects?n=1000",
+      "family": "objects",
+      "name": "objects",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.1769,
+              "minimum": 0.5964,
+              "standardDeviation": 1.2167,
+              "sampleCount": 138,
+              "innerIterations": 1,
+              "sampledDuration": 300.4184
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0023,
+              "minimum": 0.0009,
+              "standardDeviation": 0.0056,
+              "sampleCount": 100000,
+              "innerIterations": 1,
+              "sampledDuration": 229.5816
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0005,
+              "minimum": 0.0005,
+              "standardDeviation": 0.0005,
+              "sampleCount": 135,
+              "innerIterations": 4096,
+              "sampledDuration": 301.2263
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "objects/objects?n=10000",
+      "family": "objects",
+      "name": "objects",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 5.653,
+              "minimum": 5.1717,
+              "standardDeviation": 0.3133,
+              "sampleCount": 54,
+              "innerIterations": 1,
+              "sampledDuration": 305.2628
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0081,
+              "minimum": 0.0079,
+              "standardDeviation": 0.0005,
+              "sampleCount": 289,
+              "innerIterations": 128,
+              "sampledDuration": 300.0152
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0084,
+              "minimum": 0.008,
+              "standardDeviation": 0.0006,
+              "sampleCount": 278,
+              "innerIterations": 128,
+              "sampledDuration": 300.2476
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "objects/objects?n=100000",
+      "family": "objects",
+      "name": "objects",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 62.2402,
+              "minimum": 53.7923,
+              "standardDeviation": 6.5914,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 497.9213
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0799,
+              "minimum": 0.0782,
+              "standardDeviation": 0.004,
+              "sampleCount": 235,
+              "innerIterations": 16,
+              "sampledDuration": 300.2936
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.2265,
+              "minimum": 0.0771,
+              "standardDeviation": 0.1034,
+              "sampleCount": 1325,
+              "innerIterations": 1,
+              "sampledDuration": 300.1695
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "regex-validator/regex-validator?n=100",
+      "family": "regex-validator",
+      "name": "regex-validator",
+      "parameters": {
+        "n": 100.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.7892,
+              "minimum": 0.4961,
+              "standardDeviation": 1.23,
+              "sampleCount": 381,
+              "innerIterations": 1,
+              "sampledDuration": 300.6667
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0047,
+              "minimum": 0.0026,
+              "standardDeviation": 0.0388,
+              "sampleCount": 64131,
+              "innerIterations": 1,
+              "sampledDuration": 300.0025
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0015,
+              "minimum": 0.0014,
+              "standardDeviation": 0.0001,
+              "sampleCount": 201,
+              "innerIterations": 1024,
+              "sampledDuration": 301.2224
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "regex-validator/regex-validator?n=10000",
+      "family": "regex-validator",
+      "name": "regex-validator",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 47.4149,
+              "minimum": 22.0985,
+              "standardDeviation": 20.366,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 379.3189
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.2836,
+              "minimum": 0.2762,
+              "standardDeviation": 0.0122,
+              "sampleCount": 265,
+              "innerIterations": 4,
+              "sampledDuration": 300.5973
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1503,
+              "minimum": 0.1413,
+              "standardDeviation": 0.0115,
+              "sampleCount": 250,
+              "innerIterations": 8,
+              "sampledDuration": 300.6623
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "regex-validator/regex-validator?n=100000",
+      "family": "regex-validator",
+      "name": "regex-validator",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 370.2741,
+              "minimum": 184.544,
+              "standardDeviation": 133.3674,
+              "sampleCount": 7,
+              "innerIterations": 1,
+              "sampledDuration": 2591.9185
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.8253,
+              "minimum": 2.7652,
+              "standardDeviation": 0.0911,
+              "sampleCount": 107,
+              "innerIterations": 1,
+              "sampledDuration": 302.3077
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.4929,
+              "minimum": 1.4084,
+              "standardDeviation": 0.0851,
+              "sampleCount": 201,
+              "innerIterations": 1,
+              "sampledDuration": 300.0718
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "regex/regex?n=100",
+      "family": "regex",
+      "name": "regex",
+      "parameters": {
+        "n": 100.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.4897,
+              "minimum": 0.3526,
+              "standardDeviation": 1.2949,
+              "sampleCount": 613,
+              "innerIterations": 1,
+              "sampledDuration": 300.1688
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1206,
+              "minimum": 0.053,
+              "standardDeviation": 0.4207,
+              "sampleCount": 2487,
+              "innerIterations": 1,
+              "sampledDuration": 300.0455
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0158,
+              "minimum": 0.0142,
+              "standardDeviation": 0.0013,
+              "sampleCount": 296,
+              "innerIterations": 64,
+              "sampledDuration": 300.2498
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "regex/regex?n=1000",
+      "family": "regex",
+      "name": "regex",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.1596,
+              "minimum": 0.3353,
+              "standardDeviation": 1.2672,
+              "sampleCount": 259,
+              "innerIterations": 1,
+              "sampledDuration": 300.333
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.339,
+              "minimum": 0.284,
+              "standardDeviation": 0.056,
+              "sampleCount": 222,
+              "innerIterations": 4,
+              "sampledDuration": 301.054
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.1648,
+              "minimum": 0.1483,
+              "standardDeviation": 0.0187,
+              "sampleCount": 228,
+              "innerIterations": 8,
+              "sampledDuration": 300.6506
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "regex/regex?n=10000",
+      "family": "regex",
+      "name": "regex",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 3.947,
+              "minimum": 2.8656,
+              "standardDeviation": 1.6385,
+              "sampleCount": 77,
+              "innerIterations": 1,
+              "sampledDuration": 303.9197
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.9944,
+              "minimum": 2.6452,
+              "standardDeviation": 0.2864,
+              "sampleCount": 101,
+              "innerIterations": 1,
+              "sampledDuration": 302.4389
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.9925,
+              "minimum": 1.5841,
+              "standardDeviation": 0.7148,
+              "sampleCount": 151,
+              "innerIterations": 1,
+              "sampledDuration": 300.8698
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "sort/sort?n=100",
+      "family": "sort",
+      "name": "sort",
+      "parameters": {
+        "n": 100.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.3737,
+              "minimum": 0.3035,
+              "standardDeviation": 0.2661,
+              "sampleCount": 804,
+              "innerIterations": 1,
+              "sampledDuration": 300.439
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0628,
+              "minimum": 0.0517,
+              "standardDeviation": 0.0728,
+              "sampleCount": 4776,
+              "innerIterations": 1,
+              "sampledDuration": 300.0474
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0085,
+              "minimum": 0.0079,
+              "standardDeviation": 0.0007,
+              "sampleCount": 277,
+              "innerIterations": 128,
+              "sampledDuration": 300.8018
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "sort/sort?n=1000",
+      "family": "sort",
+      "name": "sort",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.783,
+              "minimum": 0.8573,
+              "standardDeviation": 3.08,
+              "sampleCount": 108,
+              "innerIterations": 1,
+              "sampledDuration": 300.5593
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.2481,
+              "minimum": 0.1683,
+              "standardDeviation": 0.1285,
+              "sampleCount": 605,
+              "innerIterations": 2,
+              "sampledDuration": 300.2548
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.2106,
+              "minimum": 0.1969,
+              "standardDeviation": 0.0217,
+              "sampleCount": 179,
+              "innerIterations": 8,
+              "sampledDuration": 301.6185
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "sort/sort?n=10000",
+      "family": "sort",
+      "name": "sort",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 23.7459,
+              "minimum": 12.2642,
+              "standardDeviation": 6.7536,
+              "sampleCount": 13,
+              "innerIterations": 1,
+              "sampledDuration": 308.697
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.6049,
+              "minimum": 2.3398,
+              "standardDeviation": 0.4473,
+              "sampleCount": 116,
+              "innerIterations": 1,
+              "sampledDuration": 302.1718
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.866,
+              "minimum": 2.6984,
+              "standardDeviation": 0.1639,
+              "sampleCount": 105,
+              "innerIterations": 1,
+              "sampledDuration": 300.9289
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "strings/strings?n=100",
+      "family": "strings",
+      "name": "strings",
+      "parameters": {
+        "n": 100.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.6757,
+              "minimum": 0.181,
+              "standardDeviation": 0.8494,
+              "sampleCount": 444,
+              "innerIterations": 1,
+              "sampledDuration": 300.0278
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0024,
+              "minimum": 0.0018,
+              "standardDeviation": 0.0051,
+              "sampleCount": 100000,
+              "innerIterations": 1,
+              "sampledDuration": 236.637
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0009,
+              "minimum": 0.0008,
+              "standardDeviation": 0.0001,
+              "sampleCount": 170,
+              "innerIterations": 2048,
+              "sampledDuration": 300.267
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "strings/strings?n=1000",
+      "family": "strings",
+      "name": "strings",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1.6359,
+              "minimum": 1.3713,
+              "standardDeviation": 0.1433,
+              "sampleCount": 184,
+              "innerIterations": 1,
+              "sampledDuration": 301.0059
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0083,
+              "minimum": 0.0066,
+              "standardDeviation": 0.002,
+              "sampleCount": 284,
+              "innerIterations": 128,
+              "sampledDuration": 300.163
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0078,
+              "minimum": 0.0067,
+              "standardDeviation": 0.0006,
+              "sampleCount": 151,
+              "innerIterations": 256,
+              "sampledDuration": 300.9954
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "strings/strings?n=10000",
+      "family": "strings",
+      "name": "strings",
+      "parameters": {
+        "n": 10000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 23.0912,
+              "minimum": 21.5201,
+              "standardDeviation": 1.4075,
+              "sampleCount": 13,
+              "innerIterations": 1,
+              "sampledDuration": 300.186
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0704,
+              "minimum": 0.0652,
+              "standardDeviation": 0.0057,
+              "sampleCount": 267,
+              "innerIterations": 16,
+              "sampledDuration": 300.6784
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0851,
+              "minimum": 0.065,
+              "standardDeviation": 0.0083,
+              "sampleCount": 221,
+              "innerIterations": 16,
+              "sampledDuration": 300.784
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "typed-arrays/typed-arrays?n=1000",
+      "family": "typed-arrays",
+      "name": "typed-arrays",
+      "parameters": {
+        "n": 1000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.9504,
+              "minimum": 1.0947,
+              "standardDeviation": 2.4277,
+              "sampleCount": 102,
+              "innerIterations": 1,
+              "sampledDuration": 300.9418
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0037,
+              "minimum": 0.002,
+              "standardDeviation": 0.0077,
+              "sampleCount": 81010,
+              "innerIterations": 1,
+              "sampledDuration": 300.0019
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.0045,
+              "minimum": 0.0019,
+              "standardDeviation": 0.0509,
+              "sampleCount": 66270,
+              "innerIterations": 1,
+              "sampledDuration": 300.0389
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "typed-arrays/typed-arrays?n=100000",
+      "family": "typed-arrays",
+      "name": "typed-arrays",
+      "parameters": {
+        "n": 100000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 103.0033,
+              "minimum": 100.9475,
+              "standardDeviation": 2.3725,
+              "sampleCount": 8,
+              "innerIterations": 1,
+              "sampledDuration": 824.0266
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.3276,
+              "minimum": 0.3124,
+              "standardDeviation": 0.0207,
+              "sampleCount": 229,
+              "innerIterations": 4,
+              "sampledDuration": 300.0753
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 0.3919,
+              "minimum": 0.3216,
+              "standardDeviation": 0.2218,
+              "sampleCount": 192,
+              "innerIterations": 4,
+              "sampledDuration": 300.9442
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    },
+    {
+      "id": "typed-arrays/typed-arrays?n=1000000",
+      "family": "typed-arrays",
+      "name": "typed-arrays",
+      "parameters": {
+        "n": 1000000.0
+      },
+      "unit": "milliseconds",
+      "direction": "lowerIsBetter",
+      "runtimes": [
+        {
+          "id": "interpreter",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 1023.9886,
+              "minimum": 1016.2319,
+              "standardDeviation": 10.9696,
+              "sampleCount": 2,
+              "innerIterations": 1,
+              "sampledDuration": 2047.9772
+            }
+          ]
+        },
+        {
+          "id": "compiled",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.2541,
+              "minimum": 1.9463,
+              "standardDeviation": 0.2968,
+              "sampleCount": 134,
+              "innerIterations": 1,
+              "sampledDuration": 302.0546
+            }
+          ]
+        },
+        {
+          "id": "node",
+          "status": "measured",
+          "measurements": [
+            {
+              "launch": 1,
+              "mean": 2.8175,
+              "minimum": 2.5234,
+              "standardDeviation": 0.3337,
+              "sampleCount": 107,
+              "innerIterations": 1,
+              "sampledDuration": 301.4725
+            }
+          ]
+        },
+        {
+          "id": "bun",
+          "status": "missing",
+          "reason": "unavailable"
+        }
+      ]
+    }
+  ]
+}

--- a/benchmarks/cross-runtime/snapshots/latest.json
+++ b/benchmarks/cross-runtime/snapshots/latest.json
@@ -2,10 +2,10 @@
   "$schema": "https://raw.githubusercontent.com/nickna/SharpTS/main/benchmarks/cross-runtime/snapshot-v1.schema.json",
   "schemaVersion": 1,
   "run": {
-    "timestampUtc": "2026-08-26T17:41:38.9567174+00:00",
+    "timestampUtc": "2026-08-26T17:57:36.4949543+00:00",
     "revision": {
-      "commit": "7843dbe3128044f48fd6beae1f87e8acf8cabe75",
-      "dirty": true
+      "commit": "0b93b1119bd1e27cbd07e83211fa31568e6ac596",
+      "dirty": false
     },
     "environment": {
       "operatingSystem": "Microsoft Windows 10.0.29639",
@@ -20,13 +20,13 @@
           "id": "interpreter",
           "selected": true,
           "available": true,
-          "version": "7843dbe3128044f48fd6beae1f87e8acf8cabe75"
+          "version": "0b93b1119bd1e27cbd07e83211fa31568e6ac596"
         },
         {
           "id": "compiled",
           "selected": true,
           "available": true,
-          "version": "7843dbe3128044f48fd6beae1f87e8acf8cabe75"
+          "version": "0b93b1119bd1e27cbd07e83211fa31568e6ac596"
         },
         {
           "id": "node",
@@ -84,12 +84,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 5.3928,
-              "minimum": 3.6098,
-              "standardDeviation": 2.2728,
-              "sampleCount": 56,
+              "mean": 5.4836,
+              "minimum": 3.9669,
+              "standardDeviation": 2.8803,
+              "sampleCount": 55,
               "innerIterations": 1,
-              "sampledDuration": 301.9961
+              "sampledDuration": 301.5987
             }
           ]
         },
@@ -99,12 +99,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0168,
-              "minimum": 0.0094,
-              "standardDeviation": 0.0228,
-              "sampleCount": 17902,
+              "mean": 0.0158,
+              "minimum": 0.0086,
+              "standardDeviation": 0.0202,
+              "sampleCount": 19013,
               "innerIterations": 1,
-              "sampledDuration": 300.003
+              "sampledDuration": 300.0035
             }
           ]
         },
@@ -114,12 +114,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0133,
-              "minimum": 0.011,
-              "standardDeviation": 0.0016,
-              "sampleCount": 177,
+              "mean": 0.013,
+              "minimum": 0.0112,
+              "standardDeviation": 0.0015,
+              "sampleCount": 180,
               "innerIterations": 128,
-              "sampledDuration": 301.5303
+              "sampledDuration": 300.6648
             }
           ]
         },
@@ -146,12 +146,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 25.2731,
-              "minimum": 10.2763,
-              "standardDeviation": 10.1293,
-              "sampleCount": 12,
+              "mean": 38.3359,
+              "minimum": 13.1451,
+              "standardDeviation": 20.0599,
+              "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 303.2777
+              "sampledDuration": 306.6871
             }
           ]
         },
@@ -161,12 +161,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1446,
-              "minimum": 0.1189,
-              "standardDeviation": 0.0146,
-              "sampleCount": 130,
+              "mean": 0.138,
+              "minimum": 0.1158,
+              "standardDeviation": 0.0122,
+              "sampleCount": 136,
               "innerIterations": 16,
-              "sampledDuration": 300.6655
+              "sampledDuration": 300.2293
             }
           ]
         },
@@ -176,12 +176,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1203,
-              "minimum": 0.112,
-              "standardDeviation": 0.0085,
-              "sampleCount": 156,
+              "mean": 0.116,
+              "minimum": 0.1122,
+              "standardDeviation": 0.0041,
+              "sampleCount": 162,
               "innerIterations": 16,
-              "sampledDuration": 300.2704
+              "sampledDuration": 300.7396
             }
           ]
         },
@@ -208,12 +208,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 133.4962,
-              "minimum": 124.9969,
-              "standardDeviation": 8.3876,
+              "mean": 124.87,
+              "minimum": 115.4055,
+              "standardDeviation": 12.3626,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 1067.9694
+              "sampledDuration": 998.96
             }
           ]
         },
@@ -223,12 +223,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.2773,
-              "minimum": 1.0842,
-              "standardDeviation": 0.1244,
-              "sampleCount": 235,
+              "mean": 1.2431,
+              "minimum": 1.0653,
+              "standardDeviation": 0.1316,
+              "sampleCount": 242,
               "innerIterations": 1,
-              "sampledDuration": 300.1568
+              "sampledDuration": 300.8408
             }
           ]
         },
@@ -238,12 +238,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.2921,
-              "minimum": 1.8938,
-              "standardDeviation": 0.4583,
-              "sampleCount": 132,
+              "mean": 2.1982,
+              "minimum": 1.8929,
+              "standardDeviation": 0.4574,
+              "sampleCount": 137,
               "innerIterations": 1,
-              "sampledDuration": 302.5583
+              "sampledDuration": 301.1573
             }
           ]
         },
@@ -270,12 +270,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0227,
-              "minimum": 0.0128,
-              "standardDeviation": 0.0106,
-              "sampleCount": 414,
-              "innerIterations": 32,
-              "sampledDuration": 300.2722
+              "mean": 0.0256,
+              "minimum": 0.0122,
+              "standardDeviation": 0.0163,
+              "sampleCount": 733,
+              "innerIterations": 16,
+              "sampledDuration": 300.1011
             }
           ]
         },
@@ -288,9 +288,9 @@
               "mean": 0.0002,
               "minimum": 0.0001,
               "standardDeviation": 0.0001,
-              "sampleCount": 219,
+              "sampleCount": 212,
               "innerIterations": 8192,
-              "sampledDuration": 300.506
+              "sampledDuration": 300.1953
             }
           ]
         },
@@ -300,12 +300,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0003,
+              "mean": 0.0004,
               "minimum": 0.0003,
               "standardDeviation": 0.0,
-              "sampleCount": 212,
+              "sampleCount": 198,
               "innerIterations": 4096,
-              "sampledDuration": 300.3966
+              "sampledDuration": 301.6423
             }
           ]
         },
@@ -332,12 +332,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1173,
-              "minimum": 0.1052,
-              "standardDeviation": 0.0141,
-              "sampleCount": 160,
+              "mean": 0.1226,
+              "minimum": 0.1048,
+              "standardDeviation": 0.0173,
+              "sampleCount": 153,
               "innerIterations": 16,
-              "sampledDuration": 300.2956
+              "sampledDuration": 300.1409
             }
           ]
         },
@@ -350,9 +350,9 @@
               "mean": 0.0001,
               "minimum": 0.0001,
               "standardDeviation": 0.0,
-              "sampleCount": 289,
+              "sampleCount": 252,
               "innerIterations": 8192,
-              "sampledDuration": 300.4023
+              "sampledDuration": 300.5261
             }
           ]
         },
@@ -363,11 +363,11 @@
             {
               "launch": 1,
               "mean": 0.0027,
-              "minimum": 0.0024,
+              "minimum": 0.0025,
               "standardDeviation": 0.0002,
-              "sampleCount": 221,
+              "sampleCount": 220,
               "innerIterations": 512,
-              "sampledDuration": 300.9527
+              "sampledDuration": 301.2448
             }
           ]
         },
@@ -394,12 +394,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.1648,
-              "minimum": 1.0239,
-              "standardDeviation": 0.2347,
-              "sampleCount": 258,
+              "mean": 1.3174,
+              "minimum": 1.0055,
+              "standardDeviation": 1.2597,
+              "sampleCount": 228,
               "innerIterations": 1,
-              "sampledDuration": 300.5152
+              "sampledDuration": 300.376
             }
           ]
         },
@@ -412,9 +412,9 @@
               "mean": 0.0005,
               "minimum": 0.0005,
               "standardDeviation": 0.0001,
-              "sampleCount": 294,
+              "sampleCount": 284,
               "innerIterations": 2048,
-              "sampledDuration": 300.5497
+              "sampledDuration": 300.8845
             }
           ]
         },
@@ -424,12 +424,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.026,
-              "minimum": 0.0226,
-              "standardDeviation": 0.0027,
-              "sampleCount": 181,
+              "mean": 0.0248,
+              "minimum": 0.0215,
+              "standardDeviation": 0.0026,
+              "sampleCount": 190,
               "innerIterations": 64,
-              "sampledDuration": 301.1727
+              "sampledDuration": 301.0979
             }
           ]
         },
@@ -456,12 +456,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0793,
-              "minimum": 0.0441,
-              "standardDeviation": 0.3284,
-              "sampleCount": 3782,
+              "mean": 0.0746,
+              "minimum": 0.0455,
+              "standardDeviation": 0.2536,
+              "sampleCount": 4021,
               "innerIterations": 1,
-              "sampledDuration": 300.002
+              "sampledDuration": 300.0938
             }
           ]
         },
@@ -471,12 +471,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0005,
+              "mean": 0.0006,
               "minimum": 0.0003,
-              "standardDeviation": 0.0091,
+              "standardDeviation": 0.014,
               "sampleCount": 100000,
               "innerIterations": 1,
-              "sampledDuration": 54.9762
+              "sampledDuration": 60.519
             }
           ]
         },
@@ -488,10 +488,10 @@
               "launch": 1,
               "mean": 0.0004,
               "minimum": 0.0003,
-              "standardDeviation": 0.0,
-              "sampleCount": 202,
+              "standardDeviation": 0.0001,
+              "sampleCount": 178,
               "innerIterations": 4096,
-              "sampledDuration": 300.247
+              "sampledDuration": 300.4058
             }
           ]
         },
@@ -518,12 +518,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.2087,
-              "minimum": 0.1052,
-              "standardDeviation": 0.7441,
-              "sampleCount": 1473,
-              "innerIterations": 1,
-              "sampledDuration": 307.4867
+              "mean": 0.2684,
+              "minimum": 0.1107,
+              "standardDeviation": 0.321,
+              "sampleCount": 72,
+              "innerIterations": 16,
+              "sampledDuration": 309.1545
             }
           ]
         },
@@ -536,9 +536,9 @@
               "mean": 0.0001,
               "minimum": 0.0001,
               "standardDeviation": 0.0,
-              "sampleCount": 577,
-              "innerIterations": 4096,
-              "sampledDuration": 300.1028
+              "sampleCount": 264,
+              "innerIterations": 8192,
+              "sampledDuration": 300.3018
             }
           ]
         },
@@ -548,12 +548,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0027,
+              "mean": 0.0028,
               "minimum": 0.0025,
-              "standardDeviation": 0.0002,
-              "sampleCount": 220,
+              "standardDeviation": 0.0003,
+              "sampleCount": 211,
               "innerIterations": 512,
-              "sampledDuration": 300.8931
+              "sampledDuration": 301.2635
             }
           ]
         },
@@ -580,12 +580,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.3703,
-              "minimum": 1.0619,
-              "standardDeviation": 4.3497,
-              "sampleCount": 127,
+              "mean": 2.4051,
+              "minimum": 1.0558,
+              "standardDeviation": 3.7801,
+              "sampleCount": 126,
               "innerIterations": 1,
-              "sampledDuration": 301.0273
+              "sampledDuration": 303.0431
             }
           ]
         },
@@ -598,9 +598,9 @@
               "mean": 0.0005,
               "minimum": 0.0005,
               "standardDeviation": 0.0001,
-              "sampleCount": 141,
-              "innerIterations": 4096,
-              "sampledDuration": 302.1802
+              "sampleCount": 283,
+              "innerIterations": 2048,
+              "sampledDuration": 300.3268
             }
           ]
         },
@@ -610,12 +610,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0267,
-              "minimum": 0.0238,
-              "standardDeviation": 0.0022,
-              "sampleCount": 176,
+              "mean": 0.0259,
+              "minimum": 0.0227,
+              "standardDeviation": 0.0029,
+              "sampleCount": 181,
               "innerIterations": 64,
-              "sampledDuration": 300.9635
+              "sampledDuration": 300.1787
             }
           ]
         },
@@ -642,12 +642,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0637,
-              "minimum": 0.032,
-              "standardDeviation": 0.3399,
-              "sampleCount": 4709,
+              "mean": 0.0707,
+              "minimum": 0.0331,
+              "standardDeviation": 0.4536,
+              "sampleCount": 4287,
               "innerIterations": 1,
-              "sampledDuration": 300.0186
+              "sampledDuration": 303.1023
             }
           ]
         },
@@ -657,12 +657,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0012,
-              "minimum": 0.0008,
-              "standardDeviation": 0.0185,
+              "mean": 0.0011,
+              "minimum": 0.0007,
+              "standardDeviation": 0.015,
               "sampleCount": 100000,
               "innerIterations": 1,
-              "sampledDuration": 122.4676
+              "sampledDuration": 108.5603
             }
           ]
         },
@@ -675,9 +675,9 @@
               "mean": 0.0005,
               "minimum": 0.0004,
               "standardDeviation": 0.0,
-              "sampleCount": 160,
+              "sampleCount": 158,
               "innerIterations": 4096,
-              "sampledDuration": 300.3775
+              "sampledDuration": 301.4802
             }
           ]
         },
@@ -704,12 +704,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.4622,
-              "minimum": 0.2455,
-              "standardDeviation": 0.8357,
-              "sampleCount": 325,
+              "mean": 0.4923,
+              "minimum": 0.2551,
+              "standardDeviation": 0.8174,
+              "sampleCount": 309,
               "innerIterations": 2,
-              "sampledDuration": 300.4617
+              "sampledDuration": 304.2515
             }
           ]
         },
@@ -719,12 +719,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.001,
-              "minimum": 0.0007,
-              "standardDeviation": 0.0003,
-              "sampleCount": 305,
+              "mean": 0.0012,
+              "minimum": 0.0008,
+              "standardDeviation": 0.0005,
+              "sampleCount": 237,
               "innerIterations": 1024,
-              "sampledDuration": 300.4802
+              "sampledDuration": 300.2965
             }
           ]
         },
@@ -734,12 +734,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0033,
+              "mean": 0.0032,
               "minimum": 0.0028,
-              "standardDeviation": 0.0003,
-              "sampleCount": 180,
+              "standardDeviation": 0.0004,
+              "sampleCount": 182,
               "innerIterations": 512,
-              "sampledDuration": 300.7992
+              "sampledDuration": 300.68
             }
           ]
         },
@@ -766,12 +766,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 4.9848,
-              "minimum": 2.3318,
-              "standardDeviation": 5.9164,
-              "sampleCount": 61,
+              "mean": 4.678,
+              "minimum": 2.4683,
+              "standardDeviation": 3.61,
+              "sampleCount": 66,
               "innerIterations": 1,
-              "sampledDuration": 304.0709
+              "sampledDuration": 308.7461
             }
           ]
         },
@@ -781,12 +781,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0052,
-              "minimum": 0.0043,
-              "standardDeviation": 0.001,
-              "sampleCount": 227,
+              "mean": 0.0056,
+              "minimum": 0.0044,
+              "standardDeviation": 0.0011,
+              "sampleCount": 212,
               "innerIterations": 256,
-              "sampledDuration": 301.0045
+              "sampledDuration": 301.4734
             }
           ]
         },
@@ -796,12 +796,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0339,
-              "minimum": 0.0293,
-              "standardDeviation": 0.0035,
-              "sampleCount": 277,
-              "innerIterations": 32,
-              "sampledDuration": 300.7958
+              "mean": 0.0302,
+              "minimum": 0.0271,
+              "standardDeviation": 0.002,
+              "sampleCount": 156,
+              "innerIterations": 64,
+              "sampledDuration": 301.761
             }
           ]
         },
@@ -828,12 +828,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0273,
-              "minimum": 0.0156,
-              "standardDeviation": 0.1811,
-              "sampleCount": 11006,
+              "mean": 0.0259,
+              "minimum": 0.0152,
+              "standardDeviation": 0.0809,
+              "sampleCount": 11575,
               "innerIterations": 1,
-              "sampledDuration": 300.0043
+              "sampledDuration": 300.0145
             }
           ]
         },
@@ -843,12 +843,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0017,
+              "mean": 0.0018,
               "minimum": 0.001,
-              "standardDeviation": 0.0225,
+              "standardDeviation": 0.0242,
               "sampleCount": 100000,
               "innerIterations": 1,
-              "sampledDuration": 172.38
+              "sampledDuration": 177.5745
             }
           ]
         },
@@ -863,7 +863,7 @@
               "standardDeviation": 0.0,
               "sampleCount": 221,
               "innerIterations": 4096,
-              "sampledDuration": 300.5603
+              "sampledDuration": 300.7783
             }
           ]
         },
@@ -890,12 +890,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1833,
-              "minimum": 0.1303,
-              "standardDeviation": 0.0933,
-              "sampleCount": 207,
+              "mean": 0.197,
+              "minimum": 0.1346,
+              "standardDeviation": 0.1009,
+              "sampleCount": 191,
               "innerIterations": 8,
-              "sampledDuration": 303.4815
+              "sampledDuration": 301.0339
             }
           ]
         },
@@ -905,12 +905,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0028,
+              "mean": 0.0031,
               "minimum": 0.0022,
-              "standardDeviation": 0.001,
-              "sampleCount": 425,
-              "innerIterations": 256,
-              "sampledDuration": 300.4416
+              "standardDeviation": 0.0019,
+              "sampleCount": 746,
+              "innerIterations": 128,
+              "sampledDuration": 300.2783
             }
           ]
         },
@@ -920,12 +920,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0026,
-              "minimum": 0.0021,
+              "mean": 0.0025,
+              "minimum": 0.0022,
               "standardDeviation": 0.0003,
-              "sampleCount": 230,
+              "sampleCount": 234,
               "innerIterations": 512,
-              "sampledDuration": 300.978
+              "sampledDuration": 300.8734
             }
           ]
         },
@@ -952,12 +952,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.7446,
-              "minimum": 1.2443,
-              "standardDeviation": 0.7651,
+              "mean": 1.7447,
+              "minimum": 1.2805,
+              "standardDeviation": 0.6091,
               "sampleCount": 172,
               "innerIterations": 1,
-              "sampledDuration": 300.0756
+              "sampledDuration": 300.0829
             }
           ]
         },
@@ -967,12 +967,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0222,
-              "minimum": 0.0179,
-              "standardDeviation": 0.0039,
-              "sampleCount": 212,
+              "mean": 0.0234,
+              "minimum": 0.018,
+              "standardDeviation": 0.0048,
+              "sampleCount": 201,
               "innerIterations": 64,
-              "sampledDuration": 300.5805
+              "sampledDuration": 300.5294
             }
           ]
         },
@@ -982,12 +982,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0269,
-              "minimum": 0.0239,
-              "standardDeviation": 0.0028,
-              "sampleCount": 175,
-              "innerIterations": 64,
-              "sampledDuration": 300.9491
+              "mean": 0.025,
+              "minimum": 0.0212,
+              "standardDeviation": 0.0032,
+              "sampleCount": 376,
+              "innerIterations": 32,
+              "sampledDuration": 300.3028
             }
           ]
         },
@@ -1014,12 +1014,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 27.6822,
-              "minimum": 18.0664,
-              "standardDeviation": 5.4844,
-              "sampleCount": 11,
+              "mean": 34.5209,
+              "minimum": 16.2084,
+              "standardDeviation": 12.9997,
+              "sampleCount": 9,
               "innerIterations": 1,
-              "sampledDuration": 304.5043
+              "sampledDuration": 310.688
             }
           ]
         },
@@ -1029,12 +1029,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0676,
-              "minimum": 0.0558,
-              "standardDeviation": 0.0109,
-              "sampleCount": 278,
-              "innerIterations": 16,
-              "sampledDuration": 300.5648
+              "mean": 0.0604,
+              "minimum": 0.0521,
+              "standardDeviation": 0.0061,
+              "sampleCount": 156,
+              "innerIterations": 32,
+              "sampledDuration": 301.6449
             }
           ]
         },
@@ -1044,12 +1044,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0736,
-              "minimum": 0.0616,
-              "standardDeviation": 0.0074,
-              "sampleCount": 255,
+              "mean": 0.0805,
+              "minimum": 0.0701,
+              "standardDeviation": 0.0082,
+              "sampleCount": 233,
               "innerIterations": 16,
-              "sampledDuration": 300.1636
+              "sampledDuration": 300.0998
             }
           ]
         },
@@ -1076,12 +1076,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 333.1057,
-              "minimum": 270.8346,
-              "standardDeviation": 47.7161,
+              "mean": 302.1209,
+              "minimum": 261.924,
+              "standardDeviation": 25.5412,
               "sampleCount": 7,
               "innerIterations": 1,
-              "sampledDuration": 2331.7401
+              "sampledDuration": 2114.8461
             }
           ]
         },
@@ -1091,12 +1091,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.4169,
-              "minimum": 0.7561,
-              "standardDeviation": 1.1862,
-              "sampleCount": 212,
+              "mean": 1.4386,
+              "minimum": 0.787,
+              "standardDeviation": 1.084,
+              "sampleCount": 209,
               "innerIterations": 1,
-              "sampledDuration": 300.3918
+              "sampledDuration": 300.6764
             }
           ]
         },
@@ -1106,12 +1106,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.393,
-              "minimum": 1.0631,
-              "standardDeviation": 0.4329,
-              "sampleCount": 216,
+              "mean": 1.3981,
+              "minimum": 1.1098,
+              "standardDeviation": 0.4593,
+              "sampleCount": 215,
               "innerIterations": 1,
-              "sampledDuration": 300.895
+              "sampledDuration": 300.6006
             }
           ]
         },
@@ -1138,12 +1138,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 4.0646,
-              "minimum": 2.1049,
-              "standardDeviation": 2.415,
-              "sampleCount": 74,
+              "mean": 4.1287,
+              "minimum": 2.9382,
+              "standardDeviation": 1.5864,
+              "sampleCount": 73,
               "innerIterations": 1,
-              "sampledDuration": 300.7834
+              "sampledDuration": 301.3953
             }
           ]
         },
@@ -1153,12 +1153,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0051,
-              "minimum": 0.0034,
-              "standardDeviation": 0.0079,
-              "sampleCount": 58807,
+              "mean": 0.0049,
+              "minimum": 0.0033,
+              "standardDeviation": 0.0084,
+              "sampleCount": 61533,
               "innerIterations": 1,
-              "sampledDuration": 300.0015
+              "sampledDuration": 300.0011
             }
           ]
         },
@@ -1168,12 +1168,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.004,
-              "minimum": 0.0037,
+              "mean": 0.0043,
+              "minimum": 0.0039,
               "standardDeviation": 0.0003,
-              "sampleCount": 290,
+              "sampleCount": 274,
               "innerIterations": 256,
-              "sampledDuration": 300.5132
+              "sampledDuration": 300.6946
             }
           ]
         },
@@ -1200,12 +1200,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 111.5413,
-              "minimum": 55.3918,
-              "standardDeviation": 98.6952,
+              "mean": 110.0355,
+              "minimum": 54.3517,
+              "standardDeviation": 94.8876,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 892.3305
+              "sampledDuration": 880.2837
             }
           ]
         },
@@ -1215,12 +1215,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.2257,
-              "minimum": 0.2069,
-              "standardDeviation": 0.0899,
-              "sampleCount": 1330,
+              "mean": 0.2274,
+              "minimum": 0.2052,
+              "standardDeviation": 0.0975,
+              "sampleCount": 1320,
               "innerIterations": 1,
-              "sampledDuration": 300.1259
+              "sampledDuration": 300.1125
             }
           ]
         },
@@ -1230,12 +1230,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1685,
-              "minimum": 0.1271,
-              "standardDeviation": 0.0924,
-              "sampleCount": 1781,
+              "mean": 0.1704,
+              "minimum": 0.1319,
+              "standardDeviation": 0.0692,
+              "sampleCount": 1761,
               "innerIterations": 1,
-              "sampledDuration": 300.0885
+              "sampledDuration": 300.1056
             }
           ]
         },
@@ -1262,12 +1262,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 543.5528,
-              "minimum": 526.6538,
-              "standardDeviation": 12.8354,
+              "mean": 538.1938,
+              "minimum": 521.8423,
+              "standardDeviation": 15.6244,
               "sampleCount": 4,
               "innerIterations": 1,
-              "sampledDuration": 2174.2113
+              "sampledDuration": 2152.7752
             }
           ]
         },
@@ -1277,12 +1277,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.1359,
-              "minimum": 2.0647,
-              "standardDeviation": 0.0884,
-              "sampleCount": 141,
+              "mean": 2.1088,
+              "minimum": 2.0486,
+              "standardDeviation": 0.0822,
+              "sampleCount": 143,
               "innerIterations": 1,
-              "sampledDuration": 301.1567
+              "sampledDuration": 301.5532
             }
           ]
         },
@@ -1292,12 +1292,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.74,
-              "minimum": 1.6551,
-              "standardDeviation": 0.1304,
-              "sampleCount": 173,
+              "mean": 1.7898,
+              "minimum": 1.6443,
+              "standardDeviation": 0.1313,
+              "sampleCount": 168,
               "innerIterations": 1,
-              "sampledDuration": 301.0271
+              "sampledDuration": 300.6909
             }
           ]
         },
@@ -1324,12 +1324,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 5343.5295,
-              "minimum": 5343.5295,
+              "mean": 5734.9322,
+              "minimum": 5734.9322,
               "standardDeviation": 0.0,
               "sampleCount": 1,
               "innerIterations": 1,
-              "sampledDuration": 5343.5295
+              "sampledDuration": 5734.9322
             }
           ]
         },
@@ -1339,12 +1339,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 21.9058,
-              "minimum": 21.1089,
-              "standardDeviation": 0.7682,
-              "sampleCount": 14,
+              "mean": 21.4483,
+              "minimum": 20.886,
+              "standardDeviation": 0.4868,
+              "sampleCount": 15,
               "innerIterations": 1,
-              "sampledDuration": 306.6813
+              "sampledDuration": 321.7241
             }
           ]
         },
@@ -1354,12 +1354,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 17.638,
-              "minimum": 17.2631,
-              "standardDeviation": 0.3557,
-              "sampleCount": 18,
+              "mean": 17.7853,
+              "minimum": 17.1034,
+              "standardDeviation": 0.4457,
+              "sampleCount": 17,
               "innerIterations": 1,
-              "sampledDuration": 317.4848
+              "sampledDuration": 302.3507
             }
           ]
         },
@@ -1386,12 +1386,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.795,
-              "minimum": 1.2017,
-              "standardDeviation": 0.94,
-              "sampleCount": 169,
+              "mean": 1.8352,
+              "minimum": 1.1865,
+              "standardDeviation": 1.0356,
+              "sampleCount": 164,
               "innerIterations": 1,
-              "sampledDuration": 303.3608
+              "sampledDuration": 300.9801
             }
           ]
         },
@@ -1401,12 +1401,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0007,
+              "mean": 0.0008,
               "minimum": 0.0005,
               "standardDeviation": 0.0008,
-              "sampleCount": 813,
+              "sampleCount": 771,
               "innerIterations": 512,
-              "sampledDuration": 300.2138
+              "sampledDuration": 300.0498
             }
           ]
         },
@@ -1419,9 +1419,9 @@
               "mean": 0.0003,
               "minimum": 0.0003,
               "standardDeviation": 0.0,
-              "sampleCount": 256,
+              "sampleCount": 257,
               "innerIterations": 4096,
-              "sampledDuration": 300.3203
+              "sampledDuration": 300.3778
             }
           ]
         },
@@ -1448,12 +1448,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 23.8923,
-              "minimum": 18.7202,
-              "standardDeviation": 4.2635,
-              "sampleCount": 13,
+              "mean": 22.988,
+              "minimum": 18.3675,
+              "standardDeviation": 3.2061,
+              "sampleCount": 14,
               "innerIterations": 1,
-              "sampledDuration": 310.5995
+              "sampledDuration": 321.8324
             }
           ]
         },
@@ -1463,12 +1463,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0042,
-              "minimum": 0.004,
-              "standardDeviation": 0.0003,
-              "sampleCount": 278,
-              "innerIterations": 256,
-              "sampledDuration": 301.0676
+              "mean": 0.0045,
+              "minimum": 0.0042,
+              "standardDeviation": 0.0005,
+              "sampleCount": 526,
+              "innerIterations": 128,
+              "sampledDuration": 300.4206
             }
           ]
         },
@@ -1478,12 +1478,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0051,
+              "mean": 0.0053,
               "minimum": 0.005,
-              "standardDeviation": 0.0003,
-              "sampleCount": 228,
+              "standardDeviation": 0.0002,
+              "sampleCount": 222,
               "innerIterations": 256,
-              "sampledDuration": 300.3624
+              "sampledDuration": 300.2207
             }
           ]
         },
@@ -1510,12 +1510,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 393.9719,
-              "minimum": 306.6882,
-              "standardDeviation": 70.7967,
+              "mean": 417.7604,
+              "minimum": 326.9386,
+              "standardDeviation": 66.1924,
               "sampleCount": 6,
               "innerIterations": 1,
-              "sampledDuration": 2363.8311
+              "sampledDuration": 2506.5626
             }
           ]
         },
@@ -1525,12 +1525,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0416,
+              "mean": 0.0427,
               "minimum": 0.0397,
-              "standardDeviation": 0.0032,
-              "sampleCount": 226,
+              "standardDeviation": 0.0034,
+              "sampleCount": 220,
               "innerIterations": 32,
-              "sampledDuration": 300.7561
+              "sampledDuration": 300.7745
             }
           ]
         },
@@ -1540,12 +1540,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.3451,
-              "minimum": 0.3119,
-              "standardDeviation": 0.0402,
-              "sampleCount": 218,
+              "mean": 0.3264,
+              "minimum": 0.2942,
+              "standardDeviation": 0.0261,
+              "sampleCount": 230,
               "innerIterations": 4,
-              "sampledDuration": 300.9309
+              "sampledDuration": 300.3208
             }
           ]
         },
@@ -1572,12 +1572,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 3.0709,
-              "minimum": 1.3613,
-              "standardDeviation": 1.4847,
-              "sampleCount": 98,
+              "mean": 2.9516,
+              "minimum": 2.4348,
+              "standardDeviation": 1.1156,
+              "sampleCount": 102,
               "innerIterations": 1,
-              "sampledDuration": 300.9503
+              "sampledDuration": 301.0649
             }
           ]
         },
@@ -1587,12 +1587,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0026,
+              "mean": 0.0025,
               "minimum": 0.0005,
-              "standardDeviation": 0.0107,
+              "standardDeviation": 0.0108,
               "sampleCount": 100000,
               "innerIterations": 1,
-              "sampledDuration": 263.5771
+              "sampledDuration": 254.2216
             }
           ]
         },
@@ -1605,9 +1605,9 @@
               "mean": 0.0004,
               "minimum": 0.0003,
               "standardDeviation": 0.0001,
-              "sampleCount": 201,
+              "sampleCount": 200,
               "innerIterations": 4096,
-              "sampledDuration": 301.1975
+              "sampledDuration": 300.857
             }
           ]
         },
@@ -1634,12 +1634,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 6.4067,
-              "minimum": 5.1055,
-              "standardDeviation": 0.9127,
-              "sampleCount": 47,
+              "mean": 7.0407,
+              "minimum": 5.5434,
+              "standardDeviation": 0.8506,
+              "sampleCount": 43,
               "innerIterations": 1,
-              "sampledDuration": 301.1144
+              "sampledDuration": 302.7481
             }
           ]
         },
@@ -1649,12 +1649,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.005,
-              "minimum": 0.0047,
-              "standardDeviation": 0.0003,
-              "sampleCount": 236,
+              "mean": 0.0052,
+              "minimum": 0.0049,
+              "standardDeviation": 0.0004,
+              "sampleCount": 227,
               "innerIterations": 256,
-              "sampledDuration": 300.6053
+              "sampledDuration": 300.9722
             }
           ]
         },
@@ -1664,12 +1664,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0063,
+              "mean": 0.0064,
               "minimum": 0.006,
-              "standardDeviation": 0.0005,
-              "sampleCount": 186,
+              "standardDeviation": 0.0003,
+              "sampleCount": 185,
               "innerIterations": 256,
-              "sampledDuration": 301.4652
+              "sampledDuration": 301.3258
             }
           ]
         },
@@ -1696,12 +1696,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 67.3117,
-              "minimum": 65.0498,
-              "standardDeviation": 1.5185,
+              "mean": 70.0062,
+              "minimum": 68.1225,
+              "standardDeviation": 2.903,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 538.4939
+              "sampledDuration": 560.0494
             }
           ]
         },
@@ -1711,12 +1711,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0546,
-              "minimum": 0.0485,
-              "standardDeviation": 0.0076,
-              "sampleCount": 172,
+              "mean": 0.0513,
+              "minimum": 0.0489,
+              "standardDeviation": 0.0025,
+              "sampleCount": 183,
               "innerIterations": 32,
-              "sampledDuration": 300.5021
+              "sampledDuration": 300.4918
             }
           ]
         },
@@ -1726,12 +1726,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0879,
-              "minimum": 0.0819,
-              "standardDeviation": 0.0053,
-              "sampleCount": 214,
+              "mean": 0.0841,
+              "minimum": 0.0813,
+              "standardDeviation": 0.0037,
+              "sampleCount": 223,
               "innerIterations": 16,
-              "sampledDuration": 301.1121
+              "sampledDuration": 300.197
             }
           ]
         },
@@ -1758,12 +1758,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.1562,
-              "minimum": 0.8441,
-              "standardDeviation": 0.3393,
-              "sampleCount": 260,
-              "innerIterations": 1,
-              "sampledDuration": 300.6228
+              "mean": 0.9085,
+              "minimum": 0.8178,
+              "standardDeviation": 0.0531,
+              "sampleCount": 166,
+              "innerIterations": 2,
+              "sampledDuration": 301.6289
             }
           ]
         },
@@ -1776,9 +1776,9 @@
               "mean": 0.0009,
               "minimum": 0.0005,
               "standardDeviation": 0.002,
-              "sampleCount": 2697,
+              "sampleCount": 2747,
               "innerIterations": 128,
-              "sampledDuration": 300.0159
+              "sampledDuration": 300.0147
             }
           ]
         },
@@ -1791,9 +1791,9 @@
               "mean": 0.0004,
               "minimum": 0.0003,
               "standardDeviation": 0.0,
-              "sampleCount": 205,
+              "sampleCount": 201,
               "innerIterations": 4096,
-              "sampledDuration": 301.3448
+              "sampledDuration": 300.5948
             }
           ]
         },
@@ -1820,12 +1820,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 10.0058,
-              "minimum": 8.2842,
-              "standardDeviation": 0.8229,
-              "sampleCount": 31,
+              "mean": 9.6831,
+              "minimum": 8.1919,
+              "standardDeviation": 0.7804,
+              "sampleCount": 32,
               "innerIterations": 1,
-              "sampledDuration": 310.1788
+              "sampledDuration": 309.8602
             }
           ]
         },
@@ -1835,12 +1835,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0053,
-              "minimum": 0.0047,
-              "standardDeviation": 0.0005,
-              "sampleCount": 223,
+              "mean": 0.0049,
+              "minimum": 0.0046,
+              "standardDeviation": 0.0002,
+              "sampleCount": 240,
               "innerIterations": 256,
-              "sampledDuration": 300.8752
+              "sampledDuration": 301.1187
             }
           ]
         },
@@ -1850,12 +1850,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0062,
+              "mean": 0.0064,
               "minimum": 0.006,
-              "standardDeviation": 0.0002,
-              "sampleCount": 190,
+              "standardDeviation": 0.0004,
+              "sampleCount": 183,
               "innerIterations": 256,
-              "sampledDuration": 300.3062
+              "sampledDuration": 301.4778
             }
           ]
         },
@@ -1882,12 +1882,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 108.3974,
-              "minimum": 98.0616,
-              "standardDeviation": 6.4888,
+              "mean": 102.5991,
+              "minimum": 96.7015,
+              "standardDeviation": 4.7252,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 867.1794
+              "sampledDuration": 820.7931
             }
           ]
         },
@@ -1897,12 +1897,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0531,
-              "minimum": 0.0485,
-              "standardDeviation": 0.0038,
-              "sampleCount": 177,
+              "mean": 0.0522,
+              "minimum": 0.0505,
+              "standardDeviation": 0.0028,
+              "sampleCount": 180,
               "innerIterations": 32,
-              "sampledDuration": 300.6573
+              "sampledDuration": 300.8513
             }
           ]
         },
@@ -1912,12 +1912,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0971,
-              "minimum": 0.0925,
-              "standardDeviation": 0.0052,
-              "sampleCount": 194,
+              "mean": 0.0909,
+              "minimum": 0.0883,
+              "standardDeviation": 0.0031,
+              "sampleCount": 207,
               "innerIterations": 16,
-              "sampledDuration": 301.3239
+              "sampledDuration": 300.9016
             }
           ]
         },
@@ -1944,12 +1944,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.916,
-              "minimum": 0.7997,
-              "standardDeviation": 0.0751,
-              "sampleCount": 328,
+              "mean": 0.8473,
+              "minimum": 0.7448,
+              "standardDeviation": 0.0672,
+              "sampleCount": 355,
               "innerIterations": 1,
-              "sampledDuration": 300.436
+              "sampledDuration": 300.7752
             }
           ]
         },
@@ -1959,12 +1959,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0009,
+              "mean": 0.0011,
               "minimum": 0.0005,
-              "standardDeviation": 0.0019,
-              "sampleCount": 2609,
+              "standardDeviation": 0.0022,
+              "sampleCount": 2151,
               "innerIterations": 128,
-              "sampledDuration": 300.0505
+              "sampledDuration": 300.013
             }
           ]
         },
@@ -1976,10 +1976,10 @@
               "launch": 1,
               "mean": 0.001,
               "minimum": 0.001,
-              "standardDeviation": 0.0001,
-              "sampleCount": 287,
-              "innerIterations": 1024,
-              "sampledDuration": 301.052
+              "standardDeviation": 0.0,
+              "sampleCount": 147,
+              "innerIterations": 2048,
+              "sampledDuration": 301.0263
             }
           ]
         },
@@ -2006,12 +2006,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 10.7893,
-              "minimum": 8.5977,
-              "standardDeviation": 1.0748,
-              "sampleCount": 28,
+              "mean": 9.7718,
+              "minimum": 8.3223,
+              "standardDeviation": 0.6592,
+              "sampleCount": 31,
               "innerIterations": 1,
-              "sampledDuration": 302.0996
+              "sampledDuration": 302.9264
             }
           ]
         },
@@ -2021,12 +2021,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0054,
+              "mean": 0.0051,
               "minimum": 0.0049,
-              "standardDeviation": 0.0008,
-              "sampleCount": 219,
+              "standardDeviation": 0.0003,
+              "sampleCount": 232,
               "innerIterations": 256,
-              "sampledDuration": 300.4839
+              "sampledDuration": 301.3832
             }
           ]
         },
@@ -2037,11 +2037,11 @@
             {
               "launch": 1,
               "mean": 0.0106,
-              "minimum": 0.0098,
-              "standardDeviation": 0.001,
-              "sampleCount": 221,
+              "minimum": 0.01,
+              "standardDeviation": 0.0005,
+              "sampleCount": 222,
               "innerIterations": 128,
-              "sampledDuration": 300.5224
+              "sampledDuration": 300.2024
             }
           ]
         },
@@ -2068,12 +2068,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 105.9738,
-              "minimum": 98.0993,
-              "standardDeviation": 5.8216,
+              "mean": 107.6645,
+              "minimum": 105.0861,
+              "standardDeviation": 1.4457,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 847.7906
+              "sampledDuration": 861.3163
             }
           ]
         },
@@ -2083,12 +2083,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0527,
-              "minimum": 0.049,
-              "standardDeviation": 0.0035,
-              "sampleCount": 178,
+              "mean": 0.0581,
+              "minimum": 0.0509,
+              "standardDeviation": 0.0112,
+              "sampleCount": 162,
               "innerIterations": 32,
-              "sampledDuration": 300.1717
+              "sampledDuration": 301.2377
             }
           ]
         },
@@ -2098,12 +2098,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0986,
-              "minimum": 0.0903,
-              "standardDeviation": 0.0067,
-              "sampleCount": 191,
+              "mean": 0.0948,
+              "minimum": 0.0875,
+              "standardDeviation": 0.0041,
+              "sampleCount": 198,
               "innerIterations": 16,
-              "sampledDuration": 301.3934
+              "sampledDuration": 300.2242
             }
           ]
         },
@@ -2130,12 +2130,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.8838,
-              "minimum": 0.7672,
-              "standardDeviation": 0.0637,
-              "sampleCount": 170,
+              "mean": 0.9211,
+              "minimum": 0.8085,
+              "standardDeviation": 0.0725,
+              "sampleCount": 163,
               "innerIterations": 2,
-              "sampledDuration": 300.4848
+              "sampledDuration": 300.2768
             }
           ]
         },
@@ -2145,12 +2145,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0009,
-              "minimum": 0.0005,
-              "standardDeviation": 0.0021,
-              "sampleCount": 2752,
-              "innerIterations": 128,
-              "sampledDuration": 300.0657
+              "mean": 0.0028,
+              "minimum": 0.0006,
+              "standardDeviation": 0.0121,
+              "sampleCount": 100000,
+              "innerIterations": 1,
+              "sampledDuration": 280.0515
             }
           ]
         },
@@ -2162,10 +2162,10 @@
               "launch": 1,
               "mean": 0.001,
               "minimum": 0.001,
-              "standardDeviation": 0.0001,
-              "sampleCount": 295,
-              "innerIterations": 1024,
-              "sampledDuration": 300.8492
+              "standardDeviation": 0.0,
+              "sampleCount": 147,
+              "innerIterations": 2048,
+              "sampledDuration": 301.308
             }
           ]
         },
@@ -2192,12 +2192,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 10.7542,
-              "minimum": 8.5048,
-              "standardDeviation": 1.7882,
-              "sampleCount": 28,
+              "mean": 9.9452,
+              "minimum": 7.6616,
+              "standardDeviation": 0.8923,
+              "sampleCount": 31,
               "innerIterations": 1,
-              "sampledDuration": 301.1165
+              "sampledDuration": 308.302
             }
           ]
         },
@@ -2208,11 +2208,11 @@
             {
               "launch": 1,
               "mean": 0.0049,
-              "minimum": 0.0047,
-              "standardDeviation": 0.0003,
+              "minimum": 0.0048,
+              "standardDeviation": 0.0002,
               "sampleCount": 238,
               "innerIterations": 256,
-              "sampledDuration": 300.6046
+              "sampledDuration": 300.2441
             }
           ]
         },
@@ -2222,12 +2222,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0107,
-              "minimum": 0.0102,
-              "standardDeviation": 0.0007,
-              "sampleCount": 220,
+              "mean": 0.0104,
+              "minimum": 0.01,
+              "standardDeviation": 0.0003,
+              "sampleCount": 225,
               "innerIterations": 128,
-              "sampledDuration": 300.2118
+              "sampledDuration": 300.2676
             }
           ]
         },
@@ -2254,12 +2254,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 118.1751,
-              "minimum": 109.5446,
-              "standardDeviation": 5.7556,
+              "mean": 112.5586,
+              "minimum": 106.9129,
+              "standardDeviation": 5.9906,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 945.401
+              "sampledDuration": 900.4689
             }
           ]
         },
@@ -2269,12 +2269,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.052,
-              "minimum": 0.0485,
-              "standardDeviation": 0.0058,
-              "sampleCount": 181,
-              "innerIterations": 32,
-              "sampledDuration": 300.8974
+              "mean": 0.0566,
+              "minimum": 0.0504,
+              "standardDeviation": 0.003,
+              "sampleCount": 332,
+              "innerIterations": 16,
+              "sampledDuration": 300.584
             }
           ]
         },
@@ -2284,12 +2284,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1017,
-              "minimum": 0.0926,
-              "standardDeviation": 0.006,
-              "sampleCount": 185,
+              "mean": 0.0968,
+              "minimum": 0.0902,
+              "standardDeviation": 0.0046,
+              "sampleCount": 194,
               "innerIterations": 16,
-              "sampledDuration": 300.907
+              "sampledDuration": 300.5689
             }
           ]
         },
@@ -2316,12 +2316,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.0034,
-              "minimum": 1.5588,
-              "standardDeviation": 0.2157,
-              "sampleCount": 150,
+              "mean": 2.2954,
+              "minimum": 0.9194,
+              "standardDeviation": 1.7221,
+              "sampleCount": 131,
               "innerIterations": 1,
-              "sampledDuration": 300.5062
+              "sampledDuration": 300.6992
             }
           ]
         },
@@ -2331,12 +2331,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0007,
+              "mean": 0.0008,
               "minimum": 0.0005,
-              "standardDeviation": 0.0013,
-              "sampleCount": 3367,
+              "standardDeviation": 0.0016,
+              "sampleCount": 3074,
               "innerIterations": 128,
-              "sampledDuration": 300.0269
+              "sampledDuration": 300.0207
             }
           ]
         },
@@ -2349,9 +2349,9 @@
               "mean": 0.0004,
               "minimum": 0.0003,
               "standardDeviation": 0.0,
-              "sampleCount": 202,
+              "sampleCount": 199,
               "innerIterations": 4096,
-              "sampledDuration": 300.9268
+              "sampledDuration": 300.3216
             }
           ]
         },
@@ -2378,12 +2378,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 10.0736,
-              "minimum": 7.9396,
-              "standardDeviation": 0.8651,
-              "sampleCount": 30,
+              "mean": 9.6393,
+              "minimum": 8.0728,
+              "standardDeviation": 0.7445,
+              "sampleCount": 32,
               "innerIterations": 1,
-              "sampledDuration": 302.2065
+              "sampledDuration": 308.4582
             }
           ]
         },
@@ -2393,12 +2393,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0053,
-              "minimum": 0.0046,
-              "standardDeviation": 0.0008,
-              "sampleCount": 222,
+              "mean": 0.0051,
+              "minimum": 0.0049,
+              "standardDeviation": 0.0005,
+              "sampleCount": 229,
               "innerIterations": 256,
-              "sampledDuration": 300.4916
+              "sampledDuration": 300.961
             }
           ]
         },
@@ -2408,12 +2408,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0062,
-              "minimum": 0.006,
-              "standardDeviation": 0.0003,
-              "sampleCount": 191,
+              "mean": 0.0066,
+              "minimum": 0.0061,
+              "standardDeviation": 0.0009,
+              "sampleCount": 178,
               "innerIterations": 256,
-              "sampledDuration": 301.3131
+              "sampledDuration": 300.5308
             }
           ]
         },
@@ -2440,12 +2440,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 99.2617,
-              "minimum": 95.1741,
-              "standardDeviation": 3.4006,
+              "mean": 101.0525,
+              "minimum": 94.4872,
+              "standardDeviation": 3.5524,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 794.0932
+              "sampledDuration": 808.4197
             }
           ]
         },
@@ -2455,12 +2455,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0502,
-              "minimum": 0.0485,
-              "standardDeviation": 0.0026,
-              "sampleCount": 187,
-              "innerIterations": 32,
-              "sampledDuration": 300.1429
+              "mean": 0.0561,
+              "minimum": 0.0486,
+              "standardDeviation": 0.0071,
+              "sampleCount": 335,
+              "innerIterations": 16,
+              "sampledDuration": 300.4949
             }
           ]
         },
@@ -2470,12 +2470,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0929,
-              "minimum": 0.0884,
-              "standardDeviation": 0.0058,
-              "sampleCount": 202,
+              "mean": 0.0919,
+              "minimum": 0.0885,
+              "standardDeviation": 0.0051,
+              "sampleCount": 205,
               "innerIterations": 16,
-              "sampledDuration": 300.0934
+              "sampledDuration": 301.3538
             }
           ]
         },
@@ -2502,12 +2502,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.6198,
-              "minimum": 1.4386,
-              "standardDeviation": 0.107,
-              "sampleCount": 186,
+              "mean": 1.5546,
+              "minimum": 1.3047,
+              "standardDeviation": 0.1312,
+              "sampleCount": 194,
               "innerIterations": 1,
-              "sampledDuration": 301.2791
+              "sampledDuration": 301.6021
             }
           ]
         },
@@ -2519,10 +2519,10 @@
               "launch": 1,
               "mean": 0.001,
               "minimum": 0.0005,
-              "standardDeviation": 0.002,
-              "sampleCount": 4816,
-              "innerIterations": 64,
-              "sampledDuration": 300.0171
+              "standardDeviation": 0.0022,
+              "sampleCount": 2372,
+              "innerIterations": 128,
+              "sampledDuration": 300.0079
             }
           ]
         },
@@ -2534,10 +2534,10 @@
               "launch": 1,
               "mean": 0.001,
               "minimum": 0.001,
-              "standardDeviation": 0.0,
-              "sampleCount": 297,
+              "standardDeviation": 0.0001,
+              "sampleCount": 295,
               "innerIterations": 1024,
-              "sampledDuration": 300.5015
+              "sampledDuration": 300.9534
             }
           ]
         },
@@ -2564,12 +2564,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 18.3468,
-              "minimum": 17.1346,
-              "standardDeviation": 1.3587,
-              "sampleCount": 17,
+              "mean": 16.9311,
+              "minimum": 16.3183,
+              "standardDeviation": 0.4019,
+              "sampleCount": 18,
               "innerIterations": 1,
-              "sampledDuration": 311.896
+              "sampledDuration": 304.7594
             }
           ]
         },
@@ -2579,12 +2579,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0054,
+              "mean": 0.0053,
               "minimum": 0.0049,
-              "standardDeviation": 0.0007,
-              "sampleCount": 436,
-              "innerIterations": 128,
-              "sampledDuration": 300.4125
+              "standardDeviation": 0.0004,
+              "sampleCount": 222,
+              "innerIterations": 256,
+              "sampledDuration": 300.3449
             }
           ]
         },
@@ -2594,12 +2594,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0102,
-              "minimum": 0.0098,
-              "standardDeviation": 0.0008,
-              "sampleCount": 231,
+              "mean": 0.0107,
+              "minimum": 0.0102,
+              "standardDeviation": 0.0007,
+              "sampleCount": 219,
               "innerIterations": 128,
-              "sampledDuration": 300.6087
+              "sampledDuration": 300.4921
             }
           ]
         },
@@ -2626,12 +2626,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 185.8481,
-              "minimum": 174.7893,
-              "standardDeviation": 8.1364,
+              "mean": 216.9036,
+              "minimum": 200.7401,
+              "standardDeviation": 12.132,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 1486.7851
+              "sampledDuration": 1735.2291
             }
           ]
         },
@@ -2641,12 +2641,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0513,
-              "minimum": 0.0487,
-              "standardDeviation": 0.0033,
-              "sampleCount": 183,
-              "innerIterations": 32,
-              "sampledDuration": 300.2921
+              "mean": 0.0556,
+              "minimum": 0.0503,
+              "standardDeviation": 0.0046,
+              "sampleCount": 338,
+              "innerIterations": 16,
+              "sampledDuration": 300.6395
             }
           ]
         },
@@ -2656,12 +2656,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1156,
-              "minimum": 0.1108,
-              "standardDeviation": 0.0054,
-              "sampleCount": 325,
-              "innerIterations": 8,
-              "sampledDuration": 300.4996
+              "mean": 0.1141,
+              "minimum": 0.1112,
+              "standardDeviation": 0.0033,
+              "sampleCount": 165,
+              "innerIterations": 16,
+              "sampledDuration": 301.1145
             }
           ]
         },
@@ -2688,12 +2688,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.9903,
-              "minimum": 0.5976,
-              "standardDeviation": 1.8019,
-              "sampleCount": 151,
+              "mean": 4.2359,
+              "minimum": 1.4298,
+              "standardDeviation": 2.2596,
+              "sampleCount": 71,
               "innerIterations": 1,
-              "sampledDuration": 300.529
+              "sampledDuration": 300.75
             }
           ]
         },
@@ -2703,12 +2703,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0035,
-              "minimum": 0.0015,
-              "standardDeviation": 0.007,
-              "sampleCount": 84816,
+              "mean": 0.0038,
+              "minimum": 0.0016,
+              "standardDeviation": 0.0073,
+              "sampleCount": 78599,
               "innerIterations": 1,
-              "sampledDuration": 300.0009
+              "sampledDuration": 300.0008
             }
           ]
         },
@@ -2718,12 +2718,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0097,
-              "minimum": 0.0076,
-              "standardDeviation": 0.0018,
-              "sampleCount": 121,
-              "innerIterations": 256,
-              "sampledDuration": 301.4998
+              "mean": 0.0183,
+              "minimum": 0.0143,
+              "standardDeviation": 0.0028,
+              "sampleCount": 128,
+              "innerIterations": 128,
+              "sampledDuration": 300.5517
             }
           ]
         },
@@ -2750,12 +2750,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 6.075,
-              "minimum": 5.7501,
-              "standardDeviation": 0.201,
-              "sampleCount": 50,
+              "mean": 11.72,
+              "minimum": 7.3087,
+              "standardDeviation": 3.0387,
+              "sampleCount": 26,
               "innerIterations": 1,
-              "sampledDuration": 303.7486
+              "sampledDuration": 304.7192
             }
           ]
         },
@@ -2765,12 +2765,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0181,
-              "minimum": 0.0158,
-              "standardDeviation": 0.003,
-              "sampleCount": 260,
+              "mean": 0.0203,
+              "minimum": 0.0177,
+              "standardDeviation": 0.0033,
+              "sampleCount": 232,
               "innerIterations": 64,
-              "sampledDuration": 300.68
+              "sampledDuration": 301.0019
             }
           ]
         },
@@ -2780,12 +2780,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0806,
-              "minimum": 0.0684,
-              "standardDeviation": 0.0142,
-              "sampleCount": 233,
-              "innerIterations": 16,
-              "sampledDuration": 300.5369
+              "mean": 0.1413,
+              "minimum": 0.1169,
+              "standardDeviation": 0.022,
+              "sampleCount": 266,
+              "innerIterations": 8,
+              "sampledDuration": 300.5967
             }
           ]
         },
@@ -2812,12 +2812,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 63.1812,
-              "minimum": 60.311,
-              "standardDeviation": 2.0221,
+              "mean": 65.765,
+              "minimum": 61.8322,
+              "standardDeviation": 3.9495,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 505.4498
+              "sampledDuration": 526.1199
             }
           ]
         },
@@ -2827,12 +2827,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1771,
-              "minimum": 0.158,
-              "standardDeviation": 0.0172,
-              "sampleCount": 212,
+              "mean": 0.2097,
+              "minimum": 0.1867,
+              "standardDeviation": 0.0326,
+              "sampleCount": 180,
               "innerIterations": 8,
-              "sampledDuration": 300.2783
+              "sampledDuration": 302.0113
             }
           ]
         },
@@ -2842,12 +2842,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.8281,
-              "minimum": 0.7114,
-              "standardDeviation": 0.1177,
-              "sampleCount": 363,
+              "mean": 1.8011,
+              "minimum": 1.2781,
+              "standardDeviation": 0.3603,
+              "sampleCount": 167,
               "innerIterations": 1,
-              "sampledDuration": 300.5851
+              "sampledDuration": 300.7808
             }
           ]
         },
@@ -2874,12 +2874,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 8.5581,
-              "minimum": 6.2204,
-              "standardDeviation": 4.3922,
-              "sampleCount": 36,
+              "mean": 12.7929,
+              "minimum": 9.2698,
+              "standardDeviation": 5.476,
+              "sampleCount": 24,
               "innerIterations": 1,
-              "sampledDuration": 308.0914
+              "sampledDuration": 307.0286
             }
           ]
         },
@@ -2889,12 +2889,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0128,
-              "minimum": 0.0067,
-              "standardDeviation": 0.0174,
-              "sampleCount": 23353,
+              "mean": 0.0124,
+              "minimum": 0.0062,
+              "standardDeviation": 0.0196,
+              "sampleCount": 24202,
               "innerIterations": 1,
-              "sampledDuration": 300.007
+              "sampledDuration": 300.0029
             }
           ]
         },
@@ -2904,12 +2904,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0029,
+              "mean": 0.0028,
               "minimum": 0.0025,
               "standardDeviation": 0.0003,
-              "sampleCount": 205,
+              "sampleCount": 209,
               "innerIterations": 512,
-              "sampledDuration": 300.6692
+              "sampledDuration": 300.5848
             }
           ]
         },
@@ -2936,12 +2936,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 55.3893,
-              "minimum": 21.5058,
-              "standardDeviation": 58.0787,
+              "mean": 59.7707,
+              "minimum": 24.3273,
+              "standardDeviation": 37.4179,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 443.1144
+              "sampledDuration": 478.1659
             }
           ]
         },
@@ -2951,12 +2951,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0821,
-              "minimum": 0.074,
-              "standardDeviation": 0.0067,
-              "sampleCount": 229,
+              "mean": 0.0797,
+              "minimum": 0.0713,
+              "standardDeviation": 0.0058,
+              "sampleCount": 236,
               "innerIterations": 16,
-              "sampledDuration": 300.6351
+              "sampledDuration": 300.8965
             }
           ]
         },
@@ -2966,12 +2966,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0419,
-              "minimum": 0.0367,
-              "standardDeviation": 0.0048,
-              "sampleCount": 224,
+              "mean": 0.0396,
+              "minimum": 0.0364,
+              "standardDeviation": 0.003,
+              "sampleCount": 237,
               "innerIterations": 32,
-              "sampledDuration": 300.3659
+              "sampledDuration": 300.3759
             }
           ]
         },
@@ -2998,12 +2998,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 226.993,
-              "minimum": 211.1688,
-              "standardDeviation": 13.6597,
+              "mean": 256.4691,
+              "minimum": 215.0322,
+              "standardDeviation": 28.6645,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 1815.9438
+              "sampledDuration": 2051.7525
             }
           ]
         },
@@ -3013,12 +3013,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.0118,
-              "minimum": 0.785,
-              "standardDeviation": 0.2662,
-              "sampleCount": 149,
+              "mean": 0.935,
+              "minimum": 0.7599,
+              "standardDeviation": 0.1927,
+              "sampleCount": 161,
               "innerIterations": 2,
-              "sampledDuration": 301.5128
+              "sampledDuration": 301.0696
             }
           ]
         },
@@ -3028,12 +3028,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.8562,
-              "minimum": 0.6863,
-              "standardDeviation": 0.267,
-              "sampleCount": 351,
-              "innerIterations": 1,
-              "sampledDuration": 300.5207
+              "mean": 0.8914,
+              "minimum": 0.7214,
+              "standardDeviation": 0.1826,
+              "sampleCount": 169,
+              "innerIterations": 2,
+              "sampledDuration": 301.2779
             }
           ]
         },
@@ -3060,12 +3060,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.4121,
-              "minimum": 0.2982,
-              "standardDeviation": 0.7271,
-              "sampleCount": 728,
+              "mean": 0.3776,
+              "minimum": 0.2867,
+              "standardDeviation": 0.3234,
+              "sampleCount": 795,
               "innerIterations": 1,
-              "sampledDuration": 300.0054
+              "sampledDuration": 300.1733
             }
           ]
         },
@@ -3075,12 +3075,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0023,
+              "mean": 0.0022,
               "minimum": 0.0018,
-              "standardDeviation": 0.0055,
+              "standardDeviation": 0.0091,
               "sampleCount": 100000,
               "innerIterations": 1,
-              "sampledDuration": 230.4859
+              "sampledDuration": 223.5548
             }
           ]
         },
@@ -3093,9 +3093,9 @@
               "mean": 0.0007,
               "minimum": 0.0006,
               "standardDeviation": 0.0001,
-              "sampleCount": 208,
+              "sampleCount": 200,
               "innerIterations": 2048,
-              "sampledDuration": 300.7719
+              "sampledDuration": 300.4905
             }
           ]
         },
@@ -3122,12 +3122,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 25.0837,
-              "minimum": 6.0762,
-              "standardDeviation": 22.3835,
-              "sampleCount": 12,
+              "mean": 12.6461,
+              "minimum": 5.5851,
+              "standardDeviation": 12.4894,
+              "sampleCount": 24,
               "innerIterations": 1,
-              "sampledDuration": 301.0039
+              "sampledDuration": 303.5067
             }
           ]
         },
@@ -3137,10 +3137,10 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.067,
-              "minimum": 0.0467,
-              "standardDeviation": 0.0332,
-              "sampleCount": 560,
+              "mean": 0.0489,
+              "minimum": 0.0428,
+              "standardDeviation": 0.0143,
+              "sampleCount": 767,
               "innerIterations": 8,
               "sampledDuration": 300.0556
             }
@@ -3152,12 +3152,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0669,
-              "minimum": 0.0571,
-              "standardDeviation": 0.0056,
-              "sampleCount": 141,
-              "innerIterations": 32,
-              "sampledDuration": 301.6813
+              "mean": 0.0646,
+              "minimum": 0.0563,
+              "standardDeviation": 0.0059,
+              "sampleCount": 291,
+              "innerIterations": 16,
+              "sampledDuration": 300.9586
             }
           ]
         },
@@ -3184,12 +3184,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 54.114,
-              "minimum": 51.446,
-              "standardDeviation": 2.274,
+              "mean": 54.2659,
+              "minimum": 53.5509,
+              "standardDeviation": 0.6603,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 432.912
+              "sampledDuration": 434.127
             }
           ]
         },
@@ -3199,12 +3199,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.4556,
-              "minimum": 0.4335,
-              "standardDeviation": 0.0193,
-              "sampleCount": 165,
+              "mean": 0.4645,
+              "minimum": 0.4333,
+              "standardDeviation": 0.0212,
+              "sampleCount": 162,
               "innerIterations": 4,
-              "sampledDuration": 300.7112
+              "sampledDuration": 301.0166
             }
           ]
         },
@@ -3214,12 +3214,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.6402,
-              "minimum": 0.536,
-              "standardDeviation": 0.1224,
-              "sampleCount": 469,
+              "mean": 0.6593,
+              "minimum": 0.549,
+              "standardDeviation": 0.1321,
+              "sampleCount": 456,
               "innerIterations": 1,
-              "sampledDuration": 300.2495
+              "sampledDuration": 300.6347
             }
           ]
         },
@@ -3246,12 +3246,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 100.8883,
-              "minimum": 38.817,
-              "standardDeviation": 89.7259,
+              "mean": 96.88,
+              "minimum": 43.8545,
+              "standardDeviation": 93.741,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 807.1064
+              "sampledDuration": 775.0399
             }
           ]
         },
@@ -3261,12 +3261,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.155,
-              "minimum": 0.1411,
-              "standardDeviation": 0.045,
-              "sampleCount": 1936,
+              "mean": 0.4117,
+              "minimum": 0.2922,
+              "standardDeviation": 0.5855,
+              "sampleCount": 729,
               "innerIterations": 1,
-              "sampledDuration": 300.0036
+              "sampledDuration": 300.1533
             }
           ]
         },
@@ -3276,12 +3276,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.069,
-              "minimum": 0.0679,
-              "standardDeviation": 0.0022,
-              "sampleCount": 272,
-              "innerIterations": 16,
-              "sampledDuration": 300.2367
+              "mean": 0.186,
+              "minimum": 0.1163,
+              "standardDeviation": 0.3813,
+              "sampleCount": 1613,
+              "innerIterations": 1,
+              "sampledDuration": 300.0448
             }
           ]
         },
@@ -3308,12 +3308,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 40.3474,
-              "minimum": 38.8353,
-              "standardDeviation": 1.2247,
+              "mean": 100.7636,
+              "minimum": 64.0598,
+              "standardDeviation": 23.5155,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 322.7791
+              "sampledDuration": 806.1091
             }
           ]
         },
@@ -3323,12 +3323,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.3885,
-              "minimum": 1.0341,
-              "standardDeviation": 2.033,
-              "sampleCount": 217,
+              "mean": 4.9723,
+              "minimum": 1.9544,
+              "standardDeviation": 6.0176,
+              "sampleCount": 65,
               "innerIterations": 1,
-              "sampledDuration": 301.3021
+              "sampledDuration": 323.1973
             }
           ]
         },
@@ -3338,12 +3338,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.3971,
-              "minimum": 0.3309,
-              "standardDeviation": 0.0218,
-              "sampleCount": 189,
-              "innerIterations": 4,
-              "sampledDuration": 300.1747
+              "mean": 1.8357,
+              "minimum": 0.7177,
+              "standardDeviation": 4.2804,
+              "sampleCount": 164,
+              "innerIterations": 1,
+              "sampledDuration": 301.0627
             }
           ]
         },
@@ -3370,12 +3370,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 39.4917,
-              "minimum": 38.5246,
-              "standardDeviation": 0.9107,
+              "mean": 119.5642,
+              "minimum": 69.6855,
+              "standardDeviation": 24.3076,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 315.9338
+              "sampledDuration": 956.5138
             }
           ]
         },
@@ -3385,12 +3385,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1944,
-              "minimum": 0.1546,
-              "standardDeviation": 0.0386,
-              "sampleCount": 1544,
+              "mean": 0.4146,
+              "minimum": 0.2696,
+              "standardDeviation": 0.2416,
+              "sampleCount": 724,
               "innerIterations": 1,
-              "sampledDuration": 300.1542
+              "sampledDuration": 300.1545
             }
           ]
         },
@@ -3400,12 +3400,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.114,
-              "minimum": 0.1116,
-              "standardDeviation": 0.0038,
-              "sampleCount": 165,
-              "innerIterations": 16,
-              "sampledDuration": 300.873
+              "mean": 0.3015,
+              "minimum": 0.1696,
+              "standardDeviation": 0.8242,
+              "sampleCount": 254,
+              "innerIterations": 4,
+              "sampledDuration": 306.3122
             }
           ]
         },
@@ -3432,12 +3432,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 45.9121,
-              "minimum": 43.7309,
-              "standardDeviation": 1.8418,
+              "mean": 81.2313,
+              "minimum": 53.3287,
+              "standardDeviation": 26.3461,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 367.2964
+              "sampledDuration": 649.8501
             }
           ]
         },
@@ -3447,12 +3447,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1514,
-              "minimum": 0.1441,
-              "standardDeviation": 0.0076,
-              "sampleCount": 248,
-              "innerIterations": 8,
-              "sampledDuration": 300.3459
+              "mean": 0.4139,
+              "minimum": 0.2947,
+              "standardDeviation": 0.588,
+              "sampleCount": 725,
+              "innerIterations": 1,
+              "sampledDuration": 300.0421
             }
           ]
         },
@@ -3462,12 +3462,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0689,
-              "minimum": 0.0679,
-              "standardDeviation": 0.0022,
-              "sampleCount": 273,
-              "innerIterations": 16,
-              "sampledDuration": 300.7404
+              "mean": 0.1783,
+              "minimum": 0.1172,
+              "standardDeviation": 0.0675,
+              "sampleCount": 211,
+              "innerIterations": 8,
+              "sampledDuration": 301.0448
             }
           ]
         },
@@ -3494,12 +3494,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1107,
-              "minimum": 0.0272,
-              "standardDeviation": 0.4281,
-              "sampleCount": 2709,
+              "mean": 0.1671,
+              "minimum": 0.049,
+              "standardDeviation": 0.2814,
+              "sampleCount": 1796,
               "innerIterations": 1,
-              "sampledDuration": 300.0077
+              "sampledDuration": 300.0479
             }
           ]
         },
@@ -3509,12 +3509,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0009,
-              "minimum": 0.0006,
-              "standardDeviation": 0.0047,
+              "mean": 0.0011,
+              "minimum": 0.0008,
+              "standardDeviation": 0.0065,
               "sampleCount": 100000,
               "innerIterations": 1,
-              "sampledDuration": 88.8106
+              "sampledDuration": 114.7189
             }
           ]
         },
@@ -3524,12 +3524,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0,
-              "minimum": 0.0,
+              "mean": 0.0001,
+              "minimum": 0.0001,
               "standardDeviation": 0.0,
-              "sampleCount": 388,
+              "sampleCount": 306,
               "innerIterations": 16384,
-              "sampledDuration": 300.4863
+              "sampledDuration": 300.205
             }
           ]
         },
@@ -3556,12 +3556,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.2617,
-              "minimum": 0.2386,
-              "standardDeviation": 0.0136,
-              "sampleCount": 144,
-              "innerIterations": 8,
-              "sampledDuration": 301.4825
+              "mean": 0.4238,
+              "minimum": 0.3374,
+              "standardDeviation": 0.0693,
+              "sampleCount": 177,
+              "innerIterations": 4,
+              "sampledDuration": 300.0239
             }
           ]
         },
@@ -3571,12 +3571,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.001,
-              "minimum": 0.0008,
-              "standardDeviation": 0.0007,
-              "sampleCount": 583,
-              "innerIterations": 512,
-              "sampledDuration": 300.1226
+              "mean": 0.0016,
+              "minimum": 0.001,
+              "standardDeviation": 0.0013,
+              "sampleCount": 749,
+              "innerIterations": 256,
+              "sampledDuration": 300.1702
             }
           ]
         },
@@ -3586,12 +3586,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0008,
-              "minimum": 0.0008,
+              "mean": 0.0009,
+              "minimum": 0.0009,
               "standardDeviation": 0.0,
-              "sampleCount": 192,
-              "innerIterations": 2048,
-              "sampledDuration": 301.1519
+              "sampleCount": 315,
+              "innerIterations": 1024,
+              "sampledDuration": 300.86
             }
           ]
         },
@@ -3618,12 +3618,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.5029,
-              "minimum": 2.3665,
-              "standardDeviation": 0.1176,
-              "sampleCount": 120,
+              "mean": 3.4366,
+              "minimum": 3.0055,
+              "standardDeviation": 0.2497,
+              "sampleCount": 88,
               "innerIterations": 1,
-              "sampledDuration": 300.3457
+              "sampledDuration": 302.4241
             }
           ]
         },
@@ -3633,12 +3633,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.008,
-              "minimum": 0.0078,
-              "standardDeviation": 0.0003,
-              "sampleCount": 293,
+              "mean": 0.0097,
+              "minimum": 0.0093,
+              "standardDeviation": 0.0004,
+              "sampleCount": 243,
               "innerIterations": 128,
-              "sampledDuration": 300.3198
+              "sampledDuration": 300.7057
             }
           ]
         },
@@ -3648,12 +3648,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0079,
-              "minimum": 0.0078,
-              "standardDeviation": 0.0003,
-              "sampleCount": 296,
+              "mean": 0.0091,
+              "minimum": 0.0085,
+              "standardDeviation": 0.0004,
+              "sampleCount": 257,
               "innerIterations": 128,
-              "sampledDuration": 300.9077
+              "sampledDuration": 300.3889
             }
           ]
         },
@@ -3680,12 +3680,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.2486,
-              "minimum": 0.0592,
-              "standardDeviation": 0.2411,
-              "sampleCount": 1207,
+              "mean": 0.4959,
+              "minimum": 0.3828,
+              "standardDeviation": 0.4627,
+              "sampleCount": 605,
               "innerIterations": 1,
-              "sampledDuration": 300.0552
+              "sampledDuration": 300.0369
             }
           ]
         },
@@ -3695,12 +3695,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0008,
-              "minimum": 0.0006,
-              "standardDeviation": 0.005,
+              "mean": 0.0014,
+              "minimum": 0.0008,
+              "standardDeviation": 0.0179,
               "sampleCount": 100000,
               "innerIterations": 1,
-              "sampledDuration": 79.7618
+              "sampledDuration": 143.7948
             }
           ]
         },
@@ -3710,12 +3710,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0004,
-              "minimum": 0.0003,
-              "standardDeviation": 0.0,
-              "sampleCount": 210,
-              "innerIterations": 4096,
-              "sampledDuration": 301.3437
+              "mean": 0.001,
+              "minimum": 0.0006,
+              "standardDeviation": 0.0004,
+              "sampleCount": 294,
+              "innerIterations": 1024,
+              "sampledDuration": 300.1897
             }
           ]
         },
@@ -3742,12 +3742,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 7.2281,
-              "minimum": 6.8823,
-              "standardDeviation": 0.1644,
-              "sampleCount": 42,
+              "mean": 38.2481,
+              "minimum": 10.1663,
+              "standardDeviation": 23.6208,
+              "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 303.5794
+              "sampledDuration": 305.9851
             }
           ]
         },
@@ -3757,12 +3757,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.02,
-              "minimum": 0.0176,
-              "standardDeviation": 0.005,
-              "sampleCount": 235,
-              "innerIterations": 64,
-              "sampledDuration": 300.1318
+              "mean": 0.0516,
+              "minimum": 0.0376,
+              "standardDeviation": 0.0256,
+              "sampleCount": 364,
+              "innerIterations": 16,
+              "sampledDuration": 300.4572
             }
           ]
         },
@@ -3772,12 +3772,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0435,
-              "minimum": 0.042,
-              "standardDeviation": 0.0025,
-              "sampleCount": 216,
-              "innerIterations": 32,
-              "sampledDuration": 300.4167
+              "mean": 0.1225,
+              "minimum": 0.0833,
+              "standardDeviation": 0.0403,
+              "sampleCount": 307,
+              "innerIterations": 8,
+              "sampledDuration": 300.7655
             }
           ]
         },
@@ -3804,12 +3804,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 879.6726,
-              "minimum": 861.1476,
-              "standardDeviation": 19.2087,
-              "sampleCount": 3,
+              "mean": 1179.9853,
+              "minimum": 1152.3182,
+              "standardDeviation": 39.1272,
+              "sampleCount": 2,
               "innerIterations": 1,
-              "sampledDuration": 2639.0177
+              "sampledDuration": 2359.9706
             }
           ]
         },
@@ -3819,12 +3819,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.205,
-              "minimum": 2.1561,
-              "standardDeviation": 0.0515,
-              "sampleCount": 137,
+              "mean": 16.8457,
+              "minimum": 4.4604,
+              "standardDeviation": 19.9143,
+              "sampleCount": 18,
               "innerIterations": 1,
-              "sampledDuration": 302.0915
+              "sampledDuration": 303.223
             }
           ]
         },
@@ -3834,12 +3834,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 5.2632,
-              "minimum": 5.1703,
-              "standardDeviation": 0.2158,
-              "sampleCount": 58,
+              "mean": 13.5219,
+              "minimum": 12.0568,
+              "standardDeviation": 1.0804,
+              "sampleCount": 23,
               "innerIterations": 1,
-              "sampledDuration": 305.2659
+              "sampledDuration": 311.0043
             }
           ]
         },
@@ -3866,12 +3866,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 9686.9027,
-              "minimum": 9686.9027,
+              "mean": 13436.78,
+              "minimum": 13436.78,
               "standardDeviation": 0.0,
               "sampleCount": 1,
               "innerIterations": 1,
-              "sampledDuration": 9686.9027
+              "sampledDuration": 13436.78
             }
           ]
         },
@@ -3881,12 +3881,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 24.3767,
-              "minimum": 24.1287,
-              "standardDeviation": 0.1961,
-              "sampleCount": 13,
+              "mean": 64.483,
+              "minimum": 51.2507,
+              "standardDeviation": 7.6676,
+              "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 316.897
+              "sampledDuration": 515.8641
             }
           ]
         },
@@ -3896,12 +3896,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 61.2812,
-              "minimum": 58.6655,
-              "standardDeviation": 2.1284,
+              "mean": 144.8243,
+              "minimum": 139.8197,
+              "standardDeviation": 3.2907,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 490.2498
+              "sampledDuration": 1158.5945
             }
           ]
         },
@@ -3928,12 +3928,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 3.7663,
-              "minimum": 3.3156,
-              "standardDeviation": 0.334,
-              "sampleCount": 80,
+              "mean": 3.903,
+              "minimum": 2.8155,
+              "standardDeviation": 0.4635,
+              "sampleCount": 77,
               "innerIterations": 1,
-              "sampledDuration": 301.301
+              "sampledDuration": 300.5293
             }
           ]
         },
@@ -3943,12 +3943,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0042,
-              "minimum": 0.0034,
-              "standardDeviation": 0.0011,
-              "sampleCount": 278,
+              "mean": 0.0045,
+              "minimum": 0.0035,
+              "standardDeviation": 0.0013,
+              "sampleCount": 260,
               "innerIterations": 256,
-              "sampledDuration": 300.6925
+              "sampledDuration": 300.2558
             }
           ]
         },
@@ -3958,12 +3958,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0049,
+              "mean": 0.0051,
               "minimum": 0.0032,
-              "standardDeviation": 0.0008,
-              "sampleCount": 238,
+              "standardDeviation": 0.0009,
+              "sampleCount": 229,
               "innerIterations": 256,
-              "sampledDuration": 300.5046
+              "sampledDuration": 300.2377
             }
           ]
         },
@@ -3990,12 +3990,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 242.7848,
-              "minimum": 236.4177,
-              "standardDeviation": 11.9604,
+              "mean": 263.8976,
+              "minimum": 243.7379,
+              "standardDeviation": 17.8407,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 1942.2786
+              "sampledDuration": 2111.181
             }
           ]
         },
@@ -4005,12 +4005,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.4825,
-              "minimum": 0.4537,
-              "standardDeviation": 0.0376,
-              "sampleCount": 156,
+              "mean": 0.4962,
+              "minimum": 0.4592,
+              "standardDeviation": 0.0416,
+              "sampleCount": 152,
               "innerIterations": 4,
-              "sampledDuration": 301.1104
+              "sampledDuration": 301.7154
             }
           ]
         },
@@ -4020,12 +4020,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.446,
-              "minimum": 0.3658,
-              "standardDeviation": 0.3742,
-              "sampleCount": 673,
-              "innerIterations": 1,
-              "sampledDuration": 300.1851
+              "mean": 0.4761,
+              "minimum": 0.3883,
+              "standardDeviation": 0.2464,
+              "sampleCount": 158,
+              "innerIterations": 4,
+              "sampledDuration": 300.88
             }
           ]
         },
@@ -4052,12 +4052,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2446.7923,
-              "minimum": 2446.7923,
+              "mean": 2625.7817,
+              "minimum": 2625.7817,
               "standardDeviation": 0.0,
               "sampleCount": 1,
               "innerIterations": 1,
-              "sampledDuration": 2446.7923
+              "sampledDuration": 2625.7817
             }
           ]
         },
@@ -4067,12 +4067,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 3.8893,
-              "minimum": 3.3842,
-              "standardDeviation": 0.4158,
-              "sampleCount": 78,
+              "mean": 3.9578,
+              "minimum": 3.3758,
+              "standardDeviation": 0.4177,
+              "sampleCount": 76,
               "innerIterations": 1,
-              "sampledDuration": 303.3665
+              "sampledDuration": 300.7946
             }
           ]
         },
@@ -4082,12 +4082,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 3.6623,
-              "minimum": 3.3371,
-              "standardDeviation": 0.2454,
-              "sampleCount": 82,
+              "mean": 3.7357,
+              "minimum": 3.3502,
+              "standardDeviation": 0.3712,
+              "sampleCount": 81,
               "innerIterations": 1,
-              "sampledDuration": 300.3071
+              "sampledDuration": 302.5913
             }
           ]
         },
@@ -4114,12 +4114,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 3.7141,
-              "minimum": 1.2771,
-              "standardDeviation": 3.0751,
-              "sampleCount": 81,
+              "mean": 5.5757,
+              "minimum": 2.0069,
+              "standardDeviation": 3.4361,
+              "sampleCount": 54,
               "innerIterations": 1,
-              "sampledDuration": 300.8437
+              "sampledDuration": 301.0857
             }
           ]
         },
@@ -4129,12 +4129,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0036,
+              "mean": 0.004,
               "minimum": 0.002,
-              "standardDeviation": 0.0082,
-              "sampleCount": 83666,
+              "standardDeviation": 0.0101,
+              "sampleCount": 75452,
               "innerIterations": 1,
-              "sampledDuration": 300.1812
+              "sampledDuration": 300.0019
             }
           ]
         },
@@ -4146,10 +4146,10 @@
               "launch": 1,
               "mean": 0.0028,
               "minimum": 0.0023,
-              "standardDeviation": 0.0004,
-              "sampleCount": 207,
+              "standardDeviation": 0.0003,
+              "sampleCount": 206,
               "innerIterations": 512,
-              "sampledDuration": 301.0011
+              "sampledDuration": 300.2812
             }
           ]
         },
@@ -4176,12 +4176,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 121.3367,
-              "minimum": 110.7579,
-              "standardDeviation": 8.747,
+              "mean": 133.2979,
+              "minimum": 115.9447,
+              "standardDeviation": 22.3194,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 970.6934
+              "sampledDuration": 1066.3829
             }
           ]
         },
@@ -4191,12 +4191,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.277,
-              "minimum": 0.2327,
-              "standardDeviation": 0.042,
-              "sampleCount": 271,
-              "innerIterations": 4,
-              "sampledDuration": 300.2604
+              "mean": 0.2915,
+              "minimum": 0.2676,
+              "standardDeviation": 0.0381,
+              "sampleCount": 129,
+              "innerIterations": 8,
+              "sampledDuration": 300.8369
             }
           ]
         },
@@ -4206,12 +4206,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.2672,
-              "minimum": 0.2244,
-              "standardDeviation": 0.1278,
-              "sampleCount": 141,
+              "mean": 0.2783,
+              "minimum": 0.2283,
+              "standardDeviation": 0.1316,
+              "sampleCount": 135,
               "innerIterations": 8,
-              "sampledDuration": 301.4233
+              "sampledDuration": 300.5889
             }
           ]
         },
@@ -4238,12 +4238,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1060.1627,
-              "minimum": 1059.1806,
-              "standardDeviation": 1.3889,
+              "mean": 1198.4807,
+              "minimum": 1164.1601,
+              "standardDeviation": 48.5366,
               "sampleCount": 2,
               "innerIterations": 1,
-              "sampledDuration": 2120.3254
+              "sampledDuration": 2396.9613
             }
           ]
         },
@@ -4253,12 +4253,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.2354,
-              "minimum": 2.0452,
-              "standardDeviation": 0.1872,
-              "sampleCount": 135,
+              "mean": 2.7605,
+              "minimum": 2.5851,
+              "standardDeviation": 0.1663,
+              "sampleCount": 109,
               "innerIterations": 1,
-              "sampledDuration": 301.7829
+              "sampledDuration": 300.8892
             }
           ]
         },
@@ -4268,12 +4268,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.1043,
-              "minimum": 1.9452,
-              "standardDeviation": 0.2521,
-              "sampleCount": 143,
+              "mean": 2.1854,
+              "minimum": 1.9828,
+              "standardDeviation": 0.2387,
+              "sampleCount": 138,
               "innerIterations": 1,
-              "sampledDuration": 300.9135
+              "sampledDuration": 301.5837
             }
           ]
         },
@@ -4300,12 +4300,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.9175,
-              "minimum": 0.7163,
-              "standardDeviation": 1.3944,
-              "sampleCount": 327,
+              "mean": 1.0763,
+              "minimum": 0.7264,
+              "standardDeviation": 1.5644,
+              "sampleCount": 279,
               "innerIterations": 1,
-              "sampledDuration": 300.0337
+              "sampledDuration": 300.2764
             }
           ]
         },
@@ -4315,12 +4315,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0169,
+              "mean": 0.0164,
               "minimum": 0.0078,
-              "standardDeviation": 0.1904,
-              "sampleCount": 17752,
+              "standardDeviation": 0.1899,
+              "sampleCount": 18255,
               "innerIterations": 1,
-              "sampledDuration": 300.0016
+              "sampledDuration": 300.0072
             }
           ]
         },
@@ -4330,12 +4330,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.02,
-              "minimum": 0.019,
-              "standardDeviation": 0.0011,
-              "sampleCount": 234,
+              "mean": 0.0213,
+              "minimum": 0.0192,
+              "standardDeviation": 0.0029,
+              "sampleCount": 221,
               "innerIterations": 64,
-              "sampledDuration": 300.1723
+              "sampledDuration": 301.3912
             }
           ]
         },
@@ -4362,12 +4362,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 7.5477,
-              "minimum": 6.9175,
-              "standardDeviation": 1.1818,
-              "sampleCount": 40,
+              "mean": 12.6875,
+              "minimum": 11.4109,
+              "standardDeviation": 1.6264,
+              "sampleCount": 24,
               "innerIterations": 1,
-              "sampledDuration": 301.9064
+              "sampledDuration": 304.4995
             }
           ]
         },
@@ -4377,12 +4377,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0869,
-              "minimum": 0.0756,
-              "standardDeviation": 0.01,
-              "sampleCount": 216,
+              "mean": 0.0935,
+              "minimum": 0.0765,
+              "standardDeviation": 0.0121,
+              "sampleCount": 201,
               "innerIterations": 16,
-              "sampledDuration": 300.1874
+              "sampledDuration": 300.6217
             }
           ]
         },
@@ -4392,12 +4392,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1822,
-              "minimum": 0.1752,
-              "standardDeviation": 0.0074,
-              "sampleCount": 206,
+              "mean": 0.2053,
+              "minimum": 0.1756,
+              "standardDeviation": 0.0294,
+              "sampleCount": 183,
               "innerIterations": 8,
-              "sampledDuration": 300.3263
+              "sampledDuration": 300.5128
             }
           ]
         },
@@ -4424,12 +4424,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 62.3703,
-              "minimum": 26.4455,
-              "standardDeviation": 30.9219,
+              "mean": 57.0084,
+              "minimum": 27.0765,
+              "standardDeviation": 22.5618,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 498.9627
+              "sampledDuration": 456.0672
             }
           ]
         },
@@ -4439,12 +4439,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 4.0528,
-              "minimum": 0.8006,
-              "standardDeviation": 5.4417,
-              "sampleCount": 75,
+              "mean": 3.9076,
+              "minimum": 0.867,
+              "standardDeviation": 4.9387,
+              "sampleCount": 77,
               "innerIterations": 1,
-              "sampledDuration": 303.963
+              "sampledDuration": 300.8868
             }
           ]
         },
@@ -4454,12 +4454,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.1659,
-              "minimum": 1.9171,
-              "standardDeviation": 0.3215,
-              "sampleCount": 139,
+              "mean": 2.4398,
+              "minimum": 2.0284,
+              "standardDeviation": 0.3549,
+              "sampleCount": 123,
               "innerIterations": 1,
-              "sampledDuration": 301.0564
+              "sampledDuration": 300.0908
             }
           ]
         },
@@ -4486,12 +4486,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.3395,
-              "minimum": 0.3158,
-              "standardDeviation": 0.0144,
-              "sampleCount": 221,
+              "mean": 0.3562,
+              "minimum": 0.3007,
+              "standardDeviation": 0.0361,
+              "sampleCount": 211,
               "innerIterations": 4,
-              "sampledDuration": 300.099
+              "sampledDuration": 300.6383
             }
           ]
         },
@@ -4503,10 +4503,10 @@
               "launch": 1,
               "mean": 0.0021,
               "minimum": 0.0015,
-              "standardDeviation": 0.0011,
-              "sampleCount": 554,
+              "standardDeviation": 0.0012,
+              "sampleCount": 556,
               "innerIterations": 256,
-              "sampledDuration": 300.2321
+              "sampledDuration": 300.0029
             }
           ]
         },
@@ -4519,9 +4519,9 @@
               "mean": 0.0004,
               "minimum": 0.0004,
               "standardDeviation": 0.0,
-              "sampleCount": 176,
+              "sampleCount": 174,
               "innerIterations": 4096,
-              "sampledDuration": 301.3967
+              "sampledDuration": 300.1896
             }
           ]
         },
@@ -4548,12 +4548,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 3.8431,
-              "minimum": 3.2824,
-              "standardDeviation": 0.2373,
-              "sampleCount": 79,
+              "mean": 3.6594,
+              "minimum": 3.3561,
+              "standardDeviation": 0.2235,
+              "sampleCount": 82,
               "innerIterations": 1,
-              "sampledDuration": 303.6018
+              "sampledDuration": 300.0742
             }
           ]
         },
@@ -4563,12 +4563,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0159,
+              "mean": 0.0163,
               "minimum": 0.0155,
-              "standardDeviation": 0.0006,
-              "sampleCount": 296,
-              "innerIterations": 64,
-              "sampledDuration": 300.6024
+              "standardDeviation": 0.001,
+              "sampleCount": 144,
+              "innerIterations": 128,
+              "sampledDuration": 300.4305
             }
           ]
         },
@@ -4578,12 +4578,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0048,
-              "minimum": 0.0046,
-              "standardDeviation": 0.0003,
-              "sampleCount": 244,
+              "mean": 0.0066,
+              "minimum": 0.0052,
+              "standardDeviation": 0.0012,
+              "sampleCount": 178,
               "innerIterations": 256,
-              "sampledDuration": 300.7741
+              "sampledDuration": 302.235
             }
           ]
         },
@@ -4610,12 +4610,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 31.7673,
-              "minimum": 31.0433,
-              "standardDeviation": 0.6224,
-              "sampleCount": 10,
+              "mean": 33.9527,
+              "minimum": 33.1882,
+              "standardDeviation": 0.5683,
+              "sampleCount": 9,
               "innerIterations": 1,
-              "sampledDuration": 317.6731
+              "sampledDuration": 305.5745
             }
           ]
         },
@@ -4625,12 +4625,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1607,
-              "minimum": 0.1549,
-              "standardDeviation": 0.0063,
-              "sampleCount": 234,
+              "mean": 0.1643,
+              "minimum": 0.1551,
+              "standardDeviation": 0.0065,
+              "sampleCount": 229,
               "innerIterations": 8,
-              "sampledDuration": 300.8016
+              "sampledDuration": 301.0129
             }
           ]
         },
@@ -4640,12 +4640,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1585,
-              "minimum": 0.1562,
-              "standardDeviation": 0.0054,
-              "sampleCount": 237,
+              "mean": 0.1918,
+              "minimum": 0.1806,
+              "standardDeviation": 0.009,
+              "sampleCount": 196,
               "innerIterations": 8,
-              "sampledDuration": 300.4369
+              "sampledDuration": 300.7813
             }
           ]
         },
@@ -4672,12 +4672,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.8609,
-              "minimum": 0.7242,
-              "standardDeviation": 0.1242,
-              "sampleCount": 349,
+              "mean": 0.8808,
+              "minimum": 0.7064,
+              "standardDeviation": 0.1648,
+              "sampleCount": 341,
               "innerIterations": 1,
-              "sampledDuration": 300.465
+              "sampledDuration": 300.3515
             }
           ]
         },
@@ -4687,12 +4687,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1035,
-              "minimum": 0.0379,
-              "standardDeviation": 0.093,
-              "sampleCount": 2898,
+              "mean": 0.1063,
+              "minimum": 0.0391,
+              "standardDeviation": 0.0944,
+              "sampleCount": 2822,
               "innerIterations": 1,
-              "sampledDuration": 300.0282
+              "sampledDuration": 300.0127
             }
           ]
         },
@@ -4702,12 +4702,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0637,
-              "minimum": 0.0597,
-              "standardDeviation": 0.0052,
-              "sampleCount": 295,
-              "innerIterations": 16,
-              "sampledDuration": 300.8404
+              "mean": 0.0636,
+              "minimum": 0.0595,
+              "standardDeviation": 0.0054,
+              "sampleCount": 148,
+              "innerIterations": 32,
+              "sampledDuration": 301.4177
             }
           ]
         },
@@ -4734,12 +4734,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 7.5637,
-              "minimum": 7.0711,
-              "standardDeviation": 0.3331,
-              "sampleCount": 40,
+              "mean": 7.9531,
+              "minimum": 7.4573,
+              "standardDeviation": 0.2873,
+              "sampleCount": 38,
               "innerIterations": 1,
-              "sampledDuration": 302.5497
+              "sampledDuration": 302.2184
             }
           ]
         },
@@ -4749,12 +4749,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.4346,
-              "minimum": 0.4122,
-              "standardDeviation": 0.0258,
-              "sampleCount": 173,
-              "innerIterations": 4,
-              "sampledDuration": 300.7718
+              "mean": 0.4609,
+              "minimum": 0.423,
+              "standardDeviation": 0.0422,
+              "sampleCount": 326,
+              "innerIterations": 2,
+              "sampledDuration": 300.5026
             }
           ]
         },
@@ -4764,12 +4764,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.6316,
-              "minimum": 0.5974,
-              "standardDeviation": 0.0386,
-              "sampleCount": 238,
-              "innerIterations": 2,
-              "sampledDuration": 300.626
+              "mean": 1.0475,
+              "minimum": 0.9277,
+              "standardDeviation": 0.1584,
+              "sampleCount": 287,
+              "innerIterations": 1,
+              "sampledDuration": 300.6192
             }
           ]
         },
@@ -4796,12 +4796,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 73.6962,
-              "minimum": 72.3429,
-              "standardDeviation": 0.6927,
+              "mean": 79.9362,
+              "minimum": 77.7114,
+              "standardDeviation": 1.7862,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 589.5697
+              "sampledDuration": 639.4893
             }
           ]
         },
@@ -4811,12 +4811,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 4.467,
-              "minimum": 4.2391,
-              "standardDeviation": 0.166,
-              "sampleCount": 68,
+              "mean": 4.7468,
+              "minimum": 4.4569,
+              "standardDeviation": 0.2906,
+              "sampleCount": 64,
               "innerIterations": 1,
-              "sampledDuration": 303.7563
+              "sampledDuration": 303.7923
             }
           ]
         },
@@ -4826,12 +4826,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 6.1808,
-              "minimum": 6.02,
-              "standardDeviation": 0.129,
-              "sampleCount": 49,
+              "mean": 8.4975,
+              "minimum": 7.8422,
+              "standardDeviation": 0.2994,
+              "sampleCount": 36,
               "innerIterations": 1,
-              "sampledDuration": 302.8614
+              "sampledDuration": 305.9097
             }
           ]
         },
@@ -4858,12 +4858,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.775,
-              "minimum": 1.3613,
-              "standardDeviation": 1.075,
+              "mean": 1.7732,
+              "minimum": 1.2195,
+              "standardDeviation": 1.1782,
               "sampleCount": 170,
               "innerIterations": 1,
-              "sampledDuration": 301.7432
+              "sampledDuration": 301.4452
             }
           ]
         },
@@ -4873,12 +4873,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0034,
+              "mean": 0.0036,
               "minimum": 0.0019,
-              "standardDeviation": 0.0052,
-              "sampleCount": 1380,
+              "standardDeviation": 0.0056,
+              "sampleCount": 1292,
               "innerIterations": 64,
-              "sampledDuration": 300.0495
+              "sampledDuration": 300.0428
             }
           ]
         },
@@ -4888,12 +4888,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.009,
+              "mean": 0.0092,
               "minimum": 0.0083,
-              "standardDeviation": 0.0007,
-              "sampleCount": 260,
+              "standardDeviation": 0.0009,
+              "sampleCount": 255,
               "innerIterations": 128,
-              "sampledDuration": 300.3891
+              "sampledDuration": 300.414
             }
           ]
         },
@@ -4920,12 +4920,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 14.0678,
-              "minimum": 12.8809,
-              "standardDeviation": 1.8389,
+              "mean": 13.8968,
+              "minimum": 12.4911,
+              "standardDeviation": 1.0541,
               "sampleCount": 22,
               "innerIterations": 1,
-              "sampledDuration": 309.4917
+              "sampledDuration": 305.7301
             }
           ]
         },
@@ -4935,12 +4935,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0196,
+              "mean": 0.02,
               "minimum": 0.0191,
-              "standardDeviation": 0.0009,
-              "sampleCount": 239,
+              "standardDeviation": 0.0015,
+              "sampleCount": 235,
               "innerIterations": 64,
-              "sampledDuration": 300.4759
+              "sampledDuration": 300.7067
             }
           ]
         },
@@ -4950,12 +4950,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.09,
-              "minimum": 0.0842,
-              "standardDeviation": 0.0068,
-              "sampleCount": 209,
-              "innerIterations": 16,
-              "sampledDuration": 301.0175
+              "mean": 0.2126,
+              "minimum": 0.1487,
+              "standardDeviation": 0.0605,
+              "sampleCount": 177,
+              "innerIterations": 8,
+              "sampledDuration": 301.0779
             }
           ]
         },
@@ -4982,12 +4982,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 121.0215,
-              "minimum": 115.2698,
-              "standardDeviation": 4.311,
+              "mean": 131.954,
+              "minimum": 121.2593,
+              "standardDeviation": 5.9023,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 968.1721
+              "sampledDuration": 1055.6324
             }
           ]
         },
@@ -4997,12 +4997,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1967,
-              "minimum": 0.1901,
-              "standardDeviation": 0.0089,
-              "sampleCount": 191,
+              "mean": 0.2393,
+              "minimum": 0.2002,
+              "standardDeviation": 0.0281,
+              "sampleCount": 157,
               "innerIterations": 8,
-              "sampledDuration": 300.6004
+              "sampledDuration": 300.5318
             }
           ]
         },
@@ -5012,12 +5012,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.901,
-              "minimum": 0.8115,
-              "standardDeviation": 0.0664,
-              "sampleCount": 333,
+              "mean": 1.1719,
+              "minimum": 1.0024,
+              "standardDeviation": 0.0885,
+              "sampleCount": 257,
               "innerIterations": 1,
-              "sampledDuration": 300.0396
+              "sampledDuration": 301.1714
             }
           ]
         },
@@ -5044,12 +5044,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.29,
-              "minimum": 0.2536,
-              "standardDeviation": 0.0259,
-              "sampleCount": 259,
+              "mean": 0.2961,
+              "minimum": 0.2545,
+              "standardDeviation": 0.0467,
+              "sampleCount": 254,
               "innerIterations": 4,
-              "sampledDuration": 300.4614
+              "sampledDuration": 300.8625
             }
           ]
         },
@@ -5062,9 +5062,9 @@
               "mean": 0.0006,
               "minimum": 0.0004,
               "standardDeviation": 0.0006,
-              "sampleCount": 1039,
+              "sampleCount": 1037,
               "innerIterations": 512,
-              "sampledDuration": 300.0802
+              "sampledDuration": 300.1113
             }
           ]
         },
@@ -5077,9 +5077,9 @@
               "mean": 0.0003,
               "minimum": 0.0003,
               "standardDeviation": 0.0,
-              "sampleCount": 256,
+              "sampleCount": 253,
               "innerIterations": 4096,
-              "sampledDuration": 300.1624
+              "sampledDuration": 300.3074
             }
           ]
         },
@@ -5106,12 +5106,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.7018,
-              "minimum": 2.5763,
-              "standardDeviation": 0.0682,
-              "sampleCount": 112,
+              "mean": 2.7417,
+              "minimum": 2.4547,
+              "standardDeviation": 0.2039,
+              "sampleCount": 110,
               "innerIterations": 1,
-              "sampledDuration": 302.6007
+              "sampledDuration": 301.5882
             }
           ]
         },
@@ -5121,12 +5121,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0041,
+              "mean": 0.0042,
               "minimum": 0.004,
-              "standardDeviation": 0.0002,
-              "sampleCount": 290,
+              "standardDeviation": 0.0003,
+              "sampleCount": 283,
               "innerIterations": 256,
-              "sampledDuration": 300.7135
+              "sampledDuration": 300.7248
             }
           ]
         },
@@ -5136,12 +5136,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0037,
-              "minimum": 0.0036,
-              "standardDeviation": 0.0002,
-              "sampleCount": 159,
+              "mean": 0.0039,
+              "minimum": 0.0037,
+              "standardDeviation": 0.0003,
+              "sampleCount": 149,
               "innerIterations": 512,
-              "sampledDuration": 300.2876
+              "sampledDuration": 301.0031
             }
           ]
         },
@@ -5168,12 +5168,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 26.3975,
-              "minimum": 25.4875,
-              "standardDeviation": 0.8401,
+              "mean": 26.9341,
+              "minimum": 26.11,
+              "standardDeviation": 0.6057,
               "sampleCount": 12,
               "innerIterations": 1,
-              "sampledDuration": 316.7697
+              "sampledDuration": 323.2091
             }
           ]
         },
@@ -5183,12 +5183,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0403,
-              "minimum": 0.0396,
-              "standardDeviation": 0.0014,
-              "sampleCount": 233,
+              "mean": 0.0429,
+              "minimum": 0.0412,
+              "standardDeviation": 0.0026,
+              "sampleCount": 219,
               "innerIterations": 32,
-              "sampledDuration": 300.7375
+              "sampledDuration": 300.382
             }
           ]
         },
@@ -5198,12 +5198,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0464,
-              "minimum": 0.0454,
-              "standardDeviation": 0.0016,
-              "sampleCount": 202,
-              "innerIterations": 32,
-              "sampledDuration": 300.184
+              "mean": 0.082,
+              "minimum": 0.0684,
+              "standardDeviation": 0.0173,
+              "sampleCount": 229,
+              "innerIterations": 16,
+              "sampledDuration": 300.4993
             }
           ]
         },
@@ -5230,12 +5230,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.7145,
-              "minimum": 0.5183,
-              "standardDeviation": 1.4271,
-              "sampleCount": 175,
+              "mean": 1.2009,
+              "minimum": 0.3616,
+              "standardDeviation": 1.2795,
+              "sampleCount": 250,
               "innerIterations": 1,
-              "sampledDuration": 300.041
+              "sampledDuration": 300.2173
             }
           ]
         },
@@ -5245,12 +5245,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0021,
+              "mean": 0.002,
               "minimum": 0.0004,
-              "standardDeviation": 0.0049,
+              "standardDeviation": 0.0054,
               "sampleCount": 100000,
               "innerIterations": 1,
-              "sampledDuration": 205.6388
+              "sampledDuration": 197.3776
             }
           ]
         },
@@ -5263,9 +5263,9 @@
               "mean": 0.0003,
               "minimum": 0.0003,
               "standardDeviation": 0.0,
-              "sampleCount": 256,
+              "sampleCount": 254,
               "innerIterations": 4096,
-              "sampledDuration": 300.2695
+              "sampledDuration": 300.4883
             }
           ]
         },
@@ -5292,12 +5292,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 3.705,
-              "minimum": 3.4611,
-              "standardDeviation": 0.1283,
-              "sampleCount": 81,
+              "mean": 3.6634,
+              "minimum": 3.2644,
+              "standardDeviation": 0.216,
+              "sampleCount": 82,
               "innerIterations": 1,
-              "sampledDuration": 300.1065
+              "sampledDuration": 300.3968
             }
           ]
         },
@@ -5307,12 +5307,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.004,
+              "mean": 0.0042,
               "minimum": 0.004,
-              "standardDeviation": 0.0001,
-              "sampleCount": 290,
+              "standardDeviation": 0.0003,
+              "sampleCount": 281,
               "innerIterations": 256,
-              "sampledDuration": 300.4181
+              "sampledDuration": 300.514
             }
           ]
         },
@@ -5324,10 +5324,10 @@
               "launch": 1,
               "mean": 0.0037,
               "minimum": 0.0036,
-              "standardDeviation": 0.0003,
-              "sampleCount": 159,
+              "standardDeviation": 0.0002,
+              "sampleCount": 157,
               "innerIterations": 512,
-              "sampledDuration": 300.3484
+              "sampledDuration": 301.1981
             }
           ]
         },
@@ -5354,12 +5354,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 34.9135,
-              "minimum": 33.8107,
-              "standardDeviation": 0.9493,
+              "mean": 37.0473,
+              "minimum": 35.4875,
+              "standardDeviation": 1.4582,
               "sampleCount": 9,
               "innerIterations": 1,
-              "sampledDuration": 314.2214
+              "sampledDuration": 333.4255
             }
           ]
         },
@@ -5369,12 +5369,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0406,
+              "mean": 0.0417,
               "minimum": 0.0396,
-              "standardDeviation": 0.0023,
-              "sampleCount": 231,
+              "standardDeviation": 0.0034,
+              "sampleCount": 226,
               "innerIterations": 32,
-              "sampledDuration": 300.3401
+              "sampledDuration": 301.2937
             }
           ]
         },
@@ -5384,12 +5384,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0464,
-              "minimum": 0.0454,
-              "standardDeviation": 0.0019,
-              "sampleCount": 202,
-              "innerIterations": 32,
-              "sampledDuration": 300.1632
+              "mean": 0.0915,
+              "minimum": 0.0788,
+              "standardDeviation": 0.0228,
+              "sampleCount": 206,
+              "innerIterations": 16,
+              "sampledDuration": 301.6757
             }
           ]
         },
@@ -5416,12 +5416,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.9166,
-              "minimum": 0.6486,
-              "standardDeviation": 0.2886,
-              "sampleCount": 328,
+              "mean": 0.8375,
+              "minimum": 0.608,
+              "standardDeviation": 0.3155,
+              "sampleCount": 359,
               "innerIterations": 1,
-              "sampledDuration": 300.6357
+              "sampledDuration": 300.6754
             }
           ]
         },
@@ -5431,12 +5431,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0007,
+              "mean": 0.0006,
               "minimum": 0.0004,
-              "standardDeviation": 0.0008,
-              "sampleCount": 860,
+              "standardDeviation": 0.0007,
+              "sampleCount": 927,
               "innerIterations": 512,
-              "sampledDuration": 300.1139
+              "sampledDuration": 300.1092
             }
           ]
         },
@@ -5449,9 +5449,9 @@
               "mean": 0.0046,
               "minimum": 0.0044,
               "standardDeviation": 0.0004,
-              "sampleCount": 257,
+              "sampleCount": 255,
               "innerIterations": 256,
-              "sampledDuration": 300.7918
+              "sampledDuration": 301.1069
             }
           ]
         },
@@ -5478,12 +5478,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 7.2207,
-              "minimum": 6.6194,
-              "standardDeviation": 0.2762,
-              "sampleCount": 42,
+              "mean": 6.6684,
+              "minimum": 6.0885,
+              "standardDeviation": 0.3943,
+              "sampleCount": 46,
               "innerIterations": 1,
-              "sampledDuration": 303.2687
+              "sampledDuration": 306.748
             }
           ]
         },
@@ -5493,12 +5493,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.004,
+              "mean": 0.0042,
               "minimum": 0.004,
-              "standardDeviation": 0.0001,
-              "sampleCount": 290,
+              "standardDeviation": 0.0002,
+              "sampleCount": 282,
               "innerIterations": 256,
-              "sampledDuration": 300.0116
+              "sampledDuration": 300.2182
             }
           ]
         },
@@ -5508,12 +5508,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0461,
-              "minimum": 0.044,
-              "standardDeviation": 0.0031,
-              "sampleCount": 204,
-              "innerIterations": 32,
-              "sampledDuration": 300.9947
+              "mean": 0.084,
+              "minimum": 0.0736,
+              "standardDeviation": 0.0182,
+              "sampleCount": 224,
+              "innerIterations": 16,
+              "sampledDuration": 301.2111
             }
           ]
         },
@@ -5540,12 +5540,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 63.3323,
-              "minimum": 62.6766,
-              "standardDeviation": 0.5728,
+              "mean": 68.4761,
+              "minimum": 64.1657,
+              "standardDeviation": 2.4135,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 506.6584
+              "sampledDuration": 547.8091
             }
           ]
         },
@@ -5555,12 +5555,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0406,
+              "mean": 0.0431,
               "minimum": 0.0396,
-              "standardDeviation": 0.002,
-              "sampleCount": 231,
+              "standardDeviation": 0.0045,
+              "sampleCount": 218,
               "innerIterations": 32,
-              "sampledDuration": 300.2894
+              "sampledDuration": 300.9328
             }
           ]
         },
@@ -5570,12 +5570,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.1559,
-              "minimum": 1.0372,
-              "standardDeviation": 0.1656,
-              "sampleCount": 260,
+              "mean": 1.5397,
+              "minimum": 1.3282,
+              "standardDeviation": 0.2259,
+              "sampleCount": 196,
               "innerIterations": 1,
-              "sampledDuration": 300.5452
+              "sampledDuration": 301.7841
             }
           ]
         },
@@ -5602,12 +5602,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.9887,
-              "minimum": 0.8835,
-              "standardDeviation": 0.0634,
-              "sampleCount": 304,
+              "mean": 0.9467,
+              "minimum": 0.8252,
+              "standardDeviation": 0.0968,
+              "sampleCount": 317,
               "innerIterations": 1,
-              "sampledDuration": 300.5673
+              "sampledDuration": 300.0984
             }
           ]
         },
@@ -5617,12 +5617,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0009,
+              "mean": 0.001,
               "minimum": 0.0006,
-              "standardDeviation": 0.0009,
-              "sampleCount": 662,
+              "standardDeviation": 0.0011,
+              "sampleCount": 597,
               "innerIterations": 512,
-              "sampledDuration": 300.0185
+              "sampledDuration": 300.2446
             }
           ]
         },
@@ -5634,10 +5634,10 @@
               "launch": 1,
               "mean": 0.0003,
               "minimum": 0.0003,
-              "standardDeviation": 0.0,
-              "sampleCount": 236,
-              "innerIterations": 4096,
-              "sampledDuration": 301.0924
+              "standardDeviation": 0.0002,
+              "sampleCount": 7420,
+              "innerIterations": 128,
+              "sampledDuration": 300.0138
             }
           ]
         },
@@ -5664,12 +5664,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 9.224,
-              "minimum": 8.4633,
-              "standardDeviation": 0.3776,
-              "sampleCount": 33,
+              "mean": 9.4253,
+              "minimum": 8.6829,
+              "standardDeviation": 0.5148,
+              "sampleCount": 32,
               "innerIterations": 1,
-              "sampledDuration": 304.3932
+              "sampledDuration": 301.6098
             }
           ]
         },
@@ -5679,12 +5679,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0056,
+              "mean": 0.0058,
               "minimum": 0.0055,
-              "standardDeviation": 0.0002,
-              "sampleCount": 209,
+              "standardDeviation": 0.0004,
+              "sampleCount": 204,
               "innerIterations": 256,
-              "sampledDuration": 300.9576
+              "sampledDuration": 301.4538
             }
           ]
         },
@@ -5694,12 +5694,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0064,
-              "minimum": 0.006,
-              "standardDeviation": 0.0004,
-              "sampleCount": 184,
+              "mean": 0.0066,
+              "minimum": 0.0063,
+              "standardDeviation": 0.0005,
+              "sampleCount": 179,
               "innerIterations": 256,
-              "sampledDuration": 301.0208
+              "sampledDuration": 300.3455
             }
           ]
         },
@@ -5726,12 +5726,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 90.8636,
-              "minimum": 88.7645,
-              "standardDeviation": 1.1439,
+              "mean": 95.2972,
+              "minimum": 93.1832,
+              "standardDeviation": 1.7134,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 726.9085
+              "sampledDuration": 762.3778
             }
           ]
         },
@@ -5741,12 +5741,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0562,
+              "mean": 0.0597,
               "minimum": 0.055,
-              "standardDeviation": 0.0023,
-              "sampleCount": 167,
+              "standardDeviation": 0.0038,
+              "sampleCount": 158,
               "innerIterations": 32,
-              "sampledDuration": 300.5873
+              "sampledDuration": 301.7315
             }
           ]
         },
@@ -5756,12 +5756,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.5082,
-              "minimum": 0.4765,
-              "standardDeviation": 0.0416,
-              "sampleCount": 296,
-              "innerIterations": 2,
-              "sampledDuration": 300.8724
+              "mean": 0.4302,
+              "minimum": 0.0724,
+              "standardDeviation": 0.4322,
+              "sampleCount": 699,
+              "innerIterations": 1,
+              "sampledDuration": 300.7026
             }
           ]
         },
@@ -5788,12 +5788,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0959,
-              "minimum": 0.0774,
-              "standardDeviation": 0.0365,
-              "sampleCount": 3128,
+              "mean": 0.188,
+              "minimum": 0.0958,
+              "standardDeviation": 0.0651,
+              "sampleCount": 1596,
               "innerIterations": 1,
-              "sampledDuration": 300.0211
+              "sampledDuration": 300.0426
             }
           ]
         },
@@ -5803,12 +5803,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0023,
-              "minimum": 0.0016,
-              "standardDeviation": 0.0011,
-              "sampleCount": 518,
+              "mean": 0.0032,
+              "minimum": 0.0021,
+              "standardDeviation": 0.0017,
+              "sampleCount": 369,
               "innerIterations": 256,
-              "sampledDuration": 300.2174
+              "sampledDuration": 300.4702
             }
           ]
         },
@@ -5818,12 +5818,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0017,
-              "minimum": 0.0015,
+              "mean": 0.0021,
+              "minimum": 0.0019,
               "standardDeviation": 0.0001,
-              "sampleCount": 177,
-              "innerIterations": 1024,
-              "sampledDuration": 301.2305
+              "sampleCount": 275,
+              "innerIterations": 512,
+              "sampledDuration": 300.7396
             }
           ]
         },
@@ -5850,12 +5850,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.7647,
-              "minimum": 0.6745,
-              "standardDeviation": 0.1176,
-              "sampleCount": 197,
+              "mean": 1.0298,
+              "minimum": 0.9058,
+              "standardDeviation": 0.1142,
+              "sampleCount": 146,
               "innerIterations": 2,
-              "sampledDuration": 301.2888
+              "sampledDuration": 300.6891
             }
           ]
         },
@@ -5865,12 +5865,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.02,
-              "minimum": 0.0158,
-              "standardDeviation": 0.0026,
-              "sampleCount": 234,
+              "mean": 0.0235,
+              "minimum": 0.0203,
+              "standardDeviation": 0.0017,
+              "sampleCount": 200,
               "innerIterations": 64,
-              "sampledDuration": 300.1874
+              "sampledDuration": 300.6235
             }
           ]
         },
@@ -5880,12 +5880,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0139,
-              "minimum": 0.0134,
-              "standardDeviation": 0.0004,
-              "sampleCount": 169,
-              "innerIterations": 128,
-              "sampledDuration": 300.0456
+              "mean": 0.015,
+              "minimum": 0.0133,
+              "standardDeviation": 0.0024,
+              "sampleCount": 312,
+              "innerIterations": 64,
+              "sampledDuration": 300.3991
             }
           ]
         },
@@ -5912,12 +5912,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 12.3329,
-              "minimum": 8.8527,
-              "standardDeviation": 4.1894,
-              "sampleCount": 25,
+              "mean": 14.5308,
+              "minimum": 10.6805,
+              "standardDeviation": 4.4385,
+              "sampleCount": 21,
               "innerIterations": 1,
-              "sampledDuration": 308.3236
+              "sampledDuration": 305.1468
             }
           ]
         },
@@ -5927,12 +5927,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.4148,
-              "minimum": 0.2185,
-              "standardDeviation": 0.0842,
-              "sampleCount": 181,
-              "innerIterations": 4,
-              "sampledDuration": 300.298
+              "mean": 0.513,
+              "minimum": 0.2734,
+              "standardDeviation": 0.228,
+              "sampleCount": 293,
+              "innerIterations": 2,
+              "sampledDuration": 300.6076
             }
           ]
         },
@@ -5942,12 +5942,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.4442,
-              "minimum": 0.3619,
-              "standardDeviation": 0.1173,
-              "sampleCount": 169,
-              "innerIterations": 4,
-              "sampledDuration": 300.283
+              "mean": 0.4318,
+              "minimum": 0.3671,
+              "standardDeviation": 0.1401,
+              "sampleCount": 348,
+              "innerIterations": 2,
+              "sampledDuration": 300.5594
             }
           ]
         },
@@ -5974,12 +5974,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.7198,
-              "minimum": 0.2172,
-              "standardDeviation": 0.7743,
-              "sampleCount": 417,
+              "mean": 0.9969,
+              "minimum": 0.4884,
+              "standardDeviation": 0.7792,
+              "sampleCount": 301,
               "innerIterations": 1,
-              "sampledDuration": 300.1557
+              "sampledDuration": 300.0575
             }
           ]
         },
@@ -5989,12 +5989,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0035,
-              "minimum": 0.0013,
-              "standardDeviation": 0.0111,
-              "sampleCount": 85713,
+              "mean": 0.0047,
+              "minimum": 0.0016,
+              "standardDeviation": 0.0137,
+              "sampleCount": 64369,
               "innerIterations": 1,
-              "sampledDuration": 300.0001
+              "sampledDuration": 300.0012
             }
           ]
         },
@@ -6004,12 +6004,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0018,
-              "minimum": 0.0016,
+              "mean": 0.0023,
+              "minimum": 0.002,
               "standardDeviation": 0.0001,
-              "sampleCount": 328,
+              "sampleCount": 254,
               "innerIterations": 512,
-              "sampledDuration": 300.797
+              "sampledDuration": 300.4728
             }
           ]
         },
@@ -6036,12 +6036,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.4931,
-              "minimum": 1.3645,
-              "standardDeviation": 0.1677,
-              "sampleCount": 201,
+              "mean": 1.9171,
+              "minimum": 1.5843,
+              "standardDeviation": 0.2333,
+              "sampleCount": 157,
               "innerIterations": 1,
-              "sampledDuration": 300.1127
+              "sampledDuration": 300.9868
             }
           ]
         },
@@ -6051,12 +6051,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0149,
-              "minimum": 0.0131,
-              "standardDeviation": 0.0015,
-              "sampleCount": 158,
-              "innerIterations": 128,
-              "sampledDuration": 301.0844
+              "mean": 0.0184,
+              "minimum": 0.0165,
+              "standardDeviation": 0.0014,
+              "sampleCount": 255,
+              "innerIterations": 64,
+              "sampledDuration": 300.0344
             }
           ]
         },
@@ -6066,12 +6066,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0169,
+              "mean": 0.0196,
               "minimum": 0.0157,
-              "standardDeviation": 0.0009,
-              "sampleCount": 278,
+              "standardDeviation": 0.0025,
+              "sampleCount": 240,
               "innerIterations": 64,
-              "sampledDuration": 300.9773
+              "sampledDuration": 300.5343
             }
           ]
         },
@@ -6098,12 +6098,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 17.6836,
-              "minimum": 16.1864,
-              "standardDeviation": 0.8082,
-              "sampleCount": 17,
+              "mean": 23.2748,
+              "minimum": 21.6457,
+              "standardDeviation": 1.2954,
+              "sampleCount": 13,
               "innerIterations": 1,
-              "sampledDuration": 300.6214
+              "sampledDuration": 302.5724
             }
           ]
         },
@@ -6113,12 +6113,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.3568,
-              "minimum": 0.1757,
-              "standardDeviation": 0.1182,
-              "sampleCount": 106,
+              "mean": 0.3583,
+              "minimum": 0.2064,
+              "standardDeviation": 0.1132,
+              "sampleCount": 105,
               "innerIterations": 8,
-              "sampledDuration": 302.5452
+              "sampledDuration": 300.9544
             }
           ]
         },
@@ -6128,12 +6128,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.5046,
-              "minimum": 0.4308,
-              "standardDeviation": 0.2248,
-              "sampleCount": 595,
+              "mean": 0.5433,
+              "minimum": 0.4516,
+              "standardDeviation": 0.2687,
+              "sampleCount": 553,
               "innerIterations": 1,
-              "sampledDuration": 300.2357
+              "sampledDuration": 300.4181
             }
           ]
         },
@@ -6160,12 +6160,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0637,
-              "minimum": 0.0561,
-              "standardDeviation": 0.0067,
-              "sampleCount": 148,
-              "innerIterations": 32,
-              "sampledDuration": 301.7816
+              "mean": 0.0733,
+              "minimum": 0.0622,
+              "standardDeviation": 0.0106,
+              "sampleCount": 256,
+              "innerIterations": 16,
+              "sampledDuration": 300.3286
             }
           ]
         },
@@ -6175,12 +6175,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.003,
-              "minimum": 0.0019,
-              "standardDeviation": 0.0016,
-              "sampleCount": 388,
+              "mean": 0.0038,
+              "minimum": 0.0025,
+              "standardDeviation": 0.0018,
+              "sampleCount": 310,
               "innerIterations": 256,
-              "sampledDuration": 300.5087
+              "sampledDuration": 300.2151
             }
           ]
         },
@@ -6190,12 +6190,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0013,
-              "minimum": 0.0012,
-              "standardDeviation": 0.0001,
-              "sampleCount": 234,
+              "mean": 0.0019,
+              "minimum": 0.0016,
+              "standardDeviation": 0.0004,
+              "sampleCount": 153,
               "innerIterations": 1024,
-              "sampledDuration": 301.0893
+              "sampledDuration": 301.1677
             }
           ]
         },
@@ -6222,12 +6222,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.6043,
-              "minimum": 0.5366,
-              "standardDeviation": 0.1007,
-              "sampleCount": 249,
+              "mean": 0.7855,
+              "minimum": 0.6882,
+              "standardDeviation": 0.102,
+              "sampleCount": 191,
               "innerIterations": 2,
-              "sampledDuration": 300.9415
+              "sampledDuration": 300.0508
             }
           ]
         },
@@ -6237,12 +6237,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0243,
-              "minimum": 0.0185,
-              "standardDeviation": 0.0096,
-              "sampleCount": 194,
+              "mean": 0.0261,
+              "minimum": 0.023,
+              "standardDeviation": 0.0019,
+              "sampleCount": 180,
               "innerIterations": 64,
-              "sampledDuration": 301.8323
+              "sampledDuration": 300.241
             }
           ]
         },
@@ -6252,12 +6252,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0115,
+              "mean": 0.0118,
               "minimum": 0.0104,
               "standardDeviation": 0.0011,
-              "sampleCount": 204,
+              "sampleCount": 199,
               "innerIterations": 128,
-              "sampledDuration": 301.3565
+              "sampledDuration": 300.1153
             }
           ]
         },
@@ -6284,12 +6284,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 8.4227,
-              "minimum": 5.5506,
-              "standardDeviation": 4.0131,
-              "sampleCount": 36,
+              "mean": 9.7776,
+              "minimum": 6.7305,
+              "standardDeviation": 2.9132,
+              "sampleCount": 31,
               "innerIterations": 1,
-              "sampledDuration": 303.2158
+              "sampledDuration": 303.1048
             }
           ]
         },
@@ -6299,12 +6299,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.3088,
-              "minimum": 0.2,
-              "standardDeviation": 0.0727,
-              "sampleCount": 244,
-              "innerIterations": 4,
-              "sampledDuration": 301.3738
+              "mean": 0.4441,
+              "minimum": 0.2425,
+              "standardDeviation": 0.3492,
+              "sampleCount": 678,
+              "innerIterations": 1,
+              "sampledDuration": 301.0907
             }
           ]
         },
@@ -6314,12 +6314,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.3353,
-              "minimum": 0.2915,
-              "standardDeviation": 0.1118,
-              "sampleCount": 224,
+              "mean": 0.3618,
+              "minimum": 0.2946,
+              "standardDeviation": 0.1609,
+              "sampleCount": 208,
               "innerIterations": 4,
-              "sampledDuration": 300.4013
+              "sampledDuration": 300.986
             }
           ]
         },
@@ -6346,12 +6346,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.135,
-              "minimum": 0.1088,
-              "standardDeviation": 0.0716,
-              "sampleCount": 2223,
+              "mean": 0.1515,
+              "minimum": 0.1262,
+              "standardDeviation": 0.0431,
+              "sampleCount": 1981,
               "innerIterations": 1,
-              "sampledDuration": 300.0811
+              "sampledDuration": 300.099
             }
           ]
         },
@@ -6361,12 +6361,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.003,
-              "minimum": 0.0019,
-              "standardDeviation": 0.002,
-              "sampleCount": 390,
-              "innerIterations": 256,
-              "sampledDuration": 300.0461
+              "mean": 0.0042,
+              "minimum": 0.0024,
+              "standardDeviation": 0.0025,
+              "sampleCount": 556,
+              "innerIterations": 128,
+              "sampledDuration": 300.1721
             }
           ]
         },
@@ -6376,12 +6376,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0015,
-              "minimum": 0.0015,
+              "mean": 0.0017,
+              "minimum": 0.0016,
               "standardDeviation": 0.0001,
-              "sampleCount": 190,
+              "sampleCount": 175,
               "innerIterations": 1024,
-              "sampledDuration": 300.4389
+              "sampledDuration": 300.6756
             }
           ]
         },
@@ -6408,12 +6408,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.2055,
-              "minimum": 1.0965,
-              "standardDeviation": 0.1528,
-              "sampleCount": 249,
+              "mean": 1.6346,
+              "minimum": 1.4067,
+              "standardDeviation": 0.1915,
+              "sampleCount": 184,
               "innerIterations": 1,
-              "sampledDuration": 300.1619
+              "sampledDuration": 300.7719
             }
           ]
         },
@@ -6423,12 +6423,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0272,
-              "minimum": 0.0186,
-              "standardDeviation": 0.0077,
-              "sampleCount": 346,
+              "mean": 0.0279,
+              "minimum": 0.0228,
+              "standardDeviation": 0.0047,
+              "sampleCount": 337,
               "innerIterations": 32,
-              "sampledDuration": 300.6951
+              "sampledDuration": 300.7111
             }
           ]
         },
@@ -6438,12 +6438,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0175,
-              "minimum": 0.0154,
-              "standardDeviation": 0.0017,
-              "sampleCount": 268,
+              "mean": 0.0181,
+              "minimum": 0.0158,
+              "standardDeviation": 0.0021,
+              "sampleCount": 259,
               "innerIterations": 64,
-              "sampledDuration": 300.2468
+              "sampledDuration": 300.5278
             }
           ]
         },
@@ -6470,12 +6470,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 14.0581,
-              "minimum": 12.1953,
-              "standardDeviation": 1.3839,
-              "sampleCount": 22,
+              "mean": 16.0664,
+              "minimum": 14.613,
+              "standardDeviation": 1.0182,
+              "sampleCount": 19,
               "innerIterations": 1,
-              "sampledDuration": 309.2787
+              "sampledDuration": 305.2608
             }
           ]
         },
@@ -6485,12 +6485,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.459,
-              "minimum": 0.2371,
-              "standardDeviation": 0.2013,
-              "sampleCount": 164,
+              "mean": 0.5292,
+              "minimum": 0.2842,
+              "standardDeviation": 0.2244,
+              "sampleCount": 142,
               "innerIterations": 4,
-              "sampledDuration": 301.0756
+              "sampledDuration": 300.5969
             }
           ]
         },
@@ -6500,12 +6500,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.484,
-              "minimum": 0.4196,
-              "standardDeviation": 0.1262,
-              "sampleCount": 155,
-              "innerIterations": 4,
-              "sampledDuration": 300.0521
+              "mean": 0.5007,
+              "minimum": 0.4262,
+              "standardDeviation": 0.1939,
+              "sampleCount": 300,
+              "innerIterations": 2,
+              "sampledDuration": 300.4212
             }
           ]
         },
@@ -6532,12 +6532,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.416,
-              "minimum": 0.7923,
-              "standardDeviation": 0.8891,
-              "sampleCount": 213,
+              "mean": 1.467,
+              "minimum": 0.816,
+              "standardDeviation": 0.3486,
+              "sampleCount": 205,
               "innerIterations": 1,
-              "sampledDuration": 301.6162
+              "sampledDuration": 300.7405
             }
           ]
         },
@@ -6547,12 +6547,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.006,
-              "minimum": 0.0035,
-              "standardDeviation": 0.0056,
-              "sampleCount": 782,
+              "mean": 0.0052,
+              "minimum": 0.0031,
+              "standardDeviation": 0.0052,
+              "sampleCount": 900,
               "innerIterations": 64,
-              "sampledDuration": 300.2942
+              "sampledDuration": 300.0531
             }
           ]
         },
@@ -6562,12 +6562,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0031,
+              "mean": 0.0032,
               "minimum": 0.0029,
               "standardDeviation": 0.0002,
-              "sampleCount": 187,
+              "sampleCount": 186,
               "innerIterations": 512,
-              "sampledDuration": 300.7615
+              "sampledDuration": 300.4612
             }
           ]
         },
@@ -6594,12 +6594,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 106.827,
-              "minimum": 96.8946,
-              "standardDeviation": 10.7431,
+              "mean": 114.2252,
+              "minimum": 98.2424,
+              "standardDeviation": 14.5172,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 854.6162
+              "sampledDuration": 913.8015
             }
           ]
         },
@@ -6609,12 +6609,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.941,
-              "minimum": 0.5783,
-              "standardDeviation": 0.3235,
-              "sampleCount": 319,
-              "innerIterations": 1,
-              "sampledDuration": 300.173
+              "mean": 0.7765,
+              "minimum": 0.6819,
+              "standardDeviation": 0.2012,
+              "sampleCount": 194,
+              "innerIterations": 2,
+              "sampledDuration": 301.2726
             }
           ]
         },
@@ -6624,12 +6624,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.7145,
-              "minimum": 0.5705,
-              "standardDeviation": 0.513,
-              "sampleCount": 420,
+              "mean": 0.7187,
+              "minimum": 0.5533,
+              "standardDeviation": 0.5241,
+              "sampleCount": 421,
               "innerIterations": 1,
-              "sampledDuration": 300.0841
+              "sampledDuration": 302.5721
             }
           ]
         },
@@ -6656,12 +6656,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1119.6098,
-              "minimum": 1061.4447,
-              "standardDeviation": 82.2578,
+              "mean": 1028.4751,
+              "minimum": 1013.8178,
+              "standardDeviation": 20.7285,
               "sampleCount": 2,
               "innerIterations": 1,
-              "sampledDuration": 2239.2195
+              "sampledDuration": 2056.9501
             }
           ]
         },
@@ -6671,12 +6671,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 5.6433,
-              "minimum": 4.2495,
-              "standardDeviation": 1.5181,
-              "sampleCount": 54,
+              "mean": 5.3753,
+              "minimum": 3.9365,
+              "standardDeviation": 1.4771,
+              "sampleCount": 56,
               "innerIterations": 1,
-              "sampledDuration": 304.7407
+              "sampledDuration": 301.017
             }
           ]
         },
@@ -6686,12 +6686,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 8.2229,
-              "minimum": 6.6098,
-              "standardDeviation": 1.7559,
-              "sampleCount": 37,
+              "mean": 8.6117,
+              "minimum": 7.4189,
+              "standardDeviation": 0.8325,
+              "sampleCount": 35,
               "innerIterations": 1,
-              "sampledDuration": 304.2473
+              "sampledDuration": 301.4081
             }
           ]
         },
@@ -6718,12 +6718,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 3.373,
-              "minimum": 0.9311,
-              "standardDeviation": 2.4694,
-              "sampleCount": 89,
+              "mean": 4.3624,
+              "minimum": 3.2427,
+              "standardDeviation": 2.4752,
+              "sampleCount": 69,
               "innerIterations": 1,
-              "sampledDuration": 300.1975
+              "sampledDuration": 301.0053
             }
           ]
         },
@@ -6733,12 +6733,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0295,
-              "minimum": 0.0234,
-              "standardDeviation": 0.0273,
-              "sampleCount": 10160,
+              "mean": 0.0326,
+              "minimum": 0.025,
+              "standardDeviation": 0.038,
+              "sampleCount": 9213,
               "innerIterations": 1,
-              "sampledDuration": 300.0109
+              "sampledDuration": 300.0196
             }
           ]
         },
@@ -6748,12 +6748,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0029,
+              "mean": 0.0027,
               "minimum": 0.0025,
               "standardDeviation": 0.0003,
-              "sampleCount": 206,
+              "sampleCount": 214,
               "innerIterations": 512,
-              "sampledDuration": 300.8125
+              "sampledDuration": 300.5702
             }
           ]
         },
@@ -6780,12 +6780,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 85.4286,
-              "minimum": 75.8148,
-              "standardDeviation": 8.9105,
+              "mean": 109.6704,
+              "minimum": 82.883,
+              "standardDeviation": 57.393,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 683.4292
+              "sampledDuration": 877.3629
             }
           ]
         },
@@ -6795,12 +6795,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.821,
-              "minimum": 0.7519,
-              "standardDeviation": 0.0905,
-              "sampleCount": 183,
+              "mean": 0.8006,
+              "minimum": 0.7157,
+              "standardDeviation": 0.0936,
+              "sampleCount": 188,
               "innerIterations": 2,
-              "sampledDuration": 300.4908
+              "sampledDuration": 301.0267
             }
           ]
         },
@@ -6810,12 +6810,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.7491,
-              "minimum": 0.5742,
-              "standardDeviation": 0.3596,
-              "sampleCount": 401,
-              "innerIterations": 1,
-              "sampledDuration": 300.3737
+              "mean": 0.7579,
+              "minimum": 0.5748,
+              "standardDeviation": 0.2092,
+              "sampleCount": 198,
+              "innerIterations": 2,
+              "sampledDuration": 300.1438
             }
           ]
         },
@@ -6842,12 +6842,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 919.1889,
-              "minimum": 884.5314,
-              "standardDeviation": 42.3722,
+              "mean": 922.3432,
+              "minimum": 876.7284,
+              "standardDeviation": 39.5855,
               "sampleCount": 3,
               "innerIterations": 1,
-              "sampledDuration": 2757.5668
+              "sampledDuration": 2767.0296
             }
           ]
         },
@@ -6857,12 +6857,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 5.6766,
-              "minimum": 4.4858,
-              "standardDeviation": 1.5199,
+              "mean": 5.7284,
+              "minimum": 4.3447,
+              "standardDeviation": 1.513,
               "sampleCount": 53,
               "innerIterations": 1,
-              "sampledDuration": 300.8575
+              "sampledDuration": 303.6032
             }
           ]
         },
@@ -6872,12 +6872,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 8.363,
-              "minimum": 6.7966,
-              "standardDeviation": 1.6393,
-              "sampleCount": 36,
+              "mean": 8.5874,
+              "minimum": 6.7587,
+              "standardDeviation": 2.1414,
+              "sampleCount": 35,
               "innerIterations": 1,
-              "sampledDuration": 301.0681
+              "sampledDuration": 300.5603
             }
           ]
         },
@@ -6904,12 +6904,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.1769,
-              "minimum": 0.5964,
-              "standardDeviation": 1.2167,
-              "sampleCount": 138,
+              "mean": 2.028,
+              "minimum": 0.528,
+              "standardDeviation": 1.6566,
+              "sampleCount": 148,
               "innerIterations": 1,
-              "sampledDuration": 300.4184
+              "sampledDuration": 300.1429
             }
           ]
         },
@@ -6919,12 +6919,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0023,
-              "minimum": 0.0009,
-              "standardDeviation": 0.0056,
+              "mean": 0.0024,
+              "minimum": 0.0008,
+              "standardDeviation": 0.006,
               "sampleCount": 100000,
               "innerIterations": 1,
-              "sampledDuration": 229.5816
+              "sampledDuration": 241.707
             }
           ]
         },
@@ -6934,12 +6934,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0005,
-              "minimum": 0.0005,
-              "standardDeviation": 0.0005,
-              "sampleCount": 135,
-              "innerIterations": 4096,
-              "sampledDuration": 301.2263
+              "mean": 0.0012,
+              "minimum": 0.0007,
+              "standardDeviation": 0.001,
+              "sampleCount": 126,
+              "innerIterations": 2048,
+              "sampledDuration": 300.1083
             }
           ]
         },
@@ -6966,12 +6966,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 5.653,
-              "minimum": 5.1717,
-              "standardDeviation": 0.3133,
-              "sampleCount": 54,
+              "mean": 5.6738,
+              "minimum": 5.1535,
+              "standardDeviation": 0.3393,
+              "sampleCount": 53,
               "innerIterations": 1,
-              "sampledDuration": 305.2628
+              "sampledDuration": 300.7115
             }
           ]
         },
@@ -6981,12 +6981,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0081,
+              "mean": 0.0083,
               "minimum": 0.0079,
-              "standardDeviation": 0.0005,
-              "sampleCount": 289,
+              "standardDeviation": 0.0007,
+              "sampleCount": 281,
               "innerIterations": 128,
-              "sampledDuration": 300.0152
+              "sampledDuration": 300.0288
             }
           ]
         },
@@ -6996,12 +6996,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0084,
-              "minimum": 0.008,
-              "standardDeviation": 0.0006,
-              "sampleCount": 278,
+              "mean": 0.0226,
+              "minimum": 0.0144,
+              "standardDeviation": 0.0071,
+              "sampleCount": 104,
               "innerIterations": 128,
-              "sampledDuration": 300.2476
+              "sampledDuration": 301.0502
             }
           ]
         },
@@ -7028,12 +7028,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 62.2402,
-              "minimum": 53.7923,
-              "standardDeviation": 6.5914,
+              "mean": 55.9513,
+              "minimum": 54.5589,
+              "standardDeviation": 1.361,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 497.9213
+              "sampledDuration": 447.6108
             }
           ]
         },
@@ -7043,12 +7043,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0799,
+              "mean": 0.0874,
               "minimum": 0.0782,
-              "standardDeviation": 0.004,
-              "sampleCount": 235,
+              "standardDeviation": 0.0072,
+              "sampleCount": 215,
               "innerIterations": 16,
-              "sampledDuration": 300.2936
+              "sampledDuration": 300.7751
             }
           ]
         },
@@ -7058,12 +7058,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.2265,
-              "minimum": 0.0771,
-              "standardDeviation": 0.1034,
-              "sampleCount": 1325,
+              "mean": 0.4047,
+              "minimum": 0.1432,
+              "standardDeviation": 0.2923,
+              "sampleCount": 742,
               "innerIterations": 1,
-              "sampledDuration": 300.1695
+              "sampledDuration": 300.2535
             }
           ]
         },
@@ -7090,12 +7090,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.7892,
-              "minimum": 0.4961,
-              "standardDeviation": 1.23,
-              "sampleCount": 381,
+              "mean": 4.2628,
+              "minimum": 1.6628,
+              "standardDeviation": 6.8642,
+              "sampleCount": 71,
               "innerIterations": 1,
-              "sampledDuration": 300.6667
+              "sampledDuration": 302.6572
             }
           ]
         },
@@ -7105,12 +7105,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0047,
-              "minimum": 0.0026,
-              "standardDeviation": 0.0388,
-              "sampleCount": 64131,
+              "mean": 0.0173,
+              "minimum": 0.0054,
+              "standardDeviation": 0.2053,
+              "sampleCount": 17305,
               "innerIterations": 1,
-              "sampledDuration": 300.0025
+              "sampledDuration": 300.008
             }
           ]
         },
@@ -7120,12 +7120,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0015,
-              "minimum": 0.0014,
-              "standardDeviation": 0.0001,
-              "sampleCount": 201,
-              "innerIterations": 1024,
-              "sampledDuration": 301.2224
+              "mean": 0.006,
+              "minimum": 0.0031,
+              "standardDeviation": 0.0012,
+              "sampleCount": 195,
+              "innerIterations": 256,
+              "sampledDuration": 301.5415
             }
           ]
         },
@@ -7152,12 +7152,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 47.4149,
-              "minimum": 22.0985,
-              "standardDeviation": 20.366,
+              "mean": 190.8641,
+              "minimum": 62.3107,
+              "standardDeviation": 136.0581,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 379.3189
+              "sampledDuration": 1526.913
             }
           ]
         },
@@ -7167,12 +7167,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.2836,
-              "minimum": 0.2762,
-              "standardDeviation": 0.0122,
-              "sampleCount": 265,
-              "innerIterations": 4,
-              "sampledDuration": 300.5973
+              "mean": 0.7985,
+              "minimum": 0.5585,
+              "standardDeviation": 0.1706,
+              "sampleCount": 188,
+              "innerIterations": 2,
+              "sampledDuration": 300.2317
             }
           ]
         },
@@ -7182,12 +7182,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1503,
-              "minimum": 0.1413,
-              "standardDeviation": 0.0115,
-              "sampleCount": 250,
-              "innerIterations": 8,
-              "sampledDuration": 300.6623
+              "mean": 0.6053,
+              "minimum": 0.2677,
+              "standardDeviation": 0.1216,
+              "sampleCount": 496,
+              "innerIterations": 1,
+              "sampledDuration": 300.2273
             }
           ]
         },
@@ -7214,12 +7214,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 370.2741,
-              "minimum": 184.544,
-              "standardDeviation": 133.3674,
-              "sampleCount": 7,
+              "mean": 850.395,
+              "minimum": 719.1984,
+              "standardDeviation": 118.8195,
+              "sampleCount": 3,
               "innerIterations": 1,
-              "sampledDuration": 2591.9185
+              "sampledDuration": 2551.1851
             }
           ]
         },
@@ -7229,12 +7229,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.8253,
-              "minimum": 2.7652,
-              "standardDeviation": 0.0911,
-              "sampleCount": 107,
+              "mean": 8.4102,
+              "minimum": 6.2974,
+              "standardDeviation": 1.396,
+              "sampleCount": 36,
               "innerIterations": 1,
-              "sampledDuration": 302.3077
+              "sampledDuration": 302.7664
             }
           ]
         },
@@ -7244,12 +7244,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.4929,
-              "minimum": 1.4084,
-              "standardDeviation": 0.0851,
-              "sampleCount": 201,
+              "mean": 6.2808,
+              "minimum": 5.1075,
+              "standardDeviation": 0.6472,
+              "sampleCount": 48,
               "innerIterations": 1,
-              "sampledDuration": 300.0718
+              "sampledDuration": 301.4775
             }
           ]
         },
@@ -7276,12 +7276,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.4897,
-              "minimum": 0.3526,
-              "standardDeviation": 1.2949,
-              "sampleCount": 613,
+              "mean": 0.3709,
+              "minimum": 0.1091,
+              "standardDeviation": 0.9417,
+              "sampleCount": 809,
               "innerIterations": 1,
-              "sampledDuration": 300.1688
+              "sampledDuration": 300.0919
             }
           ]
         },
@@ -7291,12 +7291,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1206,
-              "minimum": 0.053,
-              "standardDeviation": 0.4207,
-              "sampleCount": 2487,
+              "mean": 0.2274,
+              "minimum": 0.0969,
+              "standardDeviation": 0.7896,
+              "sampleCount": 1320,
               "innerIterations": 1,
-              "sampledDuration": 300.0455
+              "sampledDuration": 300.1022
             }
           ]
         },
@@ -7306,12 +7306,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0158,
-              "minimum": 0.0142,
-              "standardDeviation": 0.0013,
-              "sampleCount": 296,
+              "mean": 0.0346,
+              "minimum": 0.0271,
+              "standardDeviation": 0.007,
+              "sampleCount": 136,
               "innerIterations": 64,
-              "sampledDuration": 300.2498
+              "sampledDuration": 300.9574
             }
           ]
         },
@@ -7338,12 +7338,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.1596,
-              "minimum": 0.3353,
-              "standardDeviation": 1.2672,
-              "sampleCount": 259,
-              "innerIterations": 1,
-              "sampledDuration": 300.333
+              "mean": 0.464,
+              "minimum": 0.3772,
+              "standardDeviation": 0.1212,
+              "sampleCount": 324,
+              "innerIterations": 2,
+              "sampledDuration": 300.6472
             }
           ]
         },
@@ -7353,12 +7353,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.339,
-              "minimum": 0.284,
-              "standardDeviation": 0.056,
-              "sampleCount": 222,
-              "innerIterations": 4,
-              "sampledDuration": 301.054
+              "mean": 0.8036,
+              "minimum": 0.5447,
+              "standardDeviation": 0.3067,
+              "sampleCount": 187,
+              "innerIterations": 2,
+              "sampledDuration": 300.5445
             }
           ]
         },
@@ -7368,12 +7368,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.1648,
-              "minimum": 0.1483,
-              "standardDeviation": 0.0187,
-              "sampleCount": 228,
-              "innerIterations": 8,
-              "sampledDuration": 300.6506
+              "mean": 0.38,
+              "minimum": 0.2652,
+              "standardDeviation": 0.1364,
+              "sampleCount": 395,
+              "innerIterations": 2,
+              "sampledDuration": 300.1875
             }
           ]
         },
@@ -7400,12 +7400,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 3.947,
-              "minimum": 2.8656,
-              "standardDeviation": 1.6385,
-              "sampleCount": 77,
+              "mean": 3.8979,
+              "minimum": 3.2988,
+              "standardDeviation": 1.15,
+              "sampleCount": 78,
               "innerIterations": 1,
-              "sampledDuration": 303.9197
+              "sampledDuration": 304.04
             }
           ]
         },
@@ -7415,12 +7415,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.9944,
-              "minimum": 2.6452,
-              "standardDeviation": 0.2864,
-              "sampleCount": 101,
+              "mean": 6.0976,
+              "minimum": 4.8304,
+              "standardDeviation": 0.9674,
+              "sampleCount": 50,
               "innerIterations": 1,
-              "sampledDuration": 302.4389
+              "sampledDuration": 304.8796
             }
           ]
         },
@@ -7430,12 +7430,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.9925,
-              "minimum": 1.5841,
-              "standardDeviation": 0.7148,
-              "sampleCount": 151,
+              "mean": 4.4993,
+              "minimum": 2.8363,
+              "standardDeviation": 1.7457,
+              "sampleCount": 68,
               "innerIterations": 1,
-              "sampledDuration": 300.8698
+              "sampledDuration": 305.9555
             }
           ]
         },
@@ -7462,12 +7462,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.3737,
-              "minimum": 0.3035,
-              "standardDeviation": 0.2661,
-              "sampleCount": 804,
+              "mean": 0.5211,
+              "minimum": 0.4367,
+              "standardDeviation": 0.4375,
+              "sampleCount": 576,
               "innerIterations": 1,
-              "sampledDuration": 300.439
+              "sampledDuration": 300.1394
             }
           ]
         },
@@ -7477,12 +7477,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0628,
-              "minimum": 0.0517,
-              "standardDeviation": 0.0728,
-              "sampleCount": 4776,
+              "mean": 0.0833,
+              "minimum": 0.0646,
+              "standardDeviation": 0.1154,
+              "sampleCount": 3601,
               "innerIterations": 1,
-              "sampledDuration": 300.0474
+              "sampledDuration": 300.086
             }
           ]
         },
@@ -7492,12 +7492,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0085,
+              "mean": 0.0091,
               "minimum": 0.0079,
-              "standardDeviation": 0.0007,
-              "sampleCount": 277,
+              "standardDeviation": 0.0014,
+              "sampleCount": 257,
               "innerIterations": 128,
-              "sampledDuration": 300.8018
+              "sampledDuration": 300.3435
             }
           ]
         },
@@ -7524,12 +7524,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.783,
-              "minimum": 0.8573,
-              "standardDeviation": 3.08,
-              "sampleCount": 108,
+              "mean": 10.5343,
+              "minimum": 9.3838,
+              "standardDeviation": 2.1426,
+              "sampleCount": 29,
               "innerIterations": 1,
-              "sampledDuration": 300.5593
+              "sampledDuration": 305.4947
             }
           ]
         },
@@ -7539,12 +7539,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.2481,
-              "minimum": 0.1683,
-              "standardDeviation": 0.1285,
-              "sampleCount": 605,
+              "mean": 0.2656,
+              "minimum": 0.1651,
+              "standardDeviation": 0.1921,
+              "sampleCount": 565,
               "innerIterations": 2,
-              "sampledDuration": 300.2548
+              "sampledDuration": 300.1737
             }
           ]
         },
@@ -7554,12 +7554,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.2106,
-              "minimum": 0.1969,
-              "standardDeviation": 0.0217,
-              "sampleCount": 179,
+              "mean": 0.2298,
+              "minimum": 0.206,
+              "standardDeviation": 0.0138,
+              "sampleCount": 164,
               "innerIterations": 8,
-              "sampledDuration": 301.6185
+              "sampledDuration": 301.5609
             }
           ]
         },
@@ -7586,12 +7586,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 23.7459,
-              "minimum": 12.2642,
-              "standardDeviation": 6.7536,
-              "sampleCount": 13,
+              "mean": 35.2743,
+              "minimum": 25.9684,
+              "standardDeviation": 10.2033,
+              "sampleCount": 9,
               "innerIterations": 1,
-              "sampledDuration": 308.697
+              "sampledDuration": 317.4684
             }
           ]
         },
@@ -7601,12 +7601,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.6049,
-              "minimum": 2.3398,
-              "standardDeviation": 0.4473,
-              "sampleCount": 116,
+              "mean": 2.7746,
+              "minimum": 2.3725,
+              "standardDeviation": 0.6161,
+              "sampleCount": 109,
               "innerIterations": 1,
-              "sampledDuration": 302.1718
+              "sampledDuration": 302.4351
             }
           ]
         },
@@ -7616,12 +7616,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.866,
-              "minimum": 2.6984,
-              "standardDeviation": 0.1639,
-              "sampleCount": 105,
+              "mean": 2.94,
+              "minimum": 2.6906,
+              "standardDeviation": 0.1886,
+              "sampleCount": 103,
               "innerIterations": 1,
-              "sampledDuration": 300.9289
+              "sampledDuration": 302.8239
             }
           ]
         },
@@ -7648,12 +7648,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.6757,
-              "minimum": 0.181,
-              "standardDeviation": 0.8494,
-              "sampleCount": 444,
+              "mean": 0.9182,
+              "minimum": 0.678,
+              "standardDeviation": 0.7234,
+              "sampleCount": 327,
               "innerIterations": 1,
-              "sampledDuration": 300.0278
+              "sampledDuration": 300.2666
             }
           ]
         },
@@ -7663,12 +7663,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0024,
-              "minimum": 0.0018,
-              "standardDeviation": 0.0051,
+              "mean": 0.0027,
+              "minimum": 0.002,
+              "standardDeviation": 0.0058,
               "sampleCount": 100000,
               "innerIterations": 1,
-              "sampledDuration": 236.637
+              "sampledDuration": 269.2392
             }
           ]
         },
@@ -7678,12 +7678,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0009,
-              "minimum": 0.0008,
+              "mean": 0.001,
+              "minimum": 0.0009,
               "standardDeviation": 0.0001,
-              "sampleCount": 170,
-              "innerIterations": 2048,
-              "sampledDuration": 300.267
+              "sampleCount": 289,
+              "innerIterations": 1024,
+              "sampledDuration": 300.7211
             }
           ]
         },
@@ -7710,12 +7710,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1.6359,
-              "minimum": 1.3713,
-              "standardDeviation": 0.1433,
-              "sampleCount": 184,
+              "mean": 5.1752,
+              "minimum": 1.8584,
+              "standardDeviation": 2.3764,
+              "sampleCount": 58,
               "innerIterations": 1,
-              "sampledDuration": 301.0059
+              "sampledDuration": 300.1635
             }
           ]
         },
@@ -7725,12 +7725,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0083,
-              "minimum": 0.0066,
-              "standardDeviation": 0.002,
-              "sampleCount": 284,
+              "mean": 0.0096,
+              "minimum": 0.0077,
+              "standardDeviation": 0.0022,
+              "sampleCount": 246,
               "innerIterations": 128,
-              "sampledDuration": 300.163
+              "sampledDuration": 301.1624
             }
           ]
         },
@@ -7740,12 +7740,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0078,
-              "minimum": 0.0067,
-              "standardDeviation": 0.0006,
-              "sampleCount": 151,
-              "innerIterations": 256,
-              "sampledDuration": 300.9954
+              "mean": 0.0089,
+              "minimum": 0.008,
+              "standardDeviation": 0.0008,
+              "sampleCount": 264,
+              "innerIterations": 128,
+              "sampledDuration": 300.9465
             }
           ]
         },
@@ -7772,12 +7772,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 23.0912,
-              "minimum": 21.5201,
-              "standardDeviation": 1.4075,
-              "sampleCount": 13,
+              "mean": 25.9815,
+              "minimum": 23.6892,
+              "standardDeviation": 2.016,
+              "sampleCount": 12,
               "innerIterations": 1,
-              "sampledDuration": 300.186
+              "sampledDuration": 311.7784
             }
           ]
         },
@@ -7787,12 +7787,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0704,
-              "minimum": 0.0652,
-              "standardDeviation": 0.0057,
-              "sampleCount": 267,
+              "mean": 0.0809,
+              "minimum": 0.0755,
+              "standardDeviation": 0.0027,
+              "sampleCount": 232,
               "innerIterations": 16,
-              "sampledDuration": 300.6784
+              "sampledDuration": 300.2505
             }
           ]
         },
@@ -7802,12 +7802,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0851,
-              "minimum": 0.065,
-              "standardDeviation": 0.0083,
-              "sampleCount": 221,
+              "mean": 0.0964,
+              "minimum": 0.0808,
+              "standardDeviation": 0.0152,
+              "sampleCount": 195,
               "innerIterations": 16,
-              "sampledDuration": 300.784
+              "sampledDuration": 300.6447
             }
           ]
         },
@@ -7834,12 +7834,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.9504,
-              "minimum": 1.0947,
-              "standardDeviation": 2.4277,
-              "sampleCount": 102,
+              "mean": 6.7665,
+              "minimum": 5.1421,
+              "standardDeviation": 2.3299,
+              "sampleCount": 45,
               "innerIterations": 1,
-              "sampledDuration": 300.9418
+              "sampledDuration": 304.4916
             }
           ]
         },
@@ -7851,10 +7851,10 @@
               "launch": 1,
               "mean": 0.0037,
               "minimum": 0.002,
-              "standardDeviation": 0.0077,
-              "sampleCount": 81010,
+              "standardDeviation": 0.0079,
+              "sampleCount": 81564,
               "innerIterations": 1,
-              "sampledDuration": 300.0019
+              "sampledDuration": 300.0016
             }
           ]
         },
@@ -7864,12 +7864,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.0045,
-              "minimum": 0.0019,
-              "standardDeviation": 0.0509,
-              "sampleCount": 66270,
-              "innerIterations": 1,
-              "sampledDuration": 300.0389
+              "mean": 0.0038,
+              "minimum": 0.0022,
+              "standardDeviation": 0.0019,
+              "sampleCount": 621,
+              "innerIterations": 128,
+              "sampledDuration": 300.0184
             }
           ]
         },
@@ -7896,12 +7896,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 103.0033,
-              "minimum": 100.9475,
-              "standardDeviation": 2.3725,
+              "mean": 175.247,
+              "minimum": 123.2437,
+              "standardDeviation": 63.0023,
               "sampleCount": 8,
               "innerIterations": 1,
-              "sampledDuration": 824.0266
+              "sampledDuration": 1401.9764
             }
           ]
         },
@@ -7911,12 +7911,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.3276,
-              "minimum": 0.3124,
-              "standardDeviation": 0.0207,
-              "sampleCount": 229,
-              "innerIterations": 4,
-              "sampledDuration": 300.0753
+              "mean": 0.3296,
+              "minimum": 0.2484,
+              "standardDeviation": 0.0724,
+              "sampleCount": 456,
+              "innerIterations": 2,
+              "sampledDuration": 300.6187
             }
           ]
         },
@@ -7926,12 +7926,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 0.3919,
-              "minimum": 0.3216,
-              "standardDeviation": 0.2218,
+              "mean": 0.3921,
+              "minimum": 0.3304,
+              "standardDeviation": 0.2188,
               "sampleCount": 192,
               "innerIterations": 4,
-              "sampledDuration": 300.9442
+              "sampledDuration": 301.16
             }
           ]
         },
@@ -7958,12 +7958,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 1023.9886,
-              "minimum": 1016.2319,
-              "standardDeviation": 10.9696,
+              "mean": 1204.2351,
+              "minimum": 1163.0784,
+              "standardDeviation": 58.2044,
               "sampleCount": 2,
               "innerIterations": 1,
-              "sampledDuration": 2047.9772
+              "sampledDuration": 2408.4702
             }
           ]
         },
@@ -7973,12 +7973,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.2541,
-              "minimum": 1.9463,
-              "standardDeviation": 0.2968,
+              "mean": 2.2412,
+              "minimum": 1.9341,
+              "standardDeviation": 0.3043,
               "sampleCount": 134,
               "innerIterations": 1,
-              "sampledDuration": 302.0546
+              "sampledDuration": 300.3193
             }
           ]
         },
@@ -7988,12 +7988,12 @@
           "measurements": [
             {
               "launch": 1,
-              "mean": 2.8175,
-              "minimum": 2.5234,
-              "standardDeviation": 0.3337,
-              "sampleCount": 107,
+              "mean": 2.7928,
+              "minimum": 2.5705,
+              "standardDeviation": 0.2851,
+              "sampleCount": 108,
               "innerIterations": 1,
-              "sampledDuration": 301.4725
+              "sampledDuration": 301.6197
             }
           ]
         },

--- a/benchmarks/cross-runtime/test-snapshot.ps1
+++ b/benchmarks/cross-runtime/test-snapshot.ps1
@@ -1,0 +1,104 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$harnessDirectory = Split-Path -Parent $MyInvocation.MyCommand.Definition
+Import-Module (Join-Path $harnessDirectory 'Snapshot.psm1') -Force
+
+function Assert-True([bool]$Condition, [string]$Message) {
+    if (-not $Condition) { throw $Message }
+}
+
+function Assert-Throws([scriptblock]$Action, [string]$Pattern) {
+    $caught = $null
+    try { & $Action } catch { $caught = $_ }
+    if ($null -eq $caught) { throw "Expected an error matching '$Pattern', but no error was thrown." }
+    if ($caught.Exception.Message -notmatch $Pattern) {
+        throw "Expected error matching '$Pattern', got: $($caught.Exception.Message)"
+    }
+}
+
+$temporaryDirectory = Join-Path ([IO.Path]::GetTempPath()) "sharpts-snapshot-tests-$([Guid]::NewGuid().ToString('N'))"
+[IO.Directory]::CreateDirectory($temporaryDirectory) | Out-Null
+try {
+    $resultsA = Join-Path $temporaryDirectory 'results-a.txt'
+    $resultsB = Join-Path $temporaryDirectory 'results-b.txt'
+    $lines = @(
+        'node|zeta:10:5.5:5.0:0.2:12:2:310.5:family-z:2',
+        'compiled|alpha:1:2.0:1.9:0.1:20:4:300.2:family-a:1',
+        'node|alpha:1:1.0:0.9:0.05:25:8:301.7:family-a:1',
+        'node|zeta:10:5.0:4.8:0.15:10:2:305.0:family-z:1',
+        'compiled|zeta:10:6.0:5.7:0.3:11:2:302.0:family-z:1'
+    )
+    Set-Content -LiteralPath $resultsA -Value $lines
+    Set-Content -LiteralPath $resultsB -Value @($lines[4], $lines[2], $lines[0], $lines[3], $lines[1])
+
+    $fixed = @{
+        RepositoryRoot = (Resolve-Path (Join-Path $harnessDirectory '../..')).Path
+        SelectedRuntimes = @('node', 'compiled')
+        TimestampUtc = '2026-08-26T12:34:56Z'
+        DotNetVersion = '10.0.100'
+        NodeVersion = 'v24.0.0'
+        BunVersion = $null
+        RunnerIdentity = 'fixture-runner'
+        OperatingSystem = 'Fixture OS'
+        Architecture = 'x64'
+        Cpu = 'Fixture CPU'
+        Revision = [ordered]@{ commit = '1111111111111111111111111111111111111111'; dirty = $false }
+    }
+    $snapshotA = New-SharpTSPublicBenchmarkSnapshot -ResultsFile $resultsA @fixed
+    $snapshotB = New-SharpTSPublicBenchmarkSnapshot -ResultsFile $resultsB @fixed
+    $jsonA = $snapshotA | ConvertTo-Json -Depth 12
+    $jsonB = $snapshotB | ConvertTo-Json -Depth 12
+    Assert-True ($jsonA -ceq $jsonB) 'Snapshot output changed when raw input ordering changed.'
+    Assert-True ($snapshotA.cases.Count -eq 2) 'Expected two benchmark cases.'
+    Assert-True ($snapshotA.cases[0].id -ceq 'family-a/alpha?n=1') 'Cases were not sorted by stable ID.'
+    Assert-True ($snapshotA.cases[1].runtimes[2].measurements[0].launch -eq 1) 'Measurements were not sorted by launch.'
+    Assert-True ($snapshotA.cases[1].runtimes[2].measurements[1].launch -eq 2) 'Second launch was not retained.'
+    Assert-True ($snapshotA.cases[0].runtimes.Count -eq 4) 'Missing runtimes were not explicit.'
+    Assert-True ($snapshotA.cases[0].runtimes[0].status -ceq 'missing') 'Interpreter should be explicitly missing.'
+    Assert-True ($snapshotA.cases[0].runtimes[0].reason -ceq 'notSelected') 'Interpreter missing reason was notSelected.'
+    Assert-True ($snapshotA.cases[0].runtimes[3].status -ceq 'missing') 'Bun should be explicitly missing.'
+    Assert-True (-not $snapshotA.run.tools.runtimes[3].available) 'Unavailable Bun was marked available.'
+
+    $snapshotFile = Join-Path $temporaryDirectory 'snapshot.json'
+    [void](Export-SharpTSPublicBenchmarkSnapshot -ResultsFile $resultsA -OutputFile $snapshotFile @fixed)
+    Assert-True (Test-SharpTSPublicBenchmarkSnapshotFile $snapshotFile) 'Written snapshot did not validate.'
+
+    $schema = Get-Content -LiteralPath (Join-Path $harnessDirectory 'snapshot-v1.schema.json') -Raw | ConvertFrom-Json
+    Assert-True ($schema.'$schema' -ceq 'https://json-schema.org/draft/2020-12/schema') 'Schema is not JSON Schema 2020-12.'
+
+    $malformed = Join-Path $temporaryDirectory 'malformed.txt'
+    Set-Content -LiteralPath $malformed -Value 'compiled|not-enough-fields:1:2'
+    Assert-Throws { ConvertFrom-SharpTSRawBenchmarkResults $malformed } 'expected 10 payload fields'
+
+    $notFinite = Join-Path $temporaryDirectory 'not-finite.txt'
+    Set-Content -LiteralPath $notFinite -Value 'compiled|alpha:1:NaN:1:0:8:1:300:family-a:1'
+    Assert-Throws { ConvertFrom-SharpTSRawBenchmarkResults $notFinite } 'must be finite'
+
+    $duplicateMeasurement = Join-Path $temporaryDirectory 'duplicate-measurement.txt'
+    Set-Content -LiteralPath $duplicateMeasurement -Value @($lines[1], $lines[1])
+    Assert-Throws { ConvertFrom-SharpTSRawBenchmarkResults $duplicateMeasurement } 'Duplicate benchmark measurement'
+
+    $unknownSchema = $jsonA | ConvertFrom-Json
+    $unknownSchema.schemaVersion = 2
+    Assert-Throws { Assert-SharpTSPublicBenchmarkSnapshot $unknownSchema } 'Unsupported benchmark snapshot schema version'
+
+    $duplicateCase = $jsonA | ConvertFrom-Json
+    $clonedCase = $duplicateCase.cases[0] | ConvertTo-Json -Depth 12 | ConvertFrom-Json
+    $duplicateCase.cases = @($duplicateCase.cases[0], $clonedCase, $duplicateCase.cases[1])
+    Assert-Throws { Assert-SharpTSPublicBenchmarkSnapshot $duplicateCase } 'Duplicate benchmark case ID'
+
+    $invalidUnit = $jsonA | ConvertFrom-Json
+    $invalidUnit.cases[0].unit = 'seconds'
+    Assert-Throws { Assert-SharpTSPublicBenchmarkSnapshot $invalidUnit } 'unsupported unit'
+
+    $invalidRuntime = $jsonA | ConvertFrom-Json
+    $invalidRuntime.cases[0].runtimes[0].status = 'skipped'
+    Assert-Throws { Assert-SharpTSPublicBenchmarkSnapshot $invalidRuntime } 'invalid status'
+
+    Write-Host 'Cross-runtime snapshot contract tests passed.'
+} finally {
+    Remove-Item -LiteralPath $temporaryDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/benchmarks/cross-runtime/validate-snapshot.ps1
+++ b/benchmarks/cross-runtime/validate-snapshot.ps1
@@ -1,0 +1,14 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory, Position = 0)]
+    [string[]]$Path
+)
+
+$ErrorActionPreference = 'Stop'
+$harnessDirectory = Split-Path -Parent $MyInvocation.MyCommand.Definition
+Import-Module (Join-Path $harnessDirectory 'Snapshot.psm1') -Force
+
+foreach ($snapshotPath in $Path) {
+    [void](Test-SharpTSPublicBenchmarkSnapshotFile $snapshotPath)
+    Write-Host "Validated benchmark snapshot: $snapshotPath"
+}

--- a/benchmarks/gc-profiles/run-gc-profile-matrix.ps1
+++ b/benchmarks/gc-profiles/run-gc-profile-matrix.ps1
@@ -420,7 +420,7 @@ $benchRows = [Collections.Generic.List[object]]::new()
 foreach ($measurement in $measurements) {
     foreach ($line in $measurement.benchLines) {
         $parts = $line -split ':'
-        if ($parts.Count -ne 6) { continue }
+        if ($parts.Count -lt 6) { continue }
         $benchRows.Add([pscustomobject]@{
             platform = $measurement.platform
             runtimeProfile = if ($measurement.runtime -eq 'node') { 'node' } else { $measurement.profile }

--- a/scripts/PerfLocal.psm1
+++ b/scripts/PerfLocal.psm1
@@ -36,7 +36,7 @@ function ConvertFrom-SharpTSBenchmarkResults {
         }
 
         $fields = $runtimeAndPayload[1] -split ':'
-        if ($fields.Count -ne 5) {
+        if ($fields.Count -lt 5) {
             throw "Malformed benchmark payload: $line"
         }
 

--- a/scripts/perf-local.ps1
+++ b/scripts/perf-local.ps1
@@ -245,6 +245,7 @@ function Invoke-OneMeasurement {
             '-Runtimes', $runtimeList,
             '-Launches', '1',
             '-OutputDirectory', $scratch,
+            '-NoSnapshot',
             '-NoBuild'
         )
         if ($Variant -eq 'candidate') {
@@ -264,6 +265,7 @@ function Invoke-OneMeasurement {
         '-Runtimes', $runtimeList,
         '-Launches', '1',
         '-OutputDirectory', $scratch,
+        '-NoSnapshot',
         '-NoBuild'
     )
     Invoke-WslChecked (Join-BashCommand $arguments)


### PR DESCRIPTION
## Summary

- define and validate the versioned schema-v1 public cross-runtime benchmark contract
- preserve the human-readable summary while exporting deterministic machine-readable snapshots with run, environment, methodology, case, runtime, and sample metadata
- correct the documented timing scope to in-process workload timing and publish a clean canonical snapshot for pinned-source consumers
- validate the exporter and canonical snapshot in CI while continuing to upload raw diagnostics

## Validation

- `dotnet build SharpTS.sln -c Release --no-restore --disable-build-servers -m:1`
- full `run-benchmarks.ps1 -NoBuild` sweep across interpreter, compiled, and Node.js (Bun explicitly unavailable)
- `./benchmarks/cross-runtime/test-snapshot.ps1`
- `./benchmarks/cross-runtime/validate-snapshot.ps1 benchmarks/cross-runtime/snapshots/latest.json`
- `./scripts/test-perf-local.ps1`
- `./scripts/test-github-workflows.ps1`
- `git diff --check`

Closes #1511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added versioned cross-runtime benchmark snapshots with runtime, environment, launch, and measurement metadata.
  - Added commands to export and validate benchmark snapshots against a defined schema.
  - Added options to generate snapshots automatically or disable generation when needed.

- **Improvements**
  - Benchmark result parsing now supports additional metadata fields.
  - Benchmark reporting includes sample counts, batch sizes, and timing details.
  - Automated workflows now validate snapshots and preserve benchmark artifacts after failures.

- **Documentation**
  - Expanded guidance for snapshot creation, validation, refreshes, and interpreting benchmark scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->