### PR TITLE
test: stabilize process tree termination fixture

### DIFF
--- a/SharpTS.sln
+++ b/SharpTS.sln
@@ -53,6 +53,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpTS.Example.Interop", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpTS.Hosting.Abstractions", "src\SharpTS.Hosting.Abstractions\SharpTS.Hosting.Abstractions.csproj", "{60BF83DB-E00D-43A5-8A6F-4A0BDAD1F24D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpTS.ProcessTreeFixture", "tests\fixtures\SharpTS.ProcessTreeFixture\SharpTS.ProcessTreeFixture.csproj", "{6A8A8EC7-49D5-4029-B724-56C5B8F72C6F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -279,6 +281,18 @@ Global
 		{60BF83DB-E00D-43A5-8A6F-4A0BDAD1F24D}.Release|x64.Build.0 = Release|Any CPU
 		{60BF83DB-E00D-43A5-8A6F-4A0BDAD1F24D}.Release|x86.ActiveCfg = Release|Any CPU
 		{60BF83DB-E00D-43A5-8A6F-4A0BDAD1F24D}.Release|x86.Build.0 = Release|Any CPU
+		{6A8A8EC7-49D5-4029-B724-56C5B8F72C6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A8A8EC7-49D5-4029-B724-56C5B8F72C6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A8A8EC7-49D5-4029-B724-56C5B8F72C6F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6A8A8EC7-49D5-4029-B724-56C5B8F72C6F}.Debug|x64.Build.0 = Debug|Any CPU
+		{6A8A8EC7-49D5-4029-B724-56C5B8F72C6F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6A8A8EC7-49D5-4029-B724-56C5B8F72C6F}.Debug|x86.Build.0 = Debug|Any CPU
+		{6A8A8EC7-49D5-4029-B724-56C5B8F72C6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A8A8EC7-49D5-4029-B724-56C5B8F72C6F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A8A8EC7-49D5-4029-B724-56C5B8F72C6F}.Release|x64.ActiveCfg = Release|Any CPU
+		{6A8A8EC7-49D5-4029-B724-56C5B8F72C6F}.Release|x64.Build.0 = Release|Any CPU
+		{6A8A8EC7-49D5-4029-B724-56C5B8F72C6F}.Release|x86.ActiveCfg = Release|Any CPU
+		{6A8A8EC7-49D5-4029-B724-56C5B8F72C6F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -302,6 +316,7 @@ Global
 		{BD40CA0A-097E-4F9E-A889-009ED9DB802E} = {66320409-64EC-F7C5-3DEF-65E7510DAAD1}
 		{5C10D875-8106-4415-9EAA-C908202A853F} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 		{60BF83DB-E00D-43A5-8A6F-4A0BDAD1F24D} = {916B61B3-312D-841D-1457-818AC0DB32BA}
+		{6A8A8EC7-49D5-4029-B724-56C5B8F72C6F} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E1AC9D5B-73E6-42C6-B97C-2CB826ACF2C6}

--- a/tests/SharpTS.Tests/Infrastructure/ExternalProcessTestsCollection.cs
+++ b/tests/SharpTS.Tests/Infrastructure/ExternalProcessTestsCollection.cs
@@ -1,0 +1,14 @@
+using Xunit;
+
+namespace SharpTS.Tests.Infrastructure;
+
+/// <summary>
+/// Tests in this collection create and terminate real operating-system process trees. Running
+/// this small collection in xUnit's non-parallel phase prevents CPU-heavy compiler collections
+/// from turning process readiness deadlines into suite-load assertions while preserving
+/// aggressive parallelism for the rest of the test assembly.
+/// </summary>
+[CollectionDefinition("ExternalProcessTests", DisableParallelization = true)]
+public sealed class ExternalProcessTestsCollection
+{
+}

--- a/tests/SharpTS.Tests/RuntimeTests/OwnedProcessRegistryTests.cs
+++ b/tests/SharpTS.Tests/RuntimeTests/OwnedProcessRegistryTests.cs
@@ -1,16 +1,18 @@
 using System.Diagnostics;
-using System.Runtime.ExceptionServices;
-using System.Runtime.InteropServices;
 using SharpTS.Execution;
+using SharpTS.ProcessTreeFixture;
 using SharpTS.Runtime;
 using SharpTS.Tests.Infrastructure;
 using Xunit;
+using Xunit.Sdk;
 
 namespace SharpTS.Tests.RuntimeTests;
 
+[Collection("ExternalProcessTests")]
 public sealed class OwnedProcessRegistryTests
 {
     private static readonly TimeSpan ExitTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan FixtureReadyTimeout = TimeSpan.FromSeconds(10);
 
     [Fact]
     public void InterpreterDispose_TerminatesOnlyItsOwnProcesses()
@@ -45,29 +47,32 @@ public sealed class OwnedProcessRegistryTests
     }
 
     [Fact]
-    public void ProcessTreeTermination_TerminatesDescendants()
+    public async Task ProcessTreeTermination_TerminatesDescendants()
     {
         using Process parent = StartParentThatReportsChildPid();
+        Task<string> stderrTask = parent.StandardError.ReadToEndAsync();
+        var readiness = Stopwatch.StartNew();
         Process? child = null;
 
         try
         {
-            // Keep the PID handshake off the ThreadPool: under the suite's aggressive
-            // parallelism, an awaited continuation can be delayed past the child's lifetime.
-            string? line = null;
-            Exception? readException = null;
-            var reader = new Thread(() =>
+            string? line;
+            try
             {
-                try { line = parent.StandardOutput.ReadLine(); }
-                catch (Exception exception) { readException = exception; }
-            }) { IsBackground = true };
-            reader.Start();
+                line = await parent.StandardOutput.ReadLineAsync().WaitAsync(FixtureReadyTimeout);
+            }
+            catch (TimeoutException)
+            {
+                string diagnostics = StopFixtureAndDescribe(parent, stderrTask, readiness.Elapsed);
+                throw new XunitException($"Timed out waiting for the fixture parent to report a child PID. {diagnostics}");
+            }
 
-            Assert.True(reader.Join(TimeSpan.FromSeconds(10)), "Timed out waiting for the parent to report a child PID.");
-            if (readException is not null)
-                ExceptionDispatchInfo.Capture(readException).Throw();
-
-            Assert.True(int.TryParse(line, out int childPid), $"Parent did not report a child PID. Output: {line ?? "<null>"}");
+            if (!int.TryParse(line, out int childPid))
+            {
+                string diagnostics = StopFixtureAndDescribe(parent, stderrTask, readiness.Elapsed);
+                throw new XunitException(
+                    $"Fixture parent did not report a valid child PID. Output: {line ?? "<null>"}. {diagnostics}");
+            }
 
             child = Process.GetProcessById(childPid);
             Assert.False(child.HasExited);
@@ -82,6 +87,7 @@ public sealed class OwnedProcessRegistryTests
             ProcessTreeTermination.Terminate(parent);
             ProcessTreeTermination.Terminate(child);
             child?.Dispose();
+            ObserveFixtureStderr(stderrTask);
         }
     }
 
@@ -126,63 +132,78 @@ public sealed class OwnedProcessRegistryTests
 
     private static Process StartLongRunningProcess()
     {
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "powershell.exe" : "/bin/sh",
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            startInfo.ArgumentList.Add("-NoProfile");
-            startInfo.ArgumentList.Add("-NonInteractive");
-            startInfo.ArgumentList.Add("-Command");
-            startInfo.ArgumentList.Add("Start-Sleep -Seconds 120");
-        }
-        else
-        {
-            startInfo.ArgumentList.Add("-c");
-            startInfo.ArgumentList.Add("sleep 120");
-        }
-
-        return Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start long-running test process.");
+        return Process.Start(CreateFixtureStartInfo("child"))
+            ?? throw new InvalidOperationException("Failed to start long-running test process.");
     }
 
     private static Process StartParentThatReportsChildPid()
     {
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "powershell.exe" : "/bin/sh",
-            UseShellExecute = false,
-            CreateNoWindow = true,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true
-        };
-
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            startInfo.ArgumentList.Add("-NoProfile");
-            startInfo.ArgumentList.Add("-NonInteractive");
-            startInfo.ArgumentList.Add("-Command");
-            startInfo.ArgumentList.Add(
-                "$child = Start-Process powershell.exe -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 120' " +
-                "-PassThru -WindowStyle Hidden; [Console]::Out.WriteLine($child.Id); $child.WaitForExit()");
-        }
-        else
-        {
-            startInfo.ArgumentList.Add("-c");
-            startInfo.ArgumentList.Add("sleep 120 & echo $!; wait");
-        }
-
-        return Process.Start(startInfo) ?? throw new InvalidOperationException("Failed to start process-tree test parent.");
+        ProcessStartInfo startInfo = CreateFixtureStartInfo("parent");
+        startInfo.RedirectStandardOutput = true;
+        startInfo.RedirectStandardError = true;
+        return Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start process-tree test parent.");
     }
 
     private static (string Command, string Arguments) LongRunningGuestCommand()
     {
-        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? ("powershell.exe", "['-NoProfile', '-NonInteractive', '-Command', 'Start-Sleep -Seconds 120']")
-            : ("/bin/sh", "['-c', 'sleep 120']");
+        string fixturePath = EscapeTypeScriptString(typeof(ProcessTreeFixtureMarker).Assembly.Location);
+        return ("dotnet", $"['{fixturePath}', 'child']");
+    }
+
+    private static ProcessStartInfo CreateFixtureStartInfo(string mode)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add(typeof(ProcessTreeFixtureMarker).Assembly.Location);
+        startInfo.ArgumentList.Add(mode);
+        return startInfo;
+    }
+
+    private static string EscapeTypeScriptString(string value)
+    {
+        return value.Replace("\\", "\\\\").Replace("'", "\\'");
+    }
+
+    private static string StopFixtureAndDescribe(
+        Process parent,
+        Task<string> stderrTask,
+        TimeSpan elapsed)
+    {
+        ProcessTreeTermination.Terminate(parent);
+        string stderr = ObserveFixtureStderr(stderrTask);
+
+        string exitState;
+        try
+        {
+            exitState = parent.HasExited ? $"exited with code {parent.ExitCode}" : "still running";
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or ObjectDisposedException)
+        {
+            exitState = $"exit state unavailable ({exception.GetType().Name})";
+        }
+
+        string stderrDescription = string.IsNullOrWhiteSpace(stderr) ? "<empty>" : stderr.Trim();
+        return $"Parent PID: {parent.Id}; elapsed: {elapsed.TotalMilliseconds:F0} ms; parent {exitState}; stderr: {stderrDescription}";
+    }
+
+    private static string ObserveFixtureStderr(Task<string> stderrTask)
+    {
+        try
+        {
+            if (!stderrTask.Wait(ExitTimeout))
+                return "<stderr did not close within the cleanup deadline>";
+
+            return stderrTask.GetAwaiter().GetResult();
+        }
+        catch (Exception exception)
+        {
+            return $"<stderr read failed: {exception.GetType().Name}: {exception.Message}>";
+        }
     }
 
     private static bool WaitUntilExited(Process process)

--- a/tests/SharpTS.Tests/SharpTS.Tests.csproj
+++ b/tests/SharpTS.Tests/SharpTS.Tests.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\fixtures\SharpTS.ProcessTreeFixture\SharpTS.ProcessTreeFixture.csproj" />
     <ProjectReference Include="..\..\src\SharpTS\SharpTS.csproj" />
     <ProjectReference Include="..\..\src\SharpTS.DebugAdapter\SharpTS.DebugAdapter.csproj" />
     <ProjectReference Include="..\..\src\SharpTS.Sdk.Tasks\SharpTS.Sdk.Tasks.csproj" />

--- a/tests/fixtures/SharpTS.ProcessTreeFixture/Program.cs
+++ b/tests/fixtures/SharpTS.ProcessTreeFixture/Program.cs
@@ -1,0 +1,76 @@
+using System.Diagnostics;
+
+namespace SharpTS.ProcessTreeFixture;
+
+/// <summary>
+/// Provides a stable assembly identity so the test project can locate the fixture output.
+/// </summary>
+public static class ProcessTreeFixtureMarker
+{
+}
+
+internal static class Program
+{
+    private const string ParentMode = "parent";
+    private const string ChildMode = "child";
+
+    private static int Main(string[] args)
+    {
+        try
+        {
+            return args switch
+            {
+                [ParentMode] => RunParent(),
+                [ChildMode] => RunChild(),
+                _ => ReportUsage()
+            };
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(exception);
+            return 1;
+        }
+    }
+
+    private static int RunParent()
+    {
+        using Process child = Process.Start(CreateSelfStartInfo(ChildMode))
+            ?? throw new InvalidOperationException("Failed to start the process-tree fixture child.");
+
+        Console.Out.WriteLine(child.Id);
+        Console.Out.Flush();
+
+        child.WaitForExit();
+        return child.ExitCode;
+    }
+
+    private static int RunChild()
+    {
+        Thread.Sleep(Timeout.Infinite);
+        return 0;
+    }
+
+    private static ProcessStartInfo CreateSelfStartInfo(string mode)
+    {
+        string hostPath = Environment.ProcessPath
+            ?? throw new InvalidOperationException("The fixture could not locate its .NET host process.");
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = hostPath,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        if (string.Equals(Path.GetFileNameWithoutExtension(hostPath), "dotnet", StringComparison.OrdinalIgnoreCase))
+            startInfo.ArgumentList.Add(typeof(ProcessTreeFixtureMarker).Assembly.Location);
+
+        startInfo.ArgumentList.Add(mode);
+        return startInfo;
+    }
+
+    private static int ReportUsage()
+    {
+        Console.Error.WriteLine($"Usage: SharpTS.ProcessTreeFixture <{ParentMode}|{ChildMode}>");
+        return 64;
+    }
+}

--- a/tests/fixtures/SharpTS.ProcessTreeFixture/SharpTS.ProcessTreeFixture.csproj
+++ b/tests/fixtures/SharpTS.ProcessTreeFixture/SharpTS.ProcessTreeFixture.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- TargetFramework / ImplicitUsings / Nullable inherited from Directory.Build.props. -->
+    <IsPackable>false</IsPackable>
+    <RootNamespace>SharpTS.ProcessTreeFixture</RootNamespace>
+    <AssemblyName>SharpTS.ProcessTreeFixture</AssemblyName>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- replace the nested PowerShell and shell process-tree fixture with a deterministic cross-platform .NET helper
- isolate only the four tests that create real operating-system processes while preserving aggressive parallelism for the rest of the test assembly
- report bounded readiness diagnostics, including the parent PID, elapsed time, exit state, and stderr

## Root cause

The Windows failure in #1513 happened before ProcessTreeTermination.Terminate was called: the shell-based parent did not report its child PID within the 10-second readiness deadline. Historical CI timings for the same test ranged from well under a second to roughly eight seconds before the timeout failure. Starting nested PowerShell processes while the aggressively parallel suite saturated a four-core Windows runner made fixture readiness depend on scheduler and shell startup latency.

The dedicated managed fixture removes the heavyweight shell startup path. The narrowly scoped non-parallel collection prevents CPU-heavy compiler tests from consuming the fixture readiness window without serializing the main suite.

## Validation

- dotnet build SharpTS.sln --configuration Release: passed
- OwnedProcessRegistryTests: 4/4 passed
- focused stress run: 48/48 concurrent invocations passed
- full core suite: 17,541 passed, 3 skipped, 0 failed
- git diff --check: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added cross-platform process-tree test coverage using a dedicated executable fixture.
  * Improved process test reliability with serialized execution, readiness timeouts, diagnostics, and cleanup handling.
  * Added support for validating parent/child process creation and exit-code behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->