### PR TITLE
Export compiler and GUI performance evidence

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,7 +12,8 @@ permissions:
   contents: read
 
 jobs:
-  benchmark:
+  cross-runtime:
+    name: Cross-runtime comparison
     runs-on: ubuntu-24.04
     timeout-minutes: 60
 
@@ -68,6 +69,11 @@ jobs:
           ./benchmarks/cross-runtime/validate-snapshot.ps1 `
             (Join-Path $env:BENCH_RESULTS_DIR 'snapshot.json'), `
             benchmarks/cross-runtime/snapshots/latest.json
+          ./benchmarks/snapshots/export-snapshot.ps1 `
+            -CrossRuntimeSnapshot (Join-Path $env:BENCH_RESULTS_DIR 'snapshot.json') `
+            -OutputFile (Join-Path $env:BENCH_RESULTS_DIR 'public-cross-runtime.json')
+          ./benchmarks/snapshots/validate-snapshot.ps1 `
+            (Join-Path $env:BENCH_RESULTS_DIR 'public-cross-runtime.json')
 
       - name: Upload raw and structured results
         if: always() && env.BENCH_RESULTS_DIR != ''
@@ -75,4 +81,128 @@ jobs:
         with:
           name: benchmark-results
           path: ${{ env.BENCH_RESULTS_DIR }}
+          retention-days: 30
+
+  compiler-micro:
+    name: Compiler headroom
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          global-json-file: global.json
+      - name: Run BenchmarkDotNet compiler suite
+        shell: pwsh
+        run: |
+          $resultsDir = Join-Path ([System.IO.Path]::GetTempPath()) 'compiler-micro-results'
+          "COMPILER_RESULTS_DIR=$resultsDir" >> $env:GITHUB_ENV
+          dotnet run -c Release `
+            --project benchmarks/micro/SharpTS.Microbenchmarks `
+            -- --job Short --filter '*' --artifacts $resultsDir
+      - name: Export compiler snapshot run
+        shell: pwsh
+        run: |
+          $reports = @(Get-ChildItem -LiteralPath $env:COMPILER_RESULTS_DIR -Recurse -File -Filter '*report-full-compressed.json' | ForEach-Object FullName)
+          $metadata = @(Get-ChildItem -LiteralPath $env:COMPILER_RESULTS_DIR -Recurse -File -Filter '*sharpts-metadata.json' | ForEach-Object FullName)
+          ./benchmarks/snapshots/export-snapshot.ps1 `
+            -CompilerMicro `
+            -ReportPath $reports `
+            -MetadataPath $metadata `
+            -OutputFile (Join-Path $env:COMPILER_RESULTS_DIR 'public-compiler-micro.json')
+          ./benchmarks/snapshots/validate-snapshot.ps1 `
+            (Join-Path $env:COMPILER_RESULTS_DIR 'public-compiler-micro.json')
+      - name: Upload compiler evidence
+        if: always() && env.COMPILER_RESULTS_DIR != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: compiler-micro-results
+          path: ${{ env.COMPILER_RESULTS_DIR }}
+          retention-days: 30
+
+  gui:
+    name: GUI budgets
+    runs-on: windows-2025
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          global-json-file: global.json
+      - name: Run BenchmarkDotNet GUI suite
+        shell: pwsh
+        run: |
+          $resultsDir = Join-Path ([System.IO.Path]::GetTempPath()) 'gui-benchmark-results'
+          "GUI_RESULTS_DIR=$resultsDir" >> $env:GITHUB_ENV
+          dotnet run -c Release `
+            --project benchmarks/micro/SharpTS.Gui.Benchmarks `
+            -- --filter '*' --artifacts $resultsDir
+      - name: Verify budgets and export GUI snapshot run
+        shell: pwsh
+        run: |
+          $report = @(Get-ChildItem -LiteralPath $env:GUI_RESULTS_DIR -Recurse -File -Filter '*report-full-compressed.json' | ForEach-Object FullName)
+          $metadata = @(Get-ChildItem -LiteralPath $env:GUI_RESULTS_DIR -Recurse -File -Filter '*sharpts-metadata.json' | ForEach-Object FullName)
+          $csv = Get-ChildItem -LiteralPath $env:GUI_RESULTS_DIR -Recurse -File -Filter '*-report.csv' | Select-Object -First 1 -ExpandProperty FullName
+          ./benchmarks/micro/SharpTS.Gui.Benchmarks/Verify-PerformanceBudgets.ps1 -ReportPath $csv
+          ./benchmarks/snapshots/export-snapshot.ps1 `
+            -GuiBenchmark `
+            -ReportPath $report `
+            -MetadataPath $metadata `
+            -BudgetPath benchmarks/micro/SharpTS.Gui.Benchmarks/PerformanceBudgets.json `
+            -OutputFile (Join-Path $env:GUI_RESULTS_DIR 'public-gui.json')
+          ./benchmarks/snapshots/validate-snapshot.ps1 `
+            (Join-Path $env:GUI_RESULTS_DIR 'public-gui.json')
+      - name: Upload GUI evidence
+        if: always() && env.GUI_RESULTS_DIR != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: gui-benchmark-results
+          path: ${{ env.GUI_RESULTS_DIR }}
+          retention-days: 30
+
+  public-snapshot:
+    name: Compose public snapshot
+    needs: [cross-runtime, compiler-micro, gui]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: benchmark-results
+          path: artifacts/cross-runtime
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: compiler-micro-results
+          path: artifacts/compiler-micro
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: gui-benchmark-results
+          path: artifacts/gui
+      - name: Merge suite runs without merging environments
+        shell: pwsh
+        run: |
+          $snapshots = @(
+            'artifacts/cross-runtime/public-cross-runtime.json'
+            'artifacts/compiler-micro/public-compiler-micro.json'
+            'artifacts/gui/public-gui.json'
+          )
+          ./benchmarks/snapshots/merge-snapshots.ps1 `
+            -Path $snapshots `
+            -OutputFile artifacts/public-snapshot.json `
+            -RequireAllSuites
+          ./benchmarks/snapshots/validate-snapshot.ps1 artifacts/public-snapshot.json
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: public-performance-snapshot
+          path: artifacts/public-snapshot.json
+          if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
           ./benchmarks/cross-runtime/test-snapshot.ps1
           ./benchmarks/cross-runtime/validate-snapshot.ps1 `
             benchmarks/cross-runtime/snapshots/latest.json
+          ./benchmarks/snapshots/test-snapshot.ps1
           ./benchmarks/cross-runtime/run-benchmarks.ps1 -Smoke -NoBuild
           dotnet run --configuration Release --no-build `
             --project benchmarks/micro/SharpTS.Microbenchmarks -- --smoke

--- a/.github/workflows/desktop-gui.yml
+++ b/.github/workflows/desktop-gui.yml
@@ -115,13 +115,24 @@ jobs:
         run: scripts/test-gui-distribution.ps1
       - name: Packaged x64 SDK, Native AOT, performance budgets, and real windows
         shell: pwsh
-        run: tests/fixtures/SharpTS.Gui.Sdk.Consumer/Run-PackagedConsumer.ps1 -RuntimeIdentifier win-x64 -RealWindow -NativeAot -EnforcePerformanceBudgets -CandidatePackage "artifacts/desktop-gui/candidate/${{ needs.gui-sdk-candidate.outputs.package_file_name }}"
+        run: |
+          $evidence = 'artifacts/desktop-gui/win-x64/performance-evidence.json'
+          tests/fixtures/SharpTS.Gui.Sdk.Consumer/Run-PackagedConsumer.ps1 `
+            -RuntimeIdentifier win-x64 -RealWindow -NativeAot -EnforcePerformanceBudgets `
+            -PerformanceEvidencePath $evidence `
+            -CandidatePackage "artifacts/desktop-gui/candidate/${{ needs.gui-sdk-candidate.outputs.package_file_name }}"
+          ./benchmarks/snapshots/export-snapshot.ps1 `
+            -GuiPackagingEvidence $evidence `
+            -OutputFile artifacts/desktop-gui/win-x64/public-native-aot.json
+          ./benchmarks/snapshots/validate-snapshot.ps1 artifacts/desktop-gui/win-x64/public-native-aot.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: desktop-gui-windows-x64
           path: |
             artifacts/desktop-gui/win-x64/*-trace.json
+            artifacts/desktop-gui/win-x64/*evidence.json
+            artifacts/desktop-gui/win-x64/public-native-aot.json
             artifacts/desktop-gui/win-x64/published single file/*.exe
             artifacts/desktop-gui/win-x64/published native aot/*.exe
             artifacts/desktop-gui/win-x64/cli published single file/*.exe
@@ -177,13 +188,24 @@ jobs:
           path: artifacts/desktop-gui/candidate
       - name: Packaged ARM64 SDK, Native AOT, performance budgets, and real windows
         shell: pwsh
-        run: tests/fixtures/SharpTS.Gui.Sdk.Consumer/Run-PackagedConsumer.ps1 -RuntimeIdentifier win-arm64 -RealWindow -NativeAot -EnforcePerformanceBudgets -CandidatePackage "artifacts/desktop-gui/candidate/${{ needs.gui-sdk-candidate.outputs.package_file_name }}"
+        run: |
+          $evidence = 'artifacts/desktop-gui/win-arm64/performance-evidence.json'
+          tests/fixtures/SharpTS.Gui.Sdk.Consumer/Run-PackagedConsumer.ps1 `
+            -RuntimeIdentifier win-arm64 -RealWindow -NativeAot -EnforcePerformanceBudgets `
+            -PerformanceEvidencePath $evidence `
+            -CandidatePackage "artifacts/desktop-gui/candidate/${{ needs.gui-sdk-candidate.outputs.package_file_name }}"
+          ./benchmarks/snapshots/export-snapshot.ps1 `
+            -GuiPackagingEvidence $evidence `
+            -OutputFile artifacts/desktop-gui/win-arm64/public-native-aot.json
+          ./benchmarks/snapshots/validate-snapshot.ps1 artifacts/desktop-gui/win-arm64/public-native-aot.json
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
         with:
           name: desktop-gui-windows-arm64-native
           path: |
             artifacts/desktop-gui/win-arm64/*-trace.json
+            artifacts/desktop-gui/win-arm64/*evidence.json
+            artifacts/desktop-gui/win-arm64/public-native-aot.json
             artifacts/desktop-gui/win-arm64/published single file/*.exe
             artifacts/desktop-gui/win-arm64/published native aot/*.exe
             artifacts/desktop-gui/win-arm64/cli published single file/*.exe

--- a/.github/workflows/windows-gui-distribution.yml
+++ b/.github/workflows/windows-gui-distribution.yml
@@ -38,7 +38,15 @@ jobs:
 
       - name: Build and execute warning-clean x64 Native AOT candidate
         shell: pwsh
-        run: tests/fixtures/SharpTS.Gui.Sdk.Consumer/Run-PackagedConsumer.ps1 -RuntimeIdentifier win-x64 -NativeAot -EnforcePerformanceBudgets
+        run: |
+          $evidence = 'artifacts/desktop-gui/win-x64/performance-evidence.json'
+          tests/fixtures/SharpTS.Gui.Sdk.Consumer/Run-PackagedConsumer.ps1 `
+            -RuntimeIdentifier win-x64 -NativeAot -EnforcePerformanceBudgets `
+            -PerformanceEvidencePath $evidence
+          ./benchmarks/snapshots/export-snapshot.ps1 `
+            -GuiPackagingEvidence $evidence `
+            -OutputFile artifacts/desktop-gui/win-x64/public-native-aot.json
+          ./benchmarks/snapshots/validate-snapshot.ps1 artifacts/desktop-gui/win-x64/public-native-aot.json
 
       - name: Stage reusable distribution input
         shell: pwsh
@@ -47,6 +55,8 @@ jobs:
           New-Item -ItemType Directory -Path "$root/publish", "$root/assets" -Force | Out-Null
           Copy-Item -Path 'artifacts/desktop-gui/win-x64/published native aot/*' -Destination "$root/publish" -Recurse -Force
           Copy-Item -Path 'distribution/windows/assets/*.png' -Destination "$root/assets" -Force
+          Copy-Item -LiteralPath 'artifacts/desktop-gui/win-x64/performance-evidence.json' -Destination $root
+          Copy-Item -LiteralPath 'artifacts/desktop-gui/win-x64/public-native-aot.json' -Destination $root
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/benchmarks/cross-runtime/README.md
+++ b/benchmarks/cross-runtime/README.md
@@ -36,6 +36,11 @@ important but are not mixed into the workload metric.
 | `scripts/lib/bench.ts` | Shared synchronous and asynchronous timing harnesses (auto-batching, warmup, mean/min/stdev). |
 | `scripts/lib/algorithms.ts` | Algorithm bodies **shared byte-identical** with the microbenchmark suite (embedded there as a resource). |
 
+The schema-v1 file remains the versioned contract for this one suite. The
+[schema-v2 public snapshot](../snapshots/README.md) embeds it as an independent
+run beside compiler-micro and GUI evidence, preserving this environment and
+methodology rather than flattening unlike measurements together.
+
 ## Running
 
 ```powershell

--- a/benchmarks/micro/SharpTS.Gui.Benchmarks/Program.cs
+++ b/benchmarks/micro/SharpTS.Gui.Benchmarks/Program.cs
@@ -1,3 +1,10 @@
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Exporters.Json;
 using BenchmarkDotNet.Running;
+using SharpTS.Benchmarks;
 
-BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+var config = ManualConfig.Create(DefaultConfig.Instance)
+    .AddExporter(JsonExporter.FullCompressed);
+var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
+StructuredBenchmarkMetadata.Write(summaries);

--- a/benchmarks/micro/SharpTS.Gui.Benchmarks/SharpTS.Gui.Benchmarks.csproj
+++ b/benchmarks/micro/SharpTS.Gui.Benchmarks/SharpTS.Gui.Benchmarks.csproj
@@ -8,5 +8,6 @@
     <PackageReference Include="Avalonia.Headless" />
     <PackageReference Include="BenchmarkDotNet" />
     <ProjectReference Include="..\..\..\src\SharpTS.Gui\SharpTS.Gui.csproj" />
+    <Compile Include="..\StructuredBenchmarkMetadata.cs" Link="StructuredBenchmarkMetadata.cs" />
   </ItemGroup>
 </Project>

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Program.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Program.cs
@@ -1,9 +1,11 @@
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Exporters.Json;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Order;
+using SharpTS.Benchmarks;
 using SharpTS.Microbenchmarks.Infrastructure;
 
 namespace SharpTS.Microbenchmarks;
@@ -25,12 +27,14 @@ class Program
         var config = ManualConfig.Create(DefaultConfig.Instance)
             .AddExporter(MarkdownExporter.GitHub)
             .AddExporter(HtmlExporter.Default)
+            .AddExporter(JsonExporter.FullCompressed)
             .AddDiagnoser(MemoryDiagnoser.Default)
             .AddColumn(RankColumn.Arabic)
             .AddColumn(StatisticColumn.OperationsPerSecond)
             .WithOrderer(new DefaultOrderer(SummaryOrderPolicy.FastestToSlowest));
 
-        BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
+        var summaries = BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, config);
+        StructuredBenchmarkMetadata.Write(summaries);
     }
 
     private static void CompileEmbeddedTypeScript()

--- a/benchmarks/micro/SharpTS.Microbenchmarks/README.md
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/README.md
@@ -26,7 +26,7 @@ the timed region**.
 
 | Path | Purpose |
 |------|---------|
-| `Program.cs` | BenchmarkDotNet entry point (GitHub-Markdown + HTML exporters, `MemoryDiagnoser`, rank/ops-per-sec columns). |
+| `Program.cs` | BenchmarkDotNet entry point (JSON + GitHub-Markdown + HTML exporters, `MemoryDiagnoser`, rank/ops-per-sec columns). |
 | `Benchmarks/*.cs` | One file per workload family (computational, async/Promise, starter workloads, arrays, Map/Set, property access, object literals, regex). |
 | `Baselines/*.cs` | Native-type C# ceilings plus `object?`/boxing controls for the dynamic-typing tax. |
 | `Infrastructure/BenchmarkHarness.cs` | Compile TS → DLL, load it, resolve compiled methods/delegates. |
@@ -66,8 +66,11 @@ the same flat benchmark discovery without running any timed benchmark:
 dotnet run -c Release --project benchmarks/micro/SharpTS.Microbenchmarks -- --smoke
 ```
 
-Results (Markdown + HTML, plus allocation columns) are written under
-`BenchmarkDotNet.Artifacts/`.
+Results (structured JSON, Markdown, HTML, and allocation columns) are written
+under `BenchmarkDotNet.Artifacts/`. A `*-sharpts-metadata.json` companion records
+typed parameters, categories, and operations-per-invoke directly from
+BenchmarkDotNet descriptors. See the [public snapshot exporter](../../snapshots/README.md)
+for normalized compiler-headroom publication.
 
 ## Conventions
 

--- a/benchmarks/micro/SharpTS.Microbenchmarks/SharpTS.Microbenchmarks.csproj
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/SharpTS.Microbenchmarks.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\SharpTS\SharpTS.csproj" />
+    <Compile Include="..\StructuredBenchmarkMetadata.cs" Link="Infrastructure\StructuredBenchmarkMetadata.cs" />
   </ItemGroup>
 
   <!-- Embed TypeScript source files as resources for pre-compilation -->

--- a/benchmarks/micro/StructuredBenchmarkMetadata.cs
+++ b/benchmarks/micro/StructuredBenchmarkMetadata.cs
@@ -1,0 +1,67 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using BenchmarkDotNet.Reports;
+
+namespace SharpTS.Benchmarks;
+
+/// <summary>
+/// Writes the BenchmarkDotNet descriptor data that its built-in JSON exporter omits.
+/// The public snapshot transformer joins this file to the built-in structured report
+/// by summary title and report order, verifying each type and method; no presentation
+/// report or display-formatted parameter value is parsed.
+/// </summary>
+internal static class StructuredBenchmarkMetadata
+{
+    private const string SourceFormat = "sharpts-benchmarkdotnet-metadata-v1";
+
+    public static void Write(IEnumerable<Summary> summaries)
+    {
+        foreach (Summary summary in summaries)
+        {
+            if (summary.Reports.IsDefaultOrEmpty)
+                continue;
+
+            var payload = new
+            {
+                sourceFormat = SourceFormat,
+                title = summary.Title,
+                benchmarks = summary.Reports.Select(report => new
+                {
+                    fullName = GetDescriptiveFullName(report),
+                    type = report.BenchmarkCase.Descriptor.Type.Name,
+                    method = report.BenchmarkCase.Descriptor.WorkloadMethod.Name,
+                    categories = report.BenchmarkCase.Descriptor.Categories,
+                    operationsPerInvoke = report.BenchmarkCase.Descriptor.OperationsPerInvoke,
+                    parameters = report.BenchmarkCase.Parameters.Items.Select(parameter => new
+                    {
+                        name = parameter.Name,
+                        value = parameter.Value,
+                    }),
+                }),
+            };
+
+            Directory.CreateDirectory(summary.ResultsDirectoryPath);
+            string stableTitle = Regex.Replace(summary.Title, @"-\d{8}-\d{6}$", string.Empty);
+            string safeTitle = string.Concat(stableTitle.Select(character =>
+                Path.GetInvalidFileNameChars().Contains(character) ? '_' : character));
+            string path = Path.Combine(
+                summary.ResultsDirectoryPath,
+                $"{safeTitle}-sharpts-metadata.json");
+            File.WriteAllText(path, JsonSerializer.Serialize(payload, new JsonSerializerOptions
+            {
+                WriteIndented = true,
+            }) + Environment.NewLine);
+        }
+    }
+
+    private static string GetDescriptiveFullName(BenchmarkReport report)
+    {
+        string fullName = $"{report.BenchmarkCase.Descriptor.Type.FullName}.{report.BenchmarkCase.Descriptor.WorkloadMethod.Name}";
+        if (report.BenchmarkCase.Parameters.Count == 0)
+            return fullName;
+
+        string parameters = string.Join(", ", report.BenchmarkCase.Parameters.Items.Select(parameter =>
+            $"{parameter.Name}: {Convert.ToString(parameter.Value, System.Globalization.CultureInfo.InvariantCulture)}"));
+        return $"{fullName}({parameters})";
+    }
+}

--- a/benchmarks/snapshots/PublicSnapshot.psm1
+++ b/benchmarks/snapshots/PublicSnapshot.psm1
@@ -1,0 +1,811 @@
+Set-StrictMode -Version Latest
+
+$script:InvariantCulture = [Globalization.CultureInfo]::InvariantCulture
+$script:SchemaUri = 'https://raw.githubusercontent.com/nickna/SharpTS/main/benchmarks/snapshots/snapshot-v2.schema.json'
+$script:SuiteOrder = @{ 'cross-runtime' = 0; 'compiler-micro' = 1; 'gui' = 2 }
+$script:MeasurementOrder = @(
+    'mean', 'throughput', 'allocated', 'gen0Collections', 'gen1Collections',
+    'gen2Collections', 'coldStartup', 'peakWorkingSet', 'executableSize', 'shippingSize'
+)
+$script:MeasurementContract = @{
+    mean = @('nanoseconds', 'lowerIsBetter')
+    throughput = @('operationsPerSecond', 'higherIsBetter')
+    allocated = @('bytes', 'lowerIsBetter')
+    gen0Collections = @('collectionsPer1000Operations', 'lowerIsBetter')
+    gen1Collections = @('collectionsPer1000Operations', 'lowerIsBetter')
+    gen2Collections = @('collectionsPer1000Operations', 'lowerIsBetter')
+    coldStartup = @('nanoseconds', 'lowerIsBetter')
+    peakWorkingSet = @('bytes', 'lowerIsBetter')
+    executableSize = @('bytes', 'lowerIsBetter')
+    shippingSize = @('bytes', 'lowerIsBetter')
+}
+
+function Get-RequiredProperty {
+    param([object]$Value, [string]$Name, [string]$Path)
+
+    if ($null -eq $Value -or $null -eq $Value.PSObject.Properties[$Name]) {
+        throw "$Path is missing required property '$Name'."
+    }
+    return $Value.$Name
+}
+
+function Test-FiniteNumber {
+    param([object]$Value)
+
+    if ($null -eq $Value) { return $false }
+    try { $number = [double]$Value } catch { return $false }
+    return [double]::IsFinite($number)
+}
+
+function ConvertTo-UtcTimestamp {
+    param([object]$Value)
+
+    if (-not $Value) {
+        return [DateTimeOffset]::UtcNow.ToString('o', $script:InvariantCulture)
+    }
+    try {
+        if ($Value -is [DateTimeOffset]) {
+            return $Value.ToUniversalTime().ToString('o', $script:InvariantCulture)
+        }
+        if ($Value -is [DateTime]) {
+            return ([DateTimeOffset]$Value).ToUniversalTime().ToString('o', $script:InvariantCulture)
+        }
+        return [DateTimeOffset]::Parse($Value, $script:InvariantCulture).ToUniversalTime().ToString('o', $script:InvariantCulture)
+    } catch {
+        throw "Invalid timestamp '$Value'."
+    }
+}
+
+function ConvertTo-StableToken {
+    param([Parameter(Mandatory)] [string]$Value)
+
+    $token = [Text.RegularExpressions.Regex]::Replace($Value.Trim(), '([A-Z]+)([A-Z][a-z])', '$1-$2')
+    $token = [Text.RegularExpressions.Regex]::Replace($token, '([a-z0-9])([A-Z])', '$1-$2')
+    $token = [Text.RegularExpressions.Regex]::Replace($token, '[^A-Za-z0-9]+', '-')
+    $token = $token.Trim('-').ToLowerInvariant()
+    if (-not $token -or $token -notmatch '^[a-z0-9][a-z0-9-]*$') {
+        throw "'$Value' cannot be converted to a stable identifier token."
+    }
+    return $token
+}
+
+function ConvertTo-StableParameterText {
+    param([object]$Value)
+
+    if ($null -eq $Value) { return 'null' }
+    if ($Value -is [bool]) { return $Value.ToString().ToLowerInvariant() }
+    if ($Value -is [byte] -or $Value -is [sbyte] -or $Value -is [int16] -or
+        $Value -is [uint16] -or $Value -is [int32] -or $Value -is [uint32] -or
+        $Value -is [int64] -or $Value -is [uint64]) {
+        return ([IFormattable]$Value).ToString($null, $script:InvariantCulture)
+    }
+    if ($Value -is [single] -or $Value -is [double] -or $Value -is [decimal]) {
+        return ([IFormattable]$Value).ToString('G17', $script:InvariantCulture)
+    }
+    return [string]$Value
+}
+
+function New-StableBenchmarkId {
+    param([string]$Family, [string]$Method, [object[]]$Parameters)
+
+    $id = "$Family/$Method"
+    if ($Parameters.Count -gt 0) {
+        $query = @($Parameters | ForEach-Object {
+            $name = [string](Get-RequiredProperty $_ 'name' 'parameter')
+            $text = ConvertTo-StableParameterText (Get-RequiredProperty $_ 'value' "parameter[$name]")
+            '{0}={1}' -f $name, [Uri]::EscapeDataString($text)
+        }) -join '&'
+        $id += "?$query"
+    }
+    return $id
+}
+
+function Get-GitRevision {
+    param([Parameter(Mandatory)] [string]$RepositoryRoot)
+
+    $commit = @(& git -C $RepositoryRoot rev-parse HEAD 2>$null)
+    if ($LASTEXITCODE -ne 0 -or $commit.Count -ne 1 -or $commit[0] -notmatch '^[0-9a-f]{40}$') {
+        throw "Could not resolve the SharpTS revision from '$RepositoryRoot'."
+    }
+    $status = @(& git -C $RepositoryRoot status --porcelain --untracked-files=no 2>$null)
+    if ($LASTEXITCODE -ne 0) { throw "Could not inspect the SharpTS worktree at '$RepositoryRoot'." }
+    return [ordered]@{ commit = [string]$commit[0]; dirty = $status.Count -gt 0 }
+}
+
+function Get-RunnerIdentity {
+    if ($env:RUNNER_NAME) { return $env:RUNNER_NAME.Trim() }
+    return [Environment]::MachineName
+}
+
+function Read-JsonFile {
+    param([Parameter(Mandatory)] [string]$Path, [string]$Description = 'JSON file')
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { throw "$Description not found: $Path" }
+    try { return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json }
+    catch { throw "$Description is not valid JSON: $Path. $($_.Exception.Message)" }
+}
+
+function New-Measurement {
+    param(
+        [Parameter(Mandatory)] [string]$Id,
+        [Parameter(Mandatory)] [string]$Unit,
+        [Parameter(Mandatory)] [string]$Direction,
+        [object]$Actual,
+        [string]$MissingReason,
+        [object]$Budget
+    )
+
+    $record = [ordered]@{ id = $Id; unit = $Unit; direction = $Direction }
+    if ($PSBoundParameters.ContainsKey('Actual') -and $null -ne $Actual) {
+        if (-not (Test-FiniteNumber $Actual) -or [double]$Actual -lt 0) {
+            throw "Measurement '$Id' must be finite and non-negative."
+        }
+        $record.status = 'measured'
+        $record.actual = [double]$Actual
+    } else {
+        $record.status = 'missing'
+        $record.reason = if ($MissingReason) { $MissingReason } else { 'notAvailable' }
+    }
+    if ($null -ne $Budget) { $record.budget = $Budget }
+    return [pscustomobject]$record
+}
+
+function Get-BenchmarkDotNetMetricValue {
+    param([object]$Benchmark, [string]$Id)
+
+    foreach ($metric in @(Get-RequiredProperty $Benchmark 'Metrics' 'BenchmarkDotNet benchmark')) {
+        $descriptor = Get-RequiredProperty $metric 'Descriptor' 'BenchmarkDotNet metric'
+        if ([string](Get-RequiredProperty $descriptor 'Id' 'BenchmarkDotNet metric descriptor') -ceq $Id) {
+            return Get-RequiredProperty $metric 'Value' "BenchmarkDotNet metric '$Id'"
+        }
+    }
+    return $null
+}
+
+function New-BenchmarkDotNetMeasurements {
+    param([object]$Benchmark, [Collections.IDictionary]$Budgets = @{})
+
+    $statistics = $Benchmark.PSObject.Properties['Statistics']?.Value
+    $hasStatistics = $null -ne $statistics -and $null -ne $statistics.PSObject.Properties['N'] -and [int]$statistics.N -gt 0
+    $mean = if ($hasStatistics) { $statistics.Mean } else { $null }
+    $memory = $Benchmark.PSObject.Properties['Memory']?.Value
+    $allocated = if ($null -ne $memory -and $null -ne $memory.PSObject.Properties['BytesAllocatedPerOperation']) {
+        $memory.BytesAllocatedPerOperation
+    } else { $null }
+
+    $measurements = [Collections.Generic.List[object]]::new()
+    $measurements.Add((New-Measurement -Id mean -Unit nanoseconds -Direction lowerIsBetter `
+        -Actual $mean -MissingReason noMeasurement -Budget $Budgets['mean']))
+    $throughput = if ($null -ne $mean -and [double]$mean -gt 0) { 1000000000.0 / [double]$mean } else { $null }
+    $measurements.Add((New-Measurement -Id throughput -Unit operationsPerSecond -Direction higherIsBetter `
+        -Actual $throughput -MissingReason noMeasurement -Budget $Budgets['throughput']))
+    $measurements.Add((New-Measurement -Id allocated -Unit bytes -Direction lowerIsBetter `
+        -Actual $allocated -MissingReason notAvailable -Budget $Budgets['allocated']))
+
+    foreach ($generation in @(0, 1, 2)) {
+        $metricId = "Gen${generation}Collects"
+        $value = Get-BenchmarkDotNetMetricValue $Benchmark $metricId
+        if ($null -eq $value -and $null -ne $memory -and
+            $null -ne $memory.PSObject.Properties["Gen${generation}Collections"] -and
+            $null -ne $memory.PSObject.Properties['TotalOperations'] -and [long]$memory.TotalOperations -gt 0) {
+            $value = [double]$memory."Gen${generation}Collections" * 1000.0 / [double]$memory.TotalOperations
+        }
+        $measurements.Add((New-Measurement -Id "gen${generation}Collections" `
+            -Unit collectionsPer1000Operations -Direction lowerIsBetter `
+            -Actual $value -MissingReason notAvailable -Budget $Budgets["gen${generation}Collections"]))
+    }
+    return $measurements.ToArray()
+}
+
+function New-BenchmarkDotNetStatistics {
+    param([object]$Benchmark)
+
+    $statistics = $Benchmark.PSObject.Properties['Statistics']?.Value
+    if ($null -eq $statistics -or $null -eq $statistics.PSObject.Properties['N'] -or [int]$statistics.N -lt 1) {
+        return [pscustomobject][ordered]@{ status = 'missing'; reason = 'noMeasurement' }
+    }
+    $originalValues = @(Get-RequiredProperty $statistics 'OriginalValues' 'BenchmarkDotNet statistics')
+    if ($originalValues.Count -eq 0) { throw 'BenchmarkDotNet statistics contain no original values.' }
+    return [pscustomobject][ordered]@{
+        status = 'measured'
+        sampleCount = [int](Get-RequiredProperty $statistics 'N' 'BenchmarkDotNet statistics')
+        meanNanoseconds = [double](Get-RequiredProperty $statistics 'Mean' 'BenchmarkDotNet statistics')
+        minimumNanoseconds = [double](Get-RequiredProperty $statistics 'Min' 'BenchmarkDotNet statistics')
+        maximumNanoseconds = [double](Get-RequiredProperty $statistics 'Max' 'BenchmarkDotNet statistics')
+        standardDeviationNanoseconds = [double](Get-RequiredProperty $statistics 'StandardDeviation' 'BenchmarkDotNet statistics')
+        originalValuesNanoseconds = @($originalValues | ForEach-Object { [double]$_ })
+    }
+}
+
+function Read-BenchmarkDotNetSources {
+    param([Parameter(Mandatory)] [string[]]$ReportPath, [Parameter(Mandatory)] [string[]]$MetadataPath)
+
+    if ($ReportPath.Count -eq 0) { throw 'At least one BenchmarkDotNet JSON report is required.' }
+    if ($MetadataPath.Count -eq 0) { throw 'At least one SharpTS BenchmarkDotNet metadata file is required.' }
+
+    $metadataIndex = @{}
+    foreach ($path in $MetadataPath) {
+        $metadata = Read-JsonFile $path 'BenchmarkDotNet metadata file'
+        if ([string](Get-RequiredProperty $metadata 'sourceFormat' 'BenchmarkDotNet metadata') -cne
+            'sharpts-benchmarkdotnet-metadata-v1') {
+            throw "Unsupported BenchmarkDotNet metadata source format in '$path'."
+        }
+        $title = [string](Get-RequiredProperty $metadata 'title' 'BenchmarkDotNet metadata')
+        if ($metadataIndex.ContainsKey($title)) { throw "Duplicate BenchmarkDotNet metadata title '$title'." }
+        $metadataIndex[$title] = @(Get-RequiredProperty $metadata 'benchmarks' 'BenchmarkDotNet metadata')
+    }
+
+    $entries = [Collections.Generic.List[object]]::new()
+    $host = $null
+    $hostJson = $null
+    foreach ($path in $ReportPath) {
+        $report = Read-JsonFile $path 'BenchmarkDotNet JSON report'
+        $title = [string](Get-RequiredProperty $report 'Title' 'BenchmarkDotNet report')
+        if (-not $metadataIndex.ContainsKey($title)) {
+            throw "BenchmarkDotNet report '$title' has no matching structured metadata."
+        }
+        $currentHost = Get-RequiredProperty $report 'HostEnvironmentInfo' 'BenchmarkDotNet report'
+        $currentHostJson = $currentHost | ConvertTo-Json -Depth 10 -Compress
+        if ($null -eq $host) { $host = $currentHost; $hostJson = $currentHostJson }
+        elseif ($currentHostJson -cne $hostJson) {
+            throw 'BenchmarkDotNet reports from unlike host/runtime environments cannot be combined into one run.'
+        }
+
+        $benchmarks = @(Get-RequiredProperty $report 'Benchmarks' 'BenchmarkDotNet report')
+        $metadataBenchmarks = @($metadataIndex[$title])
+        if ($benchmarks.Count -ne $metadataBenchmarks.Count) {
+            throw "BenchmarkDotNet report '$title' contains $($benchmarks.Count) results but its structured metadata contains $($metadataBenchmarks.Count)."
+        }
+        for ($index = 0; $index -lt $benchmarks.Count; $index++) {
+            $benchmark = $benchmarks[$index]
+            $benchmarkMetadata = $metadataBenchmarks[$index]
+            [void](Get-RequiredProperty $benchmarkMetadata 'fullName' 'BenchmarkDotNet metadata benchmark')
+            $rawType = [string](Get-RequiredProperty $benchmark 'Type' 'BenchmarkDotNet benchmark')
+            $rawMethod = [string](Get-RequiredProperty $benchmark 'Method' 'BenchmarkDotNet benchmark')
+            $metadataType = [string](Get-RequiredProperty $benchmarkMetadata 'type' 'BenchmarkDotNet metadata benchmark')
+            $metadataMethod = [string](Get-RequiredProperty $benchmarkMetadata 'method' 'BenchmarkDotNet metadata benchmark')
+            if ($rawType -cne $metadataType -or $rawMethod -cne $metadataMethod) {
+                throw "BenchmarkDotNet report '$title' result $index ($rawType.$rawMethod) does not match its structured metadata ($metadataType.$metadataMethod)."
+            }
+            $entries.Add([pscustomobject]@{ Raw = $benchmark; Metadata = $benchmarkMetadata })
+        }
+        $metadataIndex.Remove($title)
+    }
+    if ($metadataIndex.Count -gt 0) {
+        $first = [string]($metadataIndex.Keys | Sort-Object | Select-Object -First 1)
+        throw "BenchmarkDotNet metadata '$first' has no matching JSON result."
+    }
+    if ($entries.Count -eq 0) { throw 'BenchmarkDotNet reports contain no benchmark records.' }
+    return [pscustomobject]@{ Host = $host; Entries = $entries.ToArray() }
+}
+
+function ConvertTo-NormalizedParameters {
+    param([object]$Metadata)
+
+    $parameters = [Collections.Generic.List[object]]::new()
+    $seen = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($parameter in @(Get-RequiredProperty $Metadata 'parameters' 'BenchmarkDotNet metadata benchmark')) {
+        $name = ConvertTo-StableToken ([string](Get-RequiredProperty $parameter 'name' 'BenchmarkDotNet parameter'))
+        if (-not $seen.Add($name)) { throw "Duplicate normalized BenchmarkDotNet parameter '$name'." }
+        $parameters.Add([pscustomobject][ordered]@{
+            name = $name
+            value = Get-RequiredProperty $parameter 'value' "BenchmarkDotNet parameter '$name'"
+        })
+    }
+    return @($parameters.ToArray() | Sort-Object name)
+}
+
+function Get-CompilerImplementation {
+    param([string]$Type, [string]$Method)
+
+    if ($Type -match 'Interpreter') { return 'sharpTsInterpreter' }
+    if ($Method -match '^(Equivalent|BoxedEquivalent)') { return 'equivalentCSharp' }
+    if ($Method -match '^(Idiomatic|NativeCSharp|CSharp|Bcl)') { return 'idiomaticCSharp' }
+    if ($Method -match '^SharpTS') { return 'sharpTsCompiled' }
+    if ($Type -match '^(JsonParserSubphase|ParseIntDecimal)') { return 'componentProbe' }
+    return 'sharpTsCompiled'
+}
+
+function New-RunMetadataFromBenchmarkDotNet {
+    param(
+        [object]$Host,
+        [string]$RepositoryRoot,
+        [string]$TimestampUtc,
+        [string]$RunnerIdentity,
+        [Collections.IDictionary]$Revision
+    )
+
+    if ($null -eq $Revision) { $Revision = Get-GitRevision $RepositoryRoot }
+    if (-not $RunnerIdentity) { $RunnerIdentity = Get-RunnerIdentity }
+    $frequency = Get-RequiredProperty (Get-RequiredProperty $Host 'ChronometerFrequency' 'BenchmarkDotNet host') 'Hertz' 'BenchmarkDotNet host chronometer'
+    $normalizedHost = [pscustomobject][ordered]@{
+        benchmarkDotNetCaption = [string](Get-RequiredProperty $Host 'BenchmarkDotNetCaption' 'BenchmarkDotNet host')
+        benchmarkDotNetVersion = [string](Get-RequiredProperty $Host 'BenchmarkDotNetVersion' 'BenchmarkDotNet host')
+        operatingSystem = [string](Get-RequiredProperty $Host 'OsVersion' 'BenchmarkDotNet host')
+        processorName = [string](Get-RequiredProperty $Host 'ProcessorName' 'BenchmarkDotNet host')
+        physicalProcessorCount = $Host.PhysicalProcessorCount
+        physicalCoreCount = $Host.PhysicalCoreCount
+        logicalCoreCount = $Host.LogicalCoreCount
+        runtimeVersion = [string](Get-RequiredProperty $Host 'RuntimeVersion' 'BenchmarkDotNet host')
+        architecture = [string](Get-RequiredProperty $Host 'Architecture' 'BenchmarkDotNet host')
+        hasAttachedDebugger = [bool](Get-RequiredProperty $Host 'HasAttachedDebugger' 'BenchmarkDotNet host')
+        hasRyuJit = [bool](Get-RequiredProperty $Host 'HasRyuJit' 'BenchmarkDotNet host')
+        configuration = [string](Get-RequiredProperty $Host 'Configuration' 'BenchmarkDotNet host')
+        dotNetCliVersion = [string](Get-RequiredProperty $Host 'DotNetCliVersion' 'BenchmarkDotNet host')
+        chronometerFrequencyHertz = [double]$frequency
+        hardwareTimerKind = [string](Get-RequiredProperty $Host 'HardwareTimerKind' 'BenchmarkDotNet host')
+    }
+    return [pscustomobject][ordered]@{
+        timestampUtc = ConvertTo-UtcTimestamp $TimestampUtc
+        revision = [pscustomobject][ordered]@{ commit = [string]$Revision.commit; dirty = [bool]$Revision.dirty }
+        environment = [pscustomobject][ordered]@{
+            operatingSystem = $normalizedHost.operatingSystem
+            architecture = $normalizedHost.architecture.ToLowerInvariant()
+            processor = $normalizedHost.processorName
+            runner = $RunnerIdentity
+            benchmarkDotNetHost = $normalizedHost
+        }
+        tools = [pscustomobject][ordered]@{
+            dotnet = $normalizedHost.dotNetCliVersion
+            benchmarkDotNet = $normalizedHost.benchmarkDotNetVersion
+            runtime = $normalizedHost.runtimeVersion
+        }
+    }
+}
+
+function New-CompilerMicroRun {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string[]]$ReportPath,
+        [Parameter(Mandatory)] [string[]]$MetadataPath,
+        [Parameter(Mandatory)] [string]$RepositoryRoot,
+        [string]$TimestampUtc,
+        [string]$RunnerIdentity,
+        [Collections.IDictionary]$Revision
+    )
+
+    $sources = Read-BenchmarkDotNetSources $ReportPath $MetadataPath
+    $cases = [Collections.Generic.List[object]]::new()
+    $seen = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+    foreach ($entry in $sources.Entries) {
+        $metadata = $entry.Metadata
+        $type = [string](Get-RequiredProperty $metadata 'type' 'BenchmarkDotNet metadata benchmark')
+        $methodName = [string](Get-RequiredProperty $metadata 'method' 'BenchmarkDotNet metadata benchmark')
+        $familySource = if ($type.EndsWith('Benchmarks', [StringComparison]::Ordinal)) { $type.Substring(0, $type.Length - 10) } else { $type }
+        $family = ConvertTo-StableToken $familySource
+        $method = ConvertTo-StableToken $methodName
+        $parameters = @(ConvertTo-NormalizedParameters $metadata)
+        $id = New-StableBenchmarkId $family $method $parameters
+        if (-not $seen.Add($id)) { throw "Duplicate compiler benchmark stable identity '$id'." }
+        $categories = @(@(Get-RequiredProperty $metadata 'categories' 'BenchmarkDotNet metadata benchmark') |
+            ForEach-Object { ConvertTo-StableToken ([string]$_) } | Sort-Object -Unique)
+        $operationsPerInvoke = [int](Get-RequiredProperty $metadata 'operationsPerInvoke' 'BenchmarkDotNet metadata benchmark')
+        if ($operationsPerInvoke -lt 1) { throw "Benchmark '$id' has invalid operationsPerInvoke '$operationsPerInvoke'." }
+        $cases.Add([pscustomobject][ordered]@{
+            id = $id
+            family = $family
+            method = $method
+            categories = $categories
+            parameters = $parameters
+            implementation = Get-CompilerImplementation $type $methodName
+            operationsPerInvoke = $operationsPerInvoke
+            displayInfo = [string](Get-RequiredProperty $entry.Raw 'DisplayInfo' 'BenchmarkDotNet benchmark')
+            statistics = New-BenchmarkDotNetStatistics $entry.Raw
+            measurements = New-BenchmarkDotNetMeasurements $entry.Raw
+        })
+    }
+    return [pscustomobject][ordered]@{
+        suite = 'compiler-micro'
+        source = 'benchmarkDotNet'
+        run = New-RunMetadataFromBenchmarkDotNet $sources.Host $RepositoryRoot $TimestampUtc $RunnerIdentity $Revision
+        methodology = [pscustomobject][ordered]@{
+            id = 'benchmarkdotnet-managed-in-process-v1'
+            sourceFormat = 'benchmarkdotnet-json-with-sharpts-metadata-v1'
+            timingScope = 'inProcessBenchmarkMethod'
+            units = [pscustomobject][ordered]@{
+                duration = 'nanoseconds'; allocation = 'bytes'
+                throughput = 'operationsPerSecond'; gc = 'collectionsPer1000Operations'
+            }
+        }
+        cases = @($cases.ToArray() | Sort-Object id)
+    }
+}
+
+function Get-GuiBenchmarkDefinitions {
+    return @(
+        [pscustomobject]@{ SourceMethod = 'DirectAvaloniaInitialMount'; Family = 'initial-mount'; Method = 'direct-avalonia'; Implementation = 'directAvalonia'; Operations = 1; BudgetId = $null },
+        [pscustomobject]@{ SourceMethod = 'CompiledXamlShapeBaseline'; Family = 'initial-mount'; Method = 'compiled-xaml'; Implementation = 'compiledXaml'; Operations = 1; BudgetId = $null },
+        [pscustomobject]@{ SourceMethod = 'SharpTsInitialMount'; Family = 'initial-mount'; Method = 'sharp-ts'; Implementation = 'sharpTsGui'; Operations = 1; BudgetId = 'SharpTsInitialMount' },
+        [pscustomobject]@{ SourceMethod = 'ScalarUpdate'; Family = 'scalar-update'; Method = 'sharp-ts'; Implementation = 'sharpTsGui'; Operations = 1; BudgetId = 'ScalarUpdate' },
+        [pscustomobject]@{ SourceMethod = 'BatchedScalarUpdates'; Family = 'batched-scalar-updates'; Method = 'sharp-ts'; Implementation = 'sharpTsGui'; Operations = 10; BudgetId = 'BatchedScalarUpdates' },
+        [pscustomobject]@{ SourceMethod = 'KeyedInsertMoveRemove'; Family = 'keyed-insert-move-remove'; Method = 'sharp-ts'; Implementation = 'sharpTsGui'; Operations = 1; BudgetId = 'KeyedInsertMoveRemove' },
+        [pscustomobject]@{ SourceMethod = 'InputToRenderLatency'; Family = 'input-to-render-latency'; Method = 'sharp-ts'; Implementation = 'sharpTsGui'; Operations = 1; BudgetId = 'InputToRenderLatency' }
+    )
+}
+
+function Read-GuiBudgets {
+    param([Parameter(Mandatory)] [string]$BudgetPath)
+
+    $budgets = Read-JsonFile $BudgetPath 'GUI performance budget'
+    if ([int](Get-RequiredProperty $budgets 'schemaVersion' 'GUI performance budget') -ne 1) {
+        throw "Unsupported GUI performance budget schema version '$($budgets.schemaVersion)'."
+    }
+    $definitions = @(Get-GuiBenchmarkDefinitions)
+    $known = @($definitions | Where-Object BudgetId | ForEach-Object BudgetId)
+    $benchmarkBudgets = Get-RequiredProperty $budgets 'benchmarks' 'GUI performance budget'
+    foreach ($property in $benchmarkBudgets.PSObject.Properties) {
+        if ($property.Name -notin $known) { throw "Unknown GUI benchmark budget '$($property.Name)'." }
+    }
+    foreach ($budgetId in $known) {
+        if ($null -eq $benchmarkBudgets.PSObject.Properties[$budgetId]) {
+            throw "GUI performance budget is missing '$budgetId'."
+        }
+    }
+    [void](Get-RequiredProperty $budgets 'nativeAot' 'GUI performance budget')
+    return $budgets
+}
+
+function New-GuiBenchmarkRun {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)] [string[]]$ReportPath,
+        [Parameter(Mandatory)] [string[]]$MetadataPath,
+        [Parameter(Mandatory)] [string]$BudgetPath,
+        [Parameter(Mandatory)] [string]$RepositoryRoot,
+        [string]$TimestampUtc,
+        [string]$RunnerIdentity,
+        [Collections.IDictionary]$Revision
+    )
+
+    $sources = Read-BenchmarkDotNetSources $ReportPath $MetadataPath
+    $budgets = Read-GuiBudgets $BudgetPath
+    $definitions = @(Get-GuiBenchmarkDefinitions)
+    $entryByMethod = @{}
+    foreach ($entry in $sources.Entries) {
+        $type = [string](Get-RequiredProperty $entry.Metadata 'type' 'GUI BenchmarkDotNet metadata')
+        $method = [string](Get-RequiredProperty $entry.Metadata 'method' 'GUI BenchmarkDotNet metadata')
+        if ($type -cne 'GuiRendererBenchmarks' -or $method -notin @($definitions.SourceMethod)) {
+            throw "Unknown GUI benchmark method '$type.$method'."
+        }
+        if ($entryByMethod.ContainsKey($method)) { throw "Duplicate GUI benchmark method '$method'." }
+        $entryByMethod[$method] = $entry
+    }
+
+    $cases = [Collections.Generic.List[object]]::new()
+    foreach ($definition in $definitions) {
+        $budgetMap = @{}
+        if ($definition.BudgetId) {
+            $budget = $budgets.benchmarks.($definition.BudgetId)
+            $budgetMap.mean = [pscustomobject][ordered]@{
+                limit = [double](Get-RequiredProperty $budget 'maxMeanNanoseconds' "GUI budget '$($definition.BudgetId)'")
+                sourceId = "benchmarks.$($definition.BudgetId).maxMeanNanoseconds"
+            }
+            $budgetMap.allocated = [pscustomobject][ordered]@{
+                limit = [double](Get-RequiredProperty $budget 'maxAllocatedBytes' "GUI budget '$($definition.BudgetId)'")
+                sourceId = "benchmarks.$($definition.BudgetId).maxAllocatedBytes"
+            }
+        }
+
+        $entry = $entryByMethod[$definition.SourceMethod]
+        if ($null -eq $entry) {
+            $measurements = @(
+                New-Measurement -Id mean -Unit nanoseconds -Direction lowerIsBetter -MissingReason noMeasurement -Budget $budgetMap['mean']
+                New-Measurement -Id throughput -Unit operationsPerSecond -Direction higherIsBetter -MissingReason noMeasurement
+                New-Measurement -Id allocated -Unit bytes -Direction lowerIsBetter -MissingReason noMeasurement -Budget $budgetMap['allocated']
+                New-Measurement -Id gen0Collections -Unit collectionsPer1000Operations -Direction lowerIsBetter -MissingReason noMeasurement
+                New-Measurement -Id gen1Collections -Unit collectionsPer1000Operations -Direction lowerIsBetter -MissingReason noMeasurement
+                New-Measurement -Id gen2Collections -Unit collectionsPer1000Operations -Direction lowerIsBetter -MissingReason noMeasurement
+            )
+            $statistics = [pscustomobject][ordered]@{ status = 'missing'; reason = 'noMeasurement' }
+            $operationsPerInvoke = [int]$definition.Operations
+            $displayInfo = "GuiRendererBenchmarks.$($definition.SourceMethod)"
+        } else {
+            $operationsPerInvoke = [int](Get-RequiredProperty $entry.Metadata 'operationsPerInvoke' 'GUI BenchmarkDotNet metadata')
+            if ($operationsPerInvoke -ne [int]$definition.Operations) {
+                throw "GUI benchmark '$($definition.SourceMethod)' reports operationsPerInvoke=$operationsPerInvoke; expected $($definition.Operations)."
+            }
+            if (@(Get-RequiredProperty $entry.Metadata 'parameters' 'GUI BenchmarkDotNet metadata').Count -ne 0) {
+                throw "GUI benchmark '$($definition.SourceMethod)' unexpectedly has parameters."
+            }
+            $measurements = New-BenchmarkDotNetMeasurements $entry.Raw $budgetMap
+            $statistics = New-BenchmarkDotNetStatistics $entry.Raw
+            $displayInfo = [string](Get-RequiredProperty $entry.Raw 'DisplayInfo' 'GUI BenchmarkDotNet benchmark')
+        }
+
+        $cases.Add([pscustomobject][ordered]@{
+            id = "$($definition.Family)/$($definition.Method)"
+            family = $definition.Family
+            method = $definition.Method
+            categories = @()
+            parameters = @()
+            implementation = $definition.Implementation
+            operationsPerInvoke = $operationsPerInvoke
+            displayInfo = $displayInfo
+            statistics = $statistics
+            measurements = $measurements
+        })
+    }
+    return [pscustomobject][ordered]@{
+        suite = 'gui'
+        source = 'benchmarkDotNet'
+        run = New-RunMetadataFromBenchmarkDotNet $sources.Host $RepositoryRoot $TimestampUtc $RunnerIdentity $Revision
+        methodology = [pscustomobject][ordered]@{
+            id = 'benchmarkdotnet-avalonia-headless-v1'
+            sourceFormat = 'benchmarkdotnet-json-with-sharpts-metadata-v1'
+            timingScope = 'inProcessHeadlessRenderOperation'
+            units = [pscustomobject][ordered]@{
+                duration = 'nanoseconds'; allocation = 'bytes'
+                throughput = 'operationsPerSecond'; gc = 'collectionsPer1000Operations'
+            }
+            budgetContract = [pscustomobject][ordered]@{
+                path = 'benchmarks/micro/SharpTS.Gui.Benchmarks/PerformanceBudgets.json'
+                schemaVersion = 1
+            }
+        }
+        cases = @($cases.ToArray() | Sort-Object id)
+    }
+}
+
+function New-GuiPackagingRun {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$EvidencePath)
+
+    $evidence = Read-JsonFile $EvidencePath 'GUI packaging evidence'
+    if ([string](Get-RequiredProperty $evidence 'sourceFormat' 'GUI packaging evidence') -cne 'sharpts-gui-packaging-v1') {
+        throw 'Unsupported GUI packaging evidence source format.'
+    }
+    $definitions = @(
+        [pscustomobject]@{ SourceId = 'coldStartup'; Family = 'native-aot'; Method = 'cold-start'; Metric = 'coldStartup'; InputUnit = 'milliseconds'; Unit = 'nanoseconds'; Multiplier = 1000000.0 },
+        [pscustomobject]@{ SourceId = 'peakWorkingSet'; Family = 'native-aot'; Method = 'peak-working-set'; Metric = 'peakWorkingSet'; InputUnit = 'bytes'; Unit = 'bytes'; Multiplier = 1.0 },
+        [pscustomobject]@{ SourceId = 'executableSize'; Family = 'native-aot'; Method = 'executable-size'; Metric = 'executableSize'; InputUnit = 'bytes'; Unit = 'bytes'; Multiplier = 1.0 },
+        [pscustomobject]@{ SourceId = 'shippingSize'; Family = 'native-aot'; Method = 'shipping-size'; Metric = 'shippingSize'; InputUnit = 'bytes'; Unit = 'bytes'; Multiplier = 1.0 }
+    )
+    $measurements = @(Get-RequiredProperty $evidence 'measurements' 'GUI packaging evidence')
+    foreach ($measurement in $measurements) {
+        $id = [string](Get-RequiredProperty $measurement 'id' 'GUI packaging measurement')
+        if ($id -notin @($definitions.SourceId)) { throw "Unknown GUI packaging measurement '$id'." }
+    }
+    $cases = [Collections.Generic.List[object]]::new()
+    foreach ($definition in $definitions) {
+        $matches = @($measurements | Where-Object id -CEQ $definition.SourceId)
+        if ($matches.Count -ne 1) { throw "GUI packaging evidence must contain exactly one '$($definition.SourceId)' measurement." }
+        $source = $matches[0]
+        $unit = [string](Get-RequiredProperty $source 'unit' "GUI packaging measurement '$($definition.SourceId)'")
+        if ($unit -cne $definition.InputUnit) {
+            throw "GUI packaging measurement '$($definition.SourceId)' uses '$unit'; expected '$($definition.InputUnit)'."
+        }
+        $budgetSource = Get-RequiredProperty $source 'budget' "GUI packaging measurement '$($definition.SourceId)'"
+        $budget = [pscustomobject][ordered]@{
+            limit = [double](Get-RequiredProperty $budgetSource 'limit' "GUI packaging measurement '$($definition.SourceId)' budget") * $definition.Multiplier
+            sourceId = [string](Get-RequiredProperty $budgetSource 'sourceId' "GUI packaging measurement '$($definition.SourceId)' budget")
+        }
+        $status = [string](Get-RequiredProperty $source 'status' "GUI packaging measurement '$($definition.SourceId)'")
+        if ($status -ceq 'measured') {
+            $actual = [double](Get-RequiredProperty $source 'actual' "GUI packaging measurement '$($definition.SourceId)'") * $definition.Multiplier
+            $normalized = New-Measurement -Id $definition.Metric -Unit $definition.Unit -Direction lowerIsBetter -Actual $actual -Budget $budget
+        } elseif ($status -ceq 'missing') {
+            $reason = [string](Get-RequiredProperty $source 'reason' "GUI packaging measurement '$($definition.SourceId)'")
+            $normalized = New-Measurement -Id $definition.Metric -Unit $definition.Unit -Direction lowerIsBetter -MissingReason $reason -Budget $budget
+        } else {
+            throw "GUI packaging measurement '$($definition.SourceId)' has invalid status '$status'."
+        }
+        $cases.Add([pscustomobject][ordered]@{
+            id = "$($definition.Family)/$($definition.Method)"
+            family = $definition.Family
+            method = $definition.Method
+            categories = @('product')
+            parameters = @()
+            implementation = 'sharpTsGui'
+            operationsPerInvoke = 1
+            displayInfo = "Native AOT $($definition.Method)"
+            measurements = @($normalized)
+        })
+    }
+    return [pscustomobject][ordered]@{
+        suite = 'gui'
+        source = 'nativeAotPackaging'
+        run = Get-RequiredProperty $evidence 'run' 'GUI packaging evidence'
+        methodology = [pscustomobject][ordered]@{
+            id = 'native-aot-packaging-v1'
+            sourceFormat = 'sharpts-gui-packaging-v1'
+            timingScope = 'publishedNativeAotProduct'
+            units = [pscustomobject][ordered]@{
+                duration = 'nanoseconds'; allocation = 'bytes'
+                throughput = 'operationsPerSecond'; gc = 'collectionsPer1000Operations'
+            }
+            budgetContract = [pscustomobject][ordered]@{
+                path = 'benchmarks/micro/SharpTS.Gui.Benchmarks/PerformanceBudgets.json'
+                schemaVersion = 1
+            }
+        }
+        cases = @($cases.ToArray() | Sort-Object id)
+    }
+}
+
+function New-CrossRuntimeRun {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$SnapshotPath)
+
+    $snapshot = Read-JsonFile $SnapshotPath 'Cross-runtime snapshot'
+    $crossRuntimeModule = Join-Path $PSScriptRoot '../cross-runtime/Snapshot.psm1'
+    Import-Module $crossRuntimeModule -Force
+    [void](Assert-SharpTSPublicBenchmarkSnapshot $snapshot)
+    return [pscustomobject][ordered]@{
+        suite = 'cross-runtime'
+        source = 'snapshot-v1'
+        snapshot = $snapshot
+    }
+}
+
+function Get-PublicRunSortKey {
+    param([object]$Run)
+
+    $suite = [string](Get-RequiredProperty $Run 'suite' 'run')
+    $suiteIndex = if ($script:SuiteOrder.ContainsKey($suite)) { $script:SuiteOrder[$suite] } else { 99 }
+    $source = [string](Get-RequiredProperty $Run 'source' 'run')
+    $timestamp = if ($suite -ceq 'cross-runtime') {
+        ConvertTo-UtcTimestamp $Run.snapshot.run.timestampUtc
+    } else {
+        ConvertTo-UtcTimestamp $Run.run.timestampUtc
+    }
+    return '{0:D2}|{1}|{2}' -f $suiteIndex, $timestamp, $source
+}
+
+function Assert-SharpTSPublicPerformanceSnapshot {
+    [CmdletBinding()]
+    param([Parameter(Mandatory, ValueFromPipeline)] [object]$Snapshot)
+
+    process {
+        if ([string](Get-RequiredProperty $Snapshot '$schema' 'snapshot') -cne $script:SchemaUri) {
+            throw 'Unsupported public performance snapshot schema.'
+        }
+        if ([int](Get-RequiredProperty $Snapshot 'schemaVersion' 'snapshot') -ne 2) {
+            throw 'Unsupported public performance snapshot schema version.'
+        }
+        [void](ConvertTo-UtcTimestamp (Get-RequiredProperty $Snapshot 'generatedAtUtc' 'snapshot'))
+        $runs = @(Get-RequiredProperty $Snapshot 'runs' 'snapshot')
+        if ($runs.Count -eq 0) { throw 'snapshot.runs must contain at least one run.' }
+        $previousSortKey = $null
+        foreach ($run in $runs) {
+            $sortKey = Get-PublicRunSortKey $run
+            if ($null -ne $previousSortKey -and [StringComparer]::Ordinal.Compare($previousSortKey, $sortKey) -gt 0) {
+                throw "snapshot.runs must use deterministic suite/timestamp/source ordering ('$previousSortKey' before '$sortKey')."
+            }
+            $previousSortKey = $sortKey
+            $suite = [string](Get-RequiredProperty $run 'suite' 'snapshot.runs[]')
+            if ($suite -ceq 'cross-runtime') {
+                $crossRuntimeModule = Join-Path $PSScriptRoot '../cross-runtime/Snapshot.psm1'
+                Import-Module $crossRuntimeModule -Force
+                [void](Assert-SharpTSPublicBenchmarkSnapshot (Get-RequiredProperty $run 'snapshot' 'cross-runtime run'))
+                continue
+            }
+            if ($suite -notin @('compiler-micro', 'gui')) { throw "Unknown benchmark suite '$suite'." }
+            $source = [string](Get-RequiredProperty $run 'source' "run[$suite]")
+            if ($suite -ceq 'compiler-micro' -and $source -cne 'benchmarkDotNet') {
+                throw 'compiler-micro runs must come from BenchmarkDotNet.'
+            }
+            $runMetadata = Get-RequiredProperty $run 'run' "run[$suite]"
+            [void](ConvertTo-UtcTimestamp (Get-RequiredProperty $runMetadata 'timestampUtc' "run[$suite].run"))
+            $revision = Get-RequiredProperty $runMetadata 'revision' "run[$suite].run"
+            if ([string]$revision.commit -notmatch '^[0-9a-f]{40}$' -or $revision.dirty -isnot [bool]) {
+                throw "run[$suite] has invalid revision provenance."
+            }
+            $environment = Get-RequiredProperty $runMetadata 'environment' "run[$suite].run"
+            foreach ($field in @('operatingSystem', 'architecture', 'processor', 'runner')) {
+                if ([string]::IsNullOrWhiteSpace([string](Get-RequiredProperty $environment $field "run[$suite].run.environment"))) {
+                    throw "run[$suite].run.environment.$field cannot be empty."
+                }
+            }
+            if ($source -ceq 'benchmarkDotNet' -and $null -eq $environment.PSObject.Properties['benchmarkDotNetHost']) {
+                throw "BenchmarkDotNet run[$suite] is missing complete host metadata."
+            }
+            $caseIds = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+            $previousCaseId = $null
+            foreach ($case in @(Get-RequiredProperty $run 'cases' "run[$suite]")) {
+                $caseId = [string](Get-RequiredProperty $case 'id' "run[$suite].cases[]")
+                if (-not $caseIds.Add($caseId)) { throw "Duplicate benchmark case ID '$caseId'." }
+                if ($null -ne $previousCaseId -and [StringComparer]::Ordinal.Compare($previousCaseId, $caseId) -gt 0) {
+                    throw "run[$suite].cases must use deterministic ID ordering."
+                }
+                $previousCaseId = $caseId
+                if ([int](Get-RequiredProperty $case 'operationsPerInvoke' "case[$caseId]") -lt 1) {
+                    throw "Case '$caseId' has invalid operationsPerInvoke."
+                }
+                $measurementIds = [Collections.Generic.HashSet[string]]::new([StringComparer]::Ordinal)
+                $previousMeasurementIndex = -1
+                foreach ($measurement in @(Get-RequiredProperty $case 'measurements' "case[$caseId]")) {
+                    $measurementId = [string](Get-RequiredProperty $measurement 'id' "case[$caseId].measurement")
+                    if (-not $measurementIds.Add($measurementId)) { throw "Case '$caseId' has duplicate measurement '$measurementId'." }
+                    if (-not $script:MeasurementContract.ContainsKey($measurementId)) {
+                        throw "Case '$caseId' has unknown measurement '$measurementId'."
+                    }
+                    $measurementIndex = [Array]::IndexOf($script:MeasurementOrder, $measurementId)
+                    if ($measurementIndex -lt $previousMeasurementIndex) {
+                        throw "Case '$caseId' measurements must use deterministic ordering."
+                    }
+                    $previousMeasurementIndex = $measurementIndex
+                    $contract = $script:MeasurementContract[$measurementId]
+                    $unit = [string](Get-RequiredProperty $measurement 'unit' "case[$caseId].measurement[$measurementId]")
+                    $direction = [string](Get-RequiredProperty $measurement 'direction' "case[$caseId].measurement[$measurementId]")
+                    if ($unit -cne $contract[0] -or $direction -cne $contract[1]) {
+                        throw "Case '$caseId' measurement '$measurementId' must use unit '$($contract[0])' and direction '$($contract[1])'."
+                    }
+                    $status = [string](Get-RequiredProperty $measurement 'status' "case[$caseId].measurement[$measurementId]")
+                    if ($status -ceq 'measured') {
+                        $actual = Get-RequiredProperty $measurement 'actual' "case[$caseId].measurement[$measurementId]"
+                        if (-not (Test-FiniteNumber $actual) -or [double]$actual -lt 0) {
+                            throw "Case '$caseId' measurement '$measurementId' actual must be finite and non-negative."
+                        }
+                    } elseif ($status -ceq 'missing') {
+                        [void](Get-RequiredProperty $measurement 'reason' "case[$caseId].measurement[$measurementId]")
+                        if ($null -ne $measurement.PSObject.Properties['actual']) {
+                            throw "Case '$caseId' measurement '$measurementId' cannot be missing and have an actual value."
+                        }
+                    } else { throw "Case '$caseId' measurement '$measurementId' has invalid status '$status'." }
+                    if ($null -ne $measurement.PSObject.Properties['budget']) {
+                        $limit = Get-RequiredProperty $measurement.budget 'limit' "case[$caseId].measurement[$measurementId].budget"
+                        if (-not (Test-FiniteNumber $limit) -or [double]$limit -lt 0) {
+                            throw "Case '$caseId' measurement '$measurementId' budget must be finite and non-negative."
+                        }
+                    }
+                }
+            }
+        }
+        return $Snapshot
+    }
+}
+
+function New-SharpTSPublicPerformanceSnapshot {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [object[]]$Runs, [string]$GeneratedAtUtc)
+
+    if ($Runs.Count -eq 0) { throw 'At least one performance run is required.' }
+    $snapshot = [pscustomobject][ordered]@{
+        '$schema' = $script:SchemaUri
+        schemaVersion = 2
+        generatedAtUtc = ConvertTo-UtcTimestamp $GeneratedAtUtc
+        runs = @($Runs | Sort-Object { Get-PublicRunSortKey $_ })
+    }
+    return Assert-SharpTSPublicPerformanceSnapshot $snapshot
+}
+
+function Export-SharpTSPublicPerformanceSnapshot {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [object[]]$Runs, [Parameter(Mandatory)] [string]$OutputFile, [string]$GeneratedAtUtc)
+
+    $snapshot = New-SharpTSPublicPerformanceSnapshot $Runs $GeneratedAtUtc
+    $fullPath = [IO.Path]::GetFullPath($OutputFile)
+    [IO.Directory]::CreateDirectory((Split-Path -Parent $fullPath)) | Out-Null
+    [IO.File]::WriteAllText($fullPath, ($snapshot | ConvertTo-Json -Depth 20) + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+    return $snapshot
+}
+
+function Test-SharpTSPublicPerformanceSnapshotFile {
+    [CmdletBinding()]
+    param([Parameter(Mandatory)] [string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { throw "Snapshot file not found: $Path" }
+    $raw = Get-Content -LiteralPath $Path -Raw
+    $schemaPath = Join-Path $PSScriptRoot 'snapshot-v2.schema.json'
+    try {
+        if (-not ($raw | Test-Json -SchemaFile $schemaPath -ErrorAction Stop)) {
+            throw 'JSON Schema validation returned false.'
+        }
+        $snapshot = $raw | ConvertFrom-Json
+    } catch {
+        throw "Snapshot is not valid schema-v2 JSON: $($_.Exception.Message)"
+    }
+    [void](Assert-SharpTSPublicPerformanceSnapshot $snapshot)
+    return $true
+}
+
+Export-ModuleMember -Function @(
+    'Assert-SharpTSPublicPerformanceSnapshot',
+    'Export-SharpTSPublicPerformanceSnapshot',
+    'New-CompilerMicroRun',
+    'New-CrossRuntimeRun',
+    'New-GuiBenchmarkRun',
+    'New-GuiPackagingRun',
+    'New-SharpTSPublicPerformanceSnapshot',
+    'Test-SharpTSPublicPerformanceSnapshotFile'
+)

--- a/benchmarks/snapshots/README.md
+++ b/benchmarks/snapshots/README.md
@@ -1,0 +1,85 @@
+# Public performance snapshots
+
+This directory defines schema v2 of the public SharpTS performance snapshot. A
+snapshot is an ordered collection of independent runs, not a table assembled by
+joining measurements from different machines:
+
+- `cross-runtime` embeds the existing schema-v1 Node.js/Bun comparison unchanged.
+- `compiler-micro` normalizes BenchmarkDotNet compiler-headroom results.
+- `gui` normalizes Avalonia headless benchmarks or Native AOT packaging evidence.
+
+Each run retains its own timestamp, source revision, machine identity, toolchain,
+and methodology. Consumers may compare variants inside a run. They must not trend
+absolute values across unlike environments.
+
+## BenchmarkDotNet source data
+
+Both managed benchmark executables always write BenchmarkDotNet's built-in
+`*-report-full-compressed.json` plus a `*-sharpts-metadata.json` companion. The
+companion comes directly from BenchmarkDotNet's `Summary` objects and supplies
+descriptor fields omitted by its built-in JSON exporter: categories, typed
+parameters, and `OperationsPerInvoke`. The snapshot exporter joins the two JSON
+sources by their shared summary title and report order, checking the case count,
+type, and method at every position. It never treats display-formatted parameter
+text as identity and never parses Markdown.
+
+Compiler cases use stable `<family>/<method>?<parameters>` IDs. Their records keep
+the original nanosecond samples and unrounded mean/min/max/standard deviation, and
+also expose throughput, allocated bytes per operation, and available generation
+collection counts per 1,000 operations.
+
+GUI benchmark methods have an explicit stable-ID map. Actual mean/allocation
+values are joined to `PerformanceBudgets.json`; both actual and limit remain in
+the snapshot, so pass/fail and headroom are mechanical calculations. Direct
+Avalonia and compiled-XAML mount baselines are retained without inventing budgets.
+An expected method that did not run is emitted as `missing`, never zero. Unknown
+GUI methods or budget IDs fail export.
+
+The packaged GUI harness accepts `-PerformanceEvidencePath`. With `-NativeAot`,
+it records cold startup, peak working set, executable bytes, and complete shipping
+bytes with the applicable release budgets and full run provenance. Startup and
+working set are explicitly `missing/notExecutable` on a cross-publish runner.
+
+## Commands
+
+Export one run to a schema-v2 partial snapshot:
+
+```powershell
+$reports = @(Get-ChildItem BenchmarkDotNet.Artifacts/results -Filter '*report-full-compressed.json')
+$metadata = @(Get-ChildItem BenchmarkDotNet.Artifacts/results -Filter '*sharpts-metadata.json')
+
+./benchmarks/snapshots/export-snapshot.ps1 `
+  -CompilerMicro `
+  -ReportPath $reports.FullName `
+  -MetadataPath $metadata.FullName `
+  -OutputFile compiler-micro.json
+```
+
+Use `-GuiBenchmark` plus `-BudgetPath` for the headless GUI suite,
+`-GuiPackagingEvidence` for packaging evidence, or `-CrossRuntimeSnapshot` for a
+schema-v1 cross-runtime snapshot. Compose independently captured partials without
+changing their run envelopes:
+
+```powershell
+./benchmarks/snapshots/merge-snapshots.ps1 `
+  -Path cross-runtime.json, compiler-micro.json, gui.json, native-aot.json `
+  -OutputFile public-snapshot.json `
+  -RequireAllSuites
+
+./benchmarks/snapshots/validate-snapshot.ps1 public-snapshot.json
+```
+
+`benchmarks.yml` performs the cross-runtime, compiler, and GUI measurements on
+their appropriate runners and publishes the merged `public-performance-snapshot`
+artifact. Native AOT evidence is produced by the desktop/distribution workflows
+and can be appended as another GUI run. A reviewed dated snapshot can be published
+without rewriting `PerformanceBudgets.json`; the budget file remains the release
+contract and the snapshot remains evidence.
+
+Contract tests are deterministic and do not run timed work:
+
+```powershell
+./benchmarks/snapshots/test-snapshot.ps1
+```
+
+A schema change requires a new schema file/version and explicit consumer opt-in.

--- a/benchmarks/snapshots/export-snapshot.ps1
+++ b/benchmarks/snapshots/export-snapshot.ps1
@@ -1,0 +1,63 @@
+[CmdletBinding(DefaultParameterSetName = 'CrossRuntime')]
+param(
+    [Parameter(Mandatory)] [string]$OutputFile,
+    [Parameter(Mandatory, ParameterSetName = 'CrossRuntime')] [string]$CrossRuntimeSnapshot,
+    [Parameter(Mandatory, ParameterSetName = 'CompilerMicro')] [switch]$CompilerMicro,
+    [Parameter(Mandatory, ParameterSetName = 'GuiBenchmark')] [switch]$GuiBenchmark,
+    [Parameter(Mandatory, ParameterSetName = 'GuiPackaging')] [string]$GuiPackagingEvidence,
+    [Parameter(Mandatory, ParameterSetName = 'CompilerMicro')]
+    [Parameter(Mandatory, ParameterSetName = 'GuiBenchmark')]
+    [string[]]$ReportPath,
+    [Parameter(Mandatory, ParameterSetName = 'CompilerMicro')]
+    [Parameter(Mandatory, ParameterSetName = 'GuiBenchmark')]
+    [string[]]$MetadataPath,
+    [Parameter(Mandatory, ParameterSetName = 'GuiBenchmark')] [string]$BudgetPath,
+    [Parameter(ParameterSetName = 'CompilerMicro')]
+    [Parameter(ParameterSetName = 'GuiBenchmark')]
+    [string]$RepositoryRoot,
+    [string]$TimestampUtc,
+    [string]$GeneratedAtUtc,
+    [string]$RunnerIdentity
+)
+
+$ErrorActionPreference = 'Stop'
+$snapshotDirectory = Split-Path -Parent $MyInvocation.MyCommand.Definition
+Import-Module (Join-Path $snapshotDirectory 'PublicSnapshot.psm1') -Force
+if (-not $RepositoryRoot) {
+    $RepositoryRoot = (Resolve-Path (Join-Path $snapshotDirectory '../..')).Path
+}
+
+switch ($PSCmdlet.ParameterSetName) {
+    'CrossRuntime' {
+        $run = New-CrossRuntimeRun -SnapshotPath $CrossRuntimeSnapshot
+    }
+    'CompilerMicro' {
+        $arguments = @{
+            ReportPath = $ReportPath
+            MetadataPath = $MetadataPath
+            RepositoryRoot = $RepositoryRoot
+        }
+        if ($TimestampUtc) { $arguments.TimestampUtc = $TimestampUtc }
+        if ($RunnerIdentity) { $arguments.RunnerIdentity = $RunnerIdentity }
+        $run = New-CompilerMicroRun @arguments
+    }
+    'GuiBenchmark' {
+        $arguments = @{
+            ReportPath = $ReportPath
+            MetadataPath = $MetadataPath
+            BudgetPath = $BudgetPath
+            RepositoryRoot = $RepositoryRoot
+        }
+        if ($TimestampUtc) { $arguments.TimestampUtc = $TimestampUtc }
+        if ($RunnerIdentity) { $arguments.RunnerIdentity = $RunnerIdentity }
+        $run = New-GuiBenchmarkRun @arguments
+    }
+    'GuiPackaging' {
+        $run = New-GuiPackagingRun -EvidencePath $GuiPackagingEvidence
+    }
+}
+
+$arguments = @{ Runs = @($run); OutputFile = $OutputFile }
+if ($GeneratedAtUtc) { $arguments.GeneratedAtUtc = $GeneratedAtUtc }
+[void](Export-SharpTSPublicPerformanceSnapshot @arguments)
+Write-Host "Wrote schema-v2 $($run.suite) performance snapshot to $([IO.Path]::GetFullPath($OutputFile))"

--- a/benchmarks/snapshots/merge-snapshots.ps1
+++ b/benchmarks/snapshots/merge-snapshots.ps1
@@ -1,0 +1,27 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)] [string[]]$Path,
+    [Parameter(Mandatory)] [string]$OutputFile,
+    [string]$GeneratedAtUtc,
+    [switch]$RequireAllSuites
+)
+
+$ErrorActionPreference = 'Stop'
+$snapshotDirectory = Split-Path -Parent $MyInvocation.MyCommand.Definition
+Import-Module (Join-Path $snapshotDirectory 'PublicSnapshot.psm1') -Force
+
+$runs = [Collections.Generic.List[object]]::new()
+foreach ($inputPath in $Path) {
+    [void](Test-SharpTSPublicPerformanceSnapshotFile $inputPath)
+    $snapshot = Get-Content -LiteralPath $inputPath -Raw | ConvertFrom-Json
+    foreach ($run in @($snapshot.runs)) { $runs.Add($run) }
+}
+if ($RequireAllSuites) {
+    $present = @($runs | ForEach-Object suite | Sort-Object -Unique)
+    $missing = @('cross-runtime', 'compiler-micro', 'gui') | Where-Object { $_ -notin $present }
+    if ($missing.Count -gt 0) { throw "Merged snapshot is missing required suite(s): $($missing -join ', ')." }
+}
+$arguments = @{ Runs = $runs.ToArray(); OutputFile = $OutputFile }
+if ($GeneratedAtUtc) { $arguments.GeneratedAtUtc = $GeneratedAtUtc }
+[void](Export-SharpTSPublicPerformanceSnapshot @arguments)
+Write-Host "Merged $($runs.Count) performance runs into $([IO.Path]::GetFullPath($OutputFile))"

--- a/benchmarks/snapshots/snapshot-v2.schema.json
+++ b/benchmarks/snapshots/snapshot-v2.schema.json
@@ -1,0 +1,311 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/nickna/SharpTS/main/benchmarks/snapshots/snapshot-v2.schema.json",
+  "title": "SharpTS public performance snapshot",
+  "description": "A dated collection of machine-bound benchmark runs. Runs are never combined across environments.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["$schema", "schemaVersion", "generatedAtUtc", "runs"],
+  "properties": {
+    "$schema": {
+      "const": "https://raw.githubusercontent.com/nickna/SharpTS/main/benchmarks/snapshots/snapshot-v2.schema.json"
+    },
+    "schemaVersion": { "const": 2 },
+    "generatedAtUtc": { "type": "string", "format": "date-time" },
+    "runs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          { "$ref": "#/$defs/crossRuntimeRun" },
+          { "$ref": "#/$defs/normalizedRun" }
+        ]
+      }
+    }
+  },
+  "$defs": {
+    "nonEmptyString": { "type": "string", "minLength": 1 },
+    "revision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["commit", "dirty"],
+      "properties": {
+        "commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "dirty": { "type": "boolean" }
+      }
+    },
+    "crossRuntimeRun": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["suite", "source", "snapshot"],
+      "properties": {
+        "suite": { "const": "cross-runtime" },
+        "source": { "const": "snapshot-v1" },
+        "snapshot": {
+          "type": "object",
+          "required": ["$schema", "schemaVersion", "run", "methodology", "cases"],
+          "properties": {
+            "$schema": {
+              "const": "https://raw.githubusercontent.com/nickna/SharpTS/main/benchmarks/cross-runtime/snapshot-v1.schema.json"
+            },
+            "schemaVersion": { "const": 1 },
+            "run": {
+              "type": "object",
+              "required": ["timestampUtc", "revision", "environment", "tools"]
+            },
+            "methodology": { "type": "object" },
+            "cases": { "type": "array", "minItems": 1 }
+          }
+        }
+      }
+    },
+    "benchmarkDotNetHost": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "benchmarkDotNetCaption", "benchmarkDotNetVersion", "operatingSystem",
+        "processorName", "physicalProcessorCount", "physicalCoreCount", "logicalCoreCount",
+        "runtimeVersion", "architecture", "hasAttachedDebugger", "hasRyuJit", "configuration",
+        "dotNetCliVersion", "chronometerFrequencyHertz", "hardwareTimerKind"
+      ],
+      "properties": {
+        "benchmarkDotNetCaption": { "$ref": "#/$defs/nonEmptyString" },
+        "benchmarkDotNetVersion": { "$ref": "#/$defs/nonEmptyString" },
+        "operatingSystem": { "$ref": "#/$defs/nonEmptyString" },
+        "processorName": { "$ref": "#/$defs/nonEmptyString" },
+        "physicalProcessorCount": { "type": ["integer", "null"], "minimum": 1 },
+        "physicalCoreCount": { "type": ["integer", "null"], "minimum": 1 },
+        "logicalCoreCount": { "type": ["integer", "null"], "minimum": 1 },
+        "runtimeVersion": { "$ref": "#/$defs/nonEmptyString" },
+        "architecture": { "$ref": "#/$defs/nonEmptyString" },
+        "hasAttachedDebugger": { "type": "boolean" },
+        "hasRyuJit": { "type": "boolean" },
+        "configuration": { "$ref": "#/$defs/nonEmptyString" },
+        "dotNetCliVersion": { "$ref": "#/$defs/nonEmptyString" },
+        "chronometerFrequencyHertz": { "type": "number", "exclusiveMinimum": 0 },
+        "hardwareTimerKind": { "$ref": "#/$defs/nonEmptyString" }
+      }
+    },
+    "runMetadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["timestampUtc", "revision", "environment", "tools"],
+      "properties": {
+        "timestampUtc": { "type": "string", "format": "date-time" },
+        "revision": { "$ref": "#/$defs/revision" },
+        "environment": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["operatingSystem", "architecture", "processor", "runner"],
+          "properties": {
+            "operatingSystem": { "$ref": "#/$defs/nonEmptyString" },
+            "architecture": { "$ref": "#/$defs/nonEmptyString" },
+            "processor": { "$ref": "#/$defs/nonEmptyString" },
+            "runner": { "$ref": "#/$defs/nonEmptyString" },
+            "benchmarkDotNetHost": { "$ref": "#/$defs/benchmarkDotNetHost" }
+          }
+        },
+        "tools": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["dotnet"],
+          "properties": {
+            "dotnet": { "$ref": "#/$defs/nonEmptyString" },
+            "benchmarkDotNet": { "$ref": "#/$defs/nonEmptyString" },
+            "runtime": { "$ref": "#/$defs/nonEmptyString" },
+            "runtimeIdentifier": { "$ref": "#/$defs/nonEmptyString" }
+          }
+        }
+      }
+    },
+    "methodology": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "sourceFormat", "timingScope", "units"],
+      "properties": {
+        "id": { "$ref": "#/$defs/nonEmptyString" },
+        "sourceFormat": {
+          "enum": ["benchmarkdotnet-json-with-sharpts-metadata-v1", "sharpts-gui-packaging-v1"]
+        },
+        "timingScope": { "$ref": "#/$defs/nonEmptyString" },
+        "units": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["duration", "allocation", "throughput", "gc"],
+          "properties": {
+            "duration": { "const": "nanoseconds" },
+            "allocation": { "const": "bytes" },
+            "throughput": { "const": "operationsPerSecond" },
+            "gc": { "const": "collectionsPer1000Operations" }
+          }
+        },
+        "budgetContract": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["path", "schemaVersion"],
+          "properties": {
+            "path": { "$ref": "#/$defs/nonEmptyString" },
+            "schemaVersion": { "type": "integer", "minimum": 1 }
+          }
+        }
+      }
+    },
+    "parameter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "value"],
+      "properties": {
+        "name": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "value": { "type": ["string", "number", "boolean", "null"] }
+      }
+    },
+    "statistics": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status", "sampleCount", "meanNanoseconds", "minimumNanoseconds",
+            "maximumNanoseconds", "standardDeviationNanoseconds", "originalValuesNanoseconds"
+          ],
+          "properties": {
+            "status": { "const": "measured" },
+            "sampleCount": { "type": "integer", "minimum": 1 },
+            "meanNanoseconds": { "type": "number", "minimum": 0 },
+            "minimumNanoseconds": { "type": "number", "minimum": 0 },
+            "maximumNanoseconds": { "type": "number", "minimum": 0 },
+            "standardDeviationNanoseconds": { "type": "number", "minimum": 0 },
+            "originalValuesNanoseconds": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "number", "minimum": 0 }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["status", "reason"],
+          "properties": {
+            "status": { "const": "missing" },
+            "reason": { "$ref": "#/$defs/missingReason" }
+          }
+        }
+      ]
+    },
+    "missingReason": {
+      "enum": ["noMeasurement", "notAvailable", "notRun", "notExecutable", "notApplicable"]
+    },
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["limit", "sourceId"],
+      "properties": {
+        "limit": { "type": "number", "minimum": 0 },
+        "sourceId": { "$ref": "#/$defs/nonEmptyString" }
+      }
+    },
+    "measurement": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "unit", "direction", "status", "actual"],
+          "properties": {
+            "id": { "$ref": "#/$defs/measurementId" },
+            "unit": { "$ref": "#/$defs/unit" },
+            "direction": { "$ref": "#/$defs/direction" },
+            "status": { "const": "measured" },
+            "actual": { "type": "number", "minimum": 0 },
+            "budget": { "$ref": "#/$defs/budget" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["id", "unit", "direction", "status", "reason"],
+          "properties": {
+            "id": { "$ref": "#/$defs/measurementId" },
+            "unit": { "$ref": "#/$defs/unit" },
+            "direction": { "$ref": "#/$defs/direction" },
+            "status": { "const": "missing" },
+            "reason": { "$ref": "#/$defs/missingReason" },
+            "budget": { "$ref": "#/$defs/budget" }
+          }
+        }
+      ]
+    },
+    "measurementId": {
+      "enum": [
+        "mean", "throughput", "allocated", "gen0Collections", "gen1Collections",
+        "gen2Collections", "coldStartup", "peakWorkingSet", "executableSize", "shippingSize"
+      ]
+    },
+    "unit": {
+      "enum": ["nanoseconds", "operationsPerSecond", "bytes", "collectionsPer1000Operations"]
+    },
+    "direction": { "enum": ["lowerIsBetter", "higherIsBetter"] },
+    "benchmarkCase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id", "family", "method", "categories", "parameters", "implementation",
+        "operationsPerInvoke", "displayInfo", "measurements"
+      ],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9%.-]*/[a-z0-9][a-z0-9%.-]*(\\?.+)?$" },
+        "family": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "method": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "categories": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+          "uniqueItems": true
+        },
+        "parameters": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/parameter" }
+        },
+        "implementation": {
+          "enum": [
+            "sharpTsCompiled", "sharpTsInterpreter", "equivalentCSharp", "idiomaticCSharp",
+            "componentProbe", "sharpTsGui", "directAvalonia", "compiledXaml"
+          ]
+        },
+        "operationsPerInvoke": { "type": "integer", "minimum": 1 },
+        "displayInfo": { "$ref": "#/$defs/nonEmptyString" },
+        "statistics": { "$ref": "#/$defs/statistics" },
+        "measurements": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/measurement" }
+        }
+      }
+    },
+    "normalizedRun": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["suite", "source", "run", "methodology", "cases"],
+      "properties": {
+        "suite": { "enum": ["compiler-micro", "gui"] },
+        "source": { "enum": ["benchmarkDotNet", "nativeAotPackaging"] },
+        "run": { "$ref": "#/$defs/runMetadata" },
+        "methodology": { "$ref": "#/$defs/methodology" },
+        "cases": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/benchmarkCase" }
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "suite": { "const": "compiler-micro" } } },
+          "then": { "properties": { "source": { "const": "benchmarkDotNet" } } }
+        },
+        {
+          "if": { "properties": { "source": { "const": "nativeAotPackaging" } } },
+          "then": { "properties": { "suite": { "const": "gui" } } }
+        }
+      ]
+    }
+  }
+}

--- a/benchmarks/snapshots/test-snapshot.ps1
+++ b/benchmarks/snapshots/test-snapshot.ps1
@@ -1,0 +1,217 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$snapshotDirectory = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$repositoryRoot = (Resolve-Path (Join-Path $snapshotDirectory '../..')).Path
+Import-Module (Join-Path $snapshotDirectory 'PublicSnapshot.psm1') -Force
+
+function Assert-True([bool]$Condition, [string]$Message) {
+    if (-not $Condition) { throw $Message }
+}
+
+function Assert-Throws([scriptblock]$Action, [string]$Pattern) {
+    $caught = $null
+    try { & $Action } catch { $caught = $_ }
+    if ($null -eq $caught) { throw "Expected an error matching '$Pattern', but no error was thrown." }
+    if ($caught.Exception.Message -notmatch $Pattern) {
+        throw "Expected error matching '$Pattern', got: $($caught.Exception.Message)"
+    }
+}
+
+function Write-FixtureJson([string]$Path, [object]$Value) {
+    [IO.File]::WriteAllText(
+        $Path,
+        ($Value | ConvertTo-Json -Depth 20) + [Environment]::NewLine,
+        [Text.UTF8Encoding]::new($false))
+}
+
+function New-Host([string]$Processor = 'Fixture CPU') {
+    return [ordered]@{
+        BenchmarkDotNetCaption = 'BenchmarkDotNet'
+        BenchmarkDotNetVersion = '0.14.0'
+        OsVersion = 'Fixture OS 1.0'
+        ProcessorName = $Processor
+        PhysicalProcessorCount = 1
+        PhysicalCoreCount = 4
+        LogicalCoreCount = 8
+        RuntimeVersion = '.NET 10.0.0, X64 RyuJIT'
+        Architecture = 'X64'
+        HasAttachedDebugger = $false
+        HasRyuJit = $true
+        Configuration = 'RELEASE'
+        DotNetCliVersion = '10.0.100'
+        ChronometerFrequency = [ordered]@{ Hertz = 10000000 }
+        HardwareTimerKind = 'FixtureTimer'
+    }
+}
+
+function New-RawBenchmark([string]$Type, [string]$Method, [string]$FullName, [double]$Mean, [long]$Allocated) {
+    return [ordered]@{
+        DisplayInfo = "$Type.${Method}: FixtureJob"
+        Namespace = 'SharpTS.Microbenchmarks.Benchmarks'
+        Type = $Type
+        Method = $Method
+        MethodTitle = $Method
+        Parameters = if ($FullName -match '\(N: 10\)$') { 'N=10' } else { '' }
+        FullName = $FullName
+        HardwareIntrinsics = 'FixtureIntrinsics'
+        Statistics = [ordered]@{
+            OriginalValues = @(($Mean - 0.0000000000001), ($Mean + 0.0000000000001))
+            N = 2
+            Min = $Mean - 0.0000000000001
+            Mean = $Mean
+            Max = $Mean + 0.0000000000001
+            StandardDeviation = 0.0000000000001414213562373095
+        }
+        Memory = [ordered]@{
+            Gen0Collections = 2
+            Gen1Collections = 1
+            Gen2Collections = 0
+            TotalOperations = 2000
+            BytesAllocatedPerOperation = $Allocated
+        }
+        Measurements = @()
+        Metrics = @(
+            [ordered]@{ Value = 1.0; Descriptor = [ordered]@{ Id = 'Gen0Collects' } },
+            [ordered]@{ Value = 0.5; Descriptor = [ordered]@{ Id = 'Gen1Collects' } },
+            [ordered]@{ Value = 0.0; Descriptor = [ordered]@{ Id = 'Gen2Collects' } },
+            [ordered]@{ Value = $Allocated; Descriptor = [ordered]@{ Id = 'Allocated Memory' } }
+        )
+    }
+}
+
+$temporaryDirectory = Join-Path ([IO.Path]::GetTempPath()) "sharpts-public-snapshot-tests-$([Guid]::NewGuid().ToString('N'))"
+[IO.Directory]::CreateDirectory($temporaryDirectory) | Out-Null
+try {
+    $revision = [ordered]@{ commit = '1111111111111111111111111111111111111111'; dirty = $false }
+    $fixed = @{
+        RepositoryRoot = $repositoryRoot
+        TimestampUtc = '2026-08-26T12:00:00Z'
+        RunnerIdentity = 'fixture-runner'
+        Revision = $revision
+    }
+
+    $compilerTitle = 'CompilerFixture-20260826-120000'
+    $compilerBenchmarks = @(
+        New-RawBenchmark 'FibonacciBenchmarks' 'SharpTS' 'SharpTS.Microbenchmarks.Benchmarks.FibonacciBenchmarks.SharpTS(N: 10)' 12.3456789012345 2048
+        New-RawBenchmark 'FibonacciBenchmarks' 'Equivalent' 'SharpTS.Microbenchmarks.Benchmarks.FibonacciBenchmarks.Equivalent(N: 10)' 20.25 4096
+        New-RawBenchmark 'FibonacciBenchmarks' 'Idiomatic' 'SharpTS.Microbenchmarks.Benchmarks.FibonacciBenchmarks.Idiomatic(N: 10)' 8.125 64
+    )
+    $compilerReportPath = Join-Path $temporaryDirectory 'compiler-report.json'
+    Write-FixtureJson $compilerReportPath ([ordered]@{
+        Title = $compilerTitle; HostEnvironmentInfo = (New-Host); Benchmarks = $compilerBenchmarks
+    })
+    $compilerMetadataPath = Join-Path $temporaryDirectory 'compiler-metadata.json'
+    Write-FixtureJson $compilerMetadataPath ([ordered]@{
+        sourceFormat = 'sharpts-benchmarkdotnet-metadata-v1'
+        title = $compilerTitle
+        benchmarks = @(
+            # Presentation names can differ between BenchmarkDotNet exporters; they are not identities.
+            [ordered]@{ fullName = 'FibonacciBenchmarks.SharpTS(N: "10")'; type = 'FibonacciBenchmarks'; method = 'SharpTS'; categories = @('Algorithm'); operationsPerInvoke = 1; parameters = @([ordered]@{ name = 'N'; value = 10 }) },
+            [ordered]@{ fullName = $compilerBenchmarks[1].FullName; type = 'FibonacciBenchmarks'; method = 'Equivalent'; categories = @('Algorithm'); operationsPerInvoke = 1; parameters = @([ordered]@{ name = 'N'; value = 10 }) },
+            [ordered]@{ fullName = $compilerBenchmarks[2].FullName; type = 'FibonacciBenchmarks'; method = 'Idiomatic'; categories = @('Algorithm'); operationsPerInvoke = 1; parameters = @([ordered]@{ name = 'N'; value = 10 }) }
+        )
+    })
+    $compilerRun = New-CompilerMicroRun -ReportPath $compilerReportPath -MetadataPath $compilerMetadataPath @fixed
+    Assert-True ($compilerRun.cases.Count -eq 3) 'Compiler exporter did not retain all variants.'
+    $compiledCase = $compilerRun.cases | Where-Object id -CEQ 'fibonacci/sharp-ts?n=10'
+    Assert-True ($null -ne $compiledCase) 'Compiler case did not receive a stable parameterized ID.'
+    Assert-True ($compiledCase.implementation -ceq 'sharpTsCompiled') 'SharpTS compiler variant was not classified.'
+    Assert-True ($compiledCase.categories[0] -ceq 'algorithm') 'Benchmark categories were not normalized.'
+    Assert-True ($compiledCase.statistics.meanNanoseconds -eq 12.3456789012345) 'Mean precision was not retained.'
+    Assert-True (($compiledCase.measurements | Where-Object id -CEQ allocated).actual -eq 2048) 'Allocation was not exported in bytes.'
+    Assert-True (($compiledCase.measurements | Where-Object id -CEQ gen0Collections).actual -eq 1.0) 'GC statistics were not exported.'
+    Assert-True (($compilerRun.cases | Where-Object method -CEQ equivalent).implementation -ceq 'equivalentCSharp') 'Equivalent C# variant was not classified.'
+    Assert-True (($compilerRun.cases | Where-Object method -CEQ idiomatic).implementation -ceq 'idiomaticCSharp') 'Idiomatic C# variant was not classified.'
+
+    $guiTitle = 'GuiFixture-20260826-120000'
+    $guiBenchmark = New-RawBenchmark 'GuiRendererBenchmarks' 'BatchedScalarUpdates' 'SharpTS.Gui.Benchmarks.GuiRendererBenchmarks.BatchedScalarUpdates' 90000.125 32000
+    $guiReportPath = Join-Path $temporaryDirectory 'gui-report.json'
+    Write-FixtureJson $guiReportPath ([ordered]@{
+        Title = $guiTitle; HostEnvironmentInfo = (New-Host); Benchmarks = @($guiBenchmark)
+    })
+    $guiMetadataPath = Join-Path $temporaryDirectory 'gui-metadata.json'
+    Write-FixtureJson $guiMetadataPath ([ordered]@{
+        sourceFormat = 'sharpts-benchmarkdotnet-metadata-v1'
+        title = $guiTitle
+        benchmarks = @([ordered]@{
+            fullName = $guiBenchmark.FullName; type = 'GuiRendererBenchmarks'; method = 'BatchedScalarUpdates'
+            categories = @(); operationsPerInvoke = 10; parameters = @()
+        })
+    })
+    $budgetPath = Join-Path $repositoryRoot 'benchmarks/micro/SharpTS.Gui.Benchmarks/PerformanceBudgets.json'
+    $guiRun = New-GuiBenchmarkRun -ReportPath $guiReportPath -MetadataPath $guiMetadataPath -BudgetPath $budgetPath @fixed
+    $batched = $guiRun.cases | Where-Object id -CEQ 'batched-scalar-updates/sharp-ts'
+    Assert-True ($batched.operationsPerInvoke -eq 10) 'GUI operations-per-invoke was not retained.'
+    Assert-True (($batched.measurements | Where-Object id -CEQ mean).budget.limit -eq 100000) 'GUI timing result was not joined to its budget.'
+    Assert-True (($batched.measurements | Where-Object id -CEQ allocated).budget.limit -eq 40960) 'GUI allocation result was not joined to its budget.'
+    $missingMount = $guiRun.cases | Where-Object id -CEQ 'initial-mount/sharp-ts'
+    Assert-True (($missingMount.measurements | Where-Object id -CEQ mean).status -ceq 'missing') 'Missing GUI result was not explicit.'
+    Assert-True ($null -eq ($missingMount.measurements | Where-Object id -CEQ mean).PSObject.Properties['actual']) 'Missing GUI result substituted an actual value.'
+
+    $badGuiReportPath = Join-Path $temporaryDirectory 'bad-gui-report.json'
+    $badGuiMetadataPath = Join-Path $temporaryDirectory 'bad-gui-metadata.json'
+    $unknown = New-RawBenchmark 'GuiRendererBenchmarks' 'MysteryRender' 'SharpTS.Gui.Benchmarks.GuiRendererBenchmarks.MysteryRender' 1 1
+    Write-FixtureJson $badGuiReportPath ([ordered]@{ Title = $guiTitle; HostEnvironmentInfo = (New-Host); Benchmarks = @($unknown) })
+    Write-FixtureJson $badGuiMetadataPath ([ordered]@{
+        sourceFormat = 'sharpts-benchmarkdotnet-metadata-v1'; title = $guiTitle
+        benchmarks = @([ordered]@{ fullName = $unknown.FullName; type = 'GuiRendererBenchmarks'; method = 'MysteryRender'; categories = @(); operationsPerInvoke = 1; parameters = @() })
+    })
+    Assert-Throws {
+        New-GuiBenchmarkRun -ReportPath $badGuiReportPath -MetadataPath $badGuiMetadataPath -BudgetPath $budgetPath @fixed
+    } 'Unknown GUI benchmark method'
+
+    $unknownBudgetPath = Join-Path $temporaryDirectory 'unknown-budget.json'
+    $unknownBudget = Get-Content -LiteralPath $budgetPath -Raw | ConvertFrom-Json
+    $unknownBudget.benchmarks | Add-Member -NotePropertyName MysteryRender -NotePropertyValue ([pscustomobject]@{ maxMeanNanoseconds = 1; maxAllocatedBytes = 1 })
+    Write-FixtureJson $unknownBudgetPath $unknownBudget
+    Assert-Throws {
+        New-GuiBenchmarkRun -ReportPath $guiReportPath -MetadataPath $guiMetadataPath -BudgetPath $unknownBudgetPath @fixed
+    } 'Unknown GUI benchmark budget'
+
+    $packagingEvidencePath = Join-Path $temporaryDirectory 'packaging-evidence.json'
+    Write-FixtureJson $packagingEvidencePath ([ordered]@{
+        sourceFormat = 'sharpts-gui-packaging-v1'
+        run = [ordered]@{
+            timestampUtc = '2026-08-26T12:00:00Z'
+            revision = $revision
+            environment = [ordered]@{ operatingSystem = 'Fixture OS'; architecture = 'x64'; processor = 'Fixture CPU'; runner = 'fixture-runner' }
+            tools = [ordered]@{ dotnet = '10.0.100'; runtimeIdentifier = 'win-x64' }
+        }
+        measurements = @(
+            [ordered]@{ id = 'coldStartup'; unit = 'milliseconds'; status = 'measured'; actual = 12.5; budget = [ordered]@{ limit = 1500; sourceId = 'nativeAot.maxColdStartupMilliseconds' } },
+            [ordered]@{ id = 'peakWorkingSet'; unit = 'bytes'; status = 'missing'; reason = 'notExecutable'; budget = [ordered]@{ limit = 268435456; sourceId = 'nativeAot.maxPeakWorkingSetBytes' } },
+            [ordered]@{ id = 'executableSize'; unit = 'bytes'; status = 'measured'; actual = 1234; budget = [ordered]@{ limit = 52428800; sourceId = 'nativeAot.maxExecutableBytes' } },
+            [ordered]@{ id = 'shippingSize'; unit = 'bytes'; status = 'measured'; actual = 4321; budget = [ordered]@{ limit = 68157440; sourceId = 'nativeAot.maxShippingBytes' } }
+        )
+    })
+    $packagingRun = New-GuiPackagingRun $packagingEvidencePath
+    $startup = ($packagingRun.cases | Where-Object method -CEQ cold-start).measurements[0]
+    Assert-True ($startup.actual -eq 12500000) 'Milliseconds were not converted to canonical nanoseconds.'
+    Assert-True ($startup.budget.limit -eq 1500000000) 'Duration budget was not converted with the actual.'
+    $workingSet = ($packagingRun.cases | Where-Object method -CEQ peak-working-set).measurements[0]
+    Assert-True ($workingSet.status -ceq 'missing' -and $workingSet.reason -ceq 'notExecutable') 'Packaging missing result was not retained.'
+
+    $crossRun = New-CrossRuntimeRun (Join-Path $repositoryRoot 'benchmarks/cross-runtime/snapshots/latest.json')
+    $snapshotPath = Join-Path $temporaryDirectory 'snapshot.json'
+    [void](Export-SharpTSPublicPerformanceSnapshot `
+        -Runs @($crossRun, $compilerRun, $guiRun, $packagingRun) `
+        -OutputFile $snapshotPath `
+        -GeneratedAtUtc '2026-08-26T12:05:00Z')
+    Assert-True (Test-SharpTSPublicPerformanceSnapshotFile $snapshotPath) 'Aggregate snapshot did not pass schema validation.'
+    $snapshot = Get-Content -LiteralPath $snapshotPath -Raw | ConvertFrom-Json
+    Assert-True (($snapshot.runs | ForEach-Object suite | Sort-Object -Unique).Count -eq 3) 'Aggregate snapshot does not contain all three suites.'
+    Assert-True (($snapshot.runs | Where-Object suite -CEQ gui).Count -eq 2) 'Independent GUI run boundaries were not retained.'
+
+    $invalid = Get-Content -LiteralPath $snapshotPath -Raw | ConvertFrom-Json
+    ($invalid.runs | Where-Object suite -CEQ compiler-micro).cases[0].measurements[0].unit = 'bytes'
+    $invalidPath = Join-Path $temporaryDirectory 'invalid.json'
+    Write-FixtureJson $invalidPath $invalid
+    Assert-Throws { Test-SharpTSPublicPerformanceSnapshotFile $invalidPath } 'must use unit'
+
+    Write-Host 'Public performance snapshot contract tests passed.'
+} finally {
+    Remove-Item -LiteralPath $temporaryDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/benchmarks/snapshots/validate-snapshot.ps1
+++ b/benchmarks/snapshots/validate-snapshot.ps1
@@ -1,0 +1,10 @@
+[CmdletBinding()]
+param([Parameter(Mandatory, Position = 0)] [string[]]$Path)
+
+$ErrorActionPreference = 'Stop'
+$snapshotDirectory = Split-Path -Parent $MyInvocation.MyCommand.Definition
+Import-Module (Join-Path $snapshotDirectory 'PublicSnapshot.psm1') -Force
+foreach ($snapshotPath in $Path) {
+    [void](Test-SharpTSPublicPerformanceSnapshotFile $snapshotPath)
+    Write-Host "Validated public performance snapshot: $snapshotPath"
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ known gaps, use [STATUS.md](../STATUS.md).
 - [Language server](language-server.md)
 - [External benchmark harness](../benchmarks/cross-runtime/README.md)
 - [Managed microbenchmarks](../benchmarks/micro/SharpTS.Microbenchmarks/README.md)
+- [Public performance snapshots](../benchmarks/snapshots/README.md)
 
 ## Contributor and maintainer material
 

--- a/docs/gui/performance.md
+++ b/docs/gui/performance.md
@@ -10,7 +10,7 @@ allocations, and input-to-render latency. Direct Avalonia construction and the s
 Run a Release baseline from the repository root:
 
 ```powershell
-dotnet run -c Release --project benchmarks/micro/SharpTS.Gui.Benchmarks -- --exporters JSON CSV GitHub
+dotnet run -c Release --project benchmarks/micro/SharpTS.Gui.Benchmarks
 ```
 
 Verify the generated CSV against the versioned timing and allocation limits:
@@ -18,6 +18,11 @@ Verify the generated CSV against the versioned timing and allocation limits:
 ```powershell
 ./benchmarks/micro/SharpTS.Gui.Benchmarks/Verify-PerformanceBudgets.ps1
 ```
+
+The run always emits BenchmarkDotNet JSON plus a SharpTS metadata companion with
+typed parameters, categories, and operations-per-invoke. The
+[public snapshot exporter](../../benchmarks/snapshots/README.md) joins those
+structured files to the release budgets without parsing Markdown.
 
 BenchmarkDotNet results are sensitive to hardware, runtime, power state, and machine load. Record
 the machine and runtime metadata with any intentionally committed report, compare trends on a
@@ -50,6 +55,9 @@ directory to 65 MiB. `Run-PackagedConsumer.ps1 -NativeAot` always enforces those
 artifact limits. `-EnforcePerformanceBudgets` additionally enforces a 1.5-second cold Headless
 startup and a 256 MiB peak working-set ceiling in the Desktop GUI and distribution workflows.
 The harness records both process measurements even when enforcement is disabled.
+Pass `-PerformanceEvidencePath <path>` to export those process measurements plus
+the executable and complete shipping-directory sizes, budgets, revision, and
+environment. A measurement that cannot run is recorded explicitly rather than as zero.
 
 Cross-publishing `win-arm64` does not satisfy the ARM64 performance gate. Final Native AOT linking,
 execution, and measurement require the Visual C++ ARM64 linker workload and native ARM64 Windows
@@ -71,7 +79,9 @@ x64 RyuJIT AVX2. The benchmark host did not report the processor model.
 | Keyed insert/move/remove | 449.22 us | 109.30 KB |
 | Input-to-render latency | 396.46 us | 87.77 KB |
 
-This run used one invocation per iteration to preserve complete mount and update lifecycles.
+This run used one benchmark-method invocation per iteration to preserve complete mount and update lifecycles.
+`BatchedScalarUpdates` performs ten logical operations per invocation, which the
+structured metadata and public snapshot record explicitly.
 BenchmarkDotNet warned that individual iteration times were below its recommended 100 ms minimum
 and that several distributions were multimodal.
 

--- a/tests/fixtures/SharpTS.Gui.Sdk.Consumer/Run-PackagedConsumer.ps1
+++ b/tests/fixtures/SharpTS.Gui.Sdk.Consumer/Run-PackagedConsumer.ps1
@@ -7,7 +7,8 @@ param(
     [switch]$RealWindow,
     [switch]$PublishOnly,
     [switch]$NativeAot,
-    [switch]$EnforcePerformanceBudgets
+    [switch]$EnforcePerformanceBudgets,
+    [string]$PerformanceEvidencePath
 )
 
 $ErrorActionPreference = "Stop"
@@ -50,6 +51,9 @@ $canExecute = -not $PublishOnly -and (
     ($RuntimeIdentifier.EndsWith("-arm64", [StringComparison]::Ordinal) -and $osArchitecture -eq "Arm64"))
 $consumerExecutableName = "SharpTS.Gui.Sdk.Consumer" + $(if ($isWindowsRid) { ".exe" } else { "" })
 $cliExecutableName = "cli_app_with_spaces" + $(if ($isWindowsRid) { ".exe" } else { "" })
+if ($PerformanceEvidencePath -and -not $NativeAot) {
+    throw "PerformanceEvidencePath requires -NativeAot."
+}
 $candidatePackagePath = $null
 if (-not [string]::IsNullOrWhiteSpace($CandidatePackage)) {
     $candidatePackagePath = [IO.Path]::GetFullPath($CandidatePackage, $repositoryRoot)
@@ -150,6 +154,8 @@ function Measure-Application([string]$Executable, [string[]]$Arguments, [string]
             $peakWorkingSetBytes = [Math]::Max($peakWorkingSetBytes, $process.WorkingSet64)
         }
         $stopwatch.Stop()
+        $process.Refresh()
+        $peakWorkingSetBytes = [Math]::Max($peakWorkingSetBytes, $process.PeakWorkingSet64)
         if ($process.ExitCode -ne 0) {
             throw "$Executable $($Arguments -join ' ') failed with exit code $($process.ExitCode)."
         }
@@ -161,6 +167,104 @@ function Measure-Application([string]$Executable, [string[]]$Arguments, [string]
     finally {
         $process.Dispose()
     }
+}
+
+function Write-NativeAotPerformanceEvidence(
+    [object]$Budgets,
+    [long]$ExecutableBytes,
+    [long]$ShippingBytes,
+    [object]$ApplicationMeasurement
+) {
+    if ([string]::IsNullOrWhiteSpace($PerformanceEvidencePath)) { return }
+
+    $commit = @(& git -C $repositoryRoot rev-parse HEAD 2>$null)
+    if ($LASTEXITCODE -ne 0 -or $commit.Count -ne 1 -or $commit[0] -notmatch '^[0-9a-f]{40}$') {
+        throw "Could not resolve the SharpTS revision for performance evidence."
+    }
+    $status = @(& git -C $repositoryRoot status --porcelain --untracked-files=no 2>$null)
+    if ($LASTEXITCODE -ne 0) { throw "Could not inspect the SharpTS worktree for performance evidence." }
+    $dotnetVersion = @(& dotnet --version 2>$null | Select-Object -First 1)
+    if ($LASTEXITCODE -ne 0 -or $dotnetVersion.Count -ne 1) {
+        throw "Could not resolve the .NET SDK version for performance evidence."
+    }
+
+    $coldStartup = [ordered]@{
+        id = "coldStartup"
+        unit = "milliseconds"
+        budget = [ordered]@{
+            limit = [double]$Budgets.nativeAot.maxColdStartupMilliseconds
+            sourceId = "nativeAot.maxColdStartupMilliseconds"
+        }
+    }
+    $peakWorkingSet = [ordered]@{
+        id = "peakWorkingSet"
+        unit = "bytes"
+        budget = [ordered]@{
+            limit = [double]$Budgets.nativeAot.maxPeakWorkingSetBytes
+            sourceId = "nativeAot.maxPeakWorkingSetBytes"
+        }
+    }
+    if ($null -eq $ApplicationMeasurement) {
+        $reason = if ($canExecute) { "notRun" } else { "notExecutable" }
+        $coldStartup.status = "missing"
+        $coldStartup.reason = $reason
+        $peakWorkingSet.status = "missing"
+        $peakWorkingSet.reason = $reason
+    }
+    else {
+        $coldStartup.status = "measured"
+        $coldStartup.actual = [double]$ApplicationMeasurement.ElapsedMilliseconds
+        if ([long]$ApplicationMeasurement.PeakWorkingSetBytes -gt 0) {
+            $peakWorkingSet.status = "measured"
+            $peakWorkingSet.actual = [double]$ApplicationMeasurement.PeakWorkingSetBytes
+        }
+        else {
+            $peakWorkingSet.status = "missing"
+            $peakWorkingSet.reason = "notAvailable"
+        }
+    }
+
+    $cpu = if ($env:PROCESSOR_IDENTIFIER) { $env:PROCESSOR_IDENTIFIER.Trim() } else { "unknown" }
+    $evidence = [ordered]@{
+        sourceFormat = "sharpts-gui-packaging-v1"
+        run = [ordered]@{
+            timestampUtc = [DateTimeOffset]::UtcNow.ToString("o", [Globalization.CultureInfo]::InvariantCulture)
+            revision = [ordered]@{ commit = [string]$commit[0]; dirty = $status.Count -gt 0 }
+            environment = [ordered]@{
+                operatingSystem = [Runtime.InteropServices.RuntimeInformation]::OSDescription.Trim()
+                architecture = $osArchitecture.ToLowerInvariant()
+                processor = $cpu
+                runner = if ($env:RUNNER_NAME) { $env:RUNNER_NAME.Trim() } else { [Environment]::MachineName }
+            }
+            tools = [ordered]@{
+                dotnet = [string]$dotnetVersion[0]
+                runtimeIdentifier = $RuntimeIdentifier
+            }
+        }
+        measurements = @(
+            $coldStartup
+            $peakWorkingSet
+            [ordered]@{
+                id = "executableSize"; unit = "bytes"; status = "measured"; actual = $ExecutableBytes
+                budget = [ordered]@{ limit = [double]$Budgets.nativeAot.maxExecutableBytes; sourceId = "nativeAot.maxExecutableBytes" }
+            }
+            [ordered]@{
+                id = "shippingSize"; unit = "bytes"; status = "measured"; actual = $ShippingBytes
+                budget = [ordered]@{ limit = [double]$Budgets.nativeAot.maxShippingBytes; sourceId = "nativeAot.maxShippingBytes" }
+            }
+        )
+    }
+    $fullPath = if ([IO.Path]::IsPathRooted($PerformanceEvidencePath)) {
+        [IO.Path]::GetFullPath($PerformanceEvidencePath)
+    } else {
+        [IO.Path]::GetFullPath($PerformanceEvidencePath, $repositoryRoot)
+    }
+    [IO.Directory]::CreateDirectory((Split-Path -Parent $fullPath)) | Out-Null
+    [IO.File]::WriteAllText(
+        $fullPath,
+        ($evidence | ConvertTo-Json -Depth 10) + [Environment]::NewLine,
+        [Text.UTF8Encoding]::new($false))
+    Write-Host "Native AOT performance evidence: $fullPath"
 }
 Invoke-DotNet @(
     "publish", "src\SharpTS.Gui.Host\SharpTS.Gui.Host.csproj", "-c", "Release",
@@ -480,6 +584,8 @@ if ($NativeAot) {
     $performanceBudgets = Get-Content -LiteralPath (Join-Path $repositoryRoot "benchmarks\micro\SharpTS.Gui.Benchmarks\PerformanceBudgets.json") -Raw | ConvertFrom-Json
     $nativeAotMaxExecutableBytes = $performanceBudgets.nativeAot.maxExecutableBytes
     $nativeAotMaxTotalBytes = $performanceBudgets.nativeAot.maxShippingBytes
+    $nativeAotMeasurement = $null
+    Write-NativeAotPerformanceEvidence $performanceBudgets $nativeAotExecutableBytes $nativeAotTotalBytes $nativeAotMeasurement
     if ($nativeAotExecutableBytes -gt $nativeAotMaxExecutableBytes) {
         throw "Native AOT executable budget exceeded: $nativeAotExecutableBytes bytes > $nativeAotMaxExecutableBytes bytes."
     }
@@ -493,6 +599,7 @@ if ($NativeAot) {
         $nativeAotMeasurement = Measure-Application $nativeAotExecutable @(
             "--headless", "--trace", $nativeAotTrace, "--", "--smoke-close") $nativeAotPublishRoot
         Assert-GuestTrace $nativeAotTrace "Native AOT application"
+        Write-NativeAotPerformanceEvidence $performanceBudgets $nativeAotExecutableBytes $nativeAotTotalBytes $nativeAotMeasurement
         Write-Host "Native AOT cold startup: $($nativeAotMeasurement.ElapsedMilliseconds) ms; peak working set: $($nativeAotMeasurement.PeakWorkingSetBytes) bytes."
         if ($EnforcePerformanceBudgets -and
             $nativeAotMeasurement.ElapsedMilliseconds -gt $performanceBudgets.nativeAot.maxColdStartupMilliseconds) {


### PR DESCRIPTION
## Summary

- add schema-v2 public performance snapshots that preserve independent cross-runtime, compiler-micro, and GUI run provenance
- transform BenchmarkDotNet JSON plus typed companion metadata into stable compiler and GUI cases with raw statistics, allocations, GC data, operations-per-invoke, and explicit missing values
- pair GUI measurements with release budgets and export Native AOT startup, working-set, executable-size, and shipping-size evidence
- publish a canonical three-suite workflow artifact and document the capture/review contract

## Validation

- `dotnet build SharpTS.sln -c Release --no-restore -m:1 -p:NuGetAudit=false` (0 warnings, 0 errors)
- `./benchmarks/snapshots/test-snapshot.ps1`
- `./benchmarks/cross-runtime/test-snapshot.ps1`
- `./scripts/test-github-workflows.ps1`
- full BenchmarkDotNet ShortRun: 322 compiler cases and 7 GUI cases exported and schema-validated
- composed three-suite aggregate validated successfully

Closes #1512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a standardized public performance snapshot format covering cross-runtime, compiler, GUI, and Native AOT results.
  - Added tools to export, merge, validate, and publish performance snapshots.
  - Added structured benchmark metadata and performance evidence, including environment, budget, and measurement details.

- **Documentation**
  - Documented snapshot schema, benchmark outputs, validation workflows, and GUI performance evidence.
  - Added a public performance snapshots link to the documentation hub.

- **Tests**
  - Added deterministic contract tests covering snapshot generation, validation, merging, budgets, and invalid data handling.
  - Expanded CI workflows to validate published performance results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->