### PR TITLE
Add Node built-in module breadth phase 1

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -66,21 +66,21 @@ irrelevant: `strictNullChecks` defaults on, most other strictness flags default 
 
 ## 4. Node.js built-in modules
 
-SharpTS recognizes bare and `node:` forms for 34 maintained Node module specifiers. This is a
+SharpTS recognizes bare and `node:` forms for 44 maintained Node module specifiers. This is a
 compatible subset, not a claim to implement every export in the corresponding Node release. The
 [Node API guide](docs/node-modules-api.md) is the user reference; breadth and depth work is tracked
 on [#1282](https://github.com/nickna/SharpTS/issues/1282).
 
 | Category | Modules | Status and boundaries |
 | --- | --- | --- |
-| Files, paths, and process | `fs`, `fs/promises`, `path`, `os`, `process`, `tty` | ✅ Core sync/async filesystem operations, streams/watchers, platform/path variants, process lifecycle and stdio. Some POSIX and rejection lifecycle behavior remains mode/platform-specific. |
-| Data and utilities | `assert`, `buffer`, `crypto`, `querystring`, `string_decoder`, `url`, `util`, `zlib` | ✅ Broad tested subsets. Crypto is bounded by .NET algorithms; selected advanced key APIs remain interpreter-only. |
-| Events and scheduling | `events`, `async_hooks`, `timers`, `timers/promises`, `perf_hooks`, `readline` | ✅ Includes EventEmitter, AsyncLocalStorage, timer promises, performance entries/observer, and readline basics. |
-| Streams and networking | `stream`, `stream/promises`, `stream/web`, `http`, `https`, `net`, `tls`, `dgram`, `dns`, `dns/promises` | ✅ HTTP/TCP/TLS/UDP/DNS and stream subsets. Resolver callback timing and a few platform facilities have documented deviations. |
+| Files, paths, and process | `fs`, `fs/promises`, `path`, `path/posix`, `path/win32`, `os`, `process`, `tty`, `module` | ✅ Core sync/async filesystem operations, explicit path variants, process lifecycle and stdio, built-in discovery, and scoped literal `createRequire`. Some POSIX and rejection lifecycle behavior remains mode/platform-specific. |
+| Data and utilities | `assert`, `assert/strict`, `buffer`, `console`, `crypto`, `querystring`, `string_decoder`, `url`, `util`, `util/types`, `v8`, `zlib` | ✅ Broad tested subsets. Crypto is bounded by .NET algorithms; `v8` uses a SharpTS-private serialization format and approximate managed-heap statistics. |
+| Events and scheduling | `events`, `async_hooks`, `diagnostics_channel`, `timers`, `timers/promises`, `perf_hooks`, `readline`, `readline/promises` | ✅ Includes EventEmitter, AsyncLocalStorage, synchronous diagnostics publication/tracing, timer promises, performance entries/observer, and callback/promise readline surfaces. |
+| Streams and networking | `stream`, `stream/consumers`, `stream/promises`, `stream/web`, `http`, `https`, `net`, `tls`, `dgram`, `dns`, `dns/promises` | ✅ HTTP/TCP/TLS/UDP/DNS and stream subsets, including consumers for already-queued Node/Web readables. Live pull-source consumption, resolver callback timing, and a few platform facilities have documented deviations. |
 | Processes and isolation | `child_process`, `cluster`, `worker_threads`, `vm` | ⚠️ Main APIs are available, but the implementation uses .NET processes/threads and does not reproduce every Node isolation/resource option. Some compiled operations require the co-located managed runtime and source payload. |
 
-Modules absent from the maintained surface include `module`, `v8`, `http2`,
-`diagnostics_channel`, and `node:test`. Per-export signatures and examples are in the
+Modules absent from the maintained surface include `http2`, `inspector`, `repl`,
+`sqlite`, and `node:test`. Per-export signatures and examples are in the
 [Node API guide](docs/node-modules-api.md).
 
 Several user-facing modules are TypeScript sources embedded from `src/SharpTS/stdlib/node`; host I/O remains

--- a/docs/node-modules-api.md
+++ b/docs/node-modules-api.md
@@ -43,6 +43,29 @@ assert.strictEqual(2 + 2, 4);
 await assert.rejects(Promise.reject(new Error("expected")));
 ```
 
+`assert/strict` exposes the same callable strict namespace as `assert.strict`; its legacy
+`equal`/`deepEqual` names use strict comparisons. Both `require("assert")` and
+`require("assert/strict")` return callable CommonJS exports.
+
+## module
+
+`module` exports `builtinModules`, `isBuiltin`, `createRequire`, and `syncBuiltinESMExports`.
+`builtinModules` is the canonical list of SharpTS-supported Node specifiers, and `isBuiltin`
+accepts bare or `node:` names.
+
+```typescript
+import { createRequire, isBuiltin } from "node:module";
+
+const require = createRequire(import.meta.url);
+const config = require("./config.cjs");
+console.log(isBuiltin("node:fs"), config);
+```
+
+In compiled output, `createRequire` follows strict-AOT rules: bind the result to a variable named
+`require` and use one string-literal specifier per call. Interpreter mode also honors the supplied
+base path dynamically. `syncBuiltinESMExports` is a no-op because embedded modules have one export
+namespace rather than separate mutable CJS and ESM tables.
+
 ## buffer
 
 `buffer` exports `Buffer`, `SlowBuffer`, `atob`, `btoa`, `isUtf8`, `isAscii`, `transcode`, constants,
@@ -52,6 +75,11 @@ Static APIs include `Buffer.from`, `alloc`, `allocUnsafe`, `concat`, `isBuffer`,
 `byteLength`, and `compare`. Instances support string conversion, slice/subarray, copy, write, fill,
 search/compare/equality, integer reads/writes, and `toJSON`. Maintained encodings include UTF-8,
 UTF-16LE/UCS-2, ASCII/Latin-1/binary, hex, base64, and base64url where the operation accepts them.
+
+## console
+
+The `console` module exposes the existing global console surface, including `log`, `info`, `debug`,
+`error`, `warn`, timers, counters, grouping, assertions, tables, directory inspection, and traces.
 
 ## crypto
 
@@ -125,6 +153,9 @@ console.log(path.join("dist", "app.dll"));
 console.log(path.parse("/tmp/archive.tar.gz").ext);
 ```
 
+`path/posix` and `path/win32` are also importable submodules and default-export their corresponding
+explicit path namespace.
+
 ## os
 
 `os` exports `platform`, `arch`, `cpus`, `hostname`, `homedir`, `tmpdir`, `type`, `release`,
@@ -182,6 +213,13 @@ await delay(100);
 Context flows through .NET asynchronous execution. Optional trailing callback arguments on `run`
 and `exit` are a known facade gap; close over values instead.
 
+## diagnostics_channel
+
+`diagnostics_channel` exports `channel`, `hasSubscribers`, `subscribe`, `unsubscribe`, `Channel`,
+`tracingChannel`, and `TracingChannel`. Named channels are process-local singletons and publish
+synchronously. Store bindings call compatible `AsyncLocalStorage.run` objects. Tracing channels
+provide sync, promise, and callback lifecycle helpers.
+
 ## perf_hooks
 
 `perf_hooks` exports `performance` (`now`, `timeOrigin`, marks, measures, entry queries and clears)
@@ -193,6 +231,12 @@ and `PerformanceObserver` for mark/measure entries.
 `question`, `questionSync`, `prompt`, `pause`, `resume`, `write`, `setPrompt`, `getPrompt`, and
 `close`.
 
+## readline/promises
+
+`readline/promises` exports `createInterface` and `Interface`. `question` returns a promise and
+accepts an abort signal. Input still uses the host's blocking console reader internally, so this is
+a promise-shaped compatibility layer rather than non-blocking terminal I/O.
+
 ## stream
 
 `stream` exports `Readable`, `Writable`, `Duplex`, `Transform`, and `PassThrough`, plus `pipeline`,
@@ -203,6 +247,17 @@ helpers such as `toArray`, `forEach`, `map`, and `filter`.
 ## stream/promises
 
 `stream/promises` exposes promise-returning `pipeline` and `finished`.
+
+## stream/consumers
+
+`stream/consumers` exports `arrayBuffer`, `blob`, `buffer`, `bytes`, `json`, and `text`. The helpers
+consume maintained Node `Readable` objects and WHATWG `ReadableStream` objects. `bytes` uses the
+SharpTS `Buffer` backing, which represents Node's Uint8Array-compatible byte view. `arrayBuffer`
+returns the native SharpTS `ArrayBuffer`; `blob` returns a stdlib Blob-compatible value with
+`size`, `type`, `arrayBuffer`, `bytes`, `text`, `slice`, and `stream` (global `Blob` constructor
+identity is not guaranteed in compiled mode). The maintained Phase 1 contract drains data already
+queued before the consumer call; waiting for future chunks from a live pull source remains outside
+this surface.
 
 ## stream/web
 
@@ -289,6 +344,19 @@ and legacy `parse`.
 
 `util` includes `promisify`, `callbackify`, `deprecate`, `format`, `inspect`, the `types` predicate
 object, `TextEncoder`, and `TextDecoder` where declared.
+
+`util/types` is an importable submodule for the maintained `util.types` predicate set, including
+collection, promise, error, ArrayBuffer/view, boxed primitive, function-kind, and typed-array
+checks.
+
+## v8
+
+`v8` exports `serialize`, `deserialize`, `getHeapStatistics`, `getHeapSpaceStatistics`,
+`setFlagsFromString`, and `cachedDataVersionTag`. Serialization preserves circular references and
+maintained arrays, objects, maps, sets, dates, regular expressions, BigInts, special numbers, and
+buffers. Its bytes use a SharpTS-private format and are not interchangeable with Node/V8 wire
+data. Heap statistics are managed-runtime approximations, and `setFlagsFromString` is accepted as
+an intentional no-op because SharpTS does not host V8.
 
 ## zlib
 

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -2951,6 +2951,7 @@ public class EmittedRuntime
     public MethodBuilder ReadableStreamEnqueue { get; set; } = null!;
     public MethodBuilder ReadableStreamCloseStream { get; set; } = null!;
     public MethodBuilder ReadableStreamErrorStream { get; set; } = null!;
+    public MethodBuilder ReadableStreamDrainQueuedChunks { get; set; } = null!;
     /// <summary>
     /// Static $ReadableStream.From(object iterable) → object (#269) — eagerly
     /// drains a guest iterable into a closed readable stream.

--- a/src/SharpTS/Compilation/Emitters/Modules/ModulePrimitiveEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/Modules/ModulePrimitiveEmitter.cs
@@ -1,0 +1,26 @@
+using System.Reflection.Emit;
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation.Emitters.Modules;
+
+/// <summary>
+/// Compiled backing for <c>node:module.createRequire()</c>. Compiled CommonJS
+/// require lowering is syntax-directed: a local binding named <c>require</c>
+/// followed by a string-literal call is resolved at compile time. The returned
+/// placeholder is therefore never invoked for the supported pattern.
+/// </summary>
+public sealed class ModulePrimitiveEmitter : IBuiltInModuleEmitter
+{
+    public string ModuleName => "primitive:module";
+
+    public IReadOnlyList<string> GetExportedMembers() => ["createRequire"];
+
+    public bool TryEmitMethodCall(IEmitterContext emitter, string methodName, List<Expr> arguments)
+    {
+        if (methodName != "createRequire") return false;
+        emitter.Context.IL.Emit(OpCodes.Ldnull);
+        return true;
+    }
+
+    public bool TryEmitPropertyGet(IEmitterContext emitter, string propertyName) => false;
+}

--- a/src/SharpTS/Compilation/Emitters/Modules/StreamConsumersPrimitiveEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/Modules/StreamConsumersPrimitiveEmitter.cs
@@ -1,0 +1,63 @@
+using System.Reflection.Emit;
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation.Emitters.Modules;
+
+/// <summary>Compiled host-value adapters for stream/consumers.</summary>
+public sealed class StreamConsumersPrimitiveEmitter : IBuiltInModuleEmitter
+{
+    public string ModuleName => "primitive:stream/consumers";
+
+    public IReadOnlyList<string> GetExportedMembers() => ["drainQueuedWebStream", "bufferToArrayBuffer"];
+
+    public bool TryEmitMethodCall(IEmitterContext emitter, string methodName, List<Expr> arguments)
+    {
+        if (methodName is not "drainQueuedWebStream" and not "bufferToArrayBuffer") return false;
+        if (arguments.Count == 0)
+        {
+            emitter.Context.IL.Emit(OpCodes.Ldnull);
+        }
+        else
+        {
+            emitter.EmitExpression(arguments[0]);
+            emitter.EmitBoxIfNeeded(arguments[0]);
+        }
+
+        var context = emitter.Context;
+        if (methodName == "drainQueuedWebStream")
+        {
+            context.IL.Emit(OpCodes.Castclass, context.Runtime!.ReadableStreamType);
+            context.IL.Emit(OpCodes.Callvirt, context.Runtime.ReadableStreamDrainQueuedChunks);
+            return true;
+        }
+
+        var il = context.IL;
+        var runtime = context.Runtime!;
+        var bytes = il.DeclareLocal(typeof(byte[]));
+        var result = il.DeclareLocal(runtime.ArrayBufferType);
+
+        il.Emit(OpCodes.Castclass, runtime.TSBufferType);
+        il.Emit(OpCodes.Callvirt, runtime.TSBufferGetData);
+        il.Emit(OpCodes.Stloc, bytes);
+        il.Emit(OpCodes.Ldloc, bytes);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Newobj, runtime.ArrayBufferCtor);
+        il.Emit(OpCodes.Stloc, result);
+
+        il.Emit(OpCodes.Ldloc, bytes);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldloc, result);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayBufferGetBuffer);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldloc, bytes);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Call, typeof(Array).GetMethod(
+            "Copy", [typeof(Array), typeof(int), typeof(Array), typeof(int), typeof(int)])!);
+        il.Emit(OpCodes.Ldloc, result);
+        return true;
+    }
+
+    public bool TryEmitPropertyGet(IEmitterContext emitter, string propertyName) => false;
+}

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.CommonJs.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.CommonJs.cs
@@ -183,6 +183,16 @@ public abstract partial class ExpressionEmitterBase
                 IL.Emit(OpCodes.Call, initMethod);
             }
 
+            // require('assert') and require('assert/strict') return a callable
+            // function object rather than an ESM namespace object.
+            if (resolvedPath is "stdlib:node/assert.ts" or "stdlib:node/assert/strict.ts" &&
+                exportFields.TryGetValue("$default", out var defaultField))
+            {
+                IL.Emit(OpCodes.Ldsfld, defaultField);
+                SetStackUnknown();
+                return true;
+            }
+
             var dictType = Ctx.Types.DictionaryStringObject;
             var dictCtor = Ctx.Types.GetDefaultConstructor(dictType);
             var addMethod = Ctx.Types.GetMethod(dictType, "Add", Ctx.Types.String, Ctx.Types.Object);

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.Operators.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.Operators.cs
@@ -742,7 +742,9 @@ public abstract partial class ExpressionEmitterBase
         string url = path;
         if (!string.IsNullOrEmpty(url) && !url.StartsWith("file://"))
         {
-            url = "file:///" + url.Replace("\\", "/");
+            url = System.IO.Path.IsPathRooted(path)
+                ? new Uri(System.IO.Path.GetFullPath(path)).AbsoluteUri
+                : "file:///" + path.Replace("\\", "/");
         }
         string dirname = string.IsNullOrEmpty(path) ? "" : System.IO.Path.GetDirectoryName(path) ?? "";
 

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -1202,6 +1202,8 @@ public partial class ILCompiler
         // "util" — migrated to stdlib/node/util.ts (pure-TS port).
         // "readline" — migrated to stdlib/node/readline.ts; emitter registered under primitive:readline only.
         _builtInModuleEmitterRegistry.Register(new ReadlinePrimitiveEmitter());
+        _builtInModuleEmitterRegistry.Register(new ModulePrimitiveEmitter());
+        _builtInModuleEmitterRegistry.Register(new StreamConsumersPrimitiveEmitter());
         _builtInModuleEmitterRegistry.Register(new ChildProcessModuleEmitter());
         _builtInModuleEmitterRegistry.Register(new BufferModuleEmitter());
         // "zlib" — migrated to stdlib/node/zlib.ts; emitter registered under primitive:zlib only.

--- a/src/SharpTS/Compilation/ILEmitter.Modules.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Modules.cs
@@ -760,7 +760,9 @@ public partial class ILEmitter
         string url = path;
         if (!string.IsNullOrEmpty(url) && !url.StartsWith("file://"))
         {
-            url = "file:///" + url.Replace("\\", "/");
+            url = Path.IsPathRooted(path)
+                ? new Uri(Path.GetFullPath(path)).AbsoluteUri
+                : "file:///" + path.Replace("\\", "/");
         }
         string dirname = string.IsNullOrEmpty(path) ? "" : Path.GetDirectoryName(path) ?? "";
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.ReadableStream.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.ReadableStream.cs
@@ -103,6 +103,7 @@ public partial class RuntimeEmitter
         var errorMethod = EmitReadableStreamErrorMethod(streamBuilder);
         var desiredSizeMethod = EmitReadableStreamDesiredSizeProperty(streamBuilder);
         var readMethod = EmitReadableStreamRead(streamBuilder, runtime);
+        runtime.ReadableStreamDrainQueuedChunks = EmitReadableStreamDrainQueuedChunks(streamBuilder);
         EmitReadableStreamGetReader(streamBuilder, readerCtor);
         var cancelMethod = EmitReadableStreamCancel(streamBuilder, runtime);
         var pipeToMethod = EmitReadableStreamPipeTo(streamBuilder, readMethod, cancelMethod, runtime);
@@ -150,6 +151,34 @@ public partial class RuntimeEmitter
         _readableStreamControllerField = t.DefineField("_controller", _types.Object, FieldAttributes.Private);
         _readableStreamReaderField = t.DefineField("_reader", _types.Object, FieldAttributes.Private);
         _readableStreamPendingReadsField = t.DefineField("_pendingReads", _pendingReadsQueueType, FieldAttributes.Private);
+    }
+
+    /// <summary>
+    /// Drains the chunks already queued by a synchronously-started/closed stream.
+    /// Used by the stream/consumers facade; async pull sources continue to use
+    /// their reader path rather than this snapshot helper.
+    /// </summary>
+    private MethodBuilder EmitReadableStreamDrainQueuedChunks(TypeBuilder t)
+    {
+        var method = t.DefineMethod(
+            "DrainQueuedChunks",
+            MethodAttributes.Public,
+            _types.Object,
+            Type.EmptyTypes);
+        var il = method.GetILGenerator();
+        var chunks = il.DeclareLocal(_listOfObject);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldfld, _readableStreamQueueField);
+        il.Emit(OpCodes.Stloc, chunks);
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(_listOfObject, Type.EmptyTypes)!);
+        il.Emit(OpCodes.Stfld, _readableStreamQueueField);
+
+        il.Emit(OpCodes.Ldloc, chunks);
+        il.Emit(OpCodes.Ret);
+        return method;
     }
 
     private ConstructorBuilder EmitReadableStreamConstructor(

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -241,7 +241,8 @@ public sealed class RuntimeFeatureDetector
         // Strip "node:" prefix that Node.js permits on builtins.
         var p = path.StartsWith("node:") ? path[5..] : path;
         if (p is "dns/promises" or "fs/promises" or "primitive:fs/promises" or
-            "crypto/promises" or "stream/promises" or "readline/promises" or
+            "crypto/promises" or "stream/promises" or "stream/consumers" or
+            "primitive:stream/consumers" or "readline/promises" or
             "timers/promises" or "primitive:timers/promises")
         {
             _set.UsesPromise = true;
@@ -299,6 +300,14 @@ public sealed class RuntimeFeatureDetector
             case "stream/web":
                 _set.UsesNodeStreams = true;
                 if (p == "stream/web") _set.UsesWebStreams = true;
+                break;
+            case "stream/consumers":
+            case "primitive:stream/consumers":
+                _set.UsesNodeStreams = true;
+                _set.UsesWebStreams = true;
+                _set.UsesBuffer = true;
+                _set.UsesPromise = true;
+                _set.TypedArrays |= RuntimeFeatureSet.TypedArrayKinds.ArrayBuffer;
                 break;
             case "cluster":
                 _set.UsesCluster = true; break;

--- a/src/SharpTS/Execution/Interpreter.CommonJs.cs
+++ b/src/SharpTS/Execution/Interpreter.CommonJs.cs
@@ -31,6 +31,16 @@ public partial class Interpreter
     /// <exception cref="InterpreterException">If the module cannot be resolved or fails to load.</exception>
     internal object? RequireCommonJsModule(string specifier)
     {
+        string callerPath = _currentModule?.Path ?? _moduleResolver?.GetType().Name ?? "";
+        return RequireCommonJsModule(specifier, callerPath);
+    }
+
+    /// <summary>
+    /// Resolves a CommonJS module relative to an explicit caller path. Used by
+    /// <c>module.createRequire(filename)</c>.
+    /// </summary>
+    internal object? RequireCommonJsModule(string specifier, string callerPath)
+    {
         if (_moduleResolver == null)
         {
             throw new InterpreterException(
@@ -38,7 +48,6 @@ public partial class Interpreter
         }
 
         // Resolve relative to the calling module's directory.
-        string callerPath = _currentModule?.Path ?? _moduleResolver.GetType().Name;
         string resolvedPath;
         try
         {
@@ -99,6 +108,14 @@ public partial class Interpreter
         if (instance == null)
         {
             return null;
+        }
+        // Node's assert entry points are callable CommonJS exports. Their ESM
+        // facades expose the callable object as the default export while named
+        // imports remain available to ESM consumers.
+        if (resolvedPath is "stdlib:node/assert.ts" or "stdlib:node/assert/strict.ts" &&
+            instance.DefaultExport != null)
+        {
+            return instance.DefaultExport;
         }
         return instance.CommonJsModuleObject != null
             ? instance.CommonJsModuleObject.GetProperty("exports")

--- a/src/SharpTS/Execution/Interpreter.Expressions.cs
+++ b/src/SharpTS/Execution/Interpreter.Expressions.cs
@@ -1852,7 +1852,13 @@ public partial class Interpreter
         // Convert to file:// URL format if it's a file path
         if (!string.IsNullOrEmpty(url) && !url.StartsWith("file://"))
         {
-            url = "file:///" + url.Replace("\\", "/");
+            // Absolute POSIX paths already begin with '/'. Prefixing file:/// by
+            // hand produced file:////tmp/... on Linux, which createRequire could
+            // not map back to the in-memory module path. Let Uri apply the
+            // platform-specific drive/root and escaping rules instead.
+            url = Path.IsPathRooted(path)
+                ? new Uri(Path.GetFullPath(path)).AbsoluteUri
+                : "file:///" + path.Replace("\\", "/");
         }
 
         return RuntimeValue.FromObject(new SharpTSObject(new Dictionary<string, object?>

--- a/src/SharpTS/Modules/ModuleResolver.cs
+++ b/src/SharpTS/Modules/ModuleResolver.cs
@@ -1126,13 +1126,12 @@ public class ModuleResolver
 
             // ESM modules (and scripts) can also reach modules via bare require() — it's a
             // global in SharpTS, mirroring Node's createRequire interop. Walk the body for
-            // literal require() specifiers that resolve to embedded stdlib facades so they
-            // get bundled into compiled output (#1217); without this the emitter's require()
-            // lowering finds the facade in neither CommonJsGetExportsMethods nor
-            // ModuleExportFields and lowers the call to a runtime MODULE_NOT_FOUND throw.
-            // Scoped to stdlib on purpose: user modules reached only via require() stay
-            // runtime-lazy in the interpreter and out of the static type-check graph.
-            CollectCjsRequireDependencies(module, statements, absolutePath, decoratorMode, stdlibOnly: true);
+            // literal require() specifiers so they get bundled into compiled output. This
+            // covers both the global require interop (#1217) and the canonical
+            // `const require = createRequire(import.meta.url)` pattern from node:module.
+            // Compiled mode is strict-AOT, so every literal target must be present in the
+            // static graph; the interpreter still resolves the same call lazily.
+            CollectCjsRequireDependencies(module, statements, absolutePath, decoratorMode);
 
             return module;
         }
@@ -1290,9 +1289,8 @@ public class ModuleResolver
     /// Unresolvable specifiers are also ignored — they'll either resolve via the optional-dep
     /// runtime throw path or surface as a compile error from the IL emitter.
     /// </summary>
-    /// <param name="stdlibOnly">When true (ESM/script callers, #1217), only specifiers that
-    /// resolve to embedded stdlib modules are loaded; user modules reached via require()
-    /// from non-CJS files stay runtime-lazy.</param>
+    /// <param name="stdlibOnly">When true, only specifiers that resolve to embedded stdlib
+    /// modules are loaded. Current callers include all literal targets for strict AOT.</param>
     private void CollectCjsRequireDependencies(
         ParsedModule module,
         List<Stmt> statements,

--- a/src/SharpTS/Modules/Stdlib/PrimitiveRegistry.cs
+++ b/src/SharpTS/Modules/Stdlib/PrimitiveRegistry.cs
@@ -29,6 +29,8 @@ public static class PrimitiveRegistry
         Prefix + "timers",
         Prefix + "timers/promises",
         Prefix + "readline",
+        Prefix + "module",
+        Prefix + "stream/consumers",
         Prefix + "fs",
         Prefix + "fs/promises",
         Prefix + "zlib",

--- a/src/SharpTS/Runtime/BuiltIns/Modules/Interpreter/ModulePrimitiveInterpreter.cs
+++ b/src/SharpTS/Runtime/BuiltIns/Modules/Interpreter/ModulePrimitiveInterpreter.cs
@@ -1,0 +1,45 @@
+using SharpTS.Runtime.Types;
+
+namespace SharpTS.Runtime.BuiltIns.Modules.Interpreter;
+
+/// <summary>
+/// Interpreter backing for the host-sensitive part of <c>node:module</c>.
+/// The public catalog and lookup helpers remain in the TypeScript facade.
+/// </summary>
+public static class ModulePrimitiveInterpreter
+{
+    public static Dictionary<string, object?> GetExports()
+    {
+        return new Dictionary<string, object?>
+        {
+            ["createRequire"] = BuiltInMethod.CreateV2("createRequire", 1, CreateRequire)
+        };
+    }
+
+    private static RuntimeValue CreateRequire(
+        Execution.Interpreter interpreter,
+        RuntimeValue receiver,
+        ReadOnlySpan<RuntimeValue> args)
+    {
+        var callerPath = args.Length > 0 ? args[0].ToObject()?.ToString() ?? "" : "";
+        if (Uri.TryCreate(callerPath, UriKind.Absolute, out var uri) && uri.IsFile)
+        {
+            callerPath = uri.LocalPath;
+        }
+        else if (!Path.IsPathRooted(callerPath))
+        {
+            callerPath = Path.GetFullPath(callerPath);
+        }
+
+        var require = BuiltInMethod.CreateV2("require", 1, (callInterpreter, _, requireArgs) =>
+        {
+            var specifier = requireArgs.Length > 0
+                ? requireArgs[0].ToObject()?.ToString() ?? ""
+                : "";
+            return RuntimeValue.FromBoxed(
+                callInterpreter.RequireCommonJsModule(specifier, callerPath));
+        });
+
+        return RuntimeValue.FromObject(require);
+    }
+}

--- a/src/SharpTS/Runtime/BuiltIns/Modules/Interpreter/PrimitiveModuleValues.cs
+++ b/src/SharpTS/Runtime/BuiltIns/Modules/Interpreter/PrimitiveModuleValues.cs
@@ -30,6 +30,8 @@ public static class PrimitiveModuleValues
             "timers" => TimersPrimitiveInterpreter.GetExports(),
             "timers/promises" => TimersPrimitiveInterpreter.GetPromisesExports(),
             "readline" => ReadlinePrimitiveInterpreter.GetExports(),
+            "module" => ModulePrimitiveInterpreter.GetExports(),
+            "stream/consumers" => StreamConsumersPrimitiveInterpreter.GetExports(),
             "fs" => FsModuleInterpreter.GetExports(),
             "fs/promises" => FsPromisesModuleInterpreter.GetExports(),
             "zlib" => ZlibModuleInterpreter.GetExports(),
@@ -43,6 +45,7 @@ public static class PrimitiveModuleValues
     public static bool HasInterpreterSupport(string primitiveName)
     {
         return primitiveName is "os" or "process" or "perf" or "tty" or "async_hooks"
-            or "timers" or "timers/promises" or "readline" or "fs" or "fs/promises" or "zlib";
+            or "timers" or "timers/promises" or "readline" or "module" or "stream/consumers"
+            or "fs" or "fs/promises" or "zlib";
     }
 }

--- a/src/SharpTS/Runtime/BuiltIns/Modules/Interpreter/StreamConsumersPrimitiveInterpreter.cs
+++ b/src/SharpTS/Runtime/BuiltIns/Modules/Interpreter/StreamConsumersPrimitiveInterpreter.cs
@@ -1,0 +1,43 @@
+using SharpTS.Runtime.Types;
+
+namespace SharpTS.Runtime.BuiltIns.Modules.Interpreter;
+
+/// <summary>Interpreter host-value adapters used by the TypeScript consumers facade.</summary>
+public static class StreamConsumersPrimitiveInterpreter
+{
+    public static Dictionary<string, object?> GetExports() => new()
+    {
+        ["drainQueuedWebStream"] = BuiltInMethod.CreateV2(
+            "drainQueuedWebStream", 1, DrainQueuedWebStream),
+        ["bufferToArrayBuffer"] = BuiltInMethod.CreateV2(
+            "bufferToArrayBuffer", 1, BufferToArrayBuffer)
+    };
+
+    private static RuntimeValue DrainQueuedWebStream(
+        Execution.Interpreter interpreter,
+        RuntimeValue receiver,
+        ReadOnlySpan<RuntimeValue> args)
+    {
+        if (args.Length == 0 || args[0].ToObject() is not SharpTSReadableStream stream)
+            throw new Exception("The value must be a ReadableStream");
+
+        var chunks = stream.Queue.Select(chunk => chunk.Value).ToList();
+        stream.Queue.Clear();
+        stream.QueueTotalSize = 0;
+        stream.Disturbed = true;
+        return RuntimeValue.FromObject(new SharpTSArray(chunks));
+    }
+
+    private static RuntimeValue BufferToArrayBuffer(
+        Execution.Interpreter interpreter,
+        RuntimeValue receiver,
+        ReadOnlySpan<RuntimeValue> args)
+    {
+        if (args.Length == 0 || args[0].ToObject() is not SharpTSBuffer buffer)
+            throw new Exception("The value must be a Buffer");
+
+        var result = new SharpTSArrayBuffer(buffer.Length);
+        buffer.Data.CopyTo(result.AsSpan());
+        return RuntimeValue.FromObject(result);
+    }
+}

--- a/src/SharpTS/TypeSystem/BuiltInModuleTypes.cs
+++ b/src/SharpTS/TypeSystem/BuiltInModuleTypes.cs
@@ -564,6 +564,15 @@ public static partial class BuiltInModuleTypes
             // Readline's primitive surface is the full module surface — the TS
             // facade wraps the returned Interface and forwards calls dynamically.
             "readline" => GetReadlineModuleTypes(),
+            "module" => new Dictionary<string, TypeInfo>
+            {
+                ["createRequire"] = new TypeInfo.Function([TypeInfo.Any.Shared], TypeInfo.Any.Shared),
+            },
+            "stream/consumers" => new Dictionary<string, TypeInfo>
+            {
+                ["drainQueuedWebStream"] = new TypeInfo.Function([TypeInfo.Any.Shared], TypeInfo.Any.Shared),
+                ["bufferToArrayBuffer"] = new TypeInfo.Function([TypeInfo.Any.Shared], TypeInfo.Any.Shared),
+            },
             // Primitive fs types reuse the user-facing module type shapes — the
             // primitive surface matches the Node surface; the TS facade re-exports
             // the sync ops and derives the callback forms from primitive:fs/promises.

--- a/src/SharpTS/stdlib/node/assert/strict.ts
+++ b/src/SharpTS/stdlib/node/assert/strict.ts
@@ -1,0 +1,48 @@
+// Strict assertion-mode alias for node:assert/strict.
+
+import {
+    AssertionError,
+    CallTracker,
+    deepStrictEqual,
+    doesNotMatch,
+    doesNotReject,
+    doesNotThrow,
+    fail,
+    ifError,
+    match,
+    notDeepStrictEqual,
+    notStrictEqual,
+    ok,
+    partialDeepStrictEqual,
+    rejects,
+    strict as strictAssert,
+    strictEqual,
+    throws,
+} from 'assert';
+
+export {
+    AssertionError,
+    CallTracker,
+    deepStrictEqual,
+    doesNotMatch,
+    doesNotReject,
+    doesNotThrow,
+    fail,
+    ifError,
+    match,
+    notDeepStrictEqual,
+    notStrictEqual,
+    ok,
+    partialDeepStrictEqual,
+    rejects,
+    strictEqual,
+    throws,
+};
+
+export const equal = strictEqual;
+export const notEqual = notStrictEqual;
+export const deepEqual = deepStrictEqual;
+export const notDeepEqual = notDeepStrictEqual;
+export const strict = strictAssert;
+
+export default strictAssert;

--- a/src/SharpTS/stdlib/node/console.ts
+++ b/src/SharpTS/stdlib/node/console.ts
@@ -1,0 +1,71 @@
+// Module form of the existing global console surface.
+
+export function log(...args: any[]): void {
+    if (args.length === 0) console.log();
+    else if (args.length === 1) console.log(args[0]);
+    else if (args.length === 2) console.log(args[0], args[1]);
+    else if (args.length === 3) console.log(args[0], args[1], args[2]);
+    else console.log(args[0], args[1], args[2], args[3], args.slice(4));
+}
+export function info(...args: any[]): void {
+    if (args.length === 0) console.info();
+    else if (args.length === 1) console.info(args[0]);
+    else if (args.length === 2) console.info(args[0], args[1]);
+    else console.info(args[0], args[1], args[2]);
+}
+export function debug(...args: any[]): void {
+    if (args.length === 0) console.debug();
+    else if (args.length === 1) console.debug(args[0]);
+    else if (args.length === 2) console.debug(args[0], args[1]);
+    else console.debug(args[0], args[1], args[2]);
+}
+export function error(...args: any[]): void {
+    if (args.length === 0) console.error();
+    else if (args.length === 1) console.error(args[0]);
+    else if (args.length === 2) console.error(args[0], args[1]);
+    else console.error(args[0], args[1], args[2]);
+}
+export function warn(...args: any[]): void {
+    if (args.length === 0) console.warn();
+    else if (args.length === 1) console.warn(args[0]);
+    else if (args.length === 2) console.warn(args[0], args[1]);
+    else console.warn(args[0], args[1], args[2]);
+}
+export function clear(): void { console.clear(); }
+export function time(label?: string): void { console.time(label); }
+export function timeEnd(label?: string): void { console.timeEnd(label); }
+export function timeLog(label?: string, ...args: any[]): void {
+    if (args.length === 0) console.timeLog(label);
+    else if (args.length === 1) console.timeLog(label, args[0]);
+    else console.timeLog(label, args[0], args[1]);
+}
+export function assert(condition?: boolean, ...args: any[]): void {
+    if (args.length === 0) console.assert(condition);
+    else if (args.length === 1) console.assert(condition, args[0]);
+    else console.assert(condition, args[0], args[1]);
+}
+export function count(label?: string): void { console.count(label); }
+export function countReset(label?: string): void { console.countReset(label); }
+export function table(data: any, properties?: string[]): void { console.table(data, properties); }
+export function dir(item: any, options?: any): void { console.dir(item, options); }
+export function group(...args: any[]): void {
+    if (args.length === 0) console.group();
+    else if (args.length === 1) console.group(args[0]);
+    else console.group(args[0], args[1]);
+}
+export function groupCollapsed(...args: any[]): void {
+    if (args.length === 0) console.groupCollapsed();
+    else if (args.length === 1) console.groupCollapsed(args[0]);
+    else console.groupCollapsed(args[0], args[1]);
+}
+export function groupEnd(): void { console.groupEnd(); }
+export function trace(...args: any[]): void {
+    if (args.length === 0) console.trace();
+    else if (args.length === 1) console.trace(args[0]);
+    else console.trace(args[0], args[1]);
+}
+
+export default {
+    log, info, debug, error, warn, clear, time, timeEnd, timeLog, assert,
+    count, countReset, table, dir, group, groupCollapsed, groupEnd, trace,
+};

--- a/src/SharpTS/stdlib/node/diagnostics_channel.ts
+++ b/src/SharpTS/stdlib/node/diagnostics_channel.ts
@@ -1,0 +1,231 @@
+// Node.js 'diagnostics_channel' module — SharpTS embedded stdlib implementation.
+// Target: Node.js 24.15.0. See https://nodejs.org/api/diagnostics_channel.html.
+
+type ChannelName = string | symbol;
+type Subscriber = (message: any, name: ChannelName) => void;
+
+const channels = new Map<any, Channel>();
+
+/** A named synchronous diagnostics channel. */
+export class Channel {
+    name: ChannelName;
+    private _subscribers: any[];
+    private _stores: any[];
+
+    constructor(name: ChannelName) {
+        this.name = name;
+        this._subscribers = [];
+        this._stores = [];
+    }
+
+    get hasSubscribers(): boolean {
+        return this._subscribers.length > 0;
+    }
+
+    publish(message: any): void {
+        // Snapshot the list so subscribe/unsubscribe during publication only
+        // affects the next publication, matching Node's synchronous contract.
+        const listeners = this._subscribers.slice();
+        for (let i = 0; i < listeners.length; i++) {
+            listeners[i](message, this.name);
+        }
+    }
+
+    subscribe(onMessage: any): void {
+        if (typeof onMessage !== 'function') {
+            throw new TypeError('The "onMessage" argument must be a function');
+        }
+        if (this._subscribers.indexOf(onMessage) < 0) {
+            this._subscribers.push(onMessage);
+        }
+    }
+
+    unsubscribe(onMessage: any): boolean {
+        const index = this._subscribers.indexOf(onMessage);
+        if (index < 0) return false;
+        this._subscribers.splice(index, 1);
+        return true;
+    }
+
+    bindStore(store: any, transform?: (context: any) => any): void {
+        this.unbindStore(store);
+        this._stores.push([store, transform]);
+    }
+
+    unbindStore(store: any): boolean {
+        for (let i = 0; i < this._stores.length; i++) {
+            if (this._stores[i][0] === store) {
+                this._stores.splice(i, 1);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    runStores(context: any, fn: any, thisArg?: any, ...args: any[]): any {
+        if (typeof fn !== 'function') {
+            throw new TypeError('The "fn" argument must be a function');
+        }
+
+        const bindings = this._stores.slice();
+        const invoke = (index: number): any => {
+            if (index >= bindings.length) {
+                this.publish(context);
+                return fn.apply(thisArg, args);
+            }
+            const binding = bindings[index];
+            const store = binding[0];
+            const transform = binding[1];
+            const value = typeof transform === 'function' ? transform(context) : context;
+            return store.run(value, () => invoke(index + 1));
+        };
+
+        return invoke(0);
+    }
+}
+
+/** Returns the singleton Channel for a string or symbol name. */
+export function channel(name: ChannelName): Channel {
+    let existing: any = channels.get(name);
+    if (existing === undefined) {
+        existing = new Channel(name);
+        channels.set(name, existing);
+    }
+    return existing as Channel;
+}
+
+export function hasSubscribers(name: ChannelName): boolean {
+    const existing: any = channels.get(name);
+    return existing !== undefined && existing.hasSubscribers;
+}
+
+export function subscribe(name: ChannelName, onMessage: any): void {
+    channel(name).subscribe(onMessage);
+}
+
+export function unsubscribe(name: ChannelName, onMessage: any): boolean {
+    return channel(name).unsubscribe(onMessage);
+}
+
+/** The five related channels used by tracing helpers. */
+export class TracingChannel {
+    start: Channel;
+    end: Channel;
+    asyncStart: Channel;
+    asyncEnd: Channel;
+    error: Channel;
+
+    constructor(nameOrChannels: any) {
+        if (typeof nameOrChannels === 'string' || typeof nameOrChannels === 'symbol') {
+            const base = nameOrChannels;
+            this.start = channel('tracing:' + String(base) + ':start');
+            this.end = channel('tracing:' + String(base) + ':end');
+            this.asyncStart = channel('tracing:' + String(base) + ':asyncStart');
+            this.asyncEnd = channel('tracing:' + String(base) + ':asyncEnd');
+            this.error = channel('tracing:' + String(base) + ':error');
+        } else {
+            this.start = nameOrChannels.start;
+            this.end = nameOrChannels.end;
+            this.asyncStart = nameOrChannels.asyncStart;
+            this.asyncEnd = nameOrChannels.asyncEnd;
+            this.error = nameOrChannels.error;
+        }
+    }
+
+    get hasSubscribers(): boolean {
+        return this.start.hasSubscribers || this.end.hasSubscribers ||
+            this.asyncStart.hasSubscribers || this.asyncEnd.hasSubscribers ||
+            this.error.hasSubscribers;
+    }
+
+    subscribe(handlers: any): void {
+        if (handlers.start) this.start.subscribe(handlers.start);
+        if (handlers.end) this.end.subscribe(handlers.end);
+        if (handlers.asyncStart) this.asyncStart.subscribe(handlers.asyncStart);
+        if (handlers.asyncEnd) this.asyncEnd.subscribe(handlers.asyncEnd);
+        if (handlers.error) this.error.subscribe(handlers.error);
+    }
+
+    unsubscribe(handlers: any): void {
+        if (handlers.start) this.start.unsubscribe(handlers.start);
+        if (handlers.end) this.end.unsubscribe(handlers.end);
+        if (handlers.asyncStart) this.asyncStart.unsubscribe(handlers.asyncStart);
+        if (handlers.asyncEnd) this.asyncEnd.unsubscribe(handlers.asyncEnd);
+        if (handlers.error) this.error.unsubscribe(handlers.error);
+    }
+
+    traceSync(fn: any, context?: any, thisArg?: any, ...args: any[]): any {
+        const ctx: any = context != null ? context : {};
+        this.start.publish(ctx);
+        try {
+            const result = fn.apply(thisArg, args);
+            ctx.result = result;
+            return result;
+        } catch (err) {
+            ctx.error = err;
+            this.error.publish(ctx);
+            throw err;
+        } finally {
+            this.end.publish(ctx);
+        }
+    }
+
+    async tracePromise(fn: any, context?: any, thisArg?: any, ...args: any[]): Promise<any> {
+        const ctx: any = context != null ? context : {};
+        this.start.publish(ctx);
+        try {
+            const promise = fn.apply(thisArg, args);
+            this.asyncStart.publish(ctx);
+            const result = await promise;
+            ctx.result = result;
+            return result;
+        } catch (err) {
+            ctx.error = err;
+            this.error.publish(ctx);
+            throw err;
+        } finally {
+            this.asyncEnd.publish(ctx);
+            this.end.publish(ctx);
+        }
+    }
+
+    traceCallback(fn: any, position?: number, context?: any, thisArg?: any, ...args: any[]): any {
+        const ctx: any = context != null ? context : {};
+        const callbackIndex = position != null ? position : -1;
+        if (callbackIndex >= 0 && callbackIndex < args.length) {
+            const original = args[callbackIndex];
+            args[callbackIndex] = (...callbackArgs: any[]) => {
+                this.asyncStart.publish(ctx);
+                try {
+                    return original.apply(thisArg, callbackArgs);
+                } finally {
+                    this.asyncEnd.publish(ctx);
+                    this.end.publish(ctx);
+                }
+            };
+        }
+        this.start.publish(ctx);
+        try {
+            return fn.apply(thisArg, args);
+        } catch (err) {
+            ctx.error = err;
+            this.error.publish(ctx);
+            this.end.publish(ctx);
+            throw err;
+        }
+    }
+}
+
+export function tracingChannel(nameOrChannels: any): TracingChannel {
+    return new TracingChannel(nameOrChannels);
+}
+
+export default {
+    Channel,
+    TracingChannel,
+    channel,
+    hasSubscribers,
+    subscribe,
+    unsubscribe,
+    tracingChannel,
+};

--- a/src/SharpTS/stdlib/node/module.ts
+++ b/src/SharpTS/stdlib/node/module.ts
@@ -1,0 +1,83 @@
+// Node.js 'module' compatibility surface.
+// Target: Node.js 24.15.0. The catalog intentionally describes modules that
+// SharpTS can actually resolve, so packages can use isBuiltin() as a runtime
+// capability probe instead of receiving false positives for unimplemented
+// Node modules.
+
+import { createRequire as createHostRequire } from 'primitive:module';
+
+export const builtinModules: string[] = [
+    'assert',
+    'assert/strict',
+    'async_hooks',
+    'buffer',
+    'child_process',
+    'cluster',
+    'console',
+    'crypto',
+    'dgram',
+    'diagnostics_channel',
+    'dns',
+    'dns/promises',
+    'events',
+    'fs',
+    'fs/promises',
+    'http',
+    'https',
+    'module',
+    'net',
+    'os',
+    'path',
+    'path/posix',
+    'path/win32',
+    'perf_hooks',
+    'process',
+    'querystring',
+    'readline',
+    'readline/promises',
+    'stream',
+    'stream/consumers',
+    'stream/promises',
+    'stream/web',
+    'string_decoder',
+    'timers',
+    'timers/promises',
+    'tls',
+    'tty',
+    'url',
+    'util',
+    'util/types',
+    'v8',
+    'vm',
+    'worker_threads',
+    'zlib',
+];
+
+export function isBuiltin(moduleName: string): boolean {
+    if (typeof moduleName !== 'string') return false;
+    const bare = moduleName.startsWith('node:') ? moduleName.slice(5) : moduleName;
+    return builtinModules.includes(bare);
+}
+
+// SharpTS materializes a single ESM namespace for embedded built-ins rather
+// than maintaining a separate mutable CommonJS export table. There are no
+// secondary live bindings to synchronize, so this operation is intentionally
+// a no-op.
+export function syncBuiltinESMExports(): void {}
+
+/**
+ * Creates a CommonJS require function relative to a file path or file URL.
+ * Compiled mode supports the canonical `const require = createRequire(...);`
+ * pattern with string-literal require specifiers; interpreter mode also honors
+ * the supplied base path dynamically.
+ */
+export function createRequire(filename: string | URL): any {
+    return createHostRequire(filename);
+}
+
+export default {
+    builtinModules,
+    isBuiltin,
+    syncBuiltinESMExports,
+    createRequire,
+};

--- a/src/SharpTS/stdlib/node/path/posix.ts
+++ b/src/SharpTS/stdlib/node/path/posix.ts
@@ -1,0 +1,20 @@
+// node:path/posix aliases the existing path.posix implementation.
+
+import { posix as pathPosix, win32 as pathWin32 } from 'path';
+
+export const resolve = pathPosix.resolve;
+export const normalize = pathPosix.normalize;
+export const isAbsolute = pathPosix.isAbsolute;
+export const join = pathPosix.join;
+export const relative = pathPosix.relative;
+export const dirname = pathPosix.dirname;
+export const basename = pathPosix.basename;
+export const extname = pathPosix.extname;
+export const format = pathPosix.format;
+export const parse = pathPosix.parse;
+export const sep = pathPosix.sep;
+export const delimiter = pathPosix.delimiter;
+export const posix = pathPosix;
+export const win32 = pathWin32;
+
+export default pathPosix;

--- a/src/SharpTS/stdlib/node/path/win32.ts
+++ b/src/SharpTS/stdlib/node/path/win32.ts
@@ -1,0 +1,20 @@
+// node:path/win32 aliases the existing path.win32 implementation.
+
+import { posix as pathPosix, win32 as pathWin32 } from 'path';
+
+export const resolve = pathWin32.resolve;
+export const normalize = pathWin32.normalize;
+export const isAbsolute = pathWin32.isAbsolute;
+export const join = pathWin32.join;
+export const relative = pathWin32.relative;
+export const dirname = pathWin32.dirname;
+export const basename = pathWin32.basename;
+export const extname = pathWin32.extname;
+export const format = pathWin32.format;
+export const parse = pathWin32.parse;
+export const sep = pathWin32.sep;
+export const delimiter = pathWin32.delimiter;
+export const posix = pathPosix;
+export const win32 = pathWin32;
+
+export default pathWin32;

--- a/src/SharpTS/stdlib/node/readline/promises.ts
+++ b/src/SharpTS/stdlib/node/readline/promises.ts
@@ -1,0 +1,105 @@
+// Node.js 'readline/promises' module — SharpTS embedded stdlib implementation.
+// Target: Node.js 24.15.0. The host readline primitive remains synchronous,
+// while this facade exposes the Promise-based Node API shape.
+
+import { createInterface as createHostInterface } from 'primitive:readline';
+
+export class Interface {
+    private _inner: any;
+    private _closed: boolean;
+
+    constructor(options?: any) {
+        this._inner = createHostInterface(options);
+        this._closed = false;
+    }
+
+    question(query: string, options?: any): Promise<string> {
+        if (this._closed) {
+            return Promise.reject(new Error('readline was closed'));
+        }
+
+        const signal = options != null ? options.signal : undefined;
+        if (signal != null && signal.aborted) {
+            return Promise.reject(signal.reason != null ? signal.reason : new Error('The operation was aborted'));
+        }
+
+        return new Promise((resolve: any, reject: any) => {
+            let settled = false;
+            const onAbort = () => {
+                if (settled) return;
+                settled = true;
+                reject(signal.reason != null ? signal.reason : new Error('The operation was aborted'));
+            };
+
+            if (signal != null) {
+                try {
+                    signal.addEventListener('abort', onAbort, { once: true });
+                } catch (e) {
+                    signal.onabort = onAbort;
+                }
+            }
+
+            this._inner.question(query, (answer: string) => {
+                if (settled) return;
+                settled = true;
+                resolve(answer);
+            });
+        });
+    }
+
+    close(): Interface {
+        this._closed = true;
+        this._inner.close();
+        return this;
+    }
+
+    prompt(preserveCursor?: boolean): void {
+        this._inner.prompt(preserveCursor);
+    }
+
+    pause(): Interface {
+        this._inner.pause();
+        return this;
+    }
+
+    resume(): Interface {
+        this._inner.resume();
+        return this;
+    }
+
+    write(data: string): void {
+        this._inner.write(data);
+    }
+
+    setPrompt(prompt: string): void {
+        this._inner.setPrompt(prompt);
+    }
+
+    getPrompt(): string {
+        return this._inner.getPrompt();
+    }
+
+    on(eventName: string, listener: any): Interface {
+        this._inner.on(eventName, listener);
+        return this;
+    }
+
+    once(eventName: string, listener: any): Interface {
+        this._inner.once(eventName, listener);
+        return this;
+    }
+
+    off(eventName: string, listener: any): Interface {
+        this._inner.off(eventName, listener);
+        return this;
+    }
+}
+
+export function createInterface(options?: any): Interface {
+    return new Interface(options);
+}
+
+// Node also exports a Readline class for transactional terminal updates. The
+// callback facade has no cursor-level host primitive yet, so Phase 1 keeps the
+// supported promise surface intentionally limited to Interface/createInterface.
+export default { Interface, createInterface };

--- a/src/SharpTS/stdlib/node/stream/consumers.ts
+++ b/src/SharpTS/stdlib/node/stream/consumers.ts
@@ -1,0 +1,132 @@
+// Node.js 'stream/consumers' module — SharpTS embedded stdlib implementation.
+// Target: Node.js 24.15.0. Supports Node Readable async iterators and WHATWG
+// ReadableStreams through the same conversion helpers.
+
+import { Buffer } from 'buffer';
+import { bufferToArrayBuffer, drainQueuedWebStream } from 'primitive:stream/consumers';
+
+function readIteratorChunks(iterator: any, chunks: any[]): any {
+    return iterator.next().then((item: any) => {
+        if (item.done) return chunks;
+        chunks.push(item.value);
+        return readIteratorChunks(iterator, chunks);
+    });
+}
+
+function readChunks(stream: any): any {
+    if (stream == null) {
+        return Promise.reject(new TypeError('The stream argument is required'));
+    }
+
+    const chunks: any[] = [];
+    // Check WHATWG streams first. The emitted implementation has an internal
+    // Read method visible to dynamic dispatch; treating that as Node's read()
+    // would repeatedly read promises instead of draining queued chunks.
+    if (typeof stream.getReader === 'function') {
+        return Promise.resolve(drainQueuedWebStream(stream));
+    }
+
+    // SharpTS Node Readables expose their queued data synchronously through
+    // read(). Once push(null) has closed the stream this drains without an
+    // event-loop turn, while the public consumer still resolves a Promise.
+    if (typeof stream.read === 'function') {
+        let chunk = stream.read();
+        while (chunk !== null) {
+            chunks.push(chunk);
+            chunk = stream.read();
+        }
+        return Promise.resolve(chunks);
+    }
+
+    if (stream[Symbol.asyncIterator] != null) {
+        return readIteratorChunks(stream[Symbol.asyncIterator](), chunks);
+    }
+
+    return Promise.reject(new TypeError('The value must be a readable stream'));
+}
+
+function chunkToBuffer(chunk: any): any {
+    if (Buffer.isBuffer(chunk)) return chunk;
+    if (typeof chunk === 'string') return Buffer.from(chunk, 'utf8');
+    if (chunk instanceof ArrayBuffer) return Buffer.from(chunk);
+    if (ArrayBuffer.isView(chunk)) return Buffer.from(chunk);
+    if (Array.isArray(chunk)) return Buffer.from(chunk);
+    return Buffer.from(String(chunk), 'utf8');
+}
+
+export function buffer(stream: any): Promise<any> {
+    return readChunks(stream).then((chunks: any[]) => {
+        return Buffer.concat(chunks.map((chunk: any) => chunkToBuffer(chunk)));
+    });
+}
+
+/** Node 24.14+: consumes a stream into a Uint8Array. */
+export async function bytes(stream: any): Promise<any> {
+    // Buffer is Node's Uint8Array subclass. SharpTS uses its dedicated Buffer
+    // backing type, so returning it preserves the byte-view behavior without a
+    // redundant copy.
+    return await buffer(stream);
+}
+
+export function arrayBuffer(stream: any): Promise<ArrayBuffer> {
+    return bytes(stream).then((value: any) => bufferToArrayBuffer(value));
+}
+
+export async function text(stream: any): Promise<string> {
+    const value = await buffer(stream);
+    return value.toString('utf8');
+}
+
+export async function json(stream: any): Promise<any> {
+    return JSON.parse(await text(stream));
+}
+
+// The global Blob constructor is intentionally interpreter-only today. Keep
+// stream/consumers available in standalone compiled programs with a small
+// Blob-compatible value implemented entirely in the embedded stdlib.
+class ConsumerBlob {
+    private _value: any;
+    private _type: string;
+
+    constructor(value: any, type: string = '') {
+        this._value = value;
+        this._type = type.toLowerCase();
+    }
+
+    get size(): number { return this._value.length; }
+    get type(): string { return this._type; }
+
+    arrayBuffer(): Promise<ArrayBuffer> {
+        return Promise.resolve(bufferToArrayBuffer(this._value));
+    }
+
+    bytes(): Promise<Uint8Array> {
+        // Buffer is Node's Uint8Array subclass and therefore satisfies the Blob
+        // bytes() contract while preserving the native SharpTS backing value.
+        return Promise.resolve(this._value as unknown as Uint8Array);
+    }
+
+    text(): Promise<string> {
+        return Promise.resolve(this._value.toString('utf8'));
+    }
+
+    slice(start: number = 0, end: number = this._value.length, contentType: string = ''): any {
+        return new ConsumerBlob(this._value.slice(start, end), contentType);
+    }
+
+    stream(): ReadableStream {
+        const value = this._value;
+        return new ReadableStream({
+            start(controller: any) {
+                controller.enqueue(value);
+                controller.close();
+            }
+        });
+    }
+}
+
+export function blob(stream: any): Promise<Blob> {
+    return bytes(stream).then((value: any) => new ConsumerBlob(value) as unknown as Blob);
+}
+
+export default { arrayBuffer, blob, buffer, bytes, json, text };

--- a/src/SharpTS/stdlib/node/util/types.ts
+++ b/src/SharpTS/stdlib/node/util/types.ts
@@ -1,0 +1,49 @@
+// node:util/types aliases the maintained util.types predicate namespace.
+
+import { types } from 'util';
+
+export const isArray = types.isArray;
+export const isDate = types.isDate;
+export const isFunction = types.isFunction;
+export const isNull = types.isNull;
+export const isUndefined = types.isUndefined;
+export const isPromise = types.isPromise;
+export const isRegExp = types.isRegExp;
+export const isMap = types.isMap;
+export const isSet = types.isSet;
+export const isTypedArray = types.isTypedArray;
+export const isNativeError = types.isNativeError;
+export const isBoxedPrimitive = types.isBoxedPrimitive;
+export const isWeakMap = types.isWeakMap;
+export const isWeakSet = types.isWeakSet;
+export const isArrayBuffer = types.isArrayBuffer;
+export const isSharedArrayBuffer = types.isSharedArrayBuffer;
+export const isAnyArrayBuffer = types.isAnyArrayBuffer;
+export const isDataView = types.isDataView;
+export const isArrayBufferView = types.isArrayBufferView;
+export const isBigIntObject = types.isBigIntObject;
+export const isBooleanObject = types.isBooleanObject;
+export const isNumberObject = types.isNumberObject;
+export const isStringObject = types.isStringObject;
+export const isSymbolObject = types.isSymbolObject;
+export const isProxy = types.isProxy;
+export const isExternal = types.isExternal;
+export const isModuleNamespaceObject = types.isModuleNamespaceObject;
+export const isKeyObject = types.isKeyObject;
+export const isCryptoKey = types.isCryptoKey;
+export const isGeneratorFunction = types.isGeneratorFunction;
+export const isAsyncFunction = types.isAsyncFunction;
+export const isGeneratorObject = types.isGeneratorObject;
+export const isInt8Array = types.isInt8Array;
+export const isUint8Array = types.isUint8Array;
+export const isUint8ClampedArray = types.isUint8ClampedArray;
+export const isInt16Array = types.isInt16Array;
+export const isUint16Array = types.isUint16Array;
+export const isInt32Array = types.isInt32Array;
+export const isUint32Array = types.isUint32Array;
+export const isFloat32Array = types.isFloat32Array;
+export const isFloat64Array = types.isFloat64Array;
+export const isBigInt64Array = types.isBigInt64Array;
+export const isBigUint64Array = types.isBigUint64Array;
+
+export default types;

--- a/src/SharpTS/stdlib/node/v8.ts
+++ b/src/SharpTS/stdlib/node/v8.ts
@@ -1,0 +1,196 @@
+// Node.js 'v8' module — SharpTS embedded stdlib implementation.
+// Target: Node.js 24.15.0. The serialization wire format is SharpTS-private;
+// it is intended for serialize()/deserialize() round trips, not interchange
+// with Node's V8 binary format.
+
+import { Buffer } from 'buffer';
+import { memoryUsage } from 'process';
+import { totalmem } from 'os';
+
+function cloneError(message: string): Error {
+    const error = new Error(message);
+    error.name = 'DataCloneError';
+    return error;
+}
+
+function encodeGraph(root: any): any {
+    const seen = new Map<any, number>();
+    const nodes: any[] = [];
+
+    const encode = (value: any): any => {
+        if (value === undefined) return { $type: 'undefined' };
+        if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+        if (typeof value === 'number') {
+            if (value !== value) return { $type: 'number', value: 'NaN' };
+            if (value === Infinity) return { $type: 'number', value: 'Infinity' };
+            if (value === -Infinity) return { $type: 'number', value: '-Infinity' };
+            if (value === 0 && 1 / value === -Infinity) return { $type: 'number', value: '-0' };
+            return value;
+        }
+        if (typeof value === 'bigint') return { $type: 'bigint', value: String(value) };
+        if (typeof value === 'function' || typeof value === 'symbol') {
+            throw cloneError('The value could not be cloned');
+        }
+
+        const previous = seen.get(value);
+        if (previous !== undefined) return { $ref: previous };
+
+        const id = nodes.length;
+        seen.set(value, id);
+        nodes.push(null);
+
+        if (Buffer.isBuffer(value)) {
+            nodes[id] = { kind: 'buffer', value: value.toString('base64') };
+        } else if (value instanceof Date) {
+            nodes[id] = { kind: 'date', value: value.getTime() };
+        } else if (value instanceof RegExp) {
+            nodes[id] = { kind: 'regexp', source: value.source, flags: value.flags };
+        } else if (value instanceof Map) {
+            const entries: any[] = [];
+            for (const entry of value) entries.push([encode(entry[0]), encode(entry[1])]);
+            nodes[id] = { kind: 'map', entries };
+        } else if (value instanceof Set) {
+            const values: any[] = [];
+            for (const item of value) values.push(encode(item));
+            nodes[id] = { kind: 'set', values };
+        } else if (Array.isArray(value)) {
+            const items: any[] = [];
+            for (let i = 0; i < value.length; i++) items.push(encode(value[i]));
+            nodes[id] = { kind: 'array', items };
+        } else if (value instanceof ArrayBuffer || ArrayBuffer.isView(value)) {
+            nodes[id] = { kind: 'bytes', value: Buffer.from(value).toString('base64') };
+        } else {
+            const properties: any[] = [];
+            const keys = Object.keys(value);
+            for (let i = 0; i < keys.length; i++) {
+                properties.push([keys[i], encode(value[keys[i]])]);
+            }
+            nodes[id] = { kind: 'object', properties };
+        }
+
+        return { $ref: id };
+    };
+
+    return { version: 1, root: encode(root), nodes };
+}
+
+function decodeGraph(graph: any): any {
+    if (graph == null || graph.version !== 1 || !Array.isArray(graph.nodes)) {
+        throw new Error('Unable to deserialize cloned data');
+    }
+
+    const nodes = graph.nodes;
+    const values: any[] = [];
+
+    for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
+        if (node.kind === 'array') values.push([]);
+        else if (node.kind === 'object') values.push({});
+        else if (node.kind === 'map') values.push(new Map());
+        else if (node.kind === 'set') values.push(new Set());
+        else if (node.kind === 'date') values.push(new Date(node.value));
+        else if (node.kind === 'regexp') values.push(new RegExp(node.source, node.flags));
+        else if (node.kind === 'buffer') values.push(Buffer.from(node.value, 'base64'));
+        else if (node.kind === 'bytes') {
+            const decoded = Buffer.from(node.value, 'base64');
+            const bytes = new Uint8Array(decoded.length);
+            for (let j = 0; j < decoded.length; j++) bytes[j] = decoded[j];
+            values.push(bytes);
+        } else {
+            throw new Error('Unknown serialized value kind');
+        }
+    }
+
+    const decode = (value: any): any => {
+        if (value == null || typeof value !== 'object') return value;
+        if (value.$ref !== undefined) return values[value.$ref];
+        if (value.$type === 'undefined') return undefined;
+        if (value.$type === 'bigint') return BigInt(value.value);
+        if (value.$type === 'number') {
+            if (value.value === 'NaN') return NaN;
+            if (value.value === 'Infinity') return Infinity;
+            if (value.value === '-Infinity') return -Infinity;
+            return -0;
+        }
+        return value;
+    };
+
+    for (let i = 0; i < nodes.length; i++) {
+        const node = nodes[i];
+        const target = values[i];
+        if (node.kind === 'array') {
+            for (let j = 0; j < node.items.length; j++) target.push(decode(node.items[j]));
+        } else if (node.kind === 'object') {
+            for (let j = 0; j < node.properties.length; j++) {
+                target[node.properties[j][0]] = decode(node.properties[j][1]);
+            }
+        } else if (node.kind === 'map') {
+            for (let j = 0; j < node.entries.length; j++) {
+                target.set(decode(node.entries[j][0]), decode(node.entries[j][1]));
+            }
+        } else if (node.kind === 'set') {
+            for (let j = 0; j < node.values.length; j++) target.add(decode(node.values[j]));
+        }
+    }
+
+    return decode(graph.root);
+}
+
+export function serialize(value: any): any {
+    return Buffer.from(JSON.stringify(encodeGraph(value)), 'utf8');
+}
+
+export function deserialize(buffer: any): any {
+    const input = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
+    return decodeGraph(JSON.parse(input.toString('utf8')));
+}
+
+export function getHeapStatistics(): any {
+    const usage: any = memoryUsage();
+    const heapTotal = usage.heapTotal || 0;
+    const heapUsed = usage.heapUsed || 0;
+    return {
+        total_heap_size: heapTotal,
+        total_heap_size_executable: 0,
+        total_physical_size: usage.rss || heapTotal,
+        total_available_size: totalmem(),
+        used_heap_size: heapUsed,
+        heap_size_limit: totalmem(),
+        malloced_memory: usage.external || 0,
+        peak_malloced_memory: usage.external || 0,
+        does_zap_garbage: 0,
+        number_of_native_contexts: 1,
+        number_of_detached_contexts: 0,
+        total_global_handles_size: 0,
+        used_global_handles_size: 0,
+        external_memory: usage.external || 0,
+    };
+}
+
+export function getHeapSpaceStatistics(): any[] {
+    const usage: any = memoryUsage();
+    return [{
+        space_name: 'managed_heap',
+        space_size: usage.heapTotal || 0,
+        space_used_size: usage.heapUsed || 0,
+        space_available_size: Math.max(0, (usage.heapTotal || 0) - (usage.heapUsed || 0)),
+        physical_space_size: usage.rss || usage.heapTotal || 0,
+    }];
+}
+
+/** .NET has no V8 flag parser; accepted for compatibility and intentionally ignored. */
+export function setFlagsFromString(_flags: string): void {}
+
+/** Stable tag for SharpTS's private serializer format, not V8 cached bytecode. */
+export function cachedDataVersionTag(): number {
+    return 0x53545301;
+}
+
+export default {
+    serialize,
+    deserialize,
+    getHeapStatistics,
+    getHeapSpaceStatistics,
+    setFlagsFromString,
+    cachedDataVersionTag,
+};

--- a/tests/SharpTS.Tests/SharedTests/BuiltInModules/NodeBreadthPhaseOneTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/BuiltInModules/NodeBreadthPhaseOneTests.cs
@@ -1,0 +1,275 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests.BuiltInModules;
+
+/// <summary>
+/// Cross-mode coverage for the breadth entry points added by issue #1282,
+/// Phase 1. Deeper module-specific tests remain beside their parent modules.
+/// </summary>
+public class NodeBreadthPhaseOneTests
+{
+    [Theory, ModeData]
+    public void Module_CatalogAndBuiltinLookup(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { builtinModules, isBuiltin, syncBuiltinESMExports } from 'node:module';
+                console.log(builtinModules.length);
+                console.log(isBuiltin('fs'), isBuiltin('node:fs'), isBuiltin('diagnostics_channel'));
+                console.log(isBuiltin('not-a-node-module'));
+                console.log(new Set(builtinModules).size === builtinModules.length);
+                syncBuiltinESMExports();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("44\ntrue true true\nfalse\ntrue\n", output);
+    }
+
+    [Theory, ModeData]
+    public void Module_CreateRequire_LoadsRelativeCommonJs(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { createRequire } from 'module';
+                const require = createRequire(import.meta.url);
+                const dependency = require('./dependency.cjs');
+                console.log(dependency.answer);
+                """,
+            ["dependency.cjs"] = """
+                module.exports = { answer: 42 };
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("42\n", output);
+    }
+
+    [Theory, ModeData]
+    public void AliasModules_ExposeParentNamespaces(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import strictAssert, { equal, deepEqual } from 'node:assert/strict';
+                import posix from 'path/posix';
+                import win32 from 'node:path/win32';
+                import types, { isMap } from 'util/types';
+                import { log } from 'node:console';
+
+                strictAssert(true);
+                equal(1, 1);
+                deepEqual({ value: 1 }, { value: 1 });
+                console.log(posix.join('a', 'b'));
+                console.log(win32.join('a', 'b'));
+                console.log(isMap(new Map()), types.isSet(new Set()));
+                log('console-module');
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("a/b\na\\b\ntrue true\nconsole-module\n", output);
+    }
+
+    [Theory, ModeData]
+    public void AssertStrict_CommonJsExportIsCallable(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.cjs"] = """
+                const assert = require('assert/strict');
+                assert(true);
+                assert.equal(1, 1);
+                console.log(typeof assert.strictEqual === 'function');
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.cjs", mode);
+        Assert.Equal("true\n", output);
+    }
+
+    [Theory, ModeData]
+    public void DiagnosticsChannel_PublishesSynchronouslyAndUsesSingletons(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { channel, hasSubscribers, subscribe, tracingChannel, unsubscribe } from 'diagnostics_channel';
+                const seen: string[] = [];
+                const listener = (message: any, name: any) => seen.push(name + ':' + message.value);
+                subscribe('phase-one', listener);
+                console.log(channel('phase-one') === channel('phase-one'));
+                console.log(hasSubscribers('phase-one'));
+                channel('phase-one').publish({ value: 42 });
+                console.log(seen.join(','));
+                console.log(unsubscribe('phase-one', listener), hasSubscribers('phase-one'));
+
+                const trace = tracingChannel('phase-one-trace');
+                const traceEvents: string[] = [];
+                trace.subscribe({
+                    start: () => traceEvents.push('start'),
+                    end: () => traceEvents.push('end')
+                });
+                const traced = trace.traceSync((value: number) => value * 2, {}, undefined, 3);
+                console.log(traced, traceEvents.join(','));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\ntrue\nphase-one:42\ntrue false\n6 start,end\n", output);
+    }
+
+    [Theory, ModeData]
+    public void ReadlinePromises_ExposesPromiseQuestion(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { createInterface } from 'readline/promises';
+                const rl = createInterface();
+                console.log(typeof rl.question === 'function');
+                console.log(typeof rl.close === 'function');
+                rl.close();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\ntrue\n", output);
+    }
+
+    [Theory, ModeData]
+    public void StreamConsumers_ConsumeNodeReadable(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { text, json, bytes } from 'node:stream/consumers';
+                import { Readable } from 'stream';
+
+                const first = new Readable();
+                first.push('hello');
+                first.push(null);
+                const second = new Readable();
+                second.push('{"ok":true}');
+                second.push(null);
+                const third = new Readable();
+                third.push('A');
+                third.push(null);
+
+                async function consumeText(stream: any, consumer: any) {
+                    console.log(await consumer(stream));
+                }
+                async function consumeJson(stream: any, consumer: any) {
+                    console.log((await consumer(stream)).ok);
+                }
+                async function consumeBytes(stream: any, consumer: any) {
+                    const value = await consumer(stream);
+                    console.log(value.length, value.toString());
+                }
+                consumeText(first, text);
+                consumeJson(second, json);
+                consumeBytes(third, bytes);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("hello\ntrue\n1 A\n", output);
+    }
+
+    [Theory, ModeData]
+    public void StreamConsumers_ConsumeQueuedWebReadableStream(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { text, bytes } from 'stream/consumers';
+
+                const first = new ReadableStream({
+                    start(controller) { controller.enqueue('web'); controller.close(); }
+                });
+                const second = new ReadableStream({
+                    start(controller) { controller.enqueue('B'); controller.close(); }
+                });
+
+                async function consumeText(stream: any, consumer: any) {
+                    console.log(await consumer(stream));
+                }
+                async function consumeBytes(stream: any, consumer: any) {
+                    const value = await consumer(stream);
+                    console.log(value.length, value.toString());
+                }
+                consumeText(first, text);
+                consumeBytes(second, bytes);
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("web\n1 B\n", output);
+    }
+
+    [Theory, ModeData]
+    public void StreamConsumers_ExposeBinaryConsumerShapes(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { arrayBuffer, blob, buffer } from 'stream/consumers';
+                import { Readable } from 'stream';
+
+                function readable(value: string) {
+                    const stream = new Readable();
+                    stream.push(value);
+                    stream.push(null);
+                    return stream;
+                }
+
+                async function consumeBuffer() {
+                    const value = await buffer(readable('buffer'));
+                    console.log(value.toString());
+                }
+                async function consumeBlob() {
+                    const value = await blob(readable('blob'));
+                    console.log(value.size, value.type);
+                }
+                async function consumeArrayBuffer() {
+                    const value = await arrayBuffer(readable('A'));
+                    const view = new Uint8Array(value);
+                    console.log(view.length, view[0]);
+                }
+                consumeBuffer();
+                consumeBlob();
+                consumeArrayBuffer();
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("buffer\n4 \n1 65\n", output);
+    }
+
+    [Theory, ModeData]
+    public void V8_SerializerRoundTripsReferencesAndCollections(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { serialize, deserialize, getHeapStatistics, getHeapSpaceStatistics, setFlagsFromString } from 'v8';
+                import { Buffer } from 'buffer';
+
+                const source: any = { value: 7, map: new Map([['key', 9]]), bytes: Buffer.from('ok') };
+                source.self = source;
+                const restored: any = deserialize(serialize(source));
+                console.log(restored.value, restored.self === restored);
+                console.log(restored.map.get('key'), restored.bytes.toString());
+                console.log(typeof getHeapStatistics().used_heap_size === 'number');
+                console.log(Array.isArray(getHeapSpaceStatistics()));
+                setFlagsFromString('--expose-gc');
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("7 true\n9 ok\ntrue\ntrue\n", output);
+    }
+}

--- a/tests/SharpTS.Tests/SharedTests/ImportMetaTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/ImportMetaTests.cs
@@ -85,6 +85,22 @@ public class ImportMetaTests
     }
 
     [Theory, ModeData]
+    public void ImportMeta_ModuleUrlUsesCanonicalFileUri(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                const url = import.meta.url;
+                console.log(url.startsWith('file:///'));
+                console.log(!url.startsWith('file:////'));
+                """
+        };
+
+        var output = TestHarness.RunModules(files, "main.ts", mode);
+        Assert.Equal("true\ntrue\n", output);
+    }
+
+    [Theory, ModeData]
     public void ImportMeta_UrlStartsWithFile_InSingleFileMode(ExecutionMode mode)
     {
         var source = """


### PR DESCRIPTION
## Summary

- expand the maintained Node built-in catalog from 34 to 44 specifiers, including strict assertion, path, util, and console aliases
- implement node:module with builtin discovery and scoped createRequire, diagnostics_channel, readline/promises, stream/consumers, and a bounded v8 compatibility surface
- add interpreter and standalone-compiled runtime adapters, dual-mode regression coverage, and user-facing documentation

## Compatibility boundaries

- compiled createRequire follows strict AOT: bind it as require and use string-literal specifiers
- stream consumers drain data already queued in maintained Node or WHATWG streams; waiting for future pull chunks remains follow-up work
- v8 serialization uses a SharpTS-private format and heap statistics are managed-runtime approximations

## Validation

- dotnet build SharpTS.sln -c Release: passed with zero warnings/errors and IL verification
- NodeBreadthPhaseOneTests: 20 passed in interpreter and compiled modes
- CommonJS tests: 50 passed
- Primitive module gating: 5 passed
- Test262 harness: 3,219 passed with 4 diagnostic skips; vendored corpus was not initialized in this worktree
- TypeScript conformance harness: 65 passed
- broader built-in suite: 2,472 passed; four existing host-environment failures remained in native I/O, child-process IPC, and cluster tests
- git diff --check: clean

Part of #1282.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Node.js built-in module support from 34 to 44 maintained modules.
  * Added compatibility for module loading, strict assertions, diagnostics channels, promise-based readline, stream consumers, path variants, type utilities, console APIs, and V8 serialization.
  * Added `createRequire()` support for relative CommonJS modules and stream-to-buffer conversions.

* **Documentation**
  * Expanded the Node.js built-in modules reference and updated support status and limitations.

* **Bug Fixes**
  * Corrected callable CommonJS assertion exports.
  * Fixed `import.meta.url` to produce canonical file URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->