### PR TITLE
Optimize stable numeric Map iteration

### DIFF
--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -1421,8 +1421,15 @@ public partial class ILEmitter
             // The analyzer proved that the receiver is a fresh, non-escaping
             // Map<number, number> and that the entry binding is observed only
             // through literal [0]/[1] reads.
-            EmitBoxIfNeeded(f.Iterable);
-            var stableMapIterable = IL.DeclareLocal(_ctx.Types.Object);
+            var promotedMap = f.Iterable is Expr.Variable stableMapVariable
+                ? _ctx.TryGetPromotedNumericMapLocal(stableMapVariable.Name.Lexeme)
+                : null;
+            if (promotedMap is null)
+                EmitBoxIfNeeded(f.Iterable);
+            var stableMapIterable = IL.DeclareLocal(
+                promotedMap is null
+                    ? _ctx.Types.Object
+                    : _ctx.Types.DictionaryDoubleDouble);
             IL.Emit(OpCodes.Stloc, stableMapIterable);
             EmitStableNumericMapIteration(f, stableMapIterable, labelNames);
             return;
@@ -1721,9 +1728,10 @@ public partial class ILEmitter
 
     /// <summary>
     /// Direct backing-dictionary loop for the non-escaping numeric Map shape
-    /// marked by <see cref="StableMapIterationAnalyzer"/>. Key/value objects are
-    /// held in locals and exposed to literal entry-index reads by
-    /// <c>TryEmitStableMapEntryIndex</c>; no JavaScript entry array is created.
+    /// marked by <see cref="StableMapIterationAnalyzer"/>. A promoted local uses
+    /// native <c>double</c> keys/values; the boxed fallback unboxes its entries.
+    /// Both representations expose typed locals to literal entry-index reads via
+    /// <c>TryEmitStableMapEntryIndex</c>, so no JavaScript entry array is created.
     /// </summary>
     private void EmitStableNumericMapIteration(
         Stmt.ForOf f,
@@ -1731,12 +1739,18 @@ public partial class ILEmitter
         IReadOnlyList<string>? labelNames)
     {
         var builder = _ctx.ILBuilder;
-        var dictType = _ctx.Types.DictionaryObjectObject;
+        bool promoted = iterableLocal.LocalType == _ctx.Types.DictionaryDoubleDouble;
+        var dictType = promoted
+            ? _ctx.Types.DictionaryDoubleDouble
+            : _ctx.Types.DictionaryObjectObject;
         var kvpType = EmitGenerics.MakeGenericType(
-            _ctx.Types.KeyValuePairOpen, _ctx.Types.Object, _ctx.Types.Object);
+            _ctx.Types.KeyValuePairOpen,
+            promoted ? _ctx.Types.Double : _ctx.Types.Object,
+            promoted ? _ctx.Types.Double : _ctx.Types.Object);
         var enumeratorType = EmitGenerics.MakeGenericType(
             typeof(Dictionary<,>.Enumerator).GetGenericTypeDefinition(),
-            _ctx.Types.Object, _ctx.Types.Object);
+            promoted ? _ctx.Types.Double : _ctx.Types.Object,
+            promoted ? _ctx.Types.Double : _ctx.Types.Object);
 
         var startLabel = builder.DefineLabel("forof_stable_map_start");
         var endLabel = builder.DefineLabel("forof_stable_map_end");
@@ -1744,7 +1758,8 @@ public partial class ILEmitter
 
         var dictLocal = IL.DeclareLocal(dictType);
         IL.Emit(OpCodes.Ldloc, iterableLocal);
-        IL.Emit(OpCodes.Castclass, dictType);
+        if (iterableLocal.LocalType != dictType)
+            IL.Emit(OpCodes.Castclass, dictType);
         IL.Emit(OpCodes.Stloc, dictLocal);
 
         var enumeratorLocal = IL.DeclareLocal(enumeratorType);
@@ -1770,12 +1785,14 @@ public partial class ILEmitter
 
         IL.Emit(OpCodes.Ldloca, currentLocal);
         IL.Emit(OpCodes.Call, _ctx.Types.GetProperty(kvpType, "Key")!.GetGetMethod()!);
-        IL.Emit(OpCodes.Unbox_Any, _ctx.Types.Double);
+        if (!promoted)
+            IL.Emit(OpCodes.Unbox_Any, _ctx.Types.Double);
         IL.Emit(OpCodes.Stloc, keyLocal);
 
         IL.Emit(OpCodes.Ldloca, currentLocal);
         IL.Emit(OpCodes.Call, _ctx.Types.GetProperty(kvpType, "Value")!.GetGetMethod()!);
-        IL.Emit(OpCodes.Unbox_Any, _ctx.Types.Double);
+        if (!promoted)
+            IL.Emit(OpCodes.Unbox_Any, _ctx.Types.Double);
         IL.Emit(OpCodes.Stloc, valueLocal);
 
         _stableMapEntryBindings.Push((f.Variable.Lexeme, keyLocal, valueLocal));

--- a/src/SharpTS/Compilation/NumericMapLocalPromotionAnalyzer.cs
+++ b/src/SharpTS/Compilation/NumericMapLocalPromotionAnalyzer.cs
@@ -7,8 +7,8 @@ namespace SharpTS.Compilation;
 /// <summary>
 /// Proves the deliberately narrow local lifetime in which an exact
 /// <c>Map&lt;number, number&gt;</c> may use <c>Dictionary&lt;double, double&gt;</c>
-/// storage. Any bare receiver observation, escape, alias, iteration, dynamic
-/// member access, widening call, reassignment, capture, direct eval, or
+/// storage. Any bare receiver observation, escape, alias, unproven iteration,
+/// dynamic member access, widening call, reassignment, capture, direct eval, or
 /// observable use of the intrinsic <c>Map</c> constructor disables promotion.
 /// </summary>
 internal static class NumericMapLocalPromotionAnalyzer
@@ -151,6 +151,26 @@ internal static class NumericMapLocalPromotionAnalyzer
             }
 
             base.VisitCall(expression);
+        }
+
+        protected override void VisitForOf(Stmt.ForOf statement)
+        {
+            // StableMapIterationAnalyzer runs before this pass and proves that
+            // this exact loop observes a fresh numeric Map only through literal
+            // entry[0]/entry[1] reads. That proof makes the receiver occurrence
+            // representation-transparent, so it need not disqualify native
+            // Dictionary<double, double> storage. Visit the body normally so
+            // every other candidate use still participates in escape analysis.
+            if (!statement.IsAsync
+                && statement.Iterable is Expr.Variable receiver
+                && IsExactNumericMap(_typeMap.Get(receiver))
+                && _typeMap.IsStableNumericMapIteration(statement))
+            {
+                Visit(statement.Body);
+                return;
+            }
+
+            base.VisitForOf(statement);
         }
 
         private bool IsPermittedCall(Expr.Call call, string methodName) => methodName switch

--- a/tests/SharpTS.Tests/CompilerTests/NumericMapPromotionTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/NumericMapPromotionTests.cs
@@ -83,16 +83,6 @@ public sealed class NumericMapPromotionTests
 
     public static TheoryData<string> BailoutSources => new()
     {
-        // Iteration observes insertion order and entry identity.
-        """
-        function read(): number {
-            const map = new Map<number, number>();
-            map.set(1, 2);
-            let sum: number = 0;
-            for (const entry of map) sum = sum + entry[0] + entry[1];
-            return sum;
-        }
-        """,
         // forEach observes order, callback arguments, and receiver identity.
         """
         function read(): number {

--- a/tests/SharpTS.Tests/CompilerTests/StableMapIterationTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableMapIterationTests.cs
@@ -11,10 +11,14 @@ namespace SharpTS.Tests.CompilerTests;
 public sealed class StableMapIterationTests
 {
     [Fact]
-    public void StableNumericEntryReads_UseDirectDictionaryEnumerator()
+    public void StableNumericEntryReads_UsePromotedDictionaryEnumerator()
     {
         Assembly assembly = Compile(StableSource);
-        var instructions = ReadInstructions(FindFunction(assembly, "sumMap")).ToArray();
+        MethodInfo method = FindFunction(assembly, "sumMap");
+        var instructions = ReadInstructions(method).ToArray();
+
+        Assert.Contains(method.GetMethodBody()!.LocalVariables, local =>
+            IsDoubleDictionary(local.LocalType));
 
         Assert.Contains(instructions, instruction =>
             instruction.Operand is MethodBase
@@ -22,7 +26,7 @@ public sealed class StableMapIterationTests
                 Name: "GetEnumerator",
                 DeclaringType: { IsGenericType: true } declaringType
             }
-            && declaringType.GetGenericTypeDefinition() == typeof(Dictionary<,>));
+            && IsDoubleDictionary(declaringType));
         Assert.DoesNotContain(instructions, instruction =>
             instruction.Operand is MethodBase { Name: "MapEntries" or "NormalizeToEnumerator" });
         Assert.DoesNotContain(instructions, instruction =>
@@ -31,8 +35,39 @@ public sealed class StableMapIterationTests
                 DeclaringType: { IsGenericType: true } declaringType
             }
             && declaringType.GetGenericTypeDefinition() == typeof(List<>));
-        Assert.True(instructions.Count(instruction =>
-            instruction.OpCode == OpCodes.Unbox_Any && instruction.Operand == typeof(double)) >= 2);
+        Assert.DoesNotContain(instructions, instruction =>
+            (instruction.OpCode == OpCodes.Box || instruction.OpCode == OpCodes.Unbox_Any)
+            && instruction.Operand == typeof(double));
+    }
+
+    [Fact]
+    public void BenchmarkShape_UsesTypedStorageAndCapacityReservation()
+    {
+        Assembly assembly = Compile(BenchmarkShapeSource);
+        MethodInfo method = FindFunction(assembly, "mapIteration");
+        var instructions = ReadInstructions(method).ToArray();
+
+        Assert.Contains(method.GetMethodBody()!.LocalVariables, local =>
+            IsDoubleDictionary(local.LocalType));
+        Assert.Single(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "EnsureCapacity" } capacity
+            && IsDoubleDictionary(capacity.DeclaringType));
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "set_Item" } setItem
+            && IsDoubleDictionary(setItem.DeclaringType));
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "GetEnumerator" } getEnumerator
+            && IsDoubleDictionary(getEnumerator.DeclaringType));
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "MapSet" or "MapEntries" or "NormalizeToEnumerator"
+            });
+        Assert.DoesNotContain(instructions, instruction =>
+            (instruction.OpCode == OpCodes.Box || instruction.OpCode == OpCodes.Unbox_Any)
+            && instruction.Operand == typeof(double));
+
+        Assert.Equal("20000\n", TestHarness.RunCompiled(BenchmarkShapeSource));
     }
 
     [Fact]
@@ -46,6 +81,39 @@ public sealed class StableMapIterationTests
     public void StableNumericEntryReads_WorkInStandaloneOutput()
     {
         Assert.Equal("18\n", TestHarness.RunCompiledStandalone(StableSource));
+    }
+
+    [Fact]
+    public void PromotedIteration_PreservesSameValueZeroAndInsertionOrder()
+    {
+        const string source = """
+            function inspect(): string {
+                const map = new Map<number, number>();
+                map.set(-0, 1);
+                map.set(0, 2);
+                map.set(NaN, 3);
+                map.set(NaN, 4);
+                map.set(2, 20);
+                map.set(1, 10);
+                map.set(2, 21);
+
+                let trace: string = "";
+                for (const entry of map) {
+                    if (Number.isNaN(entry[0])) {
+                        trace = trace + "n:" + entry[1] + ";";
+                    } else {
+                        trace = trace + entry[0] + ":" + entry[1] + ";";
+                    }
+                }
+                return trace + "size=" + map.size;
+            }
+            console.log(inspect());
+            """;
+
+        const string expected = "0:2;n:4;2:21;1:10;size=4\n";
+        Assert.Equal(expected, TestHarness.RunCompiled(source));
+        Assert.Equal(expected, TestHarness.RunCompiledStandalone(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
     }
 
     [Fact]
@@ -287,6 +355,22 @@ public sealed class StableMapIterationTests
         console.log(sumMap());
         """;
 
+    private const string BenchmarkShapeSource = """
+        function mapIteration(n: number): number {
+            const map = new Map<number, number>();
+            for (let i: number = 0; i < n; i++) {
+                map.set(i, i * 3 + 1);
+            }
+
+            let sum: number = 0;
+            for (const entry of map) {
+                sum = sum + entry[0] + entry[1];
+            }
+            return sum + map.size;
+        }
+        console.log(mapIteration(100));
+        """;
+
     private static Assembly Compile(string source)
     {
         var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
@@ -301,6 +385,13 @@ public sealed class StableMapIterationTests
         assembly.GetType("$Program")!
             .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
             .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static bool IsDoubleDictionary(Type? type) =>
+        type?.IsGenericType == true
+        && type.GetGenericTypeDefinition() == typeof(Dictionary<,>)
+        && type.GetGenericArguments() is [var key, var value]
+        && key == typeof(double)
+        && value == typeof(double);
 
     private static IEnumerable<(OpCode OpCode, MemberInfo? Operand)> ReadInstructions(
         MethodInfo method)


### PR DESCRIPTION
## Summary

- compose the existing stable numeric Map-iteration proof with numeric local promotion
- enumerate `Dictionary<double, double>` directly, eliminating boxed key/value storage and loop unboxing
- retain the materialized/object fallback for aliased, escaping, mutating, or otherwise unproven Maps
- add IL-shape, benchmark-shape, SameValueZero, insertion-order, standalone, and IL-verifier coverage

## Performance

Cross-runtime `map-iteration` workload, five launches; values are median mean milliseconds per operation. The Node column uses the clean baseline run because a later Node launch was system-load contaminated.

| n | SharpTS before | SharpTS after | Node | Improvement vs before | Faster than Node |
|---:|---:|---:|---:|---:|---:|
| 100 | 0.0025 | 0.0008 | 0.0017 | 3.1x | 2.1x |
| 1,000 | 0.0178 | 0.0044 | 0.0151 | 4.0x | 3.4x |
| 10,000 | 0.4200 | 0.0981 | 0.4218 | 4.3x | 4.3x |

BenchmarkDotNet at n=10,000:

| Implementation | Mean | Allocated |
|---|---:|---:|
| Idiomatic C# | 137.3 us | 276.43 KB |
| SharpTS after | 150.5 us | 276.43 KB |
| Equivalent boxed C# | 541.8 us | 1,526.54 KB |

Compared with the pre-change SharpTS result (588.8 us, 1,388.85 KB), this is 3.9x faster with 80% less allocation. SharpTS now matches idiomatic C# allocation and is within 9.6% of its mean time.

## Validation

- 33/33 focused stable-iteration and numeric-promotion tests pass
- 898/898 compiler tests pass (excluding the standalone networking/process fixture)
- full Release solution build succeeds with 0 warnings and 0 errors
- build-time IL verification passes

The unfiltered local suite was also attempted, but the restricted Windows host rejects `HttpListener` and IPC setup (`The handle is invalid`), causing unrelated networking timeouts; GitHub CI remains the authoritative full-suite run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Map` iteration for stable numeric key/value pairs.
  * Preserved numeric types during iteration, avoiding unnecessary boxing and conversions.
  * Maintained JavaScript-compatible key behavior, including `SameValueZero` comparisons and insertion order.

* **Performance**
  * Enabled more efficient direct iteration for numeric maps.
  * Added capacity reservation and optimized typed storage for supported map patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->