### PR TITLE
Stabilize SharpPaint and HTTP conformance tests

### DIFF
--- a/samples/SharpPaint/SharpPaintApp.tsx
+++ b/samples/SharpPaint/SharpPaintApp.tsx
@@ -175,8 +175,7 @@ type AppAction =
     | { type: "replaceLayer"; layerId: string; source: string; status: string; expectedRevision: number }
     | { type: "commitText"; command: DrawingCommand };
 
-function initialState(): AppState {
-    const document = createDocument();
+function initialState(document: PaintDocument = createDocument()): AppState {
     return {
         history: createHistory(document),
         selectedLayerId: document.layers[0].id,
@@ -414,10 +413,13 @@ function appReducer(state: AppState, action: any): AppState {
     return state;
 }
 
-export interface SharpPaintAppProps { readonly requestClose: () => void; }
+export interface SharpPaintAppProps {
+    readonly requestClose: () => void;
+    readonly initialDocument?: PaintDocument;
+}
 
 export function SharpPaintApp(props: SharpPaintAppProps): JSX.Element {
-    const statePair = useReducer<AppState, any>(appReducer, initialState());
+    const statePair = useReducer<AppState, any>(appReducer, initialState(props.initialDocument));
     const state = statePair[0];
     const dispatch = statePair[1];
     const closeState = useRef({ bypass: false, promptActive: false });

--- a/samples/SharpPaint/headless.tests.tsx
+++ b/samples/SharpPaint/headless.tests.tsx
@@ -24,19 +24,22 @@ let responsiveWindow: any = null;
 responsiveWindow = application.createWindow(<SharpPaintShowcase requestClose={() => responsiveWindow.close()} />);
 const responsiveDriver = createDesktopTestDriver(responsiveWindow);
 let fillWindow: any = null;
-fillWindow = application.createWindow(<SharpPaintShowcase requestClose={() => fillWindow.close()} />);
+fillWindow = application.createWindow(
+    <SharpPaintShowcase initialDocument={createDocument(320, 240)} requestClose={() => fillWindow.close()} />);
 const fillDriver = createDesktopTestDriver(fillWindow);
 let textWindow: any = null;
 textWindow = application.createWindow(<SharpPaintShowcase requestClose={() => textWindow.close()} />);
 const textDriver = createDesktopTestDriver(textWindow);
 let effectWindow: any = null;
-effectWindow = application.createWindow(<SharpPaintShowcase requestClose={() => effectWindow.close()} />);
+effectWindow = application.createWindow(
+    <SharpPaintShowcase initialDocument={createDocument(320, 240)} requestClose={() => effectWindow.close()} />);
 const effectDriver = createDesktopTestDriver(effectWindow);
-function waitForStatus(testDriver: DesktopTestDriver, expected: string, then: () => void, remaining: number = 200): void {
+const STATUS_TIMEOUT_MS = 15_000;
+function waitForStatus(testDriver: DesktopTestDriver, expected: string, then: () => void, deadline: number = Date.now() + STATUS_TIMEOUT_MS): void {
     const actual = testDriver.getText("status");
     if (actual === expected) { then(); return; }
-    if (remaining <= 0) throw new Error("Timed out waiting for status '" + expected + "'; actual status was '" + actual + "'.");
-    setTimeout((() => waitForStatus(testDriver, expected, then, remaining - 1)) as any, 10);
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for status '" + expected + "'; actual status was '" + actual + "'.");
+    setTimeout((() => waitForStatus(testDriver, expected, then, deadline)) as any, 10);
 }
 const openProjectPath = join(process.cwd(), "SharpPaint.Headless.Open.sharpaint");
 const saveProjectPath = join(process.cwd(), "SharpPaint.Headless.Save.sharpaint");

--- a/tests/SharpTS.Tests/SharedTests/HttpServerLifecycleTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/HttpServerLifecycleTests.cs
@@ -111,17 +111,19 @@ public class HttpServerLifecycleTests
     [Theory, ModeData]
     public void Server_ListenHost_UsesThirdArgumentCallbackAndReportsAddress(ExecutionMode mode)
     {
-        var port = TestPorts.GetAvailablePort();
+        // Allocate the ephemeral port at listen time. Selecting and releasing a
+        // port before compiling the guest leaves a large bind race under parallel test load.
         var files = new Dictionary<string, string>
         {
-            ["./main.ts"] = $$"""
+            ["./main.ts"] = """
                 import * as http from 'http';
                 const server = http.createServer((req: any, res: any) => res.end('ok'));
-                server.listen({{port}}, '127.0.0.1', () => {
+                server.listen(0, '127.0.0.1', () => {
                     const address = server.address();
                     console.log('callback');
                     console.log('address=' + address.address);
                     console.log('family=' + address.family);
+                    console.log('port=' + (address.port > 0));
                     server.close();
                 });
                 """
@@ -131,6 +133,7 @@ public class HttpServerLifecycleTests
         Assert.Contains("callback", output);
         Assert.Contains("address=127.0.0.1", output);
         Assert.Contains("family=IPv4", output);
+        Assert.Contains("port=true", output);
     }
 
     [Theory, ModeData]


### PR DESCRIPTION
## Summary
- let SharpPaint graphics-heavy headless scenarios use smaller injected documents
- replace turn-count polling with a 15-second wall-clock deadline
- allocate the HTTP listener port at listen time with `listen(0)` and verify the assigned port

## Testing
- `dotnet build tests\SharpTS.Tests\SharpTS.Tests.csproj -c Debug --no-restore --nologo`
- SharpPaint `InteractionsPassInInterpretedAndCompiledModes` passed three consecutive focused runs
- HTTP execution is currently blocked on this Windows host by a machine-wide `HttpListenerException: The handle is invalid`; unrelated unchanged `HttpModuleTests` reproduce the same condition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - SharpPaint can now open with a provided initial document, making it easier to start editing existing artwork.
  - Fill and effect demonstrations now begin with dedicated 320×240 canvases.

- **Bug Fixes**
  - Improved waiting behavior for SharpPaint status updates with a reliable 15-second timeout.
  - Improved local server testing by allowing automatic port assignment, reducing intermittent test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->