### PR TITLE
Fix unchecked Int32Array stencil bounds guard

### DIFF
--- a/src/SharpTS/Compilation/ILEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Operators.cs
@@ -1260,16 +1260,7 @@ public partial class ILEmitter
         var centerIndex = IL.DeclareLocal(_ctx.Types.Int32);
         IL.Emit(OpCodes.Stloc, centerIndex);
 
-        // (uint)(center - 1) < (uint)(length - 2) proves both neighboring indexes.
-        // The unsigned form also rejects negative centers and lengths below three.
-        var inRange = IL.DefineLabel();
-        IL.Emit(OpCodes.Ldloc, centerIndex);
-        IL.Emit(OpCodes.Ldc_I4_1);
-        IL.Emit(OpCodes.Sub);
-        IL.Emit(OpCodes.Ldloc, backing.LengthLocal);
-        IL.Emit(OpCodes.Ldc_I4_2);
-        IL.Emit(OpCodes.Sub);
-        IL.Emit(OpCodes.Blt_Un, inRange);
+        var inRange = EmitInt32StencilRangeTest(backing, centerIndex);
         IL.Emit(OpCodes.Newobj, _ctx.Types.GetDefaultConstructor(typeof(IndexOutOfRangeException)));
         IL.Emit(OpCodes.Throw);
         IL.MarkLabel(inRange);
@@ -1294,6 +1285,33 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Conv_R8);
         SetStackType(StackType.Double);
         return true;
+    }
+
+    /// <summary>
+    /// Branches to the returned label when <paramref name="centerIndex"/> and both neighbors are
+    /// valid element indexes. Lengths below the three-element stencil width are rejected before
+    /// the unsigned comparison, whose <c>length - 2</c> operand would otherwise underflow.
+    /// </summary>
+    private Label EmitInt32StencilRangeTest(
+        HoistedTypedArrayBacking backing,
+        LocalBuilder centerIndex)
+    {
+        var inRange = IL.DefineLabel();
+        var outOfRange = IL.DefineLabel();
+        IL.Emit(OpCodes.Ldloc, backing.LengthLocal);
+        IL.Emit(OpCodes.Ldc_I4_3);
+        IL.Emit(OpCodes.Blt, outOfRange);
+
+        // (uint)(center - 1) < (uint)(length - 2) proves both neighboring indexes.
+        IL.Emit(OpCodes.Ldloc, centerIndex);
+        IL.Emit(OpCodes.Ldc_I4_1);
+        IL.Emit(OpCodes.Sub);
+        IL.Emit(OpCodes.Ldloc, backing.LengthLocal);
+        IL.Emit(OpCodes.Ldc_I4_2);
+        IL.Emit(OpCodes.Sub);
+        IL.Emit(OpCodes.Blt_Un, inRange);
+        IL.MarkLabel(outOfRange);
+        return inRange;
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -1127,14 +1127,7 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Conv_I4);
         IL.Emit(OpCodes.Stloc, centerIndex);
 
-        var inRange = IL.DefineLabel();
-        IL.Emit(OpCodes.Ldloc, centerIndex);
-        IL.Emit(OpCodes.Ldc_I4_1);
-        IL.Emit(OpCodes.Sub);
-        IL.Emit(OpCodes.Ldloc, backing.LengthLocal);
-        IL.Emit(OpCodes.Ldc_I4_2);
-        IL.Emit(OpCodes.Sub);
-        IL.Emit(OpCodes.Blt_Un, inRange);
+        var inRange = EmitInt32StencilRangeTest(backing, centerIndex);
         EmitInt64AccumulatorStore(accumulatorDouble, accumulatorInteger);
         IL.Emit(OpCodes.Newobj, _ctx.Types.GetDefaultConstructor(typeof(IndexOutOfRangeException)));
         IL.Emit(OpCodes.Throw);

--- a/tests/SharpTS.Tests/CompilerTests/TypedArrayBackingHoistTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/TypedArrayBackingHoistTests.cs
@@ -231,13 +231,45 @@ public sealed class TypedArrayBackingHoistTests
     }
 
     [Fact]
-    public void ExactInt32Stencil_OutOfRangeStillFaults()
+    public void ExactInt32Stencil_ShortBackingFaultsOnSpecializedAndFallbackPaths()
     {
         MethodInfo hot = CompileFunction("""
+            function hot(length: number, initial: number, bound: number): number {
+                const data = new Int32Array(length);
+                let sum: number = initial;
+                for (let i: number = 1; i < bound - 1; i++) {
+                    sum = sum + (data[i - 1] - 2 * data[i] + data[i + 1]);
+                }
+                return sum;
+            }
+            """, "hot");
+
+        Assert.Contains(ReadInstructions(hot), instruction =>
+            instruction.Operand is MethodBase { Name: "DoubleToInt64Bits" });
+
+        foreach (double length in new[] { 0d, 1d, 2d })
+        {
+            foreach (double initial in new[] { 0d, 0.5d })
+            {
+                var exception = Assert.Throws<TargetInvocationException>(() =>
+                    hot.Invoke(null, [length, initial, 3d]));
+                Assert.True(
+                    exception.InnerException is IndexOutOfRangeException,
+                    $"length={length}, initial={initial}: {exception.InnerException}");
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(2)]
+    public void ExactInt32Stencil_InvalidNeighborStillFaults(int center)
+    {
+        MethodInfo hot = CompileFunction($$"""
             function hot(n: number): number {
                 const data = new Int32Array(n);
                 let sum: number = 0;
-                for (let i: number = 0; i < 1; i++) {
+                for (let i: number = {{center}}; i < {{center + 1}}; i++) {
                     sum = sum + (data[i - 1] - 2 * data[i] + data[i + 1]);
                 }
                 return sum;

--- a/tests/SharpTS.Tests/SharedTests/TypedArrayBackingHoistParityTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/TypedArrayBackingHoistParityTests.cs
@@ -64,4 +64,72 @@ public sealed class TypedArrayBackingHoistParityTests
 
         Assert.Equal("7\n", TestHarness.Run(source, mode));
     }
+
+    [Theory, ModeData]
+    public void ExactInt32Stencil_BoundsChecksMatchIndexedAccess(ExecutionMode mode)
+    {
+        const string source = """
+            function faults(action: () => number): boolean {
+                try {
+                    action();
+                    return false;
+                } catch {
+                    return true;
+                }
+            }
+
+            function reduction(length: number, initial: number, bound: number): number {
+                const data = new Int32Array(length);
+                let sum: number = initial;
+                for (let i: number = 1; i < bound - 1; i++) {
+                    sum = sum + (data[i - 1] - 2 * data[i] + data[i + 1]);
+                }
+                return sum;
+            }
+
+            function leftEdge(): number {
+                const data = new Int32Array(3);
+                let sum: number = 0;
+                for (let i: number = 0; i < 1; i++) {
+                    sum = sum + (data[i - 1] - 2 * data[i] + data[i + 1]);
+                }
+                return sum;
+            }
+
+            function rightEdge(): number {
+                const data = new Int32Array(3);
+                let sum: number = 0;
+                for (let i: number = 2; i < 3; i++) {
+                    sum = sum + (data[i - 1] - 2 * data[i] + data[i + 1]);
+                }
+                return sum;
+            }
+
+            function valid(): number {
+                const data = new Int32Array(3);
+                data[0] = 1;
+                data[1] = 4;
+                data[2] = 9;
+                let sum: number = 0;
+                for (let i: number = 1; i < 2; i++) {
+                    sum = sum + (data[i - 1] - 2 * data[i] + data[i + 1]);
+                }
+                return sum;
+            }
+
+            console.log(faults(() => reduction(0, 0, 3)));
+            console.log(faults(() => reduction(1, 0, 3)));
+            console.log(faults(() => reduction(2, 0, 3)));
+            console.log(faults(() => reduction(0, 0.5, 3)));
+            console.log(faults(() => reduction(1, 0.5, 3)));
+            console.log(faults(() => reduction(2, 0.5, 3)));
+            console.log(faults(leftEdge));
+            console.log(faults(rightEdge));
+            console.log(valid());
+            """;
+
+        Assert.Equal(
+            "true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\n2\n",
+            TestHarness.Run(source, mode));
+    }
 }


### PR DESCRIPTION
## Summary
- reject Int32 stencil backings shorter than three elements before the unsigned center-range comparison
- share the corrected guard between the ordinary stencil-expression and whole-loop reduction fast paths
- add compiler and dual-mode regressions for short arrays, negative/end neighbors, fallback execution, and a valid three-element stencil

## Testing
- `dotnet build tests\SharpTS.Tests\SharpTS.Tests.csproj -c Release --no-restore --nologo -m:1 /nr:false -p:UseSharedCompilation=false -p:BuildInParallel=false`
- focused typed-array backing tests: 33 passed
- typed-array and ArrayBuffer tests: 170 passed
- compiler tests: 956 passed; the unrelated `StandaloneDllTests.Isolated_Tls_ShouldExecuteWithoutSharpTsDll` failed with a local TLS authentication error and reproduced in isolation
- `git diff --check`

Closes #1516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `Int32Array` stencil operations failing to validate short backing arrays safely.
  - Invalid center and neighboring indexes now consistently raise `IndexOutOfRangeException`.
  - Ensured specialized and fallback execution paths produce matching bounds-checking behavior.

- **Tests**
  - Added coverage for empty, short, and edge-indexed arrays.
  - Verified valid indexed access continues to return the expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->