### PR TITLE
Fix RegExp receiver, replacement, and groups semantics

### DIFF
--- a/src/SharpTS.Gui/DescriptorRegistry.cs
+++ b/src/SharpTS.Gui/DescriptorRegistry.cs
@@ -129,20 +129,66 @@ internal static class DescriptorRegistry
 /// Explicit, reflection-free managed adapter for one custom or built-in GUI control kind.
 /// Custom kinds must be prefixed with their provider ID followed by a dot.
 /// </summary>
+/// <param name="kind">The control kind identifier.</param>
+/// <param name="minimumChildren">Minimum number of child controls allowed.</param>
+/// <param name="maximumChildren">Maximum number of child controls allowed.</param>
 public abstract class NodeDescriptor(string kind, int minimumChildren, int maximumChildren)
 {
+    /// <summary>
+    /// Gets the control kind identifier.
+    /// </summary>
     public string Kind { get; } = kind;
+
+    /// <summary>
+    /// Gets the minimum number of child controls allowed.
+    /// </summary>
     public int MinimumChildren { get; } = minimumChildren;
+
+    /// <summary>
+    /// Gets the maximum number of child controls allowed.
+    /// </summary>
     public int MaximumChildren { get; } = maximumChildren;
+
+    /// <summary>
+    /// Validates the virtual node structure.
+    /// </summary>
+    /// <param name="node">The node to validate.</param>
     public virtual void Validate(GuiVNode node) { }
+
+    /// <summary>
+    /// Creates a new control instance from the virtual node.
+    /// </summary>
+    /// <param name="node">The virtual node containing control data.</param>
+    /// <returns>The created control.</returns>
     public abstract Control Create(GuiVNode node);
+
+    /// <summary>
+    /// Updates an existing control based on changes between previous and next virtual nodes.
+    /// </summary>
+    /// <param name="control">The control to update.</param>
+    /// <param name="previous">The previous virtual node state.</param>
+    /// <param name="next">The next virtual node state.</param>
+    /// <returns>True if the control was updated; otherwise false.</returns>
     public abstract bool Update(Control control, GuiVNode previous, GuiVNode next);
 }
 
-/// <summary>A statically registered set of managed GUI control descriptors.</summary>
+/// <summary>
+/// A statically registered set of managed GUI control descriptors.
+/// </summary>
 public interface IGuiControlProvider
 {
+    /// <summary>
+    /// Gets the contract version this provider implements.
+    /// </summary>
     int ContractVersion { get; }
+
+    /// <summary>
+    /// Gets the unique provider identifier.
+    /// </summary>
     string ProviderId { get; }
+
+    /// <summary>
+    /// Gets the list of control descriptors provided by this provider.
+    /// </summary>
     IReadOnlyList<NodeDescriptor> Descriptors { get; }
 }

--- a/src/SharpTS.Hosting.Abstractions/HostingContracts.cs
+++ b/src/SharpTS.Hosting.Abstractions/HostingContracts.cs
@@ -3,17 +3,34 @@ using System.Reflection;
 
 namespace SharpTS.Hosting;
 
+/// <summary>
+/// Diagnostic identifiers for SharpTS hosting APIs.
+/// </summary>
 public static class SharpTSHostingDiagnostics
 {
+    /// <summary>
+    /// Diagnostic ID for experimental hosting APIs.
+    /// </summary>
     public const string ExperimentalId = "SHARPTS_HOSTING001";
 }
 
+/// <summary>
+/// Constants for the SharpTS hosted application binary interface (ABI).
+/// </summary>
 [Experimental(SharpTSHostingDiagnostics.ExperimentalId)]
 public static class SharpTSHostedAbi
 {
+    /// <summary>
+    /// The current ABI version. Hosted applications and hosts must agree on this version.
+    /// </summary>
     public const int CurrentVersion = 1;
 }
 
+/// <summary>
+/// Marks an assembly as a SharpTS hosted program, specifying the ABI version and factory type.
+/// </summary>
+/// <param name="abiVersion">The ABI version this program was built for.</param>
+/// <param name="factoryType">The type implementing <see cref="ISharpTSHostedProgramFactory"/> that creates the runtime.</param>
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
 [Experimental(SharpTSHostingDiagnostics.ExperimentalId)]
 public sealed class SharpTSHostedProgramAttribute(
@@ -21,70 +38,195 @@ public sealed class SharpTSHostedProgramAttribute(
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     Type factoryType) : Attribute
 {
+    /// <summary>
+    /// Gets the ABI version this program declares.
+    /// </summary>
     public int AbiVersion { get; } = abiVersion;
+
+    /// <summary>
+    /// Gets the factory type that creates the hosted runtime.
+    /// </summary>
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     public Type FactoryType { get; } = factoryType ?? throw new ArgumentNullException(nameof(factoryType));
 }
 
+/// <summary>
+/// Provides thread-affinity and scheduling services for a hosted SharpTS runtime.
+/// </summary>
 [Experimental(SharpTSHostingDiagnostics.ExperimentalId)]
 public interface ISharpTSHostDispatcher
 {
+    /// <summary>
+    /// Determines whether the calling thread is the runtime's owner thread.
+    /// </summary>
+    /// <returns>True if the caller is on the runtime's thread; otherwise false.</returns>
     bool CheckAccess();
+
+    /// <summary>
+    /// Posts an action to run on the runtime's thread.
+    /// </summary>
+    /// <param name="hostTurn">The action to execute.</param>
     void Post(Action hostTurn);
+
+    /// <summary>
+    /// Schedules an action to run on the runtime's thread after a delay.
+    /// </summary>
+    /// <param name="delay">The delay before executing the action.</param>
+    /// <param name="hostTurn">The action to execute.</param>
+    /// <returns>A handle that can cancel the scheduled work.</returns>
     ISharpTSScheduledWork Schedule(TimeSpan delay, Action hostTurn);
 }
 
+/// <summary>
+/// Represents a scheduled work item that can be canceled or disposed.
+/// </summary>
 [Experimental(SharpTSHostingDiagnostics.ExperimentalId)]
 public interface ISharpTSScheduledWork : IDisposable
 {
+    /// <summary>
+    /// Cancels the scheduled work if it has not yet executed.
+    /// </summary>
     void Cancel();
 }
 
+/// <summary>
+/// Provides host lifetime management for a hosted SharpTS runtime.
+/// </summary>
 [Experimental(SharpTSHostingDiagnostics.ExperimentalId)]
 public interface ISharpTSHostLifetime
 {
+    /// <summary>
+    /// Requests the host to exit with the specified exit code.
+    /// </summary>
+    /// <param name="exitCode">The exit code to return.</param>
     void RequestExit(int exitCode);
 }
 
+/// <summary>
+/// Receives error reports from a hosted SharpTS runtime.
+/// </summary>
 [Experimental(SharpTSHostingDiagnostics.ExperimentalId)]
 public interface ISharpTSHostedErrorSink
 {
+    /// <summary>
+    /// Reports an error that occurred during runtime operation.
+    /// </summary>
+    /// <param name="error">The error details.</param>
     void Report(SharpTSHostedError error);
 }
 
+/// <summary>
+/// Represents a hosted SharpTS runtime instance with lifecycle management and guest-host communication.
+/// </summary>
 [Experimental(SharpTSHostingDiagnostics.ExperimentalId)]
 public interface ISharpTSHostedRuntime : IDisposable, IAsyncDisposable
 {
+    /// <summary>
+    /// Gets the current state of the runtime.
+    /// </summary>
     SharpTSHostedRuntimeState State { get; }
+
+    /// <summary>
+    /// Gets the reason for shutdown, if the runtime has shut down.
+    /// </summary>
     SharpTSHostedShutdownReason? ShutdownReason { get; }
+
+    /// <summary>
+    /// Gets the managed thread ID that owns this runtime, or null if not yet initialized.
+    /// </summary>
     int? OwnerThreadId { get; }
+
+    /// <summary>
+    /// Initializes the runtime asynchronously.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token to abort initialization.</param>
+    /// <returns>A task that completes when initialization finishes.</returns>
     Task InitializeAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Shuts down the runtime asynchronously.
+    /// </summary>
+    /// <param name="reason">The reason for shutdown.</param>
+    /// <param name="exitCode">The exit code to report.</param>
+    /// <returns>A task that completes when shutdown finishes.</returns>
     Task ShutdownAsync(
         SharpTSHostedShutdownReason reason = SharpTSHostedShutdownReason.HostRequested,
         int exitCode = 0);
+
+    /// <summary>
+    /// Registers an action to be run during cleanup.
+    /// </summary>
+    /// <param name="cleanup">The cleanup action.</param>
     void RegisterCleanup(Action cleanup);
+
+    /// <summary>
+    /// Posts a notification to the guest without waiting for a result (fire-and-forget).
+    /// </summary>
+    /// <param name="guestNotification">The action to execute on the guest.</param>
     void Notify(Action guestNotification);
+
+    /// <summary>
+    /// Invokes an action on the guest and waits for it to complete.
+    /// </summary>
+    /// <param name="guestCallback">The action to execute on the guest.</param>
     void Invoke(Action guestCallback);
+
+    /// <summary>
+    /// Invokes a function on the guest and returns its result.
+    /// </summary>
+    /// <param name="guestCallback">The function to execute on the guest.</param>
+    /// <returns>The result of the guest function.</returns>
     object? Invoke(Func<object?> guestCallback);
 }
 
+/// <summary>
+/// Factory for creating hosted SharpTS runtime instances.
+/// </summary>
 [Experimental(SharpTSHostingDiagnostics.ExperimentalId)]
 public interface ISharpTSHostedProgramFactory
 {
+    /// <summary>
+    /// Gets the ABI version this factory supports.
+    /// </summary>
     int AbiVersion { get; }
+
+    /// <summary>
+    /// Creates a new hosted runtime instance.
+    /// </summary>
+    /// <param name="dispatcher">The dispatcher for thread-affinity and scheduling.</param>
+    /// <param name="lifetime">The host lifetime manager.</param>
+    /// <param name="errorSink">The error reporting sink.</param>
+    /// <returns>A new hosted runtime instance.</returns>
     ISharpTSHostedRuntime Create(
         ISharpTSHostDispatcher dispatcher,
         ISharpTSHostLifetime lifetime,
         ISharpTSHostedErrorSink errorSink);
 }
 
+/// <summary>
+/// Exception thrown when there is an ABI version mismatch or other hosting contract violation.
+/// </summary>
+/// <param name="message">The error message.</param>
+/// <param name="innerException">The inner exception, if any.</param>
 [Experimental(SharpTSHostingDiagnostics.ExperimentalId)]
 public sealed class SharpTSHostedAbiException(string message, Exception? innerException = null)
     : InvalidOperationException(message, innerException);
 
+/// <summary>
+/// Utilities for loading and creating hosted runtimes from compiled assemblies.
+/// </summary>
 [Experimental(SharpTSHostingDiagnostics.ExperimentalId)]
 public static class SharpTSHostedAssembly
 {
+    /// <summary>
+    /// Creates a hosted runtime from an assembly marked with <see cref="SharpTSHostedProgramAttribute"/>.
+    /// </summary>
+    /// <param name="assembly">The assembly containing the hosted program.</param>
+    /// <param name="dispatcher">The dispatcher for thread-affinity and scheduling.</param>
+    /// <param name="lifetime">The host lifetime manager.</param>
+    /// <param name="errorSink">The error reporting sink.</param>
+    /// <returns>A new hosted runtime instance.</returns>
+    /// <exception cref="SharpTSHostedAbiException">Thrown if the assembly metadata is invalid or ABI version mismatches.</exception>
     public static ISharpTSHostedRuntime CreateRuntime(
         Assembly assembly,
         ISharpTSHostDispatcher dispatcher,
@@ -169,39 +311,73 @@ public static class SharpTSHostedAssembly
     }
 }
 
+/// <summary>
+/// Indicates the lifecycle phase during which an error occurred.
+/// </summary>
 [Experimental(SharpTSHostingDiagnostics.ExperimentalId)]
 public enum SharpTSHostedErrorPhase
 {
+    /// <summary>Error occurred during runtime creation.</summary>
     Creation,
+    /// <summary>Error occurred during initialization.</summary>
     Initialization,
+    /// <summary>Error occurred while the runtime was running.</summary>
     Running,
+    /// <summary>Error occurred during shutdown.</summary>
     Shutdown,
+    /// <summary>Error occurred during cleanup.</summary>
     Cleanup,
 }
 
+/// <summary>
+/// Indicates why a hosted runtime shut down.
+/// </summary>
 [Experimental(SharpTSHostingDiagnostics.ExperimentalId)]
 public enum SharpTSHostedShutdownReason
 {
+    /// <summary>The host requested shutdown.</summary>
     HostRequested,
+    /// <summary>The program completed normally.</summary>
     ProgramCompleted,
+    /// <summary>The process is exiting.</summary>
     ProcessExit,
+    /// <summary>Startup failed.</summary>
     StartupFailure,
+    /// <summary>An uncaught error occurred.</summary>
     UncaughtError,
+    /// <summary>The runtime was disposed.</summary>
     Disposed,
 }
 
+/// <summary>
+/// Indicates the current state of a hosted runtime.
+/// </summary>
 [Experimental(SharpTSHostingDiagnostics.ExperimentalId)]
 public enum SharpTSHostedRuntimeState
 {
+    /// <summary>Runtime has been created but not yet initialized.</summary>
     Created,
+    /// <summary>Runtime is currently initializing.</summary>
     Initializing,
+    /// <summary>Runtime is running normally.</summary>
     Running,
+    /// <summary>Runtime is in the process of stopping.</summary>
     Stopping,
+    /// <summary>Runtime has stopped.</summary>
     Stopped,
+    /// <summary>Runtime encountered a fault.</summary>
     Faulted,
+    /// <summary>Runtime has been disposed.</summary>
     Disposed,
 }
 
+/// <summary>
+/// Contains details about an error that occurred in a hosted runtime.
+/// </summary>
+/// <param name="Exception">The exception that was thrown.</param>
+/// <param name="Phase">The lifecycle phase when the error occurred.</param>
+/// <param name="RuntimeState">The runtime state when the error occurred.</param>
+/// <param name="ShutdownReason">The shutdown reason, if applicable.</param>
 [Experimental(SharpTSHostingDiagnostics.ExperimentalId)]
 public sealed record SharpTSHostedError(
     Exception Exception,

--- a/src/SharpTS.Hosting.Abstractions/SharpTSHostedRuntimeBase.cs
+++ b/src/SharpTS.Hosting.Abstractions/SharpTSHostedRuntimeBase.cs
@@ -48,6 +48,12 @@ public abstract class SharpTSHostedRuntimeBase : ISharpTSHostedRuntime
     private long _timerGeneration;
     private bool _disposed;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SharpTSHostedRuntimeBase"/> class.
+    /// </summary>
+    /// <param name="dispatcher">The dispatcher for thread-affinity and scheduling.</param>
+    /// <param name="lifetime">The host lifetime manager.</param>
+    /// <param name="errorSink">The error reporting sink.</param>
     protected SharpTSHostedRuntimeBase(
         ISharpTSHostDispatcher dispatcher,
         ISharpTSHostLifetime lifetime,
@@ -65,16 +71,65 @@ public abstract class SharpTSHostedRuntimeBase : ISharpTSHostedRuntime
 
     public int? OwnerThreadId => _ownerThreadId;
 
+    /// <summary>
+    /// Initializes the guest program asynchronously.
+    /// </summary>
+    /// <returns>A task that completes when guest initialization finishes.</returns>
     protected abstract Task InitializeGuestAsync();
+
+    /// <summary>
+    /// Attempts to run one guest macrotask.
+    /// </summary>
+    /// <returns>True if a macrotask was executed; otherwise false.</returns>
     protected abstract bool TryRunOneGuestMacrotask();
+
+    /// <summary>
+    /// Gets a value indicating whether the guest has pending macrotasks.
+    /// </summary>
     protected abstract bool HasGuestMacrotasks { get; }
+
+    /// <summary>
+    /// Drains all pending guest microtasks.
+    /// </summary>
     protected abstract void DrainGuestMicrotasks();
+
+    /// <summary>
+    /// Gets a value indicating whether the guest has pending microtasks.
+    /// </summary>
     protected abstract bool HasGuestMicrotasks { get; }
+
+    /// <summary>
+    /// Attempts to run one guest timer callback.
+    /// </summary>
+    /// <returns>True if a timer was executed; otherwise false.</returns>
     protected abstract bool TryRunOneGuestTimer();
+
+    /// <summary>
+    /// Gets the delay until the next guest timer deadline.
+    /// </summary>
+    /// <returns>The delay, or null if no timers are pending.</returns>
     protected abstract TimeSpan? GetNextGuestTimerDelay();
+
+    /// <summary>
+    /// Rejects all pending guest work items.
+    /// </summary>
     protected abstract void RejectGuestWork();
+
+    /// <summary>
+    /// Cancels guest-owned resources (timers, I/O, etc.).
+    /// </summary>
     protected abstract void CancelGuestResources();
+
+    /// <summary>
+    /// Emits the guest's beforeExit event.
+    /// </summary>
+    /// <param name="exitCode">The exit code.</param>
     protected abstract void EmitGuestBeforeExit(int exitCode);
+
+    /// <summary>
+    /// Emits the guest's exit event.
+    /// </summary>
+    /// <param name="exitCode">The exit code.</param>
     protected abstract void EmitGuestExit(int exitCode);
 
     public Task InitializeAsync(CancellationToken cancellationToken = default)
@@ -197,7 +252,10 @@ public abstract class SharpTSHostedRuntimeBase : ISharpTSHostedRuntime
         });
     }
 
-    /// <summary>Queues one external guest callback as a macrotask.</summary>
+    /// <summary>
+    /// Queues one external guest callback as a macrotask.
+    /// </summary>
+    /// <param name="callback">The callback to queue.</param>
     public void EnqueueMacrotask(Action callback)
     {
         ArgumentNullException.ThrowIfNull(callback);
@@ -207,7 +265,10 @@ public abstract class SharpTSHostedRuntimeBase : ISharpTSHostedRuntime
         RequestTurn();
     }
 
-    /// <summary>Queues an await/promise continuation for the next microtask checkpoint.</summary>
+    /// <summary>
+    /// Queues an await/promise continuation for the next microtask checkpoint.
+    /// </summary>
+    /// <param name="callback">The callback to queue.</param>
     public void EnqueueMicrotask(Action callback)
     {
         ArgumentNullException.ThrowIfNull(callback);
@@ -217,6 +278,9 @@ public abstract class SharpTSHostedRuntimeBase : ISharpTSHostedRuntime
         RequestTurn();
     }
 
+    /// <summary>
+    /// Wakes the runtime to process pending work.
+    /// </summary>
     public void Wake() => RequestTurn();
 
     /// <summary>
@@ -225,6 +289,8 @@ public abstract class SharpTSHostedRuntimeBase : ISharpTSHostedRuntime
     /// inside the hosted microtask checkpoint, so the generated async state machine
     /// resumes there without installing a synchronization context.
     /// </summary>
+    /// <param name="task">The task to prepare.</param>
+    /// <returns>A task that completes on the owner thread.</returns>
     public Task<object?> PrepareAwait(Task<object?> task)
     {
         ArgumentNullException.ThrowIfNull(task);
@@ -245,6 +311,9 @@ public abstract class SharpTSHostedRuntimeBase : ISharpTSHostedRuntime
     /// completes only after the capture has run. Generated module initializers
     /// use this to resume a declaration in a later hosted turn.
     /// </summary>
+    /// <param name="task">The task to await.</param>
+    /// <param name="capture">The action to run with the result.</param>
+    /// <returns>A task that completes after the capture runs.</returns>
     public Task CaptureAwait(Task<object?> task, Action<object?> capture)
     {
         ArgumentNullException.ThrowIfNull(task);
@@ -278,6 +347,11 @@ public abstract class SharpTSHostedRuntimeBase : ISharpTSHostedRuntime
         return completion.Task;
     }
 
+    /// <summary>
+    /// Runs a sequence of initialization steps in order, draining microtasks between each.
+    /// </summary>
+    /// <param name="steps">The initialization steps to run.</param>
+    /// <returns>A task that completes when all steps finish.</returns>
     public Task RunInitializationSteps(IReadOnlyList<Func<Task>> steps)
     {
         ArgumentNullException.ThrowIfNull(steps);
@@ -285,7 +359,12 @@ public abstract class SharpTSHostedRuntimeBase : ISharpTSHostedRuntime
         return sequence.Run();
     }
 
-    /// <summary>Registers a compiled module initializer under a runtime import alias.</summary>
+    /// <summary>
+    /// Registers a compiled module initializer under a runtime import alias.
+    /// </summary>
+    /// <param name="alias">The import alias.</param>
+    /// <param name="canonicalPath">The canonical module path.</param>
+    /// <param name="initializer">The module initializer function.</param>
     public void RegisterHostedModule(
         string alias,
         string canonicalPath,
@@ -302,6 +381,9 @@ public abstract class SharpTSHostedRuntimeBase : ISharpTSHostedRuntime
     /// Initializes a compiled module once and returns its namespace. Active self-imports
     /// reject instead of awaiting their own initialization task indefinitely.
     /// </summary>
+    /// <param name="alias">The import alias.</param>
+    /// <param name="namespaceFactory">Factory to create the module namespace.</param>
+    /// <returns>A task that resolves to the module namespace.</returns>
     public Task<object?> ImportHostedModule(string alias, Func<object?> namespaceFactory)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(alias);
@@ -348,6 +430,10 @@ public abstract class SharpTSHostedRuntimeBase : ISharpTSHostedRuntime
     /// Attributes an uncaught compiled module-initialization failure to its source
     /// module without changing errors handled by guest try/catch code.
     /// </summary>
+    /// <param name="task">The module initialization task.</param>
+    /// <param name="modulePath">The module path for error attribution.</param>
+    /// <returns>A task that completes when the module initializes.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if module initialization fails.</exception>
     public static async Task AttributeModuleInitialization(Task task, string modulePath)
     {
         ArgumentNullException.ThrowIfNull(task);
@@ -364,6 +450,12 @@ public abstract class SharpTSHostedRuntimeBase : ISharpTSHostedRuntime
         }
     }
 
+    /// <summary>
+    /// Observes the program's main task and completes the program if it returns a numeric exit code.
+    /// </summary>
+    /// <param name="task">The main task to observe.</param>
+    /// <param name="useNumericResult">Whether to interpret a numeric result as an exit code.</param>
+    /// <returns>A task that completes when the main task completes.</returns>
     public Task ObserveProgramMain(Task<object?> task, bool useNumericResult)
     {
         ArgumentNullException.ThrowIfNull(task);
@@ -396,14 +488,21 @@ public abstract class SharpTSHostedRuntimeBase : ISharpTSHostedRuntime
         return completion.Task;
     }
 
-    /// <summary>Implements the forced hosted process-exit boundary.</summary>
+    /// <summary>
+    /// Implements the forced hosted process-exit boundary.
+    /// </summary>
+    /// <param name="exitCode">The exit code to request.</param>
+    /// <exception cref="SharpTSHostedProcessExitException">Always thrown to unwind the stack.</exception>
     public void RequestProcessExit(int exitCode)
     {
         BeginShutdown(SharpTSHostedShutdownReason.ProcessExit, exitCode);
         throw new SharpTSHostedProcessExitException(exitCode);
     }
 
-    /// <summary>Completes a numeric hosted main through the graceful lifecycle.</summary>
+    /// <summary>
+    /// Completes a numeric hosted main through the graceful lifecycle.
+    /// </summary>
+    /// <param name="exitCode">The exit code.</param>
     public void CompleteProgram(int exitCode)
     {
         if (State == SharpTSHostedRuntimeState.Initializing)
@@ -907,8 +1006,15 @@ public abstract class SharpTSHostedRuntimeBase : ISharpTSHostedRuntime
         Func<Task> Initializer);
 }
 
+/// <summary>
+/// Exception thrown to forcefully exit a hosted process.
+/// </summary>
+/// <param name="exitCode">The exit code.</param>
 [Experimental(SharpTSHostingDiagnostics.ExperimentalId)]
 public sealed class SharpTSHostedProcessExitException(int exitCode) : Exception
 {
+    /// <summary>
+    /// Gets the requested exit code.
+    /// </summary>
     public int ExitCode { get; } = exitCode;
 }

--- a/src/SharpTS/Cli/CommandLineParser.cs
+++ b/src/SharpTS/Cli/CommandLineParser.cs
@@ -192,11 +192,33 @@ public abstract record ParsedCommand
     /// <summary>Display version and exit.</summary>
     public sealed record Version() : ParsedCommand;
 
+    /// <summary>
+    /// Create a new Avalonia GUI application project.
+    /// </summary>
+    /// <param name="Name">The name of the new project.</param>
+    /// <param name="OutputDirectory">The directory to create the project in.</param>
+    /// <param name="GuiSdkVersion">The version of the GUI SDK to use.</param>
     public sealed record NewAvalonia(
         string Name,
         string OutputDirectory,
         string GuiSdkVersion) : ParsedCommand;
 
+    /// <summary>
+    /// Application command for GUI applications (build, run, publish).
+    /// </summary>
+    /// <param name="Action">The action to perform (build, run, publish).</param>
+    /// <param name="Entry">The entry point file for the application.</param>
+    /// <param name="Host">The host type to use.</param>
+    /// <param name="RuntimeIdentifier">The .NET runtime identifier.</param>
+    /// <param name="SelfContained">Whether to publish a self-contained application.</param>
+    /// <param name="SingleFile">Whether to bundle as a single file.</param>
+    /// <param name="Configuration">Build configuration (Debug or Release).</param>
+    /// <param name="OutputDirectory">Output directory for build artifacts.</param>
+    /// <param name="GuiSdkVersion">GUI SDK version to use.</param>
+    /// <param name="GuiSdkSource">GUI SDK source location.</param>
+    /// <param name="Mode">Application mode.</param>
+    /// <param name="ApplicationArgs">Arguments to pass to the application.</param>
+    /// <param name="GcProfile">Garbage collection profile.</param>
     public sealed record Application(
         string Action,
         string? Entry,

--- a/src/SharpTS/Compilation/Emitters/StringEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/StringEmitter.cs
@@ -366,6 +366,7 @@ public sealed class StringEmitter : ITypeEmitterStrategy
         emitter.EmitBoxIfNeeded(literal);
         ctx.IL.Emit(OpCodes.Castclass, ctx.Runtime.TSRegExpType);
         emitter.EmitExpression(arguments[1]);
+        emitter.EmitConversionForParameter(arguments[1], ctx.Types.String);
         ctx.IL.Emit(literal.Flags.Contains('g') ? OpCodes.Ldc_I4_1 : OpCodes.Ldc_I4_0);
         ctx.IL.Emit(OpCodes.Call, ctx.Runtime.StableRegExpReplace);
         emitter.SetStackType(StackType.String);

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSRegExp.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSRegExp.cs
@@ -3685,8 +3685,6 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4, (int)'<');
         il.Emit(OpCodes.Bne_Un, notNamedCapture);
         il.Emit(OpCodes.Ldarg_S, (byte)5);
-        il.Emit(OpCodes.Brfalse, notNamedCapture);
-        il.Emit(OpCodes.Ldarg_S, (byte)5);
         il.Emit(OpCodes.Isinst, runtime.UndefinedType);
         il.Emit(OpCodes.Brtrue, notNamedCapture);
         il.Emit(OpCodes.Ldarg_0);
@@ -3700,6 +3698,12 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, namedClose);
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Blt, notNamedCapture);
+        var namedCaptureReceiverReady = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_S, (byte)5);
+        il.Emit(OpCodes.Brtrue, namedCaptureReceiverReady);
+        GuestErrorEmitter.ThrowTypeError(
+            il, runtime, "Cannot read named capture from null groups");
+        il.MarkLabel(namedCaptureReceiverReady);
         il.Emit(OpCodes.Ldarg_S, (byte)5);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldloc, i);
@@ -4282,8 +4286,6 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, hasNamedCaptures);
         var namedCapturesReady = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, namedCaptures);
-        il.Emit(OpCodes.Brfalse, namedCapturesReady);
-        il.Emit(OpCodes.Ldloc, namedCaptures);
         il.Emit(OpCodes.Isinst, runtime.UndefinedType);
         il.Emit(OpCodes.Brtrue, namedCapturesReady);
         il.Emit(OpCodes.Ldc_I4_1);
@@ -4291,7 +4293,7 @@ public partial class RuntimeEmitter
         il.MarkLabel(namedCapturesReady);
 
         // Functional replacement: [matched, ...captures, position, S,
-        // groups?]. The final groups object is present only for named captures.
+        // groups?]. Only undefined omits the final groups value.
         il.Emit(OpCodes.Ldloc, replacementFunctionLocal);
         il.Emit(OpCodes.Brfalse, stringReplacement);
         var callArgs = il.DeclareLocal(_types.ObjectArray);
@@ -5092,6 +5094,9 @@ public partial class RuntimeEmitter
         var sLocal = il.DeclareLocal(_types.String);
         var resultLocal = il.DeclareLocal(_types.Object);
 
+        // ECMA-262 §22.2.6.16 validates the receiver before ToString(string).
+        EmitRequireObjectArg(il, runtime, method, argIndex: 0, "RegExp.prototype.test");
+
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Stloc, rxLocal);
 
@@ -5225,6 +5230,11 @@ public partial class RuntimeEmitter
         // "non-object" value and expects TypeError when passed as `this`.
         il.Emit(OpCodes.Ldarg, argIndex);
         il.Emit(OpCodes.Isinst, runtime.TSSymbolType);
+        il.Emit(OpCodes.Brtrue, throwLabel);
+
+        // Compiled BigInts use System.Numerics.BigInteger and remain primitive.
+        il.Emit(OpCodes.Ldarg, argIndex);
+        il.Emit(OpCodes.Isinst, _types.BigInteger);
         il.Emit(OpCodes.Brtrue, throwLabel);
 
         il.Emit(OpCodes.Br, okLabel);

--- a/src/SharpTS/Runtime/BuiltIns/RegExpBuiltIns.cs
+++ b/src/SharpTS/Runtime/BuiltIns/RegExpBuiltIns.cs
@@ -1011,7 +1011,7 @@ public static class RegExpBuiltIns
             }
 
             object? namedCaptures = interp.GetProperty(match, "groups");
-            bool hasNamedCaptures = namedCaptures is not (null or SharpTSUndefined);
+            bool hasNamedCaptures = namedCaptures is not SharpTSUndefined;
 
             string replacement;
             if (isCallable)
@@ -1032,7 +1032,7 @@ public static class RegExpBuiltIns
             {
                 replacement = ExpandReplacement(
                     interp, replaceStr, s, matchStr, position, captures,
-                    hasNamedCaptures ? namedCaptures : null);
+                    namedCaptures);
             }
 
             // Append the un-modified slice + replacement.
@@ -1088,7 +1088,7 @@ public static class RegExpBuiltIns
                     continue;
             }
 
-            if (next == '<' && namedCaptures is not null)
+            if (next == '<' && namedCaptures is not SharpTSUndefined)
             {
                 int close = replacement.IndexOf('>', i + 2);
                 if (close >= 0)

--- a/tests/SharpTS.Tests/CompilerTests/StableRegExpReplaceTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableRegExpReplaceTests.cs
@@ -89,6 +89,45 @@ public sealed class StableRegExpReplaceTests
         Assert.Equal("a a 0 ab a\nb b 1 ab b\nAB\n", TestHarness.Run(source, mode));
     }
 
+    [Theory, ModeData]
+    public void StableLiteralReplace_AcceptsObjectBackedStringReplacements(ExecutionMode mode)
+    {
+        const string source = """
+            const topLevelReplacement: string = "[$&]";
+            function replaceTopLevel(input: string): string {
+                return input.replace(/x/, topLevelReplacement);
+            }
+
+            function makeReplacer(replacement: string): any {
+                return function(input: string): string {
+                    return input.replace(/x/, replacement);
+                };
+            }
+
+            console.log(replaceTopLevel("x"));
+            const replaceCaptured: any = makeReplacer("<$&>");
+            console.log(replaceCaptured("x"));
+            """;
+
+        Assert.Equal("[x]\n<x>\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void StableLiteralReplace_ObjectBackedStringValuesPassIlVerification()
+    {
+        const string source = """
+            const replacement: string = "[$&]";
+            function replace(input: string): string {
+                return input.replace(/x/, replacement);
+            }
+            console.log(replace("x"));
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+        Assert.Empty(errors);
+        Assert.Equal("[x]\n", output);
+    }
+
     [Fact]
     public void RegExpPrototypeMutation_DisablesStableHelperAndRemainsObservable()
     {

--- a/tests/SharpTS.Tests/CompilerTests/StableRegExpTestTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableRegExpTestTests.cs
@@ -205,6 +205,33 @@ public sealed class StableRegExpTestTests
             TestHarness.Run(source, mode));
     }
 
+    [Theory, ModeData]
+    public void BorrowedTest_ValidatesReceiverBeforeCoercingArgument(ExecutionMode mode)
+    {
+        const string source = """
+            let coercions: number = 0;
+            const argument: any = {
+                toString: function(): string {
+                    coercions++;
+                    throw new Error("coerced");
+                }
+            };
+
+            function check(receiver: any): void {
+                try {
+                    RegExp.prototype.test.call(receiver, argument);
+                } catch (error) {
+                    console.log(error instanceof TypeError, coercions);
+                }
+            }
+
+            check(undefined);
+            check(1n);
+            """;
+
+        Assert.Equal("true 0\ntrue 0\n", TestHarness.Run(source, mode));
+    }
+
     [Fact]
     public void StableAndFallbackShapesPassIlVerification()
     {

--- a/tests/SharpTS.Tests/SharedTests/RegExpExecSemanticsTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/RegExpExecSemanticsTests.cs
@@ -165,6 +165,41 @@ public class RegExpExecSemanticsTests
     }
 
     [Theory, ModeData]
+    public void StringReplace_CustomExecDistinguishesNullAndUndefinedGroups(
+        ExecutionMode mode)
+    {
+        const string source = """
+            const withNull: any = /x/;
+            withNull.exec = function(input: string): any {
+                return { 0: "x", length: 1, index: 0, input: input, groups: null };
+            };
+            console.log("x".replace(withNull, function(): string {
+                console.log(arguments.length, arguments[3] === null);
+                return "present";
+            }));
+
+            const withoutGroups: any = /x/;
+            withoutGroups.exec = function(input: string): any {
+                return { 0: "x", length: 1, index: 0, input: input };
+            };
+            console.log("x".replace(withoutGroups, function(): string {
+                console.log(arguments.length, arguments[3] === undefined);
+                return "absent";
+            }));
+
+            try {
+                console.log("x".replace(withNull, "$<name>"));
+            } catch (error) {
+                console.log(error instanceof TypeError);
+            }
+            """;
+
+        Assert.Equal(
+            "4 true\npresent\n3 true\nabsent\ntrue\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
     public void StringMatchAndReplace_InvokePrototypeSymbolOverrides(
         ExecutionMode mode)
     {


### PR DESCRIPTION
## Summary

- validate borrowed RegExp.prototype.test receivers before coercing the input, including BigInt primitives
- convert object-backed, statically typed string replacements to the stable helper's CLR string signature
- distinguish groups: null from groups: undefined in callable and template replacements across interpreted and compiled execution
- add cross-mode regression coverage for coercion order, top-level/captured replacements, custom exec results, callback arity, and named replacement templates

## Validation

- Release solution build: succeeded with 0 warnings and 0 errors
- RegExp-focused sweep: 131 passed, 0 failed
- full core suite: 17,759 passed, 3 skipped, 0 failed
- focused receiver-order rerun after adding BigInt coverage: 2 passed, 0 failed

Closes #1519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression replacement behavior for object and captured-value replacements.
  * Correctly distinguishes `null` and `undefined` named-capture groups.
  * Throws `TypeError` for invalid regular expression receivers and null named-capture groups.
  * Ensures receiver validation occurs before coercing `RegExp.prototype.test` arguments.

* **Tests**
  * Added coverage for replacement tokens, custom `exec` results, receiver validation, and compilation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->