### PR TITLE
Harden numeric storage promotion and emission

### DIFF
--- a/src/SharpTS/Compilation/AsyncMoveNextEmitter.ArrowFunctions.cs
+++ b/src/SharpTS/Compilation/AsyncMoveNextEmitter.ArrowFunctions.cs
@@ -7,6 +7,9 @@ namespace SharpTS.Compilation;
 
 public partial class AsyncMoveNextEmitter
 {
+    protected override string ResolveCaptureSourceName(Expr.ArrowFunction af, string capturedVar) =>
+        PivotCaptureSource(_analysis.BlockScopeCaptureRenames, af, capturedVar);
+
     protected override void EmitArrowFunction(Expr.ArrowFunction af)
     {
         if (af.IsAsync)

--- a/src/SharpTS/Compilation/AsyncMoveNextEmitter.Statements.Variables.cs
+++ b/src/SharpTS/Compilation/AsyncMoveNextEmitter.Statements.Variables.cs
@@ -33,10 +33,16 @@ public partial class AsyncMoveNextEmitter
     /// </summary>
     protected override void EmitVarDeclaration(Stmt.Var v)
     {
+        bool stableNumeric = Ctx.TypeMap?.IsStableNumericStateMachineLocal(v) == true;
+
         // Resolve a shadowing block-scoped binding to its own storage before any DC routing (#766);
         // a renamed binding is never a captured/DC name, so the DC check below correctly falls through.
         if (BlockScopeRenames.TryGetValue(v, out var renamed))
+        {
             v = v with { Name = RenameToken(v.Name, renamed) };
+            if (stableNumeric)
+                Ctx.TypeMap!.MarkStableNumericStateMachineLocal(v);
+        }
 
         string name = v.Name.Lexeme;
 

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.Operators.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.Operators.cs
@@ -345,6 +345,31 @@ public abstract partial class ExpressionEmitterBase
             return false;
         }
 
+        // Hoisted state-machine storage is the resolver's source of truth. A
+        // same-named local may belong to a shadow and must never win here.
+        var field = GetHoistedVariableField(name);
+        if (field != null)
+        {
+            if (field.FieldType != Types.Double)
+                return false;
+
+            var original = IL.DeclareLocal(Types.Double);
+            var updated = IL.DeclareLocal(Types.Double);
+            IL.Emit(OpCodes.Ldarg_0);
+            IL.Emit(OpCodes.Ldfld, field);
+            IL.Emit(OpCodes.Stloc, original);
+            IL.Emit(OpCodes.Ldloc, original);
+            IL.Emit(OpCodes.Ldc_R8, delta);
+            IL.Emit(OpCodes.Add);
+            IL.Emit(OpCodes.Stloc, updated);
+            IL.Emit(OpCodes.Ldarg_0);
+            IL.Emit(OpCodes.Ldloc, updated);
+            IL.Emit(OpCodes.Stfld, field);
+            IL.Emit(OpCodes.Ldloc, isPrefix ? updated : original);
+            SetStackType(StackType.Double);
+            return true;
+        }
+
         if (Ctx.Locals.TryGetLocal(name, out var local)
             && local.LocalType == Types.Double)
         {
@@ -360,25 +385,7 @@ public abstract partial class ExpressionEmitterBase
             return true;
         }
 
-        var field = GetHoistedVariableField(name);
-        if (field == null || field.FieldType != Types.Double)
-            return false;
-
-        var original = IL.DeclareLocal(Types.Double);
-        var updated = IL.DeclareLocal(Types.Double);
-        IL.Emit(OpCodes.Ldarg_0);
-        IL.Emit(OpCodes.Ldfld, field);
-        IL.Emit(OpCodes.Stloc, original);
-        IL.Emit(OpCodes.Ldloc, original);
-        IL.Emit(OpCodes.Ldc_R8, delta);
-        IL.Emit(OpCodes.Add);
-        IL.Emit(OpCodes.Stloc, updated);
-        IL.Emit(OpCodes.Ldarg_0);
-        IL.Emit(OpCodes.Ldloc, updated);
-        IL.Emit(OpCodes.Stfld, field);
-        IL.Emit(OpCodes.Ldloc, isPrefix ? updated : original);
-        SetStackType(StackType.Double);
-        return true;
+        return false;
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/ILCompiler.Functions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Functions.cs
@@ -82,7 +82,13 @@ public partial class ILCompiler
             Type parameterType = i < emittedParameters.Length
                 ? emittedParameters[i].ParameterType
                 : typeof(object);
-            if (parameterType.IsValueType)
+            if (field.FieldType == _types.Double && parameterType != _types.Double)
+            {
+                if (parameterType.IsValueType)
+                    il.Emit(OpCodes.Box, parameterType);
+                il.Emit(OpCodes.Call, _runtime!.ConvertToNumber);
+            }
+            else if (field.FieldType == _types.Object && parameterType.IsValueType)
                 il.Emit(OpCodes.Box, parameterType);
             il.Emit(OpCodes.Stfld, field);
         }

--- a/src/SharpTS/Compilation/ILEmitter.Expressions.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Expressions.cs
@@ -504,6 +504,8 @@ public partial class ILEmitter
                     _ctx.TryGetParameter(a.Name.Lexeme, out var numericParamSync))
                 {
                     IL.Emit(OpCodes.Ldloc, numericTemp);
+                    IL.Emit(OpCodes.Box, _ctx.Types.Double);
+                    _ctx.EmitConvertForParamSlot(IL, a.Name.Lexeme);
                     IL.Emit(OpCodes.Starg, numericParamSync);
                 }
                 SetStackType(StackType.Double);

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -3617,6 +3617,7 @@ public partial class ILEmitter
         _ctx.ExceptionBlockDepth--;
 
         builder.MarkLabel(catchBody);
+        SetStackUnknown();
         _ctx.Locals.EnterScope();
         try
         {
@@ -3630,6 +3631,7 @@ public partial class ILEmitter
             _ctx.Locals.ExitScope();
         }
         builder.MarkLabel(afterCatch);
+        SetStackUnknown();
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/IteratorMoveNextEmitter.Variables.cs
+++ b/src/SharpTS/Compilation/IteratorMoveNextEmitter.Variables.cs
@@ -46,8 +46,14 @@ public partial class IteratorMoveNextEmitter
 
     protected override void EmitVarDeclaration(Stmt.Var v)
     {
+        bool stableNumeric = Ctx.TypeMap?.IsStableNumericStateMachineLocal(v) == true;
+
         if (BlockScopeRenames.TryGetValue(v, out var renamed))
+        {
             v = v with { Name = RenameToken(v.Name, renamed) };
+            if (stableNumeric)
+                Ctx.TypeMap!.MarkStableNumericStateMachineLocal(v);
+        }
 
         if (TryGetFunctionDCField(v.Name.Lexeme, out var dcField))
         {

--- a/src/SharpTS/Compilation/StableCustomIteratorAnalyzer.cs
+++ b/src/SharpTS/Compilation/StableCustomIteratorAnalyzer.cs
@@ -63,7 +63,7 @@ internal static class StableCustomIteratorAnalyzer
     private static void MarkStableNumericAccumulator(
         Stmt.ForOf loop, object? owner, TypeMap typeMap)
     {
-        if (owner is not Stmt.Function { Body: { } body } ||
+        if (owner is not Stmt.Function { IsAsync: false, Body: { } body } ||
             loop.Body is not Stmt.Expression
             {
                 Expr: Expr.Assign assignment and
@@ -119,7 +119,7 @@ internal static class StableCustomIteratorAnalyzer
         ClosureAnalyzer closures,
         TypeMap typeMap)
     {
-        if (owner is not Stmt.Function source || source.Body is null)
+        if (owner is not Stmt.Function source || source.Body is null || source.IsAsync)
             return;
 
         int iteratorDeclaration = source.Body.FindIndex(statement => statement switch

--- a/src/SharpTS/Compilation/StableNumericLoopCaptureAnalyzer.cs
+++ b/src/SharpTS/Compilation/StableNumericLoopCaptureAnalyzer.cs
@@ -184,6 +184,7 @@ internal static class StableNumericLoopCaptureAnalyzer
                         IsGenerator: false
                     } function
                     && IsStableAsyncPromiseLoop(statement, declaration.Name.Lexeme)
+                    && !collector.BindingWritten
                     && collector.StablePromiseCaptures.Count > 0)
                 {
                     _typeMap.MarkStableNumericStateMachineLocal(declaration);
@@ -230,8 +231,15 @@ internal static class StableNumericLoopCaptureAnalyzer
 
             string boundName = right.Name.Lexeme;
 
-            var parameter = function.Parameters.SingleOrDefault(candidate =>
-                candidate.Name.Lexeme == boundName);
+            Stmt.Parameter? parameter = null;
+            foreach (var candidate in function.Parameters)
+            {
+                if (candidate.Name.Lexeme != boundName)
+                    continue;
+                if (parameter is not null)
+                    return;
+                parameter = candidate;
+            }
             if (parameter is not
                 {
                     Type: "number",
@@ -333,6 +341,7 @@ internal static class StableNumericLoopCaptureAnalyzer
             new(ReferenceEqualityComparer.Instance);
         public HashSet<Expr.ArrowFunction> StablePromiseCaptures { get; } =
             new(ReferenceEqualityComparer.Instance);
+        public bool BindingWritten => _bindingWritten;
 
         protected override void VisitArrowFunction(Expr.ArrowFunction arrow)
         {
@@ -378,18 +387,55 @@ internal static class StableNumericLoopCaptureAnalyzer
             base.VisitFor(statement);
         }
 
+        protected override void VisitSwitch(Stmt.Switch statement)
+        {
+            Visit(statement.Subject);
+
+            // A switch owns one lexical scope shared by every case. A declaration in
+            // any arm therefore shadows the loop binding throughout the case block.
+            if (statement.Cases.Any(@case => DeclaresBinding(@case.Body))
+                || statement.DefaultBody is not null
+                && DeclaresBinding(statement.DefaultBody))
+            {
+                return;
+            }
+
+            foreach (var @case in statement.Cases)
+            {
+                Visit(@case.Value);
+                foreach (var child in @case.Body)
+                    Visit(child);
+            }
+            if (statement.DefaultBody is not null)
+                foreach (var child in statement.DefaultBody)
+                    Visit(child);
+        }
+
         protected override void VisitForOf(Stmt.ForOf statement)
         {
             Visit(statement.Iterable);
-            if (statement.Variable.Lexeme != _bindingName)
-                Visit(statement.Body);
+            if (statement.Variable.Lexeme == _bindingName)
+            {
+                // ForOf does not retain whether the target came from a declaration
+                // or an existing-binding assignment. Conservatively reject both:
+                // one shadows this binding and the other writes it.
+                _bindingWritten = true;
+                return;
+            }
+            Visit(statement.Body);
         }
 
         protected override void VisitForIn(Stmt.ForIn statement)
         {
             Visit(statement.Object);
-            if (statement.Variable.Lexeme != _bindingName)
-                Visit(statement.Body);
+            if (statement.Variable.Lexeme == _bindingName)
+            {
+                // The declaration form can still be `var`, which reuses a
+                // function-scoped binding. Reject the name collision conservatively.
+                _bindingWritten = true;
+                return;
+            }
+            Visit(statement.Body);
         }
 
         protected override void VisitTryCatch(Stmt.TryCatch statement)
@@ -424,6 +470,8 @@ internal static class StableNumericLoopCaptureAnalyzer
 
         public void MarkSynchronousCaptures()
         {
+            if (_bindingWritten)
+                return;
             foreach (var arrow in _directCaptures)
                 _typeMap.MarkStableNumericCaptureField(arrow, _bindingName);
             foreach (var arrow in StablePromiseCaptures)
@@ -432,9 +480,13 @@ internal static class StableNumericLoopCaptureAnalyzer
 
         public void MarkStablePromiseCaptures()
         {
+            if (_bindingWritten)
+                return;
             foreach (var arrow in StablePromiseCaptures)
                 _typeMap.MarkStableNumericCaptureField(arrow, _bindingName);
         }
+
+        private bool _bindingWritten;
     }
 
     private sealed class StablePromiseHandlerVisitor(TypeMap typeMap) : AstVisitorBase
@@ -497,6 +549,28 @@ internal static class StableNumericLoopCaptureAnalyzer
                 Safe = false;
             base.VisitPostfixIncrement(expression);
         }
+
+        protected override void VisitForOf(Stmt.ForOf statement)
+        {
+            Visit(statement.Iterable);
+            if (statement.Variable.Lexeme == bindingName)
+            {
+                Safe = false;
+                return;
+            }
+            Visit(statement.Body);
+        }
+
+        protected override void VisitForIn(Stmt.ForIn statement)
+        {
+            Visit(statement.Object);
+            if (statement.Variable.Lexeme == bindingName)
+            {
+                Safe = false;
+                return;
+            }
+            Visit(statement.Body);
+        }
     }
 
     private sealed class BindingWriteVisitor(string bindingName) : AstVisitorBase
@@ -539,6 +613,30 @@ internal static class StableNumericLoopCaptureAnalyzer
                 Written = true;
             base.VisitPostfixIncrement(expression);
         }
+
+        protected override void VisitForOf(Stmt.ForOf statement)
+        {
+            Visit(statement.Iterable);
+            if (statement.Variable.Lexeme == bindingName)
+            {
+                // The AST cannot distinguish `for (name of ...)` from a declaration,
+                // so both forms conservatively disqualify a typed parameter field.
+                Written = true;
+                return;
+            }
+            Visit(statement.Body);
+        }
+
+        protected override void VisitForIn(Stmt.ForIn statement)
+        {
+            Visit(statement.Object);
+            if (statement.Variable.Lexeme == bindingName)
+            {
+                Written = true;
+                return;
+            }
+            Visit(statement.Body);
+        }
     }
 
     private sealed class DirectEvalVisitor : AstVisitorBase
@@ -548,7 +646,7 @@ internal static class StableNumericLoopCaptureAnalyzer
         protected override void VisitCall(Expr.Call expression)
         {
             if (!expression.Optional
-                && expression.Callee is Expr.Variable { Name.Lexeme: "eval" })
+                && Unwrap(expression.Callee) is Expr.Variable { Name.Lexeme: "eval" })
             {
                 ContainsDirectEval = true;
             }

--- a/tests/SharpTS.Tests/Compilation/EmitterSyncTests.cs
+++ b/tests/SharpTS.Tests/Compilation/EmitterSyncTests.cs
@@ -87,6 +87,7 @@ public class EmitterSyncTests
             "get_Resolver",         // Abstract: provides IVariableResolver
             "GetThisField",         // Abstract: provides hoisted 'this' field
             "GetHoistedVariableField", // Hoisted variable fields on state machine
+            "ResolveCaptureSourceName", // #1517: typed Promise delegates honor block-shadow capture pivots
             "SharpTS.Compilation.Emitters.IEmitterContext.get_IL", // IEmitterContext impl
             "SharpTS.Compilation.Emitters.IEmitterContext.SetStackUnknown", // IEmitterContext impl
             "SharpTS.Compilation.Emitters.IEmitterContext.SetStackType",   // IEmitterContext impl

--- a/tests/SharpTS.Tests/CompilerTests/NumericStorageSafetyTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/NumericStorageSafetyTests.cs
@@ -1,0 +1,267 @@
+using System.Reflection;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+/// <summary>Regression coverage for numeric-storage safety issue #1517.</summary>
+public sealed class NumericStorageSafetyTests
+{
+    [Theory, ModeData]
+    public void SwitchScopedShadow_IsNotPromotedAsOuterNumericCapture(ExecutionMode mode)
+    {
+        const string source = """
+            function run(): string {
+                let result: string = "";
+                for (let i: number = 0; i < 1; i++) {
+                    switch (i) {
+                        case 0:
+                            let i: string = "shadow";
+                            const read = (): string => i;
+                            result = read();
+                            break;
+                    }
+                }
+                return result;
+            }
+            console.log(run());
+            """;
+
+        AssertOutput(source, "shadow\n", mode);
+    }
+
+    [Theory, ModeData]
+    public void GroupedDirectEval_DisablesNumericCapturePromotion(ExecutionMode mode)
+    {
+        const string source = """
+            function run(): number {
+                let total: number = 0;
+                for (let i: number = 0; i < 2; i++) {
+                    const read = (): number => i;
+                    (eval)("0");
+                    total = total + read();
+                }
+                return total;
+            }
+            console.log(run());
+            """;
+
+        AssertOutput(source, "1\n", mode);
+        if (mode == ExecutionMode.Compiled)
+            AssertCaptureFieldsHaveType(source, "i", typeof(object));
+    }
+
+    [Theory, ModeData]
+    public void HoistedOuterBinding_WinsOverSameNamedNumericLoopLocal(ExecutionMode mode)
+    {
+        const string source = """
+            async function run(n: number): Promise<number> {
+                let i: number = 7;
+                await Promise.resolve(0);
+                let chain: Promise<number> = Promise.resolve(0);
+                {
+                    for (let i: number = 0; i < n; i++) {
+                        chain = chain.then((sum: number): number => sum + i);
+                    }
+                }
+                return (await chain) + i * 0;
+            }
+            run(3).then((value: number): void => console.log(value));
+            """;
+
+        AssertOutput(source, "3\n", mode);
+    }
+
+    [Theory, ModeData]
+    public void ForOfRebinding_DisablesNumericAsyncParameterField(ExecutionMode mode)
+    {
+        const string source = """
+            async function run(n: number): Promise<number> {
+                let chain: Promise<number> = Promise.resolve(0);
+                for (let i: number = 0; i < n; i++) {
+                    chain = chain.then((sum: number): number => sum + i);
+                }
+                for (n of [1]) { }
+                return await chain;
+            }
+            run(3).then((value: number): void => console.log(value));
+            """;
+
+        AssertOutput(source, "3\n", mode);
+    }
+
+    [Theory, ModeData]
+    public void ForInRebinding_DisablesNumericAsyncParameterField(ExecutionMode mode)
+    {
+        const string source = """
+            async function run(n: number): Promise<number> {
+                let chain: Promise<number> = Promise.resolve(0);
+                for (let i: number = 0; i < n; i++) {
+                    chain = chain.then((sum: number): number => sum + i);
+                }
+                for (n in { only: 1 }) { }
+                return await chain;
+            }
+            run(3).then((value: number): void => console.log(value));
+            """;
+
+        AssertOutput(source, "3\n", mode);
+    }
+
+    [Theory, ModeData]
+    public void DuplicateAsyncParameterNames_DoNotCrashPromotionAnalysis(ExecutionMode mode)
+    {
+        const string source = """
+            async function run(n: number, n: number): Promise<number> {
+                let chain: Promise<number> = Promise.resolve(0);
+                for (let i: number = 0; i < n; i++) {
+                    chain = chain.then((sum: number): number => sum + i);
+                }
+                return await chain;
+            }
+            run(2, 3).then((value: number): void => console.log(value));
+            """;
+
+        AssertOutput(source, "3\n", mode);
+    }
+
+    [Theory, ModeData]
+    public void TryCatchMergeLabels_ResetPrimitiveStackMetadata(ExecutionMode mode)
+    {
+        const string source = """
+            function run(shouldThrow: boolean): string {
+                try {
+                    if (shouldThrow) throw "boom";
+                    1;
+                } catch {
+                    2;
+                }
+                return "done";
+            }
+            console.log(run(false) + "," + run(true));
+            """;
+
+        AssertOutput(source, "done,done\n", mode);
+    }
+
+    [Theory, ModeData]
+    public void NumericFunctionCaptureParameter_IsInitializedToDoubleField(ExecutionMode mode)
+    {
+        const string source = """
+            function iterate(n: number): number {
+                let current: number = 0;
+                const iterable = {
+                    [Symbol.iterator]() { return this; },
+                    next() {
+                        if (current < n) {
+                            const value: number = current;
+                            current = current + 1;
+                            return { value, done: false };
+                        }
+                        return { value: 0, done: true };
+                    }
+                };
+                let total: number = 0;
+                for (const value of iterable) total = total + value;
+                return total;
+            }
+            console.log(iterate(3));
+            """;
+
+        AssertOutput(source, "3\n", mode);
+    }
+
+    [Theory, ModeData]
+    public void DefaultedNumericCapture_AssignmentBoxesForObjectParameterSlot(ExecutionMode mode)
+    {
+        const string source = """
+            function iterate(n: number = 3): number {
+                let current: number = 0;
+                const iterable = {
+                    [Symbol.iterator]() { return this; },
+                    next() {
+                        if (current < n) {
+                            const value: number = current;
+                            current = current + 1;
+                            return { value, done: false };
+                        }
+                        return { value: 0, done: true };
+                    }
+                };
+                n = n + 1;
+                let total: number = 0;
+                for (const value of iterable) total = total + value;
+                return total;
+            }
+            console.log(iterate());
+            """;
+
+        AssertOutput(source, "6\n", mode);
+    }
+
+    [Theory, ModeData]
+    public void AsyncCustomIteratorAccumulator_RetainsObjectCaptureStorage(ExecutionMode mode)
+    {
+        const string source = """
+            async function iterate(n: number): Promise<number> {
+                let current: number = 0;
+                let total: number = 0;
+                const iterable = {
+                    [Symbol.iterator]() { return this; },
+                    next() {
+                        if (total === -1) return { value: 0, done: true };
+                        if (current < n) {
+                            const value: number = current;
+                            current = current + 1;
+                            return { value, done: false };
+                        }
+                        return { value: 0, done: true };
+                    }
+                };
+                for (const value of iterable) total = total + value;
+                return 3;
+            }
+            iterate(3).then((value: number): void => console.log(value));
+            """;
+
+        AssertOutput(source, "3\n", mode);
+        if (mode == ExecutionMode.Compiled)
+            AssertCaptureFieldsHaveType(source, "total", typeof(object));
+    }
+
+    private static void AssertOutput(string source, string expected, ExecutionMode mode)
+    {
+        if (mode == ExecutionMode.Compiled)
+        {
+            var errors = TestHarness.CompileAndVerifyOnly(source);
+            Assert.True(errors.Count == 0, string.Join(Environment.NewLine, errors));
+        }
+        Assert.Equal(expected, TestHarness.Run(source, mode));
+    }
+
+    private static void AssertCaptureFieldsHaveType(string source, string name, Type expected)
+    {
+        var fields = Compile(source).GetTypes()
+            .Where(type => type.Name.Contains("DisplayClass", StringComparison.Ordinal))
+            .SelectMany(type => type.GetFields(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+            .Where(field => field.Name == name || field.Name.EndsWith("_" + name, StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.NotEmpty(fields);
+        Assert.All(fields, field => Assert.Equal(expected, field.FieldType));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        TypeMap typeMap = new TypeChecker().Check(statements);
+        var deadCodeInfo = new DeadCodeAnalyzer(typeMap).Analyze(statements);
+        var compiler = new ILCompiler($"numeric_storage_safety_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, deadCodeInfo);
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+}


### PR DESCRIPTION
## Summary

- make numeric capture promotion scope-aware for switch shadows, grouped eval, duplicate parameters, and for-in/for-of rebinding
- prioritize hoisted state-machine storage and preserve renamed numeric locals/capture sources
- keep emitted field and parameter stores CLR-type-correct, reset catch-merge stack metadata, and disable unsafe async custom-iterator capture promotion
- add dual-mode execution and IL-verification regressions for every issue finding

## Validation

- CI-filtered SharpTS.Tests suite: 17,748 passed, 3 skipped, 0 failed
- focused numeric-storage and emitter-contract tests after rebasing: 21 passed
- Release builds for SharpTS and SharpTS.Tests: 0 warnings, 0 errors

Fixes #1517

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved numeric variable handling in async functions, generators, and custom iterators.
  - Fixed issues involving shadowed variables, loop rebinding, duplicate parameters, and captured values.
  - Improved numeric parameter conversions and storage when values cross function or closure boundaries.
  - Prevented incorrect optimization when direct `eval` or complex scoping could change runtime behavior.
  - Improved reliability of `try/catch` compilation and numeric increment operations involving captured variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->