### PR TITLE
Fix decimal parseInt rounding for long inputs

### DIFF
--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ParseIntDecimalBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ParseIntDecimalBenchmarks.cs
@@ -20,6 +20,8 @@ public class ParseIntDecimalBenchmarks
 
     [Params(
         "123456789012345",
+        "100000000000000070",
+        "18446744073709551616",
         "  -12345suffix",
         "\u00A0+9007199254740991tail")]
     public string Input { get; set; } = null!;

--- a/src/SharpTS/Compilation/RuntimeEmitter.Number.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Number.cs
@@ -180,6 +180,9 @@ public partial class RuntimeEmitter
         TypeBuilder typeBuilder,
         EmittedRuntime runtime)
     {
+        const long maxBeforeMultiply = (long)(ulong.MaxValue / 10);
+        const int maxLastDigit = (int)(ulong.MaxValue % 10);
+
         var method = typeBuilder.DefineMethod(
             "NumberParseIntDecimalString",
             MethodAttributes.Public | MethodAttributes.Static,
@@ -195,6 +198,9 @@ public partial class RuntimeEmitter
         var sign = il.DeclareLocal(_types.Int32);
         var digit = il.DeclareLocal(_types.Int32);
         var current = il.DeclareLocal(_types.Char);
+        var magnitude = il.DeclareLocal(_types.UInt64);
+        var overflowed = il.DeclareLocal(_types.Boolean);
+        var digitsText = il.DeclareLocal(_types.String);
         var result = il.DeclareLocal(_types.Double);
 
         var whitespaceLoop = il.DefineLabel();
@@ -204,8 +210,16 @@ public partial class RuntimeEmitter
         var notMinus = il.DefineLabel();
         var afterSign = il.DefineLabel();
         var digitLoop = il.DefineLabel();
+        var accumulateDigit = il.DefineLabel();
+        var markOverflow = il.DefineLabel();
+        var afterAccumulate = il.DefineLabel();
         var endDigits = il.DefineLabel();
         var noDigits = il.DefineLabel();
+        var parseOverflow = il.DefineLabel();
+        var sliceDigits = il.DefineLabel();
+        var digitsReady = il.DefineLabel();
+        var parseSucceeded = il.DefineLabel();
+        var applySign = il.DefineLabel();
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Callvirt,
@@ -286,8 +300,10 @@ public partial class RuntimeEmitter
         il.MarkLabel(afterSign);
         il.Emit(OpCodes.Ldloc, index);
         il.Emit(OpCodes.Stloc, digitStart);
-        il.Emit(OpCodes.Ldc_R8, 0.0);
-        il.Emit(OpCodes.Stloc, result);
+        il.Emit(OpCodes.Ldc_I8, 0L);
+        il.Emit(OpCodes.Stloc, magnitude);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Stloc, overflowed);
 
         il.MarkLabel(digitLoop);
         il.Emit(OpCodes.Ldloc, index);
@@ -304,13 +320,37 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_S, (sbyte)9);
         il.Emit(OpCodes.Bgt_Un, endDigits);
 
-        il.Emit(OpCodes.Ldloc, result);
-        il.Emit(OpCodes.Ldc_R8, 10.0);
+        // Keep the magnitude exact through UInt64. Only the uncommon overflow
+        // path needs the framework decimal parser; ordinary inputs round once
+        // when the completed integer is converted to Double.
+        il.Emit(OpCodes.Ldloc, overflowed);
+        il.Emit(OpCodes.Brtrue, afterAccumulate);
+        il.Emit(OpCodes.Ldloc, magnitude);
+        il.Emit(OpCodes.Ldc_I8, maxBeforeMultiply);
+        il.Emit(OpCodes.Bgt_Un, markOverflow);
+        il.Emit(OpCodes.Ldloc, magnitude);
+        il.Emit(OpCodes.Ldc_I8, maxBeforeMultiply);
+        il.Emit(OpCodes.Bne_Un, accumulateDigit);
+        il.Emit(OpCodes.Ldloc, digit);
+        il.Emit(OpCodes.Ldc_I4, maxLastDigit);
+        il.Emit(OpCodes.Bgt_Un, markOverflow);
+
+        il.MarkLabel(accumulateDigit);
+        il.Emit(OpCodes.Ldloc, magnitude);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)10);
+        il.Emit(OpCodes.Conv_U8);
         il.Emit(OpCodes.Mul);
         il.Emit(OpCodes.Ldloc, digit);
-        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Conv_U8);
         il.Emit(OpCodes.Add);
-        il.Emit(OpCodes.Stloc, result);
+        il.Emit(OpCodes.Stloc, magnitude);
+        il.Emit(OpCodes.Br, afterAccumulate);
+
+        il.MarkLabel(markOverflow);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stloc, overflowed);
+
+        il.MarkLabel(afterAccumulate);
         il.Emit(OpCodes.Ldloc, index);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Add);
@@ -321,6 +361,52 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, index);
         il.Emit(OpCodes.Ldloc, digitStart);
         il.Emit(OpCodes.Beq, noDigits);
+
+        il.Emit(OpCodes.Ldloc, overflowed);
+        il.Emit(OpCodes.Brtrue, parseOverflow);
+        il.Emit(OpCodes.Ldloc, magnitude);
+        il.Emit(OpCodes.Conv_R_Un);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Stloc, result);
+        il.Emit(OpCodes.Br, applySign);
+
+        il.MarkLabel(parseOverflow);
+        il.Emit(OpCodes.Ldloc, digitStart);
+        il.Emit(OpCodes.Brtrue, sliceDigits);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldloc, length);
+        il.Emit(OpCodes.Bne_Un, sliceDigits);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Stloc, digitsText);
+        il.Emit(OpCodes.Br, digitsReady);
+
+        il.MarkLabel(sliceDigits);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, digitStart);
+        il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Ldloc, digitStart);
+        il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Callvirt,
+            _types.GetMethod(_types.String, "Substring", [_types.Int32, _types.Int32])!);
+        il.Emit(OpCodes.Stloc, digitsText);
+
+        il.MarkLabel(digitsReady);
+        il.Emit(OpCodes.Ldloc, digitsText);
+        il.Emit(OpCodes.Ldc_I4, (int)NumberStyles.None);
+        il.Emit(OpCodes.Call,
+            typeof(CultureInfo).GetProperty("InvariantCulture")!.GetGetMethod()!);
+        il.Emit(OpCodes.Ldloca, result);
+        il.Emit(OpCodes.Call, _types.GetMethod(
+            _types.Double,
+            "TryParse",
+            [_types.String, typeof(NumberStyles), typeof(IFormatProvider),
+                _types.Double.MakeByRefType()])!);
+        il.Emit(OpCodes.Brtrue, parseSucceeded);
+        il.Emit(OpCodes.Ldc_R8, double.NaN);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(parseSucceeded);
+        il.MarkLabel(applySign);
         il.Emit(OpCodes.Ldloc, sign);
         il.Emit(OpCodes.Conv_R8);
         il.Emit(OpCodes.Ldloc, result);
@@ -367,6 +453,7 @@ public partial class RuntimeEmitter
         var validateRadix = il.DefineLabel();
         var radixAtLeastTwo = il.DefineLabel();
         var radixValid = il.DefineLabel();
+        var nonDecimalRadix = il.DefineLabel();
         var loop = il.DefineLabel();
         var endLoop = il.DefineLabel();
         var returnResult = il.DefineLabel();
@@ -472,6 +559,17 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
         il.MarkLabel(radixValid);
 
+        // Reuse the correctly-rounded, allocation-free decimal scanner after
+        // radix inference. Pass the original string so its ECMAScript whitespace
+        // boundary is not broadened by String.Trim above.
+        il.Emit(OpCodes.Ldloc, radixLocal);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)10);
+        il.Emit(OpCodes.Bne_Un, nonDecimalRadix);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.NumberParseIntDecimalString);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(nonDecimalRadix);
+
         il.Emit(OpCodes.Ldc_R8, 0.0);
         il.Emit(OpCodes.Stloc, resultLocal);
         il.Emit(OpCodes.Ldc_I4_0);
@@ -558,6 +656,7 @@ public partial class RuntimeEmitter
         runtime.ParseIntHelper = method;
 
         var il = method.GetILGenerator();
+        var rawStrLocal = il.DeclareLocal(_types.String);
         var strLocal = il.DeclareLocal(_types.String);
         var radixLocal = il.DeclareLocal(_types.Int32);
         var signLocal = il.DeclareLocal(_types.Int32);
@@ -575,12 +674,15 @@ public partial class RuntimeEmitter
         var loopBodyLabel = il.DefineLabel();
         var endLoopLabel = il.DefineLabel();
         var returnResultLabel = il.DefineLabel();
+        var nonDecimalRadixLabel = il.DefineLabel();
 
         // Apply ECMAScript ToString before parsing. In particular, JavaScript
         // stringifies negative zero as "0" (where Double.ToString() yields
         // "-0"), and object arguments must observe their coercion hooks.
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, runtime.ToJsString);
+        il.Emit(OpCodes.Stloc, rawStrLocal);
+        il.Emit(OpCodes.Ldloc, rawStrLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.String, "Trim", Type.EmptyTypes)!);
         il.Emit(OpCodes.Stloc, strLocal);
 
@@ -728,6 +830,14 @@ public partial class RuntimeEmitter
 
         // Parse digits: result = 0, iterate through string
         il.MarkLabel(radixNotTooLargeLabel);
+        il.Emit(OpCodes.Ldloc, radixLocal);
+        il.Emit(OpCodes.Ldc_I4_S, (sbyte)10);
+        il.Emit(OpCodes.Bne_Un, nonDecimalRadixLabel);
+        il.Emit(OpCodes.Ldloc, rawStrLocal);
+        il.Emit(OpCodes.Call, runtime.NumberParseIntDecimalString);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(nonDecimalRadixLabel);
         il.Emit(OpCodes.Ldc_I8, 0L);
         il.Emit(OpCodes.Stloc, resultLocal);
 

--- a/src/SharpTS/Runtime/BuiltIns/NumberBuiltIns.cs
+++ b/src/SharpTS/Runtime/BuiltIns/NumberBuiltIns.cs
@@ -306,7 +306,7 @@ public static class NumberBuiltIns
     /// </summary>
     public static double ParseInt(string str, int radix)
     {
-        if (radix == 10)
+        if (radix == 10 || (radix == 0 && !HasHexPrefixAfterSign(str)))
             return ParseIntDecimal(str);
 
         str = str.Trim();
@@ -354,6 +354,9 @@ public static class NumberBuiltIns
     /// </summary>
     public static double ParseIntDecimal(string str)
     {
+        const ulong maxBeforeMultiply = ulong.MaxValue / 10;
+        const int maxLastDigit = (int)(ulong.MaxValue % 10);
+
         int index = 0;
         while (index < str.Length && IsEcmaParseWhitespace(str[index]))
             index++;
@@ -373,17 +376,70 @@ public static class NumberBuiltIns
         }
 
         int digitStart = index;
-        double result = 0;
+        ulong magnitude = 0;
+        bool overflowed = false;
         while (index < str.Length)
         {
             int digit = str[index] - '0';
             if ((uint)digit > 9)
                 break;
-            result = result * 10 + digit;
+
+            if (!overflowed)
+            {
+                if (magnitude > maxBeforeMultiply
+                    || magnitude == maxBeforeMultiply && digit > maxLastDigit)
+                {
+                    overflowed = true;
+                }
+                else
+                {
+                    magnitude = magnitude * 10 + (uint)digit;
+                }
+            }
             index++;
         }
 
-        return index == digitStart ? double.NaN : sign * result;
+        if (index == digitStart)
+            return double.NaN;
+
+        double result;
+        if (!overflowed)
+        {
+            // Integral-to-double conversion performs the one final IEEE-754 rounding
+            // required by ECMA-262, instead of rounding after every input digit.
+            result = magnitude;
+        }
+        else
+        {
+            // Overflow is uncommon and necessarily requires at least 20 significant
+            // digits. Keep the ordinary path allocation-free, and let the framework's
+            // correctly-rounded decimal parser handle the full magnitude here.
+            string digits = digitStart == 0 && index == str.Length
+                ? str
+                : str.Substring(digitStart, index - digitStart);
+            if (!double.TryParse(
+                    digits,
+                    NumberStyles.None,
+                    CultureInfo.InvariantCulture,
+                    out result))
+            {
+                return double.NaN;
+            }
+        }
+
+        return sign * result;
+    }
+
+    private static bool HasHexPrefixAfterSign(string str)
+    {
+        int index = 0;
+        while (index < str.Length && IsEcmaParseWhitespace(str[index]))
+            index++;
+        if (index < str.Length && (str[index] == '+' || str[index] == '-'))
+            index++;
+        return index + 1 < str.Length
+            && str[index] == '0'
+            && (str[index + 1] == 'x' || str[index + 1] == 'X');
     }
 
     private static bool IsEcmaParseWhitespace(char value)

--- a/tests/SharpTS.Tests/CompilerTests/StableNumericStringConversionTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableNumericStringConversionTests.cs
@@ -191,6 +191,36 @@ public sealed class StableNumericStringConversionTests
     }
 
     [Fact]
+    public void CompiledDecimalParseIntPaths_UseTheSameFinalRounding()
+    {
+        Assembly assembly = Compile("""
+            function optimized(value: string): number {
+                return parseInt(value, 10);
+            }
+            function typedFallback(value: string): number {
+                return parseInt(value);
+            }
+            function dynamicFallback(value: any, radix: any): number {
+                return parseInt(value, radix);
+            }
+            """);
+        Type runtime = assembly.GetType("$Runtime")!;
+        var optimized = runtime.GetMethod("NumberParseIntDecimalString")!
+            .CreateDelegate<Func<string, double>>();
+        var typedFallback = runtime.GetMethod("NumberParseIntString")!
+            .CreateDelegate<Func<string, int, double>>();
+        var dynamicFallback = runtime.GetMethod("NumberParseInt")!
+            .CreateDelegate<Func<object, object, double>>();
+
+        const string input = "100000000000000070";
+        const double expected = 100000000000000064d;
+        Assert.Equal(expected, optimized(input));
+        Assert.Equal(expected, typedFallback(input, 10));
+        Assert.Equal(expected, typedFallback(input, 0));
+        Assert.Equal(expected, dynamicFallback(input, 10d));
+    }
+
+    [Fact]
     public void TypedToFixedLoop_AllocatesOnlyResultStrings()
     {
         Assembly assembly = Compile("""

--- a/tests/SharpTS.Tests/SharedTests/NumberTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/NumberTests.cs
@@ -158,6 +158,82 @@ public class NumberTests
     }
 
     [Theory, ModeData]
+    public void RadixTenParseInt_MatchesNodeRoundingForLongIntegers(ExecutionMode mode)
+    {
+        const string source = """
+            const inputs: string[] = [
+                "9007199254740991",
+                "9007199254740992",
+                "9007199254740993",
+                "9007199254740995",
+                "72057594037927943",
+                "72057594037927944",
+                "72057594037927945",
+                "72057594037927960",
+                "100000000000000070",
+                "-100000000000000070",
+                " \uFEFF+000000100000000000000070junk",
+                "18446744073709551615",
+                "18446744073709551616",
+                "100000000000000070000",
+                "9".repeat(400)
+            ];
+            const expected: number[] = [
+                9007199254740991,
+                9007199254740992,
+                9007199254740992,
+                9007199254740996,
+                72057594037927936,
+                72057594037927936,
+                72057594037927952,
+                72057594037927968,
+                100000000000000064,
+                -100000000000000064,
+                100000000000000064,
+                18446744073709551616,
+                18446744073709551616,
+                100000000000000065536,
+                Infinity
+            ];
+
+            function globalFast(value: string): number {
+                return parseInt(value, 10);
+            }
+            function globalDefault(value: string): number {
+                return parseInt(value);
+            }
+            function globalAuto(value: string): number {
+                return parseInt(value, 0);
+            }
+            function globalDynamic(value: any, radix: any): number {
+                return parseInt(value, radix);
+            }
+            function numberFast(value: string): number {
+                return Number.parseInt(value, 10);
+            }
+            function numberDynamic(value: any, radix: any): number {
+                return Number.parseInt(value, radix);
+            }
+
+            for (let i = 0; i < inputs.length; i++) {
+                console.log(
+                    Object.is(globalFast(inputs[i]), expected[i]),
+                    Object.is(globalDefault(inputs[i]), expected[i]),
+                    Object.is(globalAuto(inputs[i]), expected[i]),
+                    Object.is(globalDynamic(inputs[i], 10), expected[i]),
+                    Object.is(numberFast(inputs[i]), expected[i]),
+                    Object.is(numberDynamic(inputs[i], 10), expected[i]));
+            }
+            """;
+
+        string output = TestHarness.Run(source, mode);
+        Assert.Equal(
+            string.Concat(Enumerable.Repeat(
+                "true true true true true true\n", 15)),
+            output);
+    }
+
+    [Theory, ModeData]
     public void Number_parseFloat_ParsesFloats(ExecutionMode mode)
     {
         var source = """


### PR DESCRIPTION
## Summary
- accumulate radix-10 digits exactly in `UInt64`, then convert once so the final `double` uses ECMAScript's IEEE-754 rounding
- fall back to the framework's correctly-rounded decimal parser only after `UInt64` overflow, while keeping ordinary inputs allocation-free
- route typed, default-radix, radix-0, dynamic, and `Number.parseInt` decimal paths through the corrected scanner
- add Node-derived boundary coverage and extend the decimal parse benchmark matrix

## Performance
BenchmarkDotNet short run on .NET 10:
- common 15-digit input: ~14.4 ns/op, 0 B allocated
- issue input (`100000000000000070`): ~28.4 ns/op, 0 B allocated
- clean `UInt64`-overflow input: ~77.4 ns/op, 0 B allocated

## Validation
- `dotnet build SharpTS.sln -c Release --no-restore` (with Avalonia telemetry disabled): succeeded, 0 warnings/errors
- number and stable numeric conversion tests: 71 passed in Release
- Node oracle check: all 15 long-input cases matched
- microbenchmark `--smoke`: passed
- `ParseIntDecimalBenchmarks` ShortRun: completed successfully

The complete local test suite was also attempted, but this Windows sandbox cannot start `HttpListener` (`The handle is invalid`), causing unrelated HTTP/fetch tests to fail. The affected parseInt suites pass in both interpreter and compiled modes.

Fixes #1521

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decimal `parseInt` handling for very large numbers, including correct rounding, signs, whitespace, prefixes, and overflow behavior.
  * Ensured consistent results across global and `Number.parseInt` APIs and different radix options.
  * Corrected handling of hexadecimal-prefixed values when the radix is inferred.

* **Tests**
  * Added coverage for long integers, large-value precision, overflow, and equivalent parsing paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->