### PR TITLE
Optimize CI routing with Difftastic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,48 @@ jobs:
   workflow-policy:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    outputs:
+      mode: ${{ steps.scope.outputs.mode }}
+      reason: ${{ steps.scope.outputs.reason }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Classify changes
+        id: scope
+        shell: pwsh
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          $scope = ./scripts/get-ci-change-scope.ps1 `
+            -BaseSha $env:BASE_SHA -HeadSha $env:HEAD_SHA
+          $reason = $scope.Reason -replace '[\r\n]', ' '
+          "mode=$($scope.Mode)" >> $env:GITHUB_OUTPUT
+          "reason=$reason" >> $env:GITHUB_OUTPUT
+          @(
+            '### CI change scope'
+            ''
+            "- Mode: ``$($scope.Mode)``"
+            "- Reason: $reason"
+          ) >> $env:GITHUB_STEP_SUMMARY
+
+      - name: Check diff whitespace
+        shell: pwsh
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          git diff --check $env:BASE_SHA $env:HEAD_SHA
+          if ($LASTEXITCODE -ne 0) { throw 'git diff --check failed.' }
 
       - name: Enforce workflow policy
         shell: pwsh
-        run: ./scripts/test-github-workflows.ps1
+        run: |
+          ./scripts/test-ci-change-scope.ps1
+          ./scripts/test-github-workflows.ps1
 
       - name: Install and run actionlint 1.7.12
         shell: bash
@@ -44,6 +78,8 @@ jobs:
           ./actionlint
 
   build:
+    needs: workflow-policy
+    if: needs.workflow-policy.outputs.mode == 'full'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:
@@ -170,6 +206,8 @@ jobs:
   # tool and its product contract requires a real package/install/launch smoke on every supported
   # desktop platform.
   dap-macos-smoke:
+    needs: workflow-policy
+    if: needs.workflow-policy.outputs.mode == 'full'
     runs-on: macos-15
     timeout-minutes: 20
     steps:
@@ -207,6 +245,8 @@ jobs:
   # Counts are OS-independent (Roslyn analyzers over the same sources), so one
   # ubuntu job suffices.
   aot-ratchet:
+    needs: workflow-policy
+    if: needs.workflow-policy.outputs.mode == 'full'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
@@ -239,6 +279,8 @@ jobs:
   # outputs under CoreCLR. This permanently covers the Reflection.Emit fallbacks that only
   # execute when RuntimeFeature.IsDynamicCodeSupported is false (#1324 gate).
   native-aot-compile-smoke:
+    needs: workflow-policy
+    if: needs.workflow-policy.outputs.mode == 'full'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
 
@@ -462,20 +504,66 @@ jobs:
             artifacts/native-aot-publish-warning-summary.json
           retention-days: 7
 
+  lightweight-validation:
+    name: Lightweight C# validation
+    needs: workflow-policy
+    if: needs.workflow-policy.outputs.mode == 'csharp-trivia-only'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          global-json-file: global.json
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
   gate:
     name: Gate
     if: always()
-    needs: [workflow-policy, build, dap-macos-smoke, aot-ratchet, native-aot-compile-smoke]
+    needs: [workflow-policy, build, dap-macos-smoke, aot-ratchet, native-aot-compile-smoke, lightweight-validation]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - name: Require every CI job to pass
+      - name: Require the selected CI route to pass
         shell: pwsh
         env:
           JOB_RESULTS: ${{ toJson(needs) }}
+          CHANGE_MODE: ${{ needs.workflow-policy.outputs.mode }}
         run: |
           $needs = $env:JOB_RESULTS | ConvertFrom-Json
-          $bad = @($needs.PSObject.Properties | Where-Object { $_.Value.result -ne 'success' })
+          if ($needs.'workflow-policy'.result -ne 'success') {
+            throw "CI change classification or workflow policy did not pass."
+          }
+
+          $heavy = @('build', 'dap-macos-smoke', 'aot-ratchet', 'native-aot-compile-smoke')
+          if ($env:CHANGE_MODE -eq 'full') {
+            $bad = @($heavy | Where-Object { $needs.PSObject.Properties[$_].Value.result -ne 'success' })
+            if ($needs.'lightweight-validation'.result -ne 'skipped') {
+              $bad += 'lightweight-validation'
+            }
+          }
+          elseif ($env:CHANGE_MODE -eq 'csharp-trivia-only') {
+            $bad = @($heavy | Where-Object { $needs.PSObject.Properties[$_].Value.result -ne 'skipped' })
+            if ($needs.'lightweight-validation'.result -ne 'success') {
+              $bad += 'lightweight-validation'
+            }
+          }
+          elseif ($env:CHANGE_MODE -eq 'docs-only') {
+            $bad = @($heavy | Where-Object { $needs.PSObject.Properties[$_].Value.result -ne 'skipped' })
+            if ($needs.'lightweight-validation'.result -ne 'skipped') {
+              $bad += 'lightweight-validation'
+            }
+          }
+          else {
+            throw "CI reported an unknown change mode: '$($env:CHANGE_MODE)'."
+          }
+
           if ($bad.Count -gt 0) {
-            throw "CI jobs did not pass: $($bad.Name -join ', ')"
+            throw "CI jobs did not follow the '$($env:CHANGE_MODE)' route: $($bad -join ', ')"
           }

--- a/.github/workflows/desktop-gui.yml
+++ b/.github/workflows/desktop-gui.yml
@@ -34,6 +34,7 @@ jobs:
     outputs:
       windows: ${{ steps.scope.outputs.windows }}
       macos: ${{ steps.scope.outputs.macos }}
+      mode: ${{ steps.scope.outputs.mode }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -48,15 +49,34 @@ jobs:
           DISPATCH_TARGET: ${{ inputs.platform }}
         run: |
           if ('${{ github.event_name }}' -eq 'workflow_dispatch') {
-            $scope = ./scripts/get-desktop-gui-ci-scope.ps1 -Target $env:DISPATCH_TARGET
+            $desktopScope = ./scripts/get-desktop-gui-ci-scope.ps1 -Target $env:DISPATCH_TARGET
+            $mode = 'full'
+            $reason = 'Manual desktop dispatch always runs the selected platform scope.'
           }
           else {
-            $paths = @(git diff --name-only $env:BASE_SHA $env:HEAD_SHA)
-            if ($LASTEXITCODE -ne 0) { throw 'Unable to determine changed paths.' }
-            $scope = ./scripts/get-desktop-gui-ci-scope.ps1 -ChangedPath $paths
+            $changeScope = ./scripts/get-ci-change-scope.ps1 `
+              -BaseSha $env:BASE_SHA -HeadSha $env:HEAD_SHA
+            $mode = $changeScope.Mode
+            $reason = $changeScope.Reason -replace '[\r\n]', ' '
+            if ($mode -eq 'full') {
+              $desktopScope = ./scripts/get-desktop-gui-ci-scope.ps1 `
+                -ChangedPath $changeScope.BuildAffectingPaths
+            }
+            else {
+              $desktopScope = [pscustomobject]@{ Windows = $false; MacOS = $false }
+            }
           }
-          "windows=$($scope.Windows.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
-          "macos=$($scope.MacOS.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
+          "windows=$($desktopScope.Windows.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
+          "macos=$($desktopScope.MacOS.ToString().ToLowerInvariant())" >> $env:GITHUB_OUTPUT
+          "mode=$mode" >> $env:GITHUB_OUTPUT
+          @(
+            '### Desktop GUI change scope'
+            ''
+            "- Mode: ``$mode``"
+            "- Reason: $reason"
+            "- Windows: ``$($desktopScope.Windows.ToString().ToLowerInvariant())``"
+            "- macOS: ``$($desktopScope.MacOS.ToString().ToLowerInvariant())``"
+          ) >> $env:GITHUB_STEP_SUMMARY
 
   gui-sdk-candidate:
     name: Build shared GUI SDK candidate
@@ -275,9 +295,28 @@ jobs:
         shell: pwsh
         env:
           JOB_RESULTS: ${{ toJson(needs) }}
+          RUN_WINDOWS: ${{ needs.scope.outputs.windows }}
+          RUN_MACOS: ${{ needs.scope.outputs.macos }}
+          RUN_WINDOWS_ARM64_NATIVE: ${{ github.event_name == 'workflow_dispatch' && inputs.run_windows_arm64_native && needs.scope.outputs.windows == 'true' }}
         run: |
           $needs = $env:JOB_RESULTS | ConvertFrom-Json
-          $bad = @($needs.PSObject.Properties | Where-Object { $_.Value.result -in @('failure', 'cancelled') })
+          if ($needs.scope.result -ne 'success') {
+            throw 'Desktop GUI change classification did not pass.'
+          }
+
+          $expected = @{
+            'gui-sdk-candidate' = $env:RUN_WINDOWS -eq 'true' -or $env:RUN_MACOS -eq 'true'
+            'windows-x64' = $env:RUN_WINDOWS -eq 'true'
+            'windows-arm64-cross-publish' = $env:RUN_WINDOWS -eq 'true'
+            'windows-arm64-native' = $env:RUN_WINDOWS_ARM64_NATIVE -eq 'true'
+            'macos-native' = $env:RUN_MACOS -eq 'true'
+          }
+          $bad = [System.Collections.Generic.List[string]]::new()
+          foreach ($job in $expected.Keys) {
+            $wanted = if ($expected[$job]) { 'success' } else { 'skipped' }
+            $actual = $needs.PSObject.Properties[$job].Value.result
+            if ($actual -ne $wanted) { $bad.Add("$job=$actual (expected $wanted)") }
+          }
           if ($bad.Count -gt 0) {
-            throw "Desktop GUI jobs did not pass: $($bad.Name -join ', ')"
+            throw "Desktop GUI jobs did not follow the selected scope: $($bad -join ', ')"
           }

--- a/scripts/get-ci-change-scope.ps1
+++ b/scripts/get-ci-change-scope.ps1
@@ -1,0 +1,270 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[0-9a-fA-F]{40}$')]
+    [string]$BaseSha,
+
+    [Parameter(Mandatory)]
+    [ValidatePattern('^[0-9a-fA-F]{40}$')]
+    [string]$HeadSha,
+
+    [string]$DifftasticPath = '',
+
+    [string]$ToolRoot = $(
+        if ($env:RUNNER_TEMP) { Join-Path $env:RUNNER_TEMP 'sharpts-ci-tools' }
+        else { Join-Path ([IO.Path]::GetTempPath()) 'sharpts-ci-tools' }
+    )
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$difftasticVersion = '0.70.0'
+$difftasticAssets = @{
+    LinuxX64 = @{
+        Archive = 'difft-x86_64-unknown-linux-gnu.tar.gz'
+        Sha256 = '2997d2bbe620534edbd79b0049f00ce84eef3fedb15c7822456d58e38d8b05c9'
+        Executable = 'difft'
+    }
+    WindowsX64 = @{
+        Archive = 'difft-x86_64-pc-windows-msvc.zip'
+        Sha256 = 'b563ae76e22ce28c7080a8b628cfabf6fa86f9ee114a0f5697bc2ca26f9ce1d7'
+        Executable = 'difft.exe'
+    }
+}
+
+function New-ScopeResult(
+    [ValidateSet('full', 'csharp-trivia-only', 'docs-only')]
+    [string]$Mode,
+    [string]$Reason,
+    [string[]]$ChangedPaths,
+    [string[]]$BuildAffectingPaths
+) {
+    return [pscustomobject]@{
+        Mode = $Mode
+        Reason = $Reason
+        ChangedPaths = @($ChangedPaths)
+        BuildAffectingPaths = @($BuildAffectingPaths)
+    }
+}
+
+function Test-DocumentationPath([string]$Path) {
+    $normalized = $Path.Replace('\', '/')
+    return $normalized -like 'docs/*' -or
+        $normalized -like '*.md' -or
+        $normalized -eq 'LICENSE' -or
+        $normalized -eq '.gitignore' -or
+        $normalized -like '.github/ISSUE_TEMPLATE/*' -or
+        $normalized -like '.github/PULL_REQUEST_TEMPLATE*'
+}
+
+function Get-ChangedEntries {
+    $lines = @(& git -c core.quotepath=false diff --name-status --find-renames=50% $BaseSha $HeadSha --)
+    if ($LASTEXITCODE -ne 0) {
+        throw "git diff failed for $BaseSha..$HeadSha."
+    }
+
+    $entries = [System.Collections.Generic.List[object]]::new()
+    foreach ($line in $lines) {
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+        $parts = @($line -split "`t")
+        if ($parts.Count -lt 2) {
+            throw "Unexpected git diff entry: $line"
+        }
+
+        $status = $parts[0]
+        if ($status.StartsWith('R', [StringComparison]::Ordinal) -or
+            $status.StartsWith('C', [StringComparison]::Ordinal)) {
+            if ($parts.Count -ne 3) { throw "Unexpected rename/copy entry: $line" }
+            $entries.Add([pscustomobject]@{
+                Status = $status
+                OldPath = $parts[1].Replace('\', '/')
+                Path = $parts[2].Replace('\', '/')
+            })
+        }
+        else {
+            if ($parts.Count -ne 2) { throw "Unexpected changed-file entry: $line" }
+            $entries.Add([pscustomobject]@{
+                Status = $status
+                OldPath = $parts[1].Replace('\', '/')
+                Path = $parts[1].Replace('\', '/')
+            })
+        }
+    }
+    return @($entries)
+}
+
+function Get-Difftastic {
+    if ($DifftasticPath) {
+        if (Test-Path -LiteralPath $DifftasticPath -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $DifftasticPath).Path
+        }
+        Write-Warning "The requested Difftastic executable does not exist: $DifftasticPath"
+        return $null
+    }
+
+    $architecture = [Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+    if ($IsLinux -and $architecture -eq 'X64') {
+        $asset = $difftasticAssets.LinuxX64
+    }
+    elseif ($IsWindows -and $architecture -eq 'X64') {
+        $asset = $difftasticAssets.WindowsX64
+    }
+    else {
+        Write-Warning "No pinned Difftastic asset is configured for this runner."
+        return $null
+    }
+
+    $installRoot = Join-Path $ToolRoot "difftastic-$difftasticVersion"
+    $executable = Join-Path $installRoot $asset.Executable
+    if (Test-Path -LiteralPath $executable -PathType Leaf) { return $executable }
+
+    $downloadRoot = Join-Path $ToolRoot ('download-' + [Guid]::NewGuid().ToString('N'))
+    $archivePath = Join-Path $downloadRoot $asset.Archive
+    try {
+        New-Item -ItemType Directory -Path $downloadRoot -Force | Out-Null
+        $uri = "https://github.com/Wilfred/difftastic/releases/download/$difftasticVersion/$($asset.Archive)"
+        Write-Host "Downloading Difftastic $difftasticVersion from $uri"
+        Invoke-WebRequest -Uri $uri -OutFile $archivePath
+
+        $actualHash = (Get-FileHash -LiteralPath $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($actualHash -cne $asset.Sha256) {
+            throw "Difftastic archive checksum mismatch. Expected $($asset.Sha256), got $actualHash."
+        }
+
+        New-Item -ItemType Directory -Path $installRoot -Force | Out-Null
+        if ($asset.Archive.EndsWith('.zip', [StringComparison]::Ordinal)) {
+            Expand-Archive -LiteralPath $archivePath -DestinationPath $installRoot -Force
+        }
+        else {
+            & tar --extract --gzip --file $archivePath --directory $installRoot
+            if ($LASTEXITCODE -ne 0) { throw "Unable to extract $($asset.Archive)." }
+            & chmod +x $executable
+            if ($LASTEXITCODE -ne 0) { throw 'Unable to mark Difftastic executable.' }
+        }
+
+        if (-not (Test-Path -LiteralPath $executable -PathType Leaf)) {
+            throw "Difftastic archive did not contain $($asset.Executable)."
+        }
+        return $executable
+    }
+    catch {
+        if ($_.Exception.Message -like 'Difftastic archive checksum mismatch*') { throw }
+        Write-Warning "Difftastic is unavailable; selecting full CI. $($_.Exception.Message)"
+        return $null
+    }
+    finally {
+        if (Test-Path -LiteralPath $downloadRoot) {
+            $resolvedDownload = (Resolve-Path -LiteralPath $downloadRoot).Path
+            $resolvedToolRoot = (Resolve-Path -LiteralPath $ToolRoot).Path
+            if (-not $resolvedDownload.StartsWith($resolvedToolRoot, [StringComparison]::OrdinalIgnoreCase)) {
+                throw "Refusing to clean a Difftastic download outside the tool root: $resolvedDownload"
+            }
+            Remove-Item -LiteralPath $resolvedDownload -Recurse -Force
+        }
+    }
+}
+
+function Write-GitBlob([string]$Revision, [string]$Path, [string]$Destination) {
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = 'git'
+    $startInfo.WorkingDirectory = (Get-Location).ProviderPath
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.ArgumentList.Add('cat-file')
+    $startInfo.ArgumentList.Add('blob')
+    $startInfo.ArgumentList.Add("${Revision}:$Path")
+
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    if (-not $process.Start()) { throw "Unable to start git cat-file for $Path." }
+    try {
+        $stream = [IO.File]::Create($Destination)
+        try { $process.StandardOutput.BaseStream.CopyTo($stream) }
+        finally { $stream.Dispose() }
+        $errorText = $process.StandardError.ReadToEnd()
+        $process.WaitForExit()
+        if ($process.ExitCode -ne 0) {
+            throw "Unable to read ${Revision}:$Path. $errorText"
+        }
+    }
+    finally {
+        $process.Dispose()
+    }
+}
+
+function Test-NoCSharpSyntaxChange([string]$Tool, [string]$Path) {
+    $comparisonRoot = Join-Path ([IO.Path]::GetTempPath()) ('sharpts-ci-diff-' + [Guid]::NewGuid().ToString('N'))
+    try {
+        New-Item -ItemType Directory -Path $comparisonRoot | Out-Null
+        $oldPath = Join-Path $comparisonRoot 'before.cs'
+        $newPath = Join-Path $comparisonRoot 'after.cs'
+        Write-GitBlob $BaseSha $Path $oldPath
+        Write-GitBlob $HeadSha $Path $newPath
+
+        $output = @(& $Tool --ignore-comments --check-only --exit-code $oldPath $newPath 2>&1)
+        $exitCode = $LASTEXITCODE
+        foreach ($line in $output) { Write-Host $line }
+        if ($exitCode -eq 0) { return $true }
+        if ($exitCode -eq 1) { return $false }
+        throw "Difftastic failed for '$Path' with exit code $exitCode."
+    }
+    finally {
+        if (Test-Path -LiteralPath $comparisonRoot) {
+            $resolvedComparison = (Resolve-Path -LiteralPath $comparisonRoot).Path
+            $resolvedTemp = (Resolve-Path -LiteralPath ([IO.Path]::GetTempPath())).Path
+            if (-not $resolvedComparison.StartsWith($resolvedTemp, [StringComparison]::OrdinalIgnoreCase)) {
+                throw "Refusing to clean a comparison outside the temporary directory: $resolvedComparison"
+            }
+            Remove-Item -LiteralPath $resolvedComparison -Recurse -Force
+        }
+    }
+}
+
+try {
+    $entries = @(Get-ChangedEntries)
+}
+catch {
+    return New-ScopeResult 'full' "Unable to enumerate changes: $($_.Exception.Message)" @() @()
+}
+
+if ($entries.Count -eq 0) {
+    return New-ScopeResult 'full' 'No changed files were reported; selecting full CI.' @() @()
+}
+
+$changedPaths = @($entries | ForEach-Object { $_.Path } | Sort-Object -Unique)
+$nonDocumentation = @($entries | Where-Object {
+    -not (Test-DocumentationPath $_.Path) -or
+    -not (Test-DocumentationPath $_.OldPath)
+})
+if ($nonDocumentation.Count -eq 0) {
+    return New-ScopeResult 'docs-only' 'Every changed path is documentation-only.' $changedPaths @()
+}
+
+$buildAffectingPaths = @($nonDocumentation | ForEach-Object { $_.Path } | Sort-Object -Unique)
+$ineligible = @($nonDocumentation | Where-Object {
+    $_.Status -cne 'M' -or -not $_.Path.EndsWith('.cs', [StringComparison]::OrdinalIgnoreCase)
+})
+if ($ineligible.Count -gt 0) {
+    $first = $ineligible[0]
+    return New-ScopeResult 'full' "Change '$($first.Status) $($first.Path)' is not an eligible modified C# file." $changedPaths $buildAffectingPaths
+}
+
+$tool = Get-Difftastic
+if (-not $tool) {
+    return New-ScopeResult 'full' 'Difftastic was unavailable, so the change could not be proven trivia-only.' $changedPaths $buildAffectingPaths
+}
+
+foreach ($entry in $nonDocumentation) {
+    try {
+        if (-not (Test-NoCSharpSyntaxChange $tool $entry.Path)) {
+            return New-ScopeResult 'full' "Difftastic found a C# syntax change in '$($entry.Path)'." $changedPaths $buildAffectingPaths
+        }
+    }
+    catch {
+        return New-ScopeResult 'full' "Unable to classify '$($entry.Path)': $($_.Exception.Message)" $changedPaths $buildAffectingPaths
+    }
+}
+
+return New-ScopeResult 'csharp-trivia-only' 'All non-documentation changes modify only C# comments or formatting.' $changedPaths @()

--- a/scripts/test-ci-change-scope.ps1
+++ b/scripts/test-ci-change-scope.ps1
@@ -1,0 +1,141 @@
+[CmdletBinding()]
+param(
+    [string]$DifftasticPath = ''
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$scopeScript = Join-Path $PSScriptRoot 'get-ci-change-scope.ps1'
+$fixtureRoot = Join-Path ([IO.Path]::GetTempPath()) ('sharpts-ci-scope-tests-' + [Guid]::NewGuid().ToString('N'))
+
+function Invoke-Git([string[]]$Arguments) {
+    & git @Arguments | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "git $($Arguments -join ' ') failed." }
+}
+
+function Write-Fixture([string]$RelativePath, [string]$Content) {
+    $path = Join-Path $fixtureRoot $RelativePath
+    $parent = Split-Path -Parent $path
+    if ($parent) { New-Item -ItemType Directory -Path $parent -Force | Out-Null }
+    [IO.File]::WriteAllText($path, $Content.Replace("`n", [Environment]::NewLine))
+}
+
+function Save-Fixture([string]$Message) {
+    Invoke-Git @('add', '-A')
+    Invoke-Git @('commit', '--quiet', '-m', $Message)
+    $sha = (& git rev-parse HEAD).Trim()
+    if ($LASTEXITCODE -ne 0) { throw 'Unable to read fixture commit.' }
+    return $sha
+}
+
+function Get-Scope([string]$Base, [string]$Head, [string]$Tool = $DifftasticPath) {
+    $arguments = @{
+        BaseSha = $Base
+        HeadSha = $Head
+    }
+    if ($Tool) { $arguments.DifftasticPath = $Tool }
+    return & $scopeScript @arguments
+}
+
+function Assert-Mode([string]$Expected, [object]$Actual, [string]$Case) {
+    if ($Actual.Mode -cne $Expected) {
+        throw "$Case expected '$Expected', got '$($Actual.Mode)': $($Actual.Reason)"
+    }
+}
+
+try {
+    New-Item -ItemType Directory -Path $fixtureRoot | Out-Null
+    Push-Location $fixtureRoot
+    try {
+        Invoke-Git @('init', '--quiet')
+        Invoke-Git @('config', 'user.name', 'SharpTS CI scope tests')
+        Invoke-Git @('config', 'user.email', 'ci-scope@example.invalid')
+
+        Write-Fixture 'src/Sample.cs' @'
+namespace Fixture;
+
+internal static class Sample
+{
+    // Original explanation.
+    internal static string Value => "// this is a string";
+}
+'@
+        Write-Fixture 'README.md' "# Fixture`n"
+        $initial = Save-Fixture 'initial'
+
+        Write-Fixture 'src/Sample.cs' @'
+namespace Fixture;
+
+internal static class Sample
+{
+    /// <summary>A better explanation.</summary>
+    internal static string Value => "// this is a string";
+}
+'@
+        $comments = Save-Fixture 'comments only'
+        Assert-Mode 'csharp-trivia-only' (Get-Scope $initial $comments) 'comment-only change'
+
+        Write-Fixture 'README.md' "# Fixture`n`nUpdated documentation.`n"
+        $commentsAndDocs = Save-Fixture 'comments and docs'
+        Assert-Mode 'docs-only' (Get-Scope $comments $commentsAndDocs) 'documentation-only change'
+        Assert-Mode 'csharp-trivia-only' (Get-Scope $initial $commentsAndDocs) 'mixed comments and documentation'
+
+        Write-Fixture 'src/Sample.cs' @'
+namespace Fixture;
+
+internal static class Sample
+{
+    /// <summary>A better explanation.</summary>
+    internal static string Value => "/* changed string content */";
+}
+'@
+        $stringChange = Save-Fixture 'string token change'
+        Assert-Mode 'full' (Get-Scope $commentsAndDocs $stringChange) 'comment marker inside string'
+
+        Write-Fixture 'src/Sample.cs' @'
+#nullable disable
+namespace Fixture;
+
+internal static class Sample
+{
+    /// <summary>A better explanation.</summary>
+    internal static string Value => "/* changed string content */";
+}
+'@
+        $directiveChange = Save-Fixture 'directive change'
+        Assert-Mode 'full' (Get-Scope $stringChange $directiveChange) 'preprocessor directive change'
+
+        Write-Fixture 'src/Added.cs' "namespace Fixture;`ninternal sealed class Added;`n"
+        $addedFile = Save-Fixture 'add C# file'
+        Assert-Mode 'full' (Get-Scope $directiveChange $addedFile) 'added C# file'
+
+        Invoke-Git @('mv', 'src/Added.cs', 'src/Renamed.cs')
+        $renamedFile = Save-Fixture 'rename C# file'
+        Assert-Mode 'full' (Get-Scope $addedFile $renamedFile) 'renamed C# file'
+
+        New-Item -ItemType Directory -Path 'docs' -Force | Out-Null
+        Invoke-Git @('mv', 'src/Renamed.cs', 'docs/Renamed.cs')
+        $renamedIntoDocs = Save-Fixture 'rename C# file into docs'
+        Assert-Mode 'full' (Get-Scope $renamedFile $renamedIntoDocs) 'source file renamed into documentation'
+
+        $missingTool = Join-Path $fixtureRoot 'missing-difftastic'
+        $missingToolScope = Get-Scope $initial $comments $missingTool
+        Assert-Mode 'full' $missingToolScope 'missing Difftastic fallback'
+    }
+    finally {
+        Pop-Location
+    }
+}
+finally {
+    if (Test-Path -LiteralPath $fixtureRoot) {
+        $resolvedFixture = (Resolve-Path -LiteralPath $fixtureRoot).Path
+        $resolvedTemp = (Resolve-Path -LiteralPath ([IO.Path]::GetTempPath())).Path
+        if (-not $resolvedFixture.StartsWith($resolvedTemp, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Refusing to clean a fixture outside the temporary directory: $resolvedFixture"
+        }
+        Remove-Item -LiteralPath $resolvedFixture -Recurse -Force
+    }
+}
+
+Write-Host 'CI change-scope tests passed.'

--- a/scripts/test-github-workflows.ps1
+++ b/scripts/test-github-workflows.ps1
@@ -9,6 +9,16 @@ $workflowRoot = Join-Path $repositoryRoot '.github\workflows'
 $errors = [System.Collections.Generic.List[string]]::new()
 $workflowFiles = @(Get-ChildItem -LiteralPath $workflowRoot -Filter '*.yml' -File)
 
+function Get-WorkflowJob([string]$Content, [string]$Name, [string]$WorkflowName) {
+    $escapedName = [regex]::Escape($Name)
+    $match = [regex]::Match($Content, "(?ms)^  ${escapedName}:\r?\n.*?(?=^  [A-Za-z0-9_-]+:\r?\n|\z)")
+    if (-not $match.Success) {
+        $errors.Add("$WorkflowName is missing the '$Name' job.")
+        return ''
+    }
+    return $match.Value
+}
+
 foreach ($file in $workflowFiles) {
     $relativePath = [IO.Path]::GetRelativePath($repositoryRoot, $file.FullName).Replace('\', '/')
     $content = Get-Content -LiteralPath $file.FullName -Raw
@@ -55,15 +65,64 @@ if ($benchmark -notmatch 'bun-version-file:\s*\.bun-version') {
     $errors.Add('benchmarks.yml must use .bun-version.')
 }
 
+$ci = Get-Content -LiteralPath (Join-Path $workflowRoot 'ci.yml') -Raw
+foreach ($requiredText in @(
+    'scripts/get-ci-change-scope.ps1',
+    'scripts/test-ci-change-scope.ps1',
+    'fetch-depth: 0',
+    "mode: `${{ steps.scope.outputs.mode }}",
+    "reason: `${{ steps.scope.outputs.reason }}",
+    'name: Lightweight C# validation',
+    'name: Gate'
+)) {
+    if (-not $ci.Contains($requiredText, [StringComparison]::Ordinal)) {
+        $errors.Add("ci.yml is missing change-routing contract text: $requiredText")
+    }
+}
+foreach ($jobName in @('build', 'dap-macos-smoke', 'aot-ratchet', 'native-aot-compile-smoke')) {
+    $job = Get-WorkflowJob $ci $jobName 'ci.yml'
+    if (-not $job.Contains('needs: workflow-policy', [StringComparison]::Ordinal) -or
+        -not $job.Contains("if: needs.workflow-policy.outputs.mode == 'full'", [StringComparison]::Ordinal)) {
+        $errors.Add("ci.yml '$jobName' must run only after full change classification.")
+    }
+}
+$lightweightJob = Get-WorkflowJob $ci 'lightweight-validation' 'ci.yml'
+if (-not $lightweightJob.Contains("if: needs.workflow-policy.outputs.mode == 'csharp-trivia-only'", [StringComparison]::Ordinal)) {
+    $errors.Add('ci.yml lightweight-validation must run only for C# trivia changes.')
+}
+$ciGateJob = Get-WorkflowJob $ci 'gate' 'ci.yml'
+foreach ($requiredText in @('CHANGE_MODE:', "'csharp-trivia-only'", "'docs-only'", "'lightweight-validation'")) {
+    if (-not $ciGateJob.Contains($requiredText, [StringComparison]::Ordinal)) {
+        $errors.Add("ci.yml Gate is missing routed-result validation text: $requiredText")
+    }
+}
+
+$ciScopeScript = Get-Content -LiteralPath (Join-Path $repositoryRoot 'scripts\get-ci-change-scope.ps1') -Raw
+foreach ($requiredText in @(
+    "difftasticVersion = '0.70.0'",
+    '2997d2bbe620534edbd79b0049f00ce84eef3fedb15c7822456d58e38d8b05c9',
+    'b563ae76e22ce28c7080a8b628cfabf6fa86f9ee114a0f5697bc2ca26f9ce1d7',
+    'Get-FileHash -LiteralPath $archivePath -Algorithm SHA256',
+    '--ignore-comments --check-only --exit-code',
+    "return New-ScopeResult 'full'"
+)) {
+    if (-not $ciScopeScript.Contains($requiredText, [StringComparison]::Ordinal)) {
+        $errors.Add("get-ci-change-scope.ps1 is missing pinned or fail-safe routing text: $requiredText")
+    }
+}
+
 $desktop = Get-Content -LiteralPath (Join-Path $workflowRoot 'desktop-gui.yml') -Raw
 foreach ($requiredText in @(
     'name: Desktop GUI',
     'cancel-in-progress: ${{ github.event_name == ''pull_request'' }}',
+    'scripts/get-ci-change-scope.ps1',
     'scripts/get-desktop-gui-ci-scope.ps1',
+    '-ChangedPath $changeScope.BuildAffectingPaths',
     'runs-on: ubuntu-24.04',
     'retention-days: 3',
     'retention-days: 7',
     'runs-on: windows-11-vs2026-arm',
+    'RUN_WINDOWS_ARM64_NATIVE:',
     'name: Gate'
 )) {
     if (-not $desktop.Contains($requiredText, [StringComparison]::Ordinal)) {


### PR DESCRIPTION
## Summary

- classify pull-request changes as full, C# trivia-only, or documentation-only
- use pinned, checksum-verified Difftastic to distinguish comment/formatting edits from C# syntax changes
- skip the full CI and Desktop GUI runner sets for documentation or C# trivia changes while retaining policy checks and a lightweight Release build
- fail safely to full CI for unsupported changes or classifier failures, and enforce the selected route in final gate jobs

## Validation

- scripts/test-ci-change-scope.ps1
- scripts/test-github-workflows.ps1
- PowerShell parser checks
- actionlint 1.7.12
- git diff --check
- dotnet build SharpTS.sln --configuration Release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent CI change classification for documentation-only, C# trivia-only, and full changes.
  * Added targeted validation for lightweight C#-only updates.
  * Added desktop build selection based on affected platforms and changed files.
  * Added workflow summaries showing selected mode, reason, and platforms.

* **Bug Fixes**
  * Improved CI and desktop workflow gating to verify required job outcomes and reject invalid classifications.

* **Tests**
  * Added coverage for change detection, file renames, documentation updates, syntax changes, and workflow routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->