### PR TITLE
Rename Avalonia scaffolding to desktop

### DIFF
--- a/docs/gui/sdk-development.md
+++ b/docs/gui/sdk-development.md
@@ -14,7 +14,7 @@ The SharpTS CLI creates a TypeScript-only application and drives the SDK through
 project:
 
 ```powershell
-sharpts new avalonia -n CounterApp
+sharpts new desktop -n CounterApp
 cd CounterApp
 sharpts app run
 sharpts app run --mode compiled
@@ -22,10 +22,11 @@ sharpts app build
 sharpts app publish --rid win-x64 --self-contained true --single-file true
 ```
 
-`sharpts.json` records `application.type`, the entry module, and the pinned GUI SDK version. Host
-selection uses an explicit `--host avalonia|console`, then the manifest, conservative import
-inference, and finally the console default. Mixed GUI and another JSX runtime require an explicit
-host.
+`sharpts.json` records the `desktop` application type, the `avalonia` implementation host, the
+entry module, and the pinned GUI SDK version. Host selection uses an explicit
+`--host avalonia|console`, then `application.host`, conservative import inference, and finally the
+console default. Mixed GUI and another JSX runtime require an explicit host. The application type
+is a separate lifecycle and deployment contract; it is not inferred from imports.
 
 The CLI writes `.sharpts-gui.generated.csproj`, keeps generated build state under `.sharpts/gui`,
 and invokes `SharpTS.Gui.Sdk` for restore, compilation, launcher generation, native asset

--- a/src/SharpTS.Gui.Sdk/readme.md
+++ b/src/SharpTS.Gui.Sdk/readme.md
@@ -13,7 +13,7 @@ claim. macOS Intel is not supported.
 With the SharpTS tool installed:
 
 ```powershell
-sharpts new avalonia -n CounterApp
+sharpts new desktop -n CounterApp
 cd CounterApp
 sharpts app run
 sharpts app run --mode compiled

--- a/src/SharpTS/Cli/CommandLineParser.cs
+++ b/src/SharpTS/Cli/CommandLineParser.cs
@@ -193,12 +193,12 @@ public abstract record ParsedCommand
     public sealed record Version() : ParsedCommand;
 
     /// <summary>
-    /// Create a new Avalonia GUI application project.
+    /// Create a new desktop GUI application project.
     /// </summary>
     /// <param name="Name">The name of the new project.</param>
     /// <param name="OutputDirectory">The directory to create the project in.</param>
     /// <param name="GuiSdkVersion">The version of the GUI SDK to use.</param>
-    public sealed record NewAvalonia(
+    public sealed record NewDesktop(
         string Name,
         string OutputDirectory,
         string GuiSdkVersion) : ParsedCommand;
@@ -427,8 +427,8 @@ public class CommandLineParser
 
     private static ParsedCommand ParseNewCommand(string[] args)
     {
-        if (args.Length < 2 || args[1] != "avalonia")
-            return new ParsedCommand.Error("Usage: sharpts new avalonia -n <name> [-o directory]", 64);
+        if (args.Length < 2 || args[1] != "desktop")
+            return new ParsedCommand.Error("Usage: sharpts new desktop -n <name> [-o directory]", 64);
         string? name = null;
         string? output = null;
         string version = GuiApplicationCli.DefaultSdkVersion;
@@ -440,8 +440,8 @@ public class CommandLineParser
             else return new ParsedCommand.Error($"Error: Unknown or incomplete new option '{args[i]}'.", 64);
         }
         if (string.IsNullOrWhiteSpace(name))
-            return new ParsedCommand.Error("Error: sharpts new avalonia requires -n <name>.", 64);
-        return new ParsedCommand.NewAvalonia(name, output ?? name, version);
+            return new ParsedCommand.Error("Error: sharpts new desktop requires -n <name>.", 64);
+        return new ParsedCommand.NewDesktop(name, output ?? name, version);
     }
 
     private static ParsedCommand ParseApplicationCommand(string[] args, string[] applicationArgs)

--- a/src/SharpTS/Cli/GuiApplicationCli.cs
+++ b/src/SharpTS/Cli/GuiApplicationCli.cs
@@ -11,7 +11,7 @@ internal static class GuiApplicationCli
 {
     internal const string DefaultSdkVersion = GuiVersion.Value;
 
-    public static int Create(ParsedCommand.NewAvalonia command)
+    public static int Create(ParsedCommand.NewDesktop command)
     {
         string root = Path.GetFullPath(command.OutputDirectory);
         if (Directory.Exists(root) && Directory.EnumerateFileSystemEntries(root).Any())
@@ -22,7 +22,8 @@ internal static class GuiApplicationCli
         File.WriteAllText(Path.Combine(root, "sharpts.json"), $$"""
             {
               "application": {
-                "type": "avalonia",
+                "type": "desktop",
+                "host": "avalonia",
                 "entry": "main.tsx",
                 "guiSdkVersion": {{serializedVersion}}
               }
@@ -62,7 +63,7 @@ internal static class GuiApplicationCli
             """);
         File.WriteAllText(Path.Combine(root, "Assets", "README.txt"),
             "Files in this directory are embedded under asset:/// paths." + Environment.NewLine);
-        Console.WriteLine($"Created SharpTS Avalonia application '{command.Name}' in {root}");
+        Console.WriteLine($"Created SharpTS desktop application '{command.Name}' in {root}");
         return 0;
     }
 
@@ -75,7 +76,8 @@ internal static class GuiApplicationCli
         SharpTsManifest? manifest = SharpTsManifestLoader.FindAndLoad(start);
         string root = manifest?.ManifestDirectory ?? start;
         string entry = ResolveEntry(root, command.Entry ?? manifest?.Application?.Entry);
-        string host = ResolveHost(command.Host, manifest?.Application?.Type, entry);
+        string host = ResolveHost(command.Host, manifest?.Application?.Host, entry);
+        ValidateApplicationType(manifest?.Application?.Type, host);
         if (host == "console")
         {
             if (command.Action != "run")
@@ -216,6 +218,18 @@ internal static class GuiApplicationCli
             throw new InvalidOperationException(
                 "Application host inference is ambiguous; pass --host avalonia or --host console.");
         return guiImport ? "avalonia" : "console";
+    }
+
+    internal static void ValidateApplicationType(string? applicationType, string host)
+    {
+        if (string.IsNullOrWhiteSpace(applicationType)) return;
+        string normalizedType = applicationType.Trim().ToLowerInvariant();
+        if (normalizedType != "desktop")
+            throw new InvalidOperationException(
+                $"Unknown application type '{normalizedType}'; expected desktop.");
+        if (host != "avalonia")
+            throw new InvalidOperationException(
+                $"Application type 'desktop' requires the avalonia host, not '{host}'.");
     }
 
     private static (bool GuiImport, bool OtherJsxRuntime) InspectRuntimeImports(string source)

--- a/src/SharpTS/Program.cs
+++ b/src/SharpTS/Program.cs
@@ -89,7 +89,7 @@ switch (command)
         Console.WriteLine($"sharpts {GetVersion()}");
         return 0;
 
-    case ParsedCommand.NewAvalonia create:
+    case ParsedCommand.NewDesktop create:
         try { return GuiApplicationCli.Create(create); }
         catch (Exception exception) { Console.Error.WriteLine($"Error: {exception.Message}"); return 1; }
 
@@ -1627,7 +1627,7 @@ static void PrintHelp()
     Console.WriteLine("  sharpts -p <tsconfig> [--watch] [--incremental]");
     Console.WriteLine("  sharpts --build [project ...] [--watch] [--force]");
     Console.WriteLine("  sharpts --compile <script.ts> [compile-options]");
-    Console.WriteLine("  sharpts new avalonia -n <name> [-o directory] [--sdk-version version]");
+    Console.WriteLine("  sharpts new desktop -n <name> [-o directory] [--sdk-version version]");
     Console.WriteLine("  sharpts app run [entry.tsx] [--host avalonia|console] [--mode mode] [--gc-profile profile] [-- args]");
     Console.WriteLine("  sharpts app build [entry.tsx] [--host avalonia|console] [--gc-profile profile]");
     Console.WriteLine("  sharpts app publish [entry.tsx] [--rid rid] [--self-contained true|false]");

--- a/src/SharpTS/References/SharpTsManifest.cs
+++ b/src/SharpTS/References/SharpTsManifest.cs
@@ -40,6 +40,9 @@ public sealed class SharpTsApplication
     [JsonPropertyName("type")]
     public string? Type { get; set; }
 
+    [JsonPropertyName("host")]
+    public string? Host { get; set; }
+
     [JsonPropertyName("entry")]
     public string? Entry { get; set; }
 

--- a/tests/SharpTS.Tests/CliTests/CommandLineParserTests.cs
+++ b/tests/SharpTS.Tests/CliTests/CommandLineParserTests.cs
@@ -634,13 +634,22 @@ public class CommandLineParserTests
     }
 
     [Fact]
-    public void Parse_NewAvaloniaApplication()
+    public void Parse_NewDesktopApplication()
     {
-        var command = Assert.IsType<ParsedCommand.NewAvalonia>(
-            _parser.Parse(["new", "avalonia", "-n", "Counter", "-o", "apps/Counter"]));
+        var command = Assert.IsType<ParsedCommand.NewDesktop>(
+            _parser.Parse(["new", "desktop", "-n", "Counter", "-o", "apps/Counter"]));
         Assert.Equal("Counter", command.Name);
         Assert.Equal("apps/Counter", command.OutputDirectory);
         Assert.Equal(GuiApplicationCli.DefaultSdkVersion, command.GuiSdkVersion);
+    }
+
+    [Fact]
+    public void Parse_NewAvaloniaApplication_IsRejected()
+    {
+        var error = Assert.IsType<ParsedCommand.Error>(
+            _parser.Parse(["new", "avalonia", "-n", "Counter"]));
+
+        Assert.Contains("sharpts new desktop", error.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/SharpTS.Tests/CliTests/GuiApplicationCliTests.cs
+++ b/tests/SharpTS.Tests/CliTests/GuiApplicationCliTests.cs
@@ -15,12 +15,13 @@ public sealed class GuiApplicationCliTests
         using var directory = CliTestHelper.CreateTempDirectory();
         string root = directory.GetPath("quoted app");
 
-        Assert.Equal(0, GuiApplicationCli.Create(new ParsedCommand.NewAvalonia(
+        Assert.Equal(0, GuiApplicationCli.Create(new ParsedCommand.NewDesktop(
             "A \"quoted\" app", root, TestSdkVersion)));
 
         SharpTsApplication application = SharpTsManifestLoader.Load(
             Path.Combine(root, "sharpts.json")).Application!;
-        Assert.Equal("avalonia", application.Type);
+        Assert.Equal("desktop", application.Type);
+        Assert.Equal("avalonia", application.Host);
         Assert.Equal("main.tsx", application.Entry);
         Assert.Equal(TestSdkVersion, application.GuiSdkVersion);
         string source = File.ReadAllText(Path.Combine(root, "main.tsx"));
@@ -87,6 +88,21 @@ public sealed class GuiApplicationCliTests
             """);
 
         Assert.Throws<InvalidOperationException>(() => GuiApplicationCli.ResolveHost(null, null, entry));
+    }
+
+    [Fact]
+    public void ValidateApplicationType_AcceptsDesktopAvaloniaOnly()
+    {
+        GuiApplicationCli.ValidateApplicationType(" DESKTOP ", "avalonia");
+        GuiApplicationCli.ValidateApplicationType(null, "console");
+
+        var wrongHost = Assert.Throws<InvalidOperationException>(
+            () => GuiApplicationCli.ValidateApplicationType("desktop", "console"));
+        Assert.Contains("requires the avalonia host", wrongHost.Message, StringComparison.OrdinalIgnoreCase);
+
+        var unknownType = Assert.Throws<InvalidOperationException>(
+            () => GuiApplicationCli.ValidateApplicationType("avalonia", "avalonia"));
+        Assert.Contains("expected desktop", unknownType.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/SharpTS.Tests/IntegrationTests/CliHelpVersionTests.cs
+++ b/tests/SharpTS.Tests/IntegrationTests/CliHelpVersionTests.cs
@@ -59,6 +59,16 @@ public class CliHelpVersionTests
     }
 
     [Fact]
+    public void Help_AdvertisesDesktopScaffolding()
+    {
+        var result = CliTestHelper.RunCli("--help");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("sharpts new desktop", result.StandardOutput);
+        Assert.DoesNotContain("sharpts new avalonia", result.StandardOutput);
+    }
+
+    [Fact]
     public void Version_LongFlag_PrintsVersion()
     {
         var result = CliTestHelper.RunCli("--version");

--- a/tests/SharpTS.Tests/ReferencesTests/SharpTsManifestLoaderTests.cs
+++ b/tests/SharpTS.Tests/ReferencesTests/SharpTsManifestLoaderTests.cs
@@ -85,13 +85,14 @@ public class SharpTsManifestLoaderTests
     }
 
     [Fact]
-    public void Load_ApplicationHostMetadata()
+    public void Load_ApplicationMetadata()
     {
         using var dir = CliTestHelper.CreateTempDirectory();
         var path = dir.CreateFile("sharpts.json", """
             {
               "application": {
-                "type": "avalonia",
+                "type": "desktop",
+                "host": "avalonia",
                 "entry": "main.tsx",
                 "guiSdkVersion": "2.3.4-test.1",
                 "guiSdkSource": "./feed"
@@ -100,7 +101,8 @@ public class SharpTsManifestLoaderTests
             """);
 
         var application = SharpTsManifestLoader.Load(path).Application!;
-        Assert.Equal("avalonia", application.Type);
+        Assert.Equal("desktop", application.Type);
+        Assert.Equal("avalonia", application.Host);
         Assert.Equal("main.tsx", application.Entry);
         Assert.Equal("./feed", application.GuiSdkSource);
     }

--- a/tests/fixtures/SharpTS.Gui.Sdk.Consumer/Run-PackagedConsumer.ps1
+++ b/tests/fixtures/SharpTS.Gui.Sdk.Consumer/Run-PackagedConsumer.ps1
@@ -619,8 +619,13 @@ if (-not (Test-Path -LiteralPath $sharpTsCli)) {
     throw "SharpTS CLI was not built: $sharpTsCli"
 }
 Invoke-DotNet @(
-    $sharpTsCli, "new", "avalonia", "-n", "PackagedCliApp", "-o", $cliRoot,
+    $sharpTsCli, "new", "desktop", "-n", "PackagedCliApp", "-o", $cliRoot,
     "--sdk-version", $version)
+$cliProjectManifest = Get-Content -LiteralPath (Join-Path $cliRoot "sharpts.json") -Raw | ConvertFrom-Json
+if ($cliProjectManifest.application.type -ne "desktop" -or
+    $cliProjectManifest.application.host -ne "avalonia") {
+    throw "TypeScript-only CLI did not separate the desktop application type from the Avalonia host."
+}
 [IO.File]::WriteAllText((Join-Path $cliRoot "Directory.Build.props"), "<Project />")
 [IO.File]::WriteAllText((Join-Path $cliRoot "NuGet.config"), $nugetConfig)
 


### PR DESCRIPTION
## Summary

- rename the unshipped `sharpts new avalonia` command to `sharpts new desktop`
- separate the manifest lifecycle type (`desktop`) from the implementation host (`avalonia`)
- validate supported type/host combinations and update help, documentation, unit tests, and packaged-consumer coverage

## Verification

- 99 targeted CLI, manifest, and help tests passed
- 2 productization contract tests passed
- full Release solution build succeeded with 0 warnings and 0 errors
- packaged-consumer PowerShell syntax validation passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `sharpts new desktop` command for creating desktop GUI projects.
  * Generated projects now distinguish the application type (`desktop`) from the implementation host (`avalonia`).
  * Added explicit host selection through application configuration and command options.

* **Documentation**
  * Updated CLI usage, project setup guidance, and host-selection behavior.

* **Bug Fixes**
  * Improved validation for unsupported application types and incompatible hosts.
  * Removed the deprecated `sharpts new avalonia` command and provided migration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->