### PR TITLE
Add Phase 1 TypeScript types baseline infrastructure

### DIFF
--- a/tests/conformance/SharpTS.TypeScriptConformance/Fixtures/TypesBaselines/multi.types
+++ b/tests/conformance/SharpTS.TypeScriptConformance/Fixtures/TypesBaselines/multi.types
@@ -1,0 +1,19 @@
+//// [tests/cases/conformance/modules/multi.ts] ////
+
+=== ./a.ts ===
+export const value = 1;
+>value : 1
+>      : ^
+>1 : 1
+>  : ^
+
+=== b.ts ===
+import { value } from "./a";
+>value : 1
+>      : ^
+
+const copy = value;
+>copy : 1
+>     : ^
+>value : 1
+>      : ^

--- a/tests/conformance/SharpTS.TypeScriptConformance/Fixtures/TypesBaselines/single.types
+++ b/tests/conformance/SharpTS.TypeScriptConformance/Fixtures/TypesBaselines/single.types
@@ -1,0 +1,30 @@
+//// [tests/cases/conformance/types/example/single.ts] ////
+
+=== Performance Stats ===
+Type Count: 1,000
+
+
+=== single.ts ===
+const x = 1, y = 2;
+>x : 1
+>  : ^
+>1 : 1
+>  : ^
+>y : 2
+>  : ^
+>2 : 2
+>  : ^
+
+const total = x + x;
+>total : number
+>      : ^^^^^^
+>x + x : number
+>      : ^^^^^^
+>x : 1
+>  : ^
+>x : 1
+>  : ^
+
+let shape: { left: string; right: number };
+>shape : { left: string; right: number; }
+>      : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/conformance/SharpTS.TypeScriptConformance/README.md
+++ b/tests/conformance/SharpTS.TypeScriptConformance/README.md
@@ -2,7 +2,9 @@
 
 Runs SharpTS's type checker against the canonical [microsoft/TypeScript](https://github.com/microsoft/TypeScript) conformance corpus and diffs our diagnostics against `tsc`'s `*.errors.txt` baselines. Mirrors the shape of `tests/conformance/SharpTS.Test262/`.
 
-Standing tracking issue: [#1281](https://github.com/nickna/SharpTS/issues/1281).
+The diagnostic-parity campaign in [#1281](https://github.com/nickna/SharpTS/issues/1281)
+is complete. Per-node inferred-type baseline work is tracked separately in
+[#88](https://github.com/nickna/SharpTS/issues/88).
 
 ## Pinned TypeScript version
 
@@ -108,6 +110,29 @@ Diagnostics match on `(line, tsCode)` tuples. Column is intentionally dropped �
 
 Diagnostics with no `tsCode` (SharpTS-only — e.g. `@DotNetType` integration errors) are excluded from baseline matching for that test rather than forcing a fail.
 
+## Inferred-type baseline infrastructure
+
+Phase 1 of [#88](https://github.com/nickna/SharpTS/issues/88) provides the
+non-semantic infrastructure for the future `*.types` track:
+
+- `TypeScriptBaselineResolver` selects plain or target/module-configured
+  `.errors.txt` and `.types` files through the same deterministic algorithm.
+  A missing compatible file is a typed `NoBaseline` result; unsupported
+  harness axes are not guessed, and equally specific matches are reported as
+  ambiguous.
+- `TypesBaselineParser` reads the pinned writer format into ordered,
+  source-backed observations containing virtual filename, one-based source
+  line, source-line text, observed node text, occurrence ordinal, expected type
+  text, and optional underline metadata.
+- The parser receives the metadata parser's virtual source files as the
+  coordinate authority. This distinguishes real blank source lines from blank
+  separators inserted only for baseline readability.
+
+This infrastructure does not yet produce SharpTS observations or compare
+inferred types. Those semantic query, display, walking, and pilot-runner steps
+remain later phases of #88. Neither parser nor resolver invokes `tsc` at test
+time.
+
 ## JavaScript inputs
 
 Selected tests that opt into `@allowJs` / `@checkJs` are measured. Their
@@ -146,5 +171,5 @@ resolver gaps rather than harness skips.
 ## See also
 
 - `tests/conformance/SharpTS.Test262/` — equivalent project for the ECMA-262 / JavaScript spec; this one mirrors its harness shape.
-- [#1281](https://github.com/nickna/SharpTS/issues/1281) — standing TypeScript conformance work,
-  corpus growth, and diagnostic-alignment tracking.
+- [#1281](https://github.com/nickna/SharpTS/issues/1281) — completed diagnostic-parity campaign.
+- [#88](https://github.com/nickna/SharpTS/issues/88) — per-node inferred-type baseline parity.

--- a/tests/conformance/SharpTS.TypeScriptConformance/TypeScriptBaselineResolver.cs
+++ b/tests/conformance/SharpTS.TypeScriptConformance/TypeScriptBaselineResolver.cs
@@ -1,0 +1,143 @@
+namespace SharpTS.TypeScriptConformance;
+
+/// <summary>The committed TypeScript baseline family requested by a conformance track.</summary>
+public enum TypeScriptBaselineKind
+{
+    Errors,
+    Types,
+}
+
+/// <summary>The result of resolving a configured TypeScript baseline variant.</summary>
+public enum TypeScriptBaselineResolutionStatus
+{
+    Found,
+    NoBaseline,
+    Ambiguous,
+}
+
+/// <summary>
+/// A deterministic baseline lookup result. <see cref="ExpectedPath"/> is always the conventional
+/// unconfigured path and is useful in diagnostics when no compatible file exists.
+/// </summary>
+public sealed record TypeScriptBaselineResolution(
+    TypeScriptBaselineResolutionStatus Status,
+    string ExpectedPath,
+    string? Path,
+    IReadOnlyList<string> Candidates)
+{
+    public static TypeScriptBaselineResolution Found(string expectedPath, string path) =>
+        new(TypeScriptBaselineResolutionStatus.Found, expectedPath, path, [path]);
+
+    public static TypeScriptBaselineResolution NoBaseline(string expectedPath) =>
+        new(TypeScriptBaselineResolutionStatus.NoBaseline, expectedPath, null, []);
+
+    public static TypeScriptBaselineResolution Ambiguous(
+        string expectedPath,
+        IReadOnlyList<string> candidates) =>
+        new(TypeScriptBaselineResolutionStatus.Ambiguous, expectedPath, null, candidates);
+}
+
+/// <summary>
+/// Resolves plain and target/module-configured baselines using one algorithm for diagnostics and
+/// inferred types. Axes that SharpTS does not model are deliberately rejected rather than guessed.
+/// </summary>
+public static class TypeScriptBaselineResolver
+{
+    public static TypeScriptBaselineResolution Resolve(
+        string typescriptRoot,
+        string testFilePath,
+        TypeScriptConformanceMetadata metadata,
+        TypeScriptBaselineKind kind)
+    {
+        string basename = System.IO.Path.GetFileNameWithoutExtension(testFilePath);
+        string baselinesDir = TypeScriptConformancePaths.BaselinesDir(typescriptRoot);
+        string suffix = kind switch
+        {
+            TypeScriptBaselineKind.Errors => ".errors.txt",
+            TypeScriptBaselineKind.Types => ".types",
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
+        };
+        string plain = System.IO.Path.Combine(baselinesDir, basename + suffix);
+        if (File.Exists(plain))
+            return TypeScriptBaselineResolution.Found(plain, plain);
+        if (!Directory.Exists(baselinesDir))
+            return TypeScriptBaselineResolution.NoBaseline(plain);
+
+        string selectedTarget = SelectHarnessValue(metadata.Target, "es5");
+        string selectedModule = SelectHarnessValue(metadata.Module, "esnext");
+        int bestSpecificity = -1;
+        var best = new List<string>();
+
+        foreach (string path in Directory.EnumerateFiles(
+                     baselinesDir,
+                     $"{basename}(*){suffix}"))
+        {
+            if (!TryReadAxes(System.IO.Path.GetFileName(path), suffix, out var axes))
+                continue;
+            if (axes.Keys.Any(key => key is not "target" and not "module"))
+                continue;
+            if (axes.TryGetValue("target", out string? target) &&
+                NormalizeTarget(target) != NormalizeTarget(selectedTarget))
+                continue;
+            if (axes.TryGetValue("module", out string? module) &&
+                NormalizeModule(module) != NormalizeModule(selectedModule))
+                continue;
+
+            if (axes.Count > bestSpecificity)
+            {
+                bestSpecificity = axes.Count;
+                best.Clear();
+            }
+            if (axes.Count == bestSpecificity)
+                best.Add(path);
+        }
+
+        best.Sort(StringComparer.Ordinal);
+        return best.Count switch
+        {
+            0 => TypeScriptBaselineResolution.NoBaseline(plain),
+            1 => TypeScriptBaselineResolution.Found(plain, best[0]),
+            _ => TypeScriptBaselineResolution.Ambiguous(plain, best),
+        };
+    }
+
+    private static bool TryReadAxes(
+        string filename,
+        string suffix,
+        out IReadOnlyDictionary<string, string> axes)
+    {
+        axes = new Dictionary<string, string>();
+        int open = filename.IndexOf('(');
+        int close = filename.LastIndexOf(')' + suffix, StringComparison.Ordinal);
+        if (open < 0 || close <= open + 1)
+            return false;
+
+        var parsed = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (string part in filename[(open + 1)..close]
+                     .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+        {
+            string[] pair = part.Split('=', 2, StringSplitOptions.TrimEntries);
+            if (pair.Length != 2 || pair[0].Length == 0 || pair[1].Length == 0)
+                return false;
+            if (!parsed.TryAdd(pair[0].ToLowerInvariant(), pair[1]))
+                return false;
+        }
+        axes = parsed;
+        return parsed.Count > 0;
+    }
+
+    private static string SelectHarnessValue(string? values, string defaultValue)
+    {
+        string selected = values?
+            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .LastOrDefault()?
+            .ToLowerInvariant() ?? defaultValue;
+        return selected == "*" ? "esnext" : selected;
+    }
+
+    private static string NormalizeTarget(string target) =>
+        target.Trim().ToLowerInvariant() is "es6" ? "es2015" : target.Trim().ToLowerInvariant();
+
+    private static string NormalizeModule(string module) =>
+        module.Trim().ToLowerInvariant() is "es6" ? "es2015" : module.Trim().ToLowerInvariant();
+}

--- a/tests/conformance/SharpTS.TypeScriptConformance/TypeScriptBaselineResolverTests.cs
+++ b/tests/conformance/SharpTS.TypeScriptConformance/TypeScriptBaselineResolverTests.cs
@@ -1,0 +1,163 @@
+using Xunit;
+
+namespace SharpTS.TypeScriptConformance;
+
+public class TypeScriptBaselineResolverTests
+{
+    [Theory]
+    [InlineData(TypeScriptBaselineKind.Errors, "sample.errors.txt")]
+    [InlineData(TypeScriptBaselineKind.Types, "sample.types")]
+    public void Resolve_PrefersPlainBaseline(TypeScriptBaselineKind kind, string filename)
+    {
+        using TempTypeScriptRoot root = new();
+        string expected = root.WriteBaseline(filename);
+        root.WriteBaseline(kind == TypeScriptBaselineKind.Errors
+            ? "sample(target=es5).errors.txt"
+            : "sample(target=es5).types");
+
+        TypeScriptBaselineResolution result = TypeScriptBaselineResolver.Resolve(
+            root.Path,
+            "sample.ts",
+            Metadata(""),
+            kind);
+
+        Assert.Equal(TypeScriptBaselineResolutionStatus.Found, result.Status);
+        Assert.Equal(expected, result.Path);
+    }
+
+    [Theory]
+    [InlineData(TypeScriptBaselineKind.Errors, ".errors.txt")]
+    [InlineData(TypeScriptBaselineKind.Types, ".types")]
+    public void Resolve_SelectsSameMostSpecificConfiguredVariant(
+        TypeScriptBaselineKind kind,
+        string suffix)
+    {
+        using TempTypeScriptRoot root = new();
+        root.WriteBaseline("sample(target=es5)" + suffix);
+        root.WriteBaseline("sample(module=es2020)" + suffix);
+        string expected = root.WriteBaseline("sample(module=es2020,target=es5)" + suffix);
+        TypeScriptConformanceMetadata metadata = Metadata(
+            "// @target: esnext, es5\n// @module: esnext, commonjs, es2020\n");
+
+        TypeScriptBaselineResolution result = TypeScriptBaselineResolver.Resolve(
+            root.Path,
+            "sample.tsx",
+            metadata,
+            kind);
+
+        Assert.Equal(TypeScriptBaselineResolutionStatus.Found, result.Status);
+        Assert.Equal(expected, result.Path);
+    }
+
+    [Fact]
+    public void Resolve_NormalizesWildcardModuleAndEs6Target()
+    {
+        using TempTypeScriptRoot root = new();
+        string expected = root.WriteBaseline("sample(module=esnext,target=es2015).types");
+        TypeScriptConformanceMetadata metadata = Metadata(
+            "// @target: es6\n// @module: *\n");
+
+        TypeScriptBaselineResolution result = TypeScriptBaselineResolver.Resolve(
+            root.Path,
+            "sample.ts",
+            metadata,
+            TypeScriptBaselineKind.Types);
+
+        Assert.Equal(TypeScriptBaselineResolutionStatus.Found, result.Status);
+        Assert.Equal(expected, result.Path);
+    }
+
+    [Fact]
+    public void Resolve_UnsupportedAxisProducesNoBaseline()
+    {
+        using TempTypeScriptRoot root = new();
+        root.WriteBaseline("sample(module=esnext,newLine=lf).types");
+
+        TypeScriptBaselineResolution result = TypeScriptBaselineResolver.Resolve(
+            root.Path,
+            "sample.ts",
+            Metadata(""),
+            TypeScriptBaselineKind.Types);
+
+        Assert.Equal(TypeScriptBaselineResolutionStatus.NoBaseline, result.Status);
+        Assert.Null(result.Path);
+        Assert.EndsWith("sample.types", result.ExpectedPath, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Resolve_MissingDirectoryProducesNoBaseline()
+    {
+        string missingRoot = Path.Combine(Path.GetTempPath(), $"missing-sharpts-ts-{Guid.NewGuid():N}");
+
+        TypeScriptBaselineResolution result = TypeScriptBaselineResolver.Resolve(
+            missingRoot,
+            "sample.ts",
+            Metadata(""),
+            TypeScriptBaselineKind.Types);
+
+        Assert.Equal(TypeScriptBaselineResolutionStatus.NoBaseline, result.Status);
+        Assert.Empty(result.Candidates);
+        Assert.EndsWith("sample.types", result.ExpectedPath, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Resolve_EquallySpecificMatchesAreAmbiguousAndSorted()
+    {
+        using TempTypeScriptRoot root = new();
+        string target = root.WriteBaseline("sample(target=es5).types");
+        string module = root.WriteBaseline("sample(module=esnext).types");
+
+        TypeScriptBaselineResolution result = TypeScriptBaselineResolver.Resolve(
+            root.Path,
+            "sample.ts",
+            Metadata(""),
+            TypeScriptBaselineKind.Types);
+
+        Assert.Equal(TypeScriptBaselineResolutionStatus.Ambiguous, result.Status);
+        Assert.Null(result.Path);
+        Assert.Equal(new[] { module, target }.OrderBy(path => path, StringComparer.Ordinal), result.Candidates);
+    }
+
+    [Fact]
+    public void Resolve_MalformedOrDuplicateAxesAreIgnored()
+    {
+        using TempTypeScriptRoot root = new();
+        root.WriteBaseline("sample(target).types");
+        root.WriteBaseline("sample(target=es5,target=es5).types");
+
+        TypeScriptBaselineResolution result = TypeScriptBaselineResolver.Resolve(
+            root.Path,
+            "sample.ts",
+            Metadata(""),
+            TypeScriptBaselineKind.Types);
+
+        Assert.Equal(TypeScriptBaselineResolutionStatus.NoBaseline, result.Status);
+    }
+
+    private static TypeScriptConformanceMetadata Metadata(string source) =>
+        TypeScriptConformanceMetadataParser.Parse("sample.ts", source);
+
+    private sealed class TempTypeScriptRoot : IDisposable
+    {
+        public TempTypeScriptRoot()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"sharpts-baseline-resolver-{Guid.NewGuid():N}");
+            Baselines = System.IO.Path.Combine(Path, "tests", "baselines", "reference");
+            Directory.CreateDirectory(Baselines);
+        }
+
+        public string Path { get; }
+        private string Baselines { get; }
+
+        public string WriteBaseline(string filename)
+        {
+            string path = System.IO.Path.Combine(Baselines, filename);
+            File.WriteAllText(path, string.Empty);
+            return path;
+        }
+
+        public void Dispose() => Directory.Delete(Path, recursive: true);
+    }
+}

--- a/tests/conformance/SharpTS.TypeScriptConformance/TypeScriptConformanceRunner.cs
+++ b/tests/conformance/SharpTS.TypeScriptConformance/TypeScriptConformanceRunner.cs
@@ -268,10 +268,22 @@ public sealed class TypeScriptConformanceRunner
 
         var actual = ToBaselineDiagnostics(diagnostics);
 
-        var baselinePath = ResolveBaselinePath(testFilePath, metadata);
         IReadOnlyList<BaselineDiagnostic> expected;
+        string baselinePath = "<unresolved>";
         try
         {
+            TypeScriptBaselineResolution resolution = TypeScriptBaselineResolver.Resolve(
+                _typescriptRoot,
+                testFilePath,
+                metadata,
+                TypeScriptBaselineKind.Errors);
+            if (resolution.Status == TypeScriptBaselineResolutionStatus.Ambiguous)
+            {
+                throw new InvalidOperationException(
+                    $"Ambiguous TypeScript error baselines: {string.Join(", ", resolution.Candidates.Select(Path.GetFileName))}");
+            }
+
+            baselinePath = resolution.Path ?? resolution.ExpectedPath;
             expected = File.Exists(baselinePath)
                 ? ErrorsBaselineParser.Parse(File.ReadAllText(baselinePath))
                 : Array.Empty<BaselineDiagnostic>();
@@ -398,77 +410,20 @@ public sealed class TypeScriptConformanceRunner
         string testFilePath,
         TypeScriptConformanceMetadata metadata)
     {
-        var basename = Path.GetFileNameWithoutExtension(testFilePath);
-        var dir = TypeScriptConformancePaths.BaselinesDir(_typescriptRoot);
-        var plain = Path.Combine(dir, $"{basename}.errors.txt");
-        if (File.Exists(plain)) return plain;
-        return ResolveHarnessVariantBaseline(dir, basename, metadata) ?? plain;
-    }
-
-    /// <summary>
-    /// Finds the most specific target/module variant compatible with the values
-    /// selected by the runner. Other harness axes are deliberately ignored until
-    /// the runner models them; choosing one accidentally is worse than treating
-    /// the test as having no baseline.
-    /// </summary>
-    private static string? ResolveHarnessVariantBaseline(
-        string baselinesDir,
-        string basename,
-        TypeScriptConformanceMetadata metadata)
-    {
-        // A missing baselines directory means "no baseline", not a crash. Without this an
-        // uninitialized external/typescript submodule takes down the resolver with a
-        // DirectoryNotFoundException instead of bucketing cleanly.
-        if (!Directory.Exists(baselinesDir)) return null;
-
-        string selectedTarget = SelectHarnessValue(metadata.Target, "es5");
-        string selectedModule = SelectHarnessValue(
-            metadata.RawDirectives.TryGetValue("module", out string? module) ? module : null,
-            "esnext");
-
-        string? best = null;
-        int bestSpecificity = -1;
-        foreach (var path in Directory.EnumerateFiles(baselinesDir, $"{basename}(*).errors.txt"))
+        TypeScriptBaselineResolution resolution = TypeScriptBaselineResolver.Resolve(
+            _typescriptRoot,
+            testFilePath,
+            metadata,
+            TypeScriptBaselineKind.Errors);
+        return resolution.Status switch
         {
-            var file = Path.GetFileName(path);
-            int open = file.IndexOf('(');
-            int close = file.LastIndexOf(").errors.txt", StringComparison.Ordinal);
-            if (open < 0 || close <= open + 1) continue;
-
-            var axes = file[(open + 1)..close]
-                .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
-                .Select(part => part.Split('=', 2, StringSplitOptions.TrimEntries))
-                .Where(parts => parts.Length == 2)
-                .ToDictionary(parts => parts[0].ToLowerInvariant(), parts => parts[1]);
-            if (axes.Keys.Any(key => key is not "target" and not "module")) continue;
-            if (axes.TryGetValue("target", out string? target) &&
-                NormalizeTarget(target) != NormalizeTarget(selectedTarget)) continue;
-            if (axes.TryGetValue("module", out string? candidateModule) &&
-                NormalizeModule(candidateModule) != NormalizeModule(selectedModule)) continue;
-
-            if (axes.Count > bestSpecificity)
-            {
-                bestSpecificity = axes.Count;
-                best = path;
-            }
-        }
-        return best;
+            TypeScriptBaselineResolutionStatus.Found => resolution.Path!,
+            TypeScriptBaselineResolutionStatus.NoBaseline => resolution.ExpectedPath,
+            TypeScriptBaselineResolutionStatus.Ambiguous => throw new InvalidOperationException(
+                $"Ambiguous TypeScript error baselines: {string.Join(", ", resolution.Candidates.Select(Path.GetFileName))}"),
+            _ => throw new ArgumentOutOfRangeException(),
+        };
     }
-
-    private static string SelectHarnessValue(string? values, string defaultValue)
-    {
-        string selected = values?
-            .Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
-            .LastOrDefault()?
-            .ToLowerInvariant() ?? defaultValue;
-        return selected == "*" ? "esnext" : selected;
-    }
-
-    private static string NormalizeTarget(string target) =>
-        target.Trim().ToLowerInvariant() is "es6" ? "es2015" : target.Trim().ToLowerInvariant();
-
-    private static string NormalizeModule(string module) =>
-        module.Trim().ToLowerInvariant() is "es6" ? "es2015" : module.Trim().ToLowerInvariant();
 
     /// <summary>
     /// Converts SharpTS diagnostics into the (line, tsCode) match-key form.

--- a/tests/conformance/SharpTS.TypeScriptConformance/TypesBaselineIntegrationTests.cs
+++ b/tests/conformance/SharpTS.TypeScriptConformance/TypesBaselineIntegrationTests.cs
@@ -1,0 +1,148 @@
+using Xunit;
+
+namespace SharpTS.TypeScriptConformance;
+
+public class TypesBaselineIntegrationTests
+{
+    [Fact]
+    public void CurrentDiagnosticPasses_WithCompatibleTypesBaseline_ParseSuccessfully()
+    {
+        string? root = TypeScriptConformancePaths.TryFindRoot();
+        string? projectDir = TypeScriptConformancePaths.TryFindProjectDir();
+        if (root is null || projectDir is null) return;
+
+        string baselineIndex = Path.Combine(projectDir, "baselines", "interpreted.txt");
+        int parsedCount = 0;
+        foreach (string entry in File.ReadLines(baselineIndex)
+                     .Where(line => line.Length > 0 && !line.StartsWith('#')))
+        {
+            string[] parts = entry.Split(' ', 2);
+            if (parts.Length != 2 || parts[1] != "Pass")
+                continue;
+
+            const string prefix = "tests/cases/conformance/";
+            Assert.StartsWith(prefix, parts[0], StringComparison.Ordinal);
+            string relativePath = parts[0][prefix.Length..];
+            string testPath = Path.Combine(
+                TypeScriptConformancePaths.ConformanceDir(root),
+                relativePath.Replace('/', Path.DirectorySeparatorChar));
+            TypeScriptConformanceMetadata metadata = TypeScriptConformanceMetadataParser.Parse(
+                testPath,
+                File.ReadAllText(testPath));
+            TypeScriptBaselineResolution resolution = TypeScriptBaselineResolver.Resolve(
+                root,
+                testPath,
+                metadata,
+                TypeScriptBaselineKind.Types);
+
+            if (resolution.Status == TypeScriptBaselineResolutionStatus.NoBaseline)
+                continue;
+            Assert.True(
+                resolution.Status == TypeScriptBaselineResolutionStatus.Found,
+                $"{relativePath}: {resolution.Status}: {string.Join(", ", resolution.Candidates)}");
+            try
+            {
+                TypesBaselineParser.Parse(File.ReadAllText(resolution.Path!), metadata.Files);
+            }
+            catch (Exception exception)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to parse the resolved types baseline for {relativePath}: {exception.Message}",
+                    exception);
+            }
+            parsedCount++;
+        }
+
+        // 531 current diagnostic passes have a basename-matching .types family. Thirteen expose
+        // only a configuration variant outside the runner's selected target/module world, so the
+        // strict resolver correctly leaves those as NoBaseline rather than guessing.
+        Assert.Equal(518, parsedCount);
+    }
+
+    [Theory]
+    [InlineData("es2019/globalThisTypeIndexAccess.ts")]
+    [InlineData("es2021/logicalAssignment/logicalAssignment9.ts")]
+    [InlineData("types/conditional/inferTypes1.ts")]
+    [InlineData("types/conditional/inferTypesWithExtends2.ts")]
+    [InlineData("types/keyof/keyofIntersection.ts")]
+    [InlineData("types/literal/literalTypes1.ts")]
+    [InlineData("types/typeRelationships/assignmentCompatibility/intersectionIncludingPropFromGlobalAugmentation.ts")]
+    [InlineData("types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts")]
+    [InlineData("types/typeRelationships/subtypesAndSuperTypes/subtypesOfUnion.ts")]
+    [InlineData("es2017/es2017DateAPIs.ts")]
+    [InlineData("es2020/constructBigint.ts")]
+    public void NamedPilotBaseline_ResolvesAndParses(string relativePath)
+    {
+        string? root = TypeScriptConformancePaths.TryFindRoot();
+        if (root is null) return;
+
+        (TypeScriptBaselineResolution resolution, TypesBaselineDocument document) =
+            ResolveAndParse(root, relativePath);
+
+        Assert.Equal(TypeScriptBaselineResolutionStatus.Found, resolution.Status);
+        Assert.EndsWith(".types", resolution.Path!, StringComparison.Ordinal);
+        Assert.NotEmpty(document.Files);
+        Assert.NotEmpty(document.Observations);
+    }
+
+    [Fact]
+    public void PinnedMultiFileBaseline_ResolvesAndParsesEverySection()
+    {
+        string? root = TypeScriptConformancePaths.TryFindRoot();
+        if (root is null) return;
+
+        (_, TypesBaselineDocument document) = ResolveAndParse(
+            root,
+            "es2019/globalThisVarDeclaration.ts");
+
+        Assert.True(document.Files.Count > 1);
+        Assert.All(document.Files, file => Assert.NotEmpty(file.Observations));
+    }
+
+    [Theory]
+    [InlineData("es2020/modules/exportAsNamespace_exportAssignment.ts")]
+    [InlineData("es2020/modules/exportAsNamespace_missingEmitHelpers.ts")]
+    [InlineData("es2020/modules/exportAsNamespace_nonExistent.ts")]
+    public void CurrentDiagnosticPassWithoutTypesFamily_IsNoBaseline(string relativePath)
+    {
+        string? root = TypeScriptConformancePaths.TryFindRoot();
+        if (root is null) return;
+
+        string testPath = Path.Combine(
+            TypeScriptConformancePaths.ConformanceDir(root),
+            relativePath.Replace('/', Path.DirectorySeparatorChar));
+        TypeScriptConformanceMetadata metadata = TypeScriptConformanceMetadataParser.Parse(
+            testPath,
+            File.ReadAllText(testPath));
+
+        TypeScriptBaselineResolution resolution = TypeScriptBaselineResolver.Resolve(
+            root,
+            testPath,
+            metadata,
+            TypeScriptBaselineKind.Types);
+
+        Assert.Equal(TypeScriptBaselineResolutionStatus.NoBaseline, resolution.Status);
+    }
+
+    private static (TypeScriptBaselineResolution Resolution, TypesBaselineDocument Document)
+        ResolveAndParse(string root, string relativePath)
+    {
+        string testPath = Path.Combine(
+            TypeScriptConformancePaths.ConformanceDir(root),
+            relativePath.Replace('/', Path.DirectorySeparatorChar));
+        TypeScriptConformanceMetadata metadata = TypeScriptConformanceMetadataParser.Parse(
+            testPath,
+            File.ReadAllText(testPath));
+        TypeScriptBaselineResolution resolution = TypeScriptBaselineResolver.Resolve(
+            root,
+            testPath,
+            metadata,
+            TypeScriptBaselineKind.Types);
+        Assert.Equal(TypeScriptBaselineResolutionStatus.Found, resolution.Status);
+
+        TypesBaselineDocument document = TypesBaselineParser.Parse(
+            File.ReadAllText(resolution.Path!),
+            metadata.Files);
+        return (resolution, document);
+    }
+}

--- a/tests/conformance/SharpTS.TypeScriptConformance/TypesBaselineObservation.cs
+++ b/tests/conformance/SharpTS.TypeScriptConformance/TypesBaselineObservation.cs
@@ -1,0 +1,35 @@
+namespace SharpTS.TypeScriptConformance;
+
+/// <summary>One ordered type observation extracted from a TypeScript <c>*.types</c> baseline.</summary>
+public sealed record TypesBaselineObservation(
+    string VirtualFileName,
+    int SourceLine,
+    string SourceLineText,
+    string SourceText,
+    int OccurrenceOrdinal,
+    string ExpectedTypeText,
+    string? Underline);
+
+/// <summary>One virtual-file section from a TypeScript <c>*.types</c> baseline.</summary>
+public sealed record TypesBaselineFile(
+    string VirtualFileName,
+    IReadOnlyList<TypesBaselineObservation> Observations);
+
+/// <summary>A parsed TypeScript <c>*.types</c> baseline in committed file order.</summary>
+public sealed record TypesBaselineDocument(IReadOnlyList<TypesBaselineFile> Files)
+{
+    public IReadOnlyList<TypesBaselineObservation> Observations =>
+        Files.SelectMany(file => file.Observations).ToArray();
+}
+
+/// <summary>A malformed or source-inconsistent TypeScript <c>*.types</c> baseline.</summary>
+public sealed class TypesBaselineParseException : FormatException
+{
+    public TypesBaselineParseException(string message, int baselineLine)
+        : base($"Baseline line {baselineLine}: {message}")
+    {
+        BaselineLine = baselineLine;
+    }
+
+    public int BaselineLine { get; }
+}

--- a/tests/conformance/SharpTS.TypeScriptConformance/TypesBaselineParser.cs
+++ b/tests/conformance/SharpTS.TypeScriptConformance/TypesBaselineParser.cs
@@ -1,0 +1,295 @@
+using System.Text.RegularExpressions;
+
+namespace SharpTS.TypeScriptConformance;
+
+/// <summary>
+/// Parses TypeScript's committed <c>*.types</c> baseline format into source-backed ordered
+/// observations. The virtual source bodies are authoritative for line coordinates because the
+/// upstream writer inserts presentation-only blank lines between some observation groups.
+/// </summary>
+public static class TypesBaselineParser
+{
+    private const string Delimiter = " : ";
+    private const string PerformanceHeader = "=== Performance Stats ===";
+    private static readonly Regex TestPathPrefixRegex = new(
+        @"(?:(file:/{3})|/)\.(?:ts|lib|src)/",
+        RegexOptions.Compiled);
+
+    public static TypesBaselineDocument Parse(
+        string content,
+        IReadOnlyList<TypeScriptConformanceFile> sourceFiles)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+        ArgumentNullException.ThrowIfNull(sourceFiles);
+
+        string[] baselineLines = SplitBaselineLines(content);
+        SourceLookup sourceLookup = new(sourceFiles);
+        var parsedFiles = new List<TypesBaselineFile>();
+        SectionState? section = null;
+        bool inPerformanceSection = false;
+        bool sawFileSection = false;
+
+        for (int index = 0; index < baselineLines.Length; index++)
+        {
+            string line = baselineLines[index];
+            int baselineLine = index + 1;
+
+            if (TryReadSectionHeader(line, out string? sectionName))
+            {
+                FinishSection(section, baselineLine);
+                section = null;
+                if (line == PerformanceHeader)
+                {
+                    inPerformanceSection = true;
+                    continue;
+                }
+
+                inPerformanceSection = false;
+                TypeScriptConformanceFile source = sourceLookup.Resolve(sectionName!, baselineLine);
+                section = new SectionState(source);
+                parsedFiles.Add(new TypesBaselineFile(
+                    section.VirtualFileName,
+                    section.Observations));
+                sawFileSection = true;
+                continue;
+            }
+
+            if (inPerformanceSection)
+                continue;
+
+            if (section is null)
+            {
+                if (line.Length == 0 || IsPreamble(line))
+                    continue;
+                if (line.StartsWith('>'))
+                    throw Error("Type observation appears outside a virtual-file section.", baselineLine);
+                throw Error($"Unexpected content before a virtual-file section: '{line}'.", baselineLine);
+            }
+
+            // Source echo lines take precedence, including a legitimate source line beginning
+            // with '>'. A blank line that does not match the next source line is a writer-added
+            // presentation separator and is ignored.
+            if (section.TryConsumeSourceLine(line))
+                continue;
+            if (line.Length == 0)
+                continue;
+
+            if (!line.StartsWith('>'))
+            {
+                throw Error(
+                    $"Source echo for '{section.VirtualFileName}' does not match line {section.NextSourceLine}: '{line}'.",
+                    baselineLine);
+            }
+
+            if (TryReadUnderline(line, out _, out _))
+                throw Error("Underline appears without a preceding type observation.", baselineLine);
+            if (section.CurrentSourceLine == 0)
+                throw Error("Type observation appears before its source line.", baselineLine);
+
+            int delimiterIndex;
+            string? underline = null;
+            if (index + 1 < baselineLines.Length &&
+                TryReadUnderline(baselineLines[index + 1], out int sourceTextLength, out string? parsedUnderline))
+            {
+                delimiterIndex = sourceTextLength;
+                underline = parsedUnderline;
+                index++;
+            }
+            else
+            {
+                // The upstream writer omits underlines only for intrinsic any/error displays.
+                // Use the final delimiter so source expressions containing ` : ` remain intact.
+                delimiterIndex = line[1..].LastIndexOf(Delimiter, StringComparison.Ordinal);
+            }
+
+            string observationBody = line[1..];
+            if (delimiterIndex < 0 ||
+                delimiterIndex + Delimiter.Length > observationBody.Length ||
+                !observationBody.AsSpan(delimiterIndex, Delimiter.Length).SequenceEqual(Delimiter))
+            {
+                throw Error("Malformed type observation delimiter.", baselineLine);
+            }
+
+            string sourceText = observationBody[..delimiterIndex];
+            string expectedType = observationBody[(delimiterIndex + Delimiter.Length)..];
+            if (expectedType.Length == 0)
+                throw Error("Type observation has an empty expected type.", baselineLine);
+
+            int occurrence = section.NextOccurrence(sourceText);
+            section.Observations.Add(new TypesBaselineObservation(
+                section.VirtualFileName,
+                section.CurrentSourceLine,
+                section.CurrentSourceLineText,
+                sourceText,
+                occurrence,
+                expectedType,
+                underline));
+        }
+
+        FinishSection(section, baselineLines.Length + 1);
+        if (!sawFileSection)
+            throw Error("Baseline contains no virtual-file sections.", 1);
+
+        return new TypesBaselineDocument(parsedFiles);
+    }
+
+    private static void FinishSection(SectionState? section, int baselineLine)
+    {
+        if (section is null || section.HasConsumedAllSource)
+            return;
+        throw Error(
+            $"Baseline section '{section.VirtualFileName}' ended before source line {section.NextSourceLine} was echoed.",
+            baselineLine);
+    }
+
+    private static bool TryReadSectionHeader(string line, out string? name)
+    {
+        const string prefix = "=== ";
+        const string suffix = " ===";
+        if (!line.StartsWith(prefix, StringComparison.Ordinal) ||
+            !line.EndsWith(suffix, StringComparison.Ordinal) ||
+            line.Length <= prefix.Length + suffix.Length)
+        {
+            name = null;
+            return false;
+        }
+        name = line[prefix.Length..^suffix.Length];
+        return true;
+    }
+
+    private static bool TryReadUnderline(
+        string line,
+        out int sourceTextLength,
+        out string? underline)
+    {
+        sourceTextLength = -1;
+        underline = null;
+        if (!line.StartsWith('>'))
+            return false;
+
+        string body = line[1..];
+        int delimiter = body.IndexOf(Delimiter, StringComparison.Ordinal);
+        if (delimiter < 0 || body[..delimiter].Any(character => character != ' '))
+            return false;
+        string value = body[(delimiter + Delimiter.Length)..];
+        if (value.Any(character => character is not (' ' or '^')))
+            return false;
+
+        sourceTextLength = delimiter;
+        underline = value;
+        return true;
+    }
+
+    private static bool IsPreamble(string line) =>
+        line.StartsWith("//// [", StringComparison.Ordinal) &&
+        line.EndsWith("] ////", StringComparison.Ordinal);
+
+    private static string[] SplitBaselineLines(string text)
+    {
+        if (text.Length > 0 && text[0] == '\uFEFF')
+            text = text[1..];
+        return text
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n');
+    }
+
+    private static string[] SplitSourceLines(string text) =>
+        SplitBaselineLines(text)
+            .SelectMany(line => line.Split(['\r', '\u2028', '\u2029']))
+            .ToArray();
+
+    private static TypesBaselineParseException Error(string message, int baselineLine) =>
+        new(message, baselineLine);
+
+    private sealed class SectionState
+    {
+        private readonly string[] _sourceLines;
+        private readonly Dictionary<(int Line, string Text), int> _occurrences = [];
+        private int _nextSourceIndex;
+
+        public SectionState(TypeScriptConformanceFile source)
+        {
+            VirtualFileName = NormalizeName(source.Name);
+            _sourceLines = SplitSourceLines(source.Body);
+        }
+
+        public string VirtualFileName { get; }
+        public List<TypesBaselineObservation> Observations { get; } = [];
+        public int CurrentSourceLine { get; private set; }
+        public string CurrentSourceLineText => CurrentSourceLine == 0
+            ? string.Empty
+            : _sourceLines[CurrentSourceLine - 1];
+        public int NextSourceLine => _nextSourceIndex + 1;
+        public bool HasConsumedAllSource => _nextSourceIndex == _sourceLines.Length;
+
+        public bool TryConsumeSourceLine(string baselineLine)
+        {
+            if (_nextSourceIndex >= _sourceLines.Length ||
+                !string.Equals(
+                    RemoveTestPathPrefixes(_sourceLines[_nextSourceIndex]),
+                    baselineLine,
+                    StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            CurrentSourceLine = ++_nextSourceIndex;
+            return true;
+        }
+
+        public int NextOccurrence(string sourceText)
+        {
+            var key = (CurrentSourceLine, sourceText);
+            int occurrence = _occurrences.GetValueOrDefault(key) + 1;
+            _occurrences[key] = occurrence;
+            return occurrence;
+        }
+    }
+
+    private sealed class SourceLookup
+    {
+        private readonly IReadOnlyList<TypeScriptConformanceFile> _files;
+
+        public SourceLookup(IReadOnlyList<TypeScriptConformanceFile> files) => _files = files;
+
+        public TypeScriptConformanceFile Resolve(string baselineName, int baselineLine)
+        {
+            string normalized = NormalizeName(baselineName);
+            TypeScriptConformanceFile[] exact = _files
+                .Where(file => string.Equals(
+                    NormalizeName(file.Name),
+                    normalized,
+                    StringComparison.Ordinal))
+                .ToArray();
+            if (exact.Length == 1)
+                return exact[0];
+            if (exact.Length > 1)
+                throw Error($"Virtual filename '{baselineName}' is ambiguous.", baselineLine);
+
+            string basename = normalized.Split('/').Last();
+            TypeScriptConformanceFile[] byBasename = _files
+                .Where(file => string.Equals(
+                    NormalizeName(file.Name).Split('/').Last(),
+                    basename,
+                    StringComparison.Ordinal))
+                .ToArray();
+            return byBasename.Length switch
+            {
+                1 => byBasename[0],
+                0 => throw Error($"Baseline references unknown virtual file '{baselineName}'.", baselineLine),
+                _ => throw Error($"Virtual filename '{baselineName}' is ambiguous by basename.", baselineLine),
+            };
+        }
+    }
+
+    private static string NormalizeName(string name)
+    {
+        string normalized = RemoveTestPathPrefixes(name.Replace('\\', '/'));
+        while (normalized.StartsWith("./", StringComparison.Ordinal))
+            normalized = normalized[2..];
+        return normalized.TrimStart('/');
+    }
+
+    private static string RemoveTestPathPrefixes(string text) =>
+        TestPathPrefixRegex.Replace(text, match => match.Groups[1].Success ? match.Groups[1].Value : string.Empty);
+}

--- a/tests/conformance/SharpTS.TypeScriptConformance/TypesBaselineParserTests.cs
+++ b/tests/conformance/SharpTS.TypeScriptConformance/TypesBaselineParserTests.cs
@@ -1,0 +1,142 @@
+using Xunit;
+
+namespace SharpTS.TypeScriptConformance;
+
+public class TypesBaselineParserTests
+{
+    [Fact]
+    public void Parse_SingleFile_PreservesOrderTypesAndOccurrences()
+    {
+        string baseline = ReadFixture("single.types");
+        TypeScriptConformanceFile source = new(
+            "single.ts",
+            "const x = 1, y = 2;\n\nconst total = x + x;\n\nlet shape: { left: string; right: number };");
+
+        TypesBaselineDocument result = TypesBaselineParser.Parse(baseline, [source]);
+
+        TypesBaselineFile file = Assert.Single(result.Files);
+        Assert.Equal("single.ts", file.VirtualFileName);
+        Assert.Equal(9, file.Observations.Count);
+        Assert.Equal(["x", "1", "y", "2", "total", "x + x", "x", "x", "shape"],
+            file.Observations.Select(observation => observation.SourceText));
+
+        TypesBaselineObservation[] repeated = file.Observations
+            .Where(observation => observation.SourceLine == 3 && observation.SourceText == "x")
+            .ToArray();
+        Assert.Equal([1, 2], repeated.Select(observation => observation.OccurrenceOrdinal));
+        Assert.All(repeated, observation => Assert.Equal("const total = x + x;", observation.SourceLineText));
+
+        TypesBaselineObservation shape = file.Observations[^1];
+        Assert.Equal(5, shape.SourceLine);
+        Assert.Equal("{ left: string; right: number; }", shape.ExpectedTypeText);
+        Assert.Equal("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^", shape.Underline);
+    }
+
+    [Fact]
+    public void Parse_MultiFile_NormalizesNamesAndResetsCoordinates()
+    {
+        string baseline = ReadFixture("multi.types");
+        TypeScriptConformanceFile[] sources =
+        [
+            new("a.ts", "export const value = 1;"),
+            new("./b.ts", "import { value } from \"./a\";\n\nconst copy = value;"),
+        ];
+
+        TypesBaselineDocument result = TypesBaselineParser.Parse(baseline, sources);
+
+        Assert.Equal(2, result.Files.Count);
+        Assert.Equal(["a.ts", "b.ts"], result.Files.Select(file => file.VirtualFileName));
+        Assert.Equal([1, 1], result.Files[0].Observations.Select(observation => observation.SourceLine));
+        Assert.Equal([1, 3, 3], result.Files[1].Observations.Select(observation => observation.SourceLine));
+        Assert.Equal(5, result.Observations.Count);
+    }
+
+    [Fact]
+    public void Parse_UsesUnderlineColumnWhenSourceAndTypeContainColons()
+    {
+        const string nodeText = "flag ? left : right";
+        string baseline =
+            "=== edge.ts ===\n" +
+            "const value = flag ? left : right;\n" +
+            $">{nodeText} : {{ choose: (x: string) => string; fallback: string; }}\n" +
+            $">{new string(' ', nodeText.Length)} : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n";
+
+        TypesBaselineObservation observation = Assert.Single(
+            TypesBaselineParser.Parse(
+                baseline,
+                [new TypeScriptConformanceFile("edge.ts", "const value = flag ? left : right;")])
+            .Observations);
+
+        Assert.Equal(nodeText, observation.SourceText);
+        Assert.Equal("{ choose: (x: string) => string; fallback: string; }", observation.ExpectedTypeText);
+    }
+
+    [Fact]
+    public void Parse_AllowsWriterObservationWithoutUnderline()
+    {
+        const string baseline = "=== error.ts ===\ndeclare const missing: any;\n>missing : error\n";
+
+        TypesBaselineObservation observation = Assert.Single(
+            TypesBaselineParser.Parse(
+                baseline,
+                [new TypeScriptConformanceFile("error.ts", "declare const missing: any;")])
+            .Observations);
+
+        Assert.Equal("error", observation.ExpectedTypeText);
+        Assert.Null(observation.Underline);
+    }
+
+    [Theory]
+    [InlineData(">x : number\n", "outside a virtual-file section")]
+    [InlineData("=== a.ts ===\n>x : number\n", "before its source line")]
+    [InlineData("=== a.ts ===\nconst x = 1;\n>  : ^\n", "without a preceding")]
+    [InlineData("=== missing.ts ===\n", "unknown virtual file")]
+    public void Parse_RejectsMalformedOrUnanchoredContent(string baseline, string expectedMessage)
+    {
+        TypesBaselineParseException error = Assert.Throws<TypesBaselineParseException>(() =>
+            TypesBaselineParser.Parse(
+                baseline,
+                [new TypeScriptConformanceFile("a.ts", "const x = 1;")]));
+
+        Assert.Contains(expectedMessage, error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Parse_RejectsSectionThatDoesNotEchoAllSource()
+    {
+        const string baseline = "=== a.ts ===\nconst x = 1;\n>x : 1\n>  : ^\n";
+
+        TypesBaselineParseException error = Assert.Throws<TypesBaselineParseException>(() =>
+            TypesBaselineParser.Parse(
+                baseline,
+                [new TypeScriptConformanceFile("a.ts", "const x = 1;\nconst y = 2;")]));
+
+        Assert.Contains("ended before source line 2", error.Message);
+    }
+
+    [Fact]
+    public void Parse_IsDeterministicAcrossLineEndingsAndBom()
+    {
+        string baseline = "\uFEFF" + ReadFixture("multi.types").Replace("\n", "\r\n", StringComparison.Ordinal);
+        TypeScriptConformanceFile[] sources =
+        [
+            new("a.ts", "export const value = 1;"),
+            new("b.ts", "import { value } from \"./a\";\n\nconst copy = value;"),
+        ];
+
+        TypesBaselineDocument first = TypesBaselineParser.Parse(baseline, sources);
+        TypesBaselineDocument second = TypesBaselineParser.Parse(baseline, sources);
+
+        Assert.Equal(
+            first.Files.Select(file => file.VirtualFileName).ToArray(),
+            second.Files.Select(file => file.VirtualFileName).ToArray());
+        Assert.Equal(first.Observations.ToArray(), second.Observations.ToArray());
+    }
+
+    private static string ReadFixture(string name)
+    {
+        string projectDir = TypeScriptConformancePaths.TryFindProjectDir()
+            ?? throw new InvalidOperationException("Could not find the TypeScript conformance project directory.");
+        return File.ReadAllText(Path.Combine(projectDir, "Fixtures", "TypesBaselines", name));
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of #88:

- add a shared deterministic resolver for TypeScript `.errors.txt` and `.types` baselines
- parse source-backed, ordered `.types` observations for single- and multi-file tests
- represent missing compatible baselines as `NoBaseline` and reject ambiguous variants
- add focused fixtures, unit tests, and pinned-corpus integration coverage
- document the new infrastructure and its intentionally non-semantic Phase 1 scope

The existing diagnostic aggregate and Test262 baselines are unchanged.

## Validation

- `dotnet test tests/conformance/SharpTS.TypeScriptConformance/SharpTS.TypeScriptConformance.csproj -c Release --no-restore --nologo -p:UseSharedCompilation=false -m:1 -nr:false`
  - 384/384 test methods passed
  - includes the unchanged 534/534 diagnostic aggregate
- targeted parser/resolver suite: 35/35 passed
- all 518 configuration-compatible `.types` baselines in the pinned diagnostic-pass subset resolve and parse
- `git diff --cached --check` passed before commit

The unrestricted core test project was attempted locally, but this sandbox rejects `HttpListener`, certificate-store, TLS, and IPC operations; it was stopped after repeated environment-only failures and 30-second network/IPC timeouts. No production project is changed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for TypeScript inferred-type conformance baselines, including single- and multi-file cases.
  - Added reliable baseline selection across compatible target and module variants.
  - Added parsing of expected types with source locations, repeated observations, and normalized file references.

- **Bug Fixes**
  - Improved handling of missing, ambiguous, malformed, and unsupported baselines with clear outcomes.

- **Documentation**
  - Documented the inferred-type baseline workflow, current scope, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->