### PR TITLE
Fix SharpPaint correctness and cleanup follow-ups

### DIFF
--- a/samples/SharpPaint/NuGet.Config
+++ b/samples/SharpPaint/NuGet.Config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="local-sharpts-gui" value="..\..\artifacts\tsx-api-feed" />
+    <add key="local-sharpts-gui" value="../../artifacts/tsx-api-feed" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/samples/SharpPaint/SharpPaintApp.tsx
+++ b/samples/SharpPaint/SharpPaintApp.tsx
@@ -56,6 +56,7 @@ import {
     deleteLayer,
     duplicateLayer,
     extendDraft,
+    markSaved,
     moveLayer,
     parseProject,
     replaceLayerCommands,
@@ -327,7 +328,7 @@ function appReducer(state: AppState, action: any): AppState {
             const loaded = action.document as PaintDocument;
             return { ...state, history: createHistory(loaded), selectedLayerId: loaded.layers[loaded.layers.length - 1].id, filePath: action.filePath as string | null, revision: state.revision + 1, draft: null, textDraft: null, effectDialog: null, effectPreview: null, busy: null, status: action.status as string, newDialog: false };
         }
-        case "saved": return { ...state, history: createHistory(state.history.document), filePath: action.filePath as string, status: action.status as string };
+        case "saved": return { ...state, history: markSaved(state.history), filePath: action.filePath as string, status: action.status as string };
         case "status": return { ...state, status: action.status as string };
         case "showNew": return { ...state, newDialog: action.value as boolean };
         case "newWidth": return { ...state, newWidth: action.value as string };

--- a/samples/SharpPaint/document.tests.ts
+++ b/samples/SharpPaint/document.tests.ts
@@ -98,8 +98,10 @@ history = undo(history);
 expect("undo", history.document.layers[0].commands.length === beforeUndo - 1 && history.future.length === 1);
 history = redo(history);
 expect("redo", history.document.layers[0].commands.length === beforeUndo);
+const pastBeforeSave = history.past.length;
+const futureBeforeSave = history.future.length;
 history = markSaved(history);
-expect("saved state", !history.dirty);
+expect("saved state preserves history", !history.dirty && history.past.length === pastBeforeSave && history.future.length === futureBeforeSave);
 const savedHistory = commitDocument(history, appendCommand(history.document, initial.layers[0].id, { kind: "line", x1: 1, y1: 1, x2: 2, y2: 2, stroke: "#000000", strokeThickness: 1 }));
 expect("edit after save is dirty", savedHistory.dirty);
 expect("undo to saved identity is clean", !undo(savedHistory).dirty);
@@ -115,6 +117,8 @@ rejects("future version", '{"format":"sharpaint","version":2,"width":1,"height":
 rejects("duplicate layer IDs", '{"format":"sharpaint","version":1,"width":1,"height":1,"layers":[{"id":"x","name":"a","isVisible":true,"opacity":1,"commands":[]},{"id":"x","name":"b","isVisible":true,"opacity":1,"commands":[]}]}');
 rejects("non-finite geometry", '{"format":"sharpaint","version":1,"width":1e999,"height":1,"layers":[{"id":"x","name":"a","isVisible":true,"opacity":1,"commands":[]}]}');
 rejects("unsupported command", '{"format":"sharpaint","version":1,"width":1,"height":1,"layers":[{"id":"x","name":"a","isVisible":true,"opacity":1,"commands":[{"kind":"filter"}]}]}');
+rejects("negative rectangle dimensions", '{"format":"sharpaint","version":1,"width":10,"height":10,"layers":[{"id":"x","name":"a","isVisible":true,"opacity":1,"commands":[{"kind":"rectangle","x":5,"y":5,"width":-1,"height":0,"fill":"#000000","strokeThickness":1}]}]}');
+rejects("negative ellipse radii", '{"format":"sharpaint","version":1,"width":10,"height":10,"layers":[{"id":"x","name":"a","isVisible":true,"opacity":1,"commands":[{"kind":"ellipse","centerX":5,"centerY":5,"radiusX":0,"radiusY":-1,"fill":"#000000","strokeThickness":1}]}]}');
 rejects("unembedded image", '{"format":"sharpaint","version":1,"width":1,"height":1,"layers":[{"id":"x","name":"a","isVisible":true,"opacity":1,"commands":[{"kind":"image","source":"file.png","x":0,"y":0,"width":1,"height":1}]}]}');
 rejects("invalid text", '{"format":"sharpaint","version":1,"width":10,"height":10,"layers":[{"id":"x","name":"a","isVisible":true,"opacity":1,"commands":[{"kind":"text","text":"","x":0,"y":0,"width":5,"height":5,"fill":"#000000","fontFamily":"sans-serif","fontSize":12,"textAlignment":"left","textWrapping":"wrap"}]}]}');
 

--- a/samples/SharpPaint/document.ts
+++ b/samples/SharpPaint/document.ts
@@ -309,6 +309,10 @@ function validateCommand(command: any): void {
     else if (command.kind === "ellipse") numbers.push(command.centerX, command.centerY, command.radiusX, command.radiusY);
     else numbers.push(command.x, command.y, command.width, command.height);
     for (const number of numbers) if (!finite(number)) throw new Error("Drawing coordinates must be finite.");
+    if (command.kind === "rectangle" && (command.width < 0 || command.height < 0))
+        throw new Error("Rectangle dimensions must not be negative.");
+    if (command.kind === "ellipse" && (command.radiusX < 0 || command.radiusY < 0))
+        throw new Error("Ellipse radii must not be negative.");
     if (command.kind === "image") {
         if (typeof command.source !== "string" || !command.source.startsWith("data:image/png;base64,") || command.source.length > 35_000_000)
             throw new Error("Saved image layers must contain embedded PNG data.");

--- a/samples/SharpPaint/headless.tests.tsx
+++ b/samples/SharpPaint/headless.tests.tsx
@@ -1,6 +1,6 @@
 import { createDesktopApplication } from "@sharpts/gui";
 import { createDesktopTestDriver, DesktopTestDriver } from "@sharpts/gui/testing";
-import { existsSync, writeFileSync } from "fs";
+import { existsSync, unlinkSync, writeFileSync } from "fs";
 import { join } from "path";
 import { SharpPaintShowcase } from "./SharpPaintApp";
 import { createDocument, serializeProject } from "./document";
@@ -43,6 +43,12 @@ function waitForStatus(testDriver: DesktopTestDriver, expected: string, then: ()
 }
 const openProjectPath = join(process.cwd(), "SharpPaint.Headless.Open.sharpaint");
 const saveProjectPath = join(process.cwd(), "SharpPaint.Headless.Save.sharpaint");
+function cleanupProjectArtifacts(): void {
+    for (const path of [openProjectPath, saveProjectPath]) {
+        try { if (existsSync(path)) unlinkSync(path); } catch (_) { }
+    }
+}
+process.on("exit", cleanupProjectArtifacts);
 writeFileSync(openProjectPath, serializeProject(createDocument(320, 240)), "utf8");
 
 expect("initial canvas", driver.getText("command-count") === "1 commands · 1 layers");
@@ -211,18 +217,34 @@ function runFileScenario(): void {
             driver.afterRender(() => {
                 expect("open button loads project (" + driver.getText("status") + ")",
                     driver.getText("status") === "Opened SharpPaint.Headless.Open.sharpaint");
-                driver.click("save");
+                driver.dragPointer("paint-surface", [{ x: 12, y: 14 }, { x: 40, y: 42 }]);
                 driver.afterRender(() => {
-                    expect("save button reports success",
-                        driver.getText("status") === "Saved SharpPaint.Headless.Open.sharpaint");
-                    driver.queueSaveFileDialogResult(saveProjectPath);
-                    driver.clickMenuItem("menu-save-as");
+                    expect("pre-save edit is retained", driver.getText("command-count") === "2 commands · 1 layers");
+                    driver.click("save");
                     driver.afterRender(() => {
-                        expect("save-as menu writes project", existsSync(saveProjectPath));
-                        driver.clickMenuItem("menu-new");
+                        expect("save button reports success",
+                            driver.getText("status") === "Saved SharpPaint.Headless.Open.sharpaint");
+                        expect("save preserves undo", driver.getProperty("undo", "isEnabled") === "True");
+                        driver.click("undo");
                         driver.afterRender(() => {
-                            expect("new menu item opens dialog", driver.getText("new-width") === "1024");
-                            setTimeout((() => application.dispose()) as any, 25);
+                            expect("undo remains functional after save", driver.getText("command-count") === "1 commands · 1 layers");
+                            driver.click("redo");
+                            driver.afterRender(() => {
+                                expect("redo remains functional after save", driver.getText("command-count") === "2 commands · 1 layers");
+                                driver.queueSaveFileDialogResult(saveProjectPath);
+                                driver.clickMenuItem("menu-save-as");
+                                driver.afterRender(() => {
+                                    expect("save-as menu writes project", existsSync(saveProjectPath));
+                                    driver.clickMenuItem("menu-new");
+                                    driver.afterRender(() => {
+                                        expect("new menu item opens dialog", driver.getText("new-width") === "1024");
+                                        setTimeout((() => {
+                                            try { application.dispose(); }
+                                            finally { cleanupProjectArtifacts(); }
+                                        }) as any, 25);
+                                    });
+                                });
+                            });
                         });
                     });
                 });

--- a/samples/SharpPaint/run-local.ps1
+++ b/samples/SharpPaint/run-local.ps1
@@ -35,9 +35,19 @@ if ($LASTEXITCODE -ne 0) { throw 'Failed to restore SharpPaint.' }
 dotnet build $project --no-restore --no-incremental
 if ($LASTEXITCODE -ne 0) { throw 'Failed to rebuild SharpPaint against the local GUI SDK.' }
 $arguments = @('run', '--project', $project, '--no-restore', '--no-build', '--', '--mode', $Mode)
+$hadSmokeClose = Test-Path -LiteralPath 'Env:\SHARPTS_GUI_SMOKE_CLOSE'
+$previousSmokeClose = $env:SHARPTS_GUI_SMOKE_CLOSE
 if ($Headless) {
     $env:SHARPTS_GUI_SMOKE_CLOSE = '1'
     $arguments += '--headless'
 }
-dotnet @arguments
-if ($LASTEXITCODE -ne 0) { throw "SharpPaint exited with code $LASTEXITCODE." }
+try {
+    dotnet @arguments
+    if ($LASTEXITCODE -ne 0) { throw "SharpPaint exited with code $LASTEXITCODE." }
+}
+finally {
+    if ($Headless) {
+        if ($hadSmokeClose) { $env:SHARPTS_GUI_SMOKE_CLOSE = $previousSmokeClose }
+        else { Remove-Item -LiteralPath 'Env:\SHARPTS_GUI_SMOKE_CLOSE' -ErrorAction SilentlyContinue }
+    }
+}

--- a/src/SharpTS.Gui/DesktopRoot.cs
+++ b/src/SharpTS.Gui/DesktopRoot.cs
@@ -1058,6 +1058,18 @@ public sealed class DesktopRoot : IDisposable
                 mounted.LatestPointerDown is not null || mounted.LatestPointerMove is not null ||
                 mounted.LatestPointerUp is not null || mounted.LatestPointerCancel is not null;
         }
+        if (!node.CapturePointerOnPress && mounted.CapturedPointer is { } capturedPointer)
+        {
+            try
+            {
+                if (ReferenceEquals(capturedPointer.Captured, mounted.Control))
+                    capturedPointer.Capture(null);
+            }
+            finally
+            {
+                mounted.CapturedPointer = null;
+            }
+        }
         bool needsPointerDown = mounted.LatestPointerDown is not null || node.CapturePointerOnPress;
         if (needsPointerDown && mounted.PointerDownHandler is null)
         {
@@ -1579,6 +1591,7 @@ public sealed class DesktopRoot : IDisposable
             PointerMove = null,
             PointerUp = null,
             PointerCancel = null,
+            WindowMetricsChanged = null,
             CloseRequested = null,
             DragOver = null,
             Drop = null,

--- a/tests/gui-conformance/SharpTS.Gui.Conformance.Tests/DesktopRendererTests.cs
+++ b/tests/gui-conformance/SharpTS.Gui.Conformance.Tests/DesktopRendererTests.cs
@@ -414,8 +414,8 @@ public sealed class DesktopRendererTests : IDisposable
         double observedPressure = -1;
         IPointer? nativePointer = null;
         using DesktopRoot root = CreateRoot();
-        GuiVNode Surface(string version) => new(
-            "Border", Key: "pointer", Width: 100, Height: 80, Background: "#ffffff", CapturePointerOnPress: true,
+        GuiVNode Surface(string version, bool capture = true) => new(
+            "Border", Key: "pointer", Width: 100, Height: 80, Background: "#ffffff", CapturePointerOnPress: capture,
             PointerDown: (id, type, x, y, button, buttons, pressure, ctrl, alt, shift, meta) =>
             {
                 modifiersObserved = ctrl && shift && !alt && !meta;
@@ -485,8 +485,18 @@ public sealed class DesktopRendererTests : IDisposable
 
         events.Clear();
         root.Window.MouseDown(press, MouseButton.Left, RawInputModifiers.LeftMouseButton);
+        Assert.Same(original, nativePointer!.Captured);
+        root.Render(Window(Surface("capture-disabled", capture: false), width: 240, height: 180));
+        Assert.Null(nativePointer.Captured);
+        DrainGuestMicrotasks();
+        Assert.Contains(events, item => item.StartsWith("capture-disabled-cancel", StringComparison.Ordinal));
+
+        events.Clear();
+        root.Render(Window(Surface("capture-restored"), width: 240, height: 180));
+        root.Window.MouseDown(press, MouseButton.Left, RawInputModifiers.LeftMouseButton);
+        Assert.Same(original, nativePointer.Captured);
         root.Render(Window(Text("replacement", "replacement"), width: 240, height: 180));
-        Assert.DoesNotContain(events, item => item.StartsWith("new-cancel", StringComparison.Ordinal));
+        Assert.DoesNotContain(events, item => item.StartsWith("capture-restored-cancel", StringComparison.Ordinal));
         root.Dispose();
         Assert.Equal(0, root.ActiveSubscriptions);
     }
@@ -1380,7 +1390,9 @@ public sealed class DesktopRendererTests : IDisposable
         }
         Assert.Equal(1, root.ActiveSubscriptions);
 
+        root.ResetOperationCounts();
         root.Render(MetricsWindow(latest.Add));
+        Assert.Equal(new RendererOperationCounts(0, 0, 0, 0), root.OperationCounts);
         DesktopTestingBridge.SetWindowClientSize(root, 520, 360);
         Dispatcher.UIThread.RunJobs();
 

--- a/tests/gui-conformance/SharpTS.Gui.Conformance.Tests/ProductizationContractTests.cs
+++ b/tests/gui-conformance/SharpTS.Gui.Conformance.Tests/ProductizationContractTests.cs
@@ -7,6 +7,25 @@ namespace SharpTS.Gui.Conformance.Tests;
 public sealed class ProductizationContractTests
 {
     [Fact]
+    public void SharpPaintLocalToolingUsesPortableFeedAndRestoresSmokeCloseState()
+    {
+        string root = FindRepositoryRoot();
+        string sampleRoot = Path.Combine(root, "samples", "SharpPaint");
+        XDocument config = XDocument.Load(Path.Combine(sampleRoot, "NuGet.Config"));
+        XElement localFeed = Assert.Single(
+            config.Descendants("add"),
+            item => item.Attribute("key")?.Value == "local-sharpts-gui");
+        Assert.Equal("../../artifacts/tsx-api-feed", localFeed.Attribute("value")?.Value);
+
+        string runLocal = File.ReadAllText(Path.Combine(sampleRoot, "run-local.ps1"));
+        Assert.Contains("$hadSmokeClose = Test-Path", runLocal, StringComparison.Ordinal);
+        Assert.Contains("$previousSmokeClose = $env:SHARPTS_GUI_SMOKE_CLOSE", runLocal, StringComparison.Ordinal);
+        Assert.Contains("finally {", runLocal, StringComparison.Ordinal);
+        Assert.Contains("$env:SHARPTS_GUI_SMOKE_CLOSE = $previousSmokeClose", runLocal, StringComparison.Ordinal);
+        Assert.Contains("Remove-Item -LiteralPath 'Env:\\SHARPTS_GUI_SMOKE_CLOSE'", runLocal, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void SupportedPlatforms_DriveSdkAndAreCoveredByTheWorkflow()
     {
         string root = FindRepositoryRoot();

--- a/tests/gui-conformance/SharpTS.Gui.Conformance.Tests/SharpPaintHeadlessTests.cs
+++ b/tests/gui-conformance/SharpTS.Gui.Conformance.Tests/SharpPaintHeadlessTests.cs
@@ -125,6 +125,8 @@ public sealed class SharpPaintHeadlessTests
             Assert.True(process.ExitCode == 0,
                 $"SharpPaint {mode} Headless run failed with {process.ExitCode}.{Environment.NewLine}" +
                 $"stdout:{Environment.NewLine}{output}{Environment.NewLine}stderr:{Environment.NewLine}{errors}");
+            Assert.False(File.Exists(Path.Combine(stage, "SharpPaint.Headless.Open.sharpaint")));
+            Assert.False(File.Exists(Path.Combine(stage, "SharpPaint.Headless.Save.sharpaint")));
 
             using JsonDocument trace = JsonDocument.Parse(await File.ReadAllTextAsync(tracePath));
             return trace.RootElement.EnumerateArray().Select(item => new TraceEvent(


### PR DESCRIPTION
## Summary
- validate SharpPaint rectangle and ellipse geometry before rendering hand-edited projects
- preserve undo/redo history across saves and restore the caller's smoke-close environment state
- release disabled pointer capture, ignore metrics callbacks in native-property comparisons, and use a portable local NuGet feed path
- clean generated SharpPaint project files on success and failure, with focused regression coverage

## Verification
- dotnet build SharpTS.sln -c Release --no-restore -p:NuGetAudit=false (0 warnings, 0 errors)
- full GUI conformance suite: 107 passed
- SharpPaint model/headless suite: 3 passed, covering interpreted and compiled modes
- focused renderer/tooling regressions: 3 passed
- core suite: 17,790 passed and 3 skipped; one deterministic-dispatcher timeout in CompiledHostedTopLevelAwait_InitializesThroughVersionedAbi, which passed on isolated rerun
- git diff --check
- PowerShell parser validation for samples/SharpPaint/run-local.ps1

Closes #1523

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Saving documents now preserves undo and redo history.
  - Invalid negative rectangle dimensions and ellipse radii are rejected.
  - Pointer capture and window metric updates behave more reliably.
  - Headless workflows clean up temporary project files.

- **Improvements**
  - Save, undo/redo, and save-as workflows now have broader coverage.
  - Local SharpPaint tooling uses portable package paths and safely restores environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->