### PR TITLE
Fix benchmark tooling portability follow-ups

### DIFF
--- a/benchmarks/cross-runtime/README.md
+++ b/benchmarks/cross-runtime/README.md
@@ -43,6 +43,8 @@ methodology rather than flattening unlike measurements together.
 
 ## Running
 
+PowerShell 7 or later (`pwsh`) is required for the benchmark PowerShell tools.
+
 ```powershell
 # Run everything; results land in $TEMP/bench-results/{results.txt,snapshot.json}
 ./benchmarks/cross-runtime/run-benchmarks.ps1
@@ -97,7 +99,7 @@ Each workload calls `bench(name, param, fn)` from `scripts/lib/bench.ts`, which:
    method than an already-fast optimizing JIT.
 3. Emits one line per case, consumed by the PowerShell formatter and exporter:
 
-   ```
+   ```text
    BENCH:<name>:<param>:<meanMs>:<minMs>:<stdevMs>:<samples>:<inner>:<sampledMs>
    ```
 
@@ -164,6 +166,7 @@ timed sweep (shared-runner timing is noisy and the full sweep is slow).
 | **Profiling** | Wall-clock mean/min/stdev | + allocations/GC (`MemoryDiagnoser`) |
 
 They can't be merged: BenchmarkDotNet must run in-process against managed code
-(it can't drive the `node`/`bun` executables), and the cross-runtime comparison
-must be black-box at the process boundary. Keeping them separate is intentional;
-the shared `scripts/lib/algorithms.ts` ensures both measure identical source.
+(it can't drive the `node`/`bun` executables). The cross-runtime runner instead
+launches each runtime as a black-box process, while the published metric is measured
+inside that process around the workload function. Keeping the suites separate is
+intentional; the shared `scripts/lib/algorithms.ts` ensures both measure identical source.

--- a/benchmarks/cross-runtime/Snapshot.psm1
+++ b/benchmarks/cross-runtime/Snapshot.psm1
@@ -469,8 +469,8 @@ function Export-SharpTSPublicBenchmarkSnapshot {
     $snapshot = New-SharpTSPublicBenchmarkSnapshot @arguments
     $parent = Split-Path -Parent ([IO.Path]::GetFullPath($OutputFile))
     if ($parent) { [IO.Directory]::CreateDirectory($parent) | Out-Null }
-    $json = $snapshot | ConvertTo-Json -Depth 12
-    [IO.File]::WriteAllText([IO.Path]::GetFullPath($OutputFile), $json + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+    $json = ($snapshot | ConvertTo-Json -Depth 12) -replace "`r`n", "`n"
+    [IO.File]::WriteAllText([IO.Path]::GetFullPath($OutputFile), $json + "`n", [Text.UTF8Encoding]::new($false))
     return $snapshot
 }
 

--- a/benchmarks/cross-runtime/test-snapshot.ps1
+++ b/benchmarks/cross-runtime/test-snapshot.ps1
@@ -68,6 +68,12 @@ try {
     $snapshotFile = Join-Path $temporaryDirectory 'snapshot.json'
     [void](Export-SharpTSPublicBenchmarkSnapshot -ResultsFile $resultsA -OutputFile $snapshotFile @fixed)
     Assert-True (Test-SharpTSPublicBenchmarkSnapshotFile $snapshotFile) 'Written snapshot did not validate.'
+    $snapshotBytes = [IO.File]::ReadAllBytes($snapshotFile)
+    Assert-True ($snapshotBytes.Count -gt 1 -and $snapshotBytes[-1] -eq 0x0A) `
+        'Written snapshot did not end with LF.'
+    Assert-True ($snapshotBytes[-2] -ne 0x0A) 'Written snapshot ended with more than one newline.'
+    Assert-True (-not ($snapshotBytes -contains [byte]0x0D)) `
+        'Written snapshot contained a carriage return instead of LF-only newlines.'
 
     $schema = Get-Content -LiteralPath (Join-Path $harnessDirectory 'snapshot-v1.schema.json') -Raw | ConvertFrom-Json
     Assert-True ($schema.'$schema' -ceq 'https://json-schema.org/draft/2020-12/schema') 'Schema is not JSON Schema 2020-12.'

--- a/benchmarks/gc-profiles/decision.md
+++ b/benchmarks/gc-profiles/decision.md
@@ -30,8 +30,8 @@ and the metadata records the clean commit and complete host/container runtime in
 - Ubuntu 24.04 x64: the same compiled assemblies in the digest-pinned Docker image, with .NET 10
   and Node 24.19.0. Workloads ran as the non-root `app` user with read-only source mounts.
 - Inner benchmark mean/minimum came from the existing cross-runtime protocol.
-- Process elapsed time and peak working set came from `System.Diagnostics.Process` on Windows and
-  GNU `time` inside the Ubuntu container.
+- Process elapsed time and peak memory came from `System.Diagnostics.Process` elapsed/working-set
+  APIs on Windows and GNU `time` elapsed/maximum-RSS fields inside the Ubuntu container.
 - A separate quiet-host Windows JSON run used five launches per cell to confirm the acceptance
   target without the full matrix competing for resources.
 
@@ -40,16 +40,17 @@ The complete result table is preserved in
 [full-corpus-metadata.json](results/full-corpus-metadata.json), and the focused confirmation in
 [json-windows-confirmation.md](results/json-windows-confirmation.md).
 
-The process matrix records mean, minimum, standard deviation, process elapsed time, and peak RSS
-for every launch. Allocation and generation counts come from the faithful BenchmarkDotNet phase
-diagnostic cited below; the cross-runtime `BENCH` protocol does not expose managed GC counters to
-Node and therefore does not pretend its sixth timing field is allocation data.
+The process matrix records mean, minimum, standard deviation, process elapsed time, and peak memory
+for every launch. The Windows memory value is peak working set; the Ubuntu value is maximum RSS.
+Allocation and generation counts come from the faithful BenchmarkDotNet phase diagnostic cited
+below; the cross-runtime `BENCH` protocol does not expose managed GC counters to Node and therefore
+does not pretend its sixth timing field is allocation data.
 
 ## Evidence
 
 The focused Windows JSON N=10,000 confirmation measured:
 
-| Runtime/profile | Median mean | Relative to Node | Median process | Median peak RSS |
+| Runtime/profile | Median mean | Relative to Node | Median process | Median peak memory |
 | --- | ---: | ---: | ---: | ---: |
 | workstation | 3.8156 ms | 1.39x | 1133.8 ms | 62.3 MB |
 | adaptive | 2.1110 ms | 0.77x | 1142.7 ms | 95.1 MB |
@@ -84,9 +85,9 @@ Sub-millisecond async cases also produced large percentages from very small abso
 reinforce that a universal server default would be unjustified. These are explicit tradeoffs of
 the opt-in adaptive profile, not silent regressions in the default.
 
-Fixed throughput GC commonly reached 616-759 MB peak RSS and was not consistently faster than
-DATAS. It remains available because some long-lived, memory-provisioned services may measure a win,
-but SharpTS does not recommend selecting it without deployment-specific evidence.
+Fixed throughput GC commonly reached 616-759 MB peak memory and was not consistently faster than
+the adaptive profile. It remains available because some long-lived, memory-provisioned services may
+measure a win, but SharpTS does not recommend selecting it without deployment-specific evidence.
 
 ## Propagation and guardrails
 

--- a/benchmarks/gc-profiles/results/full-corpus-windows-ubuntu.md
+++ b/benchmarks/gc-profiles/results/full-corpus-windows-ubuntu.md
@@ -1,10 +1,11 @@
 # GC profile benchmark matrix
 
 Generated from commit `5c5333d53baa046fac6013188ebbb32c32851928` with 3 launches per cell.
+Peak memory is peak working set from System.Diagnostics.Process on Windows and maximum RSS from GNU time on Ubuntu.
 
 ## Largest-input benchmark results
 
-| Platform | Benchmark | Input | Runtime/profile | Median mean | Median minimum | Median stdev | Median process | Median peak RSS |
+| Platform | Benchmark | Input | Runtime/profile | Median mean | Median minimum | Median stdev | Median process | Median peak memory |
 |---|---|---:|---|---:|---:|---:|---:|---:|
 | ubuntu | accumulate | 1000000 | adaptive | 9.0289 ms | 6.4926 ms | 1.7142 ms | 2120.0 ms | 95.1 MB |
 | ubuntu | accumulate | 1000000 | node | 4.5767 ms | 3.6206 ms | 1.0063 ms | 2310.0 ms | 206.9 MB |
@@ -233,7 +234,7 @@ Generated from commit `5c5333d53baa046fac6013188ebbb32c32851928` with 3 launches
 
 ## Cold startup
 
-| Platform | Runtime/profile | Median elapsed | Median peak RSS |
+| Platform | Runtime/profile | Median elapsed | Median peak memory |
 |---|---|---:|---:|
 | ubuntu | adaptive | 60.00 ms | 29.0 MB |
 | ubuntu | throughput | 60.00 ms | 29.1 MB |

--- a/benchmarks/gc-profiles/results/json-windows-confirmation.md
+++ b/benchmarks/gc-profiles/results/json-windows-confirmation.md
@@ -1,10 +1,11 @@
 # GC profile benchmark matrix
 
 Generated from commit `5c5333d53baa046fac6013188ebbb32c32851928` with 5 launches per cell.
+Peak memory is peak working set from System.Diagnostics.Process on Windows and maximum RSS from GNU time on Ubuntu.
 
 ## Largest-input benchmark results
 
-| Platform | Benchmark | Input | Runtime/profile | Median mean | Median minimum | Median stdev | Median process | Median peak RSS |
+| Platform | Benchmark | Input | Runtime/profile | Median mean | Median minimum | Median stdev | Median process | Median peak memory |
 |---|---|---:|---|---:|---:|---:|---:|---:|
 | windows | json | 10000 | adaptive | 2.1110 ms | 0.9976 ms | 3.1925 ms | 1142.7 ms | 95.1 MB |
 | windows | json | 10000 | node | 2.7534 ms | 2.3799 ms | 0.4480 ms | 1242.1 ms | 96.4 MB |
@@ -13,7 +14,7 @@ Generated from commit `5c5333d53baa046fac6013188ebbb32c32851928` with 5 launches
 
 ## Cold startup
 
-| Platform | Runtime/profile | Median elapsed | Median peak RSS |
+| Platform | Runtime/profile | Median elapsed | Median peak memory |
 |---|---|---:|---:|
 | windows | adaptive | 90.41 ms | 24.1 MB |
 | windows | throughput | 85.04 ms | 23.3 MB |

--- a/benchmarks/gc-profiles/run-gc-profile-matrix.ps1
+++ b/benchmarks/gc-profiles/run-gc-profile-matrix.ps1
@@ -441,10 +441,11 @@ $invariantCulture = [Globalization.CultureInfo]::InvariantCulture
 $lines.Add('# GC profile benchmark matrix')
 $lines.Add('')
 $lines.Add("Generated from commit ``$($metadata.commit)`` with $Launches launches per cell.")
+$lines.Add('Peak memory is peak working set from System.Diagnostics.Process on Windows and maximum RSS from GNU time on Ubuntu.')
 $lines.Add('')
 $lines.Add('## Largest-input benchmark results')
 $lines.Add('')
-$lines.Add('| Platform | Benchmark | Input | Runtime/profile | Median mean | Median minimum | Median stdev | Median process | Median peak RSS |')
+$lines.Add('| Platform | Benchmark | Input | Runtime/profile | Median mean | Median minimum | Median stdev | Median process | Median peak memory |')
 $lines.Add('|---|---|---:|---|---:|---:|---:|---:|---:|')
 
 $namedGroups = $benchRows | Group-Object platform, name
@@ -466,7 +467,7 @@ foreach ($namedGroup in $namedGroups | Sort-Object Name) {
 $lines.Add('')
 $lines.Add('## Cold startup')
 $lines.Add('')
-$lines.Add('| Platform | Runtime/profile | Median elapsed | Median peak RSS |')
+$lines.Add('| Platform | Runtime/profile | Median elapsed | Median peak memory |')
 $lines.Add('|---|---|---:|---:|')
 $startupMeasurements = @($measurements | Where-Object { $_.workload -eq 'startup' })
 foreach ($group in $startupMeasurements | Group-Object platform, runtime, profile | Sort-Object Name) {

--- a/scripts/PerfLocal.psm1
+++ b/scripts/PerfLocal.psm1
@@ -2,6 +2,35 @@ Set-StrictMode -Version Latest
 
 $script:InvariantCulture = [Globalization.CultureInfo]::InvariantCulture
 
+function Resolve-SharpTSPerfBaselinePath {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('sync', 'measure', 'gate', 'all')]
+        [string]$Action,
+
+        [string]$BaselinePath,
+
+        [Parameter(Mandatory)]
+        [string]$RepositoryParent
+    )
+
+    if ($Action -eq 'gate') {
+        return $null
+    }
+
+    $candidatePath = if ($BaselinePath) {
+        $BaselinePath
+    } else {
+        Join-Path $RepositoryParent '.perf-baseline-worktree'
+    }
+    if (-not (Test-Path -LiteralPath $candidatePath -PathType Container)) {
+        throw "Baseline worktree '$candidatePath' was not found. Create it from origin/main, or pass -BaselinePath."
+    }
+
+    return (Resolve-Path -LiteralPath $candidatePath).Path
+}
+
 function Get-SharpTSMedian {
     [CmdletBinding()]
     param([Parameter(Mandatory)] [double[]]$Values)
@@ -177,6 +206,7 @@ function ConvertTo-SharpTSPerfMarkdown {
 }
 
 Export-ModuleMember -Function @(
+    'Resolve-SharpTSPerfBaselinePath',
     'Get-SharpTSMedian',
     'ConvertFrom-SharpTSBenchmarkResults',
     'Get-SharpTSPerfComparisons',

--- a/scripts/perf-local.ps1
+++ b/scripts/perf-local.ps1
@@ -43,11 +43,11 @@ $ErrorActionPreference = 'Stop'
 $RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
 $RepoParent = Split-Path -Parent $RepoRoot
 $Runner = Join-Path $RepoRoot 'benchmarks/cross-runtime/run-benchmarks.ps1'
-$BaselinePath = if ($BaselinePath) {
-    (Resolve-Path -LiteralPath $BaselinePath).Path
-} else {
-    (Resolve-Path -LiteralPath (Join-Path $RepoParent '.perf-baseline-worktree')).Path
-}
+Import-Module (Join-Path $PSScriptRoot 'PerfLocal.psm1') -Force
+$BaselinePath = Resolve-SharpTSPerfBaselinePath `
+    -Action $Action `
+    -BaselinePath $BaselinePath `
+    -RepositoryParent $RepoParent
 $OutputDirectory = if ($OutputDirectory) {
     [IO.Path]::GetFullPath($OutputDirectory)
 } else {
@@ -68,8 +68,6 @@ if ($Platforms.Count -eq 0) {
 if ($Workloads.Count -eq 0 -and $Action -in @('measure', 'all')) {
     throw 'At least one workload must be selected for measurement.'
 }
-
-Import-Module (Join-Path $PSScriptRoot 'PerfLocal.psm1') -Force
 
 function Quote-BashArgument {
     param([AllowEmptyString()] [string]$Value)

--- a/scripts/test-perf-local.ps1
+++ b/scripts/test-perf-local.ps1
@@ -4,6 +4,46 @@ param()
 $ErrorActionPreference = 'Stop'
 Import-Module (Join-Path $PSScriptRoot 'PerfLocal.psm1') -Force
 
+$routingTestRoot = Join-Path ([IO.Path]::GetTempPath()) "sharpts-perf-routing-$([Guid]::NewGuid().ToString('N'))"
+try {
+    $missingBaseline = Join-Path $routingTestRoot 'missing-baseline'
+    $gateBaseline = Resolve-SharpTSPerfBaselinePath `
+        -Action gate `
+        -BaselinePath $missingBaseline `
+        -RepositoryParent $routingTestRoot
+    if ($null -ne $gateBaseline) {
+        throw 'The gate action unexpectedly resolved a baseline worktree.'
+    }
+
+    $missingError = $null
+    try {
+        [void](Resolve-SharpTSPerfBaselinePath `
+            -Action measure `
+            -BaselinePath $missingBaseline `
+            -RepositoryParent $routingTestRoot)
+    } catch {
+        $missingError = $_
+    }
+    if ($null -eq $missingError -or
+        $missingError.Exception.Message -notmatch [regex]::Escape($missingBaseline)) {
+        throw 'A missing required baseline did not produce a directed path-specific error.'
+    }
+
+    $existingBaseline = Join-Path $routingTestRoot 'existing-baseline'
+    [IO.Directory]::CreateDirectory($existingBaseline) | Out-Null
+    $resolvedBaseline = Resolve-SharpTSPerfBaselinePath `
+        -Action measure `
+        -BaselinePath $existingBaseline `
+        -RepositoryParent $routingTestRoot
+    if ($resolvedBaseline -cne (Resolve-Path -LiteralPath $existingBaseline).Path) {
+        throw 'A required existing baseline did not resolve to its canonical path.'
+    }
+} finally {
+    if (Test-Path -LiteralPath $routingTestRoot) {
+        Remove-Item -LiteralPath $routingTestRoot -Recurse -Force
+    }
+}
+
 foreach ($relativePath in @(
     'perf-local.ps1',
     '../benchmarks/cross-runtime/run-benchmarks.ps1'


### PR DESCRIPTION
## Summary

- use platform-neutral peak-memory labels across the GC profile generator, decision record, and saved evidence, and name the adaptive comparison target
- defer baseline worktree resolution for the baseline-free `gate` action and cover both optional and required routing
- document PowerShell 7+, fix the Markdown fence language, and clarify black-box launch versus in-process timing
- serialize cross-runtime snapshots with LF-only newlines and assert their output bytes

This preserves the existing CI model: deterministic and smoke validation only, with no timed shared-runner performance gate.

## Validation

- `pwsh -NoProfile -File scripts/test-perf-local.ps1`
- `pwsh -NoProfile -File benchmarks/cross-runtime/test-snapshot.ps1`
- `pwsh -NoProfile -File benchmarks/cross-runtime/validate-snapshot.ps1 benchmarks/cross-runtime/snapshots/latest.json`
- `pwsh -NoProfile -File benchmarks/cross-runtime/run-benchmarks.ps1 -Smoke -NoBuild` (33 workloads)
- `markdownlint-cli2@0.23.2` MD040 on changed Markdown files
- `git diff --check`

Closes #1524

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified benchmark requirements, timing measurements, and cross-platform memory metrics.
  * Updated benchmark reports to distinguish Windows peak working set from Ubuntu maximum RSS.

* **Bug Fixes**
  * Snapshot exports now use consistent LF line endings across platforms.
  * Performance baseline handling now provides clearer validation and errors, while allowing gate checks without a baseline.

* **Tests**
  * Added coverage for snapshot line endings and performance baseline path scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->