### PR TITLE
Make timeout cleanup process-handle safe

### DIFF
--- a/tests/SharpTS.Tests/RuntimeTests/OwnedProcessRegistryTests.cs
+++ b/tests/SharpTS.Tests/RuntimeTests/OwnedProcessRegistryTests.cs
@@ -13,6 +13,7 @@ public sealed class OwnedProcessRegistryTests
 {
     private static readonly TimeSpan ExitTimeout = TimeSpan.FromSeconds(10);
     private static readonly TimeSpan FixtureReadyTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan ExecutionTimeout = TimeSpan.FromSeconds(5);
 
     [Fact]
     public void InterpreterDispose_TerminatesOnlyItsOwnProcesses()
@@ -92,12 +93,13 @@ public sealed class OwnedProcessRegistryTests
     }
 
     [Theory, ModeData]
-    public void ExecutionTimeout_TerminatesSpawnedProcess(ExecutionMode mode)
+    public async Task ExecutionTimeout_TerminatesSpawnedProcess(ExecutionMode mode)
     {
         string pidPath = Path.Combine(Path.GetTempPath(), $"sharpts-owned-process-{Guid.NewGuid():N}.pid");
         string sourcePath = pidPath.Replace("\\", "\\\\").Replace("'", "\\'");
         (string command, string arguments) = LongRunningGuestCommand();
         Process? child = null;
+        Task<string>? execution = null;
 
         string source = $$"""
             import { spawn } from 'child_process';
@@ -111,19 +113,33 @@ public sealed class OwnedProcessRegistryTests
         try
         {
             var files = new Dictionary<string, string> { ["main.ts"] = source };
-            Assert.Throws<TimeoutException>(() =>
-                TestHarness.RunModules(files, "main.ts", mode, TimeSpan.FromSeconds(1)));
+            execution = Task.Run(() =>
+                TestHarness.RunModules(files, "main.ts", mode, ExecutionTimeout));
 
-            Assert.True(File.Exists(pidPath), "The guest did not record the spawned child PID before timing out.");
-            Assert.True(int.TryParse(File.ReadAllText(pidPath), out int childPid), "The guest recorded an invalid child PID.");
+            child = await CaptureGuestChildProcessAsync(pidPath, execution, FixtureReadyTimeout);
+            int childPid = child.Id;
 
-            child = TryGetProcess(childPid);
-            Assert.True(child is null || WaitUntilExited(child), $"{mode} timeout left child PID {childPid} running.");
+            Exception? executionFailure = null;
+            try
+            {
+                await execution.WaitAsync(ExitTimeout);
+            }
+            catch (Exception exception)
+            {
+                executionFailure = exception;
+            }
+
+            Assert.True(execution.IsCompleted, $"{mode} execution did not honor its timeout.");
+            Assert.IsType<TimeoutException>(executionFailure);
+
+            Assert.True(WaitUntilExited(child), $"{mode} timeout left child PID {childPid} running.");
         }
         finally
         {
             ProcessTreeTermination.Terminate(child);
             child?.Dispose();
+            if (execution is not null)
+                await ObserveExecutionAsync(execution);
             try { File.Delete(pidPath); }
             catch (IOException) { }
             catch (UnauthorizedAccessException) { }
@@ -216,9 +232,114 @@ public sealed class OwnedProcessRegistryTests
         }, ExitTimeout);
     }
 
-    private static Process? TryGetProcess(int processId)
+    private static async Task<Process> CaptureGuestChildProcessAsync(
+        string pidPath,
+        Task<string> execution,
+        TimeSpan timeout)
     {
-        try { return Process.GetProcessById(processId); }
-        catch (ArgumentException) { return null; }
+        var readiness = Stopwatch.StartNew();
+        string lastPidFileState = "not created";
+
+        while (readiness.Elapsed < timeout)
+        {
+            if (execution.IsCompleted)
+            {
+                throw new XunitException(
+                    $"Guest execution {DescribeExecution(execution)} before its child process could be captured; " +
+                    $"elapsed: {readiness.Elapsed.TotalMilliseconds:F0} ms; PID file: {lastPidFileState}.");
+            }
+
+            try
+            {
+                if (File.Exists(pidPath))
+                {
+                    string pidText = await File.ReadAllTextAsync(pidPath);
+                    lastPidFileState = $"'{pidText}'";
+                    if (int.TryParse(pidText, out int childPid))
+                    {
+                        Process candidate;
+                        try
+                        {
+                            candidate = Process.GetProcessById(childPid);
+                        }
+                        catch (ArgumentException exception)
+                        {
+                            throw new XunitException(
+                                $"Guest child PID {childPid} exited before its process handle could be captured; " +
+                                $"elapsed: {readiness.Elapsed.TotalMilliseconds:F0} ms; " +
+                                $"lookup failed with {exception.Message}");
+                        }
+
+                        try
+                        {
+                            if (candidate.HasExited)
+                            {
+                                throw new XunitException(
+                                    $"Guest child PID {childPid} exited before its process handle could be captured; " +
+                                    $"elapsed: {readiness.Elapsed.TotalMilliseconds:F0} ms.");
+                            }
+
+                            if (execution.IsCompleted)
+                            {
+                                throw new XunitException(
+                                    $"Guest execution {DescribeExecution(execution)} while child PID {childPid} " +
+                                    "was being captured.");
+                            }
+
+                            return candidate;
+                        }
+                        catch
+                        {
+                            candidate.Dispose();
+                            throw;
+                        }
+                    }
+                }
+            }
+            catch (IOException exception)
+            {
+                lastPidFileState = $"temporarily unreadable ({exception.Message})";
+            }
+            catch (UnauthorizedAccessException exception)
+            {
+                lastPidFileState = $"temporarily inaccessible ({exception.Message})";
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(25));
+        }
+
+        throw new XunitException(
+            $"Timed out after {readiness.Elapsed.TotalMilliseconds:F0} ms waiting to capture the guest child process; " +
+            $"execution {DescribeExecution(execution)}; PID file: {lastPidFileState}.");
+    }
+
+    private static string DescribeExecution(Task<string> execution)
+    {
+        if (!execution.IsCompleted)
+            return "is still running";
+        if (execution.IsCanceled)
+            return "was canceled";
+        if (execution.IsFaulted)
+        {
+            Exception exception = execution.Exception!.GetBaseException();
+            return $"failed with {exception.GetType().Name}: {exception.Message}";
+        }
+
+        return "completed successfully";
+    }
+
+    private static async Task ObserveExecutionAsync(Task<string> execution)
+    {
+        try
+        {
+            await execution.WaitAsync(ExitTimeout);
+        }
+        catch (Exception exception) when (exception is TimeoutException or OperationCanceledException)
+        {
+        }
+        catch
+        {
+            // The test asserts the expected timeout above; this await only observes cleanup failures.
+        }
     }
 }

--- a/tests/gui-conformance/SharpTS.Gui.Conformance.Tests/SharpPaintHeadlessTests.cs
+++ b/tests/gui-conformance/SharpTS.Gui.Conformance.Tests/SharpPaintHeadlessTests.cs
@@ -6,8 +6,29 @@ namespace SharpTS.Gui.Conformance.Tests;
 
 public sealed class SharpPaintHeadlessTests
 {
+    private static readonly TimeSpan ModelTestTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan ProcessCleanupTimeout = TimeSpan.FromSeconds(5);
+
     [Fact]
     public async Task ModelTestsPassThroughSharpTSInterpreter()
+    {
+        string output = await RunModelTestsAsync(ModelTestTimeout);
+        Assert.Contains("SharpPaint model tests passed.", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ModelTestTimeoutTerminatesProcessAndObservesOutput()
+    {
+        TimeoutException exception = await Assert.ThrowsAsync<TimeoutException>(() =>
+            RunModelTestsAsync(TimeSpan.Zero));
+
+        Assert.Contains("exited with code", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("cleanup completed", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("stdout:", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("stderr:", exception.Message, StringComparison.Ordinal);
+    }
+
+    private static async Task<string> RunModelTestsAsync(TimeSpan executionTimeout)
     {
         string root = FindRepositoryRoot();
 #if DEBUG
@@ -29,11 +50,28 @@ public sealed class SharpPaintHeadlessTests
             ?? throw new InvalidOperationException("Could not start the SharpPaint model tests.");
         Task<string> stdout = process.StandardOutput.ReadToEndAsync();
         Task<string> stderr = process.StandardError.ReadToEndAsync();
-        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        await process.WaitForExitAsync(timeout.Token);
+        using var timeout = new CancellationTokenSource(executionTimeout);
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException exception) when (timeout.IsCancellationRequested)
+        {
+            string diagnostics = await TerminateAndObserveProcessAsync(
+                process,
+                stdout,
+                stderr,
+                ProcessCleanupTimeout);
+            throw new TimeoutException(
+                $"SharpPaint model tests exceeded {executionTimeout.TotalSeconds:F0} seconds. {diagnostics}",
+                exception);
+        }
+
+        string output = await stdout;
+        string errors = await stderr;
         Assert.True(process.ExitCode == 0,
-            $"SharpPaint model tests failed.{Environment.NewLine}{await stdout}{Environment.NewLine}{await stderr}");
-        Assert.Contains("SharpPaint model tests passed.", await stdout, StringComparison.Ordinal);
+            $"SharpPaint model tests failed.{Environment.NewLine}{output}{Environment.NewLine}{errors}");
+        return output;
     }
 
     [Fact]
@@ -153,6 +191,107 @@ public sealed class SharpPaintHeadlessTests
             Directory.CreateDirectory(Path.GetDirectoryName(target)!);
             File.Copy(file, target, true);
         }
+    }
+
+    private static async Task<string> TerminateAndObserveProcessAsync(
+        Process process,
+        Task<string> stdout,
+        Task<string> stderr,
+        TimeSpan timeout)
+    {
+        int processId = process.Id;
+        var cleanupNotes = new List<string>();
+
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch (Exception exception) when (exception is
+            InvalidOperationException or
+            NotSupportedException or
+            System.ComponentModel.Win32Exception)
+        {
+            cleanupNotes.Add($"termination failed with {exception.GetType().Name}: {exception.Message}");
+        }
+
+        Task exit;
+        try
+        {
+            exit = process.WaitForExitAsync();
+        }
+        catch (Exception exception) when (exception is
+            InvalidOperationException or
+            System.ComponentModel.Win32Exception)
+        {
+            cleanupNotes.Add($"exit observation failed with {exception.GetType().Name}: {exception.Message}");
+            exit = Task.CompletedTask;
+        }
+
+        Task observation = Task.WhenAll(exit, stdout, stderr);
+        try
+        {
+            await observation.WaitAsync(timeout);
+        }
+        catch (TimeoutException)
+        {
+            cleanupNotes.Add($"cleanup did not complete within {timeout.TotalSeconds:F0} seconds");
+        }
+        catch (Exception exception)
+        {
+            cleanupNotes.Add($"cleanup observation failed with {exception.GetType().Name}: {exception.Message}");
+        }
+
+        if (!observation.IsCompleted)
+        {
+            _ = observation.ContinueWith(
+                static task => _ = task.Exception,
+                CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+
+        string notes = cleanupNotes.Count == 0 ? "cleanup completed" : string.Join("; ", cleanupNotes);
+        return $"PID {processId}; {DescribeExit(process)}; {notes}; " +
+            $"{DescribeOutput("stdout", stdout)}; {DescribeOutput("stderr", stderr)}";
+    }
+
+    private static string DescribeExit(Process process)
+    {
+        try
+        {
+            return process.HasExited
+                ? $"exited with code {process.ExitCode}"
+                : "still running";
+        }
+        catch (Exception exception) when (exception is
+            InvalidOperationException or
+            System.ComponentModel.Win32Exception)
+        {
+            return $"exit state unavailable ({exception.GetType().Name}: {exception.Message})";
+        }
+    }
+
+    private static string DescribeOutput(string name, Task<string> output)
+    {
+        if (output.IsCompletedSuccessfully)
+        {
+            string text = output.Result;
+            const int limit = 2_000;
+            if (text.Length > limit)
+                text = text[..limit] + "... <truncated>";
+            return $"{name}: {(string.IsNullOrWhiteSpace(text) ? "<empty>" : text.Trim())}";
+        }
+
+        if (output.IsCanceled)
+            return $"{name}: read canceled";
+        if (output.IsFaulted)
+        {
+            Exception exception = output.Exception!.GetBaseException();
+            return $"{name}: read failed with {exception.GetType().Name}: {exception.Message}";
+        }
+
+        return $"{name}: read did not complete";
     }
 
     private static string FindRepositoryRoot()


### PR DESCRIPTION
## Summary

- capture the spawned child Process while guest execution is still active, before the expected harness timeout can release and reuse its PID
- keep timeout cleanup scoped to captured process objects and add bounded readiness and execution diagnostics
- terminate and await the SharpPaint model-test process tree on cancellation, drain redirected output under a bounded deadline, and cover the timeout path with a regression test

## Validation

- dotnet build SharpTS.sln -c Release --nologo -p:NuGetAudit=false --no-restore
- OwnedProcessRegistryTests: 4 passed
- concurrent focused stress: 4 parallel invocations, 16 tests passed
- SharpPaintHeadlessTests: 4 passed

Closes #1522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of execution timeouts and process termination.
  * Added coverage ensuring timed-out processes and their child processes exit cleanly.
  * Enhanced diagnostics with exit status and captured output when model execution fails or times out.
  * Added verification that successful model runs produce the expected output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->