### PR TITLE
Fix Difftastic classifier exit handling

### DIFF
--- a/scripts/get-ci-change-scope.ps1
+++ b/scripts/get-ci-change-scope.ps1
@@ -194,6 +194,38 @@ function Write-GitBlob([string]$Revision, [string]$Path, [string]$Destination) {
     }
 }
 
+function Invoke-DifftasticCheck([string]$Tool, [string]$OldPath, [string]$NewPath) {
+    $startInfo = [Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $Tool
+    $startInfo.WorkingDirectory = (Get-Location).ProviderPath
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.ArgumentList.Add('--ignore-comments')
+    $startInfo.ArgumentList.Add('--check-only')
+    $startInfo.ArgumentList.Add('--exit-code')
+    $startInfo.ArgumentList.Add($OldPath)
+    $startInfo.ArgumentList.Add($NewPath)
+
+    $process = [Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    if (-not $process.Start()) { throw "Unable to start Difftastic for $NewPath." }
+    try {
+        # Drain both redirected streams concurrently so neither pipe can block the process.
+        $standardOutputTask = $process.StandardOutput.ReadToEndAsync()
+        $standardErrorTask = $process.StandardError.ReadToEndAsync()
+        $process.WaitForExit()
+        return [pscustomobject]@{
+            ExitCode = $process.ExitCode
+            StandardOutput = $standardOutputTask.GetAwaiter().GetResult()
+            StandardError = $standardErrorTask.GetAwaiter().GetResult()
+        }
+    }
+    finally {
+        $process.Dispose()
+    }
+}
+
 function Test-NoCSharpSyntaxChange([string]$Tool, [string]$Path) {
     $comparisonRoot = Join-Path ([IO.Path]::GetTempPath()) ('sharpts-ci-diff-' + [Guid]::NewGuid().ToString('N'))
     try {
@@ -203,9 +235,11 @@ function Test-NoCSharpSyntaxChange([string]$Tool, [string]$Path) {
         Write-GitBlob $BaseSha $Path $oldPath
         Write-GitBlob $HeadSha $Path $newPath
 
-        $output = @(& $Tool --ignore-comments --check-only --exit-code $oldPath $newPath 2>&1)
-        $exitCode = $LASTEXITCODE
-        foreach ($line in $output) { Write-Host $line }
+        $result = Invoke-DifftasticCheck $Tool $oldPath $newPath
+        foreach ($text in @($result.StandardOutput, $result.StandardError)) {
+            if (-not [string]::IsNullOrWhiteSpace($text)) { Write-Host $text.TrimEnd() }
+        }
+        $exitCode = $result.ExitCode
         if ($exitCode -eq 0) { return $true }
         if ($exitCode -eq 1) { return $false }
         throw "Difftastic failed for '$Path' with exit code $exitCode."

--- a/scripts/test-ci-change-scope.ps1
+++ b/scripts/test-ci-change-scope.ps1
@@ -44,6 +44,12 @@ function Assert-Mode([string]$Expected, [object]$Actual, [string]$Case) {
     }
 }
 
+function Assert-NativeExitCode([int]$Expected, [int]$Actual, [string]$Case) {
+    if ($Actual -ne $Expected) {
+        throw "$Case expected native exit code $Expected, got $Actual."
+    }
+}
+
 try {
     New-Item -ItemType Directory -Path $fixtureRoot | Out-Null
     Push-Location $fixtureRoot
@@ -91,7 +97,9 @@ internal static class Sample
 }
 '@
         $stringChange = Save-Fixture 'string token change'
-        Assert-Mode 'full' (Get-Scope $commentsAndDocs $stringChange) 'comment marker inside string'
+        $stringChangeScope = Get-Scope $commentsAndDocs $stringChange
+        Assert-Mode 'full' $stringChangeScope 'comment marker inside string'
+        Assert-NativeExitCode 0 $LASTEXITCODE 'syntax-change classification'
 
         Write-Fixture 'src/Sample.cs' @'
 #nullable disable
@@ -104,7 +112,9 @@ internal static class Sample
 }
 '@
         $directiveChange = Save-Fixture 'directive change'
-        Assert-Mode 'full' (Get-Scope $stringChange $directiveChange) 'preprocessor directive change'
+        $directiveChangeScope = Get-Scope $stringChange $directiveChange
+        Assert-Mode 'full' $directiveChangeScope 'preprocessor directive change'
+        Assert-NativeExitCode 0 $LASTEXITCODE 'directive-change classification'
 
         Write-Fixture 'src/Added.cs' "namespace Fixture;`ninternal sealed class Added;`n"
         $addedFile = Save-Fixture 'add C# file'

--- a/scripts/test-github-workflows.ps1
+++ b/scripts/test-github-workflows.ps1
@@ -103,7 +103,12 @@ foreach ($requiredText in @(
     '2997d2bbe620534edbd79b0049f00ce84eef3fedb15c7822456d58e38d8b05c9',
     'b563ae76e22ce28c7080a8b628cfabf6fa86f9ee114a0f5697bc2ca26f9ce1d7',
     'Get-FileHash -LiteralPath $archivePath -Algorithm SHA256',
-    '--ignore-comments --check-only --exit-code',
+    '[Diagnostics.ProcessStartInfo]::new()',
+    "ArgumentList.Add('--ignore-comments')",
+    "ArgumentList.Add('--check-only')",
+    "ArgumentList.Add('--exit-code')",
+    'RedirectStandardOutput = $true',
+    'RedirectStandardError = $true',
     "return New-ScopeResult 'full'"
 )) {
     if (-not $ciScopeScript.Contains($requiredText, [StringComparison]::Ordinal)) {


### PR DESCRIPTION
Capture Difftastic through a contained process so its expected syntax-change result does not leak into the ambient PowerShell native exit status. Preserve full-CI fallback behavior and add regression assertions for syntax-changing comparisons. Validation: change-scope tests, workflow-policy tests, PowerShell parsing, exact PR #1570 base/head reproduction, and unexpected tool-exit fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI change-scope checks by reliably capturing tool output and exit codes.
  * Enhanced handling of native process errors during syntax and workflow validation.

* **Tests**
  * Added coverage to verify successful native process completion.
  * Updated workflow checks to validate separate command options and redirected output streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->