### PR TITLE
Fix interpreter scope capture after async calls

### DIFF
--- a/src/SharpTS/Execution/IEvaluationContext.cs
+++ b/src/SharpTS/Execution/IEvaluationContext.cs
@@ -127,8 +127,8 @@ internal sealed class AsyncEvaluationContext : IEvaluationContext
 
     public async ValueTask YieldToSchedulerAsync()
     {
-        // Async path: yield to the event loop, matching the async for-loop's await Task.Yield().
-        await Task.Yield();
+        // Async path: yield to the event loop while retaining the loop/frame environment.
+        await _interpreter.YieldPreservingEnvironment();
     }
 }
 

--- a/src/SharpTS/Execution/Interpreter.Async.cs
+++ b/src/SharpTS/Execution/Interpreter.Async.cs
@@ -59,6 +59,29 @@ public partial class Interpreter
         }
     }
 
+    /// <summary>
+    /// Yields to the scheduler without letting another async frame's ambient environment
+    /// replace the current frame's scope when execution resumes. Unlike guest await values,
+    /// <see cref="Task.Yield"/> is not represented by a <see cref="Task{TResult}"/>, so it
+    /// needs its own environment-preserving path.
+    /// </summary>
+    internal async ValueTask YieldPreservingEnvironment()
+    {
+        RuntimeEnvironment saved = _environment;
+        var savedGen = CurrentAsyncGenerator;
+        savedGen?.MarkBodySuspended();
+        try
+        {
+            await Task.Yield();
+        }
+        finally
+        {
+            _environment = saved;
+            CurrentAsyncGenerator = savedGen;
+            savedGen?.MarkBodyResumed();
+        }
+    }
+
     internal async Task<ExecutionResult> ExecuteBlockAsync(List<Stmt> statements, RuntimeEnvironment environment)
     {
         using (PushScope(environment))

--- a/src/SharpTS/Runtime/Types/SharpTSAsyncFunction.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSAsyncFunction.cs
@@ -70,9 +70,21 @@ public class SharpTSAsyncFunction : ISharpTSAsyncCallable, ITypeCategorized
     /// </summary>
     public object? Call(Interpreter interpreter, List<object?> arguments)
     {
-        // Start async execution and wrap in Promise
-        var task = NormalizePromiseRejection(CallAsync(interpreter, arguments), interpreter);
-        return new SharpTSPromise(task);
+        // An async function runs synchronously until its first suspension, but calling it
+        // still returns to the caller's lexical environment immediately. ExecuteBlockAsync
+        // keeps the function environment installed across awaits so its continuation can
+        // resume correctly; restore the caller here before sibling expressions (notably a
+        // chained .then(...) argument) are evaluated and capture the wrong closure.
+        RuntimeEnvironment callerEnvironment = interpreter.Environment;
+        try
+        {
+            var task = NormalizePromiseRejection(CallAsync(interpreter, arguments), interpreter);
+            return new SharpTSPromise(task);
+        }
+        finally
+        {
+            interpreter.SetEnvironment(callerEnvironment);
+        }
     }
 
     internal static async Task<object?> NormalizePromiseRejection(
@@ -234,9 +246,19 @@ public class SharpTSAsyncArrowFunction : ISharpTSAsyncCallable, ITypeCategorized
     /// </summary>
     public object? Call(Interpreter interpreter, List<object?> arguments)
     {
-        var task = SharpTSAsyncFunction.NormalizePromiseRejection(
-            CallAsync(interpreter, arguments), interpreter);
-        return new SharpTSPromise(task);
+        // Mirror SharpTSAsyncFunction.Call: a pending async arrow owns its suspended
+        // environment, but must not leave that environment ambient in its caller.
+        RuntimeEnvironment callerEnvironment = interpreter.Environment;
+        try
+        {
+            var task = SharpTSAsyncFunction.NormalizePromiseRejection(
+                CallAsync(interpreter, arguments), interpreter);
+            return new SharpTSPromise(task);
+        }
+        finally
+        {
+            interpreter.SetEnvironment(callerEnvironment);
+        }
     }
 
     /// <summary>

--- a/tests/SharpTS.Tests/SharedTests/AsyncArrowFunctionTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/AsyncArrowFunctionTests.cs
@@ -9,6 +9,25 @@ namespace SharpTS.Tests.SharedTests;
 /// </summary>
 public class AsyncArrowFunctionTests
 {
+    [Theory, InterpretedOnlyData]
+    public void AsyncArrow_CallRestoresCallerScopeBeforeThenCallback(ExecutionMode mode)
+    {
+        var source = """
+            const suspend = async (): Promise<void> => {
+                await new Promise((resolve: any) => setTimeout(resolve, 10));
+            };
+
+            function run(): Promise<void> {
+                const marker = "caller scope";
+                return suspend().then(() => console.log(marker));
+            }
+
+            run();
+            """;
+
+        Assert.Equal("caller scope\n", TestHarness.Run(source, mode));
+    }
+
     [Theory, ModeData]
     public void AsyncFunction_SyncArrowCapturesCanonicalTopLevelFunctionObject(ExecutionMode mode)
     {

--- a/tests/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/WorkerThreadsTests.cs
@@ -735,6 +735,66 @@ public class WorkerThreadsTests
     }
 
     /// <summary>
+    /// A Promise reaction that starts a second async worker lifecycle must retain the
+    /// lexical environment in which its nested callback was created. The interpreter
+    /// previously resumed the second measurement against an unrelated ambient scope,
+    /// so the nested callback failed to resolve the module-level runLifecycle binding.
+    /// </summary>
+    [Fact]
+    public void Worker_Lifecycle_PromiseChainRetainsModuleScope()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["worker_ready.ts"] = """
+                import { parentPort } from "worker_threads";
+                parentPort!.on("message", () => {});
+                parentPort!.postMessage({ kind: "ready" });
+                """,
+            ["main.ts"] = """
+                import { Worker } from "worker_threads";
+
+                function runLifecycle(workerPath: string): Promise<number> {
+                    const worker: any = new Worker(workerPath);
+                    return new Promise((resolve: any, reject: any) => {
+                        worker.on("message", (message: any) => {
+                            if (message.kind === "ready") {
+                                resolve(worker.terminate());
+                            }
+                        });
+                        worker.on("error", (error: any) => reject(error));
+                    }).then((exit: any) => exit);
+                }
+
+                async function measure(label: string, fn: () => Promise<number>): Promise<void> {
+                    console.log(label + ":first");
+                    await fn();
+                    console.log(label + ":second");
+                    await fn();
+                }
+
+                function main(): Promise<any> {
+                    const workerPath: string = __dirname + "/worker_ready.ts";
+                    return measure("one", () => runLifecycle(workerPath))
+                        .then(() => {
+                            console.log("transition");
+                            return measure("two", () => runLifecycle(workerPath));
+                        });
+                }
+
+                main().then(
+                    () => console.log("completed"),
+                    (error: any) => console.log("failed:" + error),
+                );
+                """,
+        };
+
+        var output = TestHarness.RunModules(
+            files, "main.ts", ExecutionMode.Interpreted, TimeSpan.FromSeconds(15));
+
+        Assert.Equal("one:first\none:second\ntransition\ntwo:first\ntwo:second\ncompleted\n", output);
+    }
+
+    /// <summary>
     /// #997: terminating a worker parked in <c>Atomics.wait</c> must actually unwind the
     /// worker thread (not just settle the promise), and the <c>'exit'</c> event must report
     /// code 1. The worker parks on a never-notified index, so before the fix the


### PR DESCRIPTION
## Summary

- restore the caller's ambient interpreter environment immediately after starting an async user function or async arrow
- keep suspended async frames isolated while sibling expressions, including Promise reaction callbacks, are evaluated
- add focused regressions for async-arrow scope capture and the worker-lifecycle benchmark chain

## Root cause

An async function executes synchronously until its first suspension. The interpreter kept that function's activation environment installed while returning its Promise to the caller. Because a Promise receiver is evaluated before the callback passed to then, the callback could capture the suspended callee's scope instead of its lexical caller's scope. Later worker-lifecycle iterations then failed to resolve bindings such as runLifecycle or workerPath.

## Validation

- Release test-project build: 0 warnings, 0 errors
- AsyncArrowFunctionTests: 59 passed
- PromiseJobSchedulingTests: 13 passed
- targeted worker lifecycle and termination tests: 7 passed
- worker-lifecycle benchmark runner: all three interpreter launches passed, producing all nine expected measurements

The HTTP-listener callback tests could not run on this Windows host because HttpListener.Start returned "The handle is invalid" in both interpreted and compiled modes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scope handling for asynchronous functions and arrow functions, ensuring callbacks can access variables from their original calling context.
  * Fixed scope resolution across repeated worker lifecycles and chained Promise or `async/await` operations.
  * Improved asynchronous scheduling so suspended and resumed operations, including async generators, retain the correct execution context.

* **Tests**
  * Added regression coverage for asynchronous callback scope restoration.
  * Added coverage for retaining module scope across repeated worker execution and Promise chains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->