### PR TITLE
Optimize length-only string slice emission

### DIFF
--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/PrimitiveStringIntrinsicBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/PrimitiveStringIntrinsicBenchmarks.cs
@@ -7,8 +7,9 @@ namespace SharpTS.Microbenchmarks.Benchmarks;
 
 /// <summary>
 /// Dynamic-input coverage for the fixed-arity primitive string intrinsics.
-/// Search operations should allocate nothing in the measured loop; slicing
-/// should allocate only the observable result strings.
+/// Search operations and length-only slice/substring operations should allocate
+/// nothing in the measured loop. The native slice rows intentionally materialize
+/// strings to show the cost avoided when only the result length is observable.
 /// </summary>
 [MemoryDiagnoser]
 [RankColumn]

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -408,6 +408,10 @@ public class EmittedRuntime
     public MethodBuilder StringIncludesPrimitive { get; set; } = null!;
     public MethodBuilder StringSlicePrimitive { get; set; } = null!;
     public MethodBuilder StringSubstringPrimitive { get; set; } = null!;
+    public MethodBuilder StringSliceFromLengthPrimitive { get; set; } = null!;
+    public MethodBuilder StringSliceLengthPrimitive { get; set; } = null!;
+    public MethodBuilder StringSubstringFromLengthPrimitive { get; set; } = null!;
+    public MethodBuilder StringSubstringLengthPrimitive { get; set; } = null!;
     public MethodBuilder StringToUpperCase { get; set; } = null!;
     public MethodBuilder StringToLowerCase { get; set; } = null!;
     public MethodBuilder StringTrim { get; set; } = null!;

--- a/src/SharpTS/Compilation/Emitters/StringEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/StringEmitter.cs
@@ -214,6 +214,83 @@ public sealed class StringEmitter : ITypeEmitterStrategy
     }
 
     /// <summary>
+    /// Keeps a statically typed primitive string length as a native double. When
+    /// the receiver is a stable slice/substring call, emits the corresponding
+    /// bounds-only helper so the temporary result string never materializes.
+    /// </summary>
+    internal static bool TryEmitPrimitiveStringLengthGet(
+        IEmitterContext emitter, Expr.Get get)
+    {
+        var ctx = emitter.Context;
+        if (get.Optional
+            || get.Name.Lexeme != "length"
+            || ctx.TypeMap?.Get(get.Object) is not TypeSystem.TypeInfo.String
+                and not TypeSystem.TypeInfo.StringLiteral)
+            return false;
+
+        if (TryEmitPrimitiveSliceLengthIntrinsic(emitter, get.Object))
+            return true;
+
+        emitter.EmitExpression(get.Object);
+        emitter.EnsureBoxed();
+        ctx.IL.Emit(OpCodes.Call, ctx.Runtime!.UnwrapStringReceiverMethod);
+        ctx.IL.Emit(OpCodes.Call,
+            ctx.Types.GetProperty(ctx.Types.String, "Length").GetGetMethod()!);
+        ctx.IL.Emit(OpCodes.Conv_R8);
+        emitter.SetStackType(StackType.Double);
+        return true;
+    }
+
+    private static bool TryEmitPrimitiveSliceLengthIntrinsic(
+        IEmitterContext emitter, Expr expression)
+    {
+        if (expression is not Expr.Call
+            {
+                Optional: false,
+                Callee: Expr.Get { Optional: false } methodGet,
+                Arguments: var arguments
+            })
+            return false;
+
+        string methodName = methodGet.Name.Lexeme;
+        if (methodName is not ("slice" or "substring"))
+            return false;
+
+        Expr receiver = methodGet.Object;
+
+        var ctx = emitter.Context;
+        if (ctx.RuntimeFeatures?.UsesStringPrototypeMutation != false
+            || !IsSideEffectFreePrimitiveString(receiver, ctx)
+            || arguments.Count is 0 or > 2
+            || arguments.Any(argument =>
+                !IsSideEffectFreePrimitiveNumber(argument, ctx)))
+            return false;
+
+        emitter.EmitExpression(receiver);
+        emitter.EmitConversionForParameter(receiver, ctx.Types.String);
+        emitter.EmitExpressionAsDouble(arguments[0]);
+        if (arguments.Count == 1)
+        {
+            ctx.IL.Emit(
+                OpCodes.Call,
+                methodName == "slice"
+                    ? ctx.Runtime!.StringSliceFromLengthPrimitive
+                    : ctx.Runtime!.StringSubstringFromLengthPrimitive);
+        }
+        else
+        {
+            emitter.EmitExpressionAsDouble(arguments[1]);
+            ctx.IL.Emit(
+                OpCodes.Call,
+                methodName == "slice"
+                    ? ctx.Runtime!.StringSliceLengthPrimitive
+                    : ctx.Runtime!.StringSubstringLengthPrimitive);
+        }
+        emitter.SetStackType(StackType.Double);
+        return true;
+    }
+
+    /// <summary>
     /// Attempts to emit IL for a property set on a string receiver.
     /// Strings are immutable in TypeScript/JavaScript.
     /// </summary>

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.cs
@@ -2869,6 +2869,9 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
 
     protected virtual void EmitGet(Expr.Get g)
     {
+        if (StringEmitter.TryEmitPrimitiveStringLengthGet(this, g))
+            return;
+
         // CommonJS: `module.exports` reads → ldsfld $exports.
         if (TryEmitCjsGet(g)) return;
 

--- a/src/SharpTS/Compilation/ILEmitter.Expressions.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Expressions.cs
@@ -848,6 +848,8 @@ public partial class ILEmitter
         var builder = _ctx.ILBuilder;
         var elseLabel = builder.DefineLabel("ternary_else");
         var endLabel = builder.DefineLabel("ternary_end");
+        bool hasNumericBranches = IsNumericTernaryBranch(_ctx.TypeMap?.Get(t.ThenBranch))
+            && IsNumericTernaryBranch(_ctx.TypeMap?.Get(t.ElseBranch));
 
         EmitExpression(t.Condition);
         // Handle condition based on what's actually on the stack
@@ -869,6 +871,19 @@ public partial class ILEmitter
         }
         builder.Emit_Brfalse(elseLabel);
 
+        if (hasNumericBranches)
+        {
+            EmitExpressionAsDouble(t.ThenBranch);
+            builder.Emit_Br(endLabel);
+
+            builder.MarkLabel(elseLabel);
+            EmitExpressionAsDouble(t.ElseBranch);
+
+            builder.MarkLabel(endLabel);
+            SetStackType(StackType.Double);
+            return;
+        }
+
         EmitExpression(t.ThenBranch);
         EmitBoxIfNeeded(t.ThenBranch);
         builder.Emit_Br(endLabel);
@@ -881,6 +896,14 @@ public partial class ILEmitter
         // Both branches box, so result is Unknown (boxed object)
         SetStackUnknown();
     }
+
+    private static bool IsNumericTernaryBranch(TypeInfo? type) => type switch
+    {
+        TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } => true,
+        TypeInfo.NumberLiteral => true,
+        TypeInfo.Union union => union.FlattenedTypes.All(IsNumericTernaryBranch),
+        _ => false
+    };
 
     protected override void EmitNullishCoalescing(Expr.NullishCoalescing nc)
     {

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -1,4 +1,5 @@
 using System.Reflection.Emit;
+using SharpTS.Compilation.Emitters;
 using SharpTS.Diagnostics.Exceptions;
 using SharpTS.Parsing;
 using SharpTS.Runtime.BuiltIns;
@@ -18,6 +19,9 @@ public partial class ILEmitter
     protected override void EmitGet(Expr.Get g)
     {
         if (TryEmitStableRecordDestructureGet(g))
+            return;
+
+        if (StringEmitter.TryEmitPrimitiveStringLengthGet(this, g))
             return;
 
         if (!g.Optional

--- a/src/SharpTS/Compilation/RuntimeEmitter.Strings.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Strings.cs
@@ -603,6 +603,335 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Callvirt, substring);
             il.Emit(OpCodes.Ret);
         }
+
+        var sliceLengthSlow = typeBuilder.DefineMethod(
+            "StringSliceLengthPrimitiveSlow",
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.Double,
+            [_types.String, _types.Double, _types.Double]);
+        sliceLengthSlow.SetImplementationFlags(MethodImplAttributes.NoInlining);
+        {
+            var il = sliceLengthSlow.GetILGenerator();
+            var length = il.DeclareLocal(_types.Int32);
+            var from = il.DeclareLocal(_types.Int32);
+            var to = il.DeclareLocal(_types.Int32);
+            var nonNegativeStart = il.DefineLabel();
+            var startReady = il.DefineLabel();
+            var nonNegativeEnd = il.DefineLabel();
+            var endReady = il.DefineLabel();
+            var returnLength = il.DefineLabel();
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, lengthGetter);
+            il.Emit(OpCodes.Stloc, length);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, toInteger);
+            il.Emit(OpCodes.Stloc, from);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Bge, nonNegativeStart);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Call, max);
+            il.Emit(OpCodes.Stloc, from);
+            il.Emit(OpCodes.Br, startReady);
+            il.MarkLabel(nonNegativeStart);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Call, min);
+            il.Emit(OpCodes.Stloc, from);
+            il.MarkLabel(startReady);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Call, toInteger);
+            il.Emit(OpCodes.Stloc, to);
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Bge, nonNegativeEnd);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Call, max);
+            il.Emit(OpCodes.Stloc, to);
+            il.Emit(OpCodes.Br, endReady);
+            il.MarkLabel(nonNegativeEnd);
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Call, min);
+            il.Emit(OpCodes.Stloc, to);
+            il.MarkLabel(endReady);
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Bgt, returnLength);
+            il.Emit(OpCodes.Ldc_R8, 0.0);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(returnLength);
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Ret);
+        }
+
+        var sliceLength = typeBuilder.DefineMethod(
+            "StringSliceLengthPrimitive",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Double,
+            [_types.String, _types.Double, _types.Double]);
+        sliceLength.SetImplementationFlags(inlineAndOptimize);
+        runtime.StringSliceLengthPrimitive = sliceLength;
+        {
+            var il = sliceLength.GetILGenerator();
+            var length = il.DeclareLocal(_types.Int32);
+            var from = il.DeclareLocal(_types.Int32);
+            var to = il.DeclareLocal(_types.Int32);
+            var returnLength = il.DefineLabel();
+            var slowPath = il.DefineLabel();
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, lengthGetter);
+            il.Emit(OpCodes.Stloc, length);
+
+            // Exact, in-range integer bounds dominate generated TypeScript.
+            // Keep that path compact; fractional, non-finite, negative, and
+            // out-of-range values retain the full JavaScript normalization.
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Stloc, from);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Bne_Un, slowPath);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Stloc, to);
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Bne_Un, slowPath);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Blt, slowPath);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Bgt, slowPath);
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Blt, slowPath);
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Bgt, slowPath);
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Bgt, returnLength);
+            il.Emit(OpCodes.Ldc_R8, 0.0);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(returnLength);
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(slowPath);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Call, sliceLengthSlow);
+            il.Emit(OpCodes.Ret);
+        }
+
+        var sliceFromLength = typeBuilder.DefineMethod(
+            "StringSliceFromLengthPrimitive",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Double,
+            [_types.String, _types.Double]);
+        sliceFromLength.SetImplementationFlags(inlineAndOptimize);
+        runtime.StringSliceFromLengthPrimitive = sliceFromLength;
+        {
+            var il = sliceFromLength.GetILGenerator();
+            var length = il.DeclareLocal(_types.Int32);
+            var from = il.DeclareLocal(_types.Int32);
+            var nonNegativeStart = il.DefineLabel();
+            var returnLength = il.DefineLabel();
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, lengthGetter);
+            il.Emit(OpCodes.Stloc, length);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, toInteger);
+            il.Emit(OpCodes.Stloc, from);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Bge, nonNegativeStart);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Add);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Call, max);
+            il.Emit(OpCodes.Stloc, from);
+            il.Emit(OpCodes.Br, returnLength);
+            il.MarkLabel(nonNegativeStart);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Call, min);
+            il.Emit(OpCodes.Stloc, from);
+            il.MarkLabel(returnLength);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Ret);
+        }
+
+        var substringLengthSlow = typeBuilder.DefineMethod(
+            "StringSubstringLengthPrimitiveSlow",
+            MethodAttributes.Private | MethodAttributes.Static,
+            _types.Double,
+            [_types.String, _types.Double, _types.Double]);
+        substringLengthSlow.SetImplementationFlags(MethodImplAttributes.NoInlining);
+        {
+            var il = substringLengthSlow.GetILGenerator();
+            var length = il.DeclareLocal(_types.Int32);
+            var start = il.DeclareLocal(_types.Int32);
+            var end = il.DeclareLocal(_types.Int32);
+            var from = il.DeclareLocal(_types.Int32);
+            var to = il.DeclareLocal(_types.Int32);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, lengthGetter);
+            il.Emit(OpCodes.Stloc, length);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, toInteger);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Call, max);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Call, min);
+            il.Emit(OpCodes.Stloc, start);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Call, toInteger);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Call, max);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Call, min);
+            il.Emit(OpCodes.Stloc, end);
+            il.Emit(OpCodes.Ldloc, start);
+            il.Emit(OpCodes.Ldloc, end);
+            il.Emit(OpCodes.Call, min);
+            il.Emit(OpCodes.Stloc, from);
+            il.Emit(OpCodes.Ldloc, start);
+            il.Emit(OpCodes.Ldloc, end);
+            il.Emit(OpCodes.Call, max);
+            il.Emit(OpCodes.Stloc, to);
+            il.Emit(OpCodes.Ldloc, to);
+            il.Emit(OpCodes.Ldloc, from);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Ret);
+        }
+
+        var substringLength = typeBuilder.DefineMethod(
+            "StringSubstringLengthPrimitive",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Double,
+            [_types.String, _types.Double, _types.Double]);
+        substringLength.SetImplementationFlags(inlineAndOptimize);
+        runtime.StringSubstringLengthPrimitive = substringLength;
+        {
+            var il = substringLength.GetILGenerator();
+            var length = il.DeclareLocal(_types.Int32);
+            var start = il.DeclareLocal(_types.Int32);
+            var end = il.DeclareLocal(_types.Int32);
+            var from = il.DeclareLocal(_types.Int32);
+            var to = il.DeclareLocal(_types.Int32);
+            var slowPath = il.DefineLabel();
+            var fastEndAfterStart = il.DefineLabel();
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, lengthGetter);
+            il.Emit(OpCodes.Stloc, length);
+
+            // Mirror slice's exact in-range arm. substring swaps reversed
+            // bounds, so the fast result is their absolute difference.
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Stloc, start);
+            il.Emit(OpCodes.Ldloc, start);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Bne_Un, slowPath);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Stloc, end);
+            il.Emit(OpCodes.Ldloc, end);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Bne_Un, slowPath);
+            il.Emit(OpCodes.Ldloc, start);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Blt, slowPath);
+            il.Emit(OpCodes.Ldloc, start);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Bgt, slowPath);
+            il.Emit(OpCodes.Ldloc, end);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Blt, slowPath);
+            il.Emit(OpCodes.Ldloc, end);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Bgt, slowPath);
+            il.Emit(OpCodes.Ldloc, end);
+            il.Emit(OpCodes.Ldloc, start);
+            il.Emit(OpCodes.Bge, fastEndAfterStart);
+            il.Emit(OpCodes.Ldloc, start);
+            il.Emit(OpCodes.Ldloc, end);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Ret);
+            il.MarkLabel(fastEndAfterStart);
+            il.Emit(OpCodes.Ldloc, end);
+            il.Emit(OpCodes.Ldloc, start);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Ret);
+
+            il.MarkLabel(slowPath);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Call, substringLengthSlow);
+            il.Emit(OpCodes.Ret);
+        }
+
+        var substringFromLength = typeBuilder.DefineMethod(
+            "StringSubstringFromLengthPrimitive",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Double,
+            [_types.String, _types.Double]);
+        substringFromLength.SetImplementationFlags(inlineAndOptimize);
+        runtime.StringSubstringFromLengthPrimitive = substringFromLength;
+        {
+            var il = substringFromLength.GetILGenerator();
+            var length = il.DeclareLocal(_types.Int32);
+            var start = il.DeclareLocal(_types.Int32);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Callvirt, lengthGetter);
+            il.Emit(OpCodes.Stloc, length);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, toInteger);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Call, max);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Call, min);
+            il.Emit(OpCodes.Stloc, start);
+            il.Emit(OpCodes.Ldloc, length);
+            il.Emit(OpCodes.Ldloc, start);
+            il.Emit(OpCodes.Sub);
+            il.Emit(OpCodes.Conv_R8);
+            il.Emit(OpCodes.Ret);
+        }
     }
 
     private MethodBuilder EmitPrimitiveStringToInteger(TypeBuilder typeBuilder)
@@ -615,9 +944,22 @@ public partial class RuntimeEmitter
         method.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
 
         var il = method.GetILGenerator();
+        var exactInteger = il.DeclareLocal(_types.Int32);
+        var exactIntegerLabel = il.DefineLabel();
         var notNaN = il.DefineLabel();
         var belowMaximum = il.DefineLabel();
         var aboveMinimum = il.DefineLabel();
+
+        // Exact int32 values dominate typed index workloads. Avoid the NaN,
+        // infinity, bounds, and truncate path while retaining it for every
+        // fractional or non-finite JavaScript number.
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Stloc, exactInteger);
+        il.Emit(OpCodes.Ldloc, exactInteger);
+        il.Emit(OpCodes.Conv_R8);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Beq, exactIntegerLabel);
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Double, "IsNaN", _types.Double));
@@ -643,6 +985,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Math, "Truncate", _types.Double));
         il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Ret);
+
+        il.MarkLabel(exactIntegerLabel);
+        il.Emit(OpCodes.Ldloc, exactInteger);
         il.Emit(OpCodes.Ret);
         return method;
     }

--- a/tests/SharpTS.Tests/CompilerTests/StablePrimitiveStringIntrinsicTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StablePrimitiveStringIntrinsicTests.cs
@@ -23,6 +23,41 @@ public sealed class StablePrimitiveStringIntrinsicTests
         function takeSubstring(input: string, start: number, end: number): string {
             return input.substring(start, end);
         }
+        function plainStringLength(input: string): number {
+            return input.length;
+        }
+        function sliceLength(input: string, start: number, end: number): number {
+            return input.slice(start, end).length;
+        }
+        function substringLength(input: string, start: number, end: number): number {
+            return input.substring(start, end).length;
+        }
+        function sliceFromLength(input: string, start: number): number {
+            return input.slice(start).length;
+        }
+        function substringFromLength(input: string, start: number): number {
+            return input.substring(start).length;
+        }
+        function sliceLengthLoop(
+            input: string, start: number, end: number, n: number): number {
+            let total: number = 0;
+            let currentStart: number = start;
+            for (let i: number = 0; i < n; i++) {
+                total = total + input.slice(currentStart, end).length;
+                currentStart = currentStart === start ? start + 1 : start;
+            }
+            return total;
+        }
+        function substringLengthLoop(
+            input: string, start: number, end: number, n: number): number {
+            let total: number = 0;
+            let currentStart: number = start;
+            for (let i: number = 0; i < n; i++) {
+                total = total + input.substring(currentStart, end).length;
+                currentStart = currentStart === start ? start + 1 : start;
+            }
+            return total;
+        }
         """;
 
     [Theory]
@@ -48,6 +83,43 @@ public sealed class StablePrimitiveStringIntrinsicTests
             {
                 Name: "UnwrapStringReceiver" or "InvokeMethodValue"
             });
+    }
+
+    [Theory]
+    [InlineData("sliceLength", "StringSliceLengthPrimitive")]
+    [InlineData("substringLength", "StringSubstringLengthPrimitive")]
+    [InlineData("sliceFromLength", "StringSliceFromLengthPrimitive")]
+    [InlineData("substringFromLength", "StringSubstringFromLengthPrimitive")]
+    public void StablePrimitiveSliceLength_UsesAllocationFreeBoundsHelper(
+        string functionName, string helperName)
+    {
+        MethodInfo method = FindFunction(Compile(IntrinsicFunctions), functionName);
+        var instructions = ReadInstructions(method).ToArray();
+
+        Assert.Contains(instructions, instruction =>
+            instruction.OpCode == OpCodes.Call
+            && instruction.Operand is MethodBase { Name: var name }
+            && name == helperName);
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.OpCode is var opCode
+            && (opCode == OpCodes.Box || opCode == OpCodes.Newarr));
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.Operand is MethodBase
+            {
+                Name: "StringSlicePrimitive" or "StringSubstringPrimitive"
+            });
+    }
+
+    [Fact]
+    public void StablePrimitiveStringLength_RemainsUnboxed()
+    {
+        MethodInfo method = FindFunction(Compile(IntrinsicFunctions), "plainStringLength");
+        var instructions = ReadInstructions(method).ToArray();
+
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "get_Length" });
+        Assert.DoesNotContain(instructions, instruction =>
+            instruction.OpCode == OpCodes.Box);
     }
 
     [Fact]
@@ -80,6 +152,36 @@ public sealed class StablePrimitiveStringIntrinsicTests
         Assert.Equal(700_000, total);
         Assert.True(allocated <= 1_024,
             $"Primitive string searches allocated {allocated:N0} bytes.");
+    }
+
+    [Fact]
+    public void StablePrimitiveSliceLengths_DoNotAllocateResultStringsOrBoxes()
+    {
+        Assembly assembly = Compile(IntrinsicFunctions);
+        var slice = FindFunction(assembly, "sliceLengthLoop")
+            .CreateDelegate<Func<string, double, double, double, double>>();
+        var substring = FindFunction(assembly, "substringLengthLoop")
+            .CreateDelegate<Func<string, double, double, double, double>>();
+        Assert.DoesNotContain(
+            ReadInstructions(FindFunction(assembly, "sliceLengthLoop")),
+            instruction => instruction.OpCode == OpCodes.Box);
+        Assert.DoesNotContain(
+            ReadInstructions(FindFunction(assembly, "substringLengthLoop")),
+            instruction => instruction.OpCode == OpCodes.Box);
+        const string input = "alpha-beta-gamma-delta";
+
+        Assert.Equal(1_450, slice(input, 3, 18, 100));
+        Assert.Equal(1_450, substring(input, 3, 18, 100));
+        _ = slice(input, 3, 18, 10_000);
+        _ = substring(input, 3, 18, 10_000);
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        Assert.Equal(1_450_000, slice(input, 3, 18, 100_000));
+        Assert.Equal(1_450_000, substring(input, 3, 18, 100_000));
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.True(allocated <= 1_024,
+            $"Primitive slice lengths allocated {allocated:N0} bytes.");
     }
 
     [Theory, ModeData]
@@ -131,11 +233,53 @@ public sealed class StablePrimitiveStringIntrinsicTests
     }
 
     [Theory, ModeData]
+    public void PrimitiveSliceLengths_PreservePositionsUtf16AndOmittedArguments(
+        ExecutionMode mode)
+    {
+        const string source = """
+            const unicode: string = "A😀BC😀D";
+            const ascii: string = "abcdef";
+            const zero: number = 0;
+            const three: number = 3;
+            const five: number = 5;
+            const notNumber: number = NaN;
+            const positiveInfinity: number = Infinity;
+            const negativeInfinity: number = -Infinity;
+            const negativeHuge: number = -1e100;
+            const fractionalStart: number = 1.9;
+            const fractionalEnd: number = 4.8;
+
+            console.log(unicode.slice(1, 3).length);
+            console.log(ascii.slice(zero).length);
+            console.log(ascii.slice(-three).length);
+            console.log(ascii.slice(negativeInfinity, positiveInfinity).length);
+            console.log(ascii.slice(notNumber, three).length);
+            console.log(ascii.slice(five, 2).length);
+            console.log(ascii.slice(positiveInfinity).length);
+            console.log(ascii.slice(fractionalStart, fractionalEnd).length);
+
+            console.log(ascii.substring(zero).length);
+            console.log(ascii.substring(-three).length);
+            console.log(ascii.substring(five, 2).length);
+            console.log(ascii.substring(notNumber, positiveInfinity).length);
+            console.log(ascii.substring(positiveInfinity, negativeHuge).length);
+            console.log(ascii.substring(fractionalStart, fractionalEnd).length);
+            """;
+
+        Assert.Equal(
+            "2\n6\n3\n6\n3\n0\n0\n3\n" +
+            "6\n6\n3\n6\n6\n3\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
     public void GenericFallback_PreservesBoxingCoercionAndRegExpRejection(
         ExecutionMode mode)
     {
         const string source = """
             const boxed: any = new String("abcdef");
+            const typedBoxed: String = new String("abcdef");
+            console.log(typedBoxed.length);
             console.log(boxed.indexOf("cd", 0));
             console.log(boxed.includes("ef", 0));
             console.log(boxed.slice(1, 4));
@@ -159,7 +303,7 @@ public sealed class StablePrimitiveStringIntrinsicTests
             """;
 
         Assert.Equal(
-            "2\ntrue\nbcd\nbcd\n2\nneedle,position\ntrue\n",
+            "6\n2\ntrue\nbcd\nbcd\n2\nneedle,position\ntrue\n",
             TestHarness.Run(source, mode));
     }
 
@@ -189,9 +333,42 @@ public sealed class StablePrimitiveStringIntrinsicTests
     }
 
     [Fact]
+    public void StringPrototypeReplacement_DisablesSliceLengthHelperAndIsObservable()
+    {
+        const string source = """
+            (String.prototype as any).slice = function(
+                start: any, end: any): string {
+                console.log("custom", this, start, end);
+                return "xy";
+            };
+            const input: string = "abcdef";
+            const start: number = 1;
+            const end: number = 4;
+            console.log(input.slice(start, end).length);
+            """;
+
+        Assembly assembly = Compile(source);
+        MethodInfo main = assembly.GetType("$Program")!.GetMethod(
+            "Main", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;
+        Assert.DoesNotContain(ReadInstructions(main), instruction =>
+            instruction.Operand is MethodBase { Name: "StringSliceLengthPrimitive" });
+        Assert.Contains(ReadInstructions(main), instruction =>
+            instruction.Operand is MethodBase { Name: "InvokeMethodValue" });
+        Assert.Equal("custom abcdef 1 4\n2\n", TestHarness.RunCompiled(source));
+    }
+
+    [Fact]
     public void StableAndFallbackShapesPassIlVerification()
     {
         const string source = IntrinsicFunctions + """
+            async function asyncSliceLength(
+                input: string, start: number, end: number): Promise<number> {
+                return input.slice(start, end).length;
+            }
+            function* substringLengthGenerator(
+                input: string, start: number, end: number): Generator<number> {
+                yield input.substring(start, end).length;
+            }
             const boxed: any = new String("abcdef");
             const localized = new Date(Date.UTC(2024, 0, 15))
                 .toLocaleDateString("en-US", { timeZone: "UTC" });


### PR DESCRIPTION
## Summary

- keep primitive string `.length` results unboxed in emitted IL
- fuse stable `slice(...).length` and `substring(...).length` into allocation-free bounds helpers, with prototype-mutation and dynamic-value fallbacks preserved
- keep numeric ternary branches native so the benchmark's alternating start index does not box every iteration
- add exact-integer hot paths plus semantic, allocation, IL-shape, fallback, and prototype-mutation coverage

## Performance

Cross-runtime benchmark, n=100,000 (three launches, adjusted time ratio versus Node):

| Benchmark | Before | After |
| --- | ---: | ---: |
| String Slice | 0.25x Node | 0.91x Node |
| String Substring | 0.33x Node | 1.05x Node |

BenchmarkDotNet ShortRun, n=100,000:

| Benchmark | Before | After | Change | Allocated before | Allocated after |
| --- | ---: | ---: | ---: | ---: | ---: |
| SharpTS Slice | ~936 us | 439.8 us | ~53% faster | 8.0 MB | 0 B |
| SharpTS Substring | ~858 us | 441.7 us | ~49% faster | 8.0 MB | 0 B |

## Validation

- `dotnet build SharpTS.sln -c Release --no-restore -p:NuGetAudit=false -m:1 --nologo` (0 warnings, 0 errors)
- full core suite: 17,878 passed, 3 skipped, 0 failed
- targeted string/operator/unboxed arithmetic suite: 455 passed, 0 failed
- BenchmarkDotNet `PrimitiveStringIntrinsicBenchmarks` ShortRun
- cross-runtime `string-intrinsics` benchmark, compiled vs Node, three launches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved performance for string `.length` access and stable `slice`/`substring` operations.
  * Reduced unnecessary intermediate string creation and boxing in optimized cases.
  * Added faster handling for common numeric bounds and integer conversions.

* **Bug Fixes**
  * Preserved JavaScript-compatible behavior for omitted, fractional, non-finite, and UTF-16 string positions.
  * Custom replacements for string methods continue to be respected instead of using optimized behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->