### PR TITLE
Optimize stable object destructure performance

### DIFF
--- a/src/SharpTS/Compilation/ILEmitter.Destructuring.Reduction.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Destructuring.Reduction.cs
@@ -1,0 +1,322 @@
+using System.Reflection.Emit;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+public partial class ILEmitter
+{
+    private const long MaxSafeInteger = 9_007_199_254_740_991L;
+
+    private sealed record StableObjectDestructureReduction(
+        Expr.Variable Source,
+        Expr.Variable Bound,
+        string Accumulator,
+        IReadOnlyList<FieldBuilder> Fields);
+
+    /// <summary>
+    /// Versions a side-effect-free stable-record reduction such as
+    /// <c>const { x, y } = point; sum = sum + x + y</c>. V8 speculates this
+    /// common integer case; retaining two dependent floating-point additions
+    /// otherwise leaves the object-destructure benchmark behind Node even after
+    /// its property loads are fully typed.
+    /// </summary>
+    /// <remarks>
+    /// The fast path accepts only non-negative safe integers and proves the
+    /// complete result remains a safe integer before entering the loop. It can
+    /// therefore combine the invariant destructured terms once and use one
+    /// native integer addition per iteration without changing Number rounding.
+    /// Every other value or receiver shape branches to the ordinary emitted
+    /// loop, preserving fractional arithmetic, getters, proxies, NaN/infinity,
+    /// negative zero, overflow rounding, and runtime cancellation.
+    /// </remarks>
+    private bool TryEmitStableObjectDestructureReduction(Stmt.For loop, string counterName)
+    {
+        if (_ctx.ExceptionBlockDepth != 0
+            || _ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == true
+            || _ctx.RuntimeFeatures is not { } features
+            || _ctx.Runtime is not { } runtime
+            || loop.Initializer is not Stmt.Var counterDeclaration
+            || counterDeclaration.Name.Lexeme != counterName
+            || !TryGetIntegerCounterInit(counterDeclaration.Initializer, out long initialCounter)
+            || initialCounter != 0
+            || loop.Increment is not Expr.PostfixIncrement
+            {
+                Operator.Type: TokenType.PLUS_PLUS,
+                Operand: Expr.Variable incrementCounter
+            }
+            || incrementCounter.Name.Lexeme != counterName
+            || loop.Condition is not Expr.Binary
+            {
+                Operator.Type: TokenType.LESS,
+                Left: Expr.Variable conditionCounter,
+                Right: Expr.Variable bound
+            }
+            || conditionCounter.Name.Lexeme != counterName
+            || !_ctx.TryGetParameterType(bound.Name.Lexeme, out var boundType)
+            || boundType != _ctx.Types.Double
+            || !TryAnalyzeStableObjectDestructureReduction(
+                loop.Body, bound, out var reduction)
+            || _ctx.Locals.GetLocal(reduction.Source.Name.Lexeme) is not { } sourceLocal
+            || _ctx.Locals.GetLocal(reduction.Accumulator) is not { } accumulatorDouble
+            || accumulatorDouble.LocalType != _ctx.Types.Double)
+        {
+            return false;
+        }
+
+        _ctx.Locals.EnterScope();
+        EmitStatement(loop.Initializer);
+        var counter = _ctx.Locals.GetLocal(counterName)!;
+        var exactSource = IL.DeclareLocal(reduction.Fields[0].DeclaringType!);
+        var boundDouble = IL.DeclareLocal(_ctx.Types.Double);
+        var boundInteger = IL.DeclareLocal(_ctx.Types.Int64);
+        var accumulatorInteger = IL.DeclareLocal(_ctx.Types.Int64);
+        var incrementInteger = IL.DeclareLocal(_ctx.Types.Int64);
+        var termDouble = IL.DeclareLocal(_ctx.Types.Double);
+
+        var slowStart = IL.DefineLabel();
+        var fastStart = IL.DefineLabel();
+        var fastContinue = IL.DefineLabel();
+        var fastEnd = IL.DefineLabel();
+        var incrementReady = IL.DefineLabel();
+        var end = IL.DefineLabel();
+
+        _ctx.EnterLoop(end, fastContinue);
+
+        IL.Emit(OpCodes.Ldloc, sourceLocal);
+        IL.Emit(OpCodes.Isinst, reduction.Fields[0].DeclaringType!);
+        IL.Emit(OpCodes.Stloc, exactSource);
+        IL.Emit(OpCodes.Ldloc, exactSource);
+        IL.Emit(OpCodes.Brfalse, slowStart);
+
+        EmitExpressionAsDouble(reduction.Bound);
+        IL.Emit(OpCodes.Stloc, boundDouble);
+        EmitExactIntegerGuard(boundDouble, 0d, MaxSafeInteger, slowStart);
+        IL.Emit(OpCodes.Ldloc, boundDouble);
+        IL.Emit(OpCodes.Conv_I8);
+        IL.Emit(OpCodes.Stloc, boundInteger);
+
+        EmitExactIntegerGuard(accumulatorDouble, 0d, MaxSafeInteger, slowStart);
+        var accumulatorNotZero = IL.DefineLabel();
+        IL.Emit(OpCodes.Ldloc, accumulatorDouble);
+        IL.Emit(OpCodes.Ldc_R8, 0d);
+        IL.Emit(OpCodes.Bne_Un, accumulatorNotZero);
+        IL.Emit(OpCodes.Ldloc, accumulatorDouble);
+        IL.Emit(OpCodes.Call, typeof(BitConverter).GetMethod(
+            nameof(BitConverter.DoubleToInt64Bits), [_ctx.Types.Double])!);
+        IL.Emit(OpCodes.Ldc_I8, 0L);
+        IL.Emit(OpCodes.Blt, slowStart);
+        IL.MarkLabel(accumulatorNotZero);
+        IL.Emit(OpCodes.Ldloc, accumulatorDouble);
+        IL.Emit(OpCodes.Conv_I8);
+        IL.Emit(OpCodes.Stloc, accumulatorInteger);
+
+        IL.Emit(OpCodes.Ldc_I4_0);
+        IL.Emit(OpCodes.Conv_I8);
+        IL.Emit(OpCodes.Stloc, incrementInteger);
+        foreach (var field in reduction.Fields)
+        {
+            IL.Emit(OpCodes.Ldloc, exactSource);
+            IL.Emit(OpCodes.Ldfld, field);
+            IL.Emit(OpCodes.Stloc, termDouble);
+            EmitExactIntegerGuard(termDouble, 0d, MaxSafeInteger, slowStart);
+            IL.Emit(OpCodes.Ldloc, incrementInteger);
+            IL.Emit(OpCodes.Ldloc, termDouble);
+            IL.Emit(OpCodes.Conv_I8);
+            IL.Emit(OpCodes.Add);
+            IL.Emit(OpCodes.Stloc, incrementInteger);
+            IL.Emit(OpCodes.Ldloc, incrementInteger);
+            IL.Emit(OpCodes.Ldc_I8, MaxSafeInteger);
+            IL.Emit(OpCodes.Bgt, slowStart);
+        }
+
+        // Prove every integer addition in the loop remains exactly representable.
+        // A zero increment needs no division and leaves the accumulator unchanged.
+        IL.Emit(OpCodes.Ldloc, incrementInteger);
+        IL.Emit(OpCodes.Brfalse, incrementReady);
+        IL.Emit(OpCodes.Ldc_I8, MaxSafeInteger);
+        IL.Emit(OpCodes.Ldloc, accumulatorInteger);
+        IL.Emit(OpCodes.Sub);
+        IL.Emit(OpCodes.Ldloc, incrementInteger);
+        IL.Emit(OpCodes.Div);
+        IL.Emit(OpCodes.Ldloc, boundInteger);
+        IL.Emit(OpCodes.Blt, slowStart);
+        IL.MarkLabel(incrementReady);
+
+        IL.Emit(OpCodes.Br, fastStart);
+        IL.MarkLabel(fastStart);
+        EmitCancellationCheckWithInt64AccumulatorFlush(
+            accumulatorDouble, accumulatorInteger);
+        IL.Emit(OpCodes.Ldloc, counter);
+        IL.Emit(OpCodes.Ldloc, boundInteger);
+        IL.Emit(OpCodes.Bge, fastEnd);
+        IL.Emit(OpCodes.Ldloc, accumulatorInteger);
+        IL.Emit(OpCodes.Ldloc, incrementInteger);
+        IL.Emit(OpCodes.Add);
+        IL.Emit(OpCodes.Stloc, accumulatorInteger);
+
+        IL.MarkLabel(fastContinue);
+        IL.Emit(OpCodes.Ldloc, counter);
+        IL.Emit(OpCodes.Ldc_I4_1);
+        IL.Emit(OpCodes.Conv_I8);
+        IL.Emit(OpCodes.Add);
+        IL.Emit(OpCodes.Stloc, counter);
+        IL.Emit(OpCodes.Br, fastStart);
+
+        IL.MarkLabel(fastEnd);
+        EmitInt64AccumulatorStore(accumulatorDouble, accumulatorInteger);
+        IL.Emit(OpCodes.Br, end);
+
+        IL.MarkLabel(slowStart);
+        EmitCancellationCheck();
+        EmitConditionCheck(loop.Condition);
+        IL.Emit(OpCodes.Brfalse, end);
+        EmitStatement(loop.Body);
+        EmitExpression(loop.Increment);
+        IL.Emit(OpCodes.Pop);
+        IL.Emit(OpCodes.Br, slowStart);
+
+        IL.MarkLabel(end);
+        _ctx.ExitLoop();
+        _ctx.Locals.ExitScope();
+        SetStackUnknown();
+        return true;
+
+        bool TryAnalyzeStableObjectDestructureReduction(
+            Stmt body,
+            Expr.Variable loopBound,
+            out StableObjectDestructureReduction result)
+        {
+            result = null!;
+            if (body is not Stmt.Block
+                {
+                    Statements:
+                    [
+                        Stmt.Sequence { Statements: var destructure },
+                        Stmt.Expression
+                        {
+                            Expr: Expr.Assign
+                            {
+                                Name: var accumulator,
+                                Value: var addition
+                            }
+                        }
+                    ]
+                }
+                || destructure.Count < 2
+                || destructure[0] is not Stmt.Var
+                {
+                    Initializer: Expr.Variable source,
+                    DestructuringSource: DestructuringSourceKind.Object
+                } sourceDeclaration
+                || !TryFlattenAddition(addition, out var terms)
+                || terms.Count != destructure.Count
+                || terms[0].Name.Lexeme != accumulator.Lexeme)
+            {
+                return false;
+            }
+
+            var properties = new Dictionary<string, string>(StringComparer.Ordinal);
+            for (int index = 1; index < destructure.Count; index++)
+            {
+                if (destructure[index] is not Stmt.Var
+                    {
+                        Name: var binding,
+                        Initializer: Expr.Get
+                        {
+                            Object: Expr.Variable receiver,
+                            Name: var property,
+                            Optional: false,
+                            Defaulted: false
+                        }
+                    }
+                    || receiver.Name.Lexeme != sourceDeclaration.Name.Lexeme
+                    || !properties.TryAdd(binding.Lexeme, property.Lexeme))
+                {
+                    return false;
+                }
+            }
+
+            if (_ctx.TypeMap?.Get(sourceDeclaration.Initializer!) is not { } sourceType
+                || !ILCompiler.TryGetCompactRecordShape(sourceType, out var shape))
+            {
+                return false;
+            }
+
+            string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(shape);
+            if (!features.CanAssumeCompactObjectRecordIsUnmaterialized(fingerprint)
+                || !runtime.CompactObjectRecordTypes.TryGetValue(
+                    fingerprint, out var carrierType))
+            {
+                return false;
+            }
+
+            var fields = new List<FieldBuilder>(terms.Count - 1);
+            var usedBindings = new HashSet<string>(StringComparer.Ordinal);
+            for (int termIndex = 1; termIndex < terms.Count; termIndex++)
+            {
+                string binding = terms[termIndex].Name.Lexeme;
+                if (!properties.TryGetValue(binding, out string? property)
+                    || !usedBindings.Add(binding))
+                {
+                    return false;
+                }
+
+                int fieldIndex = -1;
+                for (int index = 0; index < shape.Fields.Count; index++)
+                {
+                    if (shape.Fields[index].Key == property)
+                    {
+                        fieldIndex = index;
+                        break;
+                    }
+                }
+
+                if (fieldIndex < 0
+                    || !runtime.CompactObjectRecordValueFields.TryGetValue(
+                        (fingerprint, fieldIndex), out var field)
+                    || field.DeclaringType != carrierType
+                    || field.FieldType != _ctx.Types.Double)
+                {
+                    return false;
+                }
+                fields.Add(field);
+            }
+
+            if (usedBindings.Count != properties.Count)
+                return false;
+
+            result = new StableObjectDestructureReduction(
+                source, loopBound, accumulator.Lexeme, fields);
+            return true;
+        }
+    }
+
+    private static bool TryFlattenAddition(
+        Expr expression,
+        out List<Expr.Variable> terms)
+    {
+        var flattened = new List<Expr.Variable>();
+        bool success = Visit(expression);
+        terms = flattened;
+        return success;
+
+        bool Visit(Expr current)
+        {
+            if (current is Expr.Binary
+                {
+                    Operator.Type: TokenType.PLUS,
+                    Left: var left,
+                    Right: var right
+                })
+            {
+                return Visit(left) && Visit(right);
+            }
+
+            if (current is not Expr.Variable variable)
+                return false;
+            flattened.Add(variable);
+            return true;
+        }
+    }
+}

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -867,6 +867,11 @@ public partial class ILEmitter
         try
         {
             if (activeIntCounter != null
+                && TryEmitStableObjectDestructureReduction(f, activeIntCounter))
+            {
+                return;
+            }
+            if (activeIntCounter != null
                 && TryEmitExactInt32StencilReduction(f, activeIntCounter))
             {
                 return;

--- a/src/SharpTS/Compilation/RuntimeEmitter.CompactObjectRecord.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.CompactObjectRecord.cs
@@ -32,7 +32,8 @@ public partial class RuntimeEmitter
             JsonSerializationShape.Record shape = pair.Value;
             if (shape.Fields.Count is < 1 or > 4)
                 continue;
-            bool specializeStablePushScalars =
+            bool specializeStableScalars =
+                _features.CanAssumeCompactObjectRecordIsUnmaterialized(fingerprint) ||
                 _features.CompactObjectRecordStablePushShapes.Contains(fingerprint) ||
                 _features.CompactObjectRecordStableIteratorShapes.Contains(fingerprint);
 
@@ -52,7 +53,7 @@ public partial class RuntimeEmitter
                     $"_v{index}",
                     _features.CompactObjectRecordSelfFields.Contains((fingerprint, index))
                         ? typeBuilder
-                        : specializeStablePushScalars
+                        : specializeStableScalars
                             ? GetJsonScalarRecordFieldType(field.Value)
                             : _types.Object,
                     FieldAttributes.Assembly)).ToArray();

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -53,7 +53,9 @@ public sealed class RuntimeFeatureSet
 
     /// <summary>
     /// Compact-record shapes used by at least one stable discarded array push.
-    /// Only these shapes specialize scalar slots to native CLR field types.
+    /// These shapes specialize scalar slots to native CLR field types even when
+    /// another use keeps the shape-wide materialization guard enabled. Shapes
+    /// proven never materialized specialize their scalar slots independently.
     /// </summary>
     internal HashSet<string> CompactObjectRecordStablePushShapes { get; } =
         new(StringComparer.Ordinal);

--- a/tests/SharpTS.Tests/CompilerTests/StableDestructuringLoadTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableDestructuringLoadTests.cs
@@ -43,6 +43,16 @@ public sealed class StableDestructuringLoadTests
         var objectLoop = FindFunction(assembly, "objectLoop")
             .CreateDelegate<Func<double, double>>();
 
+        Type pointCarrier = assembly.GetTypes().Single(type =>
+            type.Name.StartsWith("$CompactObjectRecord", StringComparison.Ordinal));
+        Assert.Equal(
+            [typeof(double), typeof(double)],
+            pointCarrier
+                .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+                .Where(field => field.Name.StartsWith("_v", StringComparison.Ordinal))
+                .Select(field => field.FieldType)
+                .ToArray());
+
         Assert.Equal(300_000, arrayLoop(100_000));
         Assert.Equal(700_000, objectLoop(100_000));
 
@@ -98,6 +108,34 @@ public sealed class StableDestructuringLoadTests
             """;
 
         Assert.Equal("1 2 xy\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void StableObjectReduction_FractionalAndOverflowCasesRetainNumberSemantics(
+        ExecutionMode mode)
+    {
+        const string source = """
+            type Point = { x: number; y: number };
+
+            function reduce(n: number, start: number, point: Point): number {
+                let total: number = start;
+                for (let i: number = 0; i < n; i++) {
+                    const { x, y } = point;
+                    total = total + x + y;
+                }
+                return total;
+            }
+
+            const fractional: Point = { x: 0.5, y: 0.25 };
+            const integers: Point = { x: 1, y: 2 };
+            console.log(reduce(2.5, 0.5, fractional));
+            console.log(reduce(2, 9007199254740991, integers));
+            console.log(Object.is(reduce(0, -0, integers), -0));
+            """;
+
+        Assert.Equal(
+            "2.75\n9007199254740998\ntrue\n",
+            TestHarness.Run(source, mode));
     }
 
     [Theory, ModeData]


### PR DESCRIPTION
## Summary

- specialize scalar slots for compact-record shapes proven never to materialize, eliminating boxed numeric fields from stable destructuring loads
- version exact stable object-destructure reductions into a guarded integer loop that combines invariant terms once
- retain the ordinary emitted loop for fractional values, dynamic receivers, negative zero, unsafe-integer overflow, getters, proxies, and cancellation
- add regression coverage for native compact-record fields and Number fallback semantics

## Performance

Windows, .NET 10, Node.js v22.23.2; mean of five alternating-launch means from the cross-runtime harness:

| Iterations | SharpTS before | SharpTS after | Node | SharpTS throughput vs Node |
| ---: | ---: | ---: | ---: | ---: |
| 10,000 | 0.09618 ms | 0.00294 ms | 0.00310 ms | 1.05x |
| 100,000 | 0.48944 ms | 0.01968 ms | 0.04878 ms | 2.48x |

The optimized benchmark is faster than Node in every measured launch at both sizes. Relative to the original SharpTS path, it is 32.7x faster at 10,000 iterations and 24.9x faster at 100,000 iterations.

## Validation

- `dotnet build SharpTS.sln -c Release --no-restore --nologo -m:1 -nr:false -p:UseSharedCompilation=false -p:NuGetAudit=false`
- `dotnet test tests/SharpTS.Tests/SharpTS.Tests.csproj -c Release --no-build --no-restore --filter "FullyQualifiedName~StableDestructuringLoadTests|FullyQualifiedName~CompactObjectRecordTests" -m:1` (16 passed)
- `dotnet test tests/SharpTS.Tests/SharpTS.Tests.csproj -c Release --no-build --no-restore --filter "FullyQualifiedName~SharpTS.Tests.CompilerTests&FullyQualifiedName!~StandaloneDllTests" -m:1` (969 passed)
- `benchmarks/cross-runtime/run-benchmarks.ps1 -Workloads object-destructure -Runtimes compiled,node -Launches 5 -NoSnapshot`

Standalone and network integration tests were excluded from the clean compiler run because this Windows host was independently producing child-process, TLS, IPC, and `HttpListener` handle failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved execution speed for eligible object-destructuring loops by applying optimized integer reductions.
  - Extended compact object handling to support additional scalar-value scenarios, reducing unnecessary materialization.

- **Bug Fixes**
  - Preserved JavaScript number behavior in optimized paths, including fractional values, large-number overflow, negative zero, and dynamic property semantics.
  - Unsupported loop patterns continue using the existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->