### PR TITLE
Improve flattened rest benchmark controls

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -50,7 +50,9 @@ jobs:
         run: |
           $resultsDir = Join-Path ([System.IO.Path]::GetTempPath()) 'bench-results'
           "BENCH_RESULTS_DIR=$resultsDir" >> $env:GITHUB_ENV
-          ./benchmarks/cross-runtime/run-benchmarks.ps1 -OutputDirectory $resultsDir
+          ./benchmarks/cross-runtime/run-benchmarks.ps1 `
+            -Launches 3 `
+            -OutputDirectory $resultsDir
 
       - name: Publish results to job summary
         shell: pwsh

--- a/benchmarks/cross-runtime/README.md
+++ b/benchmarks/cross-runtime/README.md
@@ -14,8 +14,9 @@ side-by-side table plus a versioned JSON snapshot:
 
 Published measurements are **in-process workload timings**. They include one
 invocation of the workload function and exclude process startup, script loading,
-SharpTS compilation, warmup, and batch calibration. Startup and compilation are
-important but are not mixed into the workload metric.
+SharpTS compilation, warmup, batch calibration, and optional correctness
+validation. Startup and compilation are important but are not mixed into the
+workload metric.
 
 > For the *internal* benchmarks — SharpTS-compiled vs the idiomatic-C#
 > performance ceiling, with allocation/GC profiling — see
@@ -27,7 +28,7 @@ important but are not mixed into the workload metric.
 | Path | Purpose |
 |------|---------|
 | `run-benchmarks.ps1` | Builds SharpTS (Release), runs every `scripts/*.ts` on all runtimes, writes `results.txt` and `snapshot.json`. |
-| `format-results.ps1` | Renders `results.txt` as a Markdown table (used for the CI job summary). |
+| `format-results.ps1` | Renders the median of retained per-launch means as a Markdown table (used for the CI job summary). |
 | `Snapshot.psm1` / `export-snapshot.ps1` | Parse raw diagnostics and deterministically export the public schema-v1 snapshot. |
 | `snapshot-v1.schema.json` | Checked-in, versioned JSON Schema for the public snapshot contract. |
 | `snapshots/latest.json` | Canonical reviewed snapshot consumed from a pinned SharpTS checkout. |
@@ -54,7 +55,8 @@ methodology rather than flattening unlike measurements together.
 PowerShell 7 or later (`pwsh`) is required for the benchmark PowerShell tools.
 
 ```powershell
-# Run everything; results land in $TEMP/bench-results/{results.txt,snapshot.json}
+# Run everything; results land in $TEMP/bench-results/{results.txt,snapshot.json}.
+# Three launches per runtime/case are collected by default.
 ./benchmarks/cross-runtime/run-benchmarks.ps1
 
 # Repeat only numeric-loop workloads, excluding the advisory Bun result
@@ -81,7 +83,8 @@ same inexpensive guard used by CI):
 `-Workloads` accepts script basenames and `-Runtimes` accepts `interpreter`,
 `compiled`, `node`, and `bun`. Override the output directory with
 `-OutputDirectory` or `$env:OUTPUT_DIR`. Node and Bun are detected only when
-selected; Bun is skipped if not on `PATH`.
+selected; Bun is skipped if not on `PATH`. `-Launches` defaults to 3; use an
+explicit lower value only for quick local diagnostics, not published evidence.
 
 `-RepositoryRoot` is intended for the paired local performance harness. It lets
 the current runner compile and execute a frozen source worktree, so the baseline
@@ -95,17 +98,22 @@ For repeatable candidate-vs-baseline runs on native Windows and WSL, see
 
 ## How timing works
 
-Each workload calls `bench(name, param, fn)` from `scripts/lib/bench.ts`, which:
+Each workload calls `bench(name, param, fn, expected?)` from
+`scripts/lib/bench.ts`, which:
 
-1. Probes once. A result between 1 ms and the 100 ms warmup cap is confirmed with
+1. When `expected` is supplied, validates one invocation before probing. A
+   second validation after sampling checks the optimized steady-state result;
+   neither validation is timed.
+2. Probes once. A result between 1 ms and the 100 ms warmup cap is confirmed with
    one post-JIT probe so cold compilation cannot misclassify a fast workload. Only
    a confirmed call that consumes the full 100 ms warmup budget is sampled one call
    at a time (honest for slow cases like the tree-walking interpreter on big inputs).
-2. Otherwise it warms the JIT, calibrates an inner batch until a sample spans ≥ 1 ms
+3. Otherwise it warms the JIT, calibrates an inner batch until a sample spans ≥ 1 ms
    (lifting fast cases above timer and call-overhead noise), then samples to a budget.
    This prevents a runtime's cold first-tier JIT from selecting a different sampling
    method than an already-fast optimizing JIT.
-3. Emits one line per case, consumed by the PowerShell formatter and exporter:
+4. Emits one line per case with seven decimal places in milliseconds (0.1 ns),
+   consumed by the PowerShell formatter and exporter:
 
    ```text
    BENCH:<name>:<param>:<meanMs>:<minMs>:<stdevMs>:<samples>:<inner>:<sampledMs>
@@ -114,6 +122,18 @@ Each workload calls `bench(name, param, fn)` from `scripts/lib/bench.ts`, which:
 `performance.now()` (sub-microsecond, monotonic) is used everywhere so the
 methodology is identical across runtimes. A `guard` accumulator defeats
 dead-code elimination in both SharpTS modes and the JS engines.
+
+`language-hot-paths.ts` keeps `flattened-rest-control` grouped as
+`sum + (i + 1 + 2 + 3)`, which exactly matches the evaluation tree of
+`sum + add4(i, 1, 2, 3)` without its call/rest mechanics. The former ungrouped
+body remains as `left-associated-accumulation`, an intentionally different
+loop-carried dependency-chain probe. Direct fixed-arity rest specialization is
+reported beside indirect-call, spread-call, and dynamic-index fallback cases.
+These rest cases share a fractional accumulator seed, keeping them in
+Number/double representation from the first iteration instead of letting an
+optimizing JavaScript engine start with tagged-small-integer arithmetic and
+deopt only at larger parameters. Other integer-oriented probes intentionally
+retain their natural representation behavior.
 
 The `worker-scaling` workload uses the same parent, worker, and CPU-kernel
 TypeScript verbatim in every runtime. It keeps the total amount of CPU work
@@ -165,6 +185,9 @@ from different machines. Cases are ordered by stable
 `<script-family>/<case-name>?n=<parameter>` IDs. Every case contains explicit
 records for interpreter, compiled, Node.js, and Bun; an unselected, unavailable,
 or failed runtime is represented as `missing` rather than removing the case.
+The Markdown formatter reports the median per-launch mean and median
+within-launch standard deviation, while leaving every launch intact in the raw
+and JSON artifacts.
 
 ## Refreshing the public snapshot
 
@@ -187,9 +210,10 @@ Copy-Item .perf-cross-runtime-refresh/snapshot.json `
 Review the revision (including the `dirty` flag), environment/tool identity,
 case set, missing-runtime reasons, and per-launch variance along with the JSON
 diff. Do not hand-edit presentation values: consumers choose rounding and
-ratios from the canonical-unit measurements. A schema change requires a new
-`schemaVersion`, schema file, harness version/methodology identifier, and
-consumer opt-in; validators reject unknown versions.
+ratios from the canonical-unit measurements. A structural snapshot-contract
+change requires a new `schemaVersion` and schema file; a compatible timing or
+validation-method change requires a new harness version/methodology identifier.
+Validators reject unknown versions.
 
 If a runtime produces no `BENCH:` line (crash, parse error, missing API),
 `run-benchmarks.ps1` warns loudly and echoes the tail of its output rather than

--- a/benchmarks/cross-runtime/Snapshot.psm1
+++ b/benchmarks/cross-runtime/Snapshot.psm1
@@ -216,7 +216,31 @@ function Assert-SharpTSPublicBenchmarkSnapshot {
                 throw "snapshot.run.tools.runtimes[$runtimeId] is unavailable but has a version."
             }
         }
-        [void](Get-RequiredProperty $Snapshot 'methodology' 'snapshot')
+        $methodology = Get-RequiredProperty $Snapshot 'methodology' 'snapshot'
+        $harnessVersion = [int](Get-RequiredProperty $methodology 'harnessVersion' 'snapshot.methodology')
+        $methodologyId = [string](Get-RequiredProperty $methodology 'id' 'snapshot.methodology')
+        $methodologyIds = @{
+            1 = 'performance-now-auto-batched-v1'
+            2 = 'performance-now-confirmed-probe-auto-batched-v2'
+            3 = 'performance-now-validated-high-precision-auto-batched-v3'
+        }
+        if (-not $methodologyIds.ContainsKey($harnessVersion) -or
+            $methodologyId -cne $methodologyIds[$harnessVersion]) {
+            throw "Unsupported or mismatched benchmark methodology '$methodologyId' version '$harnessVersion'."
+        }
+        if ($harnessVersion -eq 3) {
+            $validation = Get-RequiredProperty $methodology 'validation' 'snapshot.methodology'
+            if ((Get-RequiredProperty $validation 'mode' 'snapshot.methodology.validation') -cne
+                    'optionalExpectedNumericResult' -or
+                (Get-RequiredProperty $validation 'timing' 'snapshot.methodology.validation') -cne
+                    'beforeAndAfterSampling') {
+                throw 'snapshot.methodology.validation does not describe the version-3 validation contract.'
+            }
+            $sampling = Get-RequiredProperty $methodology 'sampling' 'snapshot.methodology'
+            if ((Get-RequiredProperty $sampling 'reportedDecimalPlaces' 'snapshot.methodology.sampling') -ne 7) {
+                throw 'snapshot.methodology.sampling.reportedDecimalPlaces must be 7 for harness version 3.'
+            }
+        }
 
         $cases = @(Get-RequiredProperty $Snapshot 'cases' 'snapshot')
         if ($cases.Count -eq 0) { throw 'snapshot.cases must contain at least one case.' }
@@ -419,12 +443,23 @@ function New-SharpTSPublicBenchmarkSnapshot {
             }
         }
         methodology = [pscustomobject][ordered]@{
-            harnessVersion = 2
-            id = 'performance-now-confirmed-probe-auto-batched-v2'
+            harnessVersion = 3
+            id = 'performance-now-validated-high-precision-auto-batched-v3'
             timingScope = 'inProcessWorkload'
             clock = 'performance.now'
             includes = @('one workload function invocation')
-            excludes = @('process startup', 'script loading', 'SharpTS compilation', 'warmup', 'batch calibration')
+            excludes = @(
+                'process startup',
+                'script loading',
+                'SharpTS compilation',
+                'warmup',
+                'batch calibration',
+                'correctness validation'
+            )
+            validation = [pscustomobject][ordered]@{
+                mode = 'optionalExpectedNumericResult'
+                timing = 'beforeAndAfterSampling'
+            }
             sampling = [pscustomobject][ordered]@{
                 warmupCapMilliseconds = 100
                 minimumSampleDurationMilliseconds = 1
@@ -432,6 +467,7 @@ function New-SharpTSPublicBenchmarkSnapshot {
                 minimumSamples = 8
                 hardCapMilliseconds = 2000
                 maximumSamples = 100000
+                reportedDecimalPlaces = 7
             }
         }
         cases = $cases.ToArray()

--- a/benchmarks/cross-runtime/format-results.ps1
+++ b/benchmarks/cross-runtime/format-results.ps1
@@ -31,14 +31,17 @@ Write-Output @"
 **Environment:** .NET $DotNetVersion | Node.js $NodeVersion | Bun $BunVersion | $os $arch
 **Date:** $(Get-Date -Format 'yyyy-MM-dd')
 
-Per-call mean ms with sample standard deviation (lower is better). Per-call
-minimums are kept in the raw results artifact for deeper analysis.
+Median per-launch mean ms with the median within-launch sample standard
+deviation (lower is better). ``L#`` is the number of retained launches;
+per-launch means and minimums remain in the raw results artifact.
 
 | Benchmark | Param | Interpreter (ms) | Compiled (ms) | Node.js (ms) | Bun (ms) | Compiled vs Node |
 |-----------|-------|------------------:|--------------:|--------------:|---------:|-----------------:|
 "@
 
-# Parse results into a dictionary keyed by "bench|param".
+# Parse results into a dictionary keyed by "bench|param". Keep every launch;
+# overwriting by runtime would make the displayed table silently show only the
+# final launch now that repeated launches are the default.
 # The first five payload fields remain
 # <bench>:<param>:<mean>:<min>:<stdev>. Newer harnesses append sampling,
 # workload-family, and launch metadata for the structured exporter.
@@ -55,20 +58,48 @@ foreach ($line in Get-Content $ResultsFile) {
     if (-not $data.Contains($key)) {
         $data[$key] = @{}
     }
-    $data[$key][$runtime] = @{
+    if (-not $data[$key].ContainsKey($runtime)) {
+        $data[$key][$runtime] = [Collections.Generic.List[object]]::new()
+    }
+    [void]$data[$key][$runtime].Add([pscustomobject]@{
         mean  = $fields[2]
         stdev = if ($fields.Count -ge 5) { $fields[4] } else { $null }
+    })
+}
+
+function Get-Median([double[]]$Values) {
+    $ordered = @($Values | Sort-Object)
+    $middle = [int][Math]::Floor($ordered.Count / 2)
+    if (($ordered.Count % 2) -eq 1) { return [double]$ordered[$middle] }
+    return ([double]$ordered[$middle - 1] + [double]$ordered[$middle]) / 2
+}
+
+function Format-Number([double]$Value) {
+    return $Value.ToString('0.#######', [Globalization.CultureInfo]::InvariantCulture)
+}
+
+function Get-RuntimeSummary($entry, $runtime) {
+    if (-not $entry.ContainsKey($runtime)) { return $null }
+    $launches = @($entry[$runtime])
+    $means = @($launches | ForEach-Object { [double]$_.mean })
+    $stdevs = @($launches | Where-Object { $null -ne $_.stdev -and $_.stdev -ne '' } |
+        ForEach-Object { [double]$_.stdev })
+    return [pscustomobject]@{
+        mean = Get-Median $means
+        stdev = if ($stdevs.Count -gt 0) { Get-Median $stdevs } else { $null }
+        launches = $launches.Count
     }
 }
 
-# Render a runtime cell as "mean ±stdev" (or just "mean", or "-" if absent).
+# Render a runtime cell as "median-mean ±median-stdev (L#)".
 function Format-Cell($entry, $runtime) {
-    if (-not $entry.ContainsKey($runtime)) { return '-' }
-    $m = $entry[$runtime]
-    if ($null -ne $m.stdev -and $m.stdev -ne '') {
-        return "$($m.mean) ±$($m.stdev)"
+    $summary = Get-RuntimeSummary $entry $runtime
+    if ($null -eq $summary) { return '-' }
+    $meanText = Format-Number $summary.mean
+    if ($null -ne $summary.stdev) {
+        return "$meanText ±$(Format-Number $summary.stdev) (L$($summary.launches))"
     }
-    return "$($m.mean)"
+    return "$meanText (L$($summary.launches))"
 }
 
 foreach ($key in $data.Keys) {
@@ -84,9 +115,11 @@ foreach ($key in $data.Keys) {
 
     $ratio = '-'
     if ($entry.ContainsKey('compiled') -and $entry.ContainsKey('node')) {
-        $njsNum = [double]$entry['node'].mean
+        $compiledSummary = Get-RuntimeSummary $entry 'compiled'
+        $nodeSummary = Get-RuntimeSummary $entry 'node'
+        $njsNum = $nodeSummary.mean
         if ($njsNum -gt 0) {
-            $ratio = '{0:F2}x' -f ([double]$entry['compiled'].mean / $njsNum)
+            $ratio = '{0:F2}x' -f ($compiledSummary.mean / $njsNum)
         }
     }
 

--- a/benchmarks/cross-runtime/run-benchmarks.ps1
+++ b/benchmarks/cross-runtime/run-benchmarks.ps1
@@ -9,7 +9,7 @@ param(
     [string[]]$Runtimes = @('interpreter', 'compiled', 'node', 'bun'),
 
     [ValidateRange(1, 20)]
-    [int]$Launches = 1,
+    [int]$Launches = 3,
 
     [string]$OutputDirectory,
 

--- a/benchmarks/cross-runtime/scripts/language-hot-paths.ts
+++ b/benchmarks/cross-runtime/scripts/language-hot-paths.ts
@@ -1,5 +1,10 @@
 import { bench } from "./lib/bench.ts";
 
+// Keep the rest comparison in Number/double representation from its first
+// iteration on every runtime. An integer-zero seed lets optimizing JS engines
+// begin in tagged-small-integer mode and deopt only when larger n overflows it.
+const REST_ACCUMULATOR_SEED: number = 0.5;
+
 // Focused probes for scalar language constructs that can disappear into native
 // machine operations when their bindings and value types are stable. Keep each
 // optimized form beside an equivalent control so future regressions can be
@@ -26,17 +31,62 @@ function add4(...values: number[]): number {
 }
 
 function stableNumericRest(n: number): number {
-    let sum: number = 0;
+    let sum: number = REST_ACCUMULATOR_SEED;
     for (let i: number = 0; i < n; i++) {
         sum = sum + add4(i, 1, 2, 3);
     }
     return sum;
 }
 
+// This is the exact source-level control for stableNumericRest: the parenthesized
+// term preserves add4's evaluation tree while removing the call/rest machinery.
 function flattenedRestControl(n: number): number {
-    let sum: number = 0;
+    let sum: number = REST_ACCUMULATOR_SEED;
+    for (let i: number = 0; i < n; i++) {
+        sum = sum + (i + 1 + 2 + 3);
+    }
+    return sum;
+}
+
+// Retain the former "flattened-rest-control" body as an explicitly named
+// dependency-chain probe. Because + is left-associative, every add below depends
+// on the prior iteration's sum; it is not an equivalent rest-call control.
+function leftAssociatedAccumulation(n: number): number {
+    let sum: number = REST_ACCUMULATOR_SEED;
     for (let i: number = 0; i < n; i++) {
         sum = sum + i + 1 + 2 + 3;
+    }
+    return sum;
+}
+
+// Rest fallback coverage. These deliberately prevent the fixed-arity companion
+// from applying so the suite retains evidence for the ordinary rest ABI too.
+function indirectNumericRest(n: number): number {
+    const indirectAdd4: (...values: number[]) => number = add4;
+    let sum: number = REST_ACCUMULATOR_SEED;
+    for (let i: number = 0; i < n; i++) {
+        sum = sum + indirectAdd4(i, 1, 2, 3);
+    }
+    return sum;
+}
+
+function spreadNumericRest(n: number): number {
+    const tail: number[] = [1, 2, 3];
+    let sum: number = REST_ACCUMULATOR_SEED;
+    for (let i: number = 0; i < n; i++) {
+        sum = sum + add4(i, ...tail);
+    }
+    return sum;
+}
+
+function add4Dynamic(start: number, ...values: number[]): number {
+    return values[start] + values[start + 1] + values[start + 2] + values[start + 3];
+}
+
+function dynamicIndexNumericRest(n: number): number {
+    let sum: number = REST_ACCUMULATOR_SEED;
+    for (let i: number = 0; i < n; i++) {
+        sum = sum + add4Dynamic(0, i, 1, 2, 3);
     }
     return sum;
 }
@@ -85,11 +135,17 @@ function formatFixed(n: number): number {
 const params: number[] = [1000, 10000, 100000];
 for (let p: number = 0; p < params.length; p++) {
     const n: number = params[p];
-    bench("numeric-compound", n, () => numericCompound(n));
-    bench("numeric-assignment-control", n, () => numericAssignmentControl(n));
-    bench("stable-numeric-rest", n, () => stableNumericRest(n));
-    bench("flattened-rest-control", n, () => flattenedRestControl(n));
-    bench("generator-range", n, () => generatorRange(n));
-    bench("parse-integers", n, () => parseIntegers(n));
+    const rangeChecksum: number = n * (n - 1) / 2;
+    const restChecksum: number = REST_ACCUMULATOR_SEED + rangeChecksum + 6 * n;
+    bench("numeric-compound", n, () => numericCompound(n), rangeChecksum);
+    bench("numeric-assignment-control", n, () => numericAssignmentControl(n), rangeChecksum);
+    bench("stable-numeric-rest", n, () => stableNumericRest(n), restChecksum);
+    bench("flattened-rest-control", n, () => flattenedRestControl(n), restChecksum);
+    bench("left-associated-accumulation", n, () => leftAssociatedAccumulation(n), restChecksum);
+    bench("indirect-numeric-rest", n, () => indirectNumericRest(n), restChecksum);
+    bench("spread-numeric-rest", n, () => spreadNumericRest(n), restChecksum);
+    bench("dynamic-index-numeric-rest", n, () => dynamicIndexNumericRest(n), restChecksum);
+    bench("generator-range", n, () => generatorRange(n), rangeChecksum);
+    bench("parse-integers", n, () => parseIntegers(n), rangeChecksum);
     bench("format-fixed", n, () => formatFixed(n));
 }

--- a/benchmarks/cross-runtime/scripts/lib/bench.ts
+++ b/benchmarks/cross-runtime/scripts/lib/bench.ts
@@ -10,6 +10,10 @@
 // noise floor), then collects samples until a time budget elapses and reports
 // the per-call mean, min, and sample standard deviation.
 //
+// Cases may provide an expected numeric result. Validation runs before and
+// after sampling, outside the timed region, so optimized-code miscompilations
+// fail the workload without charging correctness checks to the measurement.
+//
 // Output line (consumed by the cross-runtime PowerShell tools):
 //   BENCH:<name>:<param>:<meanMs>:<minMs>:<stdevMs>:<samples>:<inner>:<sampledMs>
 
@@ -22,18 +26,34 @@ const MIN_SAMPLES: number = 8;       // sample floor (for a meaningful stdev)...
 const HARD_CAP_MS: number = 2000;    // ...but never exceed this, even below the floor
 const MAX_SAMPLES: number = 100000;
 const MAX_INNER: number = 1 << 24;
+const OUTPUT_SCALE: number = 10000000; // seven decimal places in milliseconds (0.1 ns)
 
 function round(x: number): number {
-    return Math.round(x * 10000) / 10000;
+    return Math.round(x * OUTPUT_SCALE) / OUTPUT_SCALE;
+}
+
+function validateExpected(name: string, param: number, actual: number, expected?: number): void {
+    if (expected !== undefined && actual !== expected) {
+        throw new Error(
+            "Benchmark checksum mismatch for " + name + "(" + param + "): expected " +
+            expected + ", received " + actual,
+        );
+    }
 }
 
 // `fn` returns a number that is accumulated into a guard so neither the
 // interpreter nor the compiler can dead-code-eliminate the measured work.
-export function bench(name: string, param: number, fn: () => number): void {
+export function bench(name: string, param: number, fn: () => number, expected?: number): void {
     let guard: number = 0;
     const samples: number[] = [];
     let total: number = 0;
     let inner: number = 1;
+
+    if (expected !== undefined) {
+        const validationResult: number = fn();
+        validateExpected(name, param, validationResult, expected);
+        guard = guard + validationResult;
+    }
 
     // One measured call up front. This probes the cost and, when a single call
     // is genuinely heavy (e.g. the tree-walking interpreter on a big input),
@@ -127,6 +147,14 @@ export function bench(name: string, param: number, fn: () => number): void {
     }
     const stdev: number = samples.length > 1 ? Math.sqrt(varSum / (samples.length - 1)) : 0;
 
+    // Re-check after the workload has reached optimized steady state. This is
+    // deliberately outside every measured sample.
+    if (expected !== undefined) {
+        const validationResult: number = fn();
+        validateExpected(name, param, validationResult, expected);
+        guard = guard + validationResult;
+    }
+
     // Anti-dead-code-elimination: force `guard` to be observably used.
     if (guard === -1) {
         console.log("guard:" + guard);
@@ -147,11 +175,18 @@ export async function benchAsync(
     name: string,
     param: number,
     fn: () => Promise<number>,
+    expected?: number,
 ): Promise<void> {
     let guard: number = 0;
     const samples: number[] = [];
     let total: number = 0;
     let inner: number = 1;
+
+    if (expected !== undefined) {
+        const validationResult: number = await fn();
+        validateExpected(name, param, validationResult, expected);
+        guard = guard + validationResult;
+    }
 
     const probeStart: number = performance.now();
     guard = guard + await fn();
@@ -231,6 +266,12 @@ export async function benchAsync(
         varSum = varSum + d * d;
     }
     const stdev: number = samples.length > 1 ? Math.sqrt(varSum / (samples.length - 1)) : 0;
+
+    if (expected !== undefined) {
+        const validationResult: number = await fn();
+        validateExpected(name, param, validationResult, expected);
+        guard = guard + validationResult;
+    }
 
     if (guard === -1) {
         console.log("guard:" + guard);

--- a/benchmarks/cross-runtime/snapshot-v1.schema.json
+++ b/benchmarks/cross-runtime/snapshot-v1.schema.json
@@ -103,14 +103,23 @@
             "harnessVersion": { "const": 2 },
             "id": { "const": "performance-now-confirmed-probe-auto-batched-v2" }
           }
+        },
+        {
+          "required": ["validation"],
+          "properties": {
+            "harnessVersion": { "const": 3 },
+            "id": { "const": "performance-now-validated-high-precision-auto-batched-v3" },
+            "sampling": { "required": ["reportedDecimalPlaces"] }
+          }
         }
       ],
       "properties": {
-        "harnessVersion": { "enum": [1, 2] },
+        "harnessVersion": { "enum": [1, 2, 3] },
         "id": {
           "enum": [
             "performance-now-auto-batched-v1",
-            "performance-now-confirmed-probe-auto-batched-v2"
+            "performance-now-confirmed-probe-auto-batched-v2",
+            "performance-now-validated-high-precision-auto-batched-v3"
           ]
         },
         "timingScope": { "const": "inProcessWorkload" },
@@ -124,6 +133,15 @@
           "type": "array",
           "minItems": 1,
           "items": { "$ref": "#/$defs/nonEmptyString" }
+        },
+        "validation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mode", "timing"],
+          "properties": {
+            "mode": { "const": "optionalExpectedNumericResult" },
+            "timing": { "const": "beforeAndAfterSampling" }
+          }
         },
         "sampling": {
           "type": "object",
@@ -142,7 +160,8 @@
             "targetDurationMilliseconds": { "type": "number", "exclusiveMinimum": 0 },
             "minimumSamples": { "type": "integer", "minimum": 1 },
             "hardCapMilliseconds": { "type": "number", "exclusiveMinimum": 0 },
-            "maximumSamples": { "type": "integer", "minimum": 1 }
+            "maximumSamples": { "type": "integer", "minimum": 1 },
+            "reportedDecimalPlaces": { "type": "integer", "minimum": 0 }
           }
         }
       }

--- a/benchmarks/cross-runtime/test-snapshot.ps1
+++ b/benchmarks/cross-runtime/test-snapshot.ps1
@@ -61,9 +61,25 @@ try {
     Assert-True ($snapshotA.cases[0].runtimes[0].reason -ceq 'notSelected') 'Interpreter missing reason was notSelected.'
     Assert-True ($snapshotA.cases[0].runtimes[3].status -ceq 'missing') 'Bun should be explicitly missing.'
     Assert-True (-not $snapshotA.run.tools.runtimes[3].available) 'Unavailable Bun was marked available.'
-    Assert-True ($snapshotA.methodology.harnessVersion -eq 2) 'Expected confirmed-probe harness version 2.'
-    Assert-True ($snapshotA.methodology.id -ceq 'performance-now-confirmed-probe-auto-batched-v2') `
-        'Expected confirmed-probe methodology ID.'
+    Assert-True ($snapshotA.methodology.harnessVersion -eq 3) 'Expected validated high-precision harness version 3.'
+    Assert-True ($snapshotA.methodology.id -ceq 'performance-now-validated-high-precision-auto-batched-v3') `
+        'Expected validated high-precision methodology ID.'
+    Assert-True ($snapshotA.methodology.validation.mode -ceq 'optionalExpectedNumericResult') `
+        'Expected optional numeric result validation metadata.'
+    Assert-True ($snapshotA.methodology.validation.timing -ceq 'beforeAndAfterSampling') `
+        'Expected untimed pre/post validation metadata.'
+    Assert-True ($snapshotA.methodology.sampling.reportedDecimalPlaces -eq 7) `
+        'Expected seven-decimal millisecond result precision.'
+
+    $formatted = (& (Join-Path $harnessDirectory 'format-results.ps1') `
+        -ResultsFile $resultsA `
+        -DotNetVersion '10.0.100' `
+        -NodeVersion 'v24.0.0' `
+        -BunVersion 'n/a') -join "`n"
+    Assert-True ($formatted -match [regex]::Escape('5.25 ±0.175 (L2)')) `
+        'Formatter did not report the median across both Node launches.'
+    Assert-True ($formatted -match [regex]::Escape('6 ±0.3 (L1)')) `
+        'Formatter did not retain the compiled launch count.'
 
     $snapshotFile = Join-Path $temporaryDirectory 'snapshot.json'
     [void](Export-SharpTSPublicBenchmarkSnapshot -ResultsFile $resultsA -OutputFile $snapshotFile @fixed)
@@ -93,6 +109,11 @@ try {
     $unknownSchema = $jsonA | ConvertFrom-Json
     $unknownSchema.schemaVersion = 2
     Assert-Throws { Assert-SharpTSPublicBenchmarkSnapshot $unknownSchema } 'Unsupported benchmark snapshot schema version'
+
+    $mismatchedMethodology = $jsonA | ConvertFrom-Json
+    $mismatchedMethodology.methodology.id = 'performance-now-confirmed-probe-auto-batched-v2'
+    Assert-Throws { Assert-SharpTSPublicBenchmarkSnapshot $mismatchedMethodology } `
+        'Unsupported or mismatched benchmark methodology'
 
     $duplicateCase = $jsonA | ConvertFrom-Json
     $clonedCase = $duplicateCase.cases[0] | ConvertTo-Json -Depth 12 | ConvertFrom-Json


### PR DESCRIPTION
## Summary

- correct the flattened-rest control so it preserves the rest function evaluation tree
- retain the former left-associated expression as a separately named dependency-chain case
- add indirect, spread, and dynamic-index fallback rest coverage
- add untimed checksum validation and higher-precision benchmark output
- collect three launches by default and report medians without discarding per-launch data
- version and validate the updated benchmark methodology

## Performance evidence

A three-launch compiled/Node diagnostic at n=100,000 showed the specialized rest case tracking the corrected flattened control (0.057 ms vs 0.063 ms compiled), while fallback cases took 25-28 ms compiled. This isolates the remaining architectural cost to fallback dispatch/rest-array handling rather than the fixed-arity specialization.

## Validation

- all 40 cross-runtime benchmark workloads smoke-tested
- focused three-launch compiled/Node benchmark completed
- cross-runtime snapshot contract tests passed
- public snapshot contract tests passed
- local performance comparison tests passed
- git diff integrity check passed

The canonical snapshot is intentionally unchanged because refreshing it requires a clean, pinned, full-runtime run including Bun.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cross-runtime benchmarks now run three launches by default and report median timing results with launch counts.
  - Benchmark output provides higher-precision measurements and updated runtime comparisons.
  - Optional correctness checks validate expected numeric results before and after sampling.

- **Documentation**
  - Added guidance for validation, launch aggregation, benchmark scenarios, numeric formatting, and snapshot compatibility.

- **Bug Fixes**
  - Prevented earlier benchmark launches from being overwritten when results are collected.
  - Added safeguards to detect incorrect benchmark results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->