### PR TITLE
Optimize object destructuring across compact records

### DIFF
--- a/benchmarks/cross-runtime/scripts/object-destructure-materialized.ts
+++ b/benchmarks/cross-runtime/scripts/object-destructure-materialized.ts
@@ -1,0 +1,21 @@
+import { bench } from "./lib/bench.ts";
+
+type Point = { x: number; y: number };
+
+function destructureMaterialized(n: number): number {
+    const point: Point = { x: 1, y: 2 };
+    const dynamicPoint: any = point;
+    dynamicPoint.extra = true;
+    let checksum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const { x, y } = point;
+        checksum = checksum + x + y;
+    }
+    return checksum;
+}
+
+const sizes: number[] = [10000, 100000];
+for (let i: number = 0; i < sizes.length; i++) {
+    const n: number = sizes[i];
+    bench("object-destructure-materialized", n, () => destructureMaterialized(n));
+}

--- a/benchmarks/cross-runtime/scripts/object-destructure-unrelated-dynamic.ts
+++ b/benchmarks/cross-runtime/scripts/object-destructure-unrelated-dynamic.ts
@@ -1,0 +1,28 @@
+import { bench } from "./lib/bench.ts";
+
+type Point = { x: number; y: number };
+
+// This function is intentionally unused. It verifies that dynamic mutation in
+// unrelated code does not globally disable compact records of every shape.
+function deleteUnknownProperty(value: any): void {
+    delete value.x;
+}
+
+function destructureWithUnrelatedDynamicMutation(n: number): number {
+    const point: Point = { x: 1, y: 2 };
+    let checksum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const { x, y } = point;
+        checksum = checksum + x + y;
+    }
+    return checksum;
+}
+
+const sizes: number[] = [10000, 100000];
+for (let i: number = 0; i < sizes.length; i++) {
+    const n: number = sizes[i];
+    bench(
+        "object-destructure-unrelated-dynamic-mutation",
+        n,
+        () => destructureWithUnrelatedDynamicMutation(n));
+}

--- a/benchmarks/cross-runtime/scripts/object-destructure.ts
+++ b/benchmarks/cross-runtime/scripts/object-destructure.ts
@@ -2,7 +2,7 @@ import { bench } from "./lib/bench.ts";
 
 type Point = { x: number; y: number };
 
-function destructureObject(n: number): number {
+function destructureInvariantFused(n: number): number {
     const point: Point = { x: 1, y: 2 };
     let checksum: number = 0;
     for (let i: number = 0; i < n; i++) {
@@ -12,8 +12,53 @@ function destructureObject(n: number): number {
     return checksum;
 }
 
+function destructureInvariantSplit(n: number): number {
+    const point: Point = { x: 1, y: 2 };
+    let checksum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const { x, y } = point;
+        checksum = checksum + x;
+        checksum = checksum + y;
+    }
+    return checksum;
+}
+
+function destructureInvariantFractional(n: number): number {
+    const point: Point = { x: 1.25, y: 2.5 };
+    let checksum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const { x, y } = point;
+        checksum = checksum + x + y;
+    }
+    return checksum;
+}
+
+function destructureVarying(points: Point[], n: number): number {
+    let checksum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const { x, y } = points[i % 2];
+        checksum = checksum + x + y;
+    }
+    return checksum;
+}
+
+function directVarying(points: Point[], n: number): number {
+    let checksum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const point: Point = points[i % 2];
+        checksum = checksum + point.x + point.y;
+    }
+    return checksum;
+}
+
+const points: Point[] = [{ x: 1, y: 2 }, { x: 3, y: 4 }];
+
 const sizes: number[] = [10000, 100000];
 for (let i: number = 0; i < sizes.length; i++) {
     const n: number = sizes[i];
-    bench("object-destructure", n, () => destructureObject(n));
+    bench("object-destructure-invariant-fused", n, () => destructureInvariantFused(n));
+    bench("object-destructure-invariant-split", n, () => destructureInvariantSplit(n));
+    bench("object-destructure-invariant-fractional", n, () => destructureInvariantFractional(n));
+    bench("object-destructure-varying", n, () => destructureVarying(points, n));
+    bench("object-direct-varying", n, () => directVarying(points, n));
 }

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -966,6 +966,7 @@ public class EmittedRuntime
     public Dictionary<string, ConstructorBuilder> CompactObjectRecordCtors { get; } = [];
     public Dictionary<(string Fingerprint, int Index), FieldBuilder> CompactObjectRecordValueFields { get; } = [];
     public Dictionary<string, FieldBuilder> CompactObjectRecordAnyMaterializedFields { get; } = [];
+    public Dictionary<string, MethodBuilder> CompactObjectRecordIsMaterializedGetters { get; } = [];
     public MethodBuilder JsonScalarRecordShapeGetter { get; set; } = null!;
     public MethodBuilder JsonScalarRecordValuesGetter { get; set; } = null!;
     public MethodBuilder JsonScalarRecordGetValue { get; set; } = null!;

--- a/src/SharpTS/Compilation/ILEmitter.Destructuring.Reduction.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Destructuring.Reduction.cs
@@ -12,7 +12,9 @@ public partial class ILEmitter
         Expr.Variable Source,
         Expr.Variable Bound,
         string Accumulator,
-        IReadOnlyList<FieldBuilder> Fields);
+        IReadOnlyList<FieldBuilder> Fields,
+        MethodBuilder IsMaterializedGetter,
+        bool RequiresMaterializationGuard);
 
     /// <summary>
     /// Versions a side-effect-free stable-record reduction such as
@@ -88,6 +90,13 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Stloc, exactSource);
         IL.Emit(OpCodes.Ldloc, exactSource);
         IL.Emit(OpCodes.Brfalse, slowStart);
+        if (reduction.RequiresMaterializationGuard &&
+            !_stableCompactRecordLocals.Contains(sourceLocal))
+        {
+            IL.Emit(OpCodes.Ldloc, exactSource);
+            IL.Emit(OpCodes.Call, reduction.IsMaterializedGetter);
+            IL.Emit(OpCodes.Brtrue, slowStart);
+        }
 
         EmitExpressionAsDouble(reduction.Bound);
         IL.Emit(OpCodes.Stloc, boundDouble);
@@ -244,9 +253,10 @@ public partial class ILEmitter
             }
 
             string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(shape);
-            if (!features.CanAssumeCompactObjectRecordIsUnmaterialized(fingerprint)
-                || !runtime.CompactObjectRecordTypes.TryGetValue(
-                    fingerprint, out var carrierType))
+            if (!runtime.CompactObjectRecordTypes.TryGetValue(
+                    fingerprint, out var carrierType)
+                || !runtime.CompactObjectRecordIsMaterializedGetters.TryGetValue(
+                    fingerprint, out var isMaterializedGetter))
             {
                 return false;
             }
@@ -287,7 +297,12 @@ public partial class ILEmitter
                 return false;
 
             result = new StableObjectDestructureReduction(
-                source, loopBound, accumulator.Lexeme, fields);
+                source,
+                loopBound,
+                accumulator.Lexeme,
+                fields,
+                isMaterializedGetter,
+                !features.CanAssumeCompactObjectRecordIsUnmaterialized(fingerprint));
             return true;
         }
     }

--- a/src/SharpTS/Compilation/ILEmitter.Destructuring.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Destructuring.cs
@@ -21,12 +21,23 @@ public partial class ILEmitter
         LocalBuilder TypedLocal,
         string Fingerprint,
         JsonSerializationShape.Record Shape,
-        bool IsExact);
+        bool IsExact,
+        bool IsProvenStable);
 
     private readonly Dictionary<string, StableArrayDestructureBinding>
         _stableArrayDestructureBindings = [];
     private readonly Dictionary<string, StableRecordDestructureBinding>
         _stableRecordDestructureBindings = [];
+    private readonly HashSet<LocalBuilder> _stableCompactRecordLocals = [];
+
+    private void RegisterStableCompactRecordLocal(Stmt.Var declaration, LocalBuilder local)
+    {
+        if (declaration.Initializer is Expr.ObjectLiteral literal &&
+            _ctx.RuntimeFeatures?.CompactObjectRecordStableLocalLiterals.Contains(literal) == true)
+        {
+            _stableCompactRecordLocals.Add(local);
+        }
+    }
 
     private void RegisterStableDestructuringSource(Stmt.Var declaration, LocalBuilder objectLocal)
     {
@@ -75,8 +86,9 @@ public partial class ILEmitter
             return;
 
         string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(shape);
-        if (!features.CanAssumeCompactObjectRecordIsUnmaterialized(fingerprint) ||
-            !_ctx.Runtime!.CompactObjectRecordTypes.TryGetValue(fingerprint, out var carrierType))
+        if (!_ctx.Runtime!.CompactObjectRecordTypes.TryGetValue(
+                fingerprint, out var carrierType) ||
+            !_ctx.Runtime.CompactObjectRecordIsMaterializedGetters.ContainsKey(fingerprint))
             return;
 
         LocalBuilder typedLocal;
@@ -99,7 +111,14 @@ public partial class ILEmitter
 
         _stableRecordDestructureBindings[declaration.Name.Lexeme] =
             new StableRecordDestructureBinding(
-                objectLocal, typedLocal, fingerprint, shape, isExact);
+                objectLocal,
+                typedLocal,
+                fingerprint,
+                shape,
+                isExact,
+                declaration.Initializer is Expr.Variable source &&
+                _ctx.Locals.GetLocal(source.Name.Lexeme) is { } sourceLocal &&
+                _stableCompactRecordLocals.Contains(sourceLocal));
     }
 
     private bool TryEmitStableArrayDestructureGet(Expr.GetIndex expression)
@@ -203,6 +222,16 @@ public partial class ILEmitter
         var end = IL.DefineLabel();
         IL.Emit(OpCodes.Ldloc, binding.TypedLocal);
         IL.Emit(OpCodes.Brfalse, fallback);
+        if (!binding.IsProvenStable &&
+            !_ctx.RuntimeFeatures!.CanAssumeCompactObjectRecordIsUnmaterialized(
+                binding.Fingerprint))
+        {
+            IL.Emit(OpCodes.Ldloc, binding.TypedLocal);
+            IL.Emit(OpCodes.Call,
+                _ctx.Runtime!.CompactObjectRecordIsMaterializedGetters[
+                    binding.Fingerprint]);
+            IL.Emit(OpCodes.Brtrue, fallback);
+        }
         IL.Emit(OpCodes.Ldloc, binding.TypedLocal);
         IL.Emit(OpCodes.Ldfld, field);
         if (field.FieldType.IsValueType)
@@ -240,6 +269,16 @@ public partial class ILEmitter
         var result = IL.DeclareLocal(_ctx.Types.Double);
         IL.Emit(OpCodes.Ldloc, binding.TypedLocal);
         IL.Emit(OpCodes.Brfalse, fallback);
+        if (!binding.IsProvenStable &&
+            !_ctx.RuntimeFeatures!.CanAssumeCompactObjectRecordIsUnmaterialized(
+                binding.Fingerprint))
+        {
+            IL.Emit(OpCodes.Ldloc, binding.TypedLocal);
+            IL.Emit(OpCodes.Call,
+                _ctx.Runtime!.CompactObjectRecordIsMaterializedGetters[
+                    binding.Fingerprint]);
+            IL.Emit(OpCodes.Brtrue, fallback);
+        }
         IL.Emit(OpCodes.Ldloc, binding.TypedLocal);
         IL.Emit(OpCodes.Ldfld, field);
         IL.Emit(OpCodes.Stloc, result);

--- a/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
@@ -303,9 +303,10 @@ public partial class ILEmitter
     }
 
     /// <summary>
-    /// Emits a provably stable small plain object literal as an exact slot-backed CLR
-    /// carrier. Open and recursive record fields are supported, but mutation, export,
-    /// and escape through an unknown call retain the ordinary dictionary path.
+    /// Emits a small plain object literal as an exact slot-backed CLR carrier. Open and
+    /// recursive record fields are supported. Mutation and dynamic observation lazily
+    /// materialize the individual carrier, so an unrelated escaped value no longer
+    /// forces every literal with this shape onto the dictionary path.
     /// </summary>
     private bool TryEmitCompactObjectRecordLiteral(Expr.ObjectLiteral literal)
     {
@@ -335,8 +336,11 @@ public partial class ILEmitter
         string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(record);
         if (!_ctx.RuntimeFeatures.CanAssumeCompactObjectRecordIsUnmaterialized(
                 fingerprint) &&
-            !_ctx.RuntimeFeatures.CompactObjectRecordStablePushLiterals.Contains(literal))
+            !_ctx.RuntimeFeatures.CompactObjectRecordStablePushLiterals.Contains(literal) &&
+            !_ctx.RuntimeFeatures.CompactObjectRecordStableLocalLiterals.Contains(literal))
+        {
             return false;
+        }
 
         if (!_ctx.Runtime!.CompactObjectRecordCtors.TryGetValue(
                 fingerprint, out var exactCtor))

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -384,6 +384,8 @@ public partial class ILEmitter
             && objType is TypeInfo.Record recordType
             && _ctx.Runtime?.UndefinedInstance != null)
         {
+            if (TryEmitTypedRecordNumberGet(g, recordType))
+                return;
             EmitTypedRecordPropertyGet(g, recordType);
             return;
         }
@@ -430,6 +432,133 @@ public partial class ILEmitter
             IL.Emit(OpCodes.Ldstr, g.Name.Lexeme);
             IL.Emit(OpCodes.Call, _ctx.Runtime!.GetProperty);
         }
+    }
+
+    /// <summary>
+    /// Keeps a numeric compact-record slot native through ordinary <c>obj.x</c>
+    /// consumers.  The fast arm is guarded by the receiver's exact carrier type
+    /// and its own materialization state; the cold arm preserves the general
+    /// property lookup and ToNumber semantics.
+    /// </summary>
+    private bool TryEmitTypedRecordNumberGet(Expr.Get g, TypeInfo.Record recordType)
+    {
+        if (_ctx.ProgramType is null || _ctx.Runtime is not { } runtime ||
+            !JsonSerializationShapeAnalyzer.TryAnalyze(recordType, out var analyzedShape) ||
+            analyzedShape is not JsonSerializationShape.Record recordShape)
+        {
+            return false;
+        }
+
+        int fieldIndex = -1;
+        for (int index = 0; index < recordShape.Fields.Count; index++)
+        {
+            if (recordShape.Fields[index].Key == g.Name.Lexeme)
+            {
+                fieldIndex = index;
+                break;
+            }
+        }
+
+        string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(recordShape);
+        TypeBuilder? jsonCarrierType = null;
+        FieldBuilder? jsonValueField = null;
+        TypeBuilder? compactCarrierType = null;
+        FieldBuilder? compactValueField = null;
+        MethodBuilder? compactIsMaterializedGetter = null;
+        bool hasJsonCarrier = fieldIndex >= 0 &&
+            runtime.JsonTypedScalarRecordTypes.TryGetValue(
+                fingerprint, out jsonCarrierType) &&
+            runtime.JsonTypedScalarRecordValueFields.TryGetValue(
+                (fingerprint, fieldIndex), out jsonValueField) &&
+            jsonValueField.FieldType == _ctx.Types.Double;
+        bool hasCompactCarrier = fieldIndex >= 0 &&
+            runtime.CompactObjectRecordTypes.TryGetValue(
+                fingerprint, out compactCarrierType) &&
+            runtime.CompactObjectRecordValueFields.TryGetValue(
+                (fingerprint, fieldIndex), out compactValueField) &&
+            compactValueField.FieldType == _ctx.Types.Double &&
+            runtime.CompactObjectRecordIsMaterializedGetters.TryGetValue(
+                fingerprint, out compactIsMaterializedGetter);
+        if (!hasJsonCarrier && !hasCompactCarrier)
+        {
+            return false;
+        }
+
+        EmitExpression(g.Object);
+        EmitBoxIfNeeded(g.Object);
+        var receiver = IL.DeclareLocal(_ctx.Types.Object);
+        var result = IL.DeclareLocal(_ctx.Types.Double);
+        var tryCompact = IL.DefineLabel();
+        var fallback = IL.DefineLabel();
+        var end = IL.DefineLabel();
+        IL.Emit(OpCodes.Stloc, receiver);
+
+        if (hasJsonCarrier)
+        {
+            var jsonExact = IL.DeclareLocal(jsonCarrierType!);
+            IL.Emit(OpCodes.Ldloc, receiver);
+            IL.Emit(OpCodes.Isinst, jsonCarrierType!);
+            IL.Emit(OpCodes.Stloc, jsonExact);
+            IL.Emit(OpCodes.Ldloc, jsonExact);
+            IL.Emit(OpCodes.Brfalse, tryCompact);
+            IL.Emit(OpCodes.Ldloc, jsonExact);
+            IL.Emit(OpCodes.Callvirt, runtime.JsonScalarRecordIsMaterializedGetter);
+            IL.Emit(OpCodes.Brtrue, fallback);
+            if (_ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == true)
+            {
+                IL.Emit(OpCodes.Ldloc, jsonExact);
+                IL.Emit(OpCodes.Call, runtime.PDSHasPropertyDescriptors);
+                IL.Emit(OpCodes.Brtrue, fallback);
+            }
+            IL.Emit(OpCodes.Ldloc, jsonExact);
+            IL.Emit(OpCodes.Ldfld, jsonValueField!);
+            IL.Emit(OpCodes.Stloc, result);
+            IL.Emit(OpCodes.Br, end);
+        }
+
+        IL.MarkLabel(tryCompact);
+        if (hasCompactCarrier)
+        {
+            var compactExact = IL.DeclareLocal(compactCarrierType!);
+            IL.Emit(OpCodes.Ldloc, receiver);
+            IL.Emit(OpCodes.Isinst, compactCarrierType!);
+            IL.Emit(OpCodes.Stloc, compactExact);
+            IL.Emit(OpCodes.Ldloc, compactExact);
+            IL.Emit(OpCodes.Brfalse, fallback);
+            if (!_ctx.RuntimeFeatures!.CanAssumeCompactObjectRecordIsUnmaterialized(
+                    fingerprint))
+            {
+                IL.Emit(OpCodes.Ldloc, compactExact);
+                IL.Emit(OpCodes.Call, compactIsMaterializedGetter!);
+                IL.Emit(OpCodes.Brtrue, fallback);
+            }
+            if (_ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == true)
+            {
+                IL.Emit(OpCodes.Ldloc, compactExact);
+                IL.Emit(OpCodes.Call, runtime.PDSHasPropertyDescriptors);
+                IL.Emit(OpCodes.Brtrue, fallback);
+            }
+            IL.Emit(OpCodes.Ldloc, compactExact);
+            IL.Emit(OpCodes.Ldfld, compactValueField!);
+            IL.Emit(OpCodes.Stloc, result);
+            IL.Emit(OpCodes.Br, end);
+        }
+        else
+        {
+            IL.Emit(OpCodes.Br, fallback);
+        }
+
+        IL.MarkLabel(fallback);
+        IL.Emit(OpCodes.Ldloc, receiver);
+        IL.Emit(OpCodes.Ldstr, g.Name.Lexeme);
+        IL.Emit(OpCodes.Call, runtime.GetProperty);
+        IL.Emit(OpCodes.Call, runtime.ConvertToNumber);
+        IL.Emit(OpCodes.Stloc, result);
+
+        IL.MarkLabel(end);
+        IL.Emit(OpCodes.Ldloc, result);
+        SetStackType(StackType.Double);
+        return true;
     }
 
     /// <summary>
@@ -524,8 +653,8 @@ public partial class ILEmitter
                     fingerprint, out var exactType) &&
                 _ctx.Runtime.CompactObjectRecordValueFields.TryGetValue(
                     (fingerprint, scalarIndex), out var exactValueField) &&
-                _ctx.Runtime.CompactObjectRecordAnyMaterializedFields.TryGetValue(
-                    fingerprint, out var anyMaterializedField))
+                _ctx.Runtime.CompactObjectRecordIsMaterializedGetters.TryGetValue(
+                    fingerprint, out var isMaterializedGetter))
             {
                 exactCarrierSpecialized = true;
                 LocalBuilder exactLocal;
@@ -548,7 +677,8 @@ public partial class ILEmitter
                 if (!_ctx.RuntimeFeatures!.CanAssumeCompactObjectRecordIsUnmaterialized(
                         fingerprint))
                 {
-                    IL.Emit(OpCodes.Ldsfld, anyMaterializedField);
+                    IL.Emit(OpCodes.Ldloc, exactLocal);
+                    IL.Emit(OpCodes.Call, isMaterializedGetter);
                     IL.Emit(OpCodes.Brtrue, fallbackLabel);
                 }
                 if (_ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == true)

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -627,6 +627,7 @@ public partial class ILEmitter
                 }
             }
             IL.Emit(OpCodes.Stloc, local);
+            RegisterStableCompactRecordLocal(v, local);
             RegisterStableDestructuringSource(v, local);
 
             foreach (var (dcInstance, field) in _ctx.SelfCaptureWriteBacks)

--- a/src/SharpTS/Compilation/RuntimeEmitter.CompactObjectRecord.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.CompactObjectRecord.cs
@@ -20,8 +20,9 @@ public partial class RuntimeEmitter
     /// Emits one exact CLR reference type per small plain-record shape.  The
     /// object contains only its value slots; a shared weak table holds the
     /// canonical dictionary only after a dynamic write or observation asks for
-    /// it.  A type-wide bit makes the untouched typed-read path a single branch
-    /// followed by ldfld while retaining full IHasFields mutation semantics.
+    /// it. Proven-stable reads go straight to the slot; guarded reads combine a
+    /// cheap type-wide negative test with a per-instance weak-table probe while
+    /// retaining full IHasFields mutation semantics.
     /// </summary>
     private void EmitCompactObjectRecordClasses(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
     {
@@ -32,11 +33,6 @@ public partial class RuntimeEmitter
             JsonSerializationShape.Record shape = pair.Value;
             if (shape.Fields.Count is < 1 or > 4)
                 continue;
-            bool specializeStableScalars =
-                _features.CanAssumeCompactObjectRecordIsUnmaterialized(fingerprint) ||
-                _features.CompactObjectRecordStablePushShapes.Contains(fingerprint) ||
-                _features.CompactObjectRecordStableIteratorShapes.Contains(fingerprint);
-
             var typeBuilder = EmitTypeDefinitions.DefineType(
                 moduleBuilder,
                 $"$CompactObjectRecord{ordinal++}",
@@ -53,9 +49,7 @@ public partial class RuntimeEmitter
                     $"_v{index}",
                     _features.CompactObjectRecordSelfFields.Contains((fingerprint, index))
                         ? typeBuilder
-                        : specializeStableScalars
-                            ? GetJsonScalarRecordFieldType(field.Value)
-                            : _types.Object,
+                        : GetJsonScalarRecordFieldType(field.Value),
                     FieldAttributes.Assembly)).ToArray();
             Type weakTableType = _types.MakeGenericType(
                 _types.ConditionalWeakTableOpen, _types.Object, _types.DictionaryStringObject);
@@ -102,6 +96,34 @@ public partial class RuntimeEmitter
                 "EnsureMaterialized", MethodAttributes.Private | MethodAttributes.HideBySig,
                 _types.DictionaryStringObject, Type.EmptyTypes);
             EmitEnsure(ensure.GetILGenerator());
+
+            // Materialization belongs to an individual value, not its CLR shape.  A
+            // type-wide bit is still a cheap negative test, while the weak-table probe
+            // distinguishes an untouched carrier from another mutated value with the
+            // same shape.
+            var isMaterialized = typeBuilder.DefineMethod(
+                "get_IsMaterialized",
+                MethodAttributes.Assembly | MethodAttributes.SpecialName |
+                MethodAttributes.HideBySig,
+                _types.Boolean,
+                Type.EmptyTypes);
+            isMaterialized.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
+            runtime.CompactObjectRecordIsMaterializedGetters.Add(
+                fingerprint, isMaterialized);
+            var isMaterializedIl = isMaterialized.GetILGenerator();
+            var probeMaterializedTable = isMaterializedIl.DefineLabel();
+            isMaterializedIl.Emit(OpCodes.Ldsfld, anyMaterialized);
+            isMaterializedIl.Emit(OpCodes.Brtrue_S, probeMaterializedTable);
+            isMaterializedIl.Emit(OpCodes.Ldc_I4_0);
+            isMaterializedIl.Emit(OpCodes.Ret);
+            isMaterializedIl.MarkLabel(probeMaterializedTable);
+            var ignoredMaterializedValue = isMaterializedIl.DeclareLocal(
+                _types.DictionaryStringObject);
+            isMaterializedIl.Emit(OpCodes.Ldsfld, materializedTable);
+            isMaterializedIl.Emit(OpCodes.Ldarg_0);
+            isMaterializedIl.Emit(OpCodes.Ldloca, ignoredMaterializedValue);
+            isMaterializedIl.Emit(OpCodes.Callvirt, tableTryGet);
+            isMaterializedIl.Emit(OpCodes.Ret);
 
             var fieldsGetter = typeBuilder.DefineMethod(
                 "get_Fields",

--- a/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureDetector.cs
@@ -136,6 +136,7 @@ public sealed class RuntimeFeatureDetector
         CollectCanonicalCompactRecordShapes(statements);
         foreach (var stmt in statements)
             VisitStmt(stmt);
+        StableCompactRecordLocalAnalyzer.Analyze(statements, typeMap, _set);
 
         // The emitter selects the discarded one-element push intrinsic only
         // while both of these whole-program guards remain clear. Keep literal

--- a/src/SharpTS/Compilation/RuntimeFeatureSet.cs
+++ b/src/SharpTS/Compilation/RuntimeFeatureSet.cs
@@ -50,6 +50,13 @@ public sealed class RuntimeFeatureSet
     /// </summary>
     internal HashSet<Expr.ObjectLiteral> CompactObjectRecordStablePushLiterals { get; } =
         new(ReferenceEqualityComparer.Instance);
+    /// <summary>
+    /// Non-escaping const literals whose only observations are fixed property or
+    /// object-destructuring reads. Eligibility is per literal, so an escaped sibling
+    /// with the same structural shape cannot deopt this value.
+    /// </summary>
+    internal HashSet<Expr.ObjectLiteral> CompactObjectRecordStableLocalLiterals { get; } =
+        new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
     /// Compact-record shapes used by at least one stable discarded array push.

--- a/src/SharpTS/Compilation/StableCompactRecordLocalAnalyzer.cs
+++ b/src/SharpTS/Compilation/StableCompactRecordLocalAnalyzer.cs
@@ -1,0 +1,203 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Finds uniquely named const object literals whose only observations are fixed
+/// property reads or parser-generated object-destructuring reads.  These values
+/// cannot have entered the compact carrier's materialization table, even when an
+/// unrelated value with the same shape has, so their emitted field loads need no
+/// per-instance weak-table probe.
+/// </summary>
+internal static class StableCompactRecordLocalAnalyzer
+{
+    internal static void Analyze(
+        IReadOnlyList<Stmt> statements,
+        TypeMap? typeMap,
+        RuntimeFeatureSet features)
+    {
+        if (typeMap is null)
+            return;
+
+        var functions = new FunctionCollector();
+        foreach (var statement in statements)
+            functions.Visit(statement);
+
+        foreach (var function in functions.Functions)
+        {
+            if (function.Body is null)
+                continue;
+
+            var collector = new CandidateCollector(typeMap, features, function);
+            foreach (var statement in function.Body)
+                collector.Visit(statement);
+            if (collector.HasNestedCallable)
+                continue;
+
+            var usage = new UsageCollector(collector.CandidateFields);
+            foreach (var statement in function.Body)
+                usage.Visit(statement);
+
+            foreach (var (name, literals) in collector.Candidates)
+            {
+                if (literals.Count == 1 &&
+                    collector.DeclarationCounts.GetValueOrDefault(name) == 1 &&
+                    !usage.Disqualified.Contains(name))
+                {
+                    features.CompactObjectRecordStableLocalLiterals.Add(literals[0]);
+                }
+            }
+        }
+    }
+
+    private sealed class FunctionCollector : AstVisitorBase
+    {
+        public List<Stmt.Function> Functions { get; } = [];
+
+        protected override void VisitFunction(Stmt.Function statement)
+        {
+            Functions.Add(statement);
+            base.VisitFunction(statement);
+        }
+    }
+
+    private sealed class CandidateCollector(
+        TypeMap typeMap,
+        RuntimeFeatureSet features,
+        Stmt.Function function) : AstVisitorBase
+    {
+        public Dictionary<string, List<Expr.ObjectLiteral>> Candidates { get; } =
+            new(StringComparer.Ordinal);
+        public Dictionary<string, HashSet<string>> CandidateFields { get; } =
+            new(StringComparer.Ordinal);
+        public Dictionary<string, int> DeclarationCounts { get; } =
+            function.Parameters
+                .GroupBy(parameter => parameter.Name.Lexeme, StringComparer.Ordinal)
+                .ToDictionary(group => group.Key, group => group.Count(), StringComparer.Ordinal);
+        public bool HasNestedCallable { get; private set; }
+
+        protected override void VisitConst(Stmt.Const statement)
+        {
+            DeclarationCounts[statement.Name.Lexeme] =
+                DeclarationCounts.GetValueOrDefault(statement.Name.Lexeme) + 1;
+            if (statement.Initializer is Expr.ObjectLiteral literal &&
+                JsonSerializationShapeAnalyzer.TryAnalyzeCompactObjectLiteral(
+                    literal, typeMap, out var shape) &&
+                features.CompactObjectRecordShapes.ContainsKey(
+                    JsonSerializationShapeAnalyzer.Fingerprint(shape)))
+            {
+                if (!Candidates.TryGetValue(statement.Name.Lexeme, out var literals))
+                {
+                    literals = [];
+                    Candidates.Add(statement.Name.Lexeme, literals);
+                }
+                literals.Add(literal);
+                if (!CandidateFields.TryGetValue(statement.Name.Lexeme, out var fields))
+                {
+                    fields = new HashSet<string>(StringComparer.Ordinal);
+                    CandidateFields.Add(statement.Name.Lexeme, fields);
+                }
+                foreach (var field in shape.Fields)
+                    fields.Add(field.Key);
+            }
+            base.VisitConst(statement);
+        }
+
+        protected override void VisitVar(Stmt.Var statement)
+        {
+            DeclarationCounts[statement.Name.Lexeme] =
+                DeclarationCounts.GetValueOrDefault(statement.Name.Lexeme) + 1;
+            base.VisitVar(statement);
+        }
+
+        protected override void VisitFunction(Stmt.Function statement) =>
+            HasNestedCallable = true;
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression) =>
+            HasNestedCallable = true;
+    }
+
+    private sealed class UsageCollector(
+        IReadOnlyDictionary<string, HashSet<string>> candidateFields) : AstVisitorBase
+    {
+        private readonly HashSet<string> _candidates =
+            new(candidateFields.Keys, StringComparer.Ordinal);
+
+        public HashSet<string> Disqualified { get; } = new(StringComparer.Ordinal);
+
+        protected override void VisitConst(Stmt.Const statement) =>
+            Visit(statement.Initializer);
+
+        protected override void VisitVar(Stmt.Var statement)
+        {
+            if (statement.DestructuringSource == DestructuringSourceKind.Object &&
+                statement.Initializer is Expr.Variable source &&
+                _candidates.Contains(source.Name.Lexeme))
+            {
+                return;
+            }
+            base.VisitVar(statement);
+        }
+
+        protected override void VisitFunction(Stmt.Function statement)
+        {
+        }
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression)
+        {
+        }
+
+        protected override void VisitGet(Expr.Get expression)
+        {
+            if (!expression.Optional && expression.Object is Expr.Variable receiver &&
+                candidateFields.TryGetValue(receiver.Name.Lexeme, out var fields) &&
+                fields.Contains(expression.Name.Lexeme))
+            {
+                return;
+            }
+            base.VisitGet(expression);
+        }
+
+        protected override void VisitVariable(Expr.Variable expression)
+        {
+            if (_candidates.Contains(expression.Name.Lexeme))
+                Disqualified.Add(expression.Name.Lexeme);
+        }
+
+        protected override void VisitAssign(Expr.Assign expression)
+        {
+            if (_candidates.Contains(expression.Name.Lexeme))
+                Disqualified.Add(expression.Name.Lexeme);
+            base.VisitAssign(expression);
+        }
+
+        protected override void VisitDelete(Expr.Delete expression)
+        {
+            DisqualifyPropertyMutation(expression.Operand);
+            base.VisitDelete(expression);
+        }
+
+        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expression)
+        {
+            DisqualifyPropertyMutation(expression.Operand);
+            base.VisitPrefixIncrement(expression);
+        }
+
+        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expression)
+        {
+            DisqualifyPropertyMutation(expression.Operand);
+            base.VisitPostfixIncrement(expression);
+        }
+
+        private void DisqualifyPropertyMutation(Expr expression)
+        {
+            if (expression is Expr.Get { Object: Expr.Variable receiver } &&
+                _candidates.Contains(receiver.Name.Lexeme))
+            {
+                Disqualified.Add(receiver.Name.Lexeme);
+            }
+        }
+    }
+}

--- a/src/SharpTS/Runtime/Types/VmContext.cs
+++ b/src/SharpTS/Runtime/Types/VmContext.cs
@@ -127,7 +127,7 @@ public static class VmContext
             foreach (var name in originalProperties.Keys)
             {
                 if (env.TryGet(name, out var value))
-                    tsObj.SetProperty(name, value);
+                    tsObj.SetProperty(name, value.ToObject());
             }
         }
         else if (contextObject is Dictionary<string, object?> dict)
@@ -135,7 +135,7 @@ public static class VmContext
             foreach (var name in originalProperties.Keys)
             {
                 if (env.TryGet(name, out var value))
-                    dict[name] = value;
+                    dict[name] = value.ToObject();
             }
         }
         else if (contextObject != null)
@@ -155,7 +155,7 @@ public static class VmContext
                 foreach (var name in originalProperties.Keys)
                 {
                     if (env.TryGet(name, out var value))
-                        setMethod.Invoke(contextObject, [name, value]);
+                        setMethod.Invoke(contextObject, [name, value.ToObject()]);
                 }
             }
         }

--- a/tests/SharpTS.Tests/CompilerTests/StableDestructuringLoadTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableDestructuringLoadTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Reflection.Emit;
 using SharpTS.Compilation;
 using SharpTS.Parsing;
 using SharpTS.Tests.Infrastructure;
@@ -81,6 +82,123 @@ public sealed class StableDestructuringLoadTests
         Assert.True(objectLargeAllocated <= objectSmallAllocated + 1_024,
             $"Object destructuring allocations scaled: {objectSmallAllocated} vs {objectLargeAllocated}.");
         Assert.Empty(TestHarness.CompileAndVerifyOnly(HotSource));
+    }
+
+    [Fact]
+    public void StableObjectReduction_SelectionIsVisibleInEmittedIl()
+    {
+        Assembly assembly = Compile(HotSource);
+        MethodInfo objectLoop = FindFunction(assembly, "objectLoop");
+        var instructions = ReadInstructions(objectLoop).ToArray();
+
+        Assert.Contains(instructions, instruction => instruction.OpCode == OpCodes.Div);
+        Assert.Contains(instructions, instruction =>
+            instruction.OpCode == OpCodes.Ldfld &&
+            instruction.Member?.DeclaringType?.Name.StartsWith(
+                "$CompactObjectRecord", StringComparison.Ordinal) == true);
+    }
+
+    [Fact]
+    public void UnrelatedUnknownMutationAndMaterializedSibling_DoNotDeoptStableRecords()
+    {
+        const string source = """
+            type Point = { x: number; y: number };
+
+            function deleteUnknownProperty(value: any): void {
+                delete value.x;
+            }
+
+            function materializeSibling(): number {
+                const sibling: Point = { x: 1, y: 2 };
+                const dynamicSibling: any = sibling;
+                dynamicSibling.x = 9;
+                return sibling.x;
+            }
+
+            function objectLoop(n: number): number {
+                const point: Point = { x: 3, y: 4 };
+                let total: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    const { x, y } = point;
+                    total = total + x + y;
+                }
+                return total;
+            }
+
+            export function directLoop(point: Point, n: number): number {
+                let total: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    total = total + point.x + point.y;
+                }
+                return total;
+            }
+
+            function runDirect(n: number): number {
+                const point: Point = { x: 3, y: 4 };
+                return directLoop(point, n);
+            }
+            """;
+
+        Assembly assembly = Compile(source);
+        Type carrier = assembly.GetTypes().Single(type =>
+            type.Name.StartsWith("$CompactObjectRecord", StringComparison.Ordinal));
+        Assert.Equal(
+            [typeof(double), typeof(double)],
+            carrier
+                .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+                .Where(field => field.Name.StartsWith("_v", StringComparison.Ordinal))
+                .Select(field => field.FieldType)
+                .ToArray());
+
+        var materializeSibling = FindFunction(assembly, "materializeSibling")
+            .CreateDelegate<Func<double>>();
+        var objectLoop = FindFunction(assembly, "objectLoop")
+            .CreateDelegate<Func<double, double>>();
+        var runDirect = FindFunction(assembly, "runDirect")
+            .CreateDelegate<Func<double, double>>();
+        MethodInfo directLoop = FindFunction(assembly, "directLoop");
+
+        Assert.Equal(9, materializeSibling());
+        Assert.Equal(700_000, objectLoop(100_000));
+        Assert.Equal(700_000, runDirect(100_000));
+        Assert.Equal(typeof(object), directLoop.GetParameters()[0].ParameterType);
+
+        var directInstructions = ReadInstructions(directLoop).ToArray();
+        Assert.Contains(directInstructions, instruction =>
+            instruction.OpCode == OpCodes.Ldfld &&
+            instruction.Member?.DeclaringType == carrier);
+        Assert.Contains(directInstructions, instruction =>
+            instruction.Member?.Name == "get_IsMaterialized");
+        Assert.DoesNotContain(directInstructions, instruction =>
+            instruction.OpCode == OpCodes.Box && instruction.Member == typeof(double));
+
+        var reductionInstructions = ReadInstructions(
+            FindFunction(assembly, "objectLoop")).ToArray();
+        Assert.Contains(reductionInstructions, instruction =>
+            instruction.OpCode == OpCodes.Div);
+        Assert.DoesNotContain(reductionInstructions, instruction =>
+            instruction.Member?.Name == "get_IsMaterialized");
+
+        objectLoop(1_000);
+        runDirect(1_000);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        objectLoop(1_000);
+        long objectSmallAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        before = GC.GetAllocatedBytesForCurrentThread();
+        objectLoop(100_000);
+        long objectLargeAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        before = GC.GetAllocatedBytesForCurrentThread();
+        runDirect(1_000);
+        long directSmallAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        before = GC.GetAllocatedBytesForCurrentThread();
+        runDirect(100_000);
+        long directLargeAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.True(objectLargeAllocated <= objectSmallAllocated + 1_024,
+            $"Object destructuring allocations scaled: {objectSmallAllocated} vs {objectLargeAllocated}.");
+        Assert.True(directLargeAllocated <= directSmallAllocated + 1_024,
+            $"Direct record-read allocations scaled: {directSmallAllocated} vs {directLargeAllocated}.");
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
     }
 
     [Theory, ModeData]
@@ -166,4 +284,57 @@ public sealed class StableDestructuringLoadTests
         assembly.GetType("$Program")!
             .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
             .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+
+    private static IEnumerable<(OpCode OpCode, MemberInfo? Member)> ReadInstructions(
+        MethodInfo method)
+    {
+        byte[] il = method.GetMethodBody()?.GetILAsByteArray()
+            ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
+        Module module = method.Module;
+
+        for (int offset = 0; offset < il.Length;)
+        {
+            byte first = il[offset++];
+            short value = first == 0xfe
+                ? unchecked((short)(0xfe00 | il[offset++]))
+                : first;
+            OpCode opCode = OpCodeByValue[value];
+            MemberInfo? member = null;
+            if (opCode.OperandType is OperandType.InlineMethod or OperandType.InlineField or
+                OperandType.InlineType)
+            {
+                int token = BitConverter.ToInt32(il, offset);
+                member = opCode.OperandType switch
+                {
+                    OperandType.InlineMethod => module.ResolveMethod(token),
+                    OperandType.InlineField => module.ResolveField(token),
+                    _ => module.ResolveType(token)
+                };
+            }
+
+            int operandSize = opCode.OperandType switch
+            {
+                OperandType.InlineNone => 0,
+                OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or
+                    OperandType.ShortInlineVar => 1,
+                OperandType.InlineVar => 2,
+                OperandType.InlineI or OperandType.InlineBrTarget or OperandType.InlineField or
+                    OperandType.InlineMethod or OperandType.InlineSig or OperandType.InlineString or
+                    OperandType.InlineTok or OperandType.InlineType or OperandType.ShortInlineR => 4,
+                OperandType.InlineI8 or OperandType.InlineR => 8,
+                OperandType.InlineSwitch => 4 + 4 * BitConverter.ToInt32(il, offset),
+                _ => throw new InvalidOperationException(
+                    $"Unsupported IL operand type {opCode.OperandType}.")
+            };
+            offset += operandSize;
+            yield return (opCode, member);
+        }
+    }
+
+    private static readonly IReadOnlyDictionary<short, OpCode> OpCodeByValue =
+        typeof(OpCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.FieldType == typeof(OpCode))
+            .Select(field => (OpCode)field.GetValue(null)!)
+            .ToDictionary(opCode => opCode.Value);
 }

--- a/tests/SharpTS.Tests/SharedTests/BuiltInModules/VmModuleTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/BuiltInModules/VmModuleTests.cs
@@ -122,11 +122,12 @@ public class VmModuleTests
                 const ctx = { x: 1 };
                 vm.runInNewContext('x = 42;', ctx);
                 console.log(ctx.x);
+                console.log(ctx.x + 1);
                 """
         };
 
         var output = TestHarness.RunModules(files, "main.ts", mode);
-        Assert.Equal("42\n", output);
+        Assert.Equal("42\n43\n", output);
     }
 
     [Theory, ModeData]


### PR DESCRIPTION
## Summary

- add conservative per-function stability analysis for compact-record locals so unrelated dynamic object operations no longer disable optimized destructuring
- use per-instance materialization guards and keep numeric record fields unboxed across stable destructuring and direct property reads
- expand the Object Destructure benchmark with split, fractional, varying, unrelated-dynamic, and materialized cases

## Performance

Indicative local results at 100,000 iterations across three launches:

| Case | SharpTS compiled | Node.js |
| --- | ---: | ---: |
| invariant fused | 0.0198-0.0203 ms | 0.059-0.061 ms |
| invariant fractional | 0.0785-0.083 ms | 0.078-0.081 ms |
| unrelated dynamic operation | 0.0198-0.0199 ms | 0.049-0.051 ms |
| varying object | 0.26-0.29 ms | about 0.079 ms |
| materialized record | 2.50-2.64 ms | 0.049-0.050 ms |

The unrelated-dynamic case previously took 3.3966 ms, so the per-local proof removes an approximately 170x regression. Varying and materialized records remain visible follow-up bottlenecks.

## Validation

- 29 targeted stable-destructuring, JSON scalar-record, and compact-record tests passed
- 982 compiler tests passed with the environment-dependent standalone integration tests excluded
- full compiler attempt passed 1028 of 1031 tests; the remaining standalone failures were child-process timeout and local TLS authentication cases unrelated to these changes
- all three Object Destructure benchmark workloads compile successfully
- staged diff passes git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved property reads and object destructuring for stable record values.
  * Added runtime safeguards that preserve correct behavior when records are modified or materialized.
  * Expanded benchmark coverage for destructuring and property-access scenarios.

* **Bug Fixes**
  * Preserved optimized, allocation-free behavior when unrelated mutations or materialized sibling records are present.
  * Fixed runtime context write-back handling and verified updated values can be reused.
  * Added regression coverage for stable destructuring results and numeric field access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->