### PR TITLE
Fix Math.max several benchmark architecture

### DIFF
--- a/benchmarks/cross-runtime/scripts/math-min-max.ts
+++ b/benchmarks/cross-runtime/scripts/math-min-max.ts
@@ -30,6 +30,17 @@ function mathMaxSeveral(
     a: number, b: number, c: number, d: number, n: number): number {
     let total: number = 0;
     for (let i: number = 0; i < n; i++) {
+        // Make the result depend on the iteration so an optimizing host must
+        // execute the four-argument max in the measured loop.
+        total = total + Math.max(a + (i % 2), b, c, d);
+    }
+    return total;
+}
+
+function mathMaxSeveralInvariant(
+    a: number, b: number, c: number, d: number, n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
         total = total + Math.max(a, b, c, d);
     }
     return total;
@@ -38,7 +49,11 @@ function mathMaxSeveral(
 function mathMinDynamic(a: any, b: any, n: number): number {
     let total: number = 0;
     for (let i: number = 0; i < n; i++) {
-        total = total + Math.min(a, b);
+        // Alternate number and string inputs. This keeps ToNumber observable
+        // inside the loop instead of letting a speculative JIT hoist a stable
+        // numeric coercion out of the workload.
+        const candidate: any = (i % 2) === 0 ? a : b;
+        total = total + Math.min(candidate, 7);
     }
     return total;
 }
@@ -51,15 +66,16 @@ function mathMaxSpread(values: number[], n: number): number {
     return total;
 }
 
-// Make the values unknown to the host optimizer while keeping their TypeScript
-// types precise enough for SharpTS's fixed-arity path.
+// Make the values unknown at compile time while keeping their TypeScript types
+// precise enough for SharpTS's fixed-arity path. The varying benchmark above
+// separately prevents loop-invariant-code motion.
 const seed: number = Date.now() & 1;
-const a: number = 3 + seed;
+const a: number = 7 + seed;
 const b: number = 4 + seed;
 const c: number = 2 + seed;
-const d: number = 7 + seed;
+const d: number = 3 + seed;
 const dynamicA: any = a;
-const dynamicB: any = b;
+const dynamicB: any = String(b);
 const spreadValues: number[] = [a, b, c, d];
 const params: number[] = [100, 10000, 100000];
 
@@ -70,6 +86,7 @@ for (let p: number = 0; p < params.length; p++) {
     bench("math-max-one", n, () => mathMaxOne(a, n));
     bench("math-min-two", n, () => mathMinTwo(n));
     bench("math-max-several", n, () => mathMaxSeveral(a, b, c, d, n));
+    bench("math-max-several-invariant", n, () => mathMaxSeveralInvariant(a, b, c, d, n));
     bench("math-min-dynamic", n, () => mathMinDynamic(dynamicA, dynamicB, n));
     bench("math-max-spread", n, () => mathMaxSpread(spreadValues, n));
 }

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/MathMinMaxBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/MathMinMaxBenchmarks.cs
@@ -18,7 +18,13 @@ public class MathMinMaxBenchmarks
     private Func<double, double, double> _one = null!;
     private Func<double, double, double, double> _two = null!;
     private Func<double, double, double, double, double, double> _several = null!;
+    private Func<double, double, double, double, double, double> _severalInvariant = null!;
+    private Func<double, double, double> _severalControl = null!;
     private Func<object, object, double, double> _dynamic = null!;
+    private double _a;
+    private double _b;
+    private double _c;
+    private double _d;
 
     [Params(100, 10_000, 100_000)]
     public int N { get; set; }
@@ -43,8 +49,19 @@ public class MathMinMaxBenchmarks
             .CreateDelegate<Func<double, double, double, double>>();
         _several = BenchmarkHarness.GetCompiledMethod(compiled, "mathMaxSeveralLoop")
             .CreateDelegate<Func<double, double, double, double, double, double>>();
+        _severalInvariant = BenchmarkHarness.GetCompiledMethod(compiled, "mathMaxSeveralInvariantLoop")
+            .CreateDelegate<Func<double, double, double, double, double, double>>();
+        _severalControl = BenchmarkHarness.GetCompiledMethod(compiled, "mathMaxSeveralControlLoop")
+            .CreateDelegate<Func<double, double, double>>();
         _dynamic = BenchmarkHarness.GetCompiledMethod(compiled, "mathMinDynamicLoop")
             .CreateDelegate<Func<object, object, double, double>>();
+
+        // Instance fields keep the native controls unknown to the C# compiler
+        // while matching the values passed to the generated TypeScript methods.
+        _a = 7;
+        _b = 4;
+        _c = 2;
+        _d = 3;
     }
 
     [Benchmark]
@@ -66,8 +83,50 @@ public class MathMinMaxBenchmarks
     }
 
     [Benchmark]
-    public double SharpTS_Several() => _several(1, 7, 3, 5, N);
+    public double SharpTS_Several() => _several(_a, _b, _c, _d, N);
 
     [Benchmark]
-    public double SharpTS_DynamicControl() => _dynamic(3d, 4d, N);
+    public double NativeCSharp_Several()
+    {
+        double a = _a;
+        double b = _b;
+        double c = _c;
+        double d = _d;
+        double total = 0;
+        for (int i = 0; i < N; i++)
+            total += Math.Max(Math.Max(Math.Max(a + (i % 2), b), c), d);
+        return total;
+    }
+
+    [Benchmark]
+    public double SharpTS_SeveralInvariant() => _severalInvariant(_a, _b, _c, _d, N);
+
+    [Benchmark]
+    public double NativeCSharp_SeveralInvariant()
+    {
+        double a = _a;
+        double b = _b;
+        double c = _c;
+        double d = _d;
+        double total = 0;
+        for (int i = 0; i < N; i++)
+            total += Math.Max(Math.Max(Math.Max(a, b), c), d);
+        return total;
+    }
+
+    [Benchmark]
+    public double SharpTS_SeveralControl() => _severalControl(_a, N);
+
+    [Benchmark]
+    public double NativeCSharp_SeveralControl()
+    {
+        double a = _a;
+        double total = 0;
+        for (int i = 0; i < N; i++)
+            total += a + (i % 2);
+        return total;
+    }
+
+    [Benchmark]
+    public double SharpTS_DynamicControl() => _dynamic(3d, "4", N);
 }

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/MathMinMax.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/MathMinMax.ts
@@ -26,7 +26,24 @@ function mathMaxSeveralLoop(
     a: number, b: number, c: number, d: number, n: number): number {
     let total: number = 0;
     for (let i: number = 0; i < n; i++) {
+        total = total + Math.max(a + (i % 2), b, c, d);
+    }
+    return total;
+}
+
+function mathMaxSeveralInvariantLoop(
+    a: number, b: number, c: number, d: number, n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
         total = total + Math.max(a, b, c, d);
+    }
+    return total;
+}
+
+function mathMaxSeveralControlLoop(a: number, n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        total = total + a + (i % 2);
     }
     return total;
 }
@@ -34,7 +51,8 @@ function mathMaxSeveralLoop(
 function mathMinDynamicLoop(a: any, b: any, n: number): number {
     let total: number = 0;
     for (let i: number = 0; i < n; i++) {
-        total = total + Math.min(a, b);
+        const candidate: any = (i % 2) === 0 ? a : b;
+        total = total + Math.min(candidate, 7);
     }
     return total;
 }


### PR DESCRIPTION
## Summary

- make the primary math-max-several workload vary per iteration so host optimizers cannot hoist Math.max out of the measured loop
- retain the original loop-invariant shape as math-max-several-invariant for diagnostic coverage
- add matching native C# and loop-only controls, and make the dynamic control alternate number/string inputs

## Performance diagnosis

The original invariant case measured different work: V8 hoisted the three Math.max comparisons out of the loop, while SharpTS/RyuJIT retained them inside. That produced an apparent ~5.3x gap.

At 100,000 iterations, the corrected workload measures 0.331 ms compiled versus 0.197 ms on Node (~1.68x); the retained invariant diagnostic remains ~5.24x.

At 10,000 iterations, BenchmarkDotNet measured 34.98 us for SharpTS versus 32.07 us for native C#. Subtracting the matched loop controls leaves 26.83 us versus 27.05 us for the Math.max work itself. The typed paths allocate no managed memory, so no compiler lowering change is warranted.

## Verification

- dotnet build benchmarks/micro/SharpTS.Microbenchmarks/SharpTS.Microbenchmarks.csproj -c Release --no-restore
- dotnet test tests/SharpTS.Tests/SharpTS.Tests.csproj -c Release --no-build --no-restore --filter FullyQualifiedName~UnboxedMathMinMaxTests (9 passed)
- benchmarks/cross-runtime/run-benchmarks.ps1 -NoBuild -NoSnapshot -Workloads math-min-max -Runtimes compiled,node -Launches 3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded performance coverage for `Math.max` and `Math.min`, including multiple arguments, varying operands, invariant workloads, and control-loop comparisons.
  - Added scenarios that exercise JavaScript-style numeric string coercion during min/max operations.
  - Improved consistency between cross-runtime and microbenchmark suites for more representative performance measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->