### PR TITLE
Optimize compiled and interpreted array queue operations

### DIFF
--- a/benchmarks/cross-runtime/README.md
+++ b/benchmarks/cross-runtime/README.md
@@ -50,6 +50,12 @@ The schema-v1 file remains the versioned contract for this one suite. The
 run beside compiler-micro and GUI evidence, preserving this environment and
 methodology rather than flattening unlike measurements together.
 
+`array-queue.ts` measures full shift/drain and unshift/build workloads at 1,000,
+2,500, 5,000, and 10,000 elements, plus a fixed-width alternating push/shift queue.
+Every case validates its checksum outside the timed region. The intermediate
+sizes expose scaling changes; the alternating case exercises reuse across many
+queue turnovers. Keep these operations intact when comparing implementations.
+
 ## Running
 
 PowerShell 7 or later (`pwsh`) is required for the benchmark PowerShell tools.

--- a/benchmarks/cross-runtime/scripts/array-queue.ts
+++ b/benchmarks/cross-runtime/scripts/array-queue.ts
@@ -21,9 +21,21 @@ function unshiftBuild(n: number): number {
     return values.length + values[0] + values[n - 1];
 }
 
-const sizes: number[] = [1000, 10000];
+function alternatingQueue(n: number): number {
+    const values: number[] = [];
+    for (let i: number = 0; i < 64; i++) values.push(i);
+    let checksum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        checksum = checksum + values.shift();
+        values.push(i + 64);
+    }
+    return checksum + values.length;
+}
+
+const sizes: number[] = [1000, 2500, 5000, 10000];
 for (let i: number = 0; i < sizes.length; i++) {
     const n: number = sizes[i];
-    bench("array-shift-drain", n, () => shiftDrain(n));
-    bench("array-unshift-build", n, () => unshiftBuild(n));
+    bench("array-shift-drain", n, () => shiftDrain(n), n * (n - 1) / 2);
+    bench("array-unshift-build", n, () => unshiftBuild(n), 2 * n - 1);
+    bench("array-alternating-queue", n, () => alternatingQueue(n), n * (n - 1) / 2 + 64);
 }

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Baselines/ArrayQueueBaselines.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Baselines/ArrayQueueBaselines.cs
@@ -2,6 +2,22 @@ namespace SharpTS.Microbenchmarks.Baselines;
 
 public static class ArrayQueueBaselines
 {
+    public static double DequeShiftDrain(int n)
+    {
+        var values = new SharpTS.Runtime.Deque<double>();
+        for (int i = 0; i < n; i++) values.AddLast(i);
+        double checksum = 0;
+        while (values.Count > 0) checksum += values.RemoveFirst();
+        return checksum;
+    }
+
+    public static double DequeUnshiftBuild(int n)
+    {
+        var values = new SharpTS.Runtime.Deque<double>();
+        for (int i = 0; i < n; i++) values.AddFirst(i);
+        return values.Count + values[0] + values[n - 1];
+    }
+
     public static double ShiftDrain(int n)
     {
         var values = new List<double>(n);

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ArrayQueueBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ArrayQueueBenchmarks.cs
@@ -33,6 +33,8 @@ public class ArrayQueueBenchmarks
         BenchmarkHarness.InitializeCompiledModules(compiled);
         _shift = BenchmarkHarness.GetCompiledNumberFunc(compiled, "arrayShiftDrain");
         _unshift = BenchmarkHarness.GetCompiledNumberFunc(compiled, "arrayUnshiftBuild");
+        if (_shift(N) != (double)N * (N - 1) / 2 || _unshift(N) != 2 * N - 1)
+            throw new InvalidOperationException("Array queue checksum mismatch.");
     }
 
     [Benchmark]
@@ -44,10 +46,18 @@ public class ArrayQueueBenchmarks
     public double CSharp_Shift() => ArrayQueueBaselines.ShiftDrain(N);
 
     [Benchmark]
+    [BenchmarkCategory("Shift")]
+    public double CSharp_DequeShift() => ArrayQueueBaselines.DequeShiftDrain(N);
+
+    [Benchmark]
     [BenchmarkCategory("Unshift")]
     public double SharpTS_Unshift() => _unshift(N);
 
     [Benchmark(Baseline = true)]
     [BenchmarkCategory("Unshift")]
     public double CSharp_Unshift() => ArrayQueueBaselines.UnshiftBuild(N);
+
+    [Benchmark]
+    [BenchmarkCategory("Unshift")]
+    public double CSharp_DequeUnshift() => ArrayQueueBaselines.DequeUnshiftBuild(N);
 }

--- a/benchmarks/micro/SharpTS.Microbenchmarks/README.md
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/README.md
@@ -72,6 +72,20 @@ typed parameters, categories, and operations-per-invoke directly from
 BenchmarkDotNet descriptors. See the [public snapshot exporter](../../snapshots/README.md)
 for normalized compiler-headroom publication.
 
+`ArrayQueueBenchmarks` retains the preallocated C# `List<double>` baselines and
+also measures the runtime's `Deque<double>` as an algorithmic ceiling. The list
+baselines repeatedly copy elements at the front, so matching those baselines
+does not establish efficient queue behavior. Deque baselines grow from empty,
+matching the TypeScript initialization. Compare allocation columns as well as
+time: counted push loops can reserve storage, while repeated unshift grows it.
+
+Compiled non-escaping queues use two typed stacks with constant-time indexed
+reads and amortized constant-time front operations. Ordinary arrays keep list
+promotion. Queues with admitted bounded literal writes use nullable slots to
+preserve holes; other write shapes and higher-order methods retain existing
+lowering. The interpreter uses its circular buffer only when conservative shape
+guards permit bypassing per-index property operations.
+
 ## Conventions
 
 - **One algorithm per class**, each with a single `[Params]` axis — a single

--- a/src/SharpTS/Compilation/ArrayLocalPromotionAnalyzer.cs
+++ b/src/SharpTS/Compilation/ArrayLocalPromotionAnalyzer.cs
@@ -59,6 +59,11 @@ public static class ArrayLocalPromotionAnalyzer
             if (!visitor.ElementToken.TryGetValue(key, out var token)) continue; // no Double/Bool use seen
             if (closures?.IsVariableCaptured(key.Name) == true) continue;
             typeMap.MarkPromotableArrayLocal(nameToken, token);
+            if (visitor.QueueReceivers.Contains(key) && !visitor.QueueIncompatible.Contains(key))
+            {
+                typeMap.MarkPromotableQueueLocal(nameToken);
+                if (visitor.QueueWrites.Contains(key)) typeMap.MarkQueueLocalWithWrites(nameToken);
+            }
             if (visitor.NumericSliceSortReceivers.TryGetValue(key, out var receiverToken))
                 typeMap.MarkStableNumericSliceSortReceiver(receiverToken);
         }
@@ -102,6 +107,9 @@ public static class ArrayLocalPromotionAnalyzer
 
         /// <summary>(scope, name) pairs with at least one disqualifying occurrence.</summary>
         public HashSet<(int Scope, string Name)> Disqualified { get; } = new();
+        public HashSet<(int Scope, string Name)> QueueReceivers { get; } = new();
+        public HashSet<(int Scope, string Name)> QueueIncompatible { get; } = new();
+        public HashSet<(int Scope, string Name)> QueueWrites { get; } = new();
 
         protected override void VisitFunction(Stmt.Function stmt) => InScope(() => base.VisitFunction(stmt));
         protected override void VisitArrowFunction(Expr.ArrowFunction expr) => InScope(() => base.VisitArrowFunction(expr));
@@ -123,6 +131,8 @@ public static class ArrayLocalPromotionAnalyzer
         private void HandleDeclaration(Token name, Expr? initializer)
         {
             var key = (_scope, name.Lexeme);
+            if (initializer is not Expr.ArrayLiteral { Elements.Count: 0 })
+                QueueIncompatible.Add(key);
             DeclCount[key] = DeclCount.GetValueOrDefault(key) + 1;
 
             // A promotable-array local is one initialized with an empty array literal `[]` OR a
@@ -228,6 +238,8 @@ public static class ArrayLocalPromotionAnalyzer
 
         protected override void VisitGetIndex(Expr.GetIndex expr)
         {
+            if (expr.Object is Expr.Variable queueIndex && !IsNumberExpression(expr.Index))
+                QueueIncompatible.Add((_scope, queueIndex.Name.Lexeme));
             // `x[i]` read — permitted when receiver is a bare variable. Record the
             // element kind and visit only the index (NOT the receiver variable).
             if (expr.Object is Expr.Variable v && !expr.Optional)
@@ -242,6 +254,12 @@ public static class ArrayLocalPromotionAnalyzer
             // `x[i] = v` write — permitted receiver; visit index and value only.
             if (expr.Object is Expr.Variable v)
             {
+                // Only bounded literal writes are admitted by the initial queue
+                // representation. Other writes retain the existing array lowering.
+                QueueWrites.Add((_scope, v.Name.Lexeme));
+                if (expr.Index is not Expr.Literal { Value: double index }
+                    || index < 0 || index > 65535 || index != Math.Truncate(index))
+                    QueueIncompatible.Add((_scope, v.Name.Lexeme));
                 NotePermittedReceiver(v);
                 // A written value whose static type admits the `undefined` sentinel
                 // (any/unknown/…) would be coerced to NaN/false by the typed setter,
@@ -271,6 +289,13 @@ public static class ArrayLocalPromotionAnalyzer
 
         protected override void VisitCall(Expr.Call expr)
         {
+            if (expr.Callee is Expr.Get { Object: Expr.Variable queueReceiver } queueMethod)
+            {
+                var key = (_scope, queueReceiver.Name.Lexeme);
+                if (queueMethod.Name.Lexeme is "shift" or "unshift") QueueReceivers.Add(key);
+                else if (queueMethod.Name.Lexeme != "push") QueueIncompatible.Add(key);
+                if (expr.Optional || queueMethod.Optional) QueueIncompatible.Add(key);
+            }
             // A stable intrinsic includes call over a number[] can scan the promoted
             // List<double> directly. Restrict both arguments to statically numeric
             // values so no ToNumber coercion (and therefore no user code or mutation)

--- a/src/SharpTS/Compilation/CompilationContext.cs
+++ b/src/SharpTS/Compilation/CompilationContext.cs
@@ -502,6 +502,17 @@ public partial class CompilationContext
         return null;
     }
 
+    public (LocalBuilder Local, ArrayQueueTypeInfo Queue)? TryGetPromotedQueueLocal(string name)
+    {
+        if (Runtime == null || !Locals.TryGetLocal(name, out var local)) return null;
+        var type = Locals.GetLocalType(name);
+        if (type == Runtime.NumberQueue.Type) return (local, Runtime.NumberQueue);
+        if (type == Runtime.BooleanQueue.Type) return (local, Runtime.BooleanQueue);
+        if (type == Runtime.NumberQueueWithHoles.Type) return (local, Runtime.NumberQueueWithHoles);
+        if (type == Runtime.BooleanQueueWithHoles.Type) return (local, Runtime.BooleanQueueWithHoles);
+        return null;
+    }
+
     /// <summary>
     /// Resolves a promoted numeric Map local. The concrete slot type is the
     /// scope-correct source of truth, so same-named boxed Maps cannot enter the

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -17,6 +17,10 @@ namespace SharpTS.Compilation;
 /// <seealso cref="ILEmitter"/>
 public class EmittedRuntime
 {
+    public ArrayQueueTypeInfo NumberQueue { get; set; } = null!;
+    public ArrayQueueTypeInfo BooleanQueue { get; set; } = null!;
+    public ArrayQueueTypeInfo NumberQueueWithHoles { get; set; } = null!;
+    public ArrayQueueTypeInfo BooleanQueueWithHoles { get; set; } = null!;
     /// <summary>
     /// Human-readable reasons this compilation emitted late binding into the SharpTS runtime
     /// assembly (e.g. "eval()", "Proxy", "Intl"). Populated during emission by

--- a/src/SharpTS/Compilation/ILEmitter.ArrayQueue.cs
+++ b/src/SharpTS/Compilation/ILEmitter.ArrayQueue.cs
@@ -1,0 +1,36 @@
+using System.Reflection.Emit;
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation;
+
+public partial class ILEmitter
+{
+    private void EmitQueueGet(LocalBuilder local, ArrayQueueTypeInfo queue, Expr index, bool numeric)
+    {
+        // A fractional/NaN/out-of-Int32 key cannot name a slot in this private
+        // representation. Evaluate it once, preserving any mutation side effects.
+        EmitExpressionAsDouble(index);
+        var key = IL.DeclareLocal(_ctx.Types.Double);
+        var integer = IL.DeclareLocal(_ctx.Types.Int32);
+        var missing = IL.DefineLabel();
+        var end = IL.DefineLabel();
+        IL.Emit(OpCodes.Stloc, key);
+        IL.Emit(OpCodes.Ldloc, key);
+        IL.Emit(OpCodes.Conv_I4);
+        IL.Emit(OpCodes.Stloc, integer);
+        IL.Emit(OpCodes.Ldloc, integer);
+        IL.Emit(OpCodes.Conv_R8);
+        IL.Emit(OpCodes.Ldloc, key);
+        IL.Emit(OpCodes.Bne_Un, missing);
+        IL.Emit(OpCodes.Ldloc, local);
+        IL.Emit(OpCodes.Ldloc, integer);
+        IL.Emit(OpCodes.Call, numeric ? queue.GetNumber! : queue.Get);
+        IL.Emit(OpCodes.Br, end);
+        IL.MarkLabel(missing);
+        if (numeric) IL.Emit(OpCodes.Ldc_R8, double.NaN);
+        else IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.UndefinedInstance);
+        IL.MarkLabel(end);
+        if (numeric) SetStackType(StackType.Double);
+        else SetStackUnknown();
+    }
+}

--- a/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.MethodDispatch.cs
@@ -12,6 +12,30 @@ public partial class ILEmitter
 {
     protected override bool TryEmitDiscardedExpression(Expr expression)
     {
+        if (expression is Expr.Call
+            {
+                Optional: false, Arguments.Count: 0,
+                Callee: Expr.Get { Optional: false, Name.Lexeme: "shift", Object: Expr.Variable shifted }
+            }
+            && _ctx.TryGetPromotedQueueLocal(shifted.Name.Lexeme) is { Queue.ShiftNumber: { } shift } numericQueue)
+        {
+            IL.Emit(OpCodes.Ldloc, numericQueue.Local);
+            IL.Emit(OpCodes.Call, shift);
+            IL.Emit(OpCodes.Pop);
+            SetStackUnknown();
+            return true;
+        }
+        if ((expression is Expr.Call { Callee: Expr.Get { Object: Expr.Variable queueCall } }
+                && _ctx.TryGetPromotedQueueLocal(queueCall.Name.Lexeme) != null)
+            || (expression is Expr.SetIndex { Object: Expr.Variable queueWrite }
+                && _ctx.TryGetPromotedQueueLocal(queueWrite.Name.Lexeme) != null))
+        {
+            // Do not route the private queue through $Array/List-only shortcuts.
+            EmitExpression(expression);
+            IL.Emit(OpCodes.Pop);
+            SetStackUnknown();
+            return true;
+        }
         // Shared-counter loops almost always discard Atomics.add's old-value result. When the
         // receiver is statically Int32/Uint32, keep all three operands unboxed and call the
         // Interlocked-backed helper directly; manufacturing a boxed double solely to pop it was
@@ -238,6 +262,41 @@ public partial class ILEmitter
                 IL.Emit(OpCodes.Ceq);
             }
             SetStackType(StackType.Boolean);
+            return;
+        }
+
+        if (!methodGet.Optional && methodGet.Object is Expr.Variable queueReceiver
+            && _ctx.TryGetPromotedQueueLocal(queueReceiver.Name.Lexeme) is { } queue)
+        {
+            if (methodName == "shift")
+            {
+                IL.Emit(OpCodes.Ldloc, queue.Local);
+                IL.Emit(OpCodes.Call, queue.Queue.Shift);
+                SetStackUnknown();
+                return;
+            }
+            // Evaluate every argument before changing the receiver, including push.
+            var values = new List<LocalBuilder>();
+            foreach (var argument in arguments)
+            {
+                EmitExpression(argument);
+                if (queue.Queue.Elements.Kind == ArrayElementsKind.Double) EnsureDouble();
+                else EnsureBoolean();
+                var value = IL.DeclareLocal(queue.Queue.Elements.GetElementType(_ctx.Types));
+                IL.Emit(OpCodes.Stloc, value);
+                values.Add(value);
+            }
+            if (methodName == "unshift") values.Reverse();
+            foreach (var value in values)
+            {
+                IL.Emit(OpCodes.Ldloc, queue.Local);
+                IL.Emit(OpCodes.Ldloc, value);
+                IL.Emit(OpCodes.Call, methodName == "unshift" ? queue.Queue.Unshift : queue.Queue.Push);
+            }
+            IL.Emit(OpCodes.Ldloc, queue.Local);
+            IL.Emit(OpCodes.Call, queue.Queue.Count);
+            IL.Emit(OpCodes.Conv_R8);
+            SetStackType(StackType.Double);
             return;
         }
 

--- a/src/SharpTS/Compilation/ILEmitter.Helpers.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Helpers.cs
@@ -322,6 +322,24 @@ public partial class ILEmitter
 
     public override void EmitExpressionAsDouble(Expr expr)
     {
+        if (expr is Expr.Call
+            {
+                Optional: false, Arguments.Count: 0,
+                Callee: Expr.Get { Optional: false, Name.Lexeme: "shift", Object: Expr.Variable receiver }
+            }
+            && _ctx.TryGetPromotedQueueLocal(receiver.Name.Lexeme) is { Queue.ShiftNumber: { } shift } queue)
+        {
+            IL.Emit(OpCodes.Ldloc, queue.Local);
+            IL.Emit(OpCodes.Call, shift);
+            SetStackType(StackType.Double);
+            return;
+        }
+        if (expr is Expr.GetIndex { Optional: false, Object: Expr.Variable indexed } index
+            && _ctx.TryGetPromotedQueueLocal(indexed.Name.Lexeme) is { Queue.GetNumber: not null } indexedQueue)
+        {
+            EmitQueueGet(indexedQueue.Local, indexedQueue.Queue, index.Index, numeric: true);
+            return;
+        }
         if (expr is Expr.Get stableRecordGet
             && TryEmitStableRecordDestructureGetAsDouble(stableRecordGet))
             return;

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -312,6 +312,16 @@ public partial class ILEmitter
                 return;
         }
 
+        if (!g.Optional && g.Name.Lexeme == "length" && g.Object is Expr.Variable queueLength
+            && _ctx.TryGetPromotedQueueLocal(queueLength.Name.Lexeme) is { } queueLen)
+        {
+            IL.Emit(OpCodes.Ldloc, queueLen.Local);
+            IL.Emit(OpCodes.Call, queueLen.Queue.Count);
+            IL.Emit(OpCodes.Conv_R8);
+            SetStackType(StackType.Double);
+            return;
+        }
+
         // Promoted typed-array local `.length` (#857): direct List<T>.Count, no GetLength/isinst.
         if (!g.Optional && g.Name.Lexeme == "length" && g.Object is Expr.Variable promVarLen
             && _ctx.TryGetPromotedArrayLocal(promVarLen.Name.Lexeme) is { } promLen)
@@ -1255,6 +1265,13 @@ public partial class ILEmitter
         // OOB/in-range merge (the #860 unboxed-element read is deferred — see plan B3). Even boxed,
         // this still drops the per-access isinst ladder and the $Array virtual dispatch. The
         // `(uint)i >= (uint)Count` compare folds the negative-index case into the OOB branch.
+        if (!gi.Optional && gi.Object is Expr.Variable queueRead
+            && _ctx.TryGetPromotedQueueLocal(queueRead.Name.Lexeme) is { } queueGet)
+        {
+            EmitQueueGet(queueGet.Local, queueGet.Queue, gi.Index, numeric: false);
+            return;
+        }
+
         if (!gi.Optional && gi.Object is Expr.Variable promVarGet
             && _ctx.TryGetPromotedArrayLocal(promVarGet.Name.Lexeme) is { } promGet
             && _ctx.TypeMap?.Get(gi.Index) is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral)
@@ -1549,6 +1566,7 @@ public partial class ILEmitter
             || ArrayElements.Resolve(_ctx.TypeMap?.Get(gi.Object)) is not
                 { Kind: ArrayElementsKind.Double }
             || _ctx.TryGetPromotedArrayLocal(arrayVariable.Name.Lexeme) != null
+            || _ctx.TryGetPromotedQueueLocal(arrayVariable.Name.Lexeme) != null
             || !IsNumericType(_ctx.TypeMap?.Get(gi.Index))
             || _ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == true
             || _ctx.RuntimeFeatures?.UsesArrayPrototypeMutation == true)
@@ -1773,6 +1791,23 @@ public partial class ILEmitter
         // overwhelmingly common in-range write as List<T>.set_Item and retain the typed auto-extend
         // helper as a cold fallback. The receiver is a side-effect-free local, so evaluating index
         // before value preserves JavaScript assignment order without an observable receiver load.
+        if (si.Object is Expr.Variable queueWrite
+            && _ctx.TryGetPromotedQueueLocal(queueWrite.Name.Lexeme) is { } queueSet)
+        {
+            var value = IL.DeclareLocal(queueSet.Queue.Elements.GetElementType(_ctx.Types));
+            EmitExpression(si.Value);
+            if (queueSet.Queue.Elements.Kind == ArrayElementsKind.Double) EnsureDouble();
+            else EnsureBoolean();
+            IL.Emit(OpCodes.Stloc, value);
+            IL.Emit(OpCodes.Ldloc, queueSet.Local);
+            EmitIndexAsInt32(si.Index); // Queue promotion admits only literal write indices.
+            IL.Emit(OpCodes.Ldloc, value);
+            IL.Emit(OpCodes.Call, queueSet.Queue.Set);
+            IL.Emit(OpCodes.Ldloc, value);
+            SetStackType(queueSet.Queue.Elements.StackType);
+            return;
+        }
+
         if (si.Object is Expr.Variable promVarSet
             && _ctx.TryGetPromotedArrayLocal(promVarSet.Name.Lexeme) is { } promSet)
         {

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -497,6 +497,18 @@ public partial class ILEmitter
         // captured name (which has no typed local) can never accidentally hit them.
         if (_ctx.TypeMap != null && _ctx.TypeMap.IsPromotableArrayLocal(v.Name, out var promoElemTok))
         {
+            if (_ctx.TypeMap.IsPromotableQueueLocal(v.Name))
+            {
+                var queue = promoElemTok == TokenType.TYPE_NUMBER
+                    ? _ctx.Runtime!.NumberQueue : _ctx.Runtime!.BooleanQueue;
+                if (_ctx.TypeMap.QueueLocalHasWrites(v.Name))
+                    queue = promoElemTok == TokenType.TYPE_NUMBER
+                        ? _ctx.Runtime!.NumberQueueWithHoles : _ctx.Runtime!.BooleanQueueWithHoles;
+                var queueLocal = _ctx.Locals.DeclareLocal(v.Name.Lexeme, queue.Type);
+                IL.Emit(OpCodes.Newobj, queue.Constructor);
+                IL.Emit(OpCodes.Stloc, queueLocal);
+                return;
+            }
             // Initializer kinds the typed slot can hold: an empty array literal `[]` (build a fresh
             // List), or a typed-double `src.map(cb)` (#861 typed-HOF pipeline) when the source is
             // itself a promoted List<double> and the mapper is a typed non-capturing arrow — decided
@@ -1667,8 +1679,9 @@ public partial class ILEmitter
             return;
 
         var promoted = _ctx.TryGetPromotedArrayLocal(reservation.Array.Name.Lexeme);
+        var queue = _ctx.TryGetPromotedQueueLocal(reservation.Array.Name.Lexeme);
         var sourceLocal = promoted?.Local ?? arrayLocal;
-        var listType = promoted?.Descriptor.GetListType(_ctx.Types) ?? _ctx.Types.ListOfObject;
+        var listType = queue?.Queue.Type ?? promoted?.Descriptor.GetListType(_ctx.Types) ?? _ctx.Types.ListOfObject;
         var listLocal = IL.DeclareLocal(listType);
         var countLocal = IL.DeclareLocal(_ctx.Types.Double);
         var skipLabel = _ctx.ILBuilder.DefineLabel("counted_push_reserve_skip");
@@ -1698,10 +1711,11 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Ldloc, countLocal);
         IL.Emit(OpCodes.Call, typeof(Math).GetMethod("Ceiling", [_ctx.Types.Double])!);
         IL.Emit(OpCodes.Conv_I4);
-        IL.Emit(OpCodes.Callvirt, _ctx.Types.GetMethod(
-            listType,
-            "EnsureCapacity",
-            [_ctx.Types.Int32])!);
+        if (queue is { } queueReservation)
+            IL.Emit(OpCodes.Call, queueReservation.Queue.Reserve);
+        else
+            IL.Emit(OpCodes.Callvirt, _ctx.Types.GetMethod(
+                listType, "EnsureCapacity", [_ctx.Types.Int32])!);
         IL.Emit(OpCodes.Pop);
 
         _ctx.ILBuilder.MarkLabel(skipLabel);
@@ -1835,7 +1849,8 @@ public partial class ILEmitter
         // fast paths read it directly; hoisting would only emit a dead isinst + local.
         foreach (var name in candidates.Keys.ToList())
         {
-            if (_ctx.TryGetHoistedArray(name) != null || _ctx.TryGetPromotedArrayLocal(name) != null)
+            if (_ctx.TryGetHoistedArray(name) != null || _ctx.TryGetPromotedArrayLocal(name) != null
+                || _ctx.TryGetPromotedQueueLocal(name) != null)
                 candidates.Remove(name);
         }
         if (candidates.Count == 0) return false;

--- a/src/SharpTS/Compilation/RuntimeEmitter.ArrayQueue.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.ArrayQueue.cs
@@ -1,0 +1,200 @@
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace SharpTS.Compilation;
+
+/// <summary>Metadata for a private, non-escaping primitive array queue.</summary>
+public sealed record ArrayQueueTypeInfo(
+    TypeBuilder Type, ConstructorBuilder Constructor, ArrayElementsDescriptor Elements,
+    MethodBuilder Count, MethodBuilder Push, MethodBuilder Unshift,
+    MethodBuilder Shift, MethodBuilder Get, MethodBuilder Set,
+    MethodBuilder? ShiftNumber, MethodBuilder? GetNumber, MethodBuilder Reserve);
+
+public partial class RuntimeEmitter
+{
+    /// <summary>
+    /// Two typed stacks implement the admitted queue operations. Front is in reverse
+    /// order; back is in insertion order. Only when front is empty does shift reverse
+    /// and swap back into front. Each appended element moves at most once, giving
+    /// amortized O(1) push/shift/unshift and O(1) indexed access without changing the
+    /// representation used by ordinary promoted array loops. Only queues admitting
+    /// indexed writes use nullable slots to preserve holes; dense queues keep native
+    /// double/bool storage. All dependencies are BCL types.
+    /// </summary>
+    private ArrayQueueTypeInfo EmitArrayQueue(ModuleBuilder module, EmittedRuntime runtime,
+        ArrayElementsDescriptor elements, bool holes = false)
+    {
+        var element = elements.GetElementType(_types);
+        var slot = holes ? _types.MakeNullable(element) : element;
+        var list = _types.MakeGenericType(_types.ListOpen, slot);
+        var type = module.DefineType("$ArrayQueue" + elements.Kind + (holes ? "WithHoles" : ""),
+            TypeAttributes.NotPublic | TypeAttributes.Sealed, _types.Object);
+        var front = type.DefineField("_front", list, FieldAttributes.Private);
+        var back = type.DefineField("_back", list, FieldAttributes.Private);
+        var listCount = _types.GetMethodNoParams(list, "get_Count");
+        var listGet = _types.GetMethod(list, "get_Item", _types.Int32);
+        var listAdd = _types.GetMethod(list, "Add", slot);
+        var slotCtor = holes ? _types.GetConstructor(slot, element) : null;
+        var ctor = type.DefineConstructor(MethodAttributes.Public,
+            CallingConventions.Standard, Type.EmptyTypes);
+        var il = ctor.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _types.GetDefaultConstructor(_types.Object));
+        foreach (var field in new[] { front, back })
+        {
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(list));
+            il.Emit(OpCodes.Stfld, field);
+        }
+        il.Emit(OpCodes.Ret);
+
+        MethodBuilder Method(string name, Type result, params Type[] args) =>
+            type.DefineMethod(name, MethodAttributes.Public | MethodAttributes.HideBySig, result, args);
+        void LoadList(ILGenerator body, FieldBuilder field)
+        {
+            body.Emit(OpCodes.Ldarg_0);
+            body.Emit(OpCodes.Ldfld, field);
+        }
+        var count = Method("Count", _types.Int32);
+        il = count.GetILGenerator();
+        LoadList(il, front); il.Emit(OpCodes.Callvirt, listCount);
+        LoadList(il, back); il.Emit(OpCodes.Callvirt, listCount);
+        il.Emit(OpCodes.Add); il.Emit(OpCodes.Ret);
+
+        MethodBuilder Append(string name, FieldBuilder field)
+        {
+            var method = Method(name, _types.Void, element);
+            var body = method.GetILGenerator();
+            LoadList(body, field);
+            body.Emit(OpCodes.Ldarg_1);
+            if (holes) body.Emit(OpCodes.Newobj, slotCtor!);
+            body.Emit(OpCodes.Callvirt, listAdd);
+            body.Emit(OpCodes.Ret);
+            return method;
+        }
+        var push = Append("Push", back);
+        var unshift = Append("Unshift", front);
+        var reserve = Method("EnsureCapacity", _types.Int32, _types.Int32);
+        il = reserve.GetILGenerator();
+        LoadList(il, back); il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(list, "EnsureCapacity", _types.Int32));
+        il.Emit(OpCodes.Ret);
+
+        var take = Method("Take", slot);
+        il = take.GetILGenerator();
+        var ready = il.DefineLabel();
+        var empty = il.DefineLabel();
+        var temp = il.DeclareLocal(list);
+        var index = il.DeclareLocal(_types.Int32);
+        var value = il.DeclareLocal(slot);
+        LoadList(il, front); il.Emit(OpCodes.Callvirt, listCount);
+        il.Emit(OpCodes.Brtrue, ready);
+        LoadList(il, back); il.Emit(OpCodes.Callvirt, listCount);
+        il.Emit(OpCodes.Brfalse, empty);
+        LoadList(il, back); il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(list, "Reverse"));
+        LoadList(il, front); il.Emit(OpCodes.Stloc, temp);
+        il.Emit(OpCodes.Ldarg_0); LoadList(il, back); il.Emit(OpCodes.Stfld, front);
+        il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Ldloc, temp); il.Emit(OpCodes.Stfld, back);
+        il.MarkLabel(ready);
+        LoadList(il, front); il.Emit(OpCodes.Callvirt, listCount);
+        il.Emit(OpCodes.Ldc_I4_1); il.Emit(OpCodes.Sub); il.Emit(OpCodes.Stloc, index);
+        LoadList(il, front); il.Emit(OpCodes.Ldloc, index); il.Emit(OpCodes.Callvirt, listGet);
+        il.Emit(OpCodes.Stloc, value);
+        LoadList(il, front); il.Emit(OpCodes.Ldloc, index);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(list, "RemoveAt", _types.Int32));
+        il.MarkLabel(empty);
+        il.Emit(OpCodes.Ldloc, value); il.Emit(OpCodes.Ret);
+
+        var read = Method("Read", slot, _types.Int32);
+        il = read.GetILGenerator();
+        var inBack = il.DefineLabel();
+        empty = il.DefineLabel();
+        value = il.DeclareLocal(slot);
+        var frontCount = il.DeclareLocal(_types.Int32);
+        il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldarg_0); il.Emit(OpCodes.Call, count);
+        il.Emit(OpCodes.Bge_Un, empty);
+        LoadList(il, front); il.Emit(OpCodes.Callvirt, listCount); il.Emit(OpCodes.Stloc, frontCount);
+        il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldloc, frontCount); il.Emit(OpCodes.Bge, inBack);
+        LoadList(il, front); il.Emit(OpCodes.Ldloc, frontCount); il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Sub); il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Callvirt, listGet); il.Emit(OpCodes.Ret);
+        il.MarkLabel(inBack);
+        LoadList(il, back); il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldloc, frontCount);
+        il.Emit(OpCodes.Sub); il.Emit(OpCodes.Callvirt, listGet); il.Emit(OpCodes.Ret);
+        il.MarkLabel(empty); il.Emit(OpCodes.Ldloc, value); il.Emit(OpCodes.Ret);
+
+        MethodBuilder ConvertResult(string name, MethodBuilder source, bool numeric, params Type[] args)
+        {
+            var method = Method(name, numeric ? _types.Double : _types.Object, args);
+            var body = method.GetILGenerator();
+            var local = body.DeclareLocal(slot);
+            var present = body.DefineLabel();
+            var missing = body.DefineLabel();
+            if (!holes)
+            {
+                if (args.Length != 0) body.Emit(OpCodes.Ldarg_1);
+                body.Emit(OpCodes.Ldarg_0); body.Emit(OpCodes.Call, count);
+                body.Emit(args.Length != 0 ? OpCodes.Bge_Un : OpCodes.Brfalse, missing);
+            }
+            body.Emit(OpCodes.Ldarg_0);
+            if (args.Length != 0) body.Emit(OpCodes.Ldarg_1);
+            body.Emit(OpCodes.Call, source); body.Emit(OpCodes.Stloc, local);
+            if (holes)
+            {
+                body.Emit(OpCodes.Ldloca, local);
+                body.Emit(OpCodes.Call, _types.GetMethodNoParams(slot, "get_HasValue"));
+                body.Emit(OpCodes.Brtrue, present);
+            }
+            else body.Emit(OpCodes.Br, present);
+            body.MarkLabel(missing);
+            if (numeric) body.Emit(OpCodes.Ldc_R8, double.NaN);
+            else body.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+            body.Emit(OpCodes.Ret);
+            body.MarkLabel(present);
+            if (holes)
+            {
+                body.Emit(OpCodes.Ldloca, local);
+                body.Emit(OpCodes.Call, _types.GetMethodNoParams(slot, "GetValueOrDefault"));
+            }
+            else body.Emit(OpCodes.Ldloc, local);
+            if (!numeric) body.Emit(OpCodes.Box, element);
+            body.Emit(OpCodes.Ret);
+            return method;
+        }
+        var shift = ConvertResult("Shift", take, false);
+        var get = ConvertResult("Get", read, false, _types.Int32);
+        var shiftNumber = elements.Kind == ArrayElementsKind.Double ? ConvertResult("ShiftNumber", take, true) : null;
+        var getNumber = elements.Kind == ArrayElementsKind.Double ? ConvertResult("GetNumber", read, true, _types.Int32) : null;
+
+        var set = Method("Set", _types.Void, _types.Int32, element);
+        il = set.GetILGenerator();
+        frontCount = il.DeclareLocal(_types.Int32);
+        var hole = il.DeclareLocal(slot);
+        inBack = il.DefineLabel();
+        var extend = il.DefineLabel();
+        var store = il.DefineLabel();
+        LoadList(il, front); il.Emit(OpCodes.Callvirt, listCount); il.Emit(OpCodes.Stloc, frontCount);
+        il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldloc, frontCount); il.Emit(OpCodes.Bge, inBack);
+        LoadList(il, front); il.Emit(OpCodes.Ldloc, frontCount); il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Sub); il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Ldarg_2);
+        if (holes) il.Emit(OpCodes.Newobj, slotCtor!);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(list, "set_Item", _types.Int32, slot));
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(inBack);
+        il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldloc, frontCount); il.Emit(OpCodes.Sub);
+        il.Emit(OpCodes.Starg_S, (byte)1);
+        il.MarkLabel(extend);
+        LoadList(il, back); il.Emit(OpCodes.Callvirt, listCount); il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Bgt, store);
+        LoadList(il, back); il.Emit(OpCodes.Ldloc, hole); il.Emit(OpCodes.Callvirt, listAdd);
+        il.Emit(OpCodes.Br, extend);
+        il.MarkLabel(store);
+        LoadList(il, back); il.Emit(OpCodes.Ldarg_1); il.Emit(OpCodes.Ldarg_2);
+        if (holes) il.Emit(OpCodes.Newobj, slotCtor!);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(list, "set_Item", _types.Int32, slot));
+        il.Emit(OpCodes.Ret);
+        type.CreateType();
+        return new(type, ctor, elements, count, push, unshift, shift, get, set, shiftNumber, getNumber, reserve);
+    }
+}

--- a/src/SharpTS/Compilation/RuntimeEmitter.ArrayQueue.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.ArrayQueue.cs
@@ -27,7 +27,7 @@ public partial class RuntimeEmitter
         var element = elements.GetElementType(_types);
         var slot = holes ? _types.MakeNullable(element) : element;
         var list = _types.MakeGenericType(_types.ListOpen, slot);
-        var type = module.DefineType("$ArrayQueue" + elements.Kind + (holes ? "WithHoles" : ""),
+        var type = EmitTypeDefinitions.DefineType(module, "$ArrayQueue" + elements.Kind + (holes ? "WithHoles" : ""),
             TypeAttributes.NotPublic | TypeAttributes.Sealed, _types.Object);
         var front = type.DefineField("_front", list, FieldAttributes.Private);
         var back = type.DefineField("_back", list, FieldAttributes.Private);

--- a/src/SharpTS/Compilation/RuntimeEmitter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.cs
@@ -43,6 +43,10 @@ public partial class RuntimeEmitter
 
         // Emit $Undefined singleton class first (other methods need this type)
         EmitUndefinedClass(moduleBuilder, runtime);
+        runtime.NumberQueue = EmitArrayQueue(moduleBuilder, runtime, ArrayElements.Double);
+        runtime.BooleanQueue = EmitArrayQueue(moduleBuilder, runtime, ArrayElements.Bool);
+        runtime.NumberQueueWithHoles = EmitArrayQueue(moduleBuilder, runtime, ArrayElements.Double, true);
+        runtime.BooleanQueueWithHoles = EmitArrayQueue(moduleBuilder, runtime, ArrayElements.Bool, true);
         EmitLexicalUninitializedClass(moduleBuilder, runtime);
 
         // Marker used only to give compiler-generated prototype constructors a

--- a/src/SharpTS/Runtime/BuiltIns/ArrayBuiltIns.cs
+++ b/src/SharpTS/Runtime/BuiltIns/ArrayBuiltIns.cs
@@ -846,6 +846,8 @@ public static class ArrayBuiltIns
     {
         long length = ToLength(
             interpreter.GetPropertyValue(receiver, "length"), interpreter);
+        if (receiver is SharpTSArray dense && dense.CanUseDenseQueueFastPath(length))
+            return length == 0 ? SharpTSUndefined.Instance : dense.RemoveFirst();
         if (length == 0)
         {
             interpreter.SetProperty(receiver, "length", 0d);
@@ -892,6 +894,18 @@ public static class ArrayBuiltIns
             interpreter.GetPropertyValue(receiver, "length"), interpreter);
         if (items.Count > MaxSafeInteger - length)
             throw TypeError("Array.prototype.unshift result exceeds the maximum safe integer.");
+
+        // Existing dense own data properties shadow prototypes. New tail indices
+        // may encounter inherited setters, so unshift also checks both intrinsic
+        // prototypes before adding slots. These checks never scan array elements.
+        if (receiver is SharpTSArray dense && dense.CanUseDenseQueueFastPath(length)
+            && length + items.Count <= int.MaxValue
+            && !interpreter.GetArrayPrototype().HasIndexedExtra(length + items.Count)
+            && !interpreter.GetObjectPrototype().HasIndexedExtra(length + items.Count))
+        {
+            for (int i = items.Count - 1; i >= 0; i--) dense.AddFirst(items[i]);
+            return dense.LongLength;
+        }
 
         if (items.Count == 0)
         {

--- a/src/SharpTS/Runtime/Types/SharpTSArray.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSArray.cs
@@ -69,6 +69,10 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     private const int SparseThreshold = 1024;
 
     private readonly Deque<object?> _dense;
+    // Conservative shape state: once holes may exist, queue operations use the
+    // property algorithm. Never scan the backing on each shift/unshift.
+    private bool _mayHaveHoles;
+    private bool _ownsDenseStorage;
     private Dictionary<uint, object?>? _sparse;
     private object? _explicitPrototype;
 
@@ -106,20 +110,37 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// array in sparse mode: only the contiguous prefix that hasn't been
     /// sparse-promoted lives here.
     /// </summary>
-    internal Deque<object?> Elements => _dense;
+    internal Deque<object?> Elements
+    {
+        get
+        {
+            _ownsDenseStorage = false; // A caller can mutate this legacy backing view.
+            return _dense;
+        }
+    }
 
     /// <summary>Creates an empty array.</summary>
-    public SharpTSArray() : this(new Deque<object?>()) { }
+    public SharpTSArray() : this(new Deque<object?>()) { _ownsDenseStorage = true; }
 
     /// <summary>Creates an array from a deque (the deque becomes the dense backing).</summary>
     public SharpTSArray(Deque<object?> elements)
     {
         _dense = elements;
         _length = elements.Count;
+        _mayHaveHoles = elements.Any(value => value is ArrayHole);
     }
 
     /// <summary>Creates an array from any enumerable (copies into a new deque).</summary>
-    public SharpTSArray(IEnumerable<object?> elements) : this(new Deque<object?>(elements)) { }
+    public SharpTSArray(IEnumerable<object?> elements) : this(new Deque<object?>(elements))
+    {
+        _ownsDenseStorage = true;
+    }
+
+    internal bool CanUseDenseQueueFastPath(long expectedLength) =>
+        GetType() == typeof(SharpTSArray) && _ownsDenseStorage && !_mayHaveHoles
+        && !HasExplicitPrototype && !IsFrozen && !IsSealed && IsExtensible && _lengthWritable
+        && _sparse is null && _length == expectedLength && _dense.Count == expectedLength
+        && (_indexAccessors?.Count ?? 0) == 0 && (_descriptors?.Count ?? 0) == 0;
 
     /// <summary>
     /// ECMA-262 array length clamped to <see cref="int.MaxValue"/>.
@@ -241,6 +262,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// </summary>
     public void DeleteAt(long index)
     {
+        _mayHaveHoles = true;
         if (IsFrozen) return;
         if ((ulong)index >= (ulong)_length) return;
         if (index <= uint.MaxValue)
@@ -278,6 +300,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// <summary>Writes the slot at the given index without mutating length or transitioning.</summary>
     private void SetCore(long index, object? value)
     {
+        _mayHaveHoles |= value is ArrayHole;
         if (_sparse == null || index < _dense.Count)
             _dense[(int)index] = value;
         else
@@ -321,6 +344,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// <summary>Appends an element. Does not check frozen/sealed state.</summary>
     public void Add(object? value)
     {
+        _mayHaveHoles |= value is ArrayHole;
         if (_sparse != null)
         {
             // Appending on a sparse array: write directly to the dict at _length.
@@ -335,6 +359,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// <summary>Appends many elements. Does not check frozen/sealed state.</summary>
     public void AddRange(IEnumerable<object?> values)
     {
+        _mayHaveHoles = true; // Unknown enumerable; do not enumerate it twice.
         if (_sparse != null)
         {
             foreach (var v in values)
@@ -351,6 +376,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// <summary>Prepends an element (O(1) in dense mode via Deque).</summary>
     public void AddFirst(object? value)
     {
+        _mayHaveHoles |= value is ArrayHole;
         MaterializeDense();
         _dense.AddFirst(value);
         _length = _dense.Count;
@@ -359,6 +385,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// <summary>Inserts at an index, shifting later elements right.</summary>
     public void Insert(int index, object? value)
     {
+        _mayHaveHoles |= value is ArrayHole;
         MaterializeDense();
         _dense.Insert(index, value);
         _length = _dense.Count;
@@ -367,6 +394,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// <summary>Inserts many elements at an index.</summary>
     public void InsertRange(int index, IEnumerable<object?> values)
     {
+        _mayHaveHoles = true;
         MaterializeDense();
         _dense.InsertRange(index, values);
         _length = _dense.Count;
@@ -536,6 +564,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     {
         if (_sparse == null)
             return;
+        _mayHaveHoles = true;
         // Materialization copies every sparse entry into the dense prefix. If
         // _length exceeds int.MaxValue we can't represent that as a dense Deque.
         // Structural mutations (Insert / RemoveAt / AddFirst / Reverse) that
@@ -722,6 +751,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// </summary>
     private void SetCoreWithExtend(long index, object? value)
     {
+        _mayHaveHoles |= value is ArrayHole || index > _length;
         if (_sparse != null)
         {
             SetCore(index, value);
@@ -768,6 +798,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
             throw new Exception($"RangeError: Array length {newLength} exceeds ECMA-262 uint32 maximum.");
 
         if (newLength == _length) return;
+        _mayHaveHoles |= newLength > _length;
 
         if (newLength < _length)
         {
@@ -1378,6 +1409,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
                 _indexAccessors[uindex] = (
                     descriptor.HasGet ? descriptor.Get : existingIsAccessor ? existingGetter : null,
                     descriptor.HasSet ? descriptor.Set : existingIsAccessor ? existingSetter : null);
+                _mayHaveHoles = true;
                 // Accessors have no data value at the same index.
                 if (_sparse == null || index < _dense.Count)
                     _dense[(int)index] = ArrayHole.Instance;

--- a/src/SharpTS/TypeSystem/TypeMap.cs
+++ b/src/SharpTS/TypeSystem/TypeMap.cs
@@ -162,6 +162,13 @@ public class TypeMap
     public bool IsPromotableArrayLocal(Token nameToken, out TokenType elementToken) =>
         _promotableArrayLocals.TryGetValue(nameToken, out elementToken);
 
+    private readonly HashSet<Token> _promotableQueueLocals = new(ReferenceEqualityComparer.Instance);
+    public void MarkPromotableQueueLocal(Token nameToken) => _promotableQueueLocals.Add(nameToken);
+    public bool IsPromotableQueueLocal(Token nameToken) => _promotableQueueLocals.Contains(nameToken);
+    private readonly HashSet<Token> _queueLocalsWithWrites = new(ReferenceEqualityComparer.Instance);
+    public void MarkQueueLocalWithWrites(Token nameToken) => _queueLocalsWithWrites.Add(nameToken);
+    public bool QueueLocalHasWrites(Token nameToken) => _queueLocalsWithWrites.Contains(nameToken);
+
     private readonly HashSet<Token> _stableNumericSliceSortReceivers =
         new(ReferenceEqualityComparer.Instance);
 

--- a/tests/SharpTS.Tests/CompilerTests/ArrayQueuePromotionTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/ArrayQueuePromotionTests.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public class ArrayQueuePromotionTests
+{
+    private const string Source = """
+        function queue(n: number): number {
+            const values: number[] = [];
+            for (let i: number = 0; i < n; i++) values.push(i);
+            let total: number = 0;
+            while (values.length > 0) total = total + values.shift();
+            return total;
+        }
+        function indexed(): number {
+            const values: number[] = [];
+            values.push(1);
+            return values[0];
+        }
+        function holes(): number {
+            const values: number[] = [];
+            values[3] = 7;
+            values.unshift(1);
+            return values.length;
+        }
+        console.log(queue(100), indexed(), holes());
+        """;
+
+    [Fact]
+    public void QueueStorageIsSelectedWithoutChangingOrdinaryListPromotion()
+    {
+        var statements = new Parser(new Lexer(Source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var compiler = new ILCompiler($"array_queue_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, new DeadCodeAnalyzer(typeMap).Analyze(statements));
+        var assembly = Assembly.Load(compiler.SaveToBytes());
+        var methods = assembly.GetType("$Program")!.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.Contains(methods.Single(m => m.Name.EndsWith("queue")).GetMethodBody()!.LocalVariables,
+            local => local.LocalType.Name == "$ArrayQueueDouble");
+        Assert.Contains(methods.Single(m => m.Name.EndsWith("indexed")).GetMethodBody()!.LocalVariables,
+            local => local.LocalType == typeof(List<double>));
+        Assert.Contains(methods.Single(m => m.Name.EndsWith("holes")).GetMethodBody()!.LocalVariables,
+            local => local.LocalType.Name == "$ArrayQueueDoubleWithHoles");
+        Assert.DoesNotContain(assembly.GetReferencedAssemblies(), reference => reference.Name == "SharpTS");
+    }
+
+    [Fact]
+    public void QueueHelpersPassIlVerification()
+    {
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(Source));
+        Assert.Equal("4950 1 5\n", TestHarness.RunCompiled(Source));
+    }
+}

--- a/tests/SharpTS.Tests/SharedTests/ArrayQueueStorageTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/ArrayQueueStorageTests.cs
@@ -1,0 +1,37 @@
+using SharpTS.Runtime;
+using SharpTS.Runtime.Types;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+// Storage-level coverage: these guards must reject unsupported shapes before
+// the interpreter bypasses any observable indexed property operation.
+public class ArrayQueueStorageTests
+{
+    [Fact]
+    public void DenseQueueGuardRejectsRestrictedAndHoleyArrays()
+    {
+        foreach (Action<SharpTSArray> change in new Action<SharpTSArray>[]
+        {
+            array => array.Seal(), array => array.Freeze(), array => array.PreventExtensions(),
+            array => array.DeleteAt(0), array => array.SetLength(3),
+            array => array.Set(4, 1d), array => array.Add(ArrayHole.Instance),
+            array => _ = array.Elements
+        })
+        {
+            var array = new SharpTSArray(new object?[] { 1d, 2d });
+            Assert.True(array.CanUseDenseQueueFastPath(2));
+            change(array);
+            Assert.False(array.CanUseDenseQueueFastPath(array.LongLength));
+        }
+    }
+
+    [Fact]
+    public void AdoptedBackingCannotBypassHoleGuard()
+    {
+        var backing = new Deque<object?>(new object?[] { 1d });
+        var array = new SharpTSArray(backing);
+        backing[0] = ArrayHole.Instance;
+        Assert.False(array.CanUseDenseQueueFastPath(1));
+    }
+}

--- a/tests/SharpTS.Tests/SharedTests/ArrayQueueTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/ArrayQueueTests.cs
@@ -1,0 +1,132 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+public class ArrayQueueTests
+{
+    [Theory, ModeData]
+    public void Queue_NumericKeysDoNotTruncateFractionalOrHugeIndices(ExecutionMode mode)
+    {
+        const string source = """
+            function run(): void {
+                const values: number[] = [];
+                values.unshift(8);
+                console.log(values[0.5] === undefined, values[-1] === undefined);
+                console.log(values[4294967296] === undefined, values[NaN] === undefined);
+                console.log(Number.isNaN(1 + values[0.5]), values[0]);
+            }
+            run();
+            """;
+        Assert.Equal("true true\ntrue true\ntrue 8\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void Queue_ReusesStorageAndPreservesLogicalIndices(ExecutionMode mode)
+    {
+        const string source = """
+            function run(): void {
+                const values: number[] = [];
+                for (let i: number = 0; i < 100; i++) values.push(i);
+                let sum: number = 0;
+                for (let i: number = 0; i < 1000; i++) {
+                    sum = sum + values.shift();
+                    values.push(i + 100);
+                    values.unshift(-1, -2);
+                    sum = sum + values.shift() + values.shift() + 3;
+                }
+                console.log(sum, values.length, values[0], values[99]);
+                values[0] = 7;
+                values[99] = 8;
+                console.log(values.shift(), values[98]);
+                while (values.length > 0) values.shift();
+                console.log(values.shift() === undefined);
+                values.push(5);
+                console.log(values.shift(), values.length);
+            }
+            run();
+            """;
+        Assert.Equal("499500 100 1000 1099\n7 8\ntrue\n5 0\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void Queue_ExtendingWritesPreserveHolesAndBooleans(ExecutionMode mode)
+    {
+        const string source = """
+            function run(): void {
+                const values: number[] = [];
+                values.push(2, 3);
+                console.log(values.shift());
+                values[4] = 9;
+                console.log(values.length, values[1] === undefined, values[4]);
+                console.log(values.shift(), values.shift() === undefined);
+                const flags: boolean[] = [];
+                flags.unshift(false, true);
+                flags[3] = false;
+                console.log(flags.shift(), flags.shift(), flags.shift() === undefined, flags.shift());
+                console.log(flags.shift() === undefined);
+            }
+            run();
+            """;
+        Assert.Equal("2\n5 true 9\n3 true\nfalse true true false\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void Queue_EvaluatesArgumentsBeforeMutationAndPreservesNumericEmpty(ExecutionMode mode)
+    {
+        const string source = """
+            function run(): void {
+                const values: number[] = [];
+                values.push(10);
+                console.log(values.unshift(values.length, values.length));
+                console.log(values.shift(), values.shift(), values.shift());
+                values.push(20);
+                console.log(values.push(values.length, values.length));
+                console.log(values.shift(), values.shift(), values.shift());
+                console.log(Number.isNaN(1 + values.shift()));
+                console.log(values.shift() === undefined);
+            }
+            run();
+            """;
+        Assert.Equal("3\n1 1 10\n3\n20 1 1\ntrue\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void Queue_FallsBackAfterShapeChanges(ExecutionMode mode)
+    {
+        const string source = """
+            const values: any[] = [];
+            values.push(1, 2, 3);
+            console.log(values.shift());
+            delete values[0];
+            Object.defineProperty(Array.prototype, "0", { configurable: true, value: 42, writable: true });
+            console.log(values.shift(), values.shift());
+            delete (Array.prototype as any)[0];
+            values.push(5, 6);
+            Object.defineProperty(values, "1", { configurable: true, get(): number { return 9; } });
+            console.log(values.shift(), values[0]);
+            const fixed: number[] = [];
+            fixed.push(1);
+            Object.defineProperty(fixed, "length", { writable: false });
+            try { fixed.unshift(2); } catch (e) { console.log(e instanceof TypeError); }
+            """;
+        Assert.Equal("1\n42 3\n5 9\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void Queue_UnshiftObservesInheritedTailSetter(ExecutionMode mode)
+    {
+        const string source = """
+            const values: any[] = [];
+            values.unshift(3);
+            let seen: number = 0;
+            Object.defineProperty(Array.prototype, "1", {
+                configurable: true,
+                set(value: number): void { seen = value; }
+            });
+            console.log(values.unshift(2), seen, values[0], values[1] === undefined);
+            delete (Array.prototype as any)[1];
+            """;
+        Assert.Equal("2 3 2 true\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
## Summary

Repeated array `shift()` and `unshift()` currently copy elements in compiled List-backed arrays, while the interpreter performs per-index property operations even for dense arrays. Promote eligible nonescaping numeric and boolean queue locals to an emitted two-stack representation, giving amortized constant-time queue operations and constant-time indexed reads. Add guarded dense-storage fast paths in the interpreter.

Preserve undefined/NaN results, supported extending writes and holes, and argument evaluation order. Keep escaped arrays, unsupported writes, and descriptor/prototype/integrity-sensitive shapes on existing fallback paths. The emitted helper uses only BCL dependencies.

Expand the queue benchmarks with four input sizes, checksum validation, an alternating push/shift workload, and C# deque baselines. Add regression coverage for representation selection, storage guards, array semantics, and standalone emitted assemblies.

## Performance

Median of three cross-runtime launches at 10,000 elements, milliseconds per complete workload (compilation and process startup excluded), using the same updated benchmark with baseline and candidate compilers:

| Workload | Before | After |
| --- | ---: | ---: |
| Shift/drain | 77.7500 | 0.01884 |
| Unshift/build | 4.0065 | 0.04749 |
| Alternating push/shift | 0.10326 | 0.01455 |

Measured on Windows with .NET 10.0.11. These are local benchmark results, not general performance guarantees. Nonqueue push/index-write/index-read controls retain identical emitted IL and local types after resolving metadata tokens.

## Validation

- Release builds of SharpTS and the microbenchmark project passed.
- 352 focused and related array tests passed, including emitted IL verification and standalone assembly dependency checks.
- Three-launch cross-runtime benchmarks passed checksum validation for compiled, Node, and interpreter execution; snapshot schema validated.
- All 12 array queue microbenchmark cases completed.
- `git diff --check` passed.

The fast paths conservatively exclude restricted arrays. A preexisting sealed-array shift issue reproduced with the unchanged baseline remains outside this performance change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved performance for common array queue operations such as `push`, `shift`, and `unshift`.
  - Added optimized handling for numeric and boolean arrays, including sparse arrays and indexed access.
  - Added dense-array fast paths while preserving correct behavior for holes and restricted properties.

- **Bug Fixes**
  - Improved handling of fractional, oversized, and invalid array indexes.
  - Preserved argument evaluation order, inherited setters, empty-array results, and fallback behavior after array shape changes.

- **Documentation**
  - Added benchmark documentation covering queue workloads and implementation comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->