### PR TITLE
Reduce allocation kernel overhead with packed arrays and typed reads

### DIFF
--- a/benchmarks/cross-runtime/scripts/worker-allocation-scaling.ts
+++ b/benchmarks/cross-runtime/scripts/worker-allocation-scaling.ts
@@ -103,6 +103,7 @@ function runWorkerCase(
                 "worker-allocation-fixed-work",
                 workerCount,
                 () => pool.run(totalItems),
+                expected,
             );
         })
         .then(
@@ -115,9 +116,11 @@ function main(): Promise<any> {
     const totalItems: number = 20000;
     const moduleMeta: any = import.meta;
     const workerPath: string = moduleMeta.dirname + "/workers/allocation-worker.ts";
-    const expected: number = allocationChecksum(0, totalItems);
+    // Sum 4*i + 4 + (i % 100 < 10 ? 6 : 7), for 0 <= i < 20000.
+    // Keep the oracle independent of the kernel under test.
+    const expected: number = 800178000;
 
-    bench("worker-allocation-direct", totalItems, () => allocationChecksum(0, totalItems));
+    bench("worker-allocation-direct", totalItems, () => allocationChecksum(0, totalItems), expected);
     return runWorkerCase(1, workerPath, totalItems, expected)
         .then(() => runWorkerCase(2, workerPath, totalItems, expected))
         .then(() => runWorkerCase(4, workerPath, totalItems, expected));

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/AllocationKernelBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/AllocationKernelBenchmarks.cs
@@ -1,0 +1,61 @@
+using BenchmarkDotNet.Attributes;
+using SharpTS.Microbenchmarks.Infrastructure;
+
+namespace SharpTS.Microbenchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+public class AllocationKernelBenchmarks
+{
+    private Func<double, double, double> _kernel = null!;
+    private Func<double, object> _build = null!;
+    private Func<object, double> _read = null!;
+    private object _records = null!;
+
+    [Params(2000, 20000)]
+    public int N { get; set; }
+
+    [Params(false, true)]
+    public bool UseTypeAlias { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var source = ReadResource("SharpTS.Microbenchmarks.allocation-kernel.ts") + "\n" +
+            ReadResource("SharpTS.Microbenchmarks.TypeScriptSources.AllocationPhases.ts");
+        if (UseTypeAlias)
+            source = source.Replace("interface AllocationRecord {", "type AllocationRecord = {")
+                .Replace("interface PhaseAllocationRecord {", "type PhaseAllocationRecord = {");
+
+        string name = UseTypeAlias ? "AllocationAlias" : "AllocationInterface";
+        var path = CompilationCache.GetOrCompile(source, name);
+        var assembly = BenchmarkHarness.LoadCompiledAssembly(path, name);
+        _kernel = BenchmarkHarness.GetCompiledNumber2Func(assembly, "allocationChecksum");
+        _build = BenchmarkHarness.GetCompiledMethod(assembly, "buildAllocationRecords")
+            .CreateDelegate<Func<double, object>>();
+        _read = BenchmarkHarness.GetCompiledMethod(assembly, "readAllocationRecords")
+            .CreateDelegate<Func<object, double>>();
+        _records = _build(N);
+
+        double expected = 0;
+        for (int i = 0; i < N; i++) expected += 4.0 * i + 4 + (i % 100 < 10 ? 6 : 7);
+        if (_kernel(0, N) != expected || _read(_records) != expected)
+            throw new InvalidOperationException("Allocation benchmark checksum mismatch.");
+    }
+
+    [Benchmark]
+    public double FullKernel() => _kernel(0, N);
+
+    [Benchmark]
+    public object BuildRecords() => _build(N);
+
+    [Benchmark]
+    public double ReadRecords() => _read(_records);
+
+    private static string ReadResource(string name)
+    {
+        using var stream = typeof(AllocationKernelBenchmarks).Assembly.GetManifestResourceStream(name)
+            ?? throw new InvalidOperationException($"Missing resource {name}");
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Program.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Program.cs
@@ -18,6 +18,17 @@ class Program
 {
     static void Main(string[] args)
     {
+        if (args is ["--allocation-smoke"])
+        {
+            foreach (int n in new[] { 2000, 20000 })
+            foreach (bool alias in new[] { false, true })
+            {
+                new Benchmarks.AllocationKernelBenchmarks { N = n, UseTypeAlias = alias }.Setup();
+                Console.WriteLine($"Validated allocation diagnostics: N={n}, UseTypeAlias={alias}");
+            }
+            return;
+        }
+
         if (args is ["--smoke"])
         {
             CompileEmbeddedTypeScript();

--- a/benchmarks/micro/SharpTS.Microbenchmarks/README.md
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/README.md
@@ -50,6 +50,18 @@ The original direct-delegate JSON benchmarks remain as a comparison.
 
 ## Running
 
+Allocation diagnostics share the unmodified cross-runtime `allocation-kernel.ts`.
+`AllocationKernelBenchmarks` measures the complete kernel, graph construction,
+and traversal of a graph built during setup, with allocation and GC counters.
+Each runs with interface and equivalent type-alias declarations. Phase timings
+are diagnostic and should not be added together: exposing the graph changes
+escape analysis and traversal starts with an already retained graph.
+
+```powershell
+dotnet run -c Release --project benchmarks/micro/SharpTS.Microbenchmarks -- --allocation-smoke
+dotnet run -c Release --project benchmarks/micro/SharpTS.Microbenchmarks -- --filter '*AllocationKernelBenchmarks*'
+```
+
 ```bash
 # From the repo root. BenchmarkDotNet requires a Release build.
 dotnet run -c Release --project benchmarks/micro/SharpTS.Microbenchmarks

--- a/benchmarks/micro/SharpTS.Microbenchmarks/SharpTS.Microbenchmarks.csproj
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/SharpTS.Microbenchmarks.csproj
@@ -34,6 +34,7 @@
     <!-- Shared with the cross-runtime shell harness (benchmarks/scripts/lib)
          so both benchmark systems measure byte-identical algorithm sources. -->
     <EmbeddedResource Include="..\..\cross-runtime\scripts\lib\algorithms.ts" LogicalName="SharpTS.Microbenchmarks.algorithms.ts" />
+    <EmbeddedResource Include="..\..\cross-runtime\scripts\workers\allocation-kernel.ts" LogicalName="SharpTS.Microbenchmarks.allocation-kernel.ts" />
   </ItemGroup>
 
   <!-- Create output directory for pre-compiled DLLs -->

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/AllocationPhases.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/AllocationPhases.ts
@@ -1,0 +1,32 @@
+// Phase diagnostics for allocation-kernel.ts. FullKernel benchmarks the original
+// shared kernel; these separate functions deliberately expose its retained graph.
+interface PhaseAllocationRecord {
+    index: number;
+    next: number;
+    label: string;
+    values: number[];
+}
+
+function buildAllocationRecords(end: number): any {
+    const records: PhaseAllocationRecord[] = [];
+    for (let i: number = 0; i < end; i++) {
+        records.push({
+            index: i,
+            next: i + 1,
+            label: "item-" + (i % 100),
+            values: [i, i + 1, i + 2, i + 3],
+        });
+    }
+    return records;
+}
+
+function readAllocationRecords(input: any): number {
+    const records: PhaseAllocationRecord[] = input;
+    let checksum: number = 0;
+    for (let i: number = 0; i < records.length; i++) {
+        const record: PhaseAllocationRecord = records[i];
+        checksum = checksum + record.index + record.next + record.label.length +
+            record.values[0] + record.values[3];
+    }
+    return checksum;
+}

--- a/src/SharpTS/Compilation/CountedPushLoopAnalyzer.cs
+++ b/src/SharpTS/Compilation/CountedPushLoopAnalyzer.cs
@@ -13,22 +13,26 @@ internal static class CountedPushLoopAnalyzer
     internal readonly record struct Reservation(
         Expr.Variable Array,
         Expr.Variable Bound,
-        Expr Value);
+        Expr Value,
+        Expr.Variable Counter);
 
-    internal static bool TryAnalyze(Stmt.For loop, out Reservation reservation)
+    internal static bool TryAnalyze(Stmt.For loop, out Reservation reservation,
+        bool allowRangeStart = false)
     {
         reservation = default;
         if (loop.Initializer is not Stmt.Var
             {
                 Name.Lexeme: var counter,
-                Initializer: Expr.Literal { Value: double initial }
+                Initializer: { } initial
             }
-            || initial != 0)
+            || (allowRangeStart
+                ? initial is not (Expr.Variable or Expr.Literal { Value: double })
+                : initial is not Expr.Literal { Value: 0.0 }))
             return false;
 
         if (loop.Condition is not Expr.Binary
             {
-                Left: Expr.Variable { Name.Lexeme: var conditionCounter },
+                Left: Expr.Variable { Name.Lexeme: var conditionCounter } counterExpression,
                 Operator.Type: TokenType.LESS,
                 Right: Expr.Variable bound
             }
@@ -63,7 +67,7 @@ internal static class CountedPushLoopAnalyzer
             || !IsPure(arguments[0]))
             return false;
 
-        reservation = new Reservation(array, bound, arguments[0]);
+        reservation = new Reservation(array, bound, arguments[0], counterExpression);
         return true;
     }
 

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -1577,6 +1577,8 @@ public class EmittedRuntime
     /// </summary>
     public MethodBuilder CallArgsPoolGet { get; set; } = null!;
     public ConstructorBuilder TSArrayCtor { get; set; } = null!;
+    public ConstructorBuilder TSArrayLiteralCtor { get; set; } = null!;
+    public ConstructorBuilder TSArrayNumericLiteralCtor { get; set; } = null!;
     public ConstructorBuilder TSArrayRestCtor { get; set; } = null!;
     public MethodBuilder TSArrayAppendRest { get; set; } = null!;
     public MethodBuilder TSArrayFinishRest { get; set; } = null!;

--- a/src/SharpTS/Compilation/ILEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Operators.cs
@@ -75,6 +75,9 @@ public partial class ILEmitter
                 if (TryEmitIntegerCounterStringConcat(b))
                     break;
 
+                if (TryEmitPrimitiveNumberStringConcat(b))
+                    break;
+
                 // If both operands are statically string, emit a direct
                 // String.Concat(string, string) — skipping the dynamic
                 // $Runtime.Add type-dispatch + ToNumber/ToString probing every
@@ -3226,6 +3229,55 @@ public partial class ILEmitter
         var rightType = _ctx.TypeMap.Get(b.Right);
 
         return IsStringTypeInfo(leftType) && IsStringTypeInfo(rightType);
+    }
+
+    private bool TryEmitPrimitiveNumberStringConcat(Expr.Binary expression)
+    {
+        bool stringFirst = IsStringTypeInfo(_ctx.TypeMap?.Get(expression.Left)) &&
+            IsNumericType(_ctx.TypeMap?.Get(expression.Right));
+        bool numberFirst = IsNumericType(_ctx.TypeMap?.Get(expression.Left)) &&
+            IsStringTypeInfo(_ctx.TypeMap?.Get(expression.Right));
+        if (!stringFirst && !numberFirst) return false;
+
+        // Storage, not just the annotation, proves that the operand is primitive.
+        // Evaluate both sides before formatting to preserve side-effect order.
+        LocalBuilder Capture(Expr value)
+        {
+            EmitExpression(value);
+            var type = StackType == StackType.Double ? _ctx.Types.Double :
+                StackType == StackType.String ? _ctx.Types.String : _ctx.Types.Object;
+            if (type == _ctx.Types.Object) EmitBoxIfNeeded(value);
+            var local = IL.DeclareLocal(type);
+            IL.Emit(OpCodes.Stloc, local);
+            return local;
+        }
+        var left = Capture(expression.Left);
+        var right = Capture(expression.Right);
+        var number = stringFirst ? right : left;
+        var text = stringFirst ? left : right;
+        var fallback = IL.DefineLabel();
+        var end = IL.DefineLabel();
+        if (number.LocalType == _ctx.Types.Double && text.LocalType == _ctx.Types.String)
+        {
+            IL.Emit(OpCodes.Ldloc, text);
+            IL.Emit(OpCodes.Brfalse, fallback);
+            if (stringFirst) IL.Emit(OpCodes.Ldloc, text);
+            IL.Emit(OpCodes.Ldloc, number);
+            IL.Emit(OpCodes.Call, _ctx.Runtime!.FormatNumber);
+            if (numberFirst) IL.Emit(OpCodes.Ldloc, text);
+            IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.String, "Concat",
+                _ctx.Types.String, _ctx.Types.String));
+            IL.Emit(OpCodes.Br, end);
+        }
+        IL.MarkLabel(fallback);
+        IL.Emit(OpCodes.Ldloc, left);
+        if (left.LocalType == _ctx.Types.Double) IL.Emit(OpCodes.Box, _ctx.Types.Double);
+        IL.Emit(OpCodes.Ldloc, right);
+        if (right.LocalType == _ctx.Types.Double) IL.Emit(OpCodes.Box, _ctx.Types.Double);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.Add);
+        IL.MarkLabel(end);
+        SetStackUnknown();
+        return true;
     }
 
     private bool TryEmitIntegerCounterStringConcat(Expr.Binary b)

--- a/src/SharpTS/Compilation/ILEmitter.Properties.Interfaces.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.Interfaces.cs
@@ -1,0 +1,49 @@
+using System.Collections.Frozen;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+public partial class ILEmitter
+{
+    private bool TryGetInterfaceReadShape(
+        TypeInfo.Interface type, out JsonSerializationShape.Record shape)
+    {
+        shape = null!;
+        if (_ctx.RuntimeFeatures is not { } features ||
+            type.HasIndexSignature || type.IsCallable || type.IsConstructable ||
+            type.GetAllOptionalMembers().Any())
+            return false;
+
+        // GetAllMembers may repeat inherited members in a diamond. Own members
+        // come first and shadow inherited declarations.
+        var members = type.GetAllMembers().GroupBy(member => member.Key)
+            .ToFrozenDictionary(group => group.Key, group => group.First().Value);
+        if (!JsonSerializationShapeAnalyzer.TryAnalyze(new TypeInfo.Record(members), out var analyzed) ||
+            analyzed is not JsonSerializationShape.Record declared)
+            return false;
+
+        foreach (var candidate in features.CompactObjectRecordShapes.Values)
+        {
+            if (candidate.Fields.Count != declared.Fields.Count ||
+                !candidate.Fields.All(field => declared.Fields.Any(other =>
+                    other.Key == field.Key &&
+                    StorageKind(other.Value) == StorageKind(field.Value))))
+                continue;
+
+            shape = candidate;
+            return true;
+        }
+        return false;
+    }
+
+    // Nested arrays/records occupy object slots regardless of their inferred
+    // element shape (e.g. a literal's (2|3)[] versus the interface's number[]).
+    // Matching storage is sufficient: reads still guard the exact carrier type.
+    private static int StorageKind(JsonSerializationShape shape) => shape switch
+    {
+        JsonSerializationShape.Number => 1,
+        JsonSerializationShape.String => 2,
+        JsonSerializationShape.Boolean => 3,
+        _ => 0
+    };
+}

--- a/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
@@ -11,6 +11,14 @@ public partial class ILEmitter
         // Check if any element is a spread
         bool hasSpreads = a.Elements.Any(e => e is Expr.Spread);
 
+        if (!hasSpreads && a.Elements.Count > 0 &&
+            ArrayElements.Resolve(_ctx.TypeMap?.Get(a))?.Kind == ArrayElementsKind.Double &&
+            Enumerable.Range(0, a.Elements.Count).All(index => !a.IsHole(index)))
+        {
+            EmitNumericArrayLiteral(a);
+            return;
+        }
+
         // Typed array optimization: emit List<double> or List<bool> for empty typed arrays.
         // Only for empty arrays (populated via index assignment) to avoid issues with
         // array methods (flatMap, map, etc.) that expect List<object?>.
@@ -99,6 +107,41 @@ public partial class ILEmitter
         // The stack now holds a List<object?> reference. Reset the stack-type
         // tracker so a subsequent EmitBoxIfNeeded doesn't reinterpret the
         // reference as whatever primitive the previous expression left behind.
+        SetStackUnknown();
+    }
+
+    private void EmitNumericArrayLiteral(Expr.ArrayLiteral literal)
+    {
+        // Evaluate once, left-to-right, before choosing storage. An annotation
+        // alone cannot justify coercing an object-backed value to a number (an
+        // `any` alias or assertion may hold a string). Keep the boxed fallback
+        // unless every emitted element is already a native number.
+        var values = new List<LocalBuilder>(literal.Elements.Count);
+        foreach (var element in literal.Elements)
+        {
+            EmitExpression(element);
+            bool nativeNumber = StackType == StackType.Double;
+            if (nativeNumber) EnsureDouble();
+            else EmitBoxIfNeeded(element);
+            var local = IL.DeclareLocal(nativeNumber ? _ctx.Types.Double : _ctx.Types.Object);
+            IL.Emit(OpCodes.Stloc, local);
+            values.Add(local);
+        }
+
+        bool numeric = values.All(local => local.LocalType == _ctx.Types.Double);
+        IL.Emit(OpCodes.Ldc_I4, values.Count);
+        IL.Emit(OpCodes.Newarr, numeric ? _ctx.Types.Double : _ctx.Types.Object);
+        for (int index = 0; index < values.Count; index++)
+        {
+            IL.Emit(OpCodes.Dup);
+            IL.Emit(OpCodes.Ldc_I4, index);
+            IL.Emit(OpCodes.Ldloc, values[index]);
+            if (!numeric && values[index].LocalType == _ctx.Types.Double)
+                IL.Emit(OpCodes.Box, _ctx.Types.Double);
+            IL.Emit(numeric ? OpCodes.Stelem_R8 : OpCodes.Stelem_Ref);
+        }
+        if (numeric) IL.Emit(OpCodes.Newobj, _ctx.Runtime!.TSArrayNumericLiteralCtor);
+        else IL.Emit(OpCodes.Call, _ctx.Runtime!.CreateArray);
         SetStackUnknown();
     }
 

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -384,9 +384,24 @@ public partial class ILEmitter
             && objType is TypeInfo.Record recordType
             && _ctx.Runtime?.UndefinedInstance != null)
         {
-            if (TryEmitTypedRecordNumberGet(g, recordType))
+            JsonSerializationShapeAnalyzer.TryAnalyze(recordType, out var analyzed);
+            var shape = analyzed as JsonSerializationShape.Record;
+            if (TryEmitTypedRecordNumberGet(g, shape))
                 return;
-            EmitTypedRecordPropertyGet(g, recordType);
+            EmitTypedRecordPropertyGet(g, shape);
+            return;
+        }
+
+        // Interface declarations do not define object insertion order. Match an
+        // emitted carrier by its field names/types, then use its canonical order.
+        // The same runtime type/materialization guards protect class instances,
+        // aliases and structurally compatible values with a different layout.
+        if (!g.Optional && objType is TypeInfo.Interface interfaceType &&
+            TryGetInterfaceReadShape(interfaceType, out var interfaceShape))
+        {
+            if (TryEmitTypedRecordNumberGet(g, interfaceShape, requireMaterializationGuard: true))
+                return;
+            EmitTypedRecordPropertyGet(g, interfaceShape, requireMaterializationGuard: true);
             return;
         }
 
@@ -440,11 +455,11 @@ public partial class ILEmitter
     /// and its own materialization state; the cold arm preserves the general
     /// property lookup and ToNumber semantics.
     /// </summary>
-    private bool TryEmitTypedRecordNumberGet(Expr.Get g, TypeInfo.Record recordType)
+    private bool TryEmitTypedRecordNumberGet(Expr.Get g, JsonSerializationShape.Record? recordShape,
+        bool requireMaterializationGuard = false)
     {
         if (_ctx.ProgramType is null || _ctx.Runtime is not { } runtime ||
-            !JsonSerializationShapeAnalyzer.TryAnalyze(recordType, out var analyzedShape) ||
-            analyzedShape is not JsonSerializationShape.Record recordShape)
+            recordShape is null)
         {
             return false;
         }
@@ -525,7 +540,7 @@ public partial class ILEmitter
             IL.Emit(OpCodes.Stloc, compactExact);
             IL.Emit(OpCodes.Ldloc, compactExact);
             IL.Emit(OpCodes.Brfalse, fallback);
-            if (!_ctx.RuntimeFeatures!.CanAssumeCompactObjectRecordIsUnmaterialized(
+            if (requireMaterializationGuard || !_ctx.RuntimeFeatures!.CanAssumeCompactObjectRecordIsUnmaterialized(
                     fingerprint))
             {
                 IL.Emit(OpCodes.Ldloc, compactExact);
@@ -571,7 +586,8 @@ public partial class ILEmitter
     /// instances downcast to record shape, etc.) we fall through to the
     /// existing dispatch.
     /// </summary>
-    private void EmitTypedRecordPropertyGet(Expr.Get g, TypeInfo.Record recordType)
+    private void EmitTypedRecordPropertyGet(Expr.Get g, JsonSerializationShape.Record? recordShape,
+        bool requireMaterializationGuard = false)
     {
         EmitExpression(g.Object);
         EmitBoxIfNeeded(g.Object);
@@ -590,8 +606,7 @@ public partial class ILEmitter
         bool exactCarrierSpecialized = false;
 
         if (hasCompactCarrier && _ctx.ProgramType is not null &&
-            JsonSerializationShapeAnalyzer.TryAnalyze(recordType, out var analyzedShape) &&
-            analyzedShape is JsonSerializationShape.Record recordShape)
+            recordShape is not null)
         {
             int scalarIndex = -1;
             for (int index = 0; index < recordShape.Fields.Count; index++)
@@ -674,7 +689,7 @@ public partial class ILEmitter
                 }
                 IL.Emit(OpCodes.Ldloc, exactLocal);
                 IL.Emit(OpCodes.Brfalse, fallbackLabel);
-                if (!_ctx.RuntimeFeatures!.CanAssumeCompactObjectRecordIsUnmaterialized(
+                if (requireMaterializationGuard || !_ctx.RuntimeFeatures!.CanAssumeCompactObjectRecordIsUnmaterialized(
                         fingerprint))
                 {
                     IL.Emit(OpCodes.Ldloc, exactLocal);
@@ -1542,10 +1557,10 @@ public partial class ILEmitter
     private bool TryEmitNumberArrayGetIndexAsDouble(Expr.GetIndex gi)
     {
         if (gi.Optional
-            || gi.Object is not Expr.Variable arrayVariable
             || ArrayElements.Resolve(_ctx.TypeMap?.Get(gi.Object)) is not
                 { Kind: ArrayElementsKind.Double }
-            || _ctx.TryGetPromotedArrayLocal(arrayVariable.Name.Lexeme) != null
+            || (gi.Object is Expr.Variable promotedVariable &&
+                _ctx.TryGetPromotedArrayLocal(promotedVariable.Name.Lexeme) != null)
             || !IsNumericType(_ctx.TypeMap?.Get(gi.Index))
             || _ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == true
             || _ctx.RuntimeFeatures?.UsesArrayPrototypeMutation == true)
@@ -1553,7 +1568,9 @@ public partial class ILEmitter
             return false;
         }
 
-        var hoisted = _ctx.TryGetHoistedArray(arrayVariable.Name.Lexeme);
+        var hoisted = gi.Object is Expr.Variable arrayVariable
+            ? _ctx.TryGetHoistedArray(arrayVariable.Name.Lexeme)
+            : null;
         if (hoisted is { Descriptor.Kind: not ArrayElementsKind.Double })
             return false;
 

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -1675,21 +1675,19 @@ public partial class ILEmitter
     }
 
     /// <summary>
-    /// Emits a stack-neutral statement-position write through a guarded numeric
-    /// <c>$Array</c>. The ordinary result-producing path must reload and box the
-    /// assigned double so arbitrary expression consumers see the JS assignment
-    /// value. A discarded expression has no such consumer, so this specialization
-    /// keeps the fast arm unboxed while retaining the guarded generic fallback
+    /// Emits a write through a guarded numeric <c>$Array</c>, optionally leaving
+    /// the assigned double as the expression result. Discarded expressions leave
+    /// the stack empty. This keeps the fast arm unboxed with a generic fallback
     /// for non-<c>$Array</c> values passed through a cast. Loop-local receivers
     /// reuse the existing hoisted guard; parameters use the same guard per write.
     /// </summary>
-    private bool TryEmitDiscardedNumberArraySetIndex(Expr.SetIndex si)
+    private bool TryEmitDiscardedNumberArraySetIndex(Expr.SetIndex si, bool discardResult = true)
     {
-        if (_ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == true
-            || si.Object is not Expr.Variable arrayVariable)
+        if (_ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors == true)
             return false;
 
-        var hoisted = _ctx.TryGetHoistedArray(arrayVariable.Name.Lexeme);
+        var hoisted = si.Object is Expr.Variable arrayVariable
+            ? _ctx.TryGetHoistedArray(arrayVariable.Name.Lexeme) : null;
         if (hoisted is not { Descriptor.Kind: ArrayElementsKind.Double }
             && ArrayElements.Resolve(_ctx.TypeMap?.Get(si.Object)) is not
                 { Kind: ArrayElementsKind.Double })
@@ -1710,8 +1708,8 @@ public partial class ILEmitter
 
         // Preserve reference evaluation order for the remaining operands:
         // index before RHS. Keep the original numeric key as a double for the
-        // array-like fallback (3.5 must remain property "3.5" there); only the
-        // guarded $Array arm narrows it exactly as the ordinary fast path does.
+        // fallback (3.5 must remain property "3.5" there); only the guarded
+        // $Array arm narrows keys after proving they are exact integer indices.
         EmitExpressionAsDouble(si.Index);
         var indexLocal = IL.DeclareLocal(_ctx.Types.Double);
         IL.Emit(OpCodes.Stloc, indexLocal);
@@ -1723,6 +1721,16 @@ public partial class ILEmitter
 
         var fallbackLabel = IL.DefineLabel();
         var endLabel = IL.DefineLabel();
+        // Narrow only exact non-negative Int32 keys. Other numeric keys are
+        // ordinary properties and must retain their original value.
+        IL.Emit(OpCodes.Ldloc, indexLocal);
+        IL.Emit(OpCodes.Ldc_R8, 0.0);
+        IL.Emit(OpCodes.Blt_Un, fallbackLabel);
+        IL.Emit(OpCodes.Ldloc, indexLocal);
+        IL.Emit(OpCodes.Ldloc, indexLocal);
+        IL.Emit(OpCodes.Conv_I4);
+        IL.Emit(OpCodes.Conv_R8);
+        IL.Emit(OpCodes.Bne_Un, fallbackLabel);
         if (hoisted is { } cached)
         {
             IL.Emit(OpCodes.Ldloc, cached.TypedLocal);
@@ -1770,6 +1778,11 @@ public partial class ILEmitter
         }
 
         IL.MarkLabel(endLabel);
+        if (!discardResult)
+        {
+            IL.Emit(OpCodes.Ldloc, valueLocal);
+            SetStackType(StackType.Double);
+        }
         return true;
     }
 
@@ -1950,6 +1963,9 @@ public partial class ILEmitter
             SetStackType(StackType.Double);
             return;
         }
+
+        if (TryEmitDiscardedNumberArraySetIndex(si, discardResult: false))
+            return;
 
         // Descriptor-driven fast path: when receiver is statically known to be an array,
         // emit direct List<T> access with auto-extension — skips runtime type dispatch,

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -1659,7 +1659,9 @@ public partial class ILEmitter
 
     private void EmitCountedPushReservation(Stmt.For loop)
     {
-        if (!CountedPushLoopAnalyzer.TryAnalyze(loop, out var reservation))
+        if (!CountedPushLoopAnalyzer.TryAnalyze(loop, out var reservation, allowRangeStart: true) ||
+            !IsNumericType(_ctx.TypeMap?.Get(reservation.Counter)) ||
+            !IsNumericType(_ctx.TypeMap?.Get(reservation.Bound)))
             return;
 
         var arrayLocal = _ctx.Locals.GetLocal(reservation.Array.Name.Lexeme);
@@ -1671,6 +1673,7 @@ public partial class ILEmitter
         var listType = promoted?.Descriptor.GetListType(_ctx.Types) ?? _ctx.Types.ListOfObject;
         var listLocal = IL.DeclareLocal(listType);
         var countLocal = IL.DeclareLocal(_ctx.Types.Double);
+        var startLocal = IL.DeclareLocal(_ctx.Types.Double);
         var skipLabel = _ctx.ILBuilder.DefineLabel("counted_push_reserve_skip");
 
         IL.Emit(OpCodes.Ldloc, sourceLocal);
@@ -1681,8 +1684,39 @@ public partial class ILEmitter
         _ctx.ILBuilder.Emit_Brfalse(skipLabel);
 
         SetStackUnknown();
+        EmitExpression(reservation.Counter);
+        if (StackType != StackType.Double)
+        {
+            // An annotation may describe object-backed storage. A reservation
+            // must not introduce an extra observable ToNumber/valueOf call.
+            IL.Emit(OpCodes.Pop);
+            _ctx.ILBuilder.MarkLabel(skipLabel);
+            SetStackUnknown();
+            return;
+        }
+        IL.Emit(OpCodes.Stloc, startLocal);
+        // Restrict range reservation to integer starts where ++ advances by
+        // exactly one throughout the capped range. Unordered branches reject NaN.
+        IL.Emit(OpCodes.Ldloc, startLocal);
+        IL.Emit(OpCodes.Ldc_R8, -4503599627370496.0);
+        IL.Emit(OpCodes.Blt_Un, skipLabel);
+        IL.Emit(OpCodes.Ldloc, startLocal);
+        IL.Emit(OpCodes.Ldc_R8, 4503599627370496.0);
+        IL.Emit(OpCodes.Bgt_Un, skipLabel);
+        IL.Emit(OpCodes.Ldloc, startLocal);
+        IL.Emit(OpCodes.Ldloc, startLocal);
+        IL.Emit(OpCodes.Call, typeof(Math).GetMethod("Truncate", [_ctx.Types.Double])!);
+        IL.Emit(OpCodes.Bne_Un, skipLabel);
         EmitExpression(reservation.Bound);
-        EnsureDouble();
+        if (StackType != StackType.Double)
+        {
+            IL.Emit(OpCodes.Pop);
+            _ctx.ILBuilder.MarkLabel(skipLabel);
+            SetStackUnknown();
+            return;
+        }
+        IL.Emit(OpCodes.Ldloc, startLocal);
+        IL.Emit(OpCodes.Sub);
         IL.Emit(OpCodes.Stloc, countLocal);
 
         // Bound eager allocation to one million elements. The unordered branch
@@ -1690,6 +1724,17 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Ldloc, countLocal);
         IL.Emit(OpCodes.Ldc_R8, 0.0);
         IL.Emit(OpCodes.Blt_Un, skipLabel);
+        IL.Emit(OpCodes.Ldloc, countLocal);
+        IL.Emit(OpCodes.Ldc_R8, 1_000_000.0);
+        IL.Emit(OpCodes.Bgt_Un, skipLabel);
+
+        // EnsureCapacity takes total capacity, including earlier appends.
+        IL.Emit(OpCodes.Ldloc, countLocal);
+        IL.Emit(OpCodes.Ldloc, listLocal);
+        IL.Emit(OpCodes.Callvirt, _ctx.Types.GetProperty(listType, "Count").GetGetMethod()!);
+        IL.Emit(OpCodes.Conv_R8);
+        IL.Emit(OpCodes.Add);
+        IL.Emit(OpCodes.Stloc, countLocal);
         IL.Emit(OpCodes.Ldloc, countLocal);
         IL.Emit(OpCodes.Ldc_R8, 1_000_000.0);
         IL.Emit(OpCodes.Bgt_Un, skipLabel);
@@ -1863,6 +1908,22 @@ public partial class ILEmitter
             if (arrLocal == null) continue; // Variable not found in locals — skip
             IL.Emit(OpCodes.Ldloc, arrLocal);
             // Array locals are always typed as object — no boxing needed
+            if (desc.Kind == ArrayElementsKind.Object)
+            {
+                // A number[] can reach this loop through an any[] alias. The
+                // cached List<object> reads require its boxed representation.
+                var notNumericArray = IL.DefineLabel();
+                IL.Emit(OpCodes.Dup);
+                IL.Emit(OpCodes.Isinst, _ctx.Runtime!.TSArrayType);
+                IL.Emit(OpCodes.Dup);
+                IL.Emit(OpCodes.Brfalse, notNumericArray);
+                IL.Emit(OpCodes.Callvirt, _ctx.Runtime.TSArrayEnsureBoxed);
+                var ready = IL.DefineLabel();
+                IL.Emit(OpCodes.Br, ready);
+                IL.MarkLabel(notNumericArray);
+                IL.Emit(OpCodes.Pop);
+                IL.MarkLabel(ready);
+            }
             IL.Emit(OpCodes.Isinst, hoistType);
             IL.Emit(OpCodes.Stloc, typedLocal);
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Arrays.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Arrays.cs
@@ -92,10 +92,9 @@ public partial class RuntimeEmitter
         runtime.CreateArray = method;
 
         var il = method.GetILGenerator();
-        // return new $Array(new List<object>(elements));
+        // Copy the literal elements directly into the final array's storage.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, _types.IEnumerableOfObject));
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.TSArrayLiteralCtor);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSArray.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSArray.cs
@@ -148,6 +148,7 @@ public partial class RuntimeEmitter
         runtime.TSArrayEnsureBoxed = _tsArrayEnsureBoxedMethod;
 
         EmitTSArrayConstructor(typeBuilder, runtime);
+        EmitTSArrayNumericLiteralConstructor(typeBuilder, runtime);
         EmitTSArrayRestConstruction(typeBuilder, runtime);
 
         // Elements returns `this` (the inherited List<object?>). In practice
@@ -1173,6 +1174,35 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
+    private void EmitTSArrayNumericLiteralConstructor(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        // The emitter hands over a fresh, dense double[]; no other value can
+        // observe its storage. Holes continue to use the ordinary literal path.
+        var ctor = typeBuilder.DefineConstructor(MethodAttributes.Assembly,
+            CallingConventions.Standard, [_types.DoubleArray]);
+        runtime.TSArrayNumericLiteralCtor = ctor;
+        var il = ctor.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, _types.GetDefaultConstructor(_types.ListOfObject));
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Stfld, _tsArrayNumStoreField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Stfld, _tsArrayNumCountField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I8);
+        il.Emit(OpCodes.Stfld, _tsArrayLengthField);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Stfld, _tsArrayIsNumericField);
+        il.Emit(OpCodes.Ret);
+    }
+
     private void EmitTSArrayConstructor(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         var ctor = typeBuilder.DefineConstructor(
@@ -1182,11 +1212,22 @@ public partial class RuntimeEmitter
         );
         runtime.TSArrayCtor = ctor;
 
-        var il = ctor.GetILGenerator();
+        // Internal element construction is distinct from the object[] overload
+        // implementing Array(...args), where one number denotes a length.
+        var literalCtor = typeBuilder.DefineConstructor(
+            MethodAttributes.Public,
+            CallingConventions.Standard,
+            [_types.IEnumerableOfObject]);
+        runtime.TSArrayLiteralCtor = literalCtor;
+        var forwardingIl = ctor.GetILGenerator();
+        forwardingIl.Emit(OpCodes.Ldarg_0);
+        forwardingIl.Emit(OpCodes.Ldarg_1);
+        forwardingIl.Emit(OpCodes.Call, literalCtor);
+        forwardingIl.Emit(OpCodes.Ret);
 
-        // base(IEnumerable<object?>) — copies the input list's items into our
-        // own List<object?> storage. Per-element copy is O(N) but callers
-        // build a fresh list per $Array allocation, so throughput is unchanged.
+        var il = literalCtor.GetILGenerator();
+
+        // One copy, directly from the supplied elements into our own storage.
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Call, _types.GetConstructor(_types.ListOfObject, _types.IEnumerableOfObject));

--- a/tests/SharpTS.Tests/Compilation/CountedPushLoopAnalyzerTests.cs
+++ b/tests/SharpTS.Tests/Compilation/CountedPushLoopAnalyzerTests.cs
@@ -22,6 +22,17 @@ public class CountedPushLoopAnalyzerTests
     }
 
     [Theory]
+    [InlineData("for (let i = start; i < end; i++) items.push({ value: i });")]
+    [InlineData("for (let i = 5; i < end; i++) items.push({ value: i });")]
+    public void RangeReservation_DoesNotEnableZeroBasedFillOptimizations(string source)
+    {
+        var loop = ParseLoop(source);
+        Assert.False(CountedPushLoopAnalyzer.TryAnalyze(loop, out _));
+        Assert.True(CountedPushLoopAnalyzer.TryAnalyze(loop, out var reservation, allowRangeStart: true));
+        Assert.Equal("i", reservation.Counter.Name.Lexeme);
+    }
+
+    [Theory]
     [InlineData("for (let i = 1; i < n; i++) items.push({ value: i });")]
     [InlineData("for (let i = 0; i <= n; i++) items.push({ value: i });")]
     [InlineData("for (let i = 0; i < n; i++) { items.push({ value: i }); log(i); }")]

--- a/tests/SharpTS.Tests/CompilerTests/CompactObjectRecordTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/CompactObjectRecordTests.cs
@@ -15,6 +15,60 @@ namespace SharpTS.Tests.CompilerTests;
 /// </summary>
 public sealed class CompactObjectRecordTests
 {
+    [Fact]
+    public void InterfaceStoredRecord_UsesGuardedNativeNumberRead()
+    {
+        const string source = """
+            interface Base { index: number; }
+            interface Item extends Base { label: string; next: number; values: number[]; }
+            function read(item: Item): number { return item.index + item.next; }
+            function exercise(): number {
+                const items: Item[] = [];
+                items.push({ index: 2, next: 3, label: "item", values: [2, 3] });
+                return read(items[0]);
+            }
+            console.log(exercise());
+            """;
+        var assembly = Compile(source);
+        Assert.Contains(ReadMembers(FindFunction(assembly, "read")), member =>
+            member.OpCode == OpCodes.Ldfld && member.Member is FieldInfo { FieldType: var t } &&
+            t == typeof(double));
+        Assert.Equal("5\n", TestHarness.RunCompiled(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    [Fact]
+    public void InterfaceReads_PreserveAliasesDescriptorsAndDifferentRuntimeShapes()
+    {
+        const string source = """
+            interface Item { value: number; label: string; }
+            interface Optional { value?: number; }
+            function read(item: Item): number { return item.value; }
+            function exercise(): void {
+                const items: Item[] = [];
+                items.push({ value: 1, label: "a" });
+                const item: Item = items[0];
+                const alias: any = item;
+                console.log(read(item));
+                item.value = 7;
+                console.log(read(item));
+                Object.defineProperty(alias, "value", { get: () => 9, configurable: true });
+                console.log(read(item));
+                console.log(read({ label: "b", value: 3 }));
+                const optional: Optional = {};
+                console.log(optional.value);
+            }
+            class Other implements Item {
+                label: string = "class";
+                get value(): number { return 11; }
+            }
+            exercise();
+            console.log(read(new Other()));
+            """;
+        Assert.Equal("1\n7\n9\n3\nundefined\n11\n", TestHarness.RunCompiled(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
     private const string TreeSource = """
         type TreeNode = { left: TreeNode | null; right: TreeNode | null };
 

--- a/tests/SharpTS.Tests/CompilerTests/DiscardedNumericArrayWriteTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/DiscardedNumericArrayWriteTests.cs
@@ -39,19 +39,22 @@ public sealed class DiscardedNumericArrayWriteTests
     [Fact]
     public void ObservedAssignment_RetainsResultProducingPath()
     {
-        Assembly assembly = Compile("""
+        const string source = """
             function set(values: number[], index: number, value: number): number {
                 return values[index] = value;
             }
-            """);
+            const values: number[] = [1, 2];
+            console.log(set(values, 1, 7), values[1]);
+            console.log(set(values, -1, 9), values.length);
+            """;
+        Assembly assembly = Compile(source);
 
         var instructions = ReadInstructions(FindFunction(assembly, "set")).ToArray();
         int setDouble = Array.FindIndex(instructions, instruction =>
             instruction.Operand is MethodBase { Name: "SetDouble" });
         Assert.True(setDouble >= 0, "Expected the numeric $Array SetDouble fast path.");
-        Assert.StartsWith("ldloc", instructions[setDouble + 1].OpCode.Name);
-        Assert.Equal(OpCodes.Box, instructions[setDouble + 2].OpCode);
-        Assert.Equal(typeof(double), instructions[setDouble + 2].Operand);
+        Assert.Equal("7 7\n9 2\n", TestHarness.RunCompiled(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
     }
 
     [Fact]

--- a/tests/SharpTS.Tests/CompilerTests/UnboxedNumberArrayReadTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/UnboxedNumberArrayReadTests.cs
@@ -11,6 +11,39 @@ namespace SharpTS.Tests.CompilerTests;
 public sealed class UnboxedNumberArrayReadTests
 {
     [Fact]
+    public void DenseNumericLiteral_ConstructsPackedStorageWithoutBoxingElements()
+    {
+        var assembly = Compile("""
+            function make(n: number): number[] { return [n, n + 1, n + 2, n + 3]; }
+            """);
+        var instructions = ReadInstructions(FindFunction(assembly, "make")).ToArray();
+        Assert.Contains(instructions, instruction => instruction.OpCode == OpCodes.Newobj &&
+            instruction.Operand is ConstructorInfo ctor && ctor.DeclaringType?.Name == "$Array" &&
+            ctor.GetParameters().Select(parameter => parameter.ParameterType)
+                .SequenceEqual(new[] { typeof(double[]) }));
+        Assert.DoesNotContain(instructions, instruction => instruction.OpCode == OpCodes.Box);
+    }
+
+    [Fact]
+    public void NestedArrayRead_UsesNumericStorageAndCapturesReceiverBeforeKey()
+    {
+        const string source = """
+            interface Record { values: number[]; }
+            function read(record: Record, index: number): number {
+                return record.values[index] * 2;
+            }
+            let record: Record = { values: [3, 4] };
+            function key(): number { record.values = [9, 10]; return 0; }
+            console.log(record.values[key()] * 2, read(record, 0));
+            """;
+        var assembly = Compile(source);
+        Assert.Contains(ReadInstructions(FindFunction(assembly, "read")), instruction =>
+            instruction.Operand is MethodBase { Name: "GetDouble" });
+        Assert.Equal("6 18\n", TestHarness.RunCompiled(source));
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    [Fact]
     public void NumericConsumer_UsesGuardedGetDoubleWithoutBoxingHotResult()
     {
         Assembly assembly = Compile("""

--- a/tests/SharpTS.Tests/SharedTests/AllocationLiteralTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/AllocationLiteralTests.cs
@@ -1,0 +1,98 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+public class AllocationLiteralTests
+{
+    [Theory, ModeData]
+    public void NumericLiteralsKeepDynamicElementsAndObjectArrayAliases(ExecutionMode mode)
+    {
+        const string source = """
+            function make(value: any): number[] { return [1, value as number, 3]; }
+            const values = make("text");
+            console.log(typeof values[1], values[1]);
+            const numbers: number[] = [1, 2, 3];
+            const alias: any[] = numbers;
+            let sum: number = 0;
+            for (let i = 0; i < alias.length; i++) sum += alias[i];
+            console.log(sum, numbers.join(","));
+            """;
+        Assert.Equal("string text\n6 1,2,3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void RangeAppendRetainsEmptyFractionalAndNonemptyCases(ExecutionMode mode)
+    {
+        const string source = """
+            function collect(start: number, end: number): string {
+                const items: any[] = ["prefix"];
+                for (let i = start; i < end; i++) items.push({ value: i });
+                let result: string = "" + items.length;
+                for (let j = 1; j < items.length; j++) result += ":" + items[j].value;
+                return result;
+            }
+            console.log(collect(3, 6), collect(6, 3), collect(-2, 1));
+            console.log(collect(0.5, 2), collect(2, 3.5), collect(NaN, 3));
+            """;
+        Assert.Equal("4:3:4:5 1 4:-2:-1:0\n3:0.5:1.5 3:2:3 1\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void NumberConcatenationPreservesFormattingAndEvaluationOrder(ExecutionMode mode)
+    {
+        const string source = """
+            function label(value: number): string { return "item-" + (value % 100); }
+            function suffix(value: number): string { return (value / 2) + "!"; }
+            console.log(label(123), label(-0), label(NaN), suffix(Infinity), suffix(1e22));
+            let calls: string = "";
+            function text(): string { calls += "s"; return "x"; }
+            function number(): number { calls += "n"; return 3; }
+            console.log(text() + number(), number() + text(), calls);
+            function dynamic(value: any): string { return "x" + (value as number); }
+            const object: any = { valueOf: () => 7, toString: () => "wrong" };
+            console.log(dynamic(object));
+            """;
+        Assert.Equal("item-23 item-0 item-NaN Infinity! 5e+21!\nx3 3x snns\nx7\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void LiteralsPreserveOrderHolesAndIndependentStorage(ExecutionMode mode)
+    {
+        const string source = """
+            let calls: number = 0;
+            function next(): number { calls++; return calls; }
+            const first: number[] = [next(), next(), next()];
+            const second: number[] = [...first];
+            first[0] = 99;
+            const sparse: any[] = [, undefined, 3];
+            console.log(first.join(","), second.join(","), calls);
+            console.log(sparse.length, 0 in sparse, 1 in sparse);
+            console.log([3].length, [3][0], new Array(3).length, 0 in new Array(3));
+            """;
+        Assert.Equal("99,2,3 1,2,3 3\n3 false true\n1 3 3 false\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void NestedNumericLiteralsPreserveSpecialValuesAndAliasedWrites(ExecutionMode mode)
+    {
+        const string source = """
+            const record = { values: [1, -0, NaN, Infinity] };
+            const alias: any = record.values;
+            console.log(record.values.length, 1 / record.values[1],
+                Number.isNaN(record.values[2]), record.values[3]);
+            alias[0] = "changed";
+            alias.push("tail");
+            console.log(record.values[0], record.values.length, alias[4]);
+            delete alias[1];
+            console.log(1 in record.values, record.values[1]);
+            Object.defineProperty(alias, "2", { get: () => 7, configurable: true });
+            console.log(record.values[2]);
+            """;
+        Assert.Equal("4 -Infinity true Infinity\nchanged 5 tail\nfalse undefined\n7\n",
+            TestHarness.Run(source, mode));
+    }
+}

--- a/tests/SharpTS.Tests/SharedTests/AllocationLiteralTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/AllocationLiteralTests.cs
@@ -6,6 +6,28 @@ namespace SharpTS.Tests.SharedTests;
 public class AllocationLiteralTests
 {
     [Theory, ModeData]
+    public void PackedWritesPreserveNumericPropertyKeys(ExecutionMode mode)
+    {
+        const string source = """
+            function read(values: any, key: number): any { return values["" + key]; }
+            function write(values: number[], key: number): void {
+                values[key] = 7;
+                console.log(read(values, key), values.length, values[1]);
+                console.log(values[key] = 9, read(values, key));
+            }
+            write([1, 2, 3], 1.5);
+            write([1, 2, 3], -1);
+            write([1, 2, 3], NaN);
+            write([1, 2, 3], Infinity);
+            write([1, 2, 3], 4294967296);
+            const record = { values: [1, 2, 3] };
+            console.log(record.values[-1] = 5, read(record.values, -1), record.values.length);
+            """;
+        Assert.Equal(string.Concat(Enumerable.Repeat("7 3 2\n9 9\n", 5)) + "5 5 3\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
     public void NumericLiteralsKeepDynamicElementsAndObjectArrayAliases(ExecutionMode mode)
     {
         const string source = """


### PR DESCRIPTION
## Summary

The allocation worker benchmark creates 20,000 retained records and nested arrays. Compiled execution was allocating about 11.40 MB per invocation, including temporary array-construction lists, boxed numeric elements, and generic interface property reads. This change reduces measured allocation to 4.80 MB per invocation while preserving the original kernel.

- Construct literals directly in the final array and use packed-double storage for proven native numeric elements.
- Use guarded compact-record reads through interfaces and guarded numeric reads for nested array receivers, preserving mutation and evaluation order.
- Reserve capacity for bounded append ranges and specialize primitive string/number concatenation without changing JavaScript number formatting.
- Add an independent checksum to the cross-runtime workload and reusable construction/traversal diagnostics with interface and type-alias variants.

GC defaults and public benchmark snapshots are unchanged.

## Local performance

Windows x64, .NET SDK 10.0.400/runtime 10.0.11; workstation GC. Three-launch medians of per-launch means, in milliseconds for 20,000 records:

| Execution | Baseline | Candidate |
|---|---:|---:|
| Direct | 30.6803 | 4.1130 |
| 1 worker | 19.3940 | 4.6284 |
| 2 workers | 17.0773 | 1.2230 |
| 4 workers | 5.0162 | 1.0319 |

The baseline used the pre-change compiler at af72038b with the same independent checksum validation. Allocation was measured separately through a warmed, strongly typed kernel delegate over 100 invocations. Timing variance is substantial; these are local diagnostics, not a public snapshot refresh or a claim of Node parity.

## Validation

- Expanded compiler/array/interface/string regression run: 1,901 passed; one local TLS handshake failure reproduced with the unmodified baseline compiler.
- All 11 numeric-array checks and all 79 final append/range/literal checks passed.
- Allocation diagnostic setup validated N=2,000 and N=20,000 with both declaration variants.
- Both three-launch cross-runtime runs and snapshot validation completed successfully.
- Final reservation safety checks leave the measured kernel's generated IL unchanged.

- Merged main queue optimizations and passed 55 focused allocation/queue checks, including nonzero-range reservation with earlier appends.
- Passed 40 numeric-array/queue/literal checks, all 7 assignment-write checks, and allocation smoke validation after the review fix.
- Broader follow-up: 1,943 passed; updated one IL-shape assertion (now passing), six HTTP-listener setup failures, and one asynchronous test that passed on isolated rerun.

CI verified on 96ff5be6: Windows and Linux builds/core suites, benchmark smoke, Native AOT, macOS debugger smoke, desktop GUI gates, workflow policy, and automated review all passed. Conditional Windows ARM64 native certification and lightweight validation jobs were skipped by the workflows.


