### PR TITLE
Optimize object spread copying and stable numeric consumers

### DIFF
--- a/benchmarks/cross-runtime/README.md
+++ b/benchmarks/cross-runtime/README.md
@@ -139,6 +139,18 @@ optimizing JavaScript engine start with tagged-small-integer arithmetic and
 deopt only at larger parameters. Other integer-oriented probes intentionally
 retain their natural representation behavior.
 
+`object-spread.ts` validates checksums for stable single-source and overwrite
+spreads, plus a mutation case passed to an `any` consumer. Controls compare a
+direct literal passed to the same consumer, the spread with its mutations
+inlined, and results retained in an array before consumption. The retained case
+also measures array allocation and traversal. The historical `escape` case name
+denotes a function boundary, not required retention: SharpTS can now specialize
+stable, bounded numeric-only consumers and preserve local object promotion.
+Truly retained results still materialize, while independent spread sources can
+remain in typed storage. Use the inline and retained controls to distinguish
+these cases, and the internal `ObjectLiteralsBenchmarks` spread cases for
+allocation/GC evidence.
+
 The `worker-scaling` workload uses the same parent, worker, and CPU-kernel
 TypeScript verbatim in every runtime. It keeps the total amount of CPU work
 fixed while varying the persistent pool size from 1 to 16 workers. Pool startup,

--- a/benchmarks/cross-runtime/scripts/object-spread.ts
+++ b/benchmarks/cross-runtime/scripts/object-spread.ts
@@ -37,10 +37,53 @@ function spreadMutationEscape(n: number): number {
     return total;
 }
 
+// Same consumer without spread: separates spread/source allocation from call and mutation costs.
+function directMutationEscape(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const directResult = { a: i, b: i + 1, c: i + 2, d: i + 3 };
+        directResult.b = directResult.b + 1;
+        total = total + consumeSpreadResult(directResult);
+    }
+    return total;
+}
+
+// Same mutations with no function boundary: local mutation can retain shape promotion.
+function spreadInlineMutation(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const inlineSource = { a: i, b: i + 1, c: i + 2 };
+        const inlineResult = { ...inlineSource, d: i + 3 };
+        inlineResult.b = inlineResult.b + 1;
+        inlineResult.d = inlineResult.d + 1;
+        total = total + (inlineResult.a + inlineResult.d);
+    }
+    return total;
+}
+
+// Retain all results before consuming them. This includes collection allocation/traversal.
+function spreadRetainedResults(n: number): number {
+    const retained: any[] = [];
+    for (let i: number = 0; i < n; i++) {
+        const retainedSource = { a: i, b: i + 1, c: i + 2 };
+        const retainedResult = { ...retainedSource, d: i + 3 };
+        retainedResult.b = retainedResult.b + 1;
+        retained.push(retainedResult);
+    }
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        total = total + consumeSpreadResult(retained[i]);
+    }
+    return total;
+}
+
 const sizes: number[] = [10000, 100000];
 for (let i: number = 0; i < sizes.length; i++) {
     const n: number = sizes[i];
-    bench("object-spread-one", n, () => spreadOneSource(n));
-    bench("object-spread-overwrite", n, () => spreadMultipleOverwrite(n));
-    bench("object-spread-escape", n, () => spreadMutationEscape(n));
+    bench("object-spread-one", n, () => spreadOneSource(n), n * (n + 2));
+    bench("object-spread-overwrite", n, () => spreadMultipleOverwrite(n), 2 * n * n + 13 * n);
+    bench("object-spread-escape", n, () => spreadMutationEscape(n), n * (n + 3));
+    bench("object-direct-escape", n, () => directMutationEscape(n), n * (n + 3));
+    bench("object-spread-inline", n, () => spreadInlineMutation(n), n * (n + 3));
+    bench("object-spread-retained", n, () => spreadRetainedResults(n), n * (n + 3));
 }

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -1012,6 +1012,7 @@ public class EmittedRuntime
 
     // Symbol storage for compiled objects (symbol as object key)
     public MethodBuilder GetSymbolDictMethod { get; set; } = null!;
+    public MethodBuilder TryGetSymbolDictMethod { get; set; } = null!;
     public MethodBuilder IsSymbolMethod { get; set; } = null!;
 
     // BigInt support

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -661,7 +661,7 @@ public partial class ILCompiler
         return statements;
     }
 
-    private void AnalyzeClosuresAndPromotions(List<Stmt> statements)
+    private void AnalyzeClosuresAndPromotions(List<Stmt> statements, IReadOnlyList<ParsedModule>? modules = null)
     {
         Phase2_AnalyzeClosures(statements);
         StableMapIterationAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
@@ -684,7 +684,18 @@ public partial class ILCompiler
         TypedArrayHoistAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         ArrayLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer, _features);
         StringAccumulatorPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
-        ObjectLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
+        // Callee identity proofs stay inside their module. The combined object-local pass
+        // still handles global name/capture conflicts conservatively across all modules.
+        Dictionary<Expr.Call, ObjectConsumerInfo>? consumers = null;
+        if (modules != null)
+        {
+            consumers = new(ReferenceEqualityComparer.Instance);
+            foreach (var module in modules)
+                if (!module.IsCommonJs)
+                    foreach (var (call, summary) in StableObjectConsumerAnalyzer.Analyze(module.Statements))
+                        consumers.Add(call, summary);
+        }
+        ObjectLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer, consumers);
     }
 
     private void DefineSingleProgramStructure(List<Stmt> statements)
@@ -1270,7 +1281,7 @@ public partial class ILCompiler
             var allStatements = PrepareModuleCompilation(modules, resolver, typeMap, deadCodeInfo);
             ModulePhase0_ExtractNamespaces(modules);
             Phase1_EmitRuntimeTypes();
-            AnalyzeClosuresAndPromotions(allStatements);
+            AnalyzeClosuresAndPromotions(allStatements, modules);
             DefineModuleProgramStructure(allStatements);
             AnalyzeModuleBindings(modules);
             ModulePhase5_DefineDeclarations(modules);
@@ -1292,7 +1303,7 @@ public partial class ILCompiler
             () => ModulePhase0_ExtractNamespaces(modules));
         _timingCollector.Measure(ExecutionPhaseTiming.EmitRuntimeTypes, Phase1_EmitRuntimeTypes);
         _timingCollector.Measure(ExecutionPhaseTiming.AnalyzeClosures,
-            () => AnalyzeClosuresAndPromotions(statements));
+            () => AnalyzeClosuresAndPromotions(statements, modules));
         _timingCollector.Measure(ExecutionPhaseTiming.DefineProgramStructure,
             () => DefineModuleProgramStructure(statements));
         _timingCollector.Measure(ExecutionPhaseTiming.AnalyzeModuleBindings,

--- a/src/SharpTS/Compilation/ILEmitter.Calls.ObjectConsumers.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.ObjectConsumers.cs
@@ -1,0 +1,63 @@
+using System.Reflection.Emit;
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation;
+
+public partial class ILEmitter
+{
+    private bool TryEmitPromotedObjectConsumer(Expr.Call call)
+    {
+        if (_ctx.TypeMap?.TryGetPromotedObjectCall(call, out var summary) != true
+            || call.Arguments is not [Expr.Variable argument]
+            || _ctx.TryGetPromotedObjectLocal(argument.Name.Lexeme) is not { } receiver)
+            return false;
+
+        // The sole argument is an exact local, so its evaluation has no effects. Emit the
+        // summarized writes against the original slot (not a copied struct), in source order.
+        foreach (var write in summary.Writes)
+        {
+            IL.Emit(OpCodes.Ldloca, receiver.Local);
+            EmitNumeric(write.Value);
+            IL.Emit(OpCodes.Stfld, receiver.Shape.FieldBuilders[write.Name.Lexeme]);
+        }
+        EmitNumeric(summary.Result);
+        SetStackType(StackType.Double);
+        return true;
+
+        void EmitNumeric(Expr expression)
+        {
+            switch (expression)
+            {
+                case Expr.Literal { Value: double value }:
+                    IL.Emit(OpCodes.Ldc_R8, value);
+                    break;
+                case Expr.Get read:
+                    IL.Emit(OpCodes.Ldloca, receiver.Local);
+                    IL.Emit(OpCodes.Ldfld, receiver.Shape.FieldBuilders[read.Name.Lexeme]);
+                    break;
+                case Expr.Grouping grouping:
+                    EmitNumeric(grouping.Expression);
+                    break;
+                case Expr.Unary unary:
+                    EmitNumeric(unary.Right);
+                    if (unary.Operator.Type == TokenType.MINUS) IL.Emit(OpCodes.Neg);
+                    break;
+                case Expr.Binary binary:
+                    EmitNumeric(binary.Left);
+                    EmitNumeric(binary.Right);
+                    IL.Emit(binary.Operator.Type switch
+                    {
+                        TokenType.PLUS => OpCodes.Add,
+                        TokenType.MINUS => OpCodes.Sub,
+                        TokenType.STAR => OpCodes.Mul,
+                        TokenType.SLASH => OpCodes.Div,
+                        TokenType.PERCENT => OpCodes.Rem,
+                        _ => throw new InvalidOperationException("Invalid numeric object-consumer operator")
+                    });
+                    break;
+                default:
+                    throw new InvalidOperationException("Invalid numeric object-consumer expression");
+            }
+        }
+    }
+}

--- a/src/SharpTS/Compilation/ILEmitter.Calls.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.cs
@@ -164,6 +164,7 @@ public partial class ILEmitter
 
     protected override void EmitCall(Expr.Call c)
     {
+        if (TryEmitPromotedObjectConsumer(c)) return;
         if (TryEmitNumericRestCompanionCall(c)) return;
         // A lexical super() inside an immediately invoked arrow must still be
         // emitted in the derived CLR constructor. Moving it into the arrow's

--- a/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
@@ -162,12 +162,16 @@ public partial class ILEmitter
         else
         {
             // Complex case: has spreads or computed keys, use Dictionary<string, object?> and SetIndex.
-            // Pre-size only when Properties.Count > 3 (matches simple-case
-            // heuristic); spreads may add more, but the resize then is
-            // hard to avoid without runtime info.
-            if (o.Properties.Count > 3)
+            // A record's merged field count is only a bounded capacity hint, never a proof
+            // of runtime keys: optional/deleted fields and structurally wider values still
+            // go through the full copy operation. Cap the hint to avoid large speculative
+            // allocations for broad annotated types.
+            int capacity = o.Properties.Count;
+            if (hasSpreads && _ctx.TypeMap?.Get(o) is SharpTS.TypeSystem.TypeInfo.Record record)
+                capacity = Math.Max(capacity, Math.Min(record.Fields.Count, 64));
+            if (capacity > 3)
             {
-                IL.Emit(OpCodes.Ldc_I4, o.Properties.Count);
+                IL.Emit(OpCodes.Ldc_I4, capacity);
                 IL.Emit(OpCodes.Newobj, _ctx.Types.GetConstructor(_ctx.Types.DictionaryStringObject, _ctx.Types.Int32));
             }
             else
@@ -181,6 +185,26 @@ public partial class ILEmitter
 
                 if (prop.IsSpread)
                 {
+                    if (prop.Value is Expr.Variable variable &&
+                        _ctx.TryGetPromotedObjectLocal(variable.Name.Lexeme) is { } source)
+                    {
+                        // Only the result escapes. Copy the source's typed fields at this
+                        // spread position without allocating or boxing a source object.
+                        foreach (var field in source.Shape.Fields)
+                        {
+                            var builder = source.Shape.FieldBuilders[field.Name];
+                            IL.Emit(OpCodes.Dup);
+                            IL.Emit(OpCodes.Ldstr, field.Name);
+                            IL.Emit(OpCodes.Ldloca, source.Local);
+                            IL.Emit(OpCodes.Ldfld, builder);
+                            if (builder.FieldType.IsValueType)
+                                IL.Emit(OpCodes.Box, builder.FieldType);
+                            IL.Emit(OpCodes.Callvirt, _ctx.Types.GetMethod(
+                                _ctx.Types.DictionaryStringObject, "set_Item", _ctx.Types.String, _ctx.Types.Object));
+                        }
+                        IL.Emit(OpCodes.Pop); // consume the duplicate target, like MergeIntoObject
+                        continue;
+                    }
                     // Spread: merge the object into target
                     EmitExpression(prop.Value);
                     EmitBoxIfNeeded(prop.Value);

--- a/src/SharpTS/Compilation/ObjectLocalPromotionAnalyzer.cs
+++ b/src/SharpTS/Compilation/ObjectLocalPromotionAnalyzer.cs
@@ -11,8 +11,8 @@ namespace SharpTS.Compilation;
 /// <see cref="NonEscapingArrowLocalAnalyzer"/>: a name qualifies only if it is provably non-escaping, so
 /// the promoted struct (which has no dynamic-object semantics — no descriptors, enumerability, prototype,
 /// <c>delete</c>, freeze) is never observed anywhere those would be needed. Stable object spread is
-/// represented by direct copies between compatible shape structs; a connected source/result chain is
-/// promoted only when every member remains non-escaping. A candidate <c>o</c>
+/// represented by direct copies between compatible shape structs. An escaping result can materialize
+/// fields from a still-promoted source. A candidate <c>o</c>
 /// qualifies iff ALL hold:
 /// <list type="number">
 ///   <item>declared <c>const</c>/<c>let</c> with an initializer that is a <em>simple</em> object literal —
@@ -23,7 +23,8 @@ namespace SharpTS.Compilation;
 ///         (which inherently excludes <c>any</c>/<c>undefined</c>-admitting fields a typed slot would
 ///         silently coerce);</item>
 ///   <item>the ONLY uses are constant-key field reads <c>o.KEY</c>, same-kind writes
-///         <c>o.KEY = v</c>, stable spread, and direct <c>Object.keys(o)</c> calls. The latter can
+///         <c>o.KEY = v</c>, stable spread, proven numeric-only consumers, and direct
+///         <c>Object.keys(o)</c> calls. The latter can
 ///         materialize the immutable key metadata without exposing the struct itself.
 ///         Any other appearance of the bare variable — argument pass, return, store to another binding,
 ///         unstable spread, <c>===</c>, <c>typeof</c>, <c>o[expr]</c>, <c>o.unknownKey</c>, <c>delete</c>,
@@ -42,15 +43,19 @@ namespace SharpTS.Compilation;
 /// </summary>
 public static class ObjectLocalPromotionAnalyzer
 {
-    public static void Analyze(List<Stmt> program, TypeMap? typeMap, ClosureAnalyzer? closures)
+    public static void Analyze(List<Stmt> program, TypeMap? typeMap, ClosureAnalyzer? closures,
+        IReadOnlyDictionary<Expr.Call, ObjectConsumerInfo>? consumers = null)
     {
         if (typeMap == null) return;
 
-        var visitor = new Visitor(typeMap);
+        var visitor = new Visitor(typeMap, consumers ?? StableObjectConsumerAnalyzer.Analyze(program));
         foreach (var stmt in program)
             visitor.Visit(stmt);
 
         var eligible = new HashSet<string>(visitor.Candidates.Keys, StringComparer.Ordinal);
+        if (visitor.Disqualified.Contains("eval")) eligible.Clear();
+        if (visitor.DeclCount.ContainsKey("Object") || visitor.Disqualified.Contains("Object"))
+            eligible.ExceptWith(visitor.ObjectKeysReceivers);
         foreach (var name in visitor.Candidates.Keys)
         {
             if (visitor.Disqualified.Contains(name)
@@ -59,18 +64,17 @@ public static class ObjectLocalPromotionAnalyzer
                 eligible.Remove(name);
         }
 
-        // A generic object cannot consume a promoted struct as a spread source, and a promoted result
-        // cannot snapshot a generic source. Therefore an instability anywhere in a spread-connected
-        // component invalidates both endpoints, transitively.
+        // A promoted result requires promoted sources, but a generic result can copy fields
+        // from a promoted source directly into its dictionary. Do not propagate an escape
+        // backwards into otherwise independent source objects.
         bool changed;
         do
         {
             changed = false;
             foreach (var (source, target) in visitor.SpreadEdges)
             {
-                if (eligible.Contains(source) && eligible.Contains(target)) continue;
-                changed |= eligible.Remove(source);
-                changed |= eligible.Remove(target);
+                if (!eligible.Contains(source))
+                    changed |= eligible.Remove(target);
             }
         } while (changed);
 
@@ -79,11 +83,16 @@ public static class ObjectLocalPromotionAnalyzer
             var candidate = visitor.Candidates[name];
             typeMap.MarkPromotableObjectLocal(candidate.NameToken, candidate.Shape);
         }
+        foreach (var (call, receiver) in visitor.ConsumerCalls)
+            if (eligible.Contains(receiver))
+                typeMap.MarkPromotedObjectCall(call, visitor.Consumers[call]);
     }
 
-    private sealed class Visitor(TypeMap typeMap) : AstVisitorBase
+    private sealed class Visitor(TypeMap typeMap, IReadOnlyDictionary<Expr.Call, ObjectConsumerInfo> consumers) : AstVisitorBase
     {
         private readonly TypeMap _typeMap = typeMap;
+        public IReadOnlyDictionary<Expr.Call, ObjectConsumerInfo> Consumers { get; } = consumers;
+        public Dictionary<Expr.Call, string> ConsumerCalls { get; } = new(ReferenceEqualityComparer.Instance);
 
         public sealed record Candidate(
             Token NameToken,
@@ -105,6 +114,7 @@ public static class ObjectLocalPromotionAnalyzer
 
         /// <summary>Names with at least one disqualifying occurrence.</summary>
         public HashSet<string> Disqualified { get; } = new();
+        public HashSet<string> ObjectKeysReceivers { get; } = new();
 
         protected override void VisitVar(Stmt.Var stmt) =>
             HandleDeclaration(stmt.Name, stmt.Initializer);
@@ -167,6 +177,16 @@ public static class ObjectLocalPromotionAnalyzer
 
         protected override void VisitCall(Expr.Call expr)
         {
+            if (Consumers.TryGetValue(expr, out var summary)
+                && expr.Arguments is [Expr.Variable argument]
+                && Candidates.TryGetValue(argument.Name.Lexeme, out var candidate)
+                && _typeMap.Get(expr) is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER }
+                && summary.NumericFields.All(name => candidate.Shape.Fields.Any(
+                    field => field.Name == name && field.Kind == TokenType.TYPE_NUMBER)))
+            {
+                ConsumerCalls[expr] = argument.Name.Lexeme;
+                return;
+            }
             // Object.keys over a closed promoted shape (#1506) observes only a fresh array of the
             // record's fixed enumerable string keys. The emitter does not load/box the struct.
             if (!expr.Optional && expr.Arguments is [Expr.Variable receiver]
@@ -177,7 +197,10 @@ public static class ObjectLocalPromotionAnalyzer
                     Name.Lexeme: "keys"
                 }
                 && Candidates.ContainsKey(receiver.Name.Lexeme))
+            {
+                ObjectKeysReceivers.Add(receiver.Name.Lexeme);
                 return;
+            }
 
             base.VisitCall(expr);
         }
@@ -209,6 +232,104 @@ public static class ObjectLocalPromotionAnalyzer
             // reassigned, ...).
             Disqualified.Add(expr.Name.Lexeme);
         }
+
+        protected override void VisitAssign(Expr.Assign expr)
+        {
+            Disqualified.Add(expr.Name.Lexeme);
+            base.VisitAssign(expr);
+        }
+
+        // Mutation operands are not ordinary reads. Traverse without the permitted field-read
+        // shortcut, including any grouping/assertion wrappers around the target.
+        private sealed class MutationVariables(HashSet<string> names) : AstVisitorBase
+        {
+            protected override void VisitVariable(Expr.Variable expr) => names.Add(expr.Name.Lexeme);
+        }
+
+        protected override void VisitDelete(Expr.Delete expr)
+        {
+            new MutationVariables(Disqualified).Visit(expr.Operand);
+            base.VisitDelete(expr);
+        }
+
+        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expr)
+        {
+            new MutationVariables(Disqualified).Visit(expr.Operand);
+            base.VisitPrefixIncrement(expr);
+        }
+
+        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expr)
+        {
+            new MutationVariables(Disqualified).Visit(expr.Operand);
+            base.VisitPostfixIncrement(expr);
+        }
+
+        protected override void VisitCompoundAssign(Expr.CompoundAssign expr)
+        {
+            Disqualified.Add(expr.Name.Lexeme);
+            base.VisitCompoundAssign(expr);
+        }
+
+        protected override void VisitLogicalAssign(Expr.LogicalAssign expr)
+        {
+            Disqualified.Add(expr.Name.Lexeme);
+            base.VisitLogicalAssign(expr);
+        }
+
+        protected override void VisitFunction(Stmt.Function statement)
+        {
+            CountName(statement.Name);
+            foreach (var parameter in statement.Parameters) CountParameter(parameter);
+            base.VisitFunction(statement);
+        }
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression)
+        {
+            foreach (var parameter in expression.Parameters) CountParameter(parameter);
+            base.VisitArrowFunction(expression);
+        }
+
+        protected override void VisitForOf(Stmt.ForOf statement)
+        {
+            CountName(statement.Variable);
+            base.VisitForOf(statement);
+        }
+
+        protected override void VisitForIn(Stmt.ForIn statement)
+        {
+            CountName(statement.Variable);
+            base.VisitForIn(statement);
+        }
+
+        protected override void VisitTryCatch(Stmt.TryCatch statement)
+        {
+            if (statement.CatchParam != null) CountName(statement.CatchParam);
+            base.VisitTryCatch(statement);
+        }
+
+        private void CountName(Token name) => DeclCount[name.Lexeme] = DeclCount.GetValueOrDefault(name.Lexeme) + 1;
+
+        private void CountParameter(Stmt.Parameter parameter)
+        {
+            CountName(parameter.Name);
+            foreach (var property in parameter.DestructuredProperties ?? []) CountName(property.Binding);
+        }
+
+        protected override void VisitAccessor(Stmt.Accessor statement)
+        {
+            if (statement.SetterParam != null) CountParameter(statement.SetterParam);
+            base.VisitAccessor(statement);
+        }
+
+        protected override void VisitImport(Stmt.Import statement)
+        {
+            if (statement.DefaultImport != null) CountName(statement.DefaultImport);
+            if (statement.NamespaceImport != null) CountName(statement.NamespaceImport);
+            foreach (var import in statement.NamedImports ?? []) CountName(import.LocalName ?? import.Imported);
+        }
+
+        protected override void VisitImportAlias(Stmt.ImportAlias statement) => CountName(statement.AliasName);
+        protected override void VisitImportRequire(Stmt.ImportRequire statement) => CountName(statement.AliasName);
 
         /// <summary>
         /// Builds the shape for a candidate object literal, or returns false if the literal is not a

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Prototype.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Prototype.cs
@@ -437,11 +437,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.ListOfObjectNullable));
         il.Emit(OpCodes.Stloc, resultLocal);
 
-        // Get symbol dictionary: var symbolDict = GetSymbolDict(obj);
+        // Return a fresh empty list without creating symbol storage on the source.
+        var returnResult = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.GetSymbolDictMethod);
+        il.Emit(OpCodes.Call, runtime.TryGetSymbolDictMethod);
         var symbolDictLocal = il.DeclareLocal(_types.DictionaryObjectObject);
         il.Emit(OpCodes.Stloc, symbolDictLocal);
+        il.Emit(OpCodes.Ldloc, symbolDictLocal);
+        il.Emit(OpCodes.Brfalse, returnResult);
 
         // Get keys and iterate: foreach (var key in symbolDict.Keys) result.Add(key);
         // symbolDict.Keys
@@ -479,6 +482,7 @@ public partial class RuntimeEmitter
         il.MarkLabel(loopEnd);
 
         // Return result
+        il.MarkLabel(returnResult);
         il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ret);
     }

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Utilities.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Utilities.cs
@@ -56,6 +56,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.UndefinedType);
         il.Emit(OpCodes.Brtrue, returnLabel);
 
+        var generalCopy = il.DefineLabel();
+        EmitPlainDataSpreadCopy(il, runtime, generalCopy, returnLabel);
+        il.MarkLabel(generalCopy);
+
         // Snapshot the complete mixed [[OwnPropertyKeys]] list once. Proxy ownKeys must be invoked
         // exactly once; ordinary carriers reuse GetKeys' mature enumerable-string ordering and append
         // Symbols for per-key descriptor filtering.
@@ -77,6 +81,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Call, runtime.GetKeys);
         il.Emit(OpCodes.Stloc, keysLocal);
+        // No symbols means no temporary symbol list (and no attached symbol storage).
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.TryGetSymbolDictMethod);
+        il.Emit(OpCodes.Brfalse, keysReady);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Call, runtime.GetOwnPropertySymbols);
         il.Emit(OpCodes.Castclass, listType);
@@ -145,6 +153,98 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(returnLabel);
         il.Emit(OpCodes.Ret);
+    }
+
+    /// <summary>
+    /// Copy an ordinary, descriptor-free dictionary directly into the fresh literal target.
+    /// Neither key enumeration nor value reads can run guest code here. Validate every key
+    /// before writing so the fallback retains complete CopyDataProperties ordering.
+    /// </summary>
+    private void EmitPlainDataSpreadCopy(
+        ILGenerator il, EmittedRuntime runtime, Label fallback, Label done)
+    {
+        var dictType = _types.DictionaryStringObject;
+        var source = il.DeclareLocal(dictType);
+        var symbols = il.DeclareLocal(_types.DictionaryObjectObject);
+        var getEnumerator = _types.GetMethodNoParams(dictType, "GetEnumerator");
+        var enumType = getEnumerator.ReturnType;
+        var enumerator = il.DeclareLocal(enumType);
+        var pairType = _types.KeyValuePairStringObject;
+        var pair = il.DeclareLocal(pairType);
+        var key = il.DeclareLocal(_types.String);
+        var firstChar = il.DeclareLocal(_types.Int32);
+        var noSymbols = il.DefineLabel();
+        var checkKey = il.DefineLabel();
+        var copyStart = il.DefineLabel();
+        var copyNext = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Isinst, dictType);
+        il.Emit(OpCodes.Stloc, source);
+        il.Emit(OpCodes.Ldloc, source);
+        il.Emit(OpCodes.Brfalse, fallback);
+        il.Emit(OpCodes.Ldloc, source);
+        il.Emit(OpCodes.Call, runtime.PDSHasPropertyDescriptors);
+        il.Emit(OpCodes.Brtrue, fallback);
+        il.Emit(OpCodes.Ldloc, source);
+        il.Emit(OpCodes.Call, runtime.TryGetSymbolDictMethod);
+        il.Emit(OpCodes.Stloc, symbols);
+        il.Emit(OpCodes.Ldloc, symbols);
+        il.Emit(OpCodes.Brfalse, noSymbols);
+        il.Emit(OpCodes.Ldloc, symbols);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.DictionaryObjectObject, "Count").GetGetMethod()!);
+        il.Emit(OpCodes.Brtrue, fallback);
+        il.MarkLabel(noSymbols);
+
+        il.Emit(OpCodes.Ldloc, source);
+        il.Emit(OpCodes.Callvirt, getEnumerator);
+        il.Emit(OpCodes.Stloc, enumerator);
+        il.MarkLabel(checkKey);
+        il.Emit(OpCodes.Ldloca, enumerator);
+        il.Emit(OpCodes.Call, _types.GetMethodNoParams(enumType, "MoveNext"));
+        il.Emit(OpCodes.Brfalse, copyStart);
+        il.Emit(OpCodes.Ldloca, enumerator);
+        il.Emit(OpCodes.Call, _types.GetProperty(enumType, "Current").GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, pair);
+        il.Emit(OpCodes.Ldloca, pair);
+        il.Emit(OpCodes.Call, _types.GetProperty(pairType, "Key").GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, key);
+        il.Emit(OpCodes.Ldloc, key);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.String, "Length").GetGetMethod()!);
+        il.Emit(OpCodes.Brfalse, checkKey);
+        // Canonical array-index keys start with an ASCII digit. Conservatively defer all
+        // such keys to NormalizeOwnPropertyKeys, including noncanonical forms like "01".
+        il.Emit(OpCodes.Ldloc, key);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.String, "Chars").GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, firstChar);
+        il.Emit(OpCodes.Ldloc, firstChar);
+        il.Emit(OpCodes.Ldc_I4, (int)'0');
+        il.Emit(OpCodes.Blt, checkKey);
+        il.Emit(OpCodes.Ldloc, firstChar);
+        il.Emit(OpCodes.Ldc_I4, (int)'9');
+        il.Emit(OpCodes.Ble, fallback);
+        il.Emit(OpCodes.Br, checkKey);
+
+        il.MarkLabel(copyStart);
+        // Dictionary's struct enumerator owns no resources; restarting it allocates nothing.
+        il.Emit(OpCodes.Ldloc, source);
+        il.Emit(OpCodes.Callvirt, getEnumerator);
+        il.Emit(OpCodes.Stloc, enumerator);
+        il.MarkLabel(copyNext);
+        il.Emit(OpCodes.Ldloca, enumerator);
+        il.Emit(OpCodes.Call, _types.GetMethodNoParams(enumType, "MoveNext"));
+        il.Emit(OpCodes.Brfalse, done);
+        il.Emit(OpCodes.Ldloca, enumerator);
+        il.Emit(OpCodes.Call, _types.GetProperty(enumType, "Current").GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, pair);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloca, pair);
+        il.Emit(OpCodes.Call, _types.GetProperty(pairType, "Key").GetGetMethod()!);
+        il.Emit(OpCodes.Ldloca, pair);
+        il.Emit(OpCodes.Call, _types.GetProperty(pairType, "Value").GetGetMethod()!);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(dictType, "set_Item", _types.String, _types.Object));
+        il.Emit(OpCodes.Br, copyNext);
     }
 
     private void EmitMergeIntoTSObject(TypeBuilder typeBuilder, EmittedRuntime runtime)

--- a/src/SharpTS/Compilation/RuntimeEmitter.Symbols.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Symbols.cs
@@ -30,6 +30,22 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(symbolStorageType, "GetOrCreateValue", [_types.Object])!);
         il.Emit(OpCodes.Ret);
+
+        // Read-only consumers must not attach empty symbol storage to every object they inspect.
+        var tryGet = typeBuilder.DefineMethod(
+            "TryGetSymbolDict", MethodAttributes.Private | MethodAttributes.Static,
+            symbolDictType, [_types.Object]);
+        runtime.TryGetSymbolDictMethod = tryGet;
+        var readIl = tryGet.GetILGenerator();
+        var result = readIl.DeclareLocal(symbolDictType);
+        readIl.Emit(OpCodes.Ldsfld, symbolStorageField);
+        readIl.Emit(OpCodes.Ldarg_0);
+        readIl.Emit(OpCodes.Ldloca, result);
+        readIl.Emit(OpCodes.Callvirt, _types.GetMethod(symbolStorageType, "TryGetValue",
+            [_types.Object, symbolDictType.MakeByRefType()])!);
+        readIl.Emit(OpCodes.Pop);
+        readIl.Emit(OpCodes.Ldloc, result);
+        readIl.Emit(OpCodes.Ret);
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/StableObjectConsumerAnalyzer.cs
+++ b/src/SharpTS/Compilation/StableObjectConsumerAnalyzer.cs
@@ -1,0 +1,113 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Resolves small numeric record consumers at exact call sites. A summary may only read numeric
+/// fields of its sole argument, write numeric expressions back to those fields, and return a
+/// numeric expression. No calls, aliases, captures, control flow, or dynamic observations occur.
+/// The caller must separately prove that the argument is a promoted record with those fields.
+/// </summary>
+internal static class StableObjectConsumerAnalyzer
+{
+    public static Dictionary<Expr.Call, ObjectConsumerInfo> Analyze(IReadOnlyList<Stmt> statements)
+    {
+        var results = new Dictionary<Expr.Call, ObjectConsumerInfo>(ReferenceEqualityComparer.Instance);
+        var stable = new HashSet<Stmt.Function>(ReferenceEqualityComparer.Instance);
+        StableFunctionBindingAnalyzer.Analyze(statements, stable);
+        var hazards = new BindingHazards();
+        foreach (var statement in statements) hazards.Visit(statement);
+        if (hazards.DynamicBindings) return results;
+        stable.RemoveWhere(function => hazards.ImportedNames.Contains(function.Name.Lexeme));
+
+        // Reuse the lexical call resolver: same-named parameters/locals and nested callable
+        // boundaries cannot inherit a top-level declaration's identity proof.
+        var calls = NumericRestCallBindingAnalyzer.Analyze(statements, stable.ToList(), stable);
+        foreach (var function in stable)
+        {
+            if (!TrySummarize(function, out var summary)) continue;
+            foreach (var call in calls.GetValueOrDefault(function) ?? [])
+                if (!call.Optional && call.Arguments is [Expr.Variable]
+                    && call.Callee is Expr.Variable callee && callee.Name.Lexeme == function.Name.Lexeme)
+                    results[call] = summary;
+        }
+        return results;
+    }
+
+    private static bool TrySummarize(Stmt.Function function, out ObjectConsumerInfo summary)
+    {
+        summary = null!;
+        if (function.IsAsync || function.IsGenerator || function.IsDeclare
+            || function.TypeParams is { Count: > 0 } || function.Decorators is { Count: > 0 }
+            || function.Parameters is not [var parameter]
+            || parameter.IsRest || parameter.IsOptional || parameter.DefaultValue is not null
+            || parameter.DestructuredProperties is not null
+            || function.Body is not { Count: > 0 and <= 8 } body
+            || body[^1] is not Stmt.Return { Value: { } result })
+            return false;
+
+        var fields = new HashSet<string>(StringComparer.Ordinal);
+        var writes = new List<Expr.Set>();
+        int budget = 64;
+        foreach (var statement in body.Take(body.Count - 1))
+        {
+            if (statement is not Stmt.Expression { Expr: Expr.Set write }
+                || write.Object is not Expr.Variable receiver || receiver.Name.Lexeme != parameter.Name.Lexeme
+                || !IsNumericExpression(write.Value, parameter.Name.Lexeme, fields, ref budget))
+                return false;
+            fields.Add(write.Name.Lexeme);
+            writes.Add(write);
+        }
+        if (!IsNumericExpression(result, parameter.Name.Lexeme, fields, ref budget)) return false;
+        summary = new(parameter.Name.Lexeme, writes, result, fields);
+        return true;
+    }
+
+    private static bool IsNumericExpression(Expr expression, string parameter,
+        HashSet<string> fields, ref int budget)
+    {
+        if (--budget < 0) return false;
+        switch (expression)
+        {
+            case Expr.Literal { Value: double }:
+                return true;
+            case Expr.Get { Optional: false, Object: Expr.Variable receiver } read
+                when receiver.Name.Lexeme == parameter:
+                fields.Add(read.Name.Lexeme);
+                return true;
+            case Expr.Grouping grouping:
+                return IsNumericExpression(grouping.Expression, parameter, fields, ref budget);
+            case Expr.Unary unary when unary.Operator.Type is TokenType.PLUS or TokenType.MINUS:
+                return IsNumericExpression(unary.Right, parameter, fields, ref budget);
+            case Expr.Binary binary when binary.Operator.Type is TokenType.PLUS or TokenType.MINUS
+                or TokenType.STAR or TokenType.SLASH or TokenType.PERCENT:
+                return IsNumericExpression(binary.Left, parameter, fields, ref budget)
+                    && IsNumericExpression(binary.Right, parameter, fields, ref budget);
+            default:
+                return false;
+        }
+    }
+
+    private sealed class BindingHazards : AstVisitorBase
+    {
+        public bool DynamicBindings { get; private set; }
+        public HashSet<string> ImportedNames { get; } = new(StringComparer.Ordinal);
+        protected override void VisitVariable(Expr.Variable expression)
+        {
+            if (expression.Name.Lexeme is "eval" or "globalThis" or "Function") DynamicBindings = true;
+        }
+        protected override void VisitThis(Expr.This expression) => DynamicBindings = true;
+        protected override void VisitImport(Stmt.Import statement)
+        {
+            if (statement.DefaultImport != null) ImportedNames.Add(statement.DefaultImport.Lexeme);
+            if (statement.NamespaceImport != null) ImportedNames.Add(statement.NamespaceImport.Lexeme);
+            foreach (var import in statement.NamedImports ?? [])
+                ImportedNames.Add((import.LocalName ?? import.Imported).Lexeme);
+        }
+        // Import-equals constructs have separate binding rules; retain general calls.
+        protected override void VisitImportAlias(Stmt.ImportAlias statement) => DynamicBindings = true;
+        protected override void VisitImportRequire(Stmt.ImportRequire statement) => DynamicBindings = true;
+    }
+}

--- a/src/SharpTS/Execution/Interpreter.Expressions.cs
+++ b/src/SharpTS/Execution/Interpreter.Expressions.cs
@@ -812,6 +812,8 @@ public partial class Interpreter
 
         if (spreadValue is SharpTSObject spreadObj)
         {
+            if (spreadObj.TryCopyPlainSpreadFields(stringFields))
+                return symbolFields;
             // CopyDataProperties obtains one complete [[OwnPropertyKeys]] snapshot before
             // consulting descriptors or invoking getters. Descriptor and value reads remain
             // live, but getter-driven string/Symbol additions cannot join this spread.
@@ -819,13 +821,13 @@ public partial class Interpreter
             var symbolKeys = spreadObj.GetSymbolPropertyNames().ToList();
             foreach (string key in stringKeys)
             {
-                if (spreadObj.GetOwnPropertyDescriptor(key)?.Enumerable != true)
+                if (!spreadObj.IsOwnEnumerableProperty(key))
                     continue;
                 stringFields[key] = GetPropertyValue(spreadObj, key);
             }
             foreach (SharpTSSymbol symbol in symbolKeys)
             {
-                if (spreadObj.GetOwnPropertyDescriptor(symbol)?.Enumerable != true)
+                if (!spreadObj.IsOwnEnumerableProperty(symbol))
                     continue;
                 (symbolFields ??= [])[symbol] = GetSymbolPropertyValue(spreadObj, symbol);
             }

--- a/src/SharpTS/Runtime/Types/SharpTSObject.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSObject.cs
@@ -1156,6 +1156,33 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
             ? OwnStringKeys().Where(key => !IsInternalSlot(key))
             : OwnStringKeys();
 
+    /// <summary>Copy untouched ordinary data properties without snapshots or descriptor objects.</summary>
+    internal bool TryCopyPlainSpreadFields(Dictionary<string, object?> destination)
+    {
+        if (GetType() != typeof(SharpTSObject) || IsPrimitiveWrapper
+            || _descriptors is not null || _accessorProperties is not null
+            || _stringPropertyOrder is not null || _symbolFields is not null
+            || _symbolAccessors is not null || _symbolDescriptors is not null)
+            return false;
+
+        // Preserve numeric key ordering and the interpreter's callable binding behavior by
+        // retaining the general path. Validate everything before modifying the destination.
+        foreach (var entry in _fields)
+            if (TryGetArrayIndex(entry.Key, out _) || entry.Value is ISharpTSCallable)
+                return false;
+
+        destination.EnsureCapacity(destination.Count + _fields.Count);
+        foreach (var entry in _fields)
+            destination[entry.Key] = entry.Value;
+        return true;
+    }
+
+    internal bool IsOwnEnumerableProperty(string name)
+        => HasOwnStringProperty(name) && GetPropertyFlags(name).Enumerable;
+
+    internal bool IsOwnEnumerableProperty(SharpTSSymbol symbol)
+        => HasSymbolProperty(symbol) && GetSymbolPropertyFlags(symbol).Enumerable;
+
     /// <summary>
     /// All own string-keyed property names in ECMA-262 OwnPropertyKeys order:
     /// canonical array indices ascending, then other strings in creation order.

--- a/src/SharpTS/TypeSystem/ObjectConsumerInfo.cs
+++ b/src/SharpTS/TypeSystem/ObjectConsumerInfo.cs
@@ -1,0 +1,8 @@
+using SharpTS.Parsing;
+
+namespace SharpTS.TypeSystem;
+
+/// <summary>A bounded numeric-only consumer whose parameter cannot escape or alias another value.</summary>
+public sealed record ObjectConsumerInfo(
+    string ParameterName, IReadOnlyList<Expr.Set> Writes, Expr Result,
+    IReadOnlySet<string> NumericFields);

--- a/src/SharpTS/TypeSystem/TypeMap.cs
+++ b/src/SharpTS/TypeSystem/TypeMap.cs
@@ -24,6 +24,7 @@ public class TypeMap
     private readonly HashSet<Token> _promotableNumericMapLocals = new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Token> _promotableStringAccumulators = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<Token, ObjectShapeInfo> _promotableObjectLocals = new(ReferenceEqualityComparer.Instance);
+    private readonly Dictionary<Expr.Call, ObjectConsumerInfo> _promotedObjectCalls = new(ReferenceEqualityComparer.Instance);
     private readonly Dictionary<Token, ClassScalarReplacementInfo> _scalarReplaceableClassLocals =
         new(ReferenceEqualityComparer.Instance);
     private readonly HashSet<Stmt.ForOf> _stableNumericMapIterations = new(ReferenceEqualityComparer.Instance);
@@ -245,6 +246,10 @@ public class TypeMap
     /// the generated types). Empty when no object local was promoted.
     /// </summary>
     public IEnumerable<ObjectShapeInfo> PromotableObjectLocalShapes => _promotableObjectLocals.Values;
+
+    public void MarkPromotedObjectCall(Expr.Call call, ObjectConsumerInfo summary) => _promotedObjectCalls[call] = summary;
+    public bool TryGetPromotedObjectCall(Expr.Call call, out ObjectConsumerInfo summary) =>
+        _promotedObjectCalls.TryGetValue(call, out summary!);
 
     /// <summary>
     /// Marks a fresh exact-class local whose allocation and pure constructor may be

--- a/tests/SharpTS.Tests/CompilerTests/ObjectConsumerAllocationTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/ObjectConsumerAllocationTests.cs
@@ -1,0 +1,127 @@
+using System.Reflection;
+using SharpTS.Compilation;
+using SharpTS.Modules;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public class ObjectConsumerAllocationTests
+{
+    [Fact]
+    public void ImportedWorkload_UsesModuleLocalSummaryDespiteUnrelatedThisUsage()
+    {
+        string virtualBase = Path.Combine(Path.GetTempPath(), $"consumer_modules_{Guid.NewGuid():N}");
+        string main = Path.Combine(virtualBase, "main.ts");
+        var files = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [Path.Combine(virtualBase, "support.ts")] = "export class Example { value(): number { return this.n; } n: number = 1; }",
+            [main] = """
+                import { Example } from './support';
+                function consume(value: any): number { value.a = value.a + 1; return value.a; }
+                export function work(n: number): number {
+                    let sum: number = 0;
+                    for (let i: number = 0; i < n; i++) {
+                        const original = { a: i };
+                        const result = { ...original };
+                        sum = sum + consume(result);
+                    }
+                    return sum;
+                }
+                """
+        };
+        var resolver = new ModuleResolver(main, files);
+        var modules = resolver.GetModulesInOrder(resolver.LoadModule(main));
+        var map = TestHarness.CheckModulesOrThrow(new TypeChecker(), modules, resolver);
+        var compiler = new ILCompiler($"consumer_modules_{Guid.NewGuid():N}");
+        compiler.CompileModules(modules, resolver, map,
+            new DeadCodeAnalyzer(map).Analyze(modules.SelectMany(module => module.Statements).ToList()));
+        var work = FindFunction(Assembly.Load(compiler.SaveToBytes()), "work").CreateDelegate<Func<double, double>>();
+        Assert.Equal(50005000, work(10000));
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        double result = work(10000);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.Equal(50005000, result);
+        Assert.Equal(0, allocated);
+    }
+
+    [Fact]
+    public void ReassignedDirectConsumer_DoesNotReceiveASummary()
+    {
+        const string source = """
+            function consume(value: any): number { value.a = value.a + 1; return value.a; }
+            function work(): number { const result = { a: 1 }; return consume(result); }
+            consume = (value: any): number => 100;
+            """;
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        Assert.Empty(StableObjectConsumerAnalyzer.Analyze(statements));
+    }
+    [Fact]
+    public void NumericConsumer_PreservesPromotionAcrossCallBoundary()
+    {
+        const string source = """
+            function consume(value: any): number {
+                value.d = value.d + 1;
+                return value.a + value.d;
+            }
+            function work(n: number): number {
+                let total: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    const original = { a: i, b: i + 1, c: i + 2 };
+                    const result = { ...original, d: i + 3 };
+                    result.b = result.b + 1;
+                    total = total + consume(result);
+                }
+                return total;
+            }
+            """;
+        var work = FindFunction(Compile(source), "work").CreateDelegate<Func<double, double>>();
+        Assert.Equal(100030000, work(10000));
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        double result = work(10000);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.Equal(100030000, result);
+        Assert.Equal(0, allocated);
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    [Fact]
+    public void EscapingResult_KeepsSourceInTypedStorage()
+    {
+        const string source = """
+            function make(n: number, flag: boolean, text: string): any {
+                const original = { a: n, b: flag, c: text };
+                const result = { ...original, d: n + 3 };
+                return result;
+            }
+            """;
+        var method = FindFunction(Compile(source), "make");
+        Assert.Contains(method.GetMethodBody()!.LocalVariables,
+            local => local.LocalType.Name.StartsWith("$Shape_", StringComparison.Ordinal));
+        var make = method.CreateDelegate<Func<double, bool, string, object>>();
+        var first = Assert.IsType<Dictionary<string, object>>(make(1, true, "three"));
+        var second = Assert.IsType<Dictionary<string, object>>(make(1, true, "three"));
+        Assert.NotSame(first, second);
+        first["a"] = 10d;
+        Assert.Equal(1d, second["a"]);
+        Assert.Equal(true, second["b"]);
+        Assert.Equal("three", second["c"]);
+        Assert.Equal(4d, second["d"]);
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    private static Assembly Compile(string source)
+    {
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var compiler = new ILCompiler($"object_consumer_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, new DeadCodeAnalyzer(typeMap).Analyze(statements));
+        return Assembly.Load(compiler.SaveToBytes());
+    }
+
+    private static MethodInfo FindFunction(Assembly assembly, string name) => assembly.GetType("$Program")!
+        .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+        .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
+}

--- a/tests/SharpTS.Tests/CompilerTests/ObjectSpreadAllocationTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/ObjectSpreadAllocationTests.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public class ObjectSpreadAllocationTests
+{
+    [Fact]
+    public void PlainSpreadAndSymbolReads_DoNotAttachStorageOrAllocateCopyTemporaries()
+    {
+        const string source = """
+            function copy(value: any): any { return { ...value, d: 4 }; }
+            function symbols(value: any): any { return Object.getOwnPropertySymbols(value); }
+            """;
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var compiler = new ILCompiler($"spread_allocation_{Guid.NewGuid():N}");
+        compiler.Compile(statements, typeMap, new DeadCodeAnalyzer(typeMap).Analyze(statements));
+        var assembly = Assembly.Load(compiler.SaveToBytes());
+        var runtime = assembly.GetType("$Runtime")!;
+        var merge = runtime.GetMethod("MergeIntoObject")!
+            .CreateDelegate<Action<Dictionary<string, object?>, object?>>();
+        var getSymbols = runtime.GetMethod("GetOwnPropertySymbols")!
+            .CreateDelegate<Func<object, object>>();
+        var storage = (ConditionalWeakTable<object, Dictionary<object, object?>>)runtime
+            .GetField("_symbolStorage", BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null)!;
+        var input = new Dictionary<string, object?> { ["a"] = 1d, ["b"] = 2d, ["c"] = 3d };
+        var target = new Dictionary<string, object?>(4);
+
+        Assert.NotSame(getSymbols(input), getSymbols(input));
+        Assert.False(storage.TryGetValue(input, out _));
+        // Reuse pre-sized storage to isolate copy overhead from the required result allocation.
+        for (int i = 0; i < 100; i++) merge(target, input);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < 1000; i++) merge(target, input);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.Equal(0, allocated);
+        Assert.Equal(3d, target["c"]);
+        Assert.False(storage.TryGetValue(input, out _));
+    }
+}

--- a/tests/SharpTS.Tests/RuntimeTests/ObjectSpreadStorageTests.cs
+++ b/tests/SharpTS.Tests/RuntimeTests/ObjectSpreadStorageTests.cs
@@ -1,0 +1,32 @@
+using SharpTS.Runtime.Types;
+using Xunit;
+
+namespace SharpTS.Tests.RuntimeTests;
+
+public class ObjectSpreadStorageTests
+{
+    [Fact]
+    public void PlainDataCopy_DoesNotAllocateTemporaryStorage()
+    {
+        var source = new SharpTSObject(new() { ["a"] = 1d, ["b"] = true, ["c"] = "three" });
+        var target = new Dictionary<string, object?>(4);
+        Assert.True(source.TryCopyPlainSpreadFields(target));
+        bool success = true;
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < 1000; i++) success &= source.TryCopyPlainSpreadFields(target);
+        long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.True(success);
+        Assert.Equal(0, allocated);
+        Assert.Equal("three", target["c"]);
+    }
+
+    [Fact]
+    public void NumericKeys_RejectFastCopyBeforeWritingAnything()
+    {
+        var source = new SharpTSObject(new() { ["a"] = 1d, ["2"] = 2d });
+        var target = new Dictionary<string, object?> { ["original"] = 10d };
+        Assert.False(source.TryCopyPlainSpreadFields(target));
+        Assert.Single(target);
+        Assert.Equal(10d, target["original"]);
+    }
+}

--- a/tests/SharpTS.Tests/SharedTests/ObjectConsumerTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/ObjectConsumerTests.cs
@@ -1,0 +1,213 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+public class ObjectConsumerTests
+{
+    [Theory, ModeData]
+    public void MutatedSpreadSources_PreserveDeletionAndIncrement(ExecutionMode mode)
+    {
+        const string source = """
+            function retain(value: any): any { return value; }
+            function work(n: number): void {
+                const removed = { a: n, b: n + 1 };
+                delete removed.a;
+                const deletedResult = { ...removed };
+                console.log(Object.keys(retain(deletedResult)).join(","));
+                const incremented = { a: n };
+                console.log(incremented.a++);
+                const postResult = { ...incremented };
+                console.log(retain(postResult).a);
+                console.log(++incremented.a);
+                const preResult = { ...incremented };
+                console.log(retain(preResult).a);
+            }
+            work(1);
+            """;
+        Assert.Equal("b\n1\n2\n3\n3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void NumericConsumer_WritesOriginalSlotInOrder(ExecutionMode mode)
+    {
+        const string source = """
+            function consume(value: any): number {
+                value.d = value.d + 1;
+                value.a = value.a * (value.d - value.b);
+                return (-value.a + value.d) / 2 + value.b % 2;
+            }
+            function work(a: number, b: number, d: number): number {
+                const original = { a: a, b: b, d: d };
+                const result = { ...original };
+                console.log(consume(result));
+                console.log(result.a);
+                console.log(result.d);
+                return original.a + original.d;
+            }
+            console.log(work(2, 3, 5));
+            """;
+        Assert.Equal("1\n6\n6\n7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void RetainedResult_MaterializesWithoutAliasingSource(ExecutionMode mode)
+    {
+        const string source = """
+            let saved: any;
+            function retain(value: any): number { saved = value; return value.a; }
+            function work(a: number, label: string, enabled: boolean): void {
+                const original = { a: a, label: label, enabled: enabled };
+                const result = { ...original, middle: (original.a = a + 2), ...original };
+                console.log(retain(result));
+                saved.a = 10;
+                console.log(result.a);
+                console.log(original.a);
+                console.log(result.label);
+                console.log(result.enabled);
+                console.log(Object.keys(result).join(","));
+                original.a = 20;
+                console.log(saved.a);
+            }
+            work(1, "first", true);
+            """;
+        Assert.Equal("3\n10\n3\nfirst\ntrue\na,label,enabled,middle\n10\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void ShadowedConsumer_UsesActualParameter(ExecutionMode mode)
+    {
+        const string source = """
+            function consume(value: any): number { value.a = value.a + 1; return value.a; }
+            function work(consume: (value: any) => number, n: number): number {
+                const original = { a: n };
+                const result = { ...original };
+                return consume(result) + result.a;
+            }
+            console.log(work((value: any): number => { value.a = 20; return 100; }, 1));
+            """;
+        Assert.Equal("120\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void ReassignedLocalConsumer_UsesReplacement(ExecutionMode mode)
+    {
+        const string source = """
+            function consume(value: any): number { value.a = value.a + 1; return value.a; }
+            function replacement(value: any): number { value.a = 9; return 100; }
+            function work(n: number): number {
+                let current = consume;
+                current = replacement;
+                const original = { a: n };
+                const result = { ...original };
+                return current(result) + result.a;
+            }
+            console.log(work(1));
+            """;
+        Assert.Equal("109\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void ModuleLocalConsumers_WithSameNameRemainIndependent(ExecutionMode mode)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["remote.ts"] = """
+                function consume(value: any): number { value.a = value.a + 100; return value.a; }
+                export function remoteWork(n: number): number {
+                    const remoteSource = { a: n };
+                    const remoteResult = { ...remoteSource };
+                    return consume(remoteResult);
+                }
+                """,
+            ["main.ts"] = """
+                import { remoteWork } from './remote';
+                function consume(value: any): number { value.a = value.a + 1; return value.a; }
+                function work(n: number): number {
+                    const localSource = { a: n };
+                    const localResult = { ...localSource };
+                    return consume(localResult);
+                }
+                console.log(work(1), remoteWork(1));
+                """
+        };
+        Assert.Equal("2 101\n", TestHarness.RunModules(files, "main.ts", mode));
+    }
+
+    [Theory, ModeData]
+    public void ReassignedSource_UsesNewValueForLaterSpread(ExecutionMode mode)
+    {
+        const string source = """
+            function retain(value: any): any { return value; }
+            function work(n: number): void {
+                let original = { a: n };
+                const before = { ...original };
+                original = { a: n + 6 };
+                const after = { ...original };
+                console.log(retain(before).a);
+                console.log(retain(after).a);
+            }
+            work(1);
+            """;
+        Assert.Equal("1\n7\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void MissingOrNonNumericFields_RetainDynamicSemantics(ExecutionMode mode)
+    {
+        const string source = """
+            function missing(value: any): number { value.d = value.d + 1; return value.d; }
+            function concatenate(value: any): any { value.a = value.a + 1; return value.a; }
+            function work(n: number, s: string): void {
+                const incomplete = { a: n };
+                const missingResult = { ...incomplete };
+                console.log(Number.isNaN(missing(missingResult)));
+                const text = { a: s };
+                const textResult = { ...text };
+                console.log(concatenate(textResult));
+                console.log(typeof textResult.a);
+            }
+            work(1, "2");
+            """;
+        Assert.Equal("true\n21\nstring\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void SharedParameterName_DoesNotConfuseLocalStorage(ExecutionMode mode)
+    {
+        const string source = """
+            function consume(value: any): number { value.a = value.a + 1; return value.a; }
+            function work(n: number): number {
+                const original = { a: n };
+                const result = { ...original };
+                return consume(result);
+            }
+            function other(result: any): number { return consume(result); }
+            console.log(work(1));
+            console.log(other({ a: 9 }));
+            """;
+        Assert.Equal("2\n10\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void ConsumerWithCallOrClosure_RetainsReferenceSemantics(ExecutionMode mode)
+    {
+        const string source = """
+            let later: () => number = () => 0;
+            function consume(value: any): number {
+                later = () => value.a;
+                value.a = value.a + 1;
+                return value.a;
+            }
+            function work(n: number): number {
+                const original = { a: n };
+                const result = { ...original };
+                consume(result);
+                result.a = 10;
+                return later() + original.a;
+            }
+            console.log(work(1));
+            """;
+        Assert.Equal("11\n", TestHarness.Run(source, mode));
+    }
+}

--- a/tests/SharpTS.Tests/SharedTests/ObjectLocalPromotionTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/ObjectLocalPromotionTests.cs
@@ -11,8 +11,8 @@ namespace SharpTS.Tests.SharedTests;
 /// <c>Dictionary&lt;string, object&gt;</c> lookup with boxing.
 ///
 /// These run against BOTH the interpreter and the compiler. The positive cases exercise the promoted
-/// fast paths, including stable spread chains; the escape cases must NOT be promoted (they fall back to
-/// the general object path) and must still produce correct results — i.e. interpreter/compiled parity
+/// fast paths, including stable spread chains and numeric consumers. Escaping values retain ordinary
+/// object semantics while independent sources may stay promoted — i.e. interpreter/compiled parity
 /// must hold even when the object is passed, returned, dynamically spread, enumerated, indexed,
 /// compared, captured, or compound-assigned.
 /// A wrong escape rule, or a miscompiled struct fast path, surfaces here as a compiled-mode mismatch.
@@ -263,7 +263,7 @@ public class ObjectLocalPromotionTests
     }
 
     [Theory, ModeData]
-    public void Escape_SpreadResultPassedAndMutatedFallsBackAsAComponent(ExecutionMode mode)
+    public void SpreadResult_NumericConsumerMutatesResultIndependentlyOfSource(ExecutionMode mode)
     {
         var source = """
             function consume(value: any): number {

--- a/tests/SharpTS.Tests/SharedTests/ObjectSpreadCopyTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/ObjectSpreadCopyTests.cs
@@ -1,0 +1,123 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+public class ObjectSpreadCopyTests
+{
+    [Theory, ModeData]
+    public void PlainCopy_PreservesOverwriteOrderAndIndependentIdentity(ExecutionMode mode)
+    {
+        const string source = """
+            function copy(first: any, second: any): any {
+                return { before: 0, ...first, b: 8, ...second, after: 9 };
+            }
+            const first: any = { a: 1, b: 2, "": 3 };
+            const second: any = { b: 4, c: 5 };
+            const result: any = copy(first, second);
+            console.log(Object.keys(result).join("|"));
+            console.log(result.a + result.b + result.c + result[""]);
+            result.a = 10;
+            first.b = 20;
+            console.log(first.a);
+            console.log(result.b);
+            console.log(result === first);
+            """;
+        Assert.Equal("before|a|b||c|after\n13\n1\n4\nfalse\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void NumericKeys_FallbackPreservesOrdering(ExecutionMode mode)
+    {
+        const string source = """
+            function copy(value: any): any { return { prefix: 0, ...value, suffix: 1 }; }
+            const value: any = { a: 1, "10": 10, "2": 2, "01": 1, "4294967295": 5 };
+            const result: any = copy(value);
+            console.log(Object.keys(result).join(","));
+            console.log(result["10"] + result["2"] + result["01"]);
+            """;
+        Assert.Equal("2,10,prefix,a,01,4294967295,suffix\n13\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void DescriptorFallback_PreservesGetterEffectsAndKeySnapshot(ExecutionMode mode)
+    {
+        const string source = """
+            function copy(value: any): any { return { ...value }; }
+            const value: any = { a: 1, b: 2 };
+            let calls: number = 0;
+            Object.defineProperty(value, "a", {
+                enumerable: true,
+                get: function(): number {
+                    calls = calls + 1;
+                    value.b = 20;
+                    value.late = 30;
+                    return 10;
+                }
+            });
+            Object.defineProperty(value, "hidden", { value: 99, enumerable: false });
+            const result: any = copy(value);
+            console.log(Object.keys(result).join(","));
+            console.log(result.a + result.b);
+            console.log(calls);
+            console.log(result.late === undefined);
+            console.log(result.hidden === undefined);
+            result.a = 40;
+            console.log(result.a);
+            """;
+        Assert.Equal("a,b\n30\n1\ntrue\ntrue\n40\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void SymbolReadsRemainFreshAndLaterWritesAreVisible(ExecutionMode mode)
+    {
+        const string source = """
+            function copy(value: any): any { return { ...value }; }
+            const value: any = { a: 1 };
+            const before: any = Object.getOwnPropertySymbols(value);
+            const again: any = Object.getOwnPropertySymbols(value);
+            console.log(before === again);
+            console.log(Object.keys(copy(value)).join(","));
+            const visible: symbol = Symbol("visible");
+            const hidden: symbol = Symbol("hidden");
+            value[visible] = 7;
+            Object.defineProperty(value, hidden, { value: 8, enumerable: false });
+            const result: any = copy(value);
+            console.log(before.length);
+            console.log(Object.getOwnPropertySymbols(value).length);
+            console.log(Object.getOwnPropertySymbols(result).length);
+            console.log(result[visible]);
+            console.log(result[hidden] === undefined);
+            """;
+        Assert.Equal("false\na\n0\n2\n1\n7\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void CapacityHint_DoesNotRestrictStructurallyWiderSource(ExecutionMode mode)
+    {
+        const string source = """
+            function copy(value: { a: number, b: number, c: number }): any {
+                return { ...value, d: 4 };
+            }
+            const wider = { a: 1, b: 2, c: 3, extra: 5 };
+            const result: any = copy(wider);
+            console.log(Object.keys(result).join(","));
+            console.log(result.extra);
+            """;
+        Assert.Equal("a,b,c,extra,d\n5\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void ConsecutiveSpreads_ObserveInterveningSourceMutation(ExecutionMode mode)
+    {
+        const string source = """
+            function mutate(value: any): number { value.a = 7; value.c = 8; return 9; }
+            function copy(value: any): any { return { ...value, middle: mutate(value), ...value }; }
+            const value: any = { a: 1, b: 2 };
+            const result: any = copy(value);
+            console.log(Object.keys(result).join(","));
+            console.log(result.a + result.b + result.middle + result.c);
+            """;
+        Assert.Equal("a,b,middle,c\n26\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
Object spreads passed to small numeric consumers currently lose local promotion and allocate dictionaries, boxed fields, and copy metadata. This change preserves typed storage through proven consumers and materializes only results that must escape, while accelerating ordinary dictionary and interpreter copies.

## Changes

- Add guarded plain-property copy paths and noncreating symbol-storage lookups; retain general behavior for descriptors, accessors, symbols, and ordered keys.
- Use bounded capacity hints and copy promoted source fields directly into escaping result dictionaries.
- Resolve bounded numeric consumer summaries at exact module-local call sites and emit ordered writes against the original local slot. Unsupported or unstable bindings retain general calls.
- Harden promotion against source reassignment, shadowing, deletion/increment targets, and dynamic binding hazards.
- Add checksum-validated direct, inline, and retained-result benchmark controls, plus semantic and allocation regression coverage.

## Validation

- Release build passed; 297 targeted tests passed with no failures, covering object consumers/spreads/promotion, symbols, proxies, module name collisions, and stable recursive module functions.
- Original and expanded benchmark assemblies passed IL verification and checksum checks.
- All nine existing compiled spread BenchmarkDotNet ShortRun cases completed with MemoryDiagnoser.
- Final allocation checks and `git diff --check` passed. Test262 corpus is not populated in this checkout.

## Local measurements

Windows/.NET 10 Release, 100,000 iterations. The comparison below is against the saved first-stage implementation of this PR; it isolates the follow-up promotion/interpreter work. Timings are medians from three rotated process launches without concurrent builds/tests.

| Case | First stage | Final |
|---|---:|---:|
| Compiled numeric consumer allocations | 73.6 MB | 0 |
| Compiled retained-result allocations | 75.7 MB | 54.1 MB |
| Compiled numeric consumer time | 30.885 ms | 0.089 ms |
| Interpreter single spread | 153.080 ms | 89.433 ms |
| Interpreter overwrite spread | 222.046 ms | 144.662 ms |
| Interpreter numeric consumer | 259.966 ms | 163.608 ms |

All three original compiled workloads are allocation-free in direct delegate probes. Retained results allocate 28.5% less, but throughput was mixed: 143.100 to 162.023 ms at 100,000 iterations, versus 7.629 to 5.441 ms at 10,000. Already allocation-free controls also varied; these are local measurements, not general speed guarantees.

## Limits

Consumer summaries accept only a single local argument, numeric field reads/writes and arithmetic, at most eight statements and 64 expression nodes. Retained results still require heap storage.

Validation reproduced a preexisting compiled function-declaration reassignment issue with the saved earlier compiler: a subsequent direct call can invoke the old declaration. This change refuses to summarize such calls; it does not repair generic dispatch. Reassigned local function bindings are covered and behave correctly in both execution modes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved object spread handling for plain objects, preserving overwrite order, independent copies, symbol properties, and source mutations.
  - Added optimized handling for eligible numeric object consumers while preserving dynamic behavior for unsupported cases.
  - Symbol-property reads no longer create unnecessary storage when none exists.

- **Bug Fixes**
  - Improved correctness for object spreads involving numeric keys, accessors, getters, closures, reassigned values, and cross-module functions.

- **Documentation**
  - Added benchmark documentation covering object spread behavior and validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->