### PR TITLE
Optimize Num Write numeric array paths

### DIFF
--- a/benchmarks/cross-runtime/README.md
+++ b/benchmarks/cross-runtime/README.md
@@ -167,6 +167,12 @@ The direct case is the serial in-process compute baseline; compare each runtime'
 2- and 4-worker times with its 1-worker time to calculate parallel speedup and
 efficiency.
 
+The `num-arrays` workload separates indexed numeric-array cost into three cases:
+`num-write` grows an escaped array and then checksums it, `num-overwrite`
+prepopulates an array outside the timed region and measures overwrite plus
+checksum, and `num-read` measures the checksum pass alone. This makes allocation
+and capacity growth distinguishable from element-store and element-load cost.
+
 `worker-allocation-scaling` applies the same fixed-total-work design to short-lived object,
 string, and array graphs. It exposes allocation throughput, shared-runtime GC interference, and
 whether adding workers continues to help once managed-heap traffic replaces an allocation-free

--- a/benchmarks/cross-runtime/scripts/num-arrays.ts
+++ b/benchmarks/cross-runtime/scripts/num-arrays.ts
@@ -8,8 +8,8 @@ import { bench } from "./lib/bench.ts";
 // ~73x Node, the gap this targets. A non-escaping local would instead promote to
 // List<double> and is covered implicitly elsewhere.
 
-// Index-write: build by index through a helper (so the array escapes), then a
-// read pass for a checksum. The dominant cost is the per-element write.
+// Growth-write: build by index through a helper (so the array escapes), then a
+// read pass for a checksum. This preserves the historical `num-write` case ID.
 function fillIndex(a: number[], n: number): void {
     for (let i: number = 0; i < n; i++) {
         a[i] = i * 3;
@@ -23,6 +23,27 @@ function numWrite(n: number): number {
         sum = sum + a[i];
     }
     return sum;
+}
+
+function checksum(a: number[], n: number): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        sum = sum + a[i];
+    }
+    return sum;
+}
+
+// Fixed-capacity control: setup happens before bench(), so the timed region is
+// overwrite + checksum and does not include allocation or geometric growth.
+function numOverwrite(a: number[], n: number): number {
+    fillIndex(a, n);
+    return checksum(a, n);
+}
+
+// Read-only control over an already populated array. This separates element
+// access and checksum cost from every write/allocation path.
+function numRead(a: number[], n: number): number {
+    return checksum(a, n);
 }
 
 // Push-built: append n elements through a helper, then a read pass. Measures the
@@ -44,8 +65,20 @@ function numPush(n: number): number {
 
 const params: number[] = [1000, 100000, 1000000];
 for (let p: number = 0; p < params.length; p++) {
-    bench("num-write", params[p], () => numWrite(params[p]));
+    const expected: number = 1.5 * params[p] * (params[p] - 1);
+    bench("num-write", params[p], () => numWrite(params[p]), expected);
 }
 for (let p: number = 0; p < params.length; p++) {
-    bench("num-push", params[p], () => numPush(params[p]));
+    const expected: number = 1.5 * params[p] * (params[p] - 1);
+    const overwrite: number[] = [];
+    const read: number[] = [];
+    fillIndex(overwrite, params[p]);
+    fillIndex(read, params[p]);
+    bench("num-overwrite", params[p], () =>
+        numOverwrite(overwrite, params[p]), expected);
+    bench("num-read", params[p], () => numRead(read, params[p]), expected);
+}
+for (let p: number = 0; p < params.length; p++) {
+    const expected: number = 1.5 * params[p] * (params[p] - 1);
+    bench("num-push", params[p], () => numPush(params[p]), expected);
 }

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Baselines/NumericArrayWriteBaselines.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Baselines/NumericArrayWriteBaselines.cs
@@ -29,4 +29,43 @@ public static class NumericArrayWriteBaselines
             sum += (double)values[i]!;
         return sum;
     }
+
+    public static double GrowingUnboxed(int n)
+    {
+        var values = new List<double>();
+        for (int i = 0; i < n; i++)
+            values.Add(i * 3.0);
+
+        double sum = 0;
+        for (int i = 0; i < n; i++)
+            sum += values[i];
+        return sum;
+    }
+
+    public static double GrowingBoxed(int n)
+    {
+        var values = new List<object?>();
+        for (int i = 0; i < n; i++)
+            values.Add(i * 3.0);
+
+        double sum = 0;
+        for (int i = 0; i < n; i++)
+            sum += (double)values[i]!;
+        return sum;
+    }
+
+    public static double Overwrite(double[] values)
+    {
+        for (int i = 0; i < values.Length; i++)
+            values[i] = i * 3.0;
+        return Read(values);
+    }
+
+    public static double Read(double[] values)
+    {
+        double sum = 0;
+        for (int i = 0; i < values.Length; i++)
+            sum += values[i];
+        return sum;
+    }
 }

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/NumericArrayOverwriteBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/NumericArrayOverwriteBenchmarks.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using SharpTS.Microbenchmarks.Baselines;
+using SharpTS.Microbenchmarks.Infrastructure;
+
+namespace SharpTS.Microbenchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class NumericArrayOverwriteBenchmarks
+{
+    private Func<double, double> _sharpTs = null!;
+    private double[] _baseline = null!;
+
+    [Params(1_000_000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Assembly compiled = NumericArrayWriteBenchmarkAssembly.Load();
+        BenchmarkHarness.GetCompiledNumberFunc(
+            compiled, "setupNumericArrays")(N);
+        _sharpTs = BenchmarkHarness.GetCompiledNumberFunc(
+            compiled, "numericArrayOverwrite");
+        _baseline = new double[N];
+    }
+
+    [Benchmark]
+    public double SharpTS() => _sharpTs(N);
+
+    [Benchmark(Baseline = true)]
+    public double IdiomaticCSharp() =>
+        NumericArrayWriteBaselines.Overwrite(_baseline);
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/NumericArrayReadBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/NumericArrayReadBenchmarks.cs
@@ -1,0 +1,61 @@
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Order;
+using SharpTS.Microbenchmarks.Baselines;
+using SharpTS.Microbenchmarks.Infrastructure;
+
+namespace SharpTS.Microbenchmarks.Benchmarks;
+
+[MemoryDiagnoser]
+[RankColumn]
+[Orderer(SummaryOrderPolicy.FastestToSlowest)]
+public class NumericArrayReadBenchmarks
+{
+    private Func<double, double> _sharpTs = null!;
+    private double[] _baseline = null!;
+
+    [Params(1_000_000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Assembly compiled = NumericArrayWriteBenchmarkAssembly.Load();
+        BenchmarkHarness.GetCompiledNumberFunc(
+            compiled, "setupNumericArrays")(N);
+        _sharpTs = BenchmarkHarness.GetCompiledNumberFunc(
+            compiled, "numericArrayRead");
+        _baseline = new double[N];
+        for (int i = 0; i < N; i++)
+            _baseline[i] = i * 3.0;
+    }
+
+    [Benchmark]
+    public double SharpTS() => _sharpTs(N);
+
+    [Benchmark(Baseline = true)]
+    public double IdiomaticCSharp() =>
+        NumericArrayWriteBaselines.Read(_baseline);
+}
+
+internal static class NumericArrayWriteBenchmarkAssembly
+{
+    private static Assembly? _compiled;
+
+    internal static Assembly Load()
+    {
+        if (_compiled is not null) return _compiled;
+        Assembly assembly = typeof(NumericArrayWriteBenchmarkAssembly).Assembly;
+        using Stream stream = assembly.GetManifestResourceStream(
+            "SharpTS.Microbenchmarks.TypeScriptSources.NumericArrayWrite.ts")
+            ?? throw new InvalidOperationException(
+                "Could not find embedded resource NumericArrayWrite.ts");
+        using var reader = new StreamReader(stream);
+        string dllPath = CompilationCache.GetOrCompile(
+            reader.ReadToEnd(), "NumericArrayWriteSplit");
+        _compiled = BenchmarkHarness.LoadCompiledAssembly(
+            dllPath, "numeric-array-write-split");
+        BenchmarkHarness.InitializeCompiledModules(_compiled);
+        return _compiled;
+    }
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/NumericArrayWriteBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/NumericArrayWriteBenchmarks.cs
@@ -48,4 +48,12 @@ public class NumericArrayWriteBenchmarks
     [Benchmark]
     public double BoxedEquivalentCSharp() =>
         NumericArrayWriteBaselines.BoxedEquivalent(N);
+
+    [Benchmark]
+    public double GrowingUnboxedCSharp() =>
+        NumericArrayWriteBaselines.GrowingUnboxed(N);
+
+    [Benchmark]
+    public double GrowingBoxedCSharp() =>
+        NumericArrayWriteBaselines.GrowingBoxed(N);
 }

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/NumericArrayWrite.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/NumericArrayWrite.ts
@@ -13,3 +13,33 @@ export function numericArrayWrite(n: number): number {
     }
     return sum;
 }
+
+let overwriteArray: number[] = [];
+let readArray: number[] = [];
+
+export function setupNumericArrays(n: number): number {
+    const overwrite: number[] = [];
+    const read: number[] = [];
+    fillIndex(overwrite, n);
+    fillIndex(read, n);
+    overwriteArray = overwrite;
+    readArray = read;
+    return n;
+}
+
+function checksumIndex(a: number[], n: number): number {
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        sum = sum + a[i];
+    }
+    return sum;
+}
+
+export function numericArrayOverwrite(n: number): number {
+    fillIndex(overwriteArray, n);
+    return checksumIndex(overwriteArray, n);
+}
+
+export function numericArrayRead(n: number): number {
+    return checksumIndex(readArray, n);
+}

--- a/src/SharpTS/Compilation/CountedIndexWriteLoopAnalyzer.cs
+++ b/src/SharpTS/Compilation/CountedIndexWriteLoopAnalyzer.cs
@@ -1,0 +1,74 @@
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Recognizes a side-effect-free sequential index-write loop:
+/// <code>for (let i = 0; i &lt; n; i++) items[i] = pureValue;</code>
+/// The emitter may reserve packed numeric storage without changing the array's
+/// length or evaluating guest expressions early.
+/// </summary>
+internal static class CountedIndexWriteLoopAnalyzer
+{
+    internal readonly record struct Reservation(
+        Expr.Variable Array,
+        Expr.Variable Bound);
+
+    internal static bool TryAnalyze(Stmt.For loop, out Reservation reservation)
+    {
+        reservation = default;
+        if (loop.Initializer is not Stmt.Var
+            {
+                Name.Lexeme: var counter,
+                Initializer: Expr.Literal { Value: double initial }
+            }
+            || initial != 0
+            || loop.Condition is not Expr.Binary
+            {
+                Left: Expr.Variable { Name.Lexeme: var conditionCounter },
+                Operator.Type: TokenType.LESS,
+                Right: Expr.Variable bound
+            }
+            || conditionCounter != counter
+            || loop.Increment is not Expr.PostfixIncrement
+            {
+                Operand: Expr.Variable { Name.Lexeme: var incrementCounter },
+                Operator.Type: TokenType.PLUS_PLUS
+            }
+            || incrementCounter != counter)
+        {
+            return false;
+        }
+
+        Stmt body = loop.Body is Stmt.Block { Statements.Count: 1 } block
+            ? block.Statements[0]
+            : loop.Body;
+        if (body is not Stmt.Expression
+            {
+                Expr: Expr.SetIndex
+                {
+                    Object: Expr.Variable array,
+                    Index: Expr.Variable { Name.Lexeme: var indexCounter },
+                    Value: var value
+                }
+            }
+            || indexCounter != counter
+            || !IsPure(value))
+        {
+            return false;
+        }
+
+        reservation = new Reservation(array, bound);
+        return true;
+    }
+
+    private static bool IsPure(Expr expression) => expression switch
+    {
+        Expr.Literal => true,
+        Expr.Variable => true,
+        Expr.Grouping grouping => IsPure(grouping.Expression),
+        Expr.Unary unary => IsPure(unary.Right),
+        Expr.Binary binary => IsPure(binary.Left) && IsPure(binary.Right),
+        _ => false
+    };
+}

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -1614,6 +1614,7 @@ public class EmittedRuntime
     public MethodBuilder TSArrayGetDouble { get; set; } = null!;
     public MethodBuilder TSArraySetDouble { get; set; } = null!;
     public MethodBuilder TSArrayPushDouble { get; set; } = null!;
+    public MethodBuilder TSArrayEnsureDoubleCapacity { get; set; } = null!;
     public MethodBuilder TSArrayEnsureBoxed { get; set; } = null!;
     public MethodBuilder TSArrayIsNumericGetter { get; set; } = null!;
     public MethodBuilder TSArrayNumericCountGetter { get; set; } = null!;

--- a/src/SharpTS/Compilation/ForLoopAnalyzer.cs
+++ b/src/SharpTS/Compilation/ForLoopAnalyzer.cs
@@ -176,6 +176,36 @@ public static class ForLoopAnalyzer
     }
 
     /// <summary>
+    /// Returns whether a C-style loop must create fresh lexical bindings for the
+    /// supplied <c>let</c>/<c>const</c> initializer names. A fresh environment is
+    /// observable only when code created by the loop captures one of the names.
+    /// Direct <c>eval</c> is conservatively treated as a capture because its source
+    /// is not available to this AST pass.
+    /// </summary>
+    public static bool RequiresPerIterationEnvironment(
+        Stmt.For forLoop,
+        IReadOnlyList<string> bindingNames)
+    {
+        foreach (var name in bindingNames)
+        {
+            if (ContainsPotentialCapture(forLoop.Body, name)
+                || (forLoop.Condition != null
+                    && ContainsPotentialCaptureExpr(forLoop.Condition, name))
+                || (forLoop.Increment != null
+                    && ContainsPotentialCaptureExpr(forLoop.Increment, name)))
+                return true;
+        }
+
+        var evalVisitor = new DirectEvalVisitor();
+        if (forLoop.Condition != null)
+            evalVisitor.VisitExpr(forLoop.Condition);
+        if (forLoop.Increment != null)
+            evalVisitor.VisitExpr(forLoop.Increment);
+        evalVisitor.Visit(forLoop.Body);
+        return evalVisitor.Found;
+    }
+
+    /// <summary>
     /// Result of analyzing a for loop for unboxed counter optimization.
     /// </summary>
     public readonly struct AnalysisResult
@@ -447,6 +477,20 @@ public static class ForLoopAnalyzer
                 HasPotentialCapture = true;
             }
             base.VisitAssign(expr);
+        }
+    }
+
+    private sealed class DirectEvalVisitor : Parsing.Visitors.AstVisitorBase
+    {
+        public bool Found { get; private set; }
+
+        public void VisitExpr(Expr expr) => Visit(expr);
+
+        protected override void VisitCall(Expr.Call expr)
+        {
+            if (expr.Callee is Expr.Variable { Name.Lexeme: "eval" })
+                Found = true;
+            base.VisitCall(expr);
         }
     }
 

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -1003,6 +1003,7 @@ public partial class ILEmitter
 
             // Array hoist preamble: emit isinst checks for loop-invariant arrays
             var hoisted = EmitArrayHoistPreamble(f.Body, f.Condition, f.Increment);
+            EmitCountedIndexWriteReservation(f);
             // Typed-array receiver hoist (#928): cast loop-invariant numeric TypedArray receivers once.
             var taHoisted = EmitTypedArrayHoistPreamble(f.Body, f.Condition, f.Increment);
             // Promoted boolean arrays can expose one stable Span<bool> per loop. Direct
@@ -1810,6 +1811,45 @@ public partial class ILEmitter
         SetStackUnknown();
     }
 
+    private void EmitCountedIndexWriteReservation(Stmt.For loop)
+    {
+        if (!CountedIndexWriteLoopAnalyzer.TryAnalyze(loop, out var reservation)
+            || _ctx.TypeMap?.Get(reservation.Array) is not TypeInfo.Array
+                { ElementType: TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } }
+            || _ctx.TypeMap.Get(reservation.Bound) is not TypeInfo.Primitive
+                { Type: TokenType.TYPE_NUMBER }
+            || _ctx.TryGetHoistedArray(reservation.Array.Name.Lexeme) is not
+                { Descriptor.Kind: ArrayElementsKind.Double } hoisted
+            || _ctx.Runtime is null)
+        {
+            return;
+        }
+
+        var boundLocal = IL.DeclareLocal(_ctx.Types.Double);
+        var skip = _ctx.ILBuilder.DefineLabel("counted_index_reserve_skip");
+
+        EmitExpressionAsDouble(reservation.Bound);
+        IL.Emit(OpCodes.Stloc, boundLocal);
+        IL.Emit(OpCodes.Ldloc, boundLocal);
+        IL.Emit(OpCodes.Ldc_R8, 0d);
+        IL.Emit(OpCodes.Blt_Un, skip);
+        IL.Emit(OpCodes.Ldloc, boundLocal);
+        IL.Emit(OpCodes.Ldc_R8, 1_000_000d);
+        IL.Emit(OpCodes.Bgt_Un, skip);
+
+        IL.Emit(OpCodes.Ldloc, hoisted.TypedLocal);
+        IL.Emit(OpCodes.Brfalse, skip);
+        IL.Emit(OpCodes.Ldloc, hoisted.TypedLocal);
+        IL.Emit(OpCodes.Ldloc, boundLocal);
+        IL.Emit(OpCodes.Call, typeof(Math).GetMethod(
+            nameof(Math.Ceiling), [_ctx.Types.Double])!);
+        IL.Emit(OpCodes.Conv_I4);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime.TSArrayEnsureDoubleCapacity);
+
+        _ctx.ILBuilder.MarkLabel(skip);
+        SetStackUnknown();
+    }
+
     protected override void EmitIf(Stmt.If i)
     {
         // Check for dead code elimination optimization
@@ -1919,13 +1959,16 @@ public partial class ILEmitter
                 : desc.GetListType(_ctx.Types);
             var typedLocal = IL.DeclareLocal(hoistType);
 
-            // Load array variable, isinst to the hoist type, store in local
-            // If the variable holds a different type, typedLocal will be null
-            // Use the local directly to avoid stack type tracking complications
-            var arrLocal = _ctx.Locals.GetLocal(varName);
-            if (arrLocal == null) continue; // Variable not found in locals — skip
-            IL.Emit(OpCodes.Ldloc, arrLocal);
-            // Array locals are always typed as object — no boxing needed
+            // Resolve once at loop entry. This covers parameters and captured
+            // bindings as well as locals; the previous local-only lookup forced
+            // helper parameters such as fillIndex(a, n) to cast on every write.
+            var loaded = _resolver.TryLoadVariable(varName);
+            if (loaded is null) continue;
+            if (loaded == StackType.Double)
+                IL.Emit(OpCodes.Box, _ctx.Types.Double);
+            else if (loaded == StackType.Boolean)
+                IL.Emit(OpCodes.Box, _ctx.Types.Boolean);
+
             if (desc.Kind == ArrayElementsKind.Object)
             {
                 // A number[] can reach this loop through an any[] alias. The
@@ -1948,6 +1991,7 @@ public partial class ILEmitter
             cache[varName] = new HoistedArrayEntry(typedLocal, desc);
         }
 
+        if (cache.Count == 0) return false;
         _ctx.HoistedArrayCaches.Push(cache);
         return true;
     }

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -1828,7 +1828,17 @@ public partial class ILEmitter
         var boundLocal = IL.DeclareLocal(_ctx.Types.Double);
         var skip = _ctx.ILBuilder.DefineLabel("counted_index_reserve_skip");
 
-        EmitExpressionAsDouble(reservation.Bound);
+        // Captured numeric bindings can still use object-backed storage. Only
+        // reserve when loading the bound is already coercion-free; otherwise
+        // the ordinary condition must retain its per-check ToNumber timing.
+        EmitExpression(reservation.Bound);
+        if (StackType != StackType.Double)
+        {
+            IL.Emit(OpCodes.Pop);
+            _ctx.ILBuilder.MarkLabel(skip);
+            SetStackUnknown();
+            return;
+        }
         IL.Emit(OpCodes.Stloc, boundLocal);
         IL.Emit(OpCodes.Ldloc, boundLocal);
         IL.Emit(OpCodes.Ldc_R8, 0d);

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSArray.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSArray.cs
@@ -297,6 +297,9 @@ public partial class RuntimeEmitter
         var pushDouble = typeBuilder.DefineMethod("PushDouble",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, [_types.Double]);
         runtime.TSArrayPushDouble = pushDouble;
+        var ensureDoubleCapacity = typeBuilder.DefineMethod("EnsureDoubleCapacity",
+            MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, [_types.Int32]);
+        runtime.TSArrayEnsureDoubleCapacity = ensureDoubleCapacity;
         // #927 step 2: these are the per-element hot paths the compiler emits at statically-number[]
         // sites. They are non-virtual (HideBySig), so a `callvirt` on a $Array-typed receiver
         // devirtualizes; AggressiveInlining lets the JIT fold the field loads + bounds check into the
@@ -305,6 +308,37 @@ public partial class RuntimeEmitter
         getDouble.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
         setDouble.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
         pushDouble.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
+
+        // Capacity reservation changes neither length nor elements. It is used
+        // only for analyzer-proven counted sequential writes and is a no-op when
+        // the array has already deoptimized to boxed storage.
+        {
+            var il = ensureDoubleCapacity.GetILGenerator();
+            var resize = il.DefineLabel();
+            var done = il.DefineLabel();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayIsNumericField);
+            il.Emit(OpCodes.Brfalse, done);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ble, done);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Brfalse, resize);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldlen);
+            il.Emit(OpCodes.Conv_I4);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Bge, done);
+            il.MarkLabel(resize);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldflda, _tsArrayNumStoreField);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Call, arrayResize);
+            il.MarkLabel(done);
+            il.Emit(OpCodes.Ret);
+        }
         var markNumeric = typeBuilder.DefineMethod("MarkNumeric",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, System.Type.EmptyTypes);
         runtime.TSArrayMarkNumeric = markNumeric;

--- a/src/SharpTS/Execution/Interpreter.Expressions.cs
+++ b/src/SharpTS/Execution/Interpreter.Expressions.cs
@@ -1044,7 +1044,8 @@ public partial class Interpreter
     /// </summary>
     private async ValueTask<RuntimeValue> EvaluateGetIndexCore(IEvaluationContext ctx, Expr.GetIndex getIndex)
     {
-        object? obj = (await ctx.EvaluateExprAsync(getIndex.Object)).ToObject();
+        RuntimeValue objectValue = await ctx.EvaluateExprAsync(getIndex.Object);
+        object? obj = objectValue.ToObject();
 
         // Optional bracket access: return undefined if object is nullish
         if (getIndex.Optional && (obj == null || obj is Runtime.Types.SharpTSUndefined))
@@ -1052,8 +1053,26 @@ public partial class Interpreter
             return RuntimeValue.Undefined;
         }
 
-        object? index = (await ctx.EvaluateExprAsync(getIndex.Index)).ToObject();
-        return PerformIndexGet(getIndex.Object, obj, index);
+        RuntimeValue indexValue = await ctx.EvaluateExprAsync(getIndex.Index);
+        if (obj is SharpTSArray directArray
+            && indexValue.Kind == ValueKind.Number)
+        {
+            double directNumber = indexValue.AsNumberUnsafe();
+            if (double.IsFinite(directNumber)
+                && directNumber >= 0
+                && directNumber <= SharpTSArray.MaxWriteIndex
+                && Math.Truncate(directNumber) == directNumber
+                && directArray.TryGetPresentDataIndexRV(
+                    (long)directNumber, out RuntimeValue directValue))
+            {
+                return directValue;
+            }
+        }
+
+        return PerformIndexGet(
+            getIndex.Object,
+            obj,
+            indexValue.ToObject());
     }
 
     /// <summary>

--- a/src/SharpTS/Execution/Interpreter.Expressions.cs
+++ b/src/SharpTS/Execution/Interpreter.Expressions.cs
@@ -1009,17 +1009,34 @@ public partial class Interpreter
     {
         // Avoid an async state machine for synchronous indexed reads. This is
         // the inner path for record-array traversal such as back[i].value.
-        object? obj = Evaluate(getIndex.Object);
+        RuntimeValue objectValue = EvaluateRV(getIndex.Object);
+        object? obj = objectValue.ToObject();
         if (getIndex.Optional
             && obj is null or Runtime.Types.SharpTSUndefined)
         {
             return RuntimeValue.Undefined;
         }
 
+        RuntimeValue indexValue = EvaluateRV(getIndex.Index);
+        if (obj is SharpTSArray directArray
+            && indexValue.Kind == ValueKind.Number)
+        {
+            double directNumber = indexValue.AsNumberUnsafe();
+            if (double.IsFinite(directNumber)
+                && directNumber >= 0
+                && directNumber <= SharpTSArray.MaxWriteIndex
+                && Math.Truncate(directNumber) == directNumber
+                && directArray.TryGetPresentDataIndexRV(
+                    (long)directNumber, out RuntimeValue directValue))
+            {
+                return directValue;
+            }
+        }
+
         return PerformIndexGet(
             getIndex.Object,
             obj,
-            Evaluate(getIndex.Index));
+            indexValue.ToObject());
     }
 
     /// <summary>
@@ -1457,18 +1474,58 @@ public partial class Interpreter
     /// Currently only supports array element assignment.
     /// </remarks>
     /// <seealso href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#bracket_notation">MDN Bracket Notation</seealso>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private RuntimeValue EvaluateSetIndex(Expr.SetIndex setIndex)
-        => EvaluateSetIndexCore(_syncContext, setIndex).GetAwaiter().GetResult();
+    {
+        RuntimeValue objectValue = EvaluateRV(setIndex.Object);
+        RuntimeValue indexValue = EvaluateRV(setIndex.Index);
+        RuntimeValue value = EvaluateRV(setIndex.Value);
+
+        if (objectValue.TryAsObject<SharpTSArray>(out var array)
+            && array is not SharpTSArguments
+            && indexValue.Kind == ValueKind.Number)
+        {
+            double number = indexValue.AsNumberUnsafe();
+            if (double.IsFinite(number)
+                && number >= 0
+                && number <= SharpTSArray.MaxWriteIndex
+                && Math.Truncate(number) == number
+                && array.TrySetDenseDataIndex((long)number, value))
+            {
+                return value;
+            }
+        }
+
+        return PerformIndexSet(
+            objectValue.ToObject(), indexValue.ToObject(), value.ToObject());
+    }
 
     /// <summary>
     /// Core indexed-assignment logic shared by the sync and async evaluators.
     /// </summary>
     private async ValueTask<RuntimeValue> EvaluateSetIndexCore(IEvaluationContext ctx, Expr.SetIndex setIndex)
     {
-        object? obj = (await ctx.EvaluateExprAsync(setIndex.Object)).ToObject();
-        object? index = (await ctx.EvaluateExprAsync(setIndex.Index)).ToObject();
-        object? value = (await ctx.EvaluateExprAsync(setIndex.Value)).ToObject();
-        return PerformIndexSet(obj, index, value);
+        RuntimeValue objectValue = await ctx.EvaluateExprAsync(setIndex.Object);
+        RuntimeValue indexValue = await ctx.EvaluateExprAsync(setIndex.Index);
+        RuntimeValue value = await ctx.EvaluateExprAsync(setIndex.Value);
+
+        if (objectValue.TryAsObject<SharpTSArray>(out var array)
+            && array is not SharpTSArguments
+            && indexValue.Kind == ValueKind.Number)
+        {
+            double number = indexValue.AsNumberUnsafe();
+            if (double.IsFinite(number)
+                && number >= 0
+                && number <= SharpTSArray.MaxWriteIndex
+                && Math.Truncate(number) == number
+                && array.TrySetDenseDataIndex((long)number, value))
+            {
+                return value;
+            }
+        }
+
+        return PerformIndexSet(
+            objectValue.ToObject(), indexValue.ToObject(), value.ToObject());
     }
 
     /// <summary>

--- a/src/SharpTS/Execution/Interpreter.Statements.cs
+++ b/src/SharpTS/Execution/Interpreter.Statements.cs
@@ -1,5 +1,6 @@
 using SharpTS.Modules;
 using SharpTS.Modules.Stdlib;
+using SharpTS.Compilation;
 using SharpTS.Parsing;
 using SharpTS.Parsing.Visitors;
 using SharpTS.Runtime;
@@ -1792,6 +1793,10 @@ public partial class Interpreter
 
             List<string>? perIterationNames =
                 CollectPerIterationBindings(forStmt.Initializer);
+            if (perIterationNames is not null
+                && !ForLoopAnalyzer.RequiresPerIterationEnvironment(
+                    forStmt, perIterationNames))
+                perIterationNames = null;
             if (perIterationNames is not null)
                 CreatePerIterationEnvironment(loopEnv, perIterationNames);
 
@@ -1811,7 +1816,8 @@ public partial class Interpreter
                             loopEnv, perIterationNames);
                     if (forStmt.Increment is not null)
                         EvaluateRV(forStmt.Increment);
-                    Thread.Sleep(0);
+                    if (HasPendingCallbacks)
+                        ProcessPendingCallbacks();
                     continue;
                 }
 
@@ -1822,7 +1828,8 @@ public partial class Interpreter
                     CreatePerIterationEnvironment(loopEnv, perIterationNames);
                 if (forStmt.Increment is not null)
                     EvaluateRV(forStmt.Increment);
-                ProcessPendingCallbacks();
+                if (HasPendingCallbacks)
+                    ProcessPendingCallbacks();
             }
 
             return ExecutionResult.Success();
@@ -1849,6 +1856,10 @@ public partial class Interpreter
             // iterations capture distinct values (#633). `var`/expression
             // initializers share a single binding and keep the no-copy fast path.
             var perIterationNames = CollectPerIterationBindings(forStmt.Initializer);
+            if (perIterationNames != null
+                && !ForLoopAnalyzer.RequiresPerIterationEnvironment(
+                    forStmt, perIterationNames))
+                perIterationNames = null;
             if (perIterationNames != null)
                 CreatePerIterationEnvironment(loopEnv, perIterationNames);
             // Loop with proper continue handling - increment always runs
@@ -1875,7 +1886,8 @@ public partial class Interpreter
                 if (forStmt.Increment != null)
                     await ctx.EvaluateExprAsync(forStmt.Increment);
                 // Process any pending timer callbacks
-                ProcessPendingCallbacks();
+                if (HasPendingCallbacks)
+                    ProcessPendingCallbacks();
             }
             return ExecutionResult.Success();
         }

--- a/src/SharpTS/Execution/Interpreter.cs
+++ b/src/SharpTS/Execution/Interpreter.cs
@@ -1000,6 +1000,13 @@ public partial class Interpreter : IDisposable
     // event-loop ticks. Weak: tracking must not keep a guest registry alive.
     private readonly List<WeakReference<SharpTSFinalizationRegistry>> _finalizationRegistries = [];
     private readonly object _finalizationRegistriesLock = new();
+    private volatile bool _hasFinalizationRegistries;
+
+    private bool HasPendingCallbacks =>
+        !_isDisposed
+        && (HasMicrotasks()
+            || _hasFinalizationRegistries
+            || _hasScheduledTimers);
 
     /// <summary>
     /// Enrolls a FinalizationRegistry so its GC-enqueued cleanups are drained on
@@ -1013,6 +1020,7 @@ public partial class Interpreter : IDisposable
                 if (wr.TryGetTarget(out var existing) && ReferenceEquals(existing, registry))
                     return;
             _finalizationRegistries.Add(new WeakReference<SharpTSFinalizationRegistry>(registry));
+            _hasFinalizationRegistries = true;
         }
     }
 
@@ -1046,7 +1054,8 @@ public partial class Interpreter : IDisposable
 
         // FinalizationRegistry cleanups ride event-loop ticks (Node runs them as
         // ordinary tasks after GC observes a target collection).
-        DrainFinalizationRegistries();
+        if (_hasFinalizationRegistries)
+            DrainFinalizationRegistries();
 
         // Quick checks before acquiring lock
         if (_isDisposed || !_hasScheduledTimers) return;

--- a/src/SharpTS/Execution/Interpreter.cs
+++ b/src/SharpTS/Execution/Interpreter.cs
@@ -1002,6 +1002,7 @@ public partial class Interpreter : IDisposable
     private readonly object _finalizationRegistriesLock = new();
     private volatile bool _hasFinalizationRegistries;
 
+    /// <summary>Whether a loop checkpoint has timer, microtask, or finalizer work.</summary>
     private bool HasPendingCallbacks =>
         !_isDisposed
         && (HasMicrotasks()
@@ -1024,9 +1025,9 @@ public partial class Interpreter : IDisposable
         }
     }
 
+    /// <summary>Prunes collected registries and drains any queued cleanup callbacks.</summary>
     private void DrainFinalizationRegistries()
     {
-        if (_finalizationRegistries.Count == 0) return;
         List<SharpTSFinalizationRegistry>? due = null;
         lock (_finalizationRegistriesLock)
         {
@@ -1039,6 +1040,7 @@ public partial class Interpreter : IDisposable
                 }
                 if (registry.HasPendingCleanups) (due ??= []).Add(registry);
             }
+            _hasFinalizationRegistries = _finalizationRegistries.Count != 0;
         }
         // Invoke outside the lock: cleanup callbacks are arbitrary guest code.
         if (due != null)

--- a/src/SharpTS/Runtime/Types/SharpTSArray.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSArray.cs
@@ -73,6 +73,12 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     // property algorithm. Never scan the backing on each shift/unshift.
     private bool _mayHaveHoles;
     private bool _ownsDenseStorage;
+    // Interpreter-only packed prefix. Empty arrays enter this mode on their
+    // first ordinary sequential numeric write; generic/object operations lazily
+    // materialize it back into _dense. This mirrors the compiled $Array
+    // elements-kind without changing SharpTSArray's public object API.
+    private double[]? _numericStore;
+    private int _numericCount;
     private Dictionary<uint, object?>? _sparse;
     private object? _explicitPrototype;
 
@@ -114,6 +120,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     {
         get
         {
+            MaterializeNumeric();
             _ownsDenseStorage = false; // A caller can mutate this legacy backing view.
             return _dense;
         }
@@ -139,7 +146,8 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     internal bool CanUseDenseQueueFastPath(long expectedLength) =>
         GetType() == typeof(SharpTSArray) && _ownsDenseStorage && !_mayHaveHoles
         && !HasExplicitPrototype && !IsFrozen && !IsSealed && IsExtensible && _lengthWritable
-        && _sparse is null && _length == expectedLength && _dense.Count == expectedLength
+        && _numericStore is null && _sparse is null
+        && _length == expectedLength && _dense.Count == expectedLength
         && (_indexAccessors?.Count ?? 0) == 0 && (_descriptors?.Count ?? 0) == 0;
 
     /// <summary>
@@ -220,6 +228,8 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     public bool HasIndex(long index)
     {
         if ((ulong)index >= (ulong)_length) return false;
+        if (_numericStore is not null)
+            return index < _numericCount;
         if (index <= uint.MaxValue
             && (_indexAccessors?.ContainsKey((uint)index) ?? false))
             return true;
@@ -241,6 +251,12 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     internal bool TryGetPresentDataIndex(long index, out object? value)
     {
         value = null;
+        if (_numericStore is not null)
+        {
+            if ((ulong)index >= (ulong)_numericCount) return false;
+            value = _numericStore[(int)index];
+            return true;
+        }
         if ((ulong)index >= (ulong)_length
             || index <= uint.MaxValue
                 && (_indexAccessors?.ContainsKey((uint)index) ?? false))
@@ -256,6 +272,131 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
         return true;
     }
 
+    [System.Runtime.CompilerServices.MethodImpl(
+        System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    internal bool TryGetPresentDataIndexRV(long index, out RuntimeValue value)
+    {
+        if (_numericStore is not null
+            && (ulong)index < (ulong)_numericCount)
+        {
+            value = RuntimeValue.FromNumber(_numericStore[(int)index]);
+            return true;
+        }
+        if (TryGetPresentDataIndex(index, out object? boxed))
+        {
+            value = RuntimeValue.FromBoxed(boxed);
+            return true;
+        }
+        value = RuntimeValue.Undefined;
+        return false;
+    }
+
+    /// <summary>
+    /// Writes the common ordinary dense-array case without property-key
+    /// conversion or descriptor lookup. Returns false when any observable array
+    /// exotic behavior requires the full interpreter property path.
+    /// </summary>
+    [System.Runtime.CompilerServices.MethodImpl(
+        System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    internal bool TrySetDenseDataIndex(long index, RuntimeValue value)
+    {
+        if (IsFrozen
+            || _sparse is not null
+            || _descriptors is not null
+            || _indexAccessors is not null
+            || index < 0
+            || index > MaxWriteIndex)
+        {
+            return false;
+        }
+
+        if (_numericStore is not null)
+        {
+            if (value.Kind != ValueKind.Number)
+            {
+                MaterializeNumeric();
+                return false;
+            }
+
+            if ((ulong)index < (ulong)_numericCount)
+            {
+                _numericStore[(int)index] = value.AsNumberUnsafe();
+                return true;
+            }
+            if (index != _numericCount
+                || !_lengthWritable
+                || !IsExtensible
+                || HasExplicitPrototype)
+            {
+                return false;
+            }
+
+            EnsureNumericCapacity(_numericCount + 1);
+            _numericStore[_numericCount++] = value.AsNumberUnsafe();
+            _length = _numericCount;
+            return true;
+        }
+
+        // An existing ordinary data property always shadows the prototype.
+        if (index < _length)
+        {
+            if (index >= _dense.Count || _dense[(int)index] is ArrayHole)
+                return false;
+            _dense[(int)index] = value.ToObject();
+            return true;
+        }
+
+        // Sequential growth is the Num Write hot path. Decline gaps and custom
+        // prototypes so inherited indexed behavior stays on the generic path.
+        if (index != _length
+            || index >= int.MaxValue
+            || !_lengthWritable
+            || !IsExtensible
+            || HasExplicitPrototype)
+        {
+            return false;
+        }
+
+        if (_length == 0 && _ownsDenseStorage && value.Kind == ValueKind.Number)
+        {
+            EnsureNumericCapacity(1);
+            _numericStore![_numericCount++] = value.AsNumberUnsafe();
+            _length = _numericCount;
+        }
+        else
+        {
+            _dense.Add(value.ToObject());
+            _length = _dense.Count;
+        }
+        return true;
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(
+        System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    private void EnsureNumericCapacity(int minimum)
+    {
+        if (_numericStore is null)
+        {
+            _numericStore = new double[Math.Max(4, minimum)];
+            return;
+        }
+        if (_numericStore.Length >= minimum) return;
+        int doubled = _numericStore.Length <= int.MaxValue / 2
+            ? _numericStore.Length * 2
+            : int.MaxValue;
+        int capacity = Math.Max(minimum, doubled);
+        Array.Resize(ref _numericStore, capacity);
+    }
+
+    private void MaterializeNumeric()
+    {
+        if (_numericStore is null) return;
+        for (int index = 0; index < _numericCount; index++)
+            _dense.Add(_numericStore[index]);
+        _numericStore = null;
+        _numericCount = 0;
+    }
+
     /// <summary>
     /// Makes <paramref name="index"/> a hole (ECMA-262 <c>delete arr[i]</c>).
     /// Length is unchanged. No-op for out-of-range indices or frozen arrays.
@@ -265,6 +406,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
         _mayHaveHoles = true;
         if (IsFrozen) return;
         if ((ulong)index >= (ulong)_length) return;
+        MaterializeNumeric();
         if (index <= uint.MaxValue)
             _indexAccessors?.Remove((uint)index);
         if (_sparse == null || index < _dense.Count)
@@ -282,6 +424,10 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// use <see cref="Get(long)"/> or convert via <see cref="UnholeForRead(object?)"/>.</summary>
     private object? GetCore(long index)
     {
+        if (_numericStore is not null)
+            return (ulong)index < (ulong)_numericCount
+                ? _numericStore[(int)index]
+                : ArrayHole.Instance;
         if (_sparse == null || index < _dense.Count)
             return _dense[(int)index];
         if (index > uint.MaxValue) return ArrayHole.Instance;
@@ -300,6 +446,15 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// <summary>Writes the slot at the given index without mutating length or transitioning.</summary>
     private void SetCore(long index, object? value)
     {
+        if (_numericStore is not null)
+        {
+            if (value is double number && index >= 0 && index < _numericCount)
+            {
+                _numericStore[(int)index] = number;
+                return;
+            }
+            MaterializeNumeric();
+        }
         _mayHaveHoles |= value is ArrayHole;
         if (_sparse == null || index < _dense.Count)
             _dense[(int)index] = value;
@@ -317,6 +472,9 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// </remarks>
     public IEnumerator<object?> GetEnumerator()
     {
+        // Iterators are live across guest mutations. Materialize once so a
+        // delete/splice between MoveNext calls cannot invalidate _numericStore.
+        MaterializeNumeric();
         // %ArrayIteratorPrototype%.next reads the array's current length on
         // every step. Mutations during iteration are therefore observable:
         // shrinking stops the iterator early, while appended elements can be
@@ -344,6 +502,17 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// <summary>Appends an element. Does not check frozen/sealed state.</summary>
     public void Add(object? value)
     {
+        if (_numericStore is not null)
+        {
+            if (value is double number)
+            {
+                EnsureNumericCapacity(_numericCount + 1);
+                _numericStore[_numericCount++] = number;
+                _length = _numericCount;
+                return;
+            }
+            MaterializeNumeric();
+        }
         _mayHaveHoles |= value is ArrayHole;
         if (_sparse != null)
         {
@@ -359,6 +528,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// <summary>Appends many elements. Does not check frozen/sealed state.</summary>
     public void AddRange(IEnumerable<object?> values)
     {
+        MaterializeNumeric();
         _mayHaveHoles = true; // Unknown enumerable; do not enumerate it twice.
         if (_sparse != null)
         {
@@ -403,6 +573,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// <summary>Removes and returns the last element. A hole reads as undefined.</summary>
     public object? RemoveLast()
     {
+        MaterializeNumeric();
         if (_length == 0)
             throw new InvalidOperationException("Array is empty.");
         long last = _length - 1;
@@ -455,6 +626,8 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     {
         _dense.Clear();
         _sparse = null;
+        _numericStore = null;
+        _numericCount = 0;
         _length = 0;
     }
 
@@ -472,6 +645,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     internal bool CanUseDenseSortFastPath(
         long expectedLength, bool checkForHoles = true)
     {
+        MaterializeNumeric();
         if (IsFrozen
             || expectedLength < 0
             || expectedLength > int.MaxValue
@@ -511,6 +685,8 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     internal void ReplaceDenseSortContents(
         IReadOnlyList<object?> defined, long undefinedCount)
     {
+        _numericStore = null;
+        _numericCount = 0;
         _dense.Clear();
         for (int index = 0; index < defined.Count; index++)
             _dense.Add(defined[index]);
@@ -523,6 +699,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// <summary>Returns a new <see cref="List{T}"/> containing the given slice.</summary>
     public List<object?> GetRange(int index, int count)
     {
+        MaterializeNumeric();
         if (index < 0 || count < 0 || index + count > _length)
             throw new ArgumentOutOfRangeException();
         if (_sparse == null && index + count <= _dense.Count)
@@ -562,6 +739,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// </summary>
     private void MaterializeDense()
     {
+        MaterializeNumeric();
         if (_sparse == null)
             return;
         _mayHaveHoles = true;
@@ -751,6 +929,24 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// </summary>
     private void SetCoreWithExtend(long index, object? value)
     {
+        if (_numericStore is not null)
+        {
+            if (value is double number && index >= 0 && index <= _numericCount)
+            {
+                if (index == _numericCount)
+                {
+                    EnsureNumericCapacity(_numericCount + 1);
+                    _numericStore[_numericCount++] = number;
+                    _length = _numericCount;
+                }
+                else
+                {
+                    _numericStore[(int)index] = number;
+                }
+                return;
+            }
+            MaterializeNumeric();
+        }
         _mayHaveHoles |= value is ArrayHole || index > _length;
         if (_sparse != null)
         {
@@ -798,6 +994,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
             throw new Exception($"RangeError: Array length {newLength} exceeds ECMA-262 uint32 maximum.");
 
         if (newLength == _length) return;
+        MaterializeNumeric();
         _mayHaveHoles |= newLength > _length;
 
         if (newLength < _length)
@@ -1177,6 +1374,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     /// </summary>
     internal IEnumerable<string> OwnStringKeys()
     {
+        MaterializeNumeric();
         int denseLimit = (int)Math.Min(_length, _dense.Count);
         for (int index = 0; index < denseLimit; index++)
         {
@@ -1285,6 +1483,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     public bool DefineProperty(string name, SharpTSPropertyDescriptor descriptor)
     {
         if (IsFrozen) return false;
+        MaterializeNumeric();
 
         // ArraySetLength (ECMA-262 §10.4.2.4). The length property is a
         // non-enumerable, non-configurable data property whose value controls

--- a/tests/SharpTS.Tests/CompilerTests/DiscardedNumericArrayWriteTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/DiscardedNumericArrayWriteTests.cs
@@ -145,6 +145,33 @@ public sealed class DiscardedNumericArrayWriteTests
         Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
     }
 
+    [Fact]
+    public void ObjectBackedCapturedBound_DoesNotEmitCountedReservation()
+    {
+        Assembly assembly = Compile("""
+            function makeFill(n: number): any {
+                function fill(values: number[]): void {
+                    for (let i: number = 0; i < n; i++) {
+                        values[i] = i;
+                    }
+                }
+                return fill;
+            }
+            """);
+
+        var reservationCallers = assembly.GetTypes()
+            .Where(type => type.Name != "$Runtime")
+            .SelectMany(type => type.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic |
+                BindingFlags.Static | BindingFlags.Instance))
+            .Where(method => method.GetMethodBody() != null)
+            .Where(method => ReadInstructions(method).Any(instruction =>
+                instruction.Operand is MethodBase { Name: "EnsureDoubleCapacity" }))
+            .ToArray();
+
+        Assert.Empty(reservationCallers);
+    }
+
     private static Assembly Compile(string source)
     {
         var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
@@ -166,6 +193,12 @@ public sealed class DiscardedNumericArrayWriteTests
         byte[] il = method.GetMethodBody()?.GetILAsByteArray()
             ?? throw new InvalidOperationException($"Method '{method.Name}' has no IL body.");
         Module module = method.Module;
+        Type[]? typeArguments = method.DeclaringType?.IsGenericType == true
+            ? method.DeclaringType.GetGenericArguments()
+            : null;
+        Type[]? methodArguments = method.IsGenericMethod
+            ? method.GetGenericArguments()
+            : null;
 
         for (int offset = 0; offset < il.Length;)
         {
@@ -179,8 +212,8 @@ public sealed class DiscardedNumericArrayWriteTests
             {
                 int token = BitConverter.ToInt32(il, offset);
                 operand = opCode.OperandType == OperandType.InlineMethod
-                    ? module.ResolveMethod(token)
-                    : module.ResolveType(token);
+                    ? module.ResolveMethod(token, typeArguments, methodArguments)
+                    : module.ResolveType(token, typeArguments, methodArguments);
             }
 
             int operandSize = opCode.OperandType switch

--- a/tests/SharpTS.Tests/CompilerTests/DiscardedNumericArrayWriteTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/DiscardedNumericArrayWriteTests.cs
@@ -22,6 +22,8 @@ public sealed class DiscardedNumericArrayWriteTests
             """);
 
         var instructions = ReadInstructions(FindFunction(assembly, "fill")).ToArray();
+        Assert.Contains(instructions, instruction =>
+            instruction.Operand is MethodBase { Name: "EnsureDoubleCapacity" });
         int setDouble = Array.FindIndex(instructions, instruction =>
             instruction.Operand is MethodBase { Name: "SetDouble" });
 

--- a/tests/SharpTS.Tests/SharedTests/PackedNumberArrayParityTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/PackedNumberArrayParityTests.cs
@@ -70,4 +70,19 @@ public sealed class PackedNumberArrayParityTests
             """;
         Assert.Equal("1,2,3 6,4,2\n", TestHarness.Run(source, mode));
     }
+
+    [Theory, ModeData]
+    public void AsyncIndexedRead_RoundTripsPackedNumbers(ExecutionMode mode)
+    {
+        const string source = """
+            async function readPacked(): Promise<number> {
+                const a: number[] = [];
+                for (let i = 0; i < 100; i++) a[i] = i * 3;
+                await Promise.resolve();
+                return a[37];
+            }
+            readPacked().then((value: number) => console.log(value));
+            """;
+        Assert.Equal("111\n", TestHarness.Run(source, mode));
+    }
 }

--- a/tests/SharpTS.Tests/SharedTests/PackedNumberArrayParityTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/PackedNumberArrayParityTests.cs
@@ -1,0 +1,73 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+/// <summary>
+/// Guards the interpreter's packed-number array representation and every
+/// transition back to the generic object/descriptor model.
+/// </summary>
+public sealed class PackedNumberArrayParityTests
+{
+    [Theory, ModeData]
+    public void SequentialIndexGrowth_RoundTripsNumbers(ExecutionMode mode)
+    {
+        const string source = """
+            const a: any[] = [];
+            for (let i = 0; i < 100; i++) a[i] = i * 3;
+            console.log(a.length, a[0], a[37], a[99]);
+            """;
+        Assert.Equal("100 0 111 297\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void NonNumberWrite_MaterializesWithoutLosingValues(ExecutionMode mode)
+    {
+        const string source = """
+            const a: any[] = [];
+            a[0] = 1; a[1] = 2; a[1] = "x"; a[2] = 3;
+            console.log(a.join(","), a.length);
+            """;
+        Assert.Equal("1,x,3 3\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void DescriptorWrite_MaterializesAndHonorsWritable(ExecutionMode mode)
+    {
+        const string source = """
+            const a: any[] = [];
+            a[0] = 1; a[1] = 2;
+            Object.defineProperty(a, "1", { writable: false });
+            a[1] = 9;
+            console.log(a.join(","));
+            """;
+        Assert.Equal("1,2\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void DeleteAndLengthChanges_PreserveHoleSemantics(ExecutionMode mode)
+    {
+        const string source = """
+            const a: any[] = [];
+            a[0] = 1; a[1] = 2; a[2] = 3;
+            delete a[1];
+            a.length = 2;
+            a.length = 4;
+            console.log([a[0], 1 in a, a[1], 2 in a, 3 in a, a.length].join("|"));
+            """;
+        Assert.Equal("1|false||false|false|4\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void IterationAndMutationHelpers_MaterializeCorrectly(ExecutionMode mode)
+    {
+        const string source = """
+            const a: any[] = [];
+            a[0] = 1; a[1] = 2; a[2] = 3;
+            const spread = [...a].join(",");
+            a.reverse();
+            console.log(spread, a.map((x: number) => x * 2).join(","));
+            """;
+        Assert.Equal("1,2,3 6,4,2\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
## Summary

- add packed `double[]` storage for interpreted ordinary arrays, with lazy materialization for holes, descriptors, queue operations, and non-number writes
- use direct `RuntimeValue` indexed reads/writes and skip unnecessary per-iteration environments and idle callback work
- hoist compiled array parameters and reserve packed capacity for proven counted index-write loops
- split Num Write into growth, overwrite, and read controls, with matching microbenchmarks and parity coverage

## Performance

Three-launch medians on Windows at 1,000,000 elements:

| Case | Interpreter | Compiled | Node 22.23.2 | Compiled vs Node |
|---|---:|---:|---:|---:|
| `num-write` | 365.769 ms | 2.902 ms | 9.214 ms | 0.31x |
| `num-overwrite` | 361.139 ms | 2.354 ms | 1.417 ms | 1.66x |
| `num-read` | 185.134 ms | 1.345 ms | 0.428 ms | 3.14x |
| `num-push` | 774.911 ms | 3.414 ms | 8.842 ms | 0.39x |

The split controls show that capacity growth is no longer the compiled bottleneck; indexed reads remain the main gap.

## Validation

- `dotnet build SharpTS.sln -c Release --no-restore -m:1 --nologo -p:NuGetAudit=false` — passed with 0 errors (two offline NuGet audit warnings)
- 92 focused packed-array, array-queue, loop-binding, compiler-emission, and promise-scheduling tests passed
- `run-benchmarks.ps1 -Smoke -Workloads num-arrays` passed
- cross-runtime snapshot contract tests passed
- three independent Num Write benchmark launches completed with checksum validation before and after sampling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved performance for numeric-array reads, sequential writes, growth, and overwrites.
  - Optimized counted loops that write sequentially into numeric arrays.
  - Added faster dense-array access paths for indexed operations.
  - Reduced unnecessary per-iteration loop overhead when bindings are not captured.

- **Bug Fixes**
  - Improved numeric-array behavior for holes, deletions, descriptors, iteration, sorting, slicing, and non-numeric values.
  - Improved loop handling for captured bindings and direct `eval` usage.
  - Improved finalization cleanup scheduling when no registries are active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->