### PR TITLE
Optimize numeric destructuring for dictionary and materialized objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,8 @@ jobs:
     needs: workflow-policy
     if: needs.workflow-policy.outputs.mode == 'full'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    # Windows needs room for the full core suite plus build and packaging gates.
+    timeout-minutes: ${{ matrix.os == 'windows-2025' && 30 || 20 }}
     strategy:
       # Don't let one platform's failure cancel the others — we want to see each
       # platform's real result independently (a flake on one shouldn't hide the rest).
@@ -181,7 +182,8 @@ jobs:
       # Run them on demand locally: dotnet test --filter "Category=npm"
       - name: Test core
         run: dotnet test tests/SharpTS.Tests/SharpTS.Tests.csproj --no-build --configuration Release --verbosity normal --filter "Category!=LiveNetwork&Category!=LoadSensitive&Category!=npm"
-        timeout-minutes: 10
+        # The passing Windows suite can exceed ten minutes on hosted runners.
+        timeout-minutes: ${{ matrix.os == 'windows-2025' && 15 || 10 }}
 
       - name: Test GUI conformance
         run: dotnet test tests/gui-conformance/SharpTS.Gui.Conformance.Tests/SharpTS.Gui.Conformance.Tests.csproj --no-build --configuration Release --verbosity normal --filter "Category!=LiveNetwork&Category!=LoadSensitive&Category!=npm"

--- a/benchmarks/cross-runtime/README.md
+++ b/benchmarks/cross-runtime/README.md
@@ -106,8 +106,10 @@ For repeatable candidate-vs-baseline runs on native Windows and WSL, see
 Set `SHARPTS_BENCH_WARMUP_MS=1500` for focused steady-state investigations.
 The optional override accepts integer milliseconds from 0 to 10000; the default
 remains 100 ms. It changes warmup only, not the sampling budget or slow-call
-sampling threshold. Use the same setting and workload sources for every runtime
-and baseline/candidate build, and retain the setting alongside raw results.
+sampling threshold. Zero skips timed warmup; correctness checks, the discarded
+cold and routing probes, and batch calibration still run. Use the same setting
+and workload sources for every runtime and baseline/candidate build, and retain
+the setting alongside raw results.
 
 `object-destructure-materialized` exercises dictionary storage from construction.
 `object-destructure-carrier-materialized` exercises a compact record that is

--- a/benchmarks/cross-runtime/README.md
+++ b/benchmarks/cross-runtime/README.md
@@ -103,14 +103,25 @@ For repeatable candidate-vs-baseline runs on native Windows and WSL, see
 
 ## How timing works
 
+Set `SHARPTS_BENCH_WARMUP_MS=1500` for focused steady-state investigations.
+The optional override accepts integer milliseconds from 0 to 10000; the default
+remains 100 ms. It changes warmup only, not the sampling budget or slow-call
+sampling threshold. Use the same setting and workload sources for every runtime
+and baseline/candidate build, and retain the setting alongside raw results.
+
+`object-destructure-materialized` exercises dictionary storage from construction.
+`object-destructure-carrier-materialized` exercises a compact record that is
+subsequently materialized. `object-destructure-materialized-controls` adds direct,
+manually hoisted, fractional, varying-receiver, and per-iteration mutation controls.
+
 Each workload calls `bench(name, param, fn, expected?)` from
 `scripts/lib/bench.ts`, which:
 
 1. When `expected` is supplied, validates one invocation before probing. A
    second validation after sampling checks the optimized steady-state result;
    neither validation is timed.
-2. Discards a cold probe, gives every runtime at least 100 ms of time-bounded
-   warmup, and discards a post-warmup routing probe. Slow and fast cases therefore
+2. Discards a cold probe, gives every runtime the configured time-bounded
+   warmup (100 ms by default), and discards a post-warmup routing probe. Slow and fast cases therefore
    both report steady-state samples rather than using different cold-start rules.
 3. A post-warmup call at or above 100 ms is sampled one call at a time. Faster
    calls are auto-batched until a sample spans ≥ 1 ms, lifting them above timer

--- a/benchmarks/cross-runtime/scripts/lib/bench.ts
+++ b/benchmarks/cross-runtime/scripts/lib/bench.ts
@@ -19,7 +19,14 @@
 
 import { performance } from "perf_hooks";
 
-const WARMUP_CAP_MS: number = 100;   // warm up the JIT, but never block for long
+const configuredWarmup = process.env.SHARPTS_BENCH_WARMUP_MS;
+const WARMUP_CAP_MS: number = configuredWarmup === undefined ? 100 : Number(configuredWarmup);
+if (configuredWarmup !== undefined && (configuredWarmup.trim() === "" ||
+    !Number.isInteger(WARMUP_CAP_MS) || WARMUP_CAP_MS < 0 || WARMUP_CAP_MS > 10000)) {
+    console.error("SHARPTS_BENCH_WARMUP_MS must be an integer from 0 to 10000");
+    process.exit(1);
+}
+const SLOW_CALL_MS: number = 100;   // sampling policy is independent of warmup duration
 const MIN_SAMPLE_MS: number = 1;     // grow the inner batch until a sample spans this
 const BUDGET_MS: number = 300;       // preferred total sampling time per case
 const MIN_SAMPLES: number = 8;       // sample floor (for a meaningful stdev)...
@@ -80,7 +87,7 @@ export function bench(name: string, param: number, fn: () => number, expected?: 
     guard = guard + fn();
     const firstMs: number = performance.now() - probeStart;
 
-    if (firstMs >= WARMUP_CAP_MS) {
+    if (firstMs >= SLOW_CALL_MS) {
         // A single call is reliably measurable — sample one call at a time,
         // bounded by the budget and the hard cap (slow cases end up with few
         // samples, and thus stdev 0, which is honest).
@@ -209,7 +216,7 @@ export async function benchAsync(
     guard = guard + await fn();
     const firstMs: number = performance.now() - probeStart;
 
-    if (firstMs >= WARMUP_CAP_MS) {
+    if (firstMs >= SLOW_CALL_MS) {
         while (samples.length < MAX_SAMPLES) {
             if (total >= HARD_CAP_MS) {
                 break;

--- a/benchmarks/cross-runtime/scripts/lib/bench.ts
+++ b/benchmarks/cross-runtime/scripts/lib/bench.ts
@@ -76,10 +76,12 @@ export function bench(name: string, param: number, fn: () => number, expected?: 
     // skipped warmup entirely. That made slow interpreter cases measure startup
     // while fast JIT cases measured steady state.
     guard = guard + fn();
-    const warmStart: number = performance.now();
-    do {
-        guard = guard + fn();
-    } while (performance.now() - warmStart < WARMUP_CAP_MS);
+    if (WARMUP_CAP_MS > 0) {
+        const warmStart: number = performance.now();
+        do {
+            guard = guard + fn();
+        } while (performance.now() - warmStart < WARMUP_CAP_MS);
+    }
 
     // This post-warmup probe selects single-call sampling versus auto-batching,
     // but is itself discarded so both branches start with fresh observations.
@@ -207,10 +209,12 @@ export async function benchAsync(
     // Keep the async methodology identical to the synchronous path: discard the
     // cold call, warm every runtime, and discard the post-warmup routing probe.
     guard = guard + await fn();
-    const warmStart: number = performance.now();
-    do {
-        guard = guard + await fn();
-    } while (performance.now() - warmStart < WARMUP_CAP_MS);
+    if (WARMUP_CAP_MS > 0) {
+        const warmStart: number = performance.now();
+        do {
+            guard = guard + await fn();
+        } while (performance.now() - warmStart < WARMUP_CAP_MS);
+    }
 
     const probeStart: number = performance.now();
     guard = guard + await fn();

--- a/benchmarks/cross-runtime/scripts/object-destructure-carrier-materialized.ts
+++ b/benchmarks/cross-runtime/scripts/object-destructure-carrier-materialized.ts
@@ -2,10 +2,11 @@ import { bench } from "./lib/bench.ts";
 
 type Point = { x: number; y: number };
 
-function destructureMaterialized(n: number): number {
-    // The dynamic alias makes this literal dictionary-backed from construction.
-    // object-destructure-carrier-materialized covers an actual carrier transition.
-    const point: Point = { x: 1, y: 2 };
+function destructureCarrierMaterialized(n: number): number {
+    // Discarded push retains compact allocation despite the subsequent dynamic write.
+    const points: Point[] = [];
+    points.push({ x: 1, y: 2 });
+    const point: Point = points[0];
     const dynamicPoint: any = point;
     dynamicPoint.extra = true;
     let checksum: number = 0;
@@ -19,5 +20,6 @@ function destructureMaterialized(n: number): number {
 const sizes: number[] = [10000, 100000];
 for (let i: number = 0; i < sizes.length; i++) {
     const n: number = sizes[i];
-    bench("object-destructure-materialized", n, () => destructureMaterialized(n), n * 3);
+    bench("object-destructure-carrier-materialized", n,
+        () => destructureCarrierMaterialized(n), n * 3);
 }

--- a/benchmarks/cross-runtime/scripts/object-destructure-materialized-controls.ts
+++ b/benchmarks/cross-runtime/scripts/object-destructure-materialized-controls.ts
@@ -1,0 +1,73 @@
+import { bench } from "./lib/bench.ts";
+
+type Point = { x: number; y: number };
+
+function direct(n: number): number {
+    const point: Point = { x: 1, y: 2 };
+    const dynamicPoint: any = point;
+    dynamicPoint.extra = true;
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) sum = sum + point.x + point.y;
+    return sum;
+}
+
+function hoisted(n: number): number {
+    const point: Point = { x: 1, y: 2 };
+    const dynamicPoint: any = point;
+    dynamicPoint.extra = true;
+    const { x, y } = point;
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) sum = sum + x + y;
+    return sum;
+}
+
+function fractional(n: number): number {
+    const point: Point = { x: 1.25, y: 2.5 };
+    const dynamicPoint: any = point;
+    dynamicPoint.extra = true;
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const { x, y } = point;
+        sum = sum + x + y;
+    }
+    return sum;
+}
+
+function varying(n: number): number {
+    const first: Point = { x: 1, y: 2 };
+    const second: Point = { x: 3, y: 4 };
+    const dynamicFirst: any = first;
+    const dynamicSecond: any = second;
+    dynamicFirst.extra = true;
+    dynamicSecond.extra = true;
+    const points: Point[] = [first, second];
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const { x, y } = points[i % 2];
+        sum = sum + x + y;
+    }
+    return sum;
+}
+
+function mutated(n: number): number {
+    const point: Point = { x: 1, y: 2 };
+    const dynamicPoint: any = point;
+    dynamicPoint.extra = true;
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        dynamicPoint.x = i;
+        const { x, y } = point;
+        sum = sum + x + y;
+    }
+    return sum;
+}
+
+const sizes: number[] = [10000, 100000];
+for (let i: number = 0; i < sizes.length; i++) {
+    const n: number = sizes[i];
+    bench("object-materialized-direct", n, () => direct(n), n * 3);
+    bench("object-materialized-hoisted", n, () => hoisted(n), n * 3);
+    bench("object-materialized-fractional", n, () => fractional(n), n * 3.75);
+    bench("object-materialized-varying", n, () => varying(n), n * 5);
+    bench("object-materialized-mutated", n, () => mutated(n), n * (n - 1) / 2 + n * 2);
+}

--- a/benchmarks/cross-runtime/scripts/object-destructure.ts
+++ b/benchmarks/cross-runtime/scripts/object-destructure.ts
@@ -56,9 +56,9 @@ const points: Point[] = [{ x: 1, y: 2 }, { x: 3, y: 4 }];
 const sizes: number[] = [10000, 100000];
 for (let i: number = 0; i < sizes.length; i++) {
     const n: number = sizes[i];
-    bench("object-destructure-invariant-fused", n, () => destructureInvariantFused(n));
-    bench("object-destructure-invariant-split", n, () => destructureInvariantSplit(n));
-    bench("object-destructure-invariant-fractional", n, () => destructureInvariantFractional(n));
-    bench("object-destructure-varying", n, () => destructureVarying(points, n));
-    bench("object-direct-varying", n, () => directVarying(points, n));
+    bench("object-destructure-invariant-fused", n, () => destructureInvariantFused(n), n * 3);
+    bench("object-destructure-invariant-split", n, () => destructureInvariantSplit(n), n * 3);
+    bench("object-destructure-invariant-fractional", n, () => destructureInvariantFractional(n), n * 3.75);
+    bench("object-destructure-varying", n, () => destructureVarying(points, n), n * 5);
+    bench("object-direct-varying", n, () => directVarying(points, n), n * 5);
 }

--- a/benchmarks/local-perf/materialized-object-destructuring.md
+++ b/benchmarks/local-perf/materialized-object-destructuring.md
@@ -1,0 +1,88 @@
+# Materialized object destructuring results
+
+Measured September 4–5, 2026. Baseline: `af72038b83e9c88449b33ca42262f3f8dc156ea7`; candidate compiler: `47f090334bb1d5e63b0048a1f1511a271564ea44`. Validation is complete, with the baseline failures and platform limits documented below.
+
+The original benchmark creates a dictionary immediately because it mutates an `any` alias. It does not measure a compact record transitioning to dictionary storage. The new `object-destructure-carrier-materialized` workload exercises that transition separately; compiler tests assert both representations.
+
+The improvement comes from acquiring own numeric values before eligible invariant loops. Guards reject descriptors, missing properties, nonnumeric values, and unsupported bounds before observable state changes. Safe integer reductions retain their exactness checks; fractional reductions retain the original addition tree. Varying or mutated receivers acquire a fresh snapshot at each destructuring operation. General dictionary property dispatch also avoids a duplicate descriptor lookup.
+
+## Measurement setup
+
+- Intel Core i7-14700T; Windows 10.0.29639; .NET SDK 10.0.400/runtime 10.0.11; Node 22.23.2.
+- Identical harness and workload copies compiled with the saved baseline compiler and candidate compiler. Only the workload size list was narrowed to `100000` for this investigation.
+- `SHARPTS_BENCH_WARMUP_MS=1500`, normal runtime tiering, 300 ms sample budget, auto-batching, validated checksums. Five fresh alternating baseline/candidate launches; three Node launches for the two target cases. Measurements ran separately from this task's builds and test suites; other host activity was not controlled.
+- Tables report the median of each launch's mean in milliseconds. Paired change is the median of `(candidate / baseline - 1) * 100` for matching launches, not the ratio of the independently selected medians.
+- Raw launch means, minima, sample standard deviations, counts, and batch sizes are retained locally under `.perf-local/destructure-implementation/`.
+
+## Windows, normal scheduling
+
+| Case, n = 100,000 | Baseline ms | Candidate ms | Paired change |
+| --- | ---: | ---: | ---: |
+| Original dictionary destructuring | 3.2384 | 0.0242 | -99.19% |
+| Actual materialized carrier | 8.3464 | 0.0246 | -99.69% |
+| Materialized fractional values | 5.6562 | 0.1665 | -97.06% |
+| Materialized varying receiver | 5.8593 | 1.7943 | -69.99% |
+| Materialized property mutation in loop | 11.9480 | 7.5449 | -36.28% |
+| Materialized direct property reads | 5.7402 | 4.6420 | -17.70% |
+| Manually hoisted materialized reads | 0.1658 | 0.1650 | -0.46% |
+
+The original case's median fell by about 134× and the actual transition case by about 339×. These are local measurements, not general guarantees. Node medians were 0.0696 ms and 0.1146 ms respectively.
+
+Some compact/direct control results varied substantially between launches. A second five-pair run pinned all children to logical CPU 2. It showed approximately unchanged arithmetic controls and improvements in varying receivers, but also greatly increased the baseline's warmup sensitivity. Its original/carrier medians were 22.14/62.38 ms before and approximately 0.02/0.03 ms after. Those results are diagnostic and are excluded from the headline speedups.
+
+## Linux, normal scheduling
+
+WSL Ubuntu 26.04, .NET SDK 10.0.400/runtime 10.0.11, and Node 22.23.2; otherwise the same paired methodology and generated assemblies as Windows.
+
+| Case, n = 100,000 | Baseline ms | Candidate ms | Paired change |
+| --- | ---: | ---: | ---: |
+| Original dictionary destructuring | 2.8534 | 0.0223 | -99.31% |
+| Actual materialized carrier | 7.6630 | 0.0210 | -99.72% |
+| Materialized fractional values | 3.0384 | 0.2028 | -93.16% |
+| Materialized varying receiver | 2.9650 | 0.9263 | -66.67% |
+| Materialized property mutation in loop | 6.2854 | 3.6102 | -46.37% |
+| Materialized direct property reads | 3.1205 | 2.4852 | -10.54% |
+| Manually hoisted materialized reads | 0.1353 | 0.1319 | -4.06% |
+| Compact fused reduction | 0.0199 | 0.0201 | -0.02% |
+| Compact split reduction | 0.1254 | 0.1303 | +1.70% |
+| Compact fractional reduction | 0.1252 | 0.0804 | -37.05% |
+| Compact varying receiver | 0.2590 | 0.2758 | +6.49% |
+| Compact direct varying receiver | 0.3160 | 0.3207 | +1.51% |
+| Unrelated dynamic mutation | 0.0207 | 0.0197 | -3.44% |
+
+The original case's median improved about 128×; the carrier case about 366×. Node medians were 0.0369 ms and 0.0456 ms respectively. No Linux control crossed the lab's 10% relative regression threshold. The +6.49% compact varying result remains worth tracking on an idle, controlled host; these measurements do not establish that every small change is noise. The two roughly 0.02 ms arithmetic controls also remained stable by paired comparison, independently of the lab's default 0.05 ms absolute threshold.
+
+## Allocations
+
+BenchmarkDotNet 0.14.0 ShortRun (one launch, three warmup and three measured iterations), using cached typed delegates and MemoryDiagnoser:
+
+| Case | Bytes/call, n = 1,000 | Bytes/call, n = 100,000 |
+| --- | ---: | ---: |
+| Dictionary | 288 | 288 |
+| Materialized carrier | 534 | 516 |
+
+Allocation does not grow with loop length. Separate per-thread allocation probes of the standalone carrier fixture measured exactly 496 bytes/call at both sizes, for both baseline and candidate. The original dictionary baseline also measured 288 bytes/call. The carrier's small amortized variation in BenchmarkDotNet is fixed overhead, not allocation per destructured property. ShortRun timing confidence intervals were wide on this host, so use the five-pair cross-runtime comparisons above for latency.
+
+## Validation
+
+The focused compiler, compact-record, destructuring, descriptor, and proxy suite passed (243 tests), followed by the additional descriptor-identity regression. IL tests find both optimized numeric loops free of property reads/conversions and confirm generic fallback and cancellation remain. Allocation tests compare 1,000 with 100,000 iterations and reject growth proportional to the loop count. Valid and invalid warmup settings were exercised against a standalone emitted assembly.
+
+- Windows full hermetic core suite: 17,918 passed, 3 skipped, 2 failed. The interpreter generator timeout and compiled Promise output failure both passed when retried in isolation (four compiled/interpreted cases). The first sandboxed attempt was stopped after local HTTP/certificate/IPC permission failures; these did not recur with normal host permissions.
+- WSL Ubuntu 26.04, x64, .NET 10.0.11: 17,920 passed, 3 failed. Restoring the tracked executable bit and Unix shebang in the copied sample resolved one failure; all three shebang tests then passed. The two remaining interpreter OS-memory tests also fail with the unchanged baseline: `freemem()` exceeds the reported `totalmem()` on this host. Interpreter memory reporting is outside this change.
+- Linux Native AOT: published the managed runtime payload and native compiler, passed `samples/AotCompileGate/main.ts` (42), and used the native compiler to compile both target benchmark modules. Both emitted programs passed checksums at 10,000 and 100,000 iterations. The source snapshot and measurement assemblies reside on WSL's ext4 filesystem.
+- The Windows solution and all selected cross-runtime fixtures built. All embedded microbenchmark sources smoke-compiled on Windows and Linux.
+- The remaining Windows full-gate checks passed: 108 GUI conformance tests, all three conformance project builds, 10 NuGet release helper tests, GUI version staging, packaged SDK compile/publish/execute smoke, and AOT analyzer enforcement (zero warnings; inventory matches the baseline).
+
+All four selected allocation benchmarks completed and their setup checksums passed, including the direct, hoisted, fractional, varying, and mutated controls. ARM and macOS were not exercised locally.
+
+## Reproduction
+
+Compile the same versions of these workloads with the baseline and candidate compiler: `object-destructure-materialized`, `object-destructure-carrier-materialized`, `object-destructure-materialized-controls`, `object-destructure`, and `object-destructure-unrelated-dynamic`. Set the warmup environment variable on both executions and alternate process order. Keep the materialization fixture in its own module so whole-program shape analysis stays representative.
+
+Run the durable allocation benchmarks with:
+
+```powershell
+dotnet run -c Release --project benchmarks/micro/SharpTS.Microbenchmarks -- --filter '*ObjectDestructuringBenchmarks*'
+```
+
+Future widening should be measured separately: descriptor-enabled programs, richer loop bodies, and more general invariant analysis remain outside this change.

--- a/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ObjectDestructuringBenchmarks.cs
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ObjectDestructuringBenchmarks.cs
@@ -1,0 +1,57 @@
+using BenchmarkDotNet.Attributes;
+using SharpTS.Microbenchmarks.Infrastructure;
+
+namespace SharpTS.Microbenchmarks.Benchmarks;
+
+/// <summary>Typed-delegate measurements; compilation and delegate creation are untimed.</summary>
+[MemoryDiagnoser]
+public class ObjectDestructuringBenchmarks
+{
+    private Func<double, double> _dictionary = null!;
+    private Func<double, double> _carrier = null!;
+    private Func<double, double> _direct = null!;
+    private Func<double, double> _hoisted = null!;
+    private Func<double, double> _fractional = null!;
+    private Func<double, double> _varying = null!;
+    private Func<double, double> _mutated = null!;
+
+    [Params(1_000, 100_000)]
+    public int N { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        using var stream = typeof(ObjectDestructuringBenchmarks).Assembly.GetManifestResourceStream(
+            "SharpTS.Microbenchmarks.TypeScriptSources.ObjectDestructuring.ts")!;
+        using var reader = new StreamReader(stream);
+        var path = CompilationCache.GetOrCompile(reader.ReadToEnd(), "ObjectDestructuring");
+        var assembly = BenchmarkHarness.LoadCompiledAssembly(path, "object-destructuring");
+        _dictionary = BenchmarkHarness.GetCompiledNumberFunc(assembly, "destructureMaterialized");
+        _carrier = BenchmarkHarness.GetCompiledNumberFunc(assembly, "destructureCarrierMaterialized");
+        _direct = BenchmarkHarness.GetCompiledNumberFunc(assembly, "direct");
+        _hoisted = BenchmarkHarness.GetCompiledNumberFunc(assembly, "hoisted");
+        _fractional = BenchmarkHarness.GetCompiledNumberFunc(assembly, "fractional");
+        _varying = BenchmarkHarness.GetCompiledNumberFunc(assembly, "varying");
+        _mutated = BenchmarkHarness.GetCompiledNumberFunc(assembly, "mutated");
+        if (_dictionary(N) != N * 3d || _carrier(N) != N * 3d || _direct(N) != N * 3d || _hoisted(N) != N * 3d ||
+            _fractional(N) != N * 3.75 || _varying(N) != N * 5d ||
+            _mutated(N) != N * (N - 1d) / 2 + N * 2d)
+            throw new InvalidOperationException("Object destructuring benchmark checksum mismatch.");
+    }
+
+    [Benchmark] public double Dictionary() => _dictionary(N);
+    [Benchmark] public double MaterializedCarrier() => _carrier(N);
+    [Benchmark] public double Direct() => _direct(N);
+    [Benchmark] public double ManuallyHoisted() => _hoisted(N);
+    [Benchmark] public double Fractional() => _fractional(N);
+    [Benchmark] public double Varying() => _varying(N);
+    [Benchmark] public double Mutated() => _mutated(N);
+
+    [Benchmark(Baseline = true)]
+    public double CSharpNumericLoop()
+    {
+        double result = 0;
+        for (int i = 0; i < N; i++) result = result + 1 + 2;
+        return result;
+    }
+}

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ObjectDestructuring.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ObjectDestructuring.ts
@@ -1,0 +1,92 @@
+type Point = { x: number; y: number };
+
+function direct(n: number): number {
+    const point: Point = { x: 1, y: 2 };
+    const dynamicPoint: any = point;
+    dynamicPoint.extra = true;
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) sum = sum + point.x + point.y;
+    return sum;
+}
+
+function hoisted(n: number): number {
+    const point: Point = { x: 1, y: 2 };
+    const dynamicPoint: any = point;
+    dynamicPoint.extra = true;
+    const { x, y } = point;
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) sum = sum + x + y;
+    return sum;
+}
+
+function fractional(n: number): number {
+    const point: Point = { x: 1.25, y: 2.5 };
+    const dynamicPoint: any = point;
+    dynamicPoint.extra = true;
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const { x, y } = point;
+        sum = sum + x + y;
+    }
+    return sum;
+}
+
+function varying(n: number): number {
+    const first: Point = { x: 1, y: 2 };
+    const second: Point = { x: 3, y: 4 };
+    const dynamicFirst: any = first;
+    const dynamicSecond: any = second;
+    dynamicFirst.extra = true;
+    dynamicSecond.extra = true;
+    const points: Point[] = [first, second];
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const { x, y } = points[i % 2];
+        sum = sum + x + y;
+    }
+    return sum;
+}
+
+function mutated(n: number): number {
+    const point: Point = { x: 1, y: 2 };
+    const dynamicPoint: any = point;
+    dynamicPoint.extra = true;
+    let sum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        dynamicPoint.x = i;
+        const { x, y } = point;
+        sum = sum + x + y;
+    }
+    return sum;
+}
+
+function destructureMaterialized(n: number): number {
+    // The dynamic alias makes this literal dictionary-backed from construction.
+    // object-destructure-carrier-materialized covers an actual carrier transition.
+    const point: Point = { x: 1, y: 2 };
+    const dynamicPoint: any = point;
+    dynamicPoint.extra = true;
+    let checksum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const { x, y } = point;
+        checksum = checksum + x + y;
+    }
+    return checksum;
+}
+
+function destructureCarrierMaterialized(n: number): number {
+    // Discarded push retains compact allocation despite the subsequent dynamic write.
+    const points: Point[] = [];
+    points.push({ x: 1, y: 2 });
+    const point: Point = points[0];
+    const dynamicPoint: any = point;
+    dynamicPoint.extra = true;
+    let checksum: number = 0;
+    for (let i: number = 0; i < n; i++) {
+        const { x, y } = point;
+        checksum = checksum + x + y;
+    }
+    return checksum;
+}
+
+

--- a/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ObjectDestructuring.ts
+++ b/benchmarks/micro/SharpTS.Microbenchmarks/TypeScriptSources/ObjectDestructuring.ts
@@ -88,5 +88,3 @@ function destructureCarrierMaterialized(n: number): number {
     }
     return checksum;
 }
-
-

--- a/docs/plans/materialized-object-destructuring.md
+++ b/docs/plans/materialized-object-destructuring.md
@@ -1,0 +1,95 @@
+# Materialized object destructuring implementation plan
+
+Status: implemented and validated. See the [performance and validation results](../../benchmarks/local-perf/materialized-object-destructuring.md) for measured gains, completed gates, baseline failures, and platform limits.
+
+Implemented stages 1–4 below. Guarded snapshots now support dictionary receivers and canonical materialized-carrier storage, including numeric shapes without compact metadata. The integer reduction retains its exactness proof; other numeric inputs use the original floating-point addition tree. Fixed numeric patterns that remain inside loops share a snapshot, and general dictionary dispatch uses one descriptor lookup. Added checksum controls, configurable warmup, typed-delegate microbenchmarks, representation/IL assertions, allocation checks, and semantic regressions.
+
+Delivered benchmark fixtures in `acce19be`, guarded snapshots with compiler tests in `80747bf7`, and the independent dictionary-dispatch change in `47f09033`. The original benchmark's median improved about 134× on Windows and 128× on Linux, with no allocation growth as the iteration count increases. Stage 5 includes full core suites, the remaining Windows full-gate checks, Linux Native AOT compile/execute, five paired launches per platform, and allocation measurements; the results document records the existing failures and isolated retries explicitly.
+
+Reduce compiled execution time for dictionary-backed and materialized compact-record destructuring. Deliver the invariant-loop optimization first, then improve repeated reads that cannot move outside a loop. Preserve JavaScript evaluation order, numeric behavior, property semantics, and cancellation.
+
+The investigation at `af72038b83e9c88449b33ca42262f3f8dc156ea7` found that `object-destructure-materialized.ts` immediately allocates a dictionary. Each iteration falls back to two general property lookups and numeric conversions. Allocation remains 288 bytes per call at n = 0 through 100,000. With 1,500 ms warmup and three launches on Windows, median compiled times at n = 100,000 were 2.801 ms for the current body, 0.093 ms with reads manually hoisted, and 0.023 ms without dynamic mutation. These diagnostic controls establish opportunity, not guaranteed implementation results. Generate fresh paired baseline/candidate evidence.
+
+**1. Establish durable benchmarks and correctness coverage.**
+
+Primary files:
+
+- `benchmarks/cross-runtime/scripts/object-destructure-materialized.ts`
+- `benchmarks/cross-runtime/scripts/object-destructure.ts`
+- New `benchmarks/cross-runtime/scripts/object-destructure-carrier-materialized.ts`
+- `benchmarks/cross-runtime/scripts/lib/bench.ts` and the cross-runtime README
+- New `benchmarks/micro/SharpTS.Microbenchmarks/Benchmarks/ObjectDestructuringBenchmarks.cs` and `TypeScriptSources/ObjectDestructuring.ts`
+- `tests/SharpTS.Tests/CompilerTests/StableDestructuringLoadTests.cs`
+
+Keep the existing benchmark name and loop body, add the expected result `n * 3`, and document its dictionary representation. Add an actual materialization fixture using a stable discarded array push of `{ x: 1, y: 2 }`, followed by retrieving the object and assigning `extra` through `any`. The investigation verified that this construction emits a compact-record constructor before the write. Assert the intended storage representation in compiler tests so both workloads remain meaningful.
+
+Add controls for direct reads, manually hoisted reads, compact records, fractional values, varying receivers, and a property updated on each iteration. Give every measured case a checksum. Keep the actual materialization case in a separate workload to avoid changing shape analysis of existing cases. Add microbenchmarks using cached typed delegates, setup outside timing, and MemoryDiagnoser; include an idiomatic C# numeric-loop control.
+
+Introduce a bounded, optional `SHARPTS_BENCH_WARMUP_MS` override with the current default retained. Document a 1,500 ms investigation setting, validate configuration, and record the setting with run evidence. Use identical harness code and settings on baseline and candidate, including new workloads; do not compare candidate-only fixtures with an older harness silently. Use an isolated case setting where earlier cases affect tiering.
+
+Done when all fixtures compile, checksums pass, representation assertions pass, and fresh baseline timings/allocations are recorded. No compiler optimization is required in this stage.
+
+**2. Hoist invariant dictionary reads into guarded numeric locals.**
+
+Primary files: `src/SharpTS/Compilation/ILEmitter.Destructuring.Reduction.cs`, with supporting changes in `ILEmitter.Destructuring.cs` and `EmittedRuntime.cs` only as needed.
+
+Refactor `StableObjectDestructureReduction` to describe property names, source/bound bindings, accumulator, and addition order separately from compact-record field metadata. Dictionary eligibility must not require an emitted compact carrier. Preserve existing compact-record specialization.
+
+Initially retain the existing narrow loop structure: a zero-initialized integer counter, numeric parameter bound, increment by one, fixed numeric destructuring bindings, and a single accumulator expression. Reject defaults, rest, computed keys, nested patterns, calls, suspension, exception regions, and writes to the receiver/source/bound. Resolve lexical bindings correctly; name shadowing or binding collisions must not invalidate the proof. A mutation completed before the loop is allowed. Do not interpret `const` as proof of immutable properties.
+
+Emit the following control flow:
+
+1. Perform the existing cancellation and loop-entry checks before acquiring values; a zero-trip loop must not introduce reads or coercions.
+2. For a dictionary receiver, call the existing `PDSHasPropertyDescriptors` guard once. Conservatively reject any attached descriptor table.
+3. Read each required own key with `TryGetValue`; require boxed doubles and unbox into temporary double locals. Do not call general conversion while probing. All failed guards branch to the original loop before committing observable state.
+4. Feed these locals into the existing safe-integer reduction when its term, bound, accumulator, negative-zero, and complete-result guards pass.
+5. Otherwise, for supported loop bounds and validated numeric values, emit a hoisted double loop with the original left-to-right addition order. Unsupported cases take the original loop. Never replace repeated floating additions with multiplication or reassociate terms without the integer proof.
+
+Keep the existing conservative program-wide descriptor eligibility restriction initially; accepting programs containing unrelated descriptor operations is a later widening, not necessary for this benchmark. Runtime descriptor guards still protect dictionary receivers. Preserve cancellation checks and accumulator flushing in every emitted loop path.
+
+Done when qualifying dictionary loops perform no property lookup, descriptor query, or numeric conversion inside the loop, existing compact loops retain their optimized path, and the correctness matrix below passes. This is the first independently useful optimization milestone.
+
+**3. Reuse canonical storage for materialized compact records.**
+
+Primary files: `src/SharpTS/Compilation/RuntimeEmitter.CompactObjectRecord.cs`, `EmittedRuntime.cs`, and `ILEmitter.Destructuring.Reduction.cs`.
+
+Emit a per-carrier nonmaterializing `TryGetMaterializedDictionary` helper, using the existing type-wide negative test and weak table. Register its method metadata in `EmittedRuntime`. It returns existing canonical storage only; it must neither call `EnsureMaterialized` nor allocate storage for an untouched record.
+
+Extend guarded value acquisition from stage 2 to use this dictionary. Check descriptors on the original carrier identity, which is the descriptor-store key; checking the backing dictionary alone is insufficient. Never read original typed slots after materialization because later writes may exist only in canonical storage. Keep the direct-field path for unmaterialized records and the ordinary fallback for missing keys or nonnumeric values.
+
+Done when the verified transition fixture uses the optimized loop and mutations to x/y made before entry are observed. Test materialized and untouched siblings of the same shape together. Acquiring an untouched receiver must not create a dictionary or add a per-call allocation.
+
+**4. Reduce lookup overhead when reads must remain inside the loop.**
+
+Primary files: `src/SharpTS/Compilation/ILEmitter.Destructuring.cs`, `RuntimeEmitter.Objects.GetPropertyBranches.cs`, and associated property-descriptor helpers if needed.
+
+Extend the stable destructuring source binding with a cached typed dictionary receiver, including canonical storage for eligible materialized carriers. For a fully validated numeric, fixed-key pattern with no intervening guest execution, share one descriptor guard across its own-property reads. Reacquire values for every destructuring operation; varying receivers and property updates must remain observable.
+
+Fall back without re-evaluating the source expression. Share guard state only where all intervening reads/conversions are proven side-effect-free. If a fallback invokes a getter, default expression, or coercion, invalidate cached assumptions before subsequent bindings. Leave unsupported patterns on the existing path.
+
+As a separately reviewable change, consolidate the dictionary branch's getter and descriptor queries into one descriptor lookup. Preserve callable getters, getter explicitly set to undefined, setter-only accessors, live dictionary values for mirrored data descriptors, and prototype fallback on an own-property miss. Measure this change on varying-receiver and mutating controls to establish its benefit independently of invariant hoisting.
+
+Done when controls that require repeated reads improve measurably, while property-order and mutation tests pass. Keep this stage separable from stages 2–3 if the wider dispatch change needs more validation.
+
+**5. Validate semantics, emitted code, and performance before delivery.**
+
+Extend existing compiler/shared tests rather than introducing wall-clock assertions in unit tests. Use compiled/interpreted parity and explicit expected results. Include:
+
+| Area | Required cases |
+| --- | --- |
+| Representation | Dictionary from construction; actual materialized carrier; untouched/materialized siblings; shapes with no usable compact metadata |
+| Mutation | Add unrelated property; update x/y before entry; update/delete inside the loop; mutation through an alias or callback; changing receivers |
+| Property behavior | Missing own key; inherited data/getter; x getter changes y; setter-only accessor; proxy; getter source order and single source evaluation |
+| Numeric behavior | Fractions; fractional/negative/NaN bounds; zero-trip loops; NaN/infinity values; negative-zero accumulator; safe-integer boundary and overflow rounding |
+| Fallback effects | Numeric annotation with runtime nonnumeric value; observable coercion; default/rest/nested pattern rejection; lexical shadowing |
+| Runtime behavior | Cancellation on optimized paths; accumulator flushing; standalone emitted execution and IL verification |
+
+For allocation coverage, compare small and large iteration counts after warmup. Require no allocation growth proportional to n; allow fixed setup allocations and platform bookkeeping. For IL coverage, inspect the optimized loop region rather than forbidding fallback calls anywhere in the method. Verify fallback calls remain reachable for rejected inputs.
+
+Run focused tests first, then the repository compiler checkpoint gate and full hermetic gate once the implementation is ready. Include the existing compact-record, descriptor, proxy, and shared destructuring tests when the shared runtime dispatcher changes. Use the local performance lab on Windows and WSL with matching harness settings; complete its configured Native AOT/standalone validation and let CI cover remaining supported architectures. Report an unavailable platform as unverified.
+
+Measure five alternating baseline/candidate launches of the dictionary case, actual carrier-materialization case, compact/fractional/varying/direct controls, and unrelated-dynamic-mutation workload. Record means, medians, dispersion, allocations, runtime versions, revision, warmup, and relevant emitted IL. Extend the baseline measurement fixtures consistently rather than dropping a missing workload. Separate true setup cost from steady-state reads in microbenchmarks.
+
+The target for the original case is at least a tenfold improvement against a fresh same-host baseline, supported by the approximately thirtyfold manual-hoist control. Treat this as an engineering target, not a promised absolute latency. Structural removal of repeated lookups and a statistically credible timing improvement are required. Investigate missed targets and material regressions using the local lab thresholds; for sub-0.05 ms controls establish a suitable measured noise floor rather than letting the default absolute threshold hide a regression. The competitive objective remains Node parity, especially for the guarded integer case.
+
+Deliver cohesive commits in stage order, with correctness tests accompanying each optimization. A final review should include the before/after table, storage-path evidence, fallback coverage, and platform limitations. Avoid preserving typed slots across dynamic expandos or introducing a general loop-invariant-code-motion framework in this sequence; both are broader follow-ups.

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -967,6 +967,7 @@ public class EmittedRuntime
     public Dictionary<(string Fingerprint, int Index), FieldBuilder> CompactObjectRecordValueFields { get; } = [];
     public Dictionary<string, FieldBuilder> CompactObjectRecordAnyMaterializedFields { get; } = [];
     public Dictionary<string, MethodBuilder> CompactObjectRecordIsMaterializedGetters { get; } = [];
+    public Dictionary<string, MethodBuilder> CompactObjectRecordTryGetMaterializedDictionary { get; } = [];
     public MethodBuilder JsonScalarRecordShapeGetter { get; set; } = null!;
     public MethodBuilder JsonScalarRecordValuesGetter { get; set; } = null!;
     public MethodBuilder JsonScalarRecordGetValue { get; set; } = null!;

--- a/src/SharpTS/Compilation/ILEmitter.Destructuring.Numeric.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Destructuring.Numeric.cs
@@ -1,0 +1,210 @@
+using System.Reflection.Emit;
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation;
+
+public partial class ILEmitter
+{
+    private sealed record NumericDestructuringLoad(LocalBuilder Receiver, LocalBuilder Valid, LocalBuilder Value);
+    private readonly Dictionary<Expr.Get, NumericDestructuringLoad> _numericDestructuringLoads =
+        new(ReferenceEqualityComparer.Instance);
+
+    private bool TryEmitNumericDestructuringSequence(Stmt.Sequence sequence)
+    {
+        if (_ctx.RuntimeFeatures?.UsesDynamicPropertyDescriptors != false ||
+            sequence.Statements.Count < 2 ||
+            sequence.Statements[0] is not Stmt.Var
+            {
+                Initializer: { } source,
+                DestructuringSource: DestructuringSourceKind.Object
+            } declaration)
+            return false;
+
+        var gets = new List<Expr.Get>();
+        foreach (var statement in sequence.Statements.Skip(1))
+        {
+            if (statement is not Stmt.Var
+                {
+                    Initializer: Expr.Get
+                    {
+                        Object: Expr.Variable receiver, Optional: false, Defaulted: false
+                    } get
+                } || receiver.Name.Lexeme != declaration.Name.Lexeme)
+                return false;
+            gets.Add(get);
+        }
+        if (!TryCreateNumericRecordReadPlan(source, gets.Select(get => get.Name.Lexeme).ToArray(), out var plan))
+            return false;
+
+        EmitStatement(declaration);
+        var receiverLocal = _ctx.Locals.GetLocal(declaration.Name.Lexeme);
+        if (receiverLocal is null || receiverLocal.LocalType != _ctx.Types.Object)
+        {
+            // Top-level and captured temporaries can use static fields or cells.
+            // Their ordinary emission already preserves the evaluated receiver.
+            foreach (var statement in sequence.Statements.Skip(1))
+                EmitStatement(statement);
+            return true;
+        }
+        var valid = IL.DeclareLocal(_ctx.Types.Boolean);
+        var values = gets.Select(_ => IL.DeclareLocal(_ctx.Types.Double)).ToArray();
+        var ready = IL.DefineLabel();
+        IL.Emit(OpCodes.Ldc_I4_0);
+        IL.Emit(OpCodes.Stloc, valid);
+        EmitNumericRecordSnapshot(receiverLocal, plan, values, ready);
+        IL.Emit(OpCodes.Ldc_I4_1);
+        IL.Emit(OpCodes.Stloc, valid);
+        IL.MarkLabel(ready);
+
+        // Cache only across a complete fixed numeric pattern. A computed key,
+        // default or nested binding could run guest code between property reads.
+        for (int index = 0; index < gets.Count; index++)
+            _numericDestructuringLoads.Add(gets[index], new(receiverLocal, valid, values[index]));
+        try
+        {
+            foreach (var statement in sequence.Statements.Skip(1))
+                EmitStatement(statement);
+        }
+        finally
+        {
+            foreach (var get in gets)
+                _numericDestructuringLoads.Remove(get);
+        }
+        return true;
+    }
+
+    private bool TryEmitNumericDestructuringLoad(Expr.Get expression, bool boxed)
+    {
+        if (!_numericDestructuringLoads.TryGetValue(expression, out var load))
+            return false;
+        var fallback = IL.DefineLabel();
+        var end = IL.DefineLabel();
+        IL.Emit(OpCodes.Ldloc, load.Valid);
+        IL.Emit(OpCodes.Brfalse, fallback);
+        IL.Emit(OpCodes.Ldloc, load.Value);
+        if (boxed)
+            IL.Emit(OpCodes.Box, _ctx.Types.Double);
+        IL.Emit(OpCodes.Br, end);
+        IL.MarkLabel(fallback);
+        IL.Emit(OpCodes.Ldloc, load.Receiver);
+        IL.Emit(OpCodes.Ldstr, expression.Name.Lexeme);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.GetProperty);
+        if (!boxed)
+            IL.Emit(OpCodes.Call, _ctx.Runtime.ConvertToNumber);
+        IL.MarkLabel(end);
+        if (boxed)
+            SetStackUnknown();
+        else
+            SetStackType(StackType.Double);
+        return true;
+    }
+
+    private sealed record NumericRecordReadPlan(
+        IReadOnlyList<string> Properties,
+        string Fingerprint,
+        IReadOnlyList<FieldBuilder>? Fields);
+
+    private bool TryCreateNumericRecordReadPlan(
+        Expr source, IReadOnlyList<string> properties, out NumericRecordReadPlan plan)
+    {
+        plan = null!;
+        if (_ctx.TypeMap?.Get(source) is not { } type ||
+            !ILCompiler.TryGetCompactRecordShape(type, out var shape) ||
+            properties.Count == 0 ||
+            properties.Any(property => !shape.Fields.Any(field =>
+                field.Key == property && field.Value is JsonSerializationShape.Number)))
+            return false;
+
+        string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(shape);
+        List<FieldBuilder>? fields = null;
+        if (_ctx.Runtime!.CompactObjectRecordTypes.TryGetValue(fingerprint, out var carrier) &&
+            _ctx.Runtime.CompactObjectRecordTryGetMaterializedDictionary.ContainsKey(fingerprint))
+        {
+            fields = [];
+            foreach (string property in properties)
+            {
+                int index = shape.Fields.ToList().FindIndex(field => field.Key == property);
+                if (!_ctx.Runtime.CompactObjectRecordValueFields.TryGetValue((fingerprint, index), out var field) ||
+                    field.DeclaringType != carrier || field.FieldType != _ctx.Types.Double)
+                {
+                    fields = null;
+                    break;
+                }
+                fields.Add(field);
+            }
+        }
+        plan = new NumericRecordReadPlan(properties, fingerprint, fields);
+        return true;
+    }
+
+    /// <summary>
+    /// Acquires only own numeric data properties. Every probe is free of guest
+    /// effects, so partial failure can safely resume ordinary property evaluation.
+    /// The descriptor key remains the original receiver after materialization.
+    /// </summary>
+    private void EmitNumericRecordSnapshot(
+        LocalBuilder receiver, NumericRecordReadPlan plan,
+        IReadOnlyList<LocalBuilder> values, Label fallback)
+    {
+        var runtime = _ctx.Runtime!;
+        var dictionary = IL.DeclareLocal(_ctx.Types.DictionaryStringObject);
+        var tryDictionary = IL.DefineLabel();
+        var dictionaryReady = IL.DefineLabel();
+        var ready = IL.DefineLabel();
+        if (plan.Fields is { } fields)
+        {
+            var exact = IL.DeclareLocal(fields[0].DeclaringType!);
+            IL.Emit(OpCodes.Ldloc, receiver);
+            IL.Emit(OpCodes.Isinst, exact.LocalType);
+            IL.Emit(OpCodes.Stloc, exact);
+            IL.Emit(OpCodes.Ldloc, exact);
+            IL.Emit(OpCodes.Brfalse, tryDictionary);
+            if (!_stableCompactRecordLocals.Contains(receiver) &&
+                !_ctx.RuntimeFeatures!.CanAssumeCompactObjectRecordIsUnmaterialized(plan.Fingerprint))
+            {
+                IL.Emit(OpCodes.Ldloc, exact);
+                IL.Emit(OpCodes.Ldloca, dictionary);
+                IL.Emit(OpCodes.Call, runtime.CompactObjectRecordTryGetMaterializedDictionary[plan.Fingerprint]);
+                IL.Emit(OpCodes.Brtrue, dictionaryReady);
+            }
+            // Callers retain the program-wide descriptor restriction for field reads.
+            for (int index = 0; index < fields.Count; index++)
+            {
+                IL.Emit(OpCodes.Ldloc, exact);
+                IL.Emit(OpCodes.Ldfld, fields[index]);
+                IL.Emit(OpCodes.Stloc, values[index]);
+            }
+            IL.Emit(OpCodes.Br, ready);
+        }
+
+        IL.MarkLabel(tryDictionary);
+        IL.Emit(OpCodes.Ldloc, receiver);
+        IL.Emit(OpCodes.Isinst, _ctx.Types.DictionaryStringObject);
+        IL.Emit(OpCodes.Stloc, dictionary);
+        IL.Emit(OpCodes.Ldloc, dictionary);
+        IL.Emit(OpCodes.Brfalse, fallback);
+        IL.MarkLabel(dictionaryReady);
+        IL.Emit(OpCodes.Ldloc, receiver);
+        IL.Emit(OpCodes.Call, runtime.PDSHasPropertyDescriptors);
+        IL.Emit(OpCodes.Brtrue, fallback);
+
+        var boxed = IL.DeclareLocal(_ctx.Types.Object);
+        for (int index = 0; index < plan.Properties.Count; index++)
+        {
+            IL.Emit(OpCodes.Ldloc, dictionary);
+            IL.Emit(OpCodes.Ldstr, plan.Properties[index]);
+            IL.Emit(OpCodes.Ldloca, boxed);
+            IL.Emit(OpCodes.Callvirt, _ctx.Types.GetMethod(
+                _ctx.Types.DictionaryStringObject, "TryGetValue", _ctx.Types.String,
+                _ctx.Types.Object.MakeByRefType()));
+            IL.Emit(OpCodes.Brfalse, fallback);
+            IL.Emit(OpCodes.Ldloc, boxed);
+            IL.Emit(OpCodes.Isinst, _ctx.Types.Double);
+            IL.Emit(OpCodes.Brfalse, fallback);
+            IL.Emit(OpCodes.Ldloc, boxed);
+            IL.Emit(OpCodes.Unbox_Any, _ctx.Types.Double);
+            IL.Emit(OpCodes.Stloc, values[index]);
+        }
+        IL.MarkLabel(ready);
+    }
+}

--- a/src/SharpTS/Compilation/ILEmitter.Destructuring.Reduction.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Destructuring.Reduction.cs
@@ -12,9 +12,9 @@ public partial class ILEmitter
         Expr.Variable Source,
         Expr.Variable Bound,
         string Accumulator,
-        IReadOnlyList<FieldBuilder> Fields,
-        MethodBuilder IsMaterializedGetter,
-        bool RequiresMaterializationGuard);
+        Expr Addition,
+        IReadOnlyList<string> Bindings,
+        NumericRecordReadPlan Reads);
 
     /// <summary>
     /// Versions a side-effect-free stable-record reduction such as
@@ -28,9 +28,8 @@ public partial class ILEmitter
     /// complete result remains a safe integer before entering the loop. It can
     /// therefore combine the invariant destructured terms once and use one
     /// native integer addition per iteration without changing Number rounding.
-    /// Every other value or receiver shape branches to the ordinary emitted
-    /// loop, preserving fractional arithmetic, getters, proxies, NaN/infinity,
-    /// negative zero, overflow rounding, and runtime cancellation.
+    /// Other numeric values retain the original addition tree in a double loop.
+    /// Receivers without proven own numeric data properties use the ordinary loop.
     /// </remarks>
     private bool TryEmitStableObjectDestructureReduction(Stmt.For loop, string counterName)
     {
@@ -59,6 +58,9 @@ public partial class ILEmitter
             || boundType != _ctx.Types.Double
             || !TryAnalyzeStableObjectDestructureReduction(
                 loop.Body, bound, out var reduction)
+            || reduction.Accumulator == counterName
+            || reduction.Accumulator == bound.Name.Lexeme
+            || reduction.Accumulator == reduction.Source.Name.Lexeme
             || _ctx.Locals.GetLocal(reduction.Source.Name.Lexeme) is not { } sourceLocal
             || _ctx.Locals.GetLocal(reduction.Accumulator) is not { } accumulatorDouble
             || accumulatorDouble.LocalType != _ctx.Types.Double)
@@ -69,43 +71,34 @@ public partial class ILEmitter
         _ctx.Locals.EnterScope();
         EmitStatement(loop.Initializer);
         var counter = _ctx.Locals.GetLocal(counterName)!;
-        var exactSource = IL.DeclareLocal(reduction.Fields[0].DeclaringType!);
         var boundDouble = IL.DeclareLocal(_ctx.Types.Double);
         var boundInteger = IL.DeclareLocal(_ctx.Types.Int64);
         var accumulatorInteger = IL.DeclareLocal(_ctx.Types.Int64);
         var incrementInteger = IL.DeclareLocal(_ctx.Types.Int64);
-        var termDouble = IL.DeclareLocal(_ctx.Types.Double);
+        var values = reduction.Bindings.Select(_ => IL.DeclareLocal(_ctx.Types.Double)).ToArray();
 
         var slowStart = IL.DefineLabel();
         var fastStart = IL.DefineLabel();
         var fastContinue = IL.DefineLabel();
         var fastEnd = IL.DefineLabel();
+        var doubleStart = IL.DefineLabel();
         var incrementReady = IL.DefineLabel();
         var end = IL.DefineLabel();
 
         _ctx.EnterLoop(end, fastContinue);
 
-        IL.Emit(OpCodes.Ldloc, sourceLocal);
-        IL.Emit(OpCodes.Isinst, reduction.Fields[0].DeclaringType!);
-        IL.Emit(OpCodes.Stloc, exactSource);
-        IL.Emit(OpCodes.Ldloc, exactSource);
-        IL.Emit(OpCodes.Brfalse, slowStart);
-        if (reduction.RequiresMaterializationGuard &&
-            !_stableCompactRecordLocals.Contains(sourceLocal))
-        {
-            IL.Emit(OpCodes.Ldloc, exactSource);
-            IL.Emit(OpCodes.Call, reduction.IsMaterializedGetter);
-            IL.Emit(OpCodes.Brtrue, slowStart);
-        }
-
+        EmitCancellationCheck();
         EmitExpressionAsDouble(reduction.Bound);
         IL.Emit(OpCodes.Stloc, boundDouble);
         EmitExactIntegerGuard(boundDouble, 0d, MaxSafeInteger, slowStart);
         IL.Emit(OpCodes.Ldloc, boundDouble);
         IL.Emit(OpCodes.Conv_I8);
         IL.Emit(OpCodes.Stloc, boundInteger);
+        IL.Emit(OpCodes.Ldloc, boundInteger);
+        IL.Emit(OpCodes.Brfalse, end);
+        EmitNumericRecordSnapshot(sourceLocal, reduction.Reads, values, slowStart);
 
-        EmitExactIntegerGuard(accumulatorDouble, 0d, MaxSafeInteger, slowStart);
+        EmitExactIntegerGuard(accumulatorDouble, 0d, MaxSafeInteger, doubleStart);
         var accumulatorNotZero = IL.DefineLabel();
         IL.Emit(OpCodes.Ldloc, accumulatorDouble);
         IL.Emit(OpCodes.Ldc_R8, 0d);
@@ -114,7 +107,7 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Call, typeof(BitConverter).GetMethod(
             nameof(BitConverter.DoubleToInt64Bits), [_ctx.Types.Double])!);
         IL.Emit(OpCodes.Ldc_I8, 0L);
-        IL.Emit(OpCodes.Blt, slowStart);
+        IL.Emit(OpCodes.Blt, doubleStart);
         IL.MarkLabel(accumulatorNotZero);
         IL.Emit(OpCodes.Ldloc, accumulatorDouble);
         IL.Emit(OpCodes.Conv_I8);
@@ -123,12 +116,9 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Ldc_I4_0);
         IL.Emit(OpCodes.Conv_I8);
         IL.Emit(OpCodes.Stloc, incrementInteger);
-        foreach (var field in reduction.Fields)
+        foreach (var termDouble in values)
         {
-            IL.Emit(OpCodes.Ldloc, exactSource);
-            IL.Emit(OpCodes.Ldfld, field);
-            IL.Emit(OpCodes.Stloc, termDouble);
-            EmitExactIntegerGuard(termDouble, 0d, MaxSafeInteger, slowStart);
+            EmitExactIntegerGuard(termDouble, 0d, MaxSafeInteger, doubleStart);
             IL.Emit(OpCodes.Ldloc, incrementInteger);
             IL.Emit(OpCodes.Ldloc, termDouble);
             IL.Emit(OpCodes.Conv_I8);
@@ -136,7 +126,7 @@ public partial class ILEmitter
             IL.Emit(OpCodes.Stloc, incrementInteger);
             IL.Emit(OpCodes.Ldloc, incrementInteger);
             IL.Emit(OpCodes.Ldc_I8, MaxSafeInteger);
-            IL.Emit(OpCodes.Bgt, slowStart);
+            IL.Emit(OpCodes.Bgt, doubleStart);
         }
 
         // Prove every integer addition in the loop remains exactly representable.
@@ -149,7 +139,7 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Ldloc, incrementInteger);
         IL.Emit(OpCodes.Div);
         IL.Emit(OpCodes.Ldloc, boundInteger);
-        IL.Emit(OpCodes.Blt, slowStart);
+        IL.Emit(OpCodes.Blt, doubleStart);
         IL.MarkLabel(incrementReady);
 
         IL.Emit(OpCodes.Br, fastStart);
@@ -176,6 +166,20 @@ public partial class ILEmitter
         EmitInt64AccumulatorStore(accumulatorDouble, accumulatorInteger);
         IL.Emit(OpCodes.Br, end);
 
+        IL.MarkLabel(doubleStart);
+        EmitCancellationCheck();
+        IL.Emit(OpCodes.Ldloc, counter);
+        IL.Emit(OpCodes.Ldloc, boundInteger);
+        IL.Emit(OpCodes.Bge, end);
+        EmitSnapshotAddition(reduction.Addition);
+        IL.Emit(OpCodes.Stloc, accumulatorDouble);
+        IL.Emit(OpCodes.Ldloc, counter);
+        IL.Emit(OpCodes.Ldc_I4_1);
+        IL.Emit(OpCodes.Conv_I8);
+        IL.Emit(OpCodes.Add);
+        IL.Emit(OpCodes.Stloc, counter);
+        IL.Emit(OpCodes.Br, doubleStart);
+
         IL.MarkLabel(slowStart);
         EmitCancellationCheck();
         EmitConditionCheck(loop.Condition);
@@ -190,6 +194,22 @@ public partial class ILEmitter
         _ctx.Locals.ExitScope();
         SetStackUnknown();
         return true;
+
+        void EmitSnapshotAddition(Expr expression)
+        {
+            if (expression is Expr.Binary binary)
+            {
+                EmitSnapshotAddition(binary.Left);
+                EmitSnapshotAddition(binary.Right);
+                IL.Emit(OpCodes.Add);
+            }
+            else
+            {
+                string name = ((Expr.Variable)expression).Name.Lexeme;
+                IL.Emit(OpCodes.Ldloc, name == reduction.Accumulator
+                    ? accumulatorDouble : values[reduction.Bindings.ToList().IndexOf(name)]);
+            }
+        }
 
         bool TryAnalyzeStableObjectDestructureReduction(
             Stmt body,
@@ -225,6 +245,11 @@ public partial class ILEmitter
                 return false;
             }
 
+            var reserved = new HashSet<string>(StringComparer.Ordinal)
+            {
+                counterName, loopBound.Name.Lexeme, source.Name.Lexeme,
+                accumulator.Lexeme, sourceDeclaration.Name.Lexeme
+            };
             var properties = new Dictionary<string, string>(StringComparer.Ordinal);
             for (int index = 1; index < destructure.Count; index++)
             {
@@ -240,28 +265,15 @@ public partial class ILEmitter
                         }
                     }
                     || receiver.Name.Lexeme != sourceDeclaration.Name.Lexeme
+                    || reserved.Contains(binding.Lexeme)
                     || !properties.TryAdd(binding.Lexeme, property.Lexeme))
                 {
                     return false;
                 }
             }
 
-            if (_ctx.TypeMap?.Get(sourceDeclaration.Initializer!) is not { } sourceType
-                || !ILCompiler.TryGetCompactRecordShape(sourceType, out var shape))
-            {
-                return false;
-            }
-
-            string fingerprint = JsonSerializationShapeAnalyzer.Fingerprint(shape);
-            if (!runtime.CompactObjectRecordTypes.TryGetValue(
-                    fingerprint, out var carrierType)
-                || !runtime.CompactObjectRecordIsMaterializedGetters.TryGetValue(
-                    fingerprint, out var isMaterializedGetter))
-            {
-                return false;
-            }
-
-            var fields = new List<FieldBuilder>(terms.Count - 1);
+            var keys = new List<string>(terms.Count - 1);
+            var bindings = new List<string>(terms.Count - 1);
             var usedBindings = new HashSet<string>(StringComparer.Ordinal);
             for (int termIndex = 1; termIndex < terms.Count; termIndex++)
             {
@@ -272,37 +284,21 @@ public partial class ILEmitter
                     return false;
                 }
 
-                int fieldIndex = -1;
-                for (int index = 0; index < shape.Fields.Count; index++)
-                {
-                    if (shape.Fields[index].Key == property)
-                    {
-                        fieldIndex = index;
-                        break;
-                    }
-                }
-
-                if (fieldIndex < 0
-                    || !runtime.CompactObjectRecordValueFields.TryGetValue(
-                        (fingerprint, fieldIndex), out var field)
-                    || field.DeclaringType != carrierType
-                    || field.FieldType != _ctx.Types.Double)
-                {
-                    return false;
-                }
-                fields.Add(field);
+                keys.Add(property);
+                bindings.Add(binding);
             }
 
-            if (usedBindings.Count != properties.Count)
+            if (usedBindings.Count != properties.Count ||
+                !TryCreateNumericRecordReadPlan(sourceDeclaration.Initializer!, keys, out var reads))
                 return false;
 
             result = new StableObjectDestructureReduction(
                 source,
                 loopBound,
                 accumulator.Lexeme,
-                fields,
-                isMaterializedGetter,
-                !features.CanAssumeCompactObjectRecordIsUnmaterialized(fingerprint));
+                addition,
+                bindings,
+                reads);
             return true;
         }
     }

--- a/src/SharpTS/Compilation/ILEmitter.Destructuring.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Destructuring.cs
@@ -203,6 +203,8 @@ public partial class ILEmitter
 
     private bool TryEmitStableRecordDestructureGet(Expr.Get expression)
     {
+        if (TryEmitNumericDestructuringLoad(expression, boxed: true))
+            return true;
         if (expression.Optional ||
             expression.Object is not Expr.Variable source ||
             !_stableRecordDestructureBindings.TryGetValue(
@@ -248,6 +250,8 @@ public partial class ILEmitter
 
     private bool TryEmitStableRecordDestructureGetAsDouble(Expr.Get expression)
     {
+        if (TryEmitNumericDestructuringLoad(expression, boxed: false))
+            return true;
         if (expression.Optional ||
             expression.Object is not Expr.Variable source ||
             !_stableRecordDestructureBindings.TryGetValue(

--- a/src/SharpTS/Compilation/ILEmitter.cs
+++ b/src/SharpTS/Compilation/ILEmitter.cs
@@ -244,6 +244,8 @@ public partial class ILEmitter : StatementEmitterBase, IEmitterContext
                 break;
 
             case Stmt.Sequence seq:
+                if (TryEmitNumericDestructuringSequence(seq))
+                    break;
                 // Execute in current scope (no new environment)
                 foreach (var s in seq.Statements)
                     EmitStatement(s);

--- a/src/SharpTS/Compilation/RuntimeEmitter.CompactObjectRecord.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.CompactObjectRecord.cs
@@ -125,6 +125,29 @@ public partial class RuntimeEmitter
             isMaterializedIl.Emit(OpCodes.Callvirt, tableTryGet);
             isMaterializedIl.Emit(OpCodes.Ret);
 
+            // Return canonical storage without materializing an untouched carrier.
+            // Callers must check descriptors on the carrier, not on this dictionary.
+            var tryGetMaterialized = typeBuilder.DefineMethod(
+                "TryGetMaterializedDictionary", MethodAttributes.Assembly | MethodAttributes.HideBySig,
+                _types.Boolean, [_types.DictionaryStringObject.MakeByRefType()]);
+            tryGetMaterialized.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
+            runtime.CompactObjectRecordTryGetMaterializedDictionary.Add(fingerprint, tryGetMaterialized);
+            var tryIl = tryGetMaterialized.GetILGenerator();
+            var probeTable = tryIl.DefineLabel();
+            tryIl.Emit(OpCodes.Ldsfld, anyMaterialized);
+            tryIl.Emit(OpCodes.Brtrue_S, probeTable);
+            tryIl.Emit(OpCodes.Ldarg_1);
+            tryIl.Emit(OpCodes.Ldnull);
+            tryIl.Emit(OpCodes.Stind_Ref);
+            tryIl.Emit(OpCodes.Ldc_I4_0);
+            tryIl.Emit(OpCodes.Ret);
+            tryIl.MarkLabel(probeTable);
+            tryIl.Emit(OpCodes.Ldsfld, materializedTable);
+            tryIl.Emit(OpCodes.Ldarg_0);
+            tryIl.Emit(OpCodes.Ldarg_1);
+            tryIl.Emit(OpCodes.Callvirt, tableTryGet);
+            tryIl.Emit(OpCodes.Ret);
+
             var fieldsGetter = typeBuilder.DefineMethod(
                 "get_Fields",
                 MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.SpecialName |

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.GetPropertyBranches.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.GetPropertyBranches.cs
@@ -1206,26 +1206,9 @@ public partial class RuntimeEmitter
         EmitObjProtoMethodCheck("hasOwnProperty", runtime.HasOwnPropertyHelperMethod, 1);
         EmitObjProtoMethodCheck("isPrototypeOf",  runtime.IsPrototypeOfHelperMethod, 1);
 
-        // Check for getter accessor via $PropertyDescriptorStore - fully standalone, no reflection
+        // Retrieve the descriptor once: querying TryGetGetter first repeated the
+        // descriptor weak-table lookup for every ordinary dictionary property.
         var getterLocal = il.DeclareLocal(_types.Object);
-        var noGetterLabel = il.DefineLabel();
-
-        // Call PDSTryGetGetter(obj, name, out getter)
-        il.Emit(OpCodes.Ldarg_0);  // obj
-        il.Emit(OpCodes.Ldarg_1);  // name
-        il.Emit(OpCodes.Ldloca, getterLocal);  // out getter
-        il.Emit(OpCodes.Call, runtime.PDSTryGetGetter);
-        il.Emit(OpCodes.Brfalse, noGetterLabel);
-
-        // Getter was found - invoke it via InvokeMethodValue(obj, getter, emptyArgs)
-        il.Emit(OpCodes.Ldarg_0);  // receiver (obj)
-        il.Emit(OpCodes.Ldloc, getterLocal);  // function (getter)
-        il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Newarr, _types.Object);  // empty args array
-        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
-        il.Emit(OpCodes.Ret);
-
-        il.MarkLabel(noGetterLabel);
 
         // A descriptor without an invokable getter still shadows both the
         // dictionary's ordinary storage and its prototype. This includes
@@ -1242,8 +1225,21 @@ public partial class RuntimeEmitter
         var returnDescriptorValueLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, ownDescriptorLocal);
         il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorGetter.GetGetMethod()!);
+        il.Emit(OpCodes.Stloc, getterLocal);
+        il.Emit(OpCodes.Ldloc, getterLocal);
         il.Emit(OpCodes.Brfalse, returnDescriptorValueLabel);
+        var invokeGetterLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, getterLocal);
+        il.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        il.Emit(OpCodes.Brfalse, invokeGetterLabel);
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(invokeGetterLabel);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldloc, getterLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Newarr, _types.Object);
+        il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(returnDescriptorValueLabel);
         // With no accessor slots this is a data descriptor. Its value is

--- a/tests/SharpTS.Tests/CompilerTests/StableDestructuringLoadTests.Materialized.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableDestructuringLoadTests.Materialized.cs
@@ -1,0 +1,327 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public sealed partial class StableDestructuringLoadTests
+{
+    private static string MaterializedLoopSource(bool carrier, string x = "1", string y = "2") => $$"""
+        type Point = { x: number; y: number };
+        function reduce(n: number): number {
+            {{(carrier ? $"const points: Point[] = []; points.push({{ x: {x}, y: {y} }}); const point: Point = points[0];"
+                : $"const point: Point = {{ x: {x}, y: {y} }};")}}
+            const dynamicPoint: any = point;
+            dynamicPoint.extra = true;
+            let total: number = 0;
+            for (let i: number = 0; i < n; i++) {
+                const { x, y } = point;
+                total = total + x + y;
+            }
+            return total;
+        }
+        """;
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void MaterializedNumericLoops_HoistReadsAndRetainFixedAllocations(bool carrier)
+    {
+        string source = MaterializedLoopSource(carrier);
+        Assembly assembly = Compile(source);
+        MethodInfo method = FindFunction(assembly, "reduce");
+        var instructions = ReadInstructions(method).ToArray();
+        Assert.Contains(instructions, i => i.OpCode == OpCodes.Newobj &&
+            (carrier ? i.Member?.DeclaringType?.Name.StartsWith("$CompactObjectRecord", StringComparison.Ordinal) == true
+                : i.Member?.DeclaringType == typeof(Dictionary<string, object>)));
+        Assert.Contains(instructions, i => i.Member?.Name == "HasPropertyDescriptors");
+        if (carrier)
+            Assert.Contains(instructions, i => i.Member?.Name == "TryGetMaterializedDictionary");
+
+        // Both numeric loops must be free of property operations; the generic
+        // fallback remains in the method and is not a reason to fail this check.
+        var numericLoops = instructions.Where(i => i.BranchTarget is { } target && target < i.Offset)
+            .Select(edge => instructions.Where(i => i.Offset >= edge.BranchTarget && i.Offset <= edge.Offset).ToArray())
+            .Where(loop => loop.Any(i => i.OpCode == OpCodes.Add) &&
+                loop.All(i => i.Member?.Name is not ("GetProperty" or "ConvertToNumber" or
+                    "TryGetValue" or "HasPropertyDescriptors" or "TryGetMaterializedDictionary")))
+            .ToArray();
+        Assert.True(numericLoops.Length >= 2, "Expected guarded integer and double loops without property reads.");
+        Assert.All(numericLoops, loop => Assert.Contains(loop, i => i.Member?.Name == "_cancelRequested"));
+        Assert.Contains(instructions, i => i.Member?.Name == "GetProperty");
+
+        var reduce = method.CreateDelegate<Func<double, double>>();
+        Assert.Equal(300_000, reduce(100_000));
+        reduce(1_000);
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        double small = reduce(1_000);
+        long smallBytes = GC.GetAllocatedBytesForCurrentThread() - before;
+        before = GC.GetAllocatedBytesForCurrentThread();
+        double large = reduce(100_000);
+        long largeBytes = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.Equal(3_000, small);
+        Assert.Equal(300_000, large);
+        Assert.True(largeBytes <= smallBytes + 1_024, $"Allocations scaled: {smallBytes} -> {largeBytes}");
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+
+        var cancel = assembly.GetType("$Runtime")!.GetField("_cancelRequested", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)!;
+        cancel.SetValue(null, true);
+        Assert.ThrowsAny<Exception>(() => reduce(100));
+        cancel.SetValue(null, false);
+        Assert.Equal(300, reduce(100));
+    }
+
+    [Fact]
+    public void DictionaryShapeWithoutCompactCarrier_StillHasNumericLoops()
+    {
+        const string source = """
+            type Wide = { a: number; b: number; c: number; d: number; e: number };
+            function reduce(n: number): number {
+                const point: Wide = { a: 1, b: 2, c: 3, d: 4, e: 5 };
+                let total: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    const { a, e } = point;
+                    total = total + a + e;
+                }
+                return total;
+            }
+            """;
+        Assembly assembly = Compile(source);
+        var method = FindFunction(assembly, "reduce");
+        Assert.Equal(600, method.CreateDelegate<Func<double, double>>()(100));
+        Assert.Contains(ReadInstructions(method), i => i.Member?.Name == "HasPropertyDescriptors");
+        Assert.Contains(ReadInstructions(method), i => i.OpCode == OpCodes.Div);
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    [Theory, ModeData]
+    public void MaterializedValues_PreserveNumberSemanticsAndZeroTripReads(ExecutionMode mode)
+    {
+        const string source = """
+            type Point = { x: number; y: number };
+            function reduce(n: number, start: number, arg: Point): number {
+                const point: Point = arg;
+                let total: number = start;
+                for (let i: number = 0; i < n; i++) {
+                    const { x, y } = point;
+                    total = total + x + y;
+                }
+                return total;
+            }
+            const point: Point = { x: 1, y: 2 };
+            const dynamicPoint: any = point;
+            dynamicPoint.extra = true;
+            dynamicPoint.x = 0.5;
+            dynamicPoint.y = 0.25;
+            console.log(reduce(3, 0.5, point), reduce(2.5, 0.5, point));
+            console.log(Object.is(reduce(0, -0, null as any), -0));
+            console.log(reduce(-1, 7, null as any), reduce(NaN, 8, null as any));
+            dynamicPoint.x = 1;
+            dynamicPoint.y = 2;
+            console.log(reduce(2, 9007199254740991, point));
+            dynamicPoint.x = -0;
+            dynamicPoint.y = -0;
+            console.log(Object.is(reduce(2, -0, point), -0));
+            dynamicPoint.x = Infinity;
+            dynamicPoint.y = -Infinity;
+            console.log(Number.isNaN(reduce(2, 0, point)));
+            dynamicPoint.x = NaN;
+            console.log(Number.isNaN(reduce(1, 0, point)));
+            """;
+        Assert.Equal("2.75 2.75\ntrue\n7 8\n9007199254740998\ntrue\ntrue\ntrue\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void NumericSnapshots_PreserveAdditionAssociation(ExecutionMode mode)
+    {
+        const string source = """
+            type Point = { x: number; y: number };
+            function reduce(n: number): number {
+                const point: Point = { x: -10000000000000000, y: 1 };
+                const dynamicPoint: any = point;
+                dynamicPoint.extra = true;
+                let total: number = 10000000000000000;
+                for (let i: number = 0; i < n; i++) {
+                    const { x, y } = point;
+                    total = total + x + y;
+                }
+                return total;
+            }
+            console.log(reduce(1));
+            """;
+        Assert.Equal("1\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void MaterializedCarrier_ReadsCanonicalValuesAndSeesMutationInsideLoop(ExecutionMode mode)
+    {
+        const string source = """
+            type Point = { x: number; y: number };
+            function reduce(n: number): number {
+                const points: Point[] = [];
+                points.push({ x: 1, y: 2 });
+                points.push({ x: 3, y: 4 });
+                const point: Point = points[0];
+                const dynamicPoint: any = point;
+                dynamicPoint.x = 10;
+                let total: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    const { x, y } = point;
+                    total = total + x + y;
+                }
+                for (let i: number = 0; i < n; i++) {
+                    dynamicPoint.x = i;
+                    const { x, y } = point;
+                    total = total + x + y;
+                }
+                for (let i: number = 0; i < n; i++) {
+                    const { x, y } = points[i % 2];
+                    total = total + x + y;
+                }
+                return total;
+            }
+            console.log(reduce(4));
+            """;
+        Assert.Equal("86\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void DictionaryFallbacks_PreserveGettersMissingKeysAndProxies(ExecutionMode mode)
+    {
+        const string source = """
+            type Point = { x: number; y: number };
+            function reduce(arg: Point, n: number): number {
+                const point: Point = arg;
+                let total: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    const { x, y } = point;
+                    total = total + x + y;
+                }
+                return total;
+            }
+            let trace: string = "";
+            const point: any = { x: 1, y: 2 };
+            Object.defineProperty(point, "x", { get: () => { trace = trace + "x"; point.y++; return 1; }, configurable: true });
+            console.log(reduce(point, 2), trace);
+            Object.defineProperty(point, "x", { get: undefined, set: (v: number) => {}, configurable: true });
+            console.log(Number.isNaN(reduce(point, 1)));
+            delete point.x;
+            Object.setPrototypeOf(point, { get x() { trace = trace + "p"; return 5; } });
+            console.log(reduce(point, 1), trace);
+            delete point.y;
+            console.log(Number.isNaN(reduce(point, 1)));
+            const proxy = new Proxy({ x: 1, y: 2 }, { get: (target: any, key: string) => { trace = trace + key; return target[key]; } });
+            console.log(reduce(proxy, 2), trace);
+            """;
+        Assert.Equal("9 xx\ntrue\n9 xxp\ntrue\n6 xxppxyxy\n", TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void MaterializedProbe_DoesNotMaterializeUntouchedCarrier()
+    {
+        Assembly assembly = Compile(MaterializedLoopSource(true));
+        Type carrier = assembly.GetTypes().Single(t => t.Name.StartsWith("$CompactObjectRecord", StringComparison.Ordinal));
+        object point = Activator.CreateInstance(carrier, 1d, 2d)!;
+        var probe = carrier.GetMethod("TryGetMaterializedDictionary", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        var args = new object?[] { null };
+        Assert.Equal(false, probe.Invoke(point, args));
+        Assert.Null(args[0]);
+        carrier.GetMethod("SetProperty")!.Invoke(point, ["x", 9d]);
+        Assert.Equal(true, probe.Invoke(point, args));
+        var dictionary = Assert.IsType<Dictionary<string, object>>(args[0]);
+        Assert.Equal(9d, dictionary["x"]);
+        object sibling = Activator.CreateInstance(carrier, 3d, 4d)!;
+        Assert.Equal(false, probe.Invoke(sibling, args));
+        Assert.Null(args[0]);
+        var isMaterialized = carrier.GetMethod("get_IsMaterialized", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        Assert.Equal(false, isMaterialized.Invoke(sibling, null));
+    }
+
+    [Fact]
+    public void MaterializedSnapshot_ChecksDescriptorsOnTheOriginalReceiver()
+    {
+        string source = MaterializedLoopSource(true) + """
+            export function sum(n: number, arg: Point): number {
+                const point: Point = arg;
+                let total: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    const { x, y } = point;
+                    total = total + x + y;
+                }
+                return total;
+            }
+            """;
+        Assembly assembly = Compile(source);
+        Type carrier = assembly.GetTypes().Single(t => t.Name.StartsWith("$CompactObjectRecord", StringComparison.Ordinal));
+        object point = Activator.CreateInstance(carrier, 1d, 2d)!;
+        carrier.GetMethod("SetProperty")!.Invoke(point, ["extra", true]);
+        var sum = FindFunction(assembly, "sum").CreateDelegate<Func<double, object, double>>();
+        Assert.Equal(6, sum(2, point));
+
+        // Attach an accessor with an undefined getter through the emitted runtime, keeping
+        // the compiler's numeric optimization enabled. The raw dictionary still
+        // contains x=1, but ordinary [[Get]] on the carrier returns undefined.
+        var descriptorType = assembly.GetType("$CompiledPropertyDescriptor")!;
+        var descriptor = Activator.CreateInstance(descriptorType)!;
+        object undefined = assembly.GetType("$Undefined")!.GetField("Instance", BindingFlags.Public | BindingFlags.Static)!.GetValue(null)!;
+        descriptorType.GetProperty("Getter")!.SetValue(descriptor, undefined);
+        descriptorType.GetProperty("Value")!.SetValue(descriptor, undefined);
+        assembly.GetType("$PropertyDescriptorStore")!.GetMethod("DefineProperty")!
+            .Invoke(null, [point, "x", descriptor]);
+        Assert.True(double.IsNaN(sum(2, point)));
+    }
+
+    [Theory, ModeData]
+    public void NumericSnapshots_RejectInterveningEffectsAndRepeatCoercions(ExecutionMode mode)
+    {
+        const string source = """
+            type Point = { x: number; y: number };
+            let calls: number = 0;
+            function reduce(n: number): number {
+                const point: Point = { x: 1, y: 2 };
+                const alias: any = point;
+                alias.x = { valueOf(): number { calls++; return 1; } };
+                let total: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    const { x, y } = point;
+                    total = total + x + y;
+                }
+                return total;
+            }
+            console.log(reduce(3), calls);
+            const point: any = { x: 1, y: 2 };
+            const alias: any = point;
+            alias.x = undefined;
+            function defaultX(): number { point.y = 9; return 1; }
+            const { x = defaultX(), y } = point;
+            console.log(x, y);
+            point.x = 1;
+            function mutate(): void { point.x = point.x! + 1; }
+            for (let i: number = 0; i < 2; i++) {
+                mutate();
+                const { x, y } = point;
+                console.log(x, y);
+            }
+            """;
+        Assert.Equal("9 3\n1 9\n2 9\n3 9\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void NumericReductions_DoNotConfuseShadowedBindingsWithLoopControl(ExecutionMode mode)
+    {
+        const string source = """
+            function reduce(n: number): number {
+                const point = { n: 1, y: 2 };
+                let total: number = 0;
+                for (let i: number = 0; i < n; i++) {
+                    const { n, y } = point;
+                    total = total + n + y;
+                }
+                return total;
+            }
+            console.log(reduce(3));
+            """;
+        Assert.Equal("9\n", TestHarness.Run(source, mode));
+    }
+}

--- a/tests/SharpTS.Tests/CompilerTests/StableDestructuringLoadTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableDestructuringLoadTests.cs
@@ -9,7 +9,7 @@ using Xunit;
 namespace SharpTS.Tests.CompilerTests;
 
 /// <summary>Regression coverage for stable typed destructuring loads (#1502).</summary>
-public sealed class StableDestructuringLoadTests
+public sealed partial class StableDestructuringLoadTests
 {
     private const string HotSource = """
         type Point = { x: number; y: number };
@@ -285,7 +285,7 @@ public sealed class StableDestructuringLoadTests
             .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
             .Single(method => method.Name.EndsWith(name, StringComparison.Ordinal));
 
-    private static IEnumerable<(OpCode OpCode, MemberInfo? Member)> ReadInstructions(
+    private static IEnumerable<(int Offset, OpCode OpCode, MemberInfo? Member, int? BranchTarget)> ReadInstructions(
         MethodInfo method)
     {
         byte[] il = method.GetMethodBody()?.GetILAsByteArray()
@@ -294,6 +294,7 @@ public sealed class StableDestructuringLoadTests
 
         for (int offset = 0; offset < il.Length;)
         {
+            int instructionOffset = offset;
             byte first = il[offset++];
             short value = first == 0xfe
                 ? unchecked((short)(0xfe00 | il[offset++]))
@@ -326,8 +327,14 @@ public sealed class StableDestructuringLoadTests
                 _ => throw new InvalidOperationException(
                     $"Unsupported IL operand type {opCode.OperandType}.")
             };
+            int? branchTarget = opCode.OperandType switch
+            {
+                OperandType.InlineBrTarget => offset + 4 + BitConverter.ToInt32(il, offset),
+                OperandType.ShortInlineBrTarget => offset + 1 + (sbyte)il[offset],
+                _ => null
+            };
             offset += operandSize;
-            yield return (opCode, member);
+            yield return (instructionOffset, opCode, member, branchTarget);
         }
     }
 


### PR DESCRIPTION
Dictionary-backed destructuring currently performs general property lookup and numeric conversion for each binding on every loop iteration. This change acquires guarded numeric snapshots before eligible invariant loops, reducing the original benchmark's median runtime by approximately 134× on Windows and 128× on Linux.

The existing `object-destructure-materialized` fixture creates a dictionary immediately. A separate fixture now verifies an actual compact-record-to-dictionary transition so both storage paths remain covered.

## Implementation

- Share numeric snapshots between invariant reductions and fixed-key destructuring patterns. Require own numeric data properties, reject attached descriptors on dictionary/materialized receivers, and retain ordinary evaluation when guards fail. Patterns inside mutating or varying-receiver loops acquire fresh values each time.
- Read existing canonical materialized storage through a nonmaterializing carrier helper. Descriptor checks use the original receiver identity.
- Preserve safe-integer exactness guards, original floating-point addition order, zero-trip behavior, generic fallbacks, and cancellation inside optimized loops.
- Consolidate general dictionary getter/descriptor handling into one descriptor lookup while preserving accessors and prototype behavior.
- Add checksum controls, bounded configurable warmup, typed-delegate allocation microbenchmarks, representation/IL assertions, and semantic regression coverage. Zero warmup skips timed warmup in both sync and async harnesses while retaining correctness checks and calibration.
- Allow 15 minutes for Windows core tests and 30 minutes for the Windows job, after the previous 10-minute step limit interrupted a run with 17,938 passing tests and no assertion failures.

## Performance

100,000 iterations; .NET 10.0.11; 1,500 ms warmup; five alternating baseline/candidate launches. Values are medians of launch means in milliseconds, compared with `af72038b` using identical harness sources.

| Workload | Platform | Before | After |
| --- | --- | ---: | ---: |
| Original dictionary fixture | Windows | 3.2384 | 0.0242 |
| Actual materialized carrier | Windows | 8.3464 | 0.0246 |
| Original dictionary fixture | Linux/WSL | 2.8534 | 0.0223 |
| Actual materialized carrier | Linux/WSL | 7.6630 | 0.0210 |

Varying-receiver and mutation controls also improved substantially. Dictionary allocation remains 288 bytes/call at both 1,000 and 100,000 iterations; carrier measurements likewise show no allocation growth with loop length. Other host activity was not controlled, and small timing differences should not be treated as definitive. The Linux compact-varying control measured +6.49%, below the 10% relative regression threshold.

The [performance report](https://github.com/nickna/SharpTS/blob/579bd8c2/benchmarks/local-perf/materialized-object-destructuring.md) contains all controls, paired changes, allocation results, methodology, and limitations. The [implementation plan](https://github.com/nickna/SharpTS/blob/579bd8c2/docs/plans/materialized-object-destructuring.md) records the eligibility and fallback constraints.

## Validation

- Hosted checks on merged head `09bf3f92` are green: [CI](https://github.com/nickna/SharpTS/actions/runs/33945619173) and [Desktop GUI](https://github.com/nickna/SharpTS/actions/runs/33945619305). Windows core: 18,013 passed, 3 skipped; Ubuntu core: 18,016 passed. Both platforms passed all 108 GUI conformance tests, release checks, and packaged SDK smoke tests. Native AOT checks and CodeRabbit also passed.
- After merging current main: 83 focused destructuring, compact-record, object-consumer, and numeric-rest tests passed. Warmup behavior passed 26 deterministic Node checks and sync/async fast/slow checks at 0, 100, and 1,500 ms in both the interpreter and compiled runtime.

- 244 focused compiler, destructuring, compact-record, descriptor, and proxy cases passed, including the descriptor-identity regression. Optimized-loop IL and allocation checks passed.
- Windows full core suite: 17,918 passed, 3 skipped, 2 failures; both failed cases passed in isolation across compiled/interpreted variants.
- Linux full core suite: 17,920 passed, 3 failures. A copied shebang permission/line-ending issue was corrected and all three shebang tests passed on retry. Two interpreter OS-memory tests still fail and reproduce with the unchanged baseline compiler.
- Linux Native AOT publish, native compiler smoke gate, and native compilation/execution of both benchmark modules passed.
- Windows solution and conformance builds, 108 GUI conformance tests, NuGet release checks, GUI version staging, packaged SDK smoke, and AOT analyzer enforcement passed; analyzer inventory matched with zero warnings.
- Cross-runtime and microbenchmark source smoke checks passed on Windows and Linux. All four selected BenchmarkDotNet allocation cases and their setup checksums passed.

ARM and macOS were not exercised locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved numeric object destructuring and reduction loops while preserving behavior for getters, missing properties, proxies, mutations, coercion, and fallback cases.

- **Benchmarking**
  - Added broader object-destructuring benchmarks covering materialized objects, varying values, mutations, fractional values, and control scenarios.
  - Added configurable warmup timing, including the option to skip timed warmup.

- **Documentation**
  - Added performance results, validation details, reproducibility guidance, and benchmark workload descriptions.
  - Clarified timing procedures, compiler-scaling commands, and workload semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
