### PR TITLE
Consolidate default-value and property semantics helpers

### DIFF
--- a/src/SharpTS/Compilation/ILEmitter.Helpers.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Helpers.cs
@@ -283,42 +283,7 @@ public partial class ILEmitter
     /// Emits a default value for the given type.
     /// Used when padding missing arguments (fallback when no overload matches).
     /// </summary>
-    public new void EmitDefaultForType(Type type)
-    {
-        if (type == typeof(double))
-        {
-            IL.Emit(OpCodes.Ldc_R8, 0.0);
-        }
-        else if (type == typeof(int))
-        {
-            IL.Emit(OpCodes.Ldc_I4_0);
-        }
-        else if (type == typeof(bool))
-        {
-            IL.Emit(OpCodes.Ldc_I4_0);
-        }
-        else if (type == typeof(float))
-        {
-            IL.Emit(OpCodes.Ldc_R4, 0.0f);
-        }
-        else if (type == typeof(long))
-        {
-            IL.Emit(OpCodes.Ldc_I8, 0L);
-        }
-        else if (type.IsValueType)
-        {
-            // For other value types, use initobj with a local
-            var local = IL.DeclareLocal(type);
-            IL.Emit(OpCodes.Ldloca, local);
-            IL.Emit(OpCodes.Initobj, type);
-            IL.Emit(OpCodes.Ldloc, local);
-        }
-        else
-        {
-            // Reference types default to null
-            IL.Emit(OpCodes.Ldnull);
-        }
-    }
+    public new void EmitDefaultForType(Type type) => base.EmitDefaultForType(type);
 
     public override void EmitExpressionAsDouble(Expr expr)
     {

--- a/src/SharpTS/Runtime/Types/PropertySemantics.cs
+++ b/src/SharpTS/Runtime/Types/PropertySemantics.cs
@@ -1,0 +1,48 @@
+namespace SharpTS.Runtime.Types;
+
+/// <summary>
+/// Property descriptor comparison and canonical index semantics for interpreter runtime values.
+/// Compiled programs use their separately emitted runtime implementations.
+/// </summary>
+internal static class PropertySemantics
+{
+    internal static bool TryGetArrayIndex(string key, out uint index)
+    {
+        // ECMA-262 array indices use the canonical decimal spelling of a
+        // uint32 other than 2^32-1. Keep ordinary names such as "01", "+1",
+        // and whitespace-padded numbers out of indexed storage.
+        if (key.Length == 0
+            || key[0] is < '0' or > '9'
+            || (key.Length > 1 && key[0] == '0'))
+        {
+            index = 0;
+            return false;
+        }
+
+        return uint.TryParse(
+                key,
+                System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out index)
+            && index < uint.MaxValue;
+    }
+
+    /// <summary>
+    /// ECMA-262 SameValue comparison used by descriptor validation.
+    /// Numbers keep NaN equal to itself and distinguish positive from negative zero;
+    /// runtime objects and callables retain their reference identity.
+    /// </summary>
+    internal static bool SameValue(object? left, object? right)
+    {
+        if (ReferenceEquals(left, right)) return true;
+        if (left is double ld && right is double rd)
+        {
+            if (double.IsNaN(ld) && double.IsNaN(rd)) return true;
+            if (ld == 0 && rd == 0)
+                return BitConverter.DoubleToInt64Bits(ld)
+                    == BitConverter.DoubleToInt64Bits(rd);
+            return ld.Equals(rd);
+        }
+        return left?.Equals(right) == true;
+    }
+}

--- a/src/SharpTS/Runtime/Types/SharpTSArray.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSArray.cs
@@ -661,7 +661,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
         {
             foreach (string key in _descriptors.Keys)
             {
-                if (TryGetArrayIndex(key, out uint index)
+                if (PropertySemantics.TryGetArrayIndex(key, out uint index)
                     && index < expectedLength)
                 {
                     return false;
@@ -1010,7 +1010,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
                 {
                     if (!pair.Value.HasExplicitDescriptor || pair.Value.Configurable)
                         continue;
-                    if (!TryGetArrayIndex(pair.Key, out uint index)
+                    if (!PropertySemantics.TryGetArrayIndex(pair.Key, out uint index)
                         || index < newLength
                         || !HasIndex(index))
                     {
@@ -1048,7 +1048,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
             {
                 foreach (var key in _descriptors.Keys.Where(key =>
                 {
-                    return TryGetArrayIndex(key, out uint index)
+                    return PropertySemantics.TryGetArrayIndex(key, out uint index)
                         && index >= effectiveLength;
                 }).ToArray())
                 {
@@ -1347,7 +1347,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
     internal bool HasOwnProperty(string name)
     {
         if (name == "length") return true;
-        if (TryGetArrayIndex(name, out uint index))
+        if (PropertySemantics.TryGetArrayIndex(name, out uint index))
             return HasIndex(index)
                 || (_indexAccessors?.ContainsKey(index) ?? false)
                 || HasNamedProperty(name);
@@ -1443,7 +1443,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
             return false;
         }
 
-        if (TryGetArrayIndex(name, out uint index))
+        if (PropertySemantics.TryGetArrayIndex(name, out uint index))
         {
             DeleteAt(index);
         }
@@ -1521,7 +1521,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
         }
 
         // Numeric index path — accept full uint32 range per ECMA-262.
-        if (TryGetArrayIndex(name, out uint uindex))
+        if (PropertySemantics.TryGetArrayIndex(name, out uint uindex))
         {
             long index = uindex;
             bool hasExisting = HasIndex(index);
@@ -1550,9 +1550,9 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
                 {
                     if (descriptorIsData
                         || (descriptor.HasGet
-                            && !SameValue(descriptor.Get, existingGetter))
+                            && !PropertySemantics.SameValue(descriptor.Get, existingGetter))
                         || (descriptor.HasSet
-                            && !SameValue(descriptor.Set, existingSetter)))
+                            && !PropertySemantics.SameValue(descriptor.Set, existingSetter)))
                     {
                         return false;
                     }
@@ -1564,7 +1564,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
                     if (!existingFlags.Writable
                         && ((descriptor.HasWritable && descriptor.Writable)
                             || (descriptor.HasValue
-                                && !SameValue(descriptor.Value, UnholeForRead(GetCore(index))))))
+                                && !PropertySemantics.SameValue(descriptor.Value, UnholeForRead(GetCore(index))))))
                     {
                         return false;
                     }
@@ -1660,9 +1660,9 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
             {
                 if (namedDescriptorIsData
                     || (descriptor.HasGet
-                        && !SameValue(descriptor.Get, existingNamedAccessor.Get))
+                        && !PropertySemantics.SameValue(descriptor.Get, existingNamedAccessor.Get))
                     || (descriptor.HasSet
-                        && !SameValue(descriptor.Set, existingNamedAccessor.Set)))
+                        && !PropertySemantics.SameValue(descriptor.Set, existingNamedAccessor.Set)))
                 {
                     return false;
                 }
@@ -1671,7 +1671,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
                 || (!namedFlags.Writable
                     && ((descriptor.HasWritable && descriptor.Writable)
                         || (descriptor.HasValue
-                            && !SameValue(descriptor.Value, _namedProperties![name])))))
+                            && !PropertySemantics.SameValue(descriptor.Value, _namedProperties![name])))))
             {
                 return false;
             }
@@ -1735,7 +1735,7 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
             };
         }
 
-        if (TryGetArrayIndex(name, out uint uindex) && (long)uindex < _length)
+        if (PropertySemantics.TryGetArrayIndex(name, out uint uindex) && (long)uindex < _length)
         {
             long index = uindex;
             if (TryGetIndexAccessor(index, out var getter, out var setter))
@@ -1820,44 +1820,6 @@ public class SharpTSArray : ITypeCategorized, IReadOnlyList<object?>
         }
 
         return null;
-    }
-
-    private static bool TryGetArrayIndex(string key, out uint index)
-    {
-        // ECMA-262 array indices use the canonical decimal spelling of a
-        // uint32 other than 2^32-1. Keep ordinary names such as "01", "+1",
-        // and whitespace-padded numbers out of indexed storage.
-        if (key.Length == 0
-            || key[0] is < '0' or > '9'
-            || (key.Length > 1 && key[0] == '0'))
-        {
-            index = 0;
-            return false;
-        }
-
-        return uint.TryParse(
-                key,
-                System.Globalization.NumberStyles.None,
-                System.Globalization.CultureInfo.InvariantCulture,
-                out index)
-            && index < uint.MaxValue;
-    }
-
-    /// <summary>
-    /// ECMA-262 SameValue comparison used by descriptor validation.
-    /// </summary>
-    private static bool SameValue(object? left, object? right)
-    {
-        if (ReferenceEquals(left, right)) return true;
-        if (left is double ld && right is double rd)
-        {
-            if (double.IsNaN(ld) && double.IsNaN(rd)) return true;
-            if (ld == 0 && rd == 0)
-                return BitConverter.DoubleToInt64Bits(ld)
-                    == BitConverter.DoubleToInt64Bits(rd);
-            return ld.Equals(rd);
-        }
-        return left?.Equals(right) == true;
     }
 
     public override string ToString()

--- a/src/SharpTS/Runtime/Types/SharpTSObject.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSObject.cs
@@ -708,8 +708,8 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
             {
                 if (descriptorIsData) return false;
                 TryGetSymbolAccessor(symbol, out var currentGet, out var currentSet);
-                if (descriptor.HasGet && !SameValue(descriptor.Get, currentGet)) return false;
-                if (descriptor.HasSet && !SameValue(descriptor.Set, currentSet)) return false;
+                if (descriptor.HasGet && !PropertySemantics.SameValue(descriptor.Get, currentGet)) return false;
+                if (descriptor.HasSet && !PropertySemantics.SameValue(descriptor.Set, currentSet)) return false;
             }
             else
             {
@@ -718,7 +718,7 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
                 {
                     if (descriptor.HasWritable && descriptor.Writable) return false;
                     if (descriptor.HasValue
-                        && !SameValue(descriptor.Value, GetBySymbol(symbol)))
+                        && !PropertySemantics.SameValue(descriptor.Value, GetBySymbol(symbol)))
                         return false;
                 }
             }
@@ -801,9 +801,9 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
             {
                 if (descriptorIsData)
                     return false;
-                if (descriptor.HasGet && !SameValue(descriptor.Get, GetGetter(name)))
+                if (descriptor.HasGet && !PropertySemantics.SameValue(descriptor.Get, GetGetter(name)))
                     return false;
-                if (descriptor.HasSet && !SameValue(descriptor.Set, GetSetter(name)))
+                if (descriptor.HasSet && !PropertySemantics.SameValue(descriptor.Set, GetSetter(name)))
                     return false;
             }
             else
@@ -815,7 +815,7 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
                     if (descriptor.HasWritable && descriptor.Writable)
                         return false;
                     var currentValue = _fields.TryGetValue(name, out var value) ? value : SharpTSUndefined.Instance;
-                    if (descriptor.HasValue && !SameValue(descriptor.Value, currentValue))
+                    if (descriptor.HasValue && !PropertySemantics.SameValue(descriptor.Value, currentValue))
                         return false;
                 }
             }
@@ -910,24 +910,6 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
         }
 
         return true;
-    }
-
-    /// <summary>
-    /// ECMA-262 SameValue comparison used by ValidateAndApplyPropertyDescriptor.
-    /// Object/callable identity is reference-based; numbers additionally keep
-    /// NaN equal to itself and distinguish positive from negative zero.
-    /// </summary>
-    internal static bool SameValue(object? left, object? right)
-    {
-        if (ReferenceEquals(left, right)) return true;
-        if (left is double ld && right is double rd)
-        {
-            if (double.IsNaN(ld) && double.IsNaN(rd)) return true;
-            if (ld == 0 && rd == 0)
-                return BitConverter.DoubleToInt64Bits(ld) == BitConverter.DoubleToInt64Bits(rd);
-            return ld.Equals(rd);
-        }
-        return left?.Equals(right) == true;
     }
 
     /// <summary>
@@ -1101,7 +1083,7 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
                 continue;
             }
 
-            if (TryGetArrayIndex(key, out uint index))
+            if (PropertySemantics.TryGetArrayIndex(key, out uint index))
             {
                 indices ??= [];
                 indices.Add((index, key));
@@ -1136,7 +1118,7 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
         {
             foreach (string key in _fields.Keys)
             {
-                if (TryGetArrayIndex(key, out _))
+                if (PropertySemantics.TryGetArrayIndex(key, out _))
                 {
                     fields = null!;
                     return false;
@@ -1168,7 +1150,7 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
         // Preserve numeric key ordering and the interpreter's callable binding behavior by
         // retaining the general path. Validate everything before modifying the destination.
         foreach (var entry in _fields)
-            if (TryGetArrayIndex(entry.Key, out _) || entry.Value is ISharpTSCallable)
+            if (PropertySemantics.TryGetArrayIndex(entry.Key, out _) || entry.Value is ISharpTSCallable)
                 return false;
 
         destination.EnsureCapacity(destination.Count + _fields.Count);
@@ -1195,7 +1177,7 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
         {
             if (!HasOwnStringProperty(key))
                 continue;
-            if (TryGetArrayIndex(key, out uint index))
+            if (PropertySemantics.TryGetArrayIndex(key, out uint index))
             {
                 indices ??= [];
                 indices.Add((index, key));
@@ -1213,7 +1195,7 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
         {
             if (!HasOwnStringProperty(key))
                 continue;
-            if (indices is not null && TryGetArrayIndex(key, out _))
+            if (indices is not null && PropertySemantics.TryGetArrayIndex(key, out _))
                 continue;
             yield return key;
         }
@@ -1230,7 +1212,7 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
         foreach (string key in StringPropertyOrder)
         {
             if (HasOwnStringProperty(key)
-                && TryGetArrayIndex(key, out uint index)
+                && PropertySemantics.TryGetArrayIndex(key, out uint index)
                 && index < exclusiveLength)
             {
                 return true;
@@ -1241,28 +1223,6 @@ public class SharpTSObject(Dictionary<string, object?> fields) : ISharpTSPropert
 
     internal bool HasOwnStringProperty(string name)
         => _fields.ContainsKey(name) || IsAccessorProperty(name);
-
-    private static bool TryGetArrayIndex(string key, out uint index)
-    {
-        // Canonical array indices contain only ASCII digits and have no
-        // leading zero unless the key is exactly "0". Reject ordinary names
-        // before entering UInt32.TryParse, and avoid allocating ToString just
-        // to verify the canonical spelling.
-        if (key.Length == 0
-            || key[0] is < '0' or > '9'
-            || (key.Length > 1 && key[0] == '0'))
-        {
-            index = 0;
-            return false;
-        }
-
-        return uint.TryParse(
-                key,
-                System.Globalization.NumberStyles.None,
-                System.Globalization.CultureInfo.InvariantCulture,
-                out index)
-            && index < uint.MaxValue;
-    }
 
     public override string ToString() => $"{{ {string.Join(", ", _fields.Select(f => $"{f.Key}: {f.Value}"))} }}";
 }

--- a/src/SharpTS/Runtime/Types/SharpTSProxy.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSProxy.cs
@@ -206,7 +206,7 @@ public class SharpTSProxy : ISharpTSCallable
         var descriptor = SharpTSPropertyDescriptor.FromAnyObject(targetDescriptor);
         if (descriptor.Configurable) return;
         if (descriptor.HasValue && !descriptor.Writable
-            && !SharpTSObject.SameValue(result, descriptor.Value))
+            && !PropertySemantics.SameValue(result, descriptor.Value))
         {
             throw new ThrowException(new SharpTSTypeError(
                 "Proxy get trap must return the value of a fixed data property"));
@@ -297,7 +297,7 @@ public class SharpTSProxy : ISharpTSCallable
         if (descriptor.Configurable) return;
 
         if (descriptor.HasValue && !descriptor.Writable
-            && !SharpTSObject.SameValue(result, descriptor.Value))
+            && !PropertySemantics.SameValue(result, descriptor.Value))
         {
             throw new ThrowException(new SharpTSTypeError(
                 "Proxy get trap must return the value of a fixed data property"));
@@ -563,7 +563,7 @@ public class SharpTSProxy : ISharpTSCallable
         var descriptor = SharpTSPropertyDescriptor.FromAnyObject(targetDescriptor);
         if (descriptor.Configurable) return true;
         if (descriptor.HasValue && !descriptor.Writable
-            && !SharpTSObject.SameValue(value, descriptor.Value))
+            && !PropertySemantics.SameValue(value, descriptor.Value))
         {
             throw new ThrowException(new SharpTSTypeError(
                 "Proxy set trap cannot change a fixed data property"));
@@ -598,7 +598,7 @@ public class SharpTSProxy : ISharpTSCallable
         var descriptor = SharpTSPropertyDescriptor.FromAnyObject(targetDescriptor);
         if (descriptor.Configurable) return true;
         if (descriptor.HasValue && !descriptor.Writable
-            && !SharpTSObject.SameValue(value, descriptor.Value))
+            && !PropertySemantics.SameValue(value, descriptor.Value))
         {
             throw new ThrowException(new SharpTSTypeError(
                 "Proxy set trap cannot change a fixed data property"));
@@ -1311,10 +1311,10 @@ public class SharpTSProxy : ISharpTSCallable
         if (targetAccessor)
         {
             if (requested.HasGet
-                && !SharpTSObject.SameValue(requested.RawGet, target.RawGet))
+                && !PropertySemantics.SameValue(requested.RawGet, target.RawGet))
                 ThrowInvariant();
             if (requested.HasSet
-                && !SharpTSObject.SameValue(requested.RawSet, target.RawSet))
+                && !PropertySemantics.SameValue(requested.RawSet, target.RawSet))
                 ThrowInvariant();
             return;
         }
@@ -1326,7 +1326,7 @@ public class SharpTSProxy : ISharpTSCallable
             if (requested.HasWritable && requested.Writable)
                 ThrowInvariant();
             if (requested.HasValue
-                && !SharpTSObject.SameValue(requested.Value, target.Value))
+                && !PropertySemantics.SameValue(requested.Value, target.Value))
                 ThrowInvariant();
         }
 

--- a/tests/SharpTS.Tests/SharedTests/PropertySemanticsTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/PropertySemanticsTests.cs
@@ -1,0 +1,57 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+public class PropertySemanticsTests
+{
+    [Theory, ModeData]
+    public void NonWritableDescriptors_PreserveSameValueAcrossReceivers(ExecutionMode mode)
+    {
+        var source = """
+            const identity: any = {};
+            const targets: any[] = [{}, [], []];
+            const keys: string[] = ["value", "0", "named"];
+            for (let i = 0; i < targets.length; i++) {
+                const target: any = targets[i];
+                const key = keys[i];
+                Object.defineProperty(target, key, { value: NaN });
+                console.log(Reflect.defineProperty(target, key, { value: NaN }));
+                console.log(Reflect.defineProperty(target, key, { value: 0 }));
+                Object.defineProperty(target, "zero", { value: 0 });
+                console.log(Reflect.defineProperty(target, "zero", { value: -0 }));
+                Object.defineProperty(target, "identity", { value: identity });
+                console.log(Reflect.defineProperty(target, "identity", { value: identity }));
+                console.log(Reflect.defineProperty(target, "identity", { value: {} }));
+            }
+            """;
+
+        Assert.Equal(string.Concat(Enumerable.Repeat("true\nfalse\nfalse\ntrue\nfalse\n", 3)),
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void PropertyKeys_DistinguishCanonicalIndicesFromOrdinaryNames(ExecutionMode mode)
+    {
+        var source = """
+            const targets: any[] = [{}, []];
+            const keys: string[] = ["01", "+1", " 1 ", "4294967295"];
+            for (const target of targets) {
+                for (const key of keys) {
+                    Object.defineProperty(target, key, {
+                        value: key, enumerable: true, configurable: true
+                    });
+                }
+                target[2] = "2";
+                target[0] = "0";
+                console.log(Object.keys(target).join(","));
+                console.log(target["01"], target["+1"], target[" 1 "], target["4294967295"]);
+            }
+            console.log(targets[1].length);
+            """;
+
+        Assert.Equal(string.Concat(Enumerable.Repeat(
+            "0,2,01,+1, 1 ,4294967295\n01 +1  1  4294967295\n", 2)) + "3\n",
+            TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
Consolidate the duplicated descriptor comparison and canonical array-index helpers so changes to those semantics have one implementation point. Objects, arrays, and proxy invariant checks now use the internal `PropertySemantics` owner. `ILEmitter.EmitDefaultForType` retains its public entry point and delegates to the existing base implementation.

The extraction preserves NaN equality, signed-zero distinctions, reference identity, canonical index parsing, and the separate undefined-padding path for omitted JavaScript arguments. The emitted runtime remains separate for standalone compilation.

Add dual-mode characterization coverage for fixed data descriptors on objects and array indexed/named properties, plus noncanonical property names, key ordering, and array length.

Fixes #1595.
Validation: Release build and all 765 selected tests passed (0 failed, 0 skipped), including descriptor/object/proxy behavior, canonical keys, default/optional arguments, undefined padding, standalone DLLs, and IL verification. `git diff --check` passed. The full solution suite and external conformance corpora were not run for this behavior-preserving extraction.

The initial sandboxed run encountered a TLS authentication failure; the complete final selection passed outside the sandbox with access to Windows cryptographic services.

```powershell
dotnet test tests/SharpTS.Tests/SharpTS.Tests.csproj -c Release --no-restore -m:1 --filter 'FullyQualifiedName~PropertySemanticsTests|FullyQualifiedName~ObjectFeatureTests|FullyQualifiedName~ObjectSpreadCopyTests|FullyQualifiedName~ObjectAccessorTests|FullyQualifiedName~ProxyTests|FullyQualifiedName~ArrayDescriptorIterationTests|FullyQualifiedName~DeleteOperatorTests|FullyQualifiedName~DefaultParameter|FullyQualifiedName~OptionalParam|FullyQualifiedName~ValueCallUndefinedPaddingTests|FullyQualifiedName~ILVerificationTests|FullyQualifiedName~StandaloneDllTests'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JavaScript property handling for canonical array indices and ordinary property names.
  - Corrected comparisons involving `NaN`, positive and negative zero, and object identity.
  - Improved validation for non-writable property redefinitions across objects, arrays, and proxies.
  - Ensured array length and indexed assignments follow ECMAScript-compatible behavior.
- **Tests**
  - Added coverage for property descriptors, array-index recognition, value comparisons, and array length updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->