### PR TITLE
Replace module-resolution message matching with typed failures

### DIFF
--- a/src/SharpTS/Modules/ModuleResolutionException.cs
+++ b/src/SharpTS/Modules/ModuleResolutionException.cs
@@ -1,0 +1,15 @@
+namespace SharpTS.Modules;
+
+/// <summary>The machine-readable reason a module could not be resolved.</summary>
+public enum ModuleResolutionFailure
+{
+    /// <summary>No matching module was found under the selected resolution rules.</summary>
+    NotFound,
+}
+
+/// <summary>A resolution failure whose diagnostic wording does not control recovery.</summary>
+public sealed class ModuleResolutionException(ModuleResolutionFailure reason, string message)
+    : Exception(message)
+{
+    public ModuleResolutionFailure Reason { get; } = reason;
+}

--- a/src/SharpTS/Modules/ModuleResolver.cs
+++ b/src/SharpTS/Modules/ModuleResolver.cs
@@ -278,8 +278,9 @@ public class ModuleResolver
                 specifier, currentDir, kind, preferDeclarations);
             if (result != null)
                 return result;
-            throw new Exception($"Module Error: Cannot resolve subpath import '{specifier}'. " +
-                                "No matching entry found in the nearest package.json \"imports\" field.");
+            throw new ModuleResolutionException(ModuleResolutionFailure.NotFound,
+                $"Module Error: Cannot resolve subpath import '{specifier}'. " +
+                "No matching entry found in the nearest package.json \"imports\" field.");
         }
         else
         {
@@ -328,7 +329,7 @@ public class ModuleResolver
 
             if (_resolutionOptions.Mode == ModuleResolutionMode.Classic)
             {
-                throw new Exception(
+                throw new ModuleResolutionException(ModuleResolutionFailure.NotFound,
                     $"Module Error: Cannot resolve bare specifier '{specifier}' with classic module resolution.");
             }
 
@@ -355,8 +356,9 @@ public class ModuleResolver
                 return npmFallbackModule.VirtualPath;
             }
 
-            throw new Exception($"Module Error: Cannot resolve bare specifier '{specifier}'. " +
-                                "Bare imports require a node_modules directory with the package installed.");
+            throw new ModuleResolutionException(ModuleResolutionFailure.NotFound,
+                $"Module Error: Cannot resolve bare specifier '{specifier}'. " +
+                "Bare imports require a node_modules directory with the package installed.");
         }
     }
 
@@ -699,7 +701,8 @@ public class ModuleResolver
     private string AddExtensionIfNeeded(string path)
     {
         return TryAddExtension(path)
-            ?? throw new Exception($"Module Error: Cannot resolve module '{path}'. File not found.");
+            ?? throw new ModuleResolutionException(ModuleResolutionFailure.NotFound,
+                $"Module Error: Cannot resolve module '{path}'. File not found.");
     }
 
     /// <summary>
@@ -1026,9 +1029,7 @@ public class ModuleResolver
                         string importedPath = ResolveModulePath(import.ModulePath, absolutePath);
                         importedModule = LoadModule(importedPath, decoratorMode);
                     }
-                    catch (Exception ex) when (
-                        _programOptions.PreferDeclarationFiles
-                        && ex.Message.StartsWith("Module Error: Cannot resolve", StringComparison.Ordinal))
+                    catch (ModuleResolutionException ex) when (CanRecoverResolutionFailure(ex))
                     {
                         // Program loading must keep the rest of the graph alive
                         // so the checker can report canonical TS2307 at the
@@ -1076,9 +1077,7 @@ public class ModuleResolver
                     {
                         reexportPath = ResolveModulePath(export.FromModulePath, absolutePath);
                     }
-                    catch (Exception ex) when (
-                        _programOptions.PreferDeclarationFiles
-                        && ex.Message.StartsWith("Module Error: Cannot resolve", StringComparison.Ordinal))
+                    catch (ModuleResolutionException ex) when (CanRecoverResolutionFailure(ex))
                     {
                         continue;
                     }
@@ -1191,6 +1190,9 @@ public class ModuleResolver
                export.NamedExports.Any(specifier => !specifier.IsTypeOnly);
     }
 
+    internal bool CanRecoverResolutionFailure(ModuleResolutionException exception) =>
+        _programOptions.PreferDeclarationFiles && exception.Reason == ModuleResolutionFailure.NotFound;
+
     private void TryAddRuntimeDependency(
         ParsedModule owner,
         string specifier,
@@ -1206,9 +1208,7 @@ public class ModuleResolver
             if (!owner.RuntimeDependencies.Contains(runtimeModule))
                 owner.RuntimeDependencies.Add(runtimeModule);
         }
-        catch (Exception ex) when (
-            _programOptions.PreferDeclarationFiles &&
-            ex.Message.StartsWith("Module Error: Cannot resolve", StringComparison.Ordinal))
+        catch (ModuleResolutionException ex) when (CanRecoverResolutionFailure(ex))
         {
             // A declaration-only package remains valid for type-only consumers. A value
             // consumer receives the normal runtime module-not-found diagnostic if executed.

--- a/tests/SharpTS.Tests/Modules/ModuleResolutionFailureTests.cs
+++ b/tests/SharpTS.Tests/Modules/ModuleResolutionFailureTests.cs
@@ -1,0 +1,154 @@
+using SharpTS.Configuration;
+using SharpTS.Modules;
+using SharpTS.Modules.Stdlib;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.Modules;
+
+public class ModuleResolutionFailureTests
+{
+    private static readonly string Entry = Path.GetFullPath(Path.Combine(
+        Path.GetTempPath(), "sharpts-resolution-failures", "main.ts"));
+
+    private static ModuleResolver CreateResolver(string source, bool declarations,
+        string? dependency = null, bool runtime = false)
+    {
+        var files = new Dictionary<string, string> { [Entry] = source };
+        if (dependency is not null)
+            files[Path.Combine(Path.GetDirectoryName(Entry)!, runtime ? "dep.ts" : "dep.d.ts")] = dependency;
+        return new ModuleResolver(Entry, files,
+            new TypeScriptProgramOptions { PreferDeclarationFiles = declarations });
+    }
+
+    [Theory]
+    [InlineData("import { value } from './missing';")]
+    [InlineData("export { value } from './missing';")]
+    [InlineData("export * from './missing';")]
+    public void MissingDependency_RecoversForCheckingButFailsForRuntime(string source)
+    {
+        var resolver = CreateResolver(source, declarations: true);
+        var entry = resolver.LoadModule(Entry);
+        Assert.Empty(entry.Dependencies);
+        var checker = new TypeChecker();
+        checker.CheckModules(resolver.GetModulesInOrder(entry), resolver);
+        Assert.Contains(checker.GetDiagnostics(), diagnostic =>
+            diagnostic.TsCode == "TS2307" && diagnostic.Line == 1);
+
+        var runtimeResolver = CreateResolver(source, declarations: false);
+        var exception = Assert.Throws<ModuleResolutionException>(() => runtimeResolver.LoadModule(Entry));
+        Assert.Equal(ModuleResolutionFailure.NotFound, exception.Reason);
+    }
+
+    [Theory]
+    [InlineData("import { value } from './dep';")]
+    [InlineData("export { value } from './dep';")]
+    [InlineData("export * from './dep';")]
+    [InlineData("import dep = require('./dep');")]
+    public void DeclarationOnlyDependency_PreservesDeclarationGraph(string source)
+    {
+        string packagePath = Path.Combine(Path.GetDirectoryName(Entry)!, "node_modules", "dep");
+        var resolver = new ModuleResolver(Entry, new Dictionary<string, string>
+        {
+            [Entry] = source.Replace("./dep", "dep"),
+            [Path.Combine(packagePath, "package.json")] =
+                """{ "types": "./types.d.ts", "main": "./missing.js" }""",
+            [Path.Combine(packagePath, "types.d.ts")] = "export declare const value: number;",
+        }, new TypeScriptProgramOptions { PreferDeclarationFiles = true });
+        var entry = resolver.LoadModule(Entry);
+        Assert.True(Assert.Single(entry.Dependencies).IsDeclarationFile);
+        Assert.Empty(entry.RuntimeDependencies);
+        Assert.Throws<ModuleResolutionException>(() => resolver.ResolveRuntimeModulePath("dep", Entry));
+    }
+
+    [Theory]
+    [InlineData("Module Error: Cannot resolve anything")]
+    [InlineData("No matching module exists")]
+    [InlineData("")]
+    public void RecoveryPolicy_IsIndependentOfDiagnosticWording(string message)
+    {
+        var exception = new ModuleResolutionException(ModuleResolutionFailure.NotFound, message);
+        Assert.True(CreateResolver("", declarations: true).CanRecoverResolutionFailure(exception));
+        Assert.False(CreateResolver("", declarations: false).CanRecoverResolutionFailure(exception));
+        Assert.Equal(message, exception.Message);
+    }
+
+    [Theory]
+    [InlineData("import { value } from './dep';")]
+    [InlineData("export { value } from './dep';")]
+    public void DependencyParserFailure_IsNotRecovered(string source)
+    {
+        var resolver = CreateResolver(source, declarations: true, "export const = ;", runtime: true);
+        var exception = Record.Exception(() => resolver.LoadModule(Entry));
+        Assert.NotNull(exception);
+        Assert.IsNotType<ModuleResolutionException>(exception);
+    }
+
+    [Theory]
+    [InlineData("import { value } from 'dep';", false)]
+    [InlineData("export { value } from 'dep';", false)]
+    [InlineData("import { value } from 'dep';", true)]
+    [InlineData("export { value } from 'dep';", true)]
+    public void ProviderFailure_UsesTypeInsteadOfMessage(string source, bool runtimeDependency)
+    {
+        foreach (bool unresolved in new[] { false, true })
+        {
+            var resolver = CreateResolver(source, declarations: true, "export declare const value: number;");
+            Exception failure = unresolved
+                ? new ModuleResolutionException(ModuleResolutionFailure.NotFound, "Diagnostic wording changed")
+                : new IOException("Module Error: Cannot resolve host resource");
+            // Inject a provider through the internal chain to exercise the real catch boundaries.
+            var providers = Assert.IsType<List<IModuleProvider>>(resolver.StdlibChain.Providers);
+            providers.Insert(0, new FailingProvider(failure, runtimeDependency));
+
+            if (unresolved)
+            {
+                var entry = resolver.LoadModule(Entry);
+                Assert.Empty(entry.RuntimeDependencies);
+                Assert.Equal(runtimeDependency ? 1 : 0, entry.Dependencies.Count);
+            }
+            else
+            {
+                Assert.Same(failure, Record.Exception(() => resolver.LoadModule(Entry)));
+            }
+        }
+    }
+
+    private sealed class FailingProvider(Exception failure, bool runtimeDependency) : IModuleProvider
+    {
+        private int _calls;
+        public string Name => "test-failure";
+        public IReadOnlyCollection<string> ProvidedModules => ["dep"];
+
+        public bool TryResolve(string specifier, out StdlibModule? module)
+        {
+            module = null;
+            if (specifier != "dep")
+                return false;
+            if (runtimeDependency && _calls++ == 0)
+            {
+                module = new StdlibModule("dep", new TypeScriptSource(""), Name,
+                    Path.Combine(Path.GetDirectoryName(Entry)!, "dep.d.ts"));
+                return true;
+            }
+            throw failure;
+        }
+    }
+
+    [Theory]
+    [InlineData("missing", ModuleResolutionMode.Node16,
+        "Module Error: Cannot resolve bare specifier 'missing'. Bare imports require a node_modules directory with the package installed.")]
+    [InlineData("missing", ModuleResolutionMode.Classic,
+        "Module Error: Cannot resolve bare specifier 'missing' with classic module resolution.")]
+    [InlineData("#missing", ModuleResolutionMode.Node16,
+        "Module Error: Cannot resolve subpath import '#missing'. No matching entry found in the nearest package.json \"imports\" field.")]
+    public void UnresolvedSpecifier_PreservesDiagnostic(string specifier, ModuleResolutionMode mode, string message)
+    {
+        var resolver = new ModuleResolver(Entry,
+            new ModuleResolutionOptions(mode, null, new Dictionary<string, IReadOnlyList<string>>()),
+            new Dictionary<string, string>());
+        var exception = Assert.Throws<ModuleResolutionException>(() => resolver.ResolveModulePath(specifier, Entry));
+        Assert.Equal(ModuleResolutionFailure.NotFound, exception.Reason);
+        Assert.Equal(message, exception.Message);
+    }
+}

--- a/tests/SharpTS.Tests/Modules/NpmFallbackResolutionTests.cs
+++ b/tests/SharpTS.Tests/Modules/NpmFallbackResolutionTests.cs
@@ -93,7 +93,7 @@ public class NpmFallbackResolutionTests
         var entry = dir.CreateFile("main.ts", "export {};");
         var resolver = new ModuleResolver(entry);
 
-        var ex = Assert.Throws<Exception>(() => resolver.ResolveModulePath("left-pad", entry));
+        var ex = Assert.Throws<ModuleResolutionException>(() => resolver.ResolveModulePath("left-pad", entry));
         Assert.Contains("Cannot resolve bare specifier", ex.Message);
     }
 }


### PR DESCRIPTION
Module graph loading used exception-message prefixes to decide whether missing imports should be deferred to the checker. Changing diagnostic wording could therefore change program-loading behavior, and unrelated host failures with that prefix could be swallowed.

Introduce `ModuleResolutionException` with a `NotFound` reason and use it at all four unresolved-module throw sites and all three recovery boundaries. Preserve existing messages, declaration-mode recovery and TS2307 attribution, and eager runtime failures. Unrelated provider and parser exceptions propagate.

Regression coverage includes imports, named/star re-exports, declaration-only packages (including import-require), diagnostic wording changes, and host failures that imitate the former message prefix.

Validation:
- 327 targeted tests passed: module resolution/program tests, diagnostic attribution, and shared interpreter/compiler module tests.
- TypeScript conformance project: 383 passed, 1 failed in the unchanged `Parse_IsDeterministicAcrossLineEndingsAndBom` fixture test. On this Windows checkout, the fixture already has CRLF endings and the test replaces LF with CRLF, producing CRCRLF. This failure is outside the resolver refactor.
- `git diff --check` passed.

Closes #1597.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved module resolution error reporting with clearer, typed failures for missing modules and unresolved imports.
  - Preserved diagnostic details when module resolution fails.
  - Improved handling of missing dependencies during declaration checking while ensuring runtime execution still reports unresolved dependencies.
  - Prevented unrelated parsing and provider errors from being incorrectly treated as missing-module cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->