### PR TITLE
Share Promise mutation analysis across primitive optimizations

### DIFF
--- a/src/SharpTS/Compilation/ExpressionEmitterBase.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.cs
@@ -492,7 +492,7 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
 
     private bool HasNativeNumericLocal(Expr expression)
     {
-        expression = UnwrapNumericOperand(expression);
+        expression = ExpressionUnwrapper.Unwrap(expression);
         if (expression is not Expr.Variable variable)
             return false;
 
@@ -504,7 +504,7 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
 
     private static bool IsSimpleNumericOperand(Expr expression)
     {
-        expression = UnwrapNumericOperand(expression);
+        expression = ExpressionUnwrapper.Unwrap(expression);
         return expression is Expr.Variable
             or Expr.Literal { Value: double }
             or Expr.Unary
@@ -512,30 +512,6 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
             Operator.Type: TokenType.MINUS or TokenType.PLUS,
             Right: Expr.Literal { Value: double }
         };
-    }
-
-    private static Expr UnwrapNumericOperand(Expr expression)
-    {
-        while (true)
-        {
-            switch (expression)
-            {
-                case Expr.Grouping grouping:
-                    expression = grouping.Expression;
-                    continue;
-                case Expr.TypeAssertion assertion:
-                    expression = assertion.Expression;
-                    continue;
-                case Expr.Satisfies satisfies:
-                    expression = satisfies.Expression;
-                    continue;
-                case Expr.NonNullAssertion nonNull:
-                    expression = nonNull.Expression;
-                    continue;
-                default:
-                    return expression;
-            }
-        }
     }
 
     private static bool IsNumericType(TypeSystem.TypeInfo? type) => type is

--- a/src/SharpTS/Compilation/ExpressionUnwrapper.cs
+++ b/src/SharpTS/Compilation/ExpressionUnwrapper.cs
@@ -1,0 +1,31 @@
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation;
+
+/// <summary>Removes grouping and type-only wrappers without changing the underlying expression.</summary>
+internal static class ExpressionUnwrapper
+{
+    public static Expr Unwrap(Expr expression)
+    {
+        while (true)
+        {
+            switch (expression)
+            {
+                case Expr.Grouping grouping:
+                    expression = grouping.Expression;
+                    continue;
+                case Expr.TypeAssertion assertion:
+                    expression = assertion.Expression;
+                    continue;
+                case Expr.Satisfies satisfies:
+                    expression = satisfies.Expression;
+                    continue;
+                case Expr.NonNullAssertion nonNull:
+                    expression = nonNull.Expression;
+                    continue;
+                default:
+                    return expression;
+            }
+        }
+    }
+}

--- a/src/SharpTS/Compilation/ILCompiler.cs
+++ b/src/SharpTS/Compilation/ILCompiler.cs
@@ -669,10 +669,12 @@ public partial class ILCompiler
             statements, _typeMap, _closures.Analyzer, _features);
         StableNumericFunctionCaptureAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
         NumericMapLocalPromotionAnalyzer.Analyze(statements, _typeMap, _closures.Analyzer);
+        bool hasObservablePromiseMutation = _typeMap is not null
+            && PromiseMutationAnalyzer.HasObservableMutation(statements, _typeMap);
         StablePrimitivePromiseThenAnalyzer.Analyze(
-            statements, _typeMap, _closures.Analyzer);
+            statements, _typeMap, _closures.Analyzer, hasObservablePromiseMutation);
         StablePrimitivePromiseAllAnalyzer.Analyze(
-            statements, _typeMap, _closures.Analyzer, _features);
+            statements, _typeMap, _closures.Analyzer, _features, hasObservablePromiseMutation);
         StableExactClassMethodCallAnalyzer.Analyze(statements, _typeMap, _features);
         NonEscapingArrowLocalAnalyzer.Analyze(
             statements, _closures.DirectCallArrowBindings, _closures.Analyzer);

--- a/src/SharpTS/Compilation/PromiseMutationAnalyzer.cs
+++ b/src/SharpTS/Compilation/PromiseMutationAnalyzer.cs
@@ -1,0 +1,127 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Detects observable Promise mutation that invalidates primitive Promise optimizations.
+/// The compiler shares one result across the all and then eligibility passes.
+/// </summary>
+internal static class PromiseMutationAnalyzer
+{
+    public static bool HasObservableMutation(IReadOnlyList<Stmt> program, TypeMap typeMap)
+    {
+        var visitor = new PromiseMutationVisitor(typeMap);
+        foreach (var statement in program)
+            visitor.Visit(statement);
+        return visitor.HasObservableMutation;
+    }
+
+    private sealed class PromiseMutationVisitor(TypeMap typeMap) : AstVisitorBase
+    {
+        private readonly TypeMap _typeMap = typeMap;
+        public bool HasObservableMutation { get; private set; }
+
+        protected override void VisitCall(Expr.Call expression)
+        {
+            if (expression.Callee is Expr.Variable { Name.Lexeme: "eval" })
+                HasObservableMutation = true;
+
+            if (expression.Arguments.Count > 0
+                && expression.Callee is Expr.Get
+                {
+                    Object: Expr.Variable { Name.Lexeme: "Object" or "Reflect" },
+                    Name.Lexeme: "assign" or "defineProperty" or "defineProperties"
+                        or "set" or "deleteProperty" or "setPrototypeOf"
+                }
+                && IsPromiseTarget(expression.Arguments[0]))
+            {
+                HasObservableMutation = true;
+            }
+            base.VisitCall(expression);
+        }
+
+        protected override void VisitGet(Expr.Get expression)
+        {
+            if (IsPromisePrototype(expression))
+                HasObservableMutation = true;
+            base.VisitGet(expression);
+        }
+
+        protected override void VisitAssign(Expr.Assign expression)
+        {
+            if (expression.Name.Lexeme == "Promise")
+                HasObservableMutation = true;
+            base.VisitAssign(expression);
+        }
+
+        protected override void VisitSet(Expr.Set expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitSet(expression);
+        }
+
+        protected override void VisitSetIndex(Expr.SetIndex expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitSetIndex(expression);
+        }
+
+        protected override void VisitCompoundSet(Expr.CompoundSet expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitCompoundSet(expression);
+        }
+
+        protected override void VisitCompoundSetIndex(Expr.CompoundSetIndex expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitCompoundSetIndex(expression);
+        }
+
+        protected override void VisitLogicalSet(Expr.LogicalSet expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitLogicalSet(expression);
+        }
+
+        protected override void VisitLogicalSetIndex(Expr.LogicalSetIndex expression)
+        {
+            if (IsPromiseTarget(expression.Object))
+                HasObservableMutation = true;
+            base.VisitLogicalSetIndex(expression);
+        }
+
+        protected override void VisitDelete(Expr.Delete expression)
+        {
+            Expr operand = ExpressionUnwrapper.Unwrap(expression.Operand);
+            if (operand is Expr.Get property && IsPromiseTarget(property.Object)
+                || operand is Expr.GetIndex index && IsPromiseTarget(index.Object))
+            {
+                HasObservableMutation = true;
+            }
+            base.VisitDelete(expression);
+        }
+
+        private bool IsPromiseTarget(Expr expression)
+        {
+            expression = ExpressionUnwrapper.Unwrap(expression);
+            return expression is Expr.Variable { Name.Lexeme: "Promise" }
+                || IsPromisePrototype(expression)
+                || _typeMap.Get(expression) is TypeInfo.Promise;
+        }
+
+        private static bool IsPromisePrototype(Expr expression) => ExpressionUnwrapper.Unwrap(expression) is Expr.Get
+        {
+            Optional: false,
+            Object: Expr.Variable { Name.Lexeme: "Promise" },
+            Name.Lexeme: "prototype"
+        };
+    }
+}

--- a/src/SharpTS/Compilation/StableNumericLoopCaptureAnalyzer.cs
+++ b/src/SharpTS/Compilation/StableNumericLoopCaptureAnalyzer.cs
@@ -75,37 +75,13 @@ internal static class StableNumericLoopCaptureAnalyzer
 
     private static bool IsNumericLiteral(Expr expression)
     {
-        expression = Unwrap(expression);
+        expression = ExpressionUnwrapper.Unwrap(expression);
         return expression is Expr.Literal { Value: double }
             or Expr.Unary
         {
             Operator.Type: TokenType.MINUS,
             Right: Expr.Literal { Value: double }
         };
-    }
-
-    private static Expr Unwrap(Expr expression)
-    {
-        while (true)
-        {
-            switch (expression)
-            {
-                case Expr.Grouping grouping:
-                    expression = grouping.Expression;
-                    continue;
-                case Expr.TypeAssertion assertion:
-                    expression = assertion.Expression;
-                    continue;
-                case Expr.Satisfies satisfies:
-                    expression = satisfies.Expression;
-                    continue;
-                case Expr.NonNullAssertion nonNull:
-                    expression = nonNull.Expression;
-                    continue;
-                default:
-                    return expression;
-            }
-        }
     }
 
     private sealed class LoopVisitor(
@@ -646,7 +622,7 @@ internal static class StableNumericLoopCaptureAnalyzer
         protected override void VisitCall(Expr.Call expression)
         {
             if (!expression.Optional
-                && Unwrap(expression.Callee) is Expr.Variable { Name.Lexeme: "eval" })
+                && ExpressionUnwrapper.Unwrap(expression.Callee) is Expr.Variable { Name.Lexeme: "eval" })
             {
                 ContainsDirectEval = true;
             }

--- a/src/SharpTS/Compilation/StablePrimitivePromiseAllAnalyzer.cs
+++ b/src/SharpTS/Compilation/StablePrimitivePromiseAllAnalyzer.cs
@@ -17,17 +17,15 @@ internal static class StablePrimitivePromiseAllAnalyzer
         List<Stmt> program,
         TypeMap? typeMap,
         ClosureAnalyzer? closures,
-        RuntimeFeatureSet? features)
+        RuntimeFeatureSet? features,
+        bool hasObservablePromiseMutation)
     {
         if (typeMap is null
             || features?.UsesArrayPrototypeMutation == true
             || features?.UsesDynamicPropertyDescriptors == true)
             return;
 
-        var mutations = new PromiseMutationVisitor(typeMap);
-        foreach (var statement in program)
-            mutations.Visit(statement);
-        if (mutations.HasObservableMutation)
+        if (hasObservablePromiseMutation)
             return;
 
         var visitor = new BindingVisitor(typeMap);
@@ -71,7 +69,7 @@ internal static class StablePrimitivePromiseAllAnalyzer
         out Expr value)
     {
         value = null!;
-        expression = Unwrap(expression);
+        expression = ExpressionUnwrapper.Unwrap(expression);
         if (expression is not Expr.Call
         {
             Optional: false,
@@ -99,11 +97,11 @@ internal static class StablePrimitivePromiseAllAnalyzer
         if (expression is null)
             return false;
 
-        expression = Unwrap(expression);
+        expression = ExpressionUnwrapper.Unwrap(expression);
         if (expression is not Expr.Await awaitExpression)
             return false;
 
-        Expr awaited = Unwrap(awaitExpression.Expression);
+        Expr awaited = ExpressionUnwrapper.Unwrap(awaitExpression.Expression);
         if (awaited is not Expr.Call
             {
                 Optional: false,
@@ -121,30 +119,6 @@ internal static class StablePrimitivePromiseAllAnalyzer
 
         iterable = source;
         return true;
-    }
-
-    private static Expr Unwrap(Expr expression)
-    {
-        while (true)
-        {
-            switch (expression)
-            {
-                case Expr.Grouping grouping:
-                    expression = grouping.Expression;
-                    continue;
-                case Expr.TypeAssertion assertion:
-                    expression = assertion.Expression;
-                    continue;
-                case Expr.Satisfies satisfies:
-                    expression = satisfies.Expression;
-                    continue;
-                case Expr.NonNullAssertion nonNull:
-                    expression = nonNull.Expression;
-                    continue;
-                default:
-                    return expression;
-            }
-        }
     }
 
     private sealed class BindingVisitor(TypeMap typeMap) : AstVisitorBase
@@ -335,7 +309,7 @@ internal static class StablePrimitivePromiseAllAnalyzer
             Expr expression,
             int scope)
         {
-            expression = Unwrap(expression);
+            expression = ExpressionUnwrapper.Unwrap(expression);
             if (expression is Expr.Literal { Value: double })
                 return true;
 
@@ -359,112 +333,5 @@ internal static class StablePrimitivePromiseAllAnalyzer
         public sealed record ResultCandidate(
             (int Scope, string Name) InputKey,
             Expr.Variable Iterable);
-    }
-
-    private sealed class PromiseMutationVisitor(TypeMap typeMap) : AstVisitorBase
-    {
-        private readonly TypeMap _typeMap = typeMap;
-        public bool HasObservableMutation { get; private set; }
-
-        protected override void VisitCall(Expr.Call expression)
-        {
-            if (expression.Callee is Expr.Variable { Name.Lexeme: "eval" })
-                HasObservableMutation = true;
-
-            if (expression.Arguments.Count > 0
-                && expression.Callee is Expr.Get
-                {
-                    Object: Expr.Variable { Name.Lexeme: "Object" or "Reflect" },
-                    Name.Lexeme: "assign" or "defineProperty" or "defineProperties"
-                        or "set" or "deleteProperty" or "setPrototypeOf"
-                }
-                && IsPromiseTarget(expression.Arguments[0]))
-            {
-                HasObservableMutation = true;
-            }
-            base.VisitCall(expression);
-        }
-
-        protected override void VisitGet(Expr.Get expression)
-        {
-            if (IsPromisePrototype(expression))
-                HasObservableMutation = true;
-            base.VisitGet(expression);
-        }
-
-        protected override void VisitAssign(Expr.Assign expression)
-        {
-            if (expression.Name.Lexeme == "Promise")
-                HasObservableMutation = true;
-            base.VisitAssign(expression);
-        }
-
-        protected override void VisitSet(Expr.Set expression)
-        {
-            if (IsPromiseTarget(expression.Object))
-                HasObservableMutation = true;
-            base.VisitSet(expression);
-        }
-
-        protected override void VisitSetIndex(Expr.SetIndex expression)
-        {
-            if (IsPromiseTarget(expression.Object))
-                HasObservableMutation = true;
-            base.VisitSetIndex(expression);
-        }
-
-        protected override void VisitCompoundSet(Expr.CompoundSet expression)
-        {
-            if (IsPromiseTarget(expression.Object))
-                HasObservableMutation = true;
-            base.VisitCompoundSet(expression);
-        }
-
-        protected override void VisitCompoundSetIndex(Expr.CompoundSetIndex expression)
-        {
-            if (IsPromiseTarget(expression.Object))
-                HasObservableMutation = true;
-            base.VisitCompoundSetIndex(expression);
-        }
-
-        protected override void VisitLogicalSet(Expr.LogicalSet expression)
-        {
-            if (IsPromiseTarget(expression.Object))
-                HasObservableMutation = true;
-            base.VisitLogicalSet(expression);
-        }
-
-        protected override void VisitLogicalSetIndex(Expr.LogicalSetIndex expression)
-        {
-            if (IsPromiseTarget(expression.Object))
-                HasObservableMutation = true;
-            base.VisitLogicalSetIndex(expression);
-        }
-
-        protected override void VisitDelete(Expr.Delete expression)
-        {
-            Expr operand = Unwrap(expression.Operand);
-            if (operand is Expr.Get property && IsPromiseTarget(property.Object)
-                || operand is Expr.GetIndex index && IsPromiseTarget(index.Object))
-            {
-                HasObservableMutation = true;
-            }
-            base.VisitDelete(expression);
-        }
-
-        private bool IsPromiseTarget(Expr expression)
-        {
-            expression = Unwrap(expression);
-            return expression is Expr.Variable { Name.Lexeme: "Promise" }
-                || IsPromisePrototype(expression)
-                || _typeMap.Get(expression) is TypeInfo.Promise;
-        }
-
-        private static bool IsPromisePrototype(Expr expression) => Unwrap(expression) is Expr.Get
-        {
-            Optional: false,
-            Object: Expr.Variable { Name.Lexeme: "Promise" },
-            Name.Lexeme: "prototype"
-        };
     }
 }

--- a/src/SharpTS/Compilation/StablePrimitivePromiseThenAnalyzer.cs
+++ b/src/SharpTS/Compilation/StablePrimitivePromiseThenAnalyzer.cs
@@ -16,15 +16,13 @@ internal static class StablePrimitivePromiseThenAnalyzer
     public static void Analyze(
         List<Stmt> program,
         TypeMap? typeMap,
-        ClosureAnalyzer? closures)
+        ClosureAnalyzer? closures,
+        bool hasObservablePromiseMutation)
     {
         if (typeMap is null)
             return;
 
-        var mutationVisitor = new PromiseMutationVisitor(typeMap);
-        foreach (var statement in program)
-            mutationVisitor.Visit(statement);
-        if (mutationVisitor.HasObservableMutation)
+        if (hasObservablePromiseMutation)
             return;
 
         var visitor = new BindingVisitor(typeMap);
@@ -120,7 +118,7 @@ internal static class StablePrimitivePromiseThenAnalyzer
 
     private static bool IsIntrinsicResolveSeed(Expr expression)
     {
-        expression = Unwrap(expression);
+        expression = ExpressionUnwrapper.Unwrap(expression);
         return expression is Expr.Call
         {
             Optional: false,
@@ -131,30 +129,6 @@ internal static class StablePrimitivePromiseThenAnalyzer
                 Name.Lexeme: "resolve"
             }
         };
-    }
-
-    private static Expr Unwrap(Expr expression)
-    {
-        while (true)
-        {
-            switch (expression)
-            {
-                case Expr.Grouping grouping:
-                    expression = grouping.Expression;
-                    continue;
-                case Expr.TypeAssertion assertion:
-                    expression = assertion.Expression;
-                    continue;
-                case Expr.Satisfies satisfies:
-                    expression = satisfies.Expression;
-                    continue;
-                case Expr.NonNullAssertion nonNull:
-                    expression = nonNull.Expression;
-                    continue;
-                default:
-                    return expression;
-            }
-        }
     }
 
     private sealed class BindingVisitor(TypeMap typeMap) : AstVisitorBase
@@ -211,7 +185,7 @@ internal static class StablePrimitivePromiseThenAnalyzer
         protected override void VisitExpression(Stmt.Expression statement)
         {
             var saved = _linearAssignmentStatement;
-            _linearAssignmentStatement = Unwrap(statement.Expr) as Expr.Assign;
+            _linearAssignmentStatement = ExpressionUnwrapper.Unwrap(statement.Expr) as Expr.Assign;
             try
             {
                 Visit(statement.Expr);
@@ -286,7 +260,7 @@ internal static class StablePrimitivePromiseThenAnalyzer
 
         protected override void VisitAwait(Expr.Await expression)
         {
-            if (Unwrap(expression.Expression) is Expr.Variable variable)
+            if (ExpressionUnwrapper.Unwrap(expression.Expression) is Expr.Variable variable)
             {
                 RecordTerminal((_scope, variable.Name.Lexeme));
                 return;
@@ -297,7 +271,7 @@ internal static class StablePrimitivePromiseThenAnalyzer
         protected override void VisitReturn(Stmt.Return statement)
         {
             if (statement.Value is not null
-                && Unwrap(statement.Value) is Expr.Variable variable)
+                && ExpressionUnwrapper.Unwrap(statement.Value) is Expr.Variable variable)
             {
                 RecordTerminal((_scope, variable.Name.Lexeme));
                 return;
@@ -339,113 +313,5 @@ internal static class StablePrimitivePromiseThenAnalyzer
                 Disqualified.Add((_scope, variable.Name.Lexeme));
             base.VisitPostfixIncrement(expression);
         }
-    }
-
-    private sealed class PromiseMutationVisitor(TypeMap typeMap) : AstVisitorBase
-    {
-        private readonly TypeMap _typeMap = typeMap;
-        public bool HasObservableMutation { get; private set; }
-
-        protected override void VisitCall(Expr.Call expression)
-        {
-            if (expression.Callee is Expr.Variable { Name.Lexeme: "eval" })
-                HasObservableMutation = true;
-
-            if (expression.Arguments.Count > 0
-                && expression.Callee is Expr.Get
-                {
-                    Object: Expr.Variable { Name.Lexeme: "Object" or "Reflect" },
-                    Name.Lexeme: "assign" or "defineProperty" or "defineProperties"
-                        or "set" or "deleteProperty" or "setPrototypeOf"
-                }
-                && IsPromiseTarget(expression.Arguments[0]))
-            {
-                HasObservableMutation = true;
-            }
-
-            base.VisitCall(expression);
-        }
-
-        protected override void VisitGet(Expr.Get expression)
-        {
-            if (IsPromisePrototype(expression))
-                HasObservableMutation = true;
-            base.VisitGet(expression);
-        }
-
-        protected override void VisitAssign(Expr.Assign expression)
-        {
-            if (expression.Name.Lexeme == "Promise")
-                HasObservableMutation = true;
-            base.VisitAssign(expression);
-        }
-
-        protected override void VisitSet(Expr.Set expression)
-        {
-            if (IsPromiseTarget(expression.Object))
-                HasObservableMutation = true;
-            base.VisitSet(expression);
-        }
-
-        protected override void VisitSetIndex(Expr.SetIndex expression)
-        {
-            if (IsPromiseTarget(expression.Object))
-                HasObservableMutation = true;
-            base.VisitSetIndex(expression);
-        }
-
-        protected override void VisitCompoundSet(Expr.CompoundSet expression)
-        {
-            if (IsPromiseTarget(expression.Object))
-                HasObservableMutation = true;
-            base.VisitCompoundSet(expression);
-        }
-
-        protected override void VisitCompoundSetIndex(Expr.CompoundSetIndex expression)
-        {
-            if (IsPromiseTarget(expression.Object))
-                HasObservableMutation = true;
-            base.VisitCompoundSetIndex(expression);
-        }
-
-        protected override void VisitLogicalSet(Expr.LogicalSet expression)
-        {
-            if (IsPromiseTarget(expression.Object))
-                HasObservableMutation = true;
-            base.VisitLogicalSet(expression);
-        }
-
-        protected override void VisitLogicalSetIndex(Expr.LogicalSetIndex expression)
-        {
-            if (IsPromiseTarget(expression.Object))
-                HasObservableMutation = true;
-            base.VisitLogicalSetIndex(expression);
-        }
-
-        protected override void VisitDelete(Expr.Delete expression)
-        {
-            Expr operand = Unwrap(expression.Operand);
-            if (operand is Expr.Get property && IsPromiseTarget(property.Object)
-                || operand is Expr.GetIndex index && IsPromiseTarget(index.Object))
-            {
-                HasObservableMutation = true;
-            }
-            base.VisitDelete(expression);
-        }
-
-        private bool IsPromiseTarget(Expr expression)
-        {
-            expression = Unwrap(expression);
-            return expression is Expr.Variable { Name.Lexeme: "Promise" }
-                || IsPromisePrototype(expression)
-                || _typeMap.Get(expression) is TypeInfo.Promise;
-        }
-
-        private static bool IsPromisePrototype(Expr expression) => Unwrap(expression) is Expr.Get
-        {
-            Optional: false,
-            Object: Expr.Variable { Name.Lexeme: "Promise" },
-            Name.Lexeme: "prototype"
-        };
     }
 }

--- a/tests/SharpTS.Tests/CompilerTests/StablePrimitivePromiseThenTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StablePrimitivePromiseThenTests.cs
@@ -32,6 +32,55 @@ public sealed class StablePrimitivePromiseThenTests
         Assert.Equal("45\n", TestHarness.Run(StableSource, mode));
     }
 
+    [Theory]
+    [InlineData("", true)]
+    [InlineData("const ordinary: any = {}; ordinary.value = 1;", true)]
+    [InlineData("eval('');", false)]
+    [InlineData("const prototype: any = Promise.prototype;", false)]
+    [InlineData("(Promise as any).extra = 1;", false)]
+    [InlineData("(Promise as any)['extra'] = 1;", false)]
+    [InlineData("(Promise as any).extra += 1;", false)]
+    [InlineData("(Promise as any)[0] += 1;", false)]
+    [InlineData("(Promise as any).extra ||= 1;", false)]
+    [InlineData("(Promise as any)['extra'] ??= 1;", false)]
+    [InlineData("delete (Promise as any).extra;", false)]
+    [InlineData("delete (Promise as any)['extra'];", false)]
+    [InlineData("Object.assign(Promise, {});", false)]
+    [InlineData("Object.defineProperty(Promise, 'extra', { value: 1 });", false)]
+    [InlineData("Object.defineProperties(Promise, { extra: { value: 1 } });", false)]
+    [InlineData("Reflect.set(Promise, 'extra', 1);", false)]
+    [InlineData("Reflect.deleteProperty(Promise, 'extra');", false)]
+    [InlineData("Object.setPrototypeOf(Promise, {});", false)]
+    [InlineData("const p: Promise<number> = Promise.resolve(0); (p as any).extra = 1;", false)]
+    [InlineData("((Promise as any)!)['extra'] = 1;", false)]
+    [InlineData("((Promise as any) satisfies any).extra = 1;", false)]
+    public void SharedMutationProof_GatesBothPrimitiveOptimizations(string mutation, bool optimized)
+    {
+        string source = mutation + "\n" + StableSource + """
+
+            async function gather(): Promise<number> {
+                const promises: Promise<number>[] = [];
+                promises.push(Promise.resolve(1));
+                const values: number[] = await Promise.all(promises);
+                return values[0];
+            }
+            gather();
+            """;
+
+        Assembly assembly = Compile(source);
+        foreach (string method in new[] { "PromiseThenPrimitive", "PromiseAllPrimitive" })
+            Assert.Equal(optimized, FindCallers(assembly, method).Count > 0);
+    }
+
+    [Fact]
+    public void PromiseReassignment_IsConservativelyRejectedBeforeBindingAnalysis()
+    {
+        // The checker currently rejects assignment to the built-in Promise binding;
+        // keep the mutation proof conservative for ASTs supplied by other callers.
+        var statements = new Parser(new Lexer("Promise = Promise;").ScanTokens()).ParseOrThrow();
+        Assert.True(PromiseMutationAnalyzer.HasObservableMutation(statements, new TypeMap()));
+    }
+
     [Theory, ModeData]
     public void StableNumericHandlerThrow_RejectsOnce(ExecutionMode mode)
     {


### PR DESCRIPTION
The primitive Promise.all and Promise.then optimizations duplicated the same mutation visitor, making it possible for a safety fix to reach only one pass. Both now consume one shared Promise mutation result computed by ILCompiler, removing a redundant AST traversal while preserving their separate binding, capture, feature, and primitive-value checks.

Extract the identical grouping/type-assertion/satisfies/non-null unwrapping loops from the two Promise analyzers, numeric loop capture analyzer, and numeric operand emitter into ExpressionUnwrapper. The extracted visitor and wrapper logic match the originals.

Add a regression matrix that checks both emitted optimization paths for eval, prototype access, property/index writes, compound/logical writes, deletes, Object/Reflect mutations, typed Promise instances, and wrapped targets. Safe programs still optimize. An AST-level case preserves conservative Promise reassignment rejection.

Validation: Release build succeeded; all 944 selected tests passed, with 0 failures and 0 skips. Coverage includes interpreter/compiler Promise behavior, numeric optimizations, standalone DLLs, and IL verification. git diff --check passed. The full solution and external conformance suites were not run.

The initial sandboxed run passed 940 tests but failed four HTTP listener, TLS, and child-process fixtures. The same complete selection passed outside the sandbox.

```powershell
dotnet test tests/SharpTS.Tests/SharpTS.Tests.csproj -c Release --no-restore -m:1 --filter 'FullyQualifiedName~Promise|FullyQualifiedName~StableNumeric|FullyQualifiedName~NumericStorageSafety|FullyQualifiedName~Arithmetic|FullyQualifiedName~ILVerificationTests|FullyQualifiedName~StandaloneDllTests'
```

Fixes #1596.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric expression handling across compiler analyses, including wrapped expressions.
  * Primitive `Promise.then` and `Promise.all` optimizations are now disabled when observable Promise-related mutations could affect behavior.
  * Improved detection of mutations involving Promise properties, prototypes, reflection, reassignment, and deletion.

* **Tests**
  * Added regression coverage for Promise mutation scenarios and conservative handling of built-in Promise reassignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->