### PR TITLE
Extract DNS runtime metadata into a checked feature component

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -164,6 +164,27 @@ Key compiler analyses include module bindings, closure/capture shape, runtime fe
 typed/local representation opportunities, and hosted output. Optimizations may use static type
 facts but must preserve JavaScript object identity, coercion, evaluation order, and exceptions.
 
+### Runtime metadata components
+
+Migrate `EmittedRuntime` metadata one feature family at a time. DNS is the first component:
+`Dns` is null when `UsesDns` is false, and `RequireDns()` reports accidental use of a disabled
+feature. `RuntimeEmitter.EmitAll` creates the component before emission and completes it before
+returning the runtime. Completion validates all required handles and promise wrappers and rejects
+subsequent writes. Consumers can read the component but cannot replace its handles or mutate its
+wrapper registry.
+
+During emission, each handle becomes readable as soon as its declaration is assigned, so forward
+references do not require a method body to exist yet. An early read names the missing declaration.
+Completion is an orchestration boundary, not an IL verifier: body emission and type finalization
+must finish before that boundary. Preserve existing emission order when migrating a family.
+
+Follow this pattern for subsequent families: explicit optional availability, checked declarations,
+one completion boundary, and no retained flat aliases. Pass the component to helpers that only
+need that family's metadata (for example, DNS resolver declaration); retain `EmittedRuntime` where
+cross-feature helpers are needed. These holders belong to the compiler host and must never appear
+as metadata dependencies in guest output. Keep feature gating, emitted signatures, and deployment
+capability recording unchanged.
+
 ### Specialized representations
 
 The compiler may replace ordinary boxed JavaScript storage with generated CLR locals, fields,

--- a/src/SharpTS/Compilation/EmittedDnsRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedDnsRuntime.cs
@@ -1,0 +1,319 @@
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// DNS metadata for one compilation. Handles become readable as they are declared,
+/// before their bodies are emitted; completion freezes the component for consumers.
+/// </summary>
+public sealed class EmittedDnsRuntime
+{
+    internal EmittedDnsRuntime()
+    {
+        PromisesWrapperMethods = new System.Collections.ObjectModel.ReadOnlyDictionary<string, MethodBuilder>(_promiseWrappers);
+    }
+
+    public bool IsComplete { get; private set; }
+
+    private MethodBuilder? _lookup;
+    public MethodBuilder Lookup
+    {
+        get => Require(_lookup);
+        internal set => Set(ref _lookup, value);
+    }
+
+    private MethodBuilder? _getDefaultResultOrder;
+    public MethodBuilder GetDefaultResultOrder
+    {
+        get => Require(_getDefaultResultOrder);
+        internal set => Set(ref _getDefaultResultOrder, value);
+    }
+
+    private MethodBuilder? _setDefaultResultOrder;
+    public MethodBuilder SetDefaultResultOrder
+    {
+        get => Require(_setDefaultResultOrder);
+        internal set => Set(ref _setDefaultResultOrder, value);
+    }
+
+    private MethodBuilder? _lookupService;
+    public MethodBuilder LookupService
+    {
+        get => Require(_lookupService);
+        internal set => Set(ref _lookupService, value);
+    }
+
+    private MethodBuilder? _getLookup;
+    public MethodBuilder GetLookup
+    {
+        get => Require(_getLookup);
+        internal set => Set(ref _getLookup, value);
+    }
+
+    private MethodBuilder? _getLookupService;
+    public MethodBuilder GetLookupService
+    {
+        get => Require(_getLookupService);
+        internal set => Set(ref _getLookupService, value);
+    }
+
+    private MethodBuilder? _resolveRecord;
+    public MethodBuilder ResolveRecord
+    {
+        get => Require(_resolveRecord);
+        internal set => Set(ref _resolveRecord, value);
+    }
+
+    private MethodBuilder? _convertList;
+    public MethodBuilder ConvertList
+    {
+        get => Require(_convertList);
+        internal set => Set(ref _convertList, value);
+    }
+
+    private MethodBuilder? _doQuery;
+    public MethodBuilder DoQuery
+    {
+        get => Require(_doQuery);
+        internal set => Set(ref _doQuery, value);
+    }
+
+    private MethodBuilder? _getTimeoutMs;
+    public MethodBuilder GetTimeoutMs
+    {
+        get => Require(_getTimeoutMs);
+        internal set => Set(ref _getTimeoutMs, value);
+    }
+
+    private MethodBuilder? _parseServerEndpoint;
+    public MethodBuilder ParseServerEndpoint
+    {
+        get => Require(_parseServerEndpoint);
+        internal set => Set(ref _parseServerEndpoint, value);
+    }
+
+    private MethodBuilder? _getSystemDns;
+    public MethodBuilder GetSystemDns
+    {
+        get => Require(_getSystemDns);
+        internal set => Set(ref _getSystemDns, value);
+    }
+
+    private MethodBuilder? _buildQuery;
+    public MethodBuilder BuildQuery
+    {
+        get => Require(_buildQuery);
+        internal set => Set(ref _buildQuery, value);
+    }
+
+    private MethodBuilder? _sendReceive;
+    public MethodBuilder SendReceive
+    {
+        get => Require(_sendReceive);
+        internal set => Set(ref _sendReceive, value);
+    }
+
+    private MethodBuilder? _readName;
+    public MethodBuilder ReadName
+    {
+        get => Require(_readName);
+        internal set => Set(ref _readName, value);
+    }
+
+    private MethodBuilder? _skipName;
+    public MethodBuilder SkipName
+    {
+        get => Require(_skipName);
+        internal set => Set(ref _skipName, value);
+    }
+
+    private MethodBuilder? _parseResponse;
+    public MethodBuilder ParseResponse
+    {
+        get => Require(_parseResponse);
+        internal set => Set(ref _parseResponse, value);
+    }
+
+    private MethodBuilder? _readCharString;
+    public MethodBuilder ReadCharString
+    {
+        get => Require(_readCharString);
+        internal set => Set(ref _readCharString, value);
+    }
+
+    private MethodBuilder? _readUInt32;
+    public MethodBuilder ReadUInt32
+    {
+        get => Require(_readUInt32);
+        internal set => Set(ref _readUInt32, value);
+    }
+
+    private MethodBuilder? _readUInt16;
+    public MethodBuilder ReadUInt16
+    {
+        get => Require(_readUInt16);
+        internal set => Set(ref _readUInt16, value);
+    }
+
+    private MethodBuilder? _parseRecord;
+    public MethodBuilder ParseRecord
+    {
+        get => Require(_parseRecord);
+        internal set => Set(ref _parseRecord, value);
+    }
+
+    private MethodBuilder? _sendViaTcp;
+    public MethodBuilder SendViaTcp
+    {
+        get => Require(_sendViaTcp);
+        internal set => Set(ref _sendViaTcp, value);
+    }
+
+    private MethodBuilder? _readExact;
+    public MethodBuilder ReadExact
+    {
+        get => Require(_readExact);
+        internal set => Set(ref _readExact, value);
+    }
+
+    private MethodBuilder? _encodeName;
+    public MethodBuilder EncodeName
+    {
+        get => Require(_encodeName);
+        internal set => Set(ref _encodeName, value);
+    }
+
+    private MethodBuilder? _getPromisesNamespace;
+    public MethodBuilder GetPromisesNamespace
+    {
+        get => Require(_getPromisesNamespace);
+        internal set => Set(ref _getPromisesNamespace, value);
+    }
+
+    private MethodBuilder? _resolverFactory;
+    public MethodBuilder ResolverFactory
+    {
+        get => Require(_resolverFactory);
+        internal set => Set(ref _resolverFactory, value);
+    }
+
+    private MethodBuilder? _resolverSetServers;
+    public MethodBuilder ResolverSetServers
+    {
+        get => Require(_resolverSetServers);
+        internal set => Set(ref _resolverSetServers, value);
+    }
+
+    private MethodBuilder? _resolverGetServers;
+    public MethodBuilder ResolverGetServers
+    {
+        get => Require(_resolverGetServers);
+        internal set => Set(ref _resolverGetServers, value);
+    }
+
+    private MethodBuilder? _resolverCancel;
+    public MethodBuilder ResolverCancel
+    {
+        get => Require(_resolverCancel);
+        internal set => Set(ref _resolverCancel, value);
+    }
+
+    private MethodBuilder? _resolverGetGeneration;
+    public MethodBuilder ResolverGetGeneration
+    {
+        get => Require(_resolverGetGeneration);
+        internal set => Set(ref _resolverGetGeneration, value);
+    }
+
+    private MethodBuilder? _resolverSetLocalAddress;
+    public MethodBuilder ResolverSetLocalAddress
+    {
+        get => Require(_resolverSetLocalAddress);
+        internal set => Set(ref _resolverSetLocalAddress, value);
+    }
+
+    private MethodBuilder? _resolverResolve;
+    public MethodBuilder ResolverResolve
+    {
+        get => Require(_resolverResolve);
+        internal set => Set(ref _resolverResolve, value);
+    }
+
+    private readonly Dictionary<string, MethodBuilder> _promiseWrappers = new(StringComparer.Ordinal);
+    public IReadOnlyDictionary<string, MethodBuilder> PromisesWrapperMethods { get; }
+
+    internal void RegisterPromiseWrapper(string name, MethodBuilder method)
+    {
+        EnsureMutable();
+        _promiseWrappers.Add(name, method);
+    }
+
+    private static MethodBuilder Require(MethodBuilder? method, [CallerMemberName] string name = "") =>
+        method ?? throw new InvalidOperationException($"DNS metadata '{name}' has not been declared.");
+
+    private void Set(ref MethodBuilder? field, MethodBuilder value)
+    {
+        EnsureMutable();
+        ArgumentNullException.ThrowIfNull(value);
+        field = value;
+    }
+
+    private void EnsureMutable()
+    {
+        if (IsComplete)
+            throw new InvalidOperationException("DNS metadata emission is already complete.");
+    }
+
+    internal void CompleteEmission()
+    {
+        EnsureMutable();
+        _ = Lookup;
+        _ = GetDefaultResultOrder;
+        _ = SetDefaultResultOrder;
+        _ = LookupService;
+        _ = GetLookup;
+        _ = GetLookupService;
+        _ = ResolveRecord;
+        _ = ConvertList;
+        _ = DoQuery;
+        _ = GetTimeoutMs;
+        _ = ParseServerEndpoint;
+        _ = GetSystemDns;
+        _ = BuildQuery;
+        _ = SendReceive;
+        _ = ReadName;
+        _ = SkipName;
+        _ = ParseResponse;
+        _ = ReadCharString;
+        _ = ReadUInt32;
+        _ = ReadUInt16;
+        _ = ParseRecord;
+        _ = SendViaTcp;
+        _ = ReadExact;
+        _ = EncodeName;
+        _ = GetPromisesNamespace;
+        _ = ResolverFactory;
+        _ = ResolverSetServers;
+        _ = ResolverGetServers;
+        _ = ResolverCancel;
+        _ = ResolverGetGeneration;
+        _ = ResolverSetLocalAddress;
+        _ = ResolverResolve;
+        string[] requiredWrappers =
+        [
+            "DnsPromisesResolve4", "DnsPromisesResolve6", "DnsPromisesResolveMx",
+            "DnsPromisesResolveTxt", "DnsPromisesResolveSrv", "DnsPromisesResolveCname",
+            "DnsPromisesResolveNs", "DnsPromisesResolveSoa", "DnsPromisesResolvePtr",
+            "DnsPromisesResolveCaa", "DnsPromisesResolveNaptr", "DnsPromisesLookup",
+            "DnsPromisesLookupService", "DnsPromisesResolve", "DnsPromisesReverse",
+            "DnsResolverResolveAsync"
+        ];
+        foreach (string name in requiredWrappers)
+        {
+            if (!_promiseWrappers.ContainsKey(name))
+                throw new InvalidOperationException($"DNS promise wrapper '{name}' has not been declared.");
+        }
+        IsComplete = true;
+    }
+}

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -2819,48 +2819,18 @@ public class EmittedRuntime
     public MethodBuilder WorkerThreadsSetEnvironmentData { get; set; } = null!;
     public MethodBuilder WorkerThreadsMarkAsUntransferable { get; set; } = null!;
 
-    // DNS module methods
-    public MethodBuilder DnsLookup { get; set; } = null!;
+    /// <summary>DNS metadata, or null when DNS is tree-shaken from this compilation.</summary>
+    public EmittedDnsRuntime? Dns { get; private set; }
 
-    // dns default result order (#1072)
-    public MethodBuilder DnsGetDefaultResultOrder { get; set; } = null!;
-    public MethodBuilder DnsSetDefaultResultOrder { get; set; } = null!;
-    public MethodBuilder DnsLookupService { get; set; } = null!;
-    public MethodBuilder DnsGetLookup { get; set; } = null!;
-    public MethodBuilder DnsGetLookupService { get; set; } = null!;
-    public MethodBuilder DnsResolveRecord { get; set; } = null!;
-    public MethodBuilder DnsConvertList { get; set; } = null!;
-    public MethodBuilder DnsDoQuery { get; set; } = null!;
+    internal void BeginDnsEmission()
+    {
+        if (Dns is not null)
+            throw new InvalidOperationException("DNS metadata emission has already started.");
+        Dns = new EmittedDnsRuntime();
+    }
 
-    // DNS wire protocol helpers (emitted into output assembly)
-    public MethodBuilder DnsGetTimeoutMs { get; set; } = null!;
-    public MethodBuilder DnsParseServerEndpoint { get; set; } = null!;
-    public MethodBuilder DnsGetSystemDns { get; set; } = null!;
-    public MethodBuilder DnsBuildQuery { get; set; } = null!;
-    public MethodBuilder DnsSendReceive { get; set; } = null!;
-    public MethodBuilder DnsReadName { get; set; } = null!;
-    public MethodBuilder DnsSkipName { get; set; } = null!;
-    public MethodBuilder DnsParseResponse { get; set; } = null!;
-    public MethodBuilder DnsReadCharString { get; set; } = null!;
-    public MethodBuilder DnsReadUInt32 { get; set; } = null!;
-    public MethodBuilder DnsReadUInt16 { get; set; } = null!;
-    public MethodBuilder DnsParseRecord { get; set; } = null!;
-    public MethodBuilder DnsSendViaTcp { get; set; } = null!;
-    public MethodBuilder DnsReadExact { get; set; } = null!;
-    public MethodBuilder DnsEncodeName { get; set; } = null!;
-
-    // DNS promises namespace
-    public MethodBuilder DnsGetPromisesNamespace { get; set; } = null!;
-    public Dictionary<string, MethodBuilder> DnsPromisesWrapperMethods { get; set; } = new();
-
-    // DNS Resolver factory
-    public MethodBuilder DnsResolverFactory { get; set; } = null!;
-    public MethodBuilder DnsResolverSetServers { get; set; } = null!;
-    public MethodBuilder DnsResolverGetServers { get; set; } = null!;
-    public MethodBuilder DnsResolverCancel { get; set; } = null!;
-    public MethodBuilder DnsResolverGetGeneration { get; set; } = null!;
-    public MethodBuilder DnsResolverSetLocalAddress { get; set; } = null!;
-    public MethodBuilder DnsResolverResolve { get; set; } = null!;
+    public EmittedDnsRuntime RequireDns() => Dns
+        ?? throw new InvalidOperationException("DNS runtime was not enabled for this compilation.");
 
     // $Stats type - emitted for fs.stat() and related methods
     // Provides Node.js-compatible Stats object with methods like isFile(), isDirectory(), etc.

--- a/src/SharpTS/Compilation/Emitters/Modules/DnsModuleEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/Modules/DnsModuleEmitter.cs
@@ -41,18 +41,18 @@ public sealed class DnsModuleEmitter : IBuiltInModuleEmitter
             "setDefaultResultOrder" => EmitSetDefaultResultOrder(emitter, arguments),
             "getDefaultResultOrder" => EmitGetDefaultResultOrder(emitter),
             "createResolver" => EmitCreateResolver(emitter),
-            "resolverSetServers" => EmitPrimitiveCall(emitter, arguments, emitter.Context.Runtime!.DnsResolverSetServers, 2),
-            "resolverGetServers" => EmitPrimitiveCall(emitter, arguments, emitter.Context.Runtime!.DnsResolverGetServers, 1),
-            "resolverCancel" => EmitPrimitiveCall(emitter, arguments, emitter.Context.Runtime!.DnsResolverCancel, 1),
-            "resolverGetGeneration" => EmitPrimitiveCall(emitter, arguments, emitter.Context.Runtime!.DnsResolverGetGeneration, 1),
-            "resolverSetLocalAddress" => EmitPrimitiveCall(emitter, arguments, emitter.Context.Runtime!.DnsResolverSetLocalAddress, 3),
+            "resolverSetServers" => EmitPrimitiveCall(emitter, arguments, emitter.Context.Runtime!.RequireDns().ResolverSetServers, 2),
+            "resolverGetServers" => EmitPrimitiveCall(emitter, arguments, emitter.Context.Runtime!.RequireDns().ResolverGetServers, 1),
+            "resolverCancel" => EmitPrimitiveCall(emitter, arguments, emitter.Context.Runtime!.RequireDns().ResolverCancel, 1),
+            "resolverGetGeneration" => EmitPrimitiveCall(emitter, arguments, emitter.Context.Runtime!.RequireDns().ResolverGetGeneration, 1),
+            "resolverSetLocalAddress" => EmitPrimitiveCall(emitter, arguments, emitter.Context.Runtime!.RequireDns().ResolverSetLocalAddress, 3),
             _ => false
         };
     }
 
     private static bool EmitCreateResolver(IEmitterContext emitter)
     {
-        emitter.Context.IL.Emit(OpCodes.Call, emitter.Context.Runtime!.DnsResolverFactory);
+        emitter.Context.IL.Emit(OpCodes.Call, emitter.Context.Runtime!.RequireDns().ResolverFactory);
         return true;
     }
 
@@ -93,7 +93,7 @@ public sealed class DnsModuleEmitter : IBuiltInModuleEmitter
         {
             il.Emit(OpCodes.Ldnull);
         }
-        il.Emit(OpCodes.Call, ctx.Runtime!.DnsSetDefaultResultOrder);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireDns().SetDefaultResultOrder);
         return true;
     }
 
@@ -101,7 +101,7 @@ public sealed class DnsModuleEmitter : IBuiltInModuleEmitter
     private static bool EmitGetDefaultResultOrder(IEmitterContext emitter)
     {
         var ctx = emitter.Context;
-        ctx.IL.Emit(OpCodes.Call, ctx.Runtime!.DnsGetDefaultResultOrder);
+        ctx.IL.Emit(OpCodes.Call, ctx.Runtime!.RequireDns().GetDefaultResultOrder);
         return true;
     }
 
@@ -151,7 +151,7 @@ public sealed class DnsModuleEmitter : IBuiltInModuleEmitter
     {
         var ctx = emitter.Context;
         var il = ctx.IL;
-        il.Emit(OpCodes.Call, ctx.Runtime!.DnsGetPromisesNamespace);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireDns().GetPromisesNamespace);
         return true;
     }
 
@@ -159,7 +159,7 @@ public sealed class DnsModuleEmitter : IBuiltInModuleEmitter
     {
         var ctx = emitter.Context;
         var il = ctx.IL;
-        il.Emit(OpCodes.Call, ctx.Runtime!.DnsGetLookup);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireDns().GetLookup);
         return true;
     }
 
@@ -167,7 +167,7 @@ public sealed class DnsModuleEmitter : IBuiltInModuleEmitter
     {
         var ctx = emitter.Context;
         var il = ctx.IL;
-        il.Emit(OpCodes.Call, ctx.Runtime!.DnsGetLookupService);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireDns().GetLookupService);
         return true;
     }
 
@@ -224,8 +224,8 @@ public sealed class DnsModuleEmitter : IBuiltInModuleEmitter
             il.Emit(OpCodes.Ldnull);
         }
 
-        // Call $Runtime.DnsLookup(hostname, options)
-        il.Emit(OpCodes.Call, ctx.Runtime!.DnsLookup);
+        // Call $Runtime.RequireDns().Lookup(hostname, options)
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireDns().Lookup);
 
         return true;
     }
@@ -260,8 +260,8 @@ public sealed class DnsModuleEmitter : IBuiltInModuleEmitter
             il.Emit(OpCodes.Ldnull);
         }
 
-        // Call $Runtime.DnsLookupService(address, port)
-        il.Emit(OpCodes.Call, ctx.Runtime!.DnsLookupService);
+        // Call $Runtime.RequireDns().LookupService(address, port)
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireDns().LookupService);
 
         return true;
     }

--- a/src/SharpTS/Compilation/Emitters/Modules/DnsPromisesModuleEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/Modules/DnsPromisesModuleEmitter.cs
@@ -66,7 +66,7 @@ public sealed class DnsPromisesModuleEmitter : IBuiltInModuleEmitter
         {
             il.Emit(OpCodes.Ldnull);
         }
-        il.Emit(OpCodes.Call, ctx.Runtime!.DnsSetDefaultResultOrder);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireDns().SetDefaultResultOrder);
         return true;
     }
 
@@ -74,7 +74,7 @@ public sealed class DnsPromisesModuleEmitter : IBuiltInModuleEmitter
     private static bool EmitGetDefaultResultOrder(IEmitterContext emitter)
     {
         var ctx = emitter.Context;
-        ctx.IL.Emit(OpCodes.Call, ctx.Runtime!.DnsGetDefaultResultOrder);
+        ctx.IL.Emit(OpCodes.Call, ctx.Runtime!.RequireDns().GetDefaultResultOrder);
         return true;
     }
 
@@ -93,7 +93,7 @@ public sealed class DnsPromisesModuleEmitter : IBuiltInModuleEmitter
         }
 
         // Wrappers already return $Promise (they call WrapTaskAsPromise internally)
-        il.Emit(OpCodes.Call, ctx.Runtime!.DnsPromisesWrapperMethods[runtimeMethod]);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireDns().PromisesWrapperMethods[runtimeMethod]);
         return true;
     }
 
@@ -122,7 +122,7 @@ public sealed class DnsPromisesModuleEmitter : IBuiltInModuleEmitter
             il.Emit(OpCodes.Ldnull);
 
         // Wrapper already calls WrapTaskAsPromise internally
-        il.Emit(OpCodes.Call, ctx.Runtime!.DnsPromisesWrapperMethods["DnsPromisesLookup"]);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireDns().PromisesWrapperMethods["DnsPromisesLookup"]);
         return true;
     }
 
@@ -144,7 +144,7 @@ public sealed class DnsPromisesModuleEmitter : IBuiltInModuleEmitter
             }
         }
 
-        il.Emit(OpCodes.Call, ctx.Runtime!.DnsPromisesWrapperMethods["DnsPromisesLookupService"]);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireDns().PromisesWrapperMethods["DnsPromisesLookupService"]);
         return true;
     }
 
@@ -171,7 +171,7 @@ public sealed class DnsPromisesModuleEmitter : IBuiltInModuleEmitter
             il.Emit(OpCodes.Stelem_Ref);
         }
 
-        il.Emit(OpCodes.Call, ctx.Runtime!.DnsPromisesWrapperMethods["DnsResolverResolveAsync"]);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireDns().PromisesWrapperMethods["DnsResolverResolveAsync"]);
         return true;
     }
 
@@ -200,7 +200,7 @@ public sealed class DnsPromisesModuleEmitter : IBuiltInModuleEmitter
             il.Emit(OpCodes.Ldnull);
 
         // Wrapper already calls WrapTaskAsPromise internally
-        il.Emit(OpCodes.Call, ctx.Runtime!.DnsPromisesWrapperMethods["DnsPromisesResolve"]);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireDns().PromisesWrapperMethods["DnsPromisesResolve"]);
         return true;
     }
 }

--- a/src/SharpTS/Compilation/RuntimeEmitter.Dns.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Dns.cs
@@ -79,7 +79,7 @@ public partial class RuntimeEmitter
                 _types.Object,
                 Type.EmptyTypes
             );
-            runtime.DnsGetDefaultResultOrder = method;
+            runtime.RequireDns().GetDefaultResultOrder = method;
             runtime.RegisterBuiltInModuleMethod("dns", "getDefaultResultOrder", method);
             runtime.RegisterBuiltInModuleMethod("dns/promises", "getDefaultResultOrder", method);
 
@@ -102,7 +102,7 @@ public partial class RuntimeEmitter
                 _types.Object,
                 [_types.Object]
             );
-            runtime.DnsSetDefaultResultOrder = method;
+            runtime.RequireDns().SetDefaultResultOrder = method;
             runtime.RegisterBuiltInModuleMethod("dns", "setDefaultResultOrder", method);
             runtime.RegisterBuiltInModuleMethod("dns/promises", "setDefaultResultOrder", method);
 
@@ -189,7 +189,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object, _types.Object]
         );
-        runtime.DnsLookup = method;
+        runtime.RequireDns().Lookup = method;
 
         var il = method.GetILGenerator();
 
@@ -473,7 +473,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object, _types.Object]
         );
-        runtime.DnsLookupService = method;
+        runtime.RequireDns().LookupService = method;
 
         var il = method.GetILGenerator();
 
@@ -636,7 +636,7 @@ public partial class RuntimeEmitter
         // Call DnsLookup(hostname, options)
         il.Emit(OpCodes.Ldloc, hostnameLocal);
         il.Emit(OpCodes.Ldloc, optionsLocal);
-        il.Emit(OpCodes.Call, runtime.DnsLookup);
+        il.Emit(OpCodes.Call, runtime.RequireDns().Lookup);
         il.Emit(OpCodes.Ret);
 
         // Now create the getter method that returns a TSFunction
@@ -646,7 +646,7 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.DnsGetLookup = getterMethod;
+        runtime.RequireDns().GetLookup = getterMethod;
 
         var getterIl = getterMethod.GetILGenerator();
 
@@ -714,7 +714,7 @@ public partial class RuntimeEmitter
         // Call DnsLookupService(address, port)
         il.Emit(OpCodes.Ldloc, addressLocal);
         il.Emit(OpCodes.Ldloc, portLocal);
-        il.Emit(OpCodes.Call, runtime.DnsLookupService);
+        il.Emit(OpCodes.Call, runtime.RequireDns().LookupService);
         il.Emit(OpCodes.Ret);
 
         // Now create the getter method that returns a TSFunction
@@ -724,7 +724,7 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.DnsGetLookupService = getterMethod;
+        runtime.RequireDns().GetLookupService = getterMethod;
 
         var getterIl = getterMethod.GetILGenerator();
 
@@ -749,7 +749,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object]);
-        runtime.DnsResolveRecord = method;
+        runtime.RequireDns().ResolveRecord = method;
 
         var il = method.GetILGenerator();
 
@@ -832,7 +832,7 @@ public partial class RuntimeEmitter
         il.MarkLabel(soaLabel);
         il.Emit(OpCodes.Ldloc, hostnameLocal);
         il.Emit(OpCodes.Ldc_I4, qtSOA);
-        il.Emit(OpCodes.Call, runtime.DnsDoQuery);
+        il.Emit(OpCodes.Call, runtime.RequireDns().DoQuery);
         // SOA returns a Dictionary<string, object?> directly, wrap as $Object
         il.Emit(OpCodes.Castclass, _types.DictionaryStringObject);
         il.Emit(OpCodes.Call, runtime.CreateObject);
@@ -888,12 +888,12 @@ public partial class RuntimeEmitter
     {
         il.Emit(OpCodes.Ldloc, hostnameLocal);
         il.Emit(OpCodes.Ldc_I4, queryType);
-        il.Emit(OpCodes.Call, runtime.DnsDoQuery);
+        il.Emit(OpCodes.Call, runtime.RequireDns().DoQuery);
         // DnsDoQuery returns List<object?> for non-SOA types
         il.Emit(OpCodes.Castclass, _types.ListOfObject);
         if (wrapWithConvertList)
         {
-            il.Emit(OpCodes.Call, runtime.DnsConvertList);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ConvertList);
         }
         else
         {
@@ -1015,7 +1015,7 @@ public partial class RuntimeEmitter
             il.MarkLabel(qLoopTop);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldloc, offArrLocal);
-            il.Emit(OpCodes.Call, runtime.DnsSkipName);
+            il.Emit(OpCodes.Call, runtime.RequireDns().SkipName);
             il.Emit(OpCodes.Ldloc, offArrLocal);
             il.Emit(OpCodes.Ldc_I4_0);
             il.Emit(OpCodes.Ldloc, offArrLocal);
@@ -1048,7 +1048,7 @@ public partial class RuntimeEmitter
             il.MarkLabel(aLoopTop);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldloc, offArrLocal);
-            il.Emit(OpCodes.Call, runtime.DnsSkipName);
+            il.Emit(OpCodes.Call, runtime.RequireDns().SkipName);
 
             // off = offArr[0]
             il.Emit(OpCodes.Ldloc, offArrLocal);
@@ -1120,7 +1120,7 @@ public partial class RuntimeEmitter
                 il.Emit(OpCodes.Stelem_I4);
                 il.Emit(OpCodes.Ldarg_0);
                 il.Emit(OpCodes.Ldloc, nameOffLocal);
-                il.Emit(OpCodes.Call, runtime.DnsReadName);
+                il.Emit(OpCodes.Call, runtime.RequireDns().ReadName);
                 il.Emit(OpCodes.Stloc, resultLocal);
             }
             il.MarkLabel(notCname);
@@ -1163,7 +1163,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.String, _types.Int32]);
-        runtime.DnsDoQuery = method;
+        runtime.RequireDns().DoQuery = method;
 
         var il = method.GetILGenerator();
         var nameLocal = il.DeclareLocal(_types.String);
@@ -1185,12 +1185,12 @@ public partial class RuntimeEmitter
         // byte[] query = DnsBuildQuery(name, queryType)
         il.Emit(OpCodes.Ldloc, nameLocal);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.DnsBuildQuery);
+        il.Emit(OpCodes.Call, runtime.RequireDns().BuildQuery);
         il.Emit(OpCodes.Stloc, queryLocal);
 
         // byte[] response = DnsSendReceive(query)
         il.Emit(OpCodes.Ldloc, queryLocal);
-        il.Emit(OpCodes.Call, runtime.DnsSendReceive);
+        il.Emit(OpCodes.Call, runtime.RequireDns().SendReceive);
         il.Emit(OpCodes.Stloc, responseLocal);
 
         // CNAME chase (#1073): A(1)/AAAA(28) only, bounded depth 8
@@ -1230,7 +1230,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, responseLocal);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.DnsParseResponse);
+        il.Emit(OpCodes.Call, runtime.RequireDns().ParseResponse);
         il.Emit(OpCodes.Ret);
     }
 
@@ -1245,7 +1245,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Int32,
             [typeof(byte[]), typeof(int[])]);
-        runtime.DnsReadUInt16 = method;
+        runtime.RequireDns().ReadUInt16 = method;
 
         var il = method.GetILGenerator();
 
@@ -1295,7 +1295,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Int32,
             [typeof(byte[]), typeof(int[])]);
-        runtime.DnsReadUInt32 = method;
+        runtime.RequireDns().ReadUInt32 = method;
 
         var il = method.GetILGenerator();
 
@@ -1366,7 +1366,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.String,
             [typeof(byte[]), typeof(int[])]);
-        runtime.DnsReadCharString = method;
+        runtime.RequireDns().ReadCharString = method;
 
         var il = method.GetILGenerator();
 
@@ -1425,7 +1425,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             typeof(void),
             [typeof(System.Net.Sockets.NetworkStream), typeof(byte[]), _types.Int32, _types.Int32]);
-        runtime.DnsReadExact = method;
+        runtime.RequireDns().ReadExact = method;
 
         var il = method.GetILGenerator();
 
@@ -1456,7 +1456,7 @@ public partial class RuntimeEmitter
 
         // if (!readTask.Wait(DnsGetTimeoutMs())) throw SocketException(TimedOut)
         il.Emit(OpCodes.Ldloc, readTaskLocal);
-        il.Emit(OpCodes.Call, runtime.DnsGetTimeoutMs);
+        il.Emit(OpCodes.Call, runtime.RequireDns().GetTimeoutMs);
         il.Emit(OpCodes.Callvirt, typeof(Task).GetMethod("Wait", [_types.Int32])!);
         var waitOkLabel = il.DefineLabel();
         il.Emit(OpCodes.Brtrue, waitOkLabel);
@@ -1515,7 +1515,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             typeof(void),
             [typeof(List<byte>), _types.String]);
-        runtime.DnsEncodeName = method;
+        runtime.RequireDns().EncodeName = method;
 
         var il = method.GetILGenerator();
 
@@ -1600,7 +1600,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.String,
             [typeof(byte[]), typeof(int[])]);
-        runtime.DnsReadName = method;
+        runtime.RequireDns().ReadName = method;
 
         var il = method.GetILGenerator();
 
@@ -1787,7 +1787,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             typeof(void),
             [typeof(byte[]), typeof(int[])]);
-        runtime.DnsSkipName = method;
+        runtime.RequireDns().SkipName = method;
 
         var il = method.GetILGenerator();
 
@@ -1879,7 +1879,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Int32,
             Type.EmptyTypes);
-        runtime.DnsGetTimeoutMs = method;
+        runtime.RequireDns().GetTimeoutMs = method;
 
         var il = method.GetILGenerator();
 
@@ -1928,7 +1928,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             typeof(IPEndPoint),
             [_types.String]);
-        runtime.DnsParseServerEndpoint = method;
+        runtime.RequireDns().ParseServerEndpoint = method;
 
         var il = method.GetILGenerator();
 
@@ -1966,7 +1966,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.String,
             Type.EmptyTypes);
-        runtime.DnsGetSystemDns = method;
+        runtime.RequireDns().GetSystemDns = method;
 
         var il = method.GetILGenerator();
 
@@ -2167,7 +2167,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             typeof(byte[]),
             [_types.String, _types.Int32]);
-        runtime.DnsBuildQuery = method;
+        runtime.RequireDns().BuildQuery = method;
 
         var il = method.GetILGenerator();
 
@@ -2230,7 +2230,7 @@ public partial class RuntimeEmitter
         // EncodeName(packet, hostname)
         il.Emit(OpCodes.Ldloc, packetLocal);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.DnsEncodeName);
+        il.Emit(OpCodes.Call, runtime.RequireDns().EncodeName);
 
         // QTYPE (2 bytes, big-endian)
         il.Emit(OpCodes.Ldloc, packetLocal);
@@ -2279,7 +2279,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             typeof(byte[]),
             [typeof(byte[]), _types.String]);
-        runtime.DnsSendViaTcp = method;
+        runtime.RequireDns().SendViaTcp = method;
 
         var il = method.GetILGenerator();
 
@@ -2289,7 +2289,7 @@ public partial class RuntimeEmitter
         // var endpoint = DnsParseServerEndpoint(server) — handles "host" and "host:port"
         var endpointLocal = il.DeclareLocal(typeof(IPEndPoint));
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.DnsParseServerEndpoint);
+        il.Emit(OpCodes.Call, runtime.RequireDns().ParseServerEndpoint);
         il.Emit(OpCodes.Stloc, endpointLocal);
 
         // using var tcp = new TcpClient()
@@ -2301,7 +2301,7 @@ public partial class RuntimeEmitter
 
         // tcp.SendTimeout = DnsGetTimeoutMs()
         il.Emit(OpCodes.Ldloc, tcpLocal);
-        il.Emit(OpCodes.Call, runtime.DnsGetTimeoutMs);
+        il.Emit(OpCodes.Call, runtime.RequireDns().GetTimeoutMs);
         il.Emit(OpCodes.Callvirt, typeof(TcpClient).GetProperty("SendTimeout")!.GetSetMethod()!);
 
         // tcp.ConnectAsync(endpoint.Address, endpoint.Port).WaitAsync(TimeSpan.FromMilliseconds(DnsGetTimeoutMs())).GetAwaiter().GetResult()
@@ -2312,7 +2312,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, typeof(IPEndPoint).GetProperty("Port")!.GetGetMethod()!);
         il.Emit(OpCodes.Callvirt, typeof(TcpClient).GetMethod("ConnectAsync", [typeof(IPAddress), _types.Int32])!);
         // Task.WaitAsync(TimeSpan) for reliable timeout
-        il.Emit(OpCodes.Call, runtime.DnsGetTimeoutMs);
+        il.Emit(OpCodes.Call, runtime.RequireDns().GetTimeoutMs);
         il.Emit(OpCodes.Conv_R8);
         il.Emit(OpCodes.Call, typeof(TimeSpan).GetMethod("FromMilliseconds", [typeof(double)])!);
         il.Emit(OpCodes.Callvirt, typeof(Task).GetMethod("WaitAsync", [typeof(TimeSpan)])!);
@@ -2389,7 +2389,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, respLenBufLocal);
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Ldc_I4_2);
-        il.Emit(OpCodes.Call, runtime.DnsReadExact);
+        il.Emit(OpCodes.Call, runtime.RequireDns().ReadExact);
 
         // int respLen = (respLenBuf[0] << 8) | respLenBuf[1]
         var respLenLocal = il.DeclareLocal(_types.Int32);
@@ -2414,7 +2414,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Ldloc, respLenLocal);
-        il.Emit(OpCodes.Call, runtime.DnsReadExact);
+        il.Emit(OpCodes.Call, runtime.RequireDns().ReadExact);
 
         il.Emit(OpCodes.Leave, returnLabel);
 
@@ -2447,19 +2447,19 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             typeof(byte[]),
             [typeof(byte[])]);
-        runtime.DnsSendReceive = method;
+        runtime.RequireDns().SendReceive = method;
 
         var il = method.GetILGenerator();
 
         // string dnsServer = DnsGetSystemDns()
         var serverLocal = il.DeclareLocal(_types.String); // 0
-        il.Emit(OpCodes.Call, runtime.DnsGetSystemDns);
+        il.Emit(OpCodes.Call, runtime.RequireDns().GetSystemDns);
         il.Emit(OpCodes.Stloc, serverLocal);
 
         // var endpoint = DnsParseServerEndpoint(server) — handles "host" and "host:port"
         var endpointLocal = il.DeclareLocal(typeof(IPEndPoint)); // 1
         il.Emit(OpCodes.Ldloc, serverLocal);
-        il.Emit(OpCodes.Call, runtime.DnsParseServerEndpoint);
+        il.Emit(OpCodes.Call, runtime.RequireDns().ParseServerEndpoint);
         il.Emit(OpCodes.Stloc, endpointLocal);
 
         // byte[] result = null
@@ -2491,7 +2491,7 @@ public partial class RuntimeEmitter
         // udp.Client.SendTimeout = DnsGetTimeoutMs()
         il.Emit(OpCodes.Ldloc, udpLocal);
         il.Emit(OpCodes.Callvirt, typeof(UdpClient).GetProperty("Client")!.GetGetMethod()!);
-        il.Emit(OpCodes.Call, runtime.DnsGetTimeoutMs);
+        il.Emit(OpCodes.Call, runtime.RequireDns().GetTimeoutMs);
         il.Emit(OpCodes.Callvirt, typeof(Socket).GetProperty("SendTimeout")!.GetSetMethod()!);
 
         // udp.Send(query, query.Length, endpoint)
@@ -2531,7 +2531,7 @@ public partial class RuntimeEmitter
 
         // if (!task.Wait(DnsGetTimeoutMs())) { udp.Close(); throw SocketException(TimedOut); }
         il.Emit(OpCodes.Ldloc, taskLocal);
-        il.Emit(OpCodes.Call, runtime.DnsGetTimeoutMs);
+        il.Emit(OpCodes.Call, runtime.RequireDns().GetTimeoutMs);
         il.Emit(OpCodes.Callvirt, typeof(Task).GetMethod("Wait", [_types.Int32])!);
         var waitOkLabel = il.DefineLabel();
         il.Emit(OpCodes.Brtrue, waitOkLabel);
@@ -2615,7 +2615,7 @@ public partial class RuntimeEmitter
         var rcodeCheckLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldloc, serverLocal);
-        il.Emit(OpCodes.Call, runtime.DnsSendViaTcp);
+        il.Emit(OpCodes.Call, runtime.RequireDns().SendViaTcp);
         il.Emit(OpCodes.Stloc, resultLocal);
         il.Emit(OpCodes.Br, rcodeCheckLabel);
 
@@ -2713,7 +2713,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [typeof(byte[]), typeof(int[]), _types.Int32, _types.Int32, _types.Int32]);
-        runtime.DnsParseRecord = method;
+        runtime.RequireDns().ParseRecord = method;
 
         var il = method.GetILGenerator();
 
@@ -2856,13 +2856,13 @@ public partial class RuntimeEmitter
         {
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadUInt16);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadUInt16);
             var prefLocal = il.DeclareLocal(_types.Int32);
             il.Emit(OpCodes.Stloc, prefLocal);
 
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadName);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadName);
             var exchangeLocal = il.DeclareLocal(_types.String);
             il.Emit(OpCodes.Stloc, exchangeLocal);
 
@@ -2971,25 +2971,25 @@ public partial class RuntimeEmitter
             var priorityLocal = il.DeclareLocal(_types.Int32);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadUInt16);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadUInt16);
             il.Emit(OpCodes.Stloc, priorityLocal);
 
             var weightLocal = il.DeclareLocal(_types.Int32);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadUInt16);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadUInt16);
             il.Emit(OpCodes.Stloc, weightLocal);
 
             var portLocal = il.DeclareLocal(_types.Int32);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadUInt16);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadUInt16);
             il.Emit(OpCodes.Stloc, portLocal);
 
             var targetLocal = il.DeclareLocal(_types.String);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadName);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadName);
             il.Emit(OpCodes.Stloc, targetLocal);
 
             il.Emit(OpCodes.Newobj, dictCtor);
@@ -3026,7 +3026,7 @@ public partial class RuntimeEmitter
         {
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadName);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadName);
             il.Emit(OpCodes.Stloc, resultLocal);
             EmitSetOffsetToRdataEnd(il);
             il.Emit(OpCodes.Br, returnLabel);
@@ -3037,7 +3037,7 @@ public partial class RuntimeEmitter
         {
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadName);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadName);
             il.Emit(OpCodes.Stloc, resultLocal);
             EmitSetOffsetToRdataEnd(il);
             il.Emit(OpCodes.Br, returnLabel);
@@ -3049,43 +3049,43 @@ public partial class RuntimeEmitter
             var mnameLocal = il.DeclareLocal(_types.String);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadName);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadName);
             il.Emit(OpCodes.Stloc, mnameLocal);
 
             var rnameLocal = il.DeclareLocal(_types.String);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadName);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadName);
             il.Emit(OpCodes.Stloc, rnameLocal);
 
             var serialLocal = il.DeclareLocal(_types.Int32);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadUInt32);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadUInt32);
             il.Emit(OpCodes.Stloc, serialLocal);
 
             var refreshLocal = il.DeclareLocal(_types.Int32);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadUInt32);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadUInt32);
             il.Emit(OpCodes.Stloc, refreshLocal);
 
             var retryLocal = il.DeclareLocal(_types.Int32);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadUInt32);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadUInt32);
             il.Emit(OpCodes.Stloc, retryLocal);
 
             var expireLocal = il.DeclareLocal(_types.Int32);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadUInt32);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadUInt32);
             il.Emit(OpCodes.Stloc, expireLocal);
 
             var minimumLocal = il.DeclareLocal(_types.Int32);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadUInt32);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadUInt32);
             il.Emit(OpCodes.Stloc, minimumLocal);
 
             il.Emit(OpCodes.Newobj, dictCtor);
@@ -3124,7 +3124,7 @@ public partial class RuntimeEmitter
         {
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadName);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadName);
             il.Emit(OpCodes.Stloc, resultLocal);
             EmitSetOffsetToRdataEnd(il);
             il.Emit(OpCodes.Br, returnLabel);
@@ -3237,37 +3237,37 @@ public partial class RuntimeEmitter
             var orderLocal = il.DeclareLocal(_types.Int32);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadUInt16);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadUInt16);
             il.Emit(OpCodes.Stloc, orderLocal);
 
             var prefLocal = il.DeclareLocal(_types.Int32);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadUInt16);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadUInt16);
             il.Emit(OpCodes.Stloc, prefLocal);
 
             var naptrFlagsLocal = il.DeclareLocal(_types.String);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadCharString);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadCharString);
             il.Emit(OpCodes.Stloc, naptrFlagsLocal);
 
             var serviceLocal = il.DeclareLocal(_types.String);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadCharString);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadCharString);
             il.Emit(OpCodes.Stloc, serviceLocal);
 
             var regexpLocal = il.DeclareLocal(_types.String);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadCharString);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadCharString);
             il.Emit(OpCodes.Stloc, regexpLocal);
 
             var replacementLocal = il.DeclareLocal(_types.String);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsReadName);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ReadName);
             il.Emit(OpCodes.Stloc, replacementLocal);
 
             il.Emit(OpCodes.Newobj, dictCtor);
@@ -3350,7 +3350,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [typeof(byte[]), _types.Int32, _types.String]);
-        runtime.DnsParseResponse = method;
+        runtime.RequireDns().ParseResponse = method;
 
         var il = method.GetILGenerator();
 
@@ -3503,7 +3503,7 @@ public partial class RuntimeEmitter
         il.MarkLabel(qLoopStart);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldloc, offsetLocal);
-        il.Emit(OpCodes.Call, runtime.DnsSkipName);
+        il.Emit(OpCodes.Call, runtime.RequireDns().SkipName);
         // offset[0] += 4 (QTYPE + QCLASS)
         il.Emit(OpCodes.Ldloc, offsetLocal);
         il.Emit(OpCodes.Ldc_I4_0);
@@ -3540,7 +3540,7 @@ public partial class RuntimeEmitter
         // SkipName(data, offset)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldloc, offsetLocal);
-        il.Emit(OpCodes.Call, runtime.DnsSkipName);
+        il.Emit(OpCodes.Call, runtime.RequireDns().SkipName);
 
         // int type = (data[offset[0]] << 8) | data[offset[0] + 1]
         var typeLocal = il.DeclareLocal(_types.Int32); // 9
@@ -3639,7 +3639,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, typeLocal);
         il.Emit(OpCodes.Ldloc, rdlengthLocal);
         il.Emit(OpCodes.Ldloc, rdataStartLocal);
-        il.Emit(OpCodes.Call, runtime.DnsParseRecord);
+        il.Emit(OpCodes.Call, runtime.RequireDns().ParseRecord);
         var recordLocal = il.DeclareLocal(_types.Object); // 12
         il.Emit(OpCodes.Stloc, recordLocal);
 
@@ -3737,7 +3737,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.ListOfObject]);
-        runtime.DnsConvertList = method;
+        runtime.RequireDns().ConvertList = method;
 
         var il = method.GetILGenerator();
 
@@ -3862,7 +3862,7 @@ public partial class RuntimeEmitter
         // hosts-file lookup), mirroring the interpreter. Returns a $Array of IP strings.
         il.Emit(OpCodes.Ldarg_0); // hostname (object)
         il.Emit(OpCodes.Ldstr, family == 4 ? "A" : "AAAA");
-        il.Emit(OpCodes.Call, runtime.DnsResolveRecord);
+        il.Emit(OpCodes.Call, runtime.RequireDns().ResolveRecord);
         il.Emit(OpCodes.Stloc, resultLocal);
 
         // callback.Invoke([null, result])
@@ -3990,7 +3990,7 @@ public partial class RuntimeEmitter
 
         il.Emit(OpCodes.Ldarg_0); // hostname
         il.Emit(OpCodes.Ldloc, rrtypeLocal); // rrtype
-        il.Emit(OpCodes.Call, runtime.DnsResolveRecord);
+        il.Emit(OpCodes.Call, runtime.RequireDns().ResolveRecord);
         var recordResultLocal = il.DeclareLocal(_types.Object);
         il.Emit(OpCodes.Stloc, recordResultLocal);
 
@@ -4053,7 +4053,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Pop);          // drop null
         il.Emit(OpCodes.Ldstr, "A");   // default rrtype
         il.MarkLabel(haveRrtypeLabel);
-        il.Emit(OpCodes.Call, runtime.DnsResolveRecord);
+        il.Emit(OpCodes.Call, runtime.RequireDns().ResolveRecord);
         var resultLocal = il.DeclareLocal(_types.Object);
         il.Emit(OpCodes.Stloc, resultLocal);
 
@@ -4368,7 +4368,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldfld, hostnameField);
             il.Emit(OpCodes.Castclass, _types.String);
             il.Emit(OpCodes.Ldstr, rrtype);
-            il.Emit(OpCodes.Call, runtime.DnsResolveRecord);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ResolveRecord);
             il.Emit(OpCodes.Stfld, resultField);
             il.Emit(OpCodes.Leave, afterTry);
 
@@ -4404,6 +4404,6 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitDnsResolverFactory(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        EmitDnsResolverFactoryMethod(typeBuilder, runtime);
+        EmitDnsResolverFactoryMethod(typeBuilder, runtime.RequireDns());
     }
 }

--- a/src/SharpTS/Compilation/RuntimeEmitter.DnsPromises.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.DnsPromises.cs
@@ -35,8 +35,6 @@ public partial class RuntimeEmitter
 
     private void EmitDnsPromisesMethods(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        runtime.DnsPromisesWrapperMethods = new Dictionary<string, MethodBuilder>();
-
         // Emit display classes for closures
         EmitDnsDisplayClass1(typeBuilder.Module as ModuleBuilder ?? throw new Exception("need ModuleBuilder"));
         EmitDnsDisplayClass2(typeBuilder.Module as ModuleBuilder ?? throw new Exception("need ModuleBuilder"));
@@ -64,7 +62,7 @@ public partial class RuntimeEmitter
             {
                 il.Emit(OpCodes.Ldarg_0); // hostname
                 il.Emit(OpCodes.Ldstr, rrtype);
-                il.Emit(OpCodes.Call, runtime.DnsResolveRecord);
+                il.Emit(OpCodes.Call, runtime.RequireDns().ResolveRecord);
             });
             EmitDnsAsyncWrapper1(typeBuilder, runtime, methodName, syncHelper);
         }
@@ -74,7 +72,7 @@ public partial class RuntimeEmitter
         {
             il.Emit(OpCodes.Ldarg_0); // hostname
             il.Emit(OpCodes.Ldarg_1); // options
-            il.Emit(OpCodes.Call, runtime.DnsLookup);
+            il.Emit(OpCodes.Call, runtime.RequireDns().Lookup);
         });
         EmitDnsAsyncWrapper2(typeBuilder, runtime, "DnsPromisesLookup", lookupSync);
 
@@ -83,7 +81,7 @@ public partial class RuntimeEmitter
         {
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.DnsLookupService);
+            il.Emit(OpCodes.Call, runtime.RequireDns().LookupService);
         });
         EmitDnsAsyncWrapper2(typeBuilder, runtime, "DnsPromisesLookupService", lookupServiceSync);
 
@@ -92,7 +90,7 @@ public partial class RuntimeEmitter
         {
             il.Emit(OpCodes.Ldarg_0); // hostname
             il.Emit(OpCodes.Ldarg_1); // rrtype (already defaulted in wrapper)
-            il.Emit(OpCodes.Call, runtime.DnsResolveRecord);
+            il.Emit(OpCodes.Call, runtime.RequireDns().ResolveRecord);
         });
         EmitDnsAsyncWrapper2(typeBuilder, runtime, "DnsPromisesResolve", resolveSync);
 
@@ -121,7 +119,7 @@ public partial class RuntimeEmitter
         // Resolver queries use the same event-loop-aware Task.Run path. The sync
         // target late-binds to the shared DnsResolverInstance state in SharpTS.dll;
         // its single object[] request carries state/method/identifier/rrtype.
-        EmitDnsAsyncWrapper1(typeBuilder, runtime, "DnsResolverResolveAsync", runtime.DnsResolverResolve);
+        EmitDnsAsyncWrapper1(typeBuilder, runtime, "DnsResolverResolveAsync", runtime.RequireDns().ResolverResolve);
 
         // Namespace getter for dns.promises sub-property
         EmitDnsGetPromisesNamespace(typeBuilder, runtime);
@@ -505,7 +503,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.WrapTaskAsPromise);
         il.Emit(OpCodes.Ret);
 
-        runtime.DnsPromisesWrapperMethods[methodName] = wrapper;
+        runtime.RequireDns().RegisterPromiseWrapper(methodName, wrapper);
     }
 
     /// <summary>
@@ -564,7 +562,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.WrapTaskAsPromise);
         il.Emit(OpCodes.Ret);
 
-        runtime.DnsPromisesWrapperMethods[methodName] = wrapper;
+        runtime.RequireDns().RegisterPromiseWrapper(methodName, wrapper);
     }
 
     /// <summary>
@@ -578,7 +576,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             Type.EmptyTypes);
-        runtime.DnsGetPromisesNamespace = method;
+        runtime.RequireDns().GetPromisesNamespace = method;
 
         var il = method.GetILGenerator();
 
@@ -614,7 +612,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldstr, jsName);
 
             il.Emit(OpCodes.Ldnull);
-            il.Emit(OpCodes.Ldtoken, runtime.DnsPromisesWrapperMethods[wrapperKey]);
+            il.Emit(OpCodes.Ldtoken, runtime.RequireDns().PromisesWrapperMethods[wrapperKey]);
             il.Emit(OpCodes.Call, typeof(MethodBase).GetMethod("GetMethodFromHandle", [typeof(RuntimeMethodHandle)])!);
             il.Emit(OpCodes.Castclass, typeof(MethodInfo));
             il.Emit(OpCodes.Newobj, runtime.TSFunctionCtor);

--- a/src/SharpTS/Compilation/RuntimeEmitter.DnsResolver.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.DnsResolver.cs
@@ -12,14 +12,14 @@ public partial class RuntimeEmitter
     /// Emits resolver state/configuration helpers plus the synchronous reflection
     /// target that the shared DNS async runner wraps as a Promise.
     /// </summary>
-    private void EmitDnsResolverFactoryMethod(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitDnsResolverFactoryMethod(TypeBuilder typeBuilder, EmittedDnsRuntime dns)
     {
-        runtime.DnsResolverFactory = EmitReflectionHelper(typeBuilder, "DnsCreateResolverState", 0);
-        runtime.DnsResolverSetServers = EmitReflectionHelper(typeBuilder, "DnsResolverSetServers", 2);
-        runtime.DnsResolverGetServers = EmitReflectionHelper(typeBuilder, "DnsResolverGetServers", 1);
-        runtime.DnsResolverCancel = EmitReflectionHelper(typeBuilder, "DnsResolverCancel", 1);
-        runtime.DnsResolverGetGeneration = EmitReflectionHelper(typeBuilder, "DnsResolverGetGeneration", 1);
-        runtime.DnsResolverSetLocalAddress = EmitReflectionHelper(typeBuilder, "DnsResolverSetLocalAddress", 3);
-        runtime.DnsResolverResolve = EmitReflectionHelper(typeBuilder, "DnsResolverResolve", 1);
+        dns.ResolverFactory = EmitReflectionHelper(typeBuilder, "DnsCreateResolverState", 0);
+        dns.ResolverSetServers = EmitReflectionHelper(typeBuilder, "DnsResolverSetServers", 2);
+        dns.ResolverGetServers = EmitReflectionHelper(typeBuilder, "DnsResolverGetServers", 1);
+        dns.ResolverCancel = EmitReflectionHelper(typeBuilder, "DnsResolverCancel", 1);
+        dns.ResolverGetGeneration = EmitReflectionHelper(typeBuilder, "DnsResolverGetGeneration", 1);
+        dns.ResolverSetLocalAddress = EmitReflectionHelper(typeBuilder, "DnsResolverSetLocalAddress", 3);
+        dns.ResolverResolve = EmitReflectionHelper(typeBuilder, "DnsResolverResolve", 1);
     }
 }

--- a/src/SharpTS/Compilation/RuntimeEmitter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.cs
@@ -40,6 +40,8 @@ public partial class RuntimeEmitter
         if (_emitHosted)
             _features.UsesPromise = true;
         var runtime = new EmittedRuntime();
+        if (features.UsesDns)
+            runtime.BeginDnsEmission();
 
         // Emit $Undefined singleton class first (other methods need this type)
         EmitUndefinedClass(moduleBuilder, runtime);
@@ -603,6 +605,7 @@ public partial class RuntimeEmitter
             EmitBoundDHMethodFinalize(runtime);
         }
 
+        runtime.Dns?.CompleteEmission();
         return runtime;
     }
 }

--- a/tests/SharpTS.Tests/CompilerTests/EmittedDnsRuntimeTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/EmittedDnsRuntimeTests.cs
@@ -1,0 +1,84 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public class EmittedDnsRuntimeTests
+{
+    [Fact]
+    public void DnsAndPromiseConsumersPassILVerification()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { lookup, Resolver, getDefaultResultOrder } from 'dns';
+                import { resolve4 } from 'dns/promises';
+                console.log(getDefaultResultOrder());
+                console.log(lookup('localhost'));
+                const resolver = new Resolver();
+                resolver.setServers(['127.0.0.1']);
+                resolve4('localhost').then(value => console.log(value));
+                """
+        };
+        Assert.Empty(TestHarness.CompileModulesAndVerifyOnly(files, "main.ts"));
+    }
+
+    [Fact]
+    public void DisabledFeatureHasNoMetadataAndReportsAccidentalUse()
+    {
+        var runtime = EmitRuntime(false);
+        Assert.Null(runtime.Dns);
+        Assert.Contains("not enabled", Assert.Throws<InvalidOperationException>(runtime.RequireDns).Message);
+        Assert.DoesNotContain(runtime.RuntimeType.GetMethods(), method => method.Name.StartsWith("Dns", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DeclaredHandleCanBeUsedBeforeBodyEmission()
+    {
+        var runtime = new EmittedRuntime();
+        runtime.BeginDnsEmission();
+        var dns = runtime.RequireDns();
+        Assert.False(dns.IsComplete);
+        Assert.Contains("Lookup", Assert.Throws<InvalidOperationException>(() => dns.Lookup).Message);
+
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName("dns_forward"), typeof(object).Assembly);
+        var type = assembly.DefineDynamicModule("main").DefineType("Runtime");
+        var method = type.DefineMethod("Lookup", MethodAttributes.Public | MethodAttributes.Static, typeof(void), Type.EmptyTypes);
+        dns.Lookup = method;
+        Assert.Same(method, dns.Lookup);
+        Assert.Throws<InvalidOperationException>(runtime.BeginDnsEmission);
+        Assert.Contains("GetDefaultResultOrder", Assert.Throws<InvalidOperationException>(dns.CompleteEmission).Message);
+        Assert.False(dns.IsComplete);
+    }
+
+    [Fact]
+    public void EnabledFeatureCompletesAllHandlesAndRejectsFurtherWrites()
+    {
+        var dns = EmitRuntime(true).RequireDns();
+        Assert.True(dns.IsComplete);
+        Assert.Equal("DnsLookup", dns.Lookup.Name);
+        Assert.Equal(16, dns.PromisesWrapperMethods.Count);
+        Assert.All(typeof(EmittedDnsRuntime).GetProperties()
+            .Where(property => property.PropertyType == typeof(MethodBuilder)),
+            property => Assert.NotNull(property.GetValue(dns)));
+        Assert.Throws<InvalidOperationException>(() => dns.Lookup = dns.Lookup);
+        Assert.Throws<InvalidOperationException>(() => dns.RegisterPromiseWrapper("extra", dns.Lookup));
+        Assert.Throws<InvalidOperationException>(dns.CompleteEmission);
+        var dictionary = Assert.IsAssignableFrom<IDictionary<string, MethodBuilder>>(dns.PromisesWrapperMethods);
+        Assert.Throws<NotSupportedException>(() => dictionary.Add("extra", dns.Lookup));
+    }
+
+    private static EmittedRuntime EmitRuntime(bool usesDns)
+    {
+        var statements = new Parser(new Lexer("console.log(1);").ScanTokens()).ParseOrThrow();
+        var features = new RuntimeFeatureDetector().Detect(statements);
+        features.UsesDns = usesDns;
+        features.UsesPromise = usesDns;
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName($"dns_metadata_{Guid.NewGuid():N}"), typeof(object).Assembly);
+        return new RuntimeEmitter(TypeProvider.Runtime).EmitAll(assembly.DefineDynamicModule("main"), features);
+    }
+}


### PR DESCRIPTION
DNS metadata was spread across 33 mutable properties on EmittedRuntime, with callers relying on null-forgiving initialization and implicit feature availability. Move those handles and the promise-wrapper registry into EmittedDnsRuntime and remove the old flat properties.

The component is absent when DNS is tree-shaken. Declared handles remain available for forward references before body emission; premature access names the missing declaration. Runtime emission validates the complete handle set and wrapper registry before returning, then rejects further writes. Resolver declaration now takes the DNS component directly. Preserve emission order, emitted signatures, and deployment requirements.

Document the migration pattern in ARCHITECTURE.md. This is the first bounded feature migration for #1599; the issue remains open for subsequent families.

Validation:
- Release build succeeded.
- All 309 focused tests passed (0 failed, 0 skipped), covering DNS interpreter/compiler parity and transport, feature gating, lifecycle checks, DNS-specific and existing IL verification, and standalone output without SharpTS.dll.
- git diff --cached --check passed; no unrelated worktree changes.
- The initial sandboxed run hit existing TLS authentication and VM subprocess timeout failures. The final complete selection passed outside the sandbox with normal Windows cryptographic/subprocess access. Restore reported NU1900 vulnerability-feed warnings. The full solution suite was not run.

```powershell
dotnet test tests/SharpTS.Tests/SharpTS.Tests.csproj -c Release --no-restore -m:1 --filter 'FullyQualifiedName~EmittedDnsRuntimeTests|FullyQualifiedName~Dns|FullyQualifiedName~ILVerificationTests|FullyQualifiedName~StandaloneDllTests|FullyQualifiedName~PromiseRuntimeFeatureGatingTests'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation and consistency for DNS and `dns/promises` runtime support.
  - Prevented invalid or incomplete DNS runtime configurations from being used.
  - Preserved existing DNS lookup, resolver, record parsing, and promise behavior.

- **Refactor**
  - Consolidated DNS runtime handling into a dedicated component.
  - Improved support for DNS feature gating and forward references during compilation.

- **Tests**
  - Added coverage for DNS and `dns/promises` compilation, disabled features, initialization, and runtime metadata integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->