### PR TITLE
Extract descriptor receiver handling and class signature collection

### DIFF
--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.cs
@@ -21,33 +21,11 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
     }
 
-    /// <summary>
-    /// Emits Object.defineProperty(obj, prop, descriptor) - defines or modifies a property.
-    /// Signature: object ObjectDefineProperty(object obj, object prop, object descriptor)
-    /// Creates a $CompiledPropertyDescriptor and registers it in the emitted $PropertyDescriptorStore.
-    /// </summary>
-    private void EmitObjectDefineProperty(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    // These stages require an empty evaluation stack and leave it empty on fallthrough.
+    // Receiver branches own their labels and return from the emitted method when handled;
+    // the caller owns shared locals and preserves dispatch/coercion order.
+    private void EmitDefinePropertyReceiverValidation(ILGenerator il, EmittedRuntime runtime)
     {
-        var method = typeBuilder.DefineMethod(
-            "ObjectDefineProperty",
-            MethodAttributes.Public | MethodAttributes.Static,
-            _types.Object,
-            [_types.Object, _types.Object, _types.Object]
-        );
-        runtime.ObjectDefineProperty = method;
-
-        var il = method.GetILGenerator();
-
-        // Emit standalone property descriptor creation and registration
-        // This avoids any runtime dependency on SharpTS.dll
-
-        var descriptorLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
-        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
-        var propNameLocal = il.DeclareLocal(_types.String);
-        var valueLocal = il.DeclareLocal(_types.Object);
-        var notDictLabel = il.DefineLabel();
-        var setDescriptorDoneLabel = il.DefineLabel();
-
         // ECMA-262 §20.1.2.4 step 1: If Type(O) is not Object, throw TypeError.
         // Covers null/undefined/primitives. test262 15.2.3.6-{1-*}.js verify.
         var primitiveThrowLabel = il.DefineLabel();
@@ -77,7 +55,10 @@ public partial class RuntimeEmitter
         il.MarkLabel(primitiveThrowLabel);
         GuestErrorEmitter.ThrowTypeError(il, runtime, "Object.defineProperty called on non-object");
         il.MarkLabel(skipTypeThrowLabel);
+    }
 
+    private void EmitDefinePropertySymbolReceiver(ILGenerator il, EmittedRuntime runtime, MethodBuilder method, LocalBuilder descriptorLocal)
+    {
         // Symbol-keyed properties live in the object's symbol dictionary. Normalize
         // the supplied descriptor through this same method using an ephemeral
         // string-keyed holder, then store the resulting compiled descriptor. This
@@ -132,17 +113,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(notSymbolLabel);
+    }
 
-        // propName = $Runtime.ToJsString(prop) — ECMA-262 §7.1.19 ToPropertyKey
-        // string path via the spec-shaped ToString. Avoids the prop.ToString()
-        // Callvirt-on-null NRE for `Object.defineProperty(obj, null, ...)`,
-        // and unlike runtime.Stringify (which produces debug "[1, 2]" form for
-        // arrays) honors `Array.prototype.toString` join semantics so
-        // `defineProperty(obj, [1], ...)` lands at key "1" (matches V8/SM).
-        il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.ToJsString);
-        il.Emit(OpCodes.Stloc, propNameLocal);
-
+    private void EmitDefinePropertyProxyReceiver(ILGenerator il, EmittedRuntime runtime, MethodBuilder method, LocalBuilder propNameLocal)
+    {
         // Proxy [[DefineOwnProperty]] dispatch. The callback lets the runtime
         // proxy forward a missing trap to the emitted target representation.
         var notProxyForDefineLabel = il.DefineLabel();
@@ -203,6 +177,50 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notProxyForDefineLabel);
+    }
+
+    /// <summary>
+    /// Emits Object.defineProperty(obj, prop, descriptor) - defines or modifies a property.
+    /// Signature: object ObjectDefineProperty(object obj, object prop, object descriptor)
+    /// Creates a $CompiledPropertyDescriptor and registers it in the emitted $PropertyDescriptorStore.
+    /// </summary>
+    private void EmitObjectDefineProperty(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        var method = typeBuilder.DefineMethod(
+            "ObjectDefineProperty",
+            MethodAttributes.Public | MethodAttributes.Static,
+            _types.Object,
+            [_types.Object, _types.Object, _types.Object]
+        );
+        runtime.ObjectDefineProperty = method;
+
+        var il = method.GetILGenerator();
+
+        // Emit standalone property descriptor creation and registration
+        // This avoids any runtime dependency on SharpTS.dll
+
+        var descriptorLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
+        var dictLocal = il.DeclareLocal(_types.DictionaryStringObject);
+        var propNameLocal = il.DeclareLocal(_types.String);
+        var valueLocal = il.DeclareLocal(_types.Object);
+        var notDictLabel = il.DefineLabel();
+        var setDescriptorDoneLabel = il.DefineLabel();
+
+        EmitDefinePropertyReceiverValidation(il, runtime);
+
+        EmitDefinePropertySymbolReceiver(il, runtime, method, descriptorLocal);
+
+        // propName = $Runtime.ToJsString(prop) — ECMA-262 §7.1.19 ToPropertyKey
+        // string path via the spec-shaped ToString. Avoids the prop.ToString()
+        // Callvirt-on-null NRE for `Object.defineProperty(obj, null, ...)`,
+        // and unlike runtime.Stringify (which produces debug "[1, 2]" form for
+        // arrays) honors `Array.prototype.toString` join semantics so
+        // `defineProperty(obj, [1], ...)` lands at key "1" (matches V8/SM).
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.ToJsString);
+        il.Emit(OpCodes.Stloc, propNameLocal);
+
+        EmitDefinePropertyProxyReceiver(il, runtime, method, propNameLocal);
 
         // ECMA-262 10.4.2.4 ArraySetLength steps 3-4: newLen =
         // ToUint32(Desc.[[Value]]), numberLen = ToNumber(Desc.[[Value]]) —

--- a/src/SharpTS/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/src/SharpTS/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -63,6 +63,220 @@ public partial class TypeChecker
         }
     }
 
+    // Helper to build a TypeInfo.Function from a method declaration
+    private TypeInfo.Function BuildDeclaredClassMethodType(Stmt.Function method)
+    {
+        var (paramTypes, requiredParams, hasRest, paramNames) = BuildFunctionSignature(
+            method.Parameters,
+            validateDefaults: true,
+            contextName: $"method '{method.Name.Lexeme}'"
+        );
+
+        TypeInfo returnType = ResolveAnnotation(method.ReturnType, method.ReturnTypeNode)
+            ?? TypeInfo.Inferred.Shared;
+
+        // Wrap return type for generator/async generator methods (skip when inferring)
+        if (method.ReturnType != null && method.IsGenerator)
+        {
+            if (method.IsAsync && returnType is not TypeInfo.AsyncGenerator)
+            {
+                returnType = new TypeInfo.AsyncGenerator(returnType);
+            }
+            else if (!method.IsAsync && returnType is not TypeInfo.Generator)
+            {
+                returnType = new TypeInfo.Generator(returnType);
+            }
+        }
+
+        TypeInfo? explicitThisType = ResolveAnnotation(method.ThisType, method.ThisTypeNode);
+        return new TypeInfo.Function(
+            paramTypes, returnType, requiredParams, hasRest, explicitThisType, paramNames);
+    }
+
+    // Signature collection runs in the caller-owned class type environment and populates
+    // the supplied class metadata. Diagnostic recovery and scope restoration remain
+    // owned by CheckClassDeclaration, including when collection throws.
+    private void CollectComputedClassMethodSignatures(Stmt.Class classStmt, TypeInfo.MutableClass mutableClass)
+    {
+        // Computed symbol-keyed methods (`[Symbol.iterator]() {...}`) are modeled under their canonical
+        // well-known-symbol member name (@@iterator, @@asyncIterator, …) so structural iterability and
+        // member lookup see them (#592/#485). They carry the synthetic `<computed>` name, so they are
+        // pulled out of the name-keyed overload grouping below and grouped here instead by (IsStatic,
+        // canonical name) — running the SAME overload/duplicate-implementation/static-consistency
+        // validation string-named methods get, rather than silently "last one wins" registration.
+        // Arbitrary computed keys (e.g. `[v]()`) aren't statically named members and are skipped
+        // (still parsed/checked, just untyped — like computed accessors).
+        var computedMethodGroups = classStmt.Methods
+            .Where(m => m.ComputedKey != null)
+            .Select(m => (Method: m, Name: TryGetWellKnownSymbolMemberName(m.ComputedKey)))
+            .Where(x => x.Name != null)
+            // Grouped by canonical NAME ONLY (not IsStatic too): the static-consistency check
+            // below needs static AND instance declarations of the same name in one group to
+            // compare them against each other — grouping by (IsStatic, Name) would silently
+            // split a static/instance mismatch into two single-member groups that never meet.
+            .GroupBy(x => x.Name!)
+            .ToList();
+
+        foreach (var group in computedMethodGroups)
+        {
+            string memberName = group.Key;
+            var members = group.Select(x => x.Method).ToList();
+
+            // TS2387/TS2388: tsc requires every declaration in an overload group to agree on
+            // static-ness. It compares consecutive pairs in source order and reports the mismatch
+            // at the LATER member, choosing the message from the EARLIER member's own static-ness
+            // ("must be static" when the earlier one was static, "must not be static" otherwise) —
+            // verified against symbolProperty42's exact (line, code) pairs.
+            for (int i = 1; i < members.Count; i++)
+            {
+                if (members[i - 1].IsStatic != members[i].IsStatic)
+                {
+                    var (msg, code) = members[i - 1].IsStatic
+                        ? (" Function overload must be static.", "TS2387")
+                        : (" Function overload must not be static.", "TS2388");
+                    RecordTypeError(new TypeCheckException(msg, line: members[i].Name.Line, tsCode: code));
+                }
+            }
+
+            var signatures = members.Where(m => m.Body == null && !m.IsAbstract).ToList();
+            var implementations = members.Where(m => m.Body != null).ToList();
+
+            if (implementations.Count > 1)
+            {
+                // tsc flags EVERY declaration in the group once a second implementation appears —
+                // signatures included, not just the implementations.
+                foreach (var m in members)
+                    RecordTypeError(new TypeCheckException(" Duplicate function implementation.", line: m.Name.Line, tsCode: "TS2393"));
+            }
+            else if (implementations.Count == 0 && signatures.Count > 0)
+            {
+                RecordTypeError(new TypeCheckException(
+                    " Function implementation is missing or not immediately following the declaration.",
+                    line: members[^1].Name.Line, tsCode: "TS2391"));
+            }
+
+            // Register the group's type from the single implementation when there is exactly one
+            // (the common, error-free case), else the last declaration as a best-effort fallback so
+            // an error'd group still gets SOME type. Build the factory signature WITHOUT the
+            // generator-return wrapping BuildDeclaredClassMethodType applies: a [Symbol.iterator]()/
+            // [Symbol.asyncIterator]() factory must return the iterator type itself (e.g.
+            // `Iterator<number>` — what for...of consumes and reads its element from), not
+            // Generator<Iterator<number>>. An un-annotated generator factory stays <inferred> here
+            // and is filled in by the inferred-return post-pass below as Generator<yieldType>.
+            var representative = implementations.Count == 1 ? implementations[0] : members[^1];
+            var (cParamTypes, cRequired, cHasRest, cParamNames) = BuildFunctionSignature(
+                representative.Parameters, validateDefaults: true, contextName: $"method '{memberName}'");
+            TypeInfo factoryReturn = ResolveAnnotation(representative.ReturnType, representative.ReturnTypeNode) ?? TypeInfo.Inferred.Shared;
+            var funcType = new TypeInfo.Function(cParamTypes, factoryReturn, cRequired, cHasRest, null, cParamNames);
+            if (representative.IsStatic)
+                mutableClass.StaticMethods[memberName] = funcType;
+            else
+                mutableClass.Methods[memberName] = funcType;
+            (representative.IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[memberName] = representative.Access;
+        }
+    }
+
+    private void CollectNamedClassMethodSignatures(Stmt.Class classStmt, TypeInfo.MutableClass mutableClass)
+    {
+        // First pass: collect signatures, grouping overloads
+        // Group methods by name to detect overloads (computed-key methods handled above)
+        var methodGroups = classStmt.Methods.Where(m => m.ComputedKey == null).GroupBy(m => (m.IsStatic, Name: m.Name.Lexeme)).ToList();
+
+        foreach (var group in methodGroups)
+        {
+            string methodName = group.Key.Name;
+            var methods = group.ToList();
+
+            // Separate overload signatures (null body) from implementations
+            var signatures = methods.Where(m => m.Body == null && !m.IsAbstract).ToList();
+            var implementations = methods.Where(m => m.Body != null).ToList();
+            var abstractDecls = methods.Where(m => m.IsAbstract).ToList();
+
+            // Handle abstract methods (no body, but marked abstract)
+            if (abstractDecls.Count > 0)
+            {
+                if (abstractDecls.Count > 1)
+                {
+                    throw new TypeCheckException($" Cannot have multiple abstract declarations for method '{methodName}'.", tsCode: "TS2516");
+                }
+                var abstractMethod = abstractDecls[0];
+                var funcType = BuildDeclaredClassMethodType(abstractMethod);
+
+                if (abstractMethod.IsStatic)
+                    mutableClass.StaticMethods[methodName] = funcType;
+                else
+                    mutableClass.Methods[methodName] = funcType;
+
+                (abstractMethod.IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[methodName] = abstractMethod.Access;
+                mutableClass.AbstractMethods.Add(methodName);
+                continue;
+            }
+
+            // Handle overloaded methods
+            if (signatures.Count > 0)
+            {
+                if (implementations.Count == 0)
+                {
+                    throw new TypeCheckException($" Overloaded method '{methodName}' has no implementation.", tsCode: "TS2391");
+                }
+                if (implementations.Count > 1)
+                {
+                    throw new TypeCheckException($" Overloaded method '{methodName}' has multiple implementations.", tsCode: "TS2393");
+                }
+
+                var implementation = implementations[0];
+                var signatureTypes = signatures.Select(BuildDeclaredClassMethodType).ToList();
+                var implType = BuildDeclaredClassMethodType(implementation);
+
+                // Validate implementation is compatible with all signatures
+                foreach (var sig in signatureTypes)
+                {
+                    if (implType.MinArity > sig.MinArity)
+                    {
+                        throw new TypeCheckException($" Implementation of '{methodName}' requires {implType.MinArity} arguments but overload signature requires only {sig.MinArity}.", tsCode: "TS2394");
+                    }
+                }
+
+                var overloadedFunc = new TypeInfo.OverloadedFunction(signatureTypes, implType);
+
+                if (implementation.IsStatic)
+                    mutableClass.StaticMethods[methodName] = overloadedFunc;
+                else
+                    mutableClass.Methods[methodName] = overloadedFunc;
+
+                (implementation.IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[methodName] = implementation.Access;
+            }
+            else if (implementations.Count == 1)
+            {
+                // Single non-overloaded method
+                var method = implementations[0];
+                var funcType = BuildDeclaredClassMethodType(method);
+
+                // Handle ES2022 private methods (#method)
+                if (method.IsPrivate)
+                {
+                    if (method.IsStatic)
+                        mutableClass.StaticPrivateMethods[methodName] = funcType;
+                    else
+                        mutableClass.PrivateMethods[methodName] = funcType;
+                }
+                else
+                {
+                    if (method.IsStatic)
+                        mutableClass.StaticMethods[methodName] = funcType;
+                    else
+                        mutableClass.Methods[methodName] = funcType;
+
+                    (method.IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[methodName] = method.Access;
+                }
+            }
+            else if (implementations.Count > 1)
+            {
+                throw new TypeCheckException($" Multiple implementations of method '{methodName}' without overload signatures.", tsCode: "TS2393");
+            }
+        }
+    }
+
     private void CheckClassDeclaration(Stmt.Class classStmt)
     {
         bool previousRecoveryMode = _recoveryMode;
@@ -163,210 +377,9 @@ public partial class TypeChecker
             }
         }
 
-        // Helper to build a TypeInfo.Function from a method declaration
-        TypeInfo.Function BuildMethodFuncType(Stmt.Function method)
-        {
-            var (paramTypes, requiredParams, hasRest, paramNames) = BuildFunctionSignature(
-                method.Parameters,
-                validateDefaults: true,
-                contextName: $"method '{method.Name.Lexeme}'"
-            );
+        CollectComputedClassMethodSignatures(classStmt, mutableClass);
 
-            TypeInfo returnType = ResolveAnnotation(method.ReturnType, method.ReturnTypeNode)
-                ?? TypeInfo.Inferred.Shared;
-
-            // Wrap return type for generator/async generator methods (skip when inferring)
-            if (method.ReturnType != null && method.IsGenerator)
-            {
-                if (method.IsAsync && returnType is not TypeInfo.AsyncGenerator)
-                {
-                    returnType = new TypeInfo.AsyncGenerator(returnType);
-                }
-                else if (!method.IsAsync && returnType is not TypeInfo.Generator)
-                {
-                    returnType = new TypeInfo.Generator(returnType);
-                }
-            }
-
-            TypeInfo? explicitThisType = ResolveAnnotation(method.ThisType, method.ThisTypeNode);
-            return new TypeInfo.Function(
-                paramTypes, returnType, requiredParams, hasRest, explicitThisType, paramNames);
-        }
-
-        // Computed symbol-keyed methods (`[Symbol.iterator]() {...}`) are modeled under their canonical
-        // well-known-symbol member name (@@iterator, @@asyncIterator, …) so structural iterability and
-        // member lookup see them (#592/#485). They carry the synthetic `<computed>` name, so they are
-        // pulled out of the name-keyed overload grouping below and grouped here instead by (IsStatic,
-        // canonical name) — running the SAME overload/duplicate-implementation/static-consistency
-        // validation string-named methods get, rather than silently "last one wins" registration.
-        // Arbitrary computed keys (e.g. `[v]()`) aren't statically named members and are skipped
-        // (still parsed/checked, just untyped — like computed accessors).
-        var computedMethodGroups = classStmt.Methods
-            .Where(m => m.ComputedKey != null)
-            .Select(m => (Method: m, Name: TryGetWellKnownSymbolMemberName(m.ComputedKey)))
-            .Where(x => x.Name != null)
-            // Grouped by canonical NAME ONLY (not IsStatic too): the static-consistency check
-            // below needs static AND instance declarations of the same name in one group to
-            // compare them against each other — grouping by (IsStatic, Name) would silently
-            // split a static/instance mismatch into two single-member groups that never meet.
-            .GroupBy(x => x.Name!)
-            .ToList();
-
-        foreach (var group in computedMethodGroups)
-        {
-            string memberName = group.Key;
-            var members = group.Select(x => x.Method).ToList();
-
-            // TS2387/TS2388: tsc requires every declaration in an overload group to agree on
-            // static-ness. It compares consecutive pairs in source order and reports the mismatch
-            // at the LATER member, choosing the message from the EARLIER member's own static-ness
-            // ("must be static" when the earlier one was static, "must not be static" otherwise) —
-            // verified against symbolProperty42's exact (line, code) pairs.
-            for (int i = 1; i < members.Count; i++)
-            {
-                if (members[i - 1].IsStatic != members[i].IsStatic)
-                {
-                    var (msg, code) = members[i - 1].IsStatic
-                        ? (" Function overload must be static.", "TS2387")
-                        : (" Function overload must not be static.", "TS2388");
-                    RecordTypeError(new TypeCheckException(msg, line: members[i].Name.Line, tsCode: code));
-                }
-            }
-
-            var signatures = members.Where(m => m.Body == null && !m.IsAbstract).ToList();
-            var implementations = members.Where(m => m.Body != null).ToList();
-
-            if (implementations.Count > 1)
-            {
-                // tsc flags EVERY declaration in the group once a second implementation appears —
-                // signatures included, not just the implementations.
-                foreach (var m in members)
-                    RecordTypeError(new TypeCheckException(" Duplicate function implementation.", line: m.Name.Line, tsCode: "TS2393"));
-            }
-            else if (implementations.Count == 0 && signatures.Count > 0)
-            {
-                RecordTypeError(new TypeCheckException(
-                    " Function implementation is missing or not immediately following the declaration.",
-                    line: members[^1].Name.Line, tsCode: "TS2391"));
-            }
-
-            // Register the group's type from the single implementation when there is exactly one
-            // (the common, error-free case), else the last declaration as a best-effort fallback so
-            // an error'd group still gets SOME type. Build the factory signature WITHOUT the
-            // generator-return wrapping BuildMethodFuncType applies: a [Symbol.iterator]()/
-            // [Symbol.asyncIterator]() factory must return the iterator type itself (e.g.
-            // `Iterator<number>` — what for...of consumes and reads its element from), not
-            // Generator<Iterator<number>>. An un-annotated generator factory stays <inferred> here
-            // and is filled in by the inferred-return post-pass below as Generator<yieldType>.
-            var representative = implementations.Count == 1 ? implementations[0] : members[^1];
-            var (cParamTypes, cRequired, cHasRest, cParamNames) = BuildFunctionSignature(
-                representative.Parameters, validateDefaults: true, contextName: $"method '{memberName}'");
-            TypeInfo factoryReturn = ResolveAnnotation(representative.ReturnType, representative.ReturnTypeNode) ?? TypeInfo.Inferred.Shared;
-            var funcType = new TypeInfo.Function(cParamTypes, factoryReturn, cRequired, cHasRest, null, cParamNames);
-            if (representative.IsStatic)
-                mutableClass.StaticMethods[memberName] = funcType;
-            else
-                mutableClass.Methods[memberName] = funcType;
-            (representative.IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[memberName] = representative.Access;
-        }
-
-        // First pass: collect signatures, grouping overloads
-        // Group methods by name to detect overloads (computed-key methods handled above)
-        var methodGroups = classStmt.Methods.Where(m => m.ComputedKey == null).GroupBy(m => (m.IsStatic, Name: m.Name.Lexeme)).ToList();
-
-        foreach (var group in methodGroups)
-        {
-            string methodName = group.Key.Name;
-            var methods = group.ToList();
-
-            // Separate overload signatures (null body) from implementations
-            var signatures = methods.Where(m => m.Body == null && !m.IsAbstract).ToList();
-            var implementations = methods.Where(m => m.Body != null).ToList();
-            var abstractDecls = methods.Where(m => m.IsAbstract).ToList();
-
-            // Handle abstract methods (no body, but marked abstract)
-            if (abstractDecls.Count > 0)
-            {
-                if (abstractDecls.Count > 1)
-                {
-                    throw new TypeCheckException($" Cannot have multiple abstract declarations for method '{methodName}'.", tsCode: "TS2516");
-                }
-                var abstractMethod = abstractDecls[0];
-                var funcType = BuildMethodFuncType(abstractMethod);
-
-                if (abstractMethod.IsStatic)
-                    mutableClass.StaticMethods[methodName] = funcType;
-                else
-                    mutableClass.Methods[methodName] = funcType;
-
-                (abstractMethod.IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[methodName] = abstractMethod.Access;
-                mutableClass.AbstractMethods.Add(methodName);
-                continue;
-            }
-
-            // Handle overloaded methods
-            if (signatures.Count > 0)
-            {
-                if (implementations.Count == 0)
-                {
-                    throw new TypeCheckException($" Overloaded method '{methodName}' has no implementation.", tsCode: "TS2391");
-                }
-                if (implementations.Count > 1)
-                {
-                    throw new TypeCheckException($" Overloaded method '{methodName}' has multiple implementations.", tsCode: "TS2393");
-                }
-
-                var implementation = implementations[0];
-                var signatureTypes = signatures.Select(BuildMethodFuncType).ToList();
-                var implType = BuildMethodFuncType(implementation);
-
-                // Validate implementation is compatible with all signatures
-                foreach (var sig in signatureTypes)
-                {
-                    if (implType.MinArity > sig.MinArity)
-                    {
-                        throw new TypeCheckException($" Implementation of '{methodName}' requires {implType.MinArity} arguments but overload signature requires only {sig.MinArity}.", tsCode: "TS2394");
-                    }
-                }
-
-                var overloadedFunc = new TypeInfo.OverloadedFunction(signatureTypes, implType);
-
-                if (implementation.IsStatic)
-                    mutableClass.StaticMethods[methodName] = overloadedFunc;
-                else
-                    mutableClass.Methods[methodName] = overloadedFunc;
-
-                (implementation.IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[methodName] = implementation.Access;
-            }
-            else if (implementations.Count == 1)
-            {
-                // Single non-overloaded method
-                var method = implementations[0];
-                var funcType = BuildMethodFuncType(method);
-
-                // Handle ES2022 private methods (#method)
-                if (method.IsPrivate)
-                {
-                    if (method.IsStatic)
-                        mutableClass.StaticPrivateMethods[methodName] = funcType;
-                    else
-                        mutableClass.PrivateMethods[methodName] = funcType;
-                }
-                else
-                {
-                    if (method.IsStatic)
-                        mutableClass.StaticMethods[methodName] = funcType;
-                    else
-                        mutableClass.Methods[methodName] = funcType;
-
-                    (method.IsStatic ? mutableClass.StaticMethodAccess : mutableClass.MethodAccess)[methodName] = method.Access;
-                }
-            }
-            else if (implementations.Count > 1)
-            {
-                throw new TypeCheckException($" Multiple implementations of method '{methodName}' without overload signatures.", tsCode: "TS2393");
-            }
-        }
+        CollectNamedClassMethodSignatures(classStmt, mutableClass);
 
         // Collect static property types, field access modifiers, and non-static field types
         foreach (var field in classStmt.Fields)


### PR DESCRIPTION
Object.defineProperty emission and class declaration checking mix receiver dispatch and signature registration into large orchestration methods. Extract primitive-receiver validation, symbol-property handling, and proxy dispatch into separate emission stages, and extract computed/named class method signature collection plus its signature factory.

The extracted stages preserve the original operation order, diagnostics, and source locations. Emission stages own their branch labels and leave an empty evaluation stack on fallthrough; the caller retains shared locals and method metadata. Class checking retains the existing environment and recovery scopes around both signature collection stages. No guest behavior changes are intended.

This is a first reviewable increment for #1598, following its request for small extractions. Leave the issue open for remaining descriptor validation/receiver paths, getOwnPropertyDescriptor, and class field/accessor/body stages.

Validation:
- Release core build passed.
- Expanded each extracted helper at its call site and compared with the original code, ignoring comments/whitespace and the signature-factory rename; both orchestrations and the factory matched.
- All 3,382 selected tests passed, with zero failures/skips, including checker tests, descriptor/class parity, IL verification, and standalone output.
- git diff --check passed.

The first sandboxed selection passed 3,087 tests and failed three standalone subprocess/TLS tests. The final expanded selection ran with normal Windows subprocess/TLS access. Restore emitted NU1900 vulnerability-feed warnings. The full solution and external conformance suites were not run.

```powershell
dotnet build src/SharpTS/SharpTS.csproj -c Release -m:1
dotnet test tests/SharpTS.Tests/SharpTS.Tests.csproj -c Release --no-restore -m:1 --filter 'FullyQualifiedName~TypeCheckerTests|FullyQualifiedName~Class|FullyQualifiedName~Symbol|FullyQualifiedName~Descriptor|FullyQualifiedName~Proxy|FullyQualifiedName~ObjectTests|FullyQualifiedName~ILVerificationTests|FullyQualifiedName~StandaloneDllTests|FullyQualifiedName~Overload|FullyQualifiedName~ObjectFeatureTests|FullyQualifiedName~PropertySemanticsTests|FullyQualifiedName~ReflectApiTests'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Object.defineProperty` behavior for symbol-keyed properties, proxy receivers, non-extensible objects, arrays, and accessor properties.
  * Added more consistent descriptor validation, inheritance handling, and updates to object and array-backed storage.
  * Improved validation of class method declarations, including overloads, static methods, duplicate implementations, abstract methods, and generators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->