### PR TITLE
Align CodeRabbit docstring checks with documentation policy

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+# Retain the existing review settings while applying SharpTS's documentation policy.
+inheritance: true
+reviews:
+  pre_merge_checks:
+    # Coverage cannot distinguish supported public APIs from implementation methods.
+    # Review documentation against CONTRIBUTING.md instead of a percentage target.
+    docstrings:
+      mode: "off"
+  path_instructions:
+    - path: "**/*.cs"
+      instructions: >-
+        Follow the XML documentation policy in CONTRIBUTING.md. Require useful XML
+        documentation for new or changed supported consumer-facing APIs, including
+        externally consumed protected extension points. C# public visibility alone
+        does not make an implementation type a supported API. For internal/private
+        implementation methods and tests, request comments only for non-obvious
+        contracts or invariants; do not request blanket docstrings or percentage
+        coverage. Continue reporting correctness, security, and behavioral issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,42 @@ them but does not execute them.
   warnings — keep the count at zero
 - **Comments:** State constraints the code can't show; don't narrate the code
 
+### XML Documentation Policy
+
+- **Supported consumer-facing APIs:** Add or update XML documentation when changing
+  APIs intended for external callers, including public hosting/interop contracts and
+  protected extension points. Explain their purpose and any relevant parameter/return
+  semantics, exceptions, ownership, lifetime, threading, or cancellation requirements.
+  Use `<inheritdoc/>` when the inherited contract fully describes the implementation.
+  A C# `public` modifier alone does not make a compiler/runtime implementation type a
+  supported consumer API.
+- **Internal implementation and tests:** XML documentation is optional. Prefer clear
+  names and focused methods; do not add summaries that merely repeat the signature
+  or comments that narrate each step. Untouched code needs no documentation backfill.
+- **Non-obvious invariants:** Document constraints where maintainers need them, such as
+  emitted IL stack requirements, standalone-runtime restrictions, observable evaluation
+  order, and ownership or concurrency assumptions. Use a focused code comment or XML
+  remarks; put stable cross-cutting contracts in [ARCHITECTURE.md](ARCHITECTURE.md).
+
+SharpTS does not require a percentage of touched functions to have docstrings.
+[.coderabbit.yaml](.coderabbit.yaml) disables CodeRabbit's blanket docstring coverage
+pre-merge check and gives C# reviewers the policy above. The coverage check exposes
+only a mode and threshold, so it cannot enforce this distinction between supported
+APIs and implementation methods. Documentation findings should identify a missing
+contract required by this policy, rather than request comments to meet a quota.
+Correctness, security, and behavioral findings remain part of normal review.
+
+The repository configuration enables
+[configuration inheritance](https://docs.coderabbit.ai/configuration/configuration-inheritance)
+to preserve parent review settings while overriding the coverage check for SharpTS.
+Organization UI settings need not be changed for other repositories. Organization or
+workspace global overrides can still take precedence. To verify a review, inspect
+CodeRabbit's run configuration and pre-merge checks: the repository YAML should be in
+use and no percentage-based Docstring Coverage warning should appear. Maintainers can
+use `@coderabbitai configuration` on a PR to inspect the resolved configuration; if an
+organization/global override still enforces coverage, adjust that setting to match
+this policy. See CodeRabbit's [check reference](https://docs.coderabbit.ai/reference/configuration).
+
 ### AST Node Pattern
 
 All AST nodes are immutable records in `Parsing/AST.cs`:


### PR DESCRIPTION
CodeRabbit reported 0% docstring coverage on internal process-test helpers in #1515 and demanded an 80% threshold. SharpTS now documents when XML comments are required: supported consumer-facing APIs and meaningful contracts or invariants, with no blanket quota for internal methods or tests.

Add a repository-owned CodeRabbit configuration that disables the percentage check, inherits parent review settings, and gives C# reviews the documentation policy. This applies the issue's requested policy to SharpTS through a version-controlled override instead of changing organization settings for every repository. Correctness and security review remain enabled through the inherited settings. Contributor guidance explains how to inspect effective settings and handle a higher-priority global override.

Validation:
- Parsed `.coderabbit.yaml` and validated it with Ajv (JSON Schema draft 2020-12) against CodeRabbit's published schema in `coderabbitai/awesome-coderabbit/schema.v2.json`: passed.
- `git diff --cached --check`: passed.
- Reviewed CodeRabbit's official configuration inheritance and pre-merge check documentation.
- No runtime code changes; .NET build/test suites were not run.
- Live CodeRabbit review used Repository YAML with Organization UI inherited, completed with no actionable comments, and showed four passing pre-merge checks with no Docstring Coverage check or warning. This PR changes configuration/documentation only; a C# diff was not introduced just to exercise the review service.

Fixes #1525.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an XML documentation policy for supported consumer-facing APIs and internal implementation code.
  - Clarified required documentation topics, acceptable inheritance documentation, and non-obvious invariants.
  - Documented code review configuration and verification practices.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

