### PR TITLE
Extract zlib runtime metadata with explicit emission lifecycle

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -173,6 +173,14 @@ returning the runtime. Completion validates all required handles and promise wra
 subsequent writes. Consumers can read the component but cannot replace its handles or mutate its
 wrapper registry.
 
+Zlib follows the same contract through `Zlib` / `RequireZlib()`. `EmitAll` starts the component
+only when `UsesZlib` is enabled, before the transform constructor is emitted. `EmitZlibMethods`
+then emits compression and streaming handles in dependency order and registers named-import
+wrappers. `EmitAll` completes the component after type finalization. The 24 handles live only in
+`EmittedZlibRuntime`; module consumers use that component. Buffer and base stream types remain
+separate dependencies, and zlib retains
+its standalone output behavior.
+
 During emission, each handle becomes readable as soon as its declaration is assigned, so forward
 references do not require a method body to exist yet. An early read names the missing declaration.
 Completion is an orchestration boundary, not an IL verifier: body emission and type finalization

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -2467,35 +2467,18 @@ public class EmittedRuntime
 
     // Querystring module methods
 
-    // Zlib module methods
-    public MethodBuilder ZlibGzipSync { get; set; } = null!;
-    public MethodBuilder ZlibGunzipSync { get; set; } = null!;
-    public MethodBuilder ZlibDeflateSync { get; set; } = null!;
-    public MethodBuilder ZlibInflateSync { get; set; } = null!;
-    public MethodBuilder ZlibDeflateRawSync { get; set; } = null!;
-    public MethodBuilder ZlibInflateRawSync { get; set; } = null!;
-    public MethodBuilder ZlibBrotliCompressSync { get; set; } = null!;
-    public MethodBuilder ZlibBrotliDecompressSync { get; set; } = null!;
-    public MethodBuilder ZlibZstdCompressSync { get; set; } = null!;
-    public MethodBuilder ZlibZstdDecompressSync { get; set; } = null!;
-    public MethodBuilder ZlibUnzipSync { get; set; } = null!;
-    public MethodBuilder ZlibCrc32 { get; set; } = null!;
+    /// <summary>Zlib metadata, or null when zlib is tree-shaken from this compilation.</summary>
+    public EmittedZlibRuntime? Zlib { get; private set; }
 
-    // Zlib streaming APIs
-    public MethodBuilder ZlibCreateGzip { get; set; } = null!;
-    public MethodBuilder ZlibCreateGunzip { get; set; } = null!;
-    public MethodBuilder ZlibCreateDeflate { get; set; } = null!;
-    public MethodBuilder ZlibCreateInflate { get; set; } = null!;
-    public MethodBuilder ZlibCreateDeflateRaw { get; set; } = null!;
-    public MethodBuilder ZlibCreateInflateRaw { get; set; } = null!;
-    public MethodBuilder ZlibCreateBrotliCompress { get; set; } = null!;
-    public MethodBuilder ZlibCreateBrotliDecompress { get; set; } = null!;
-    public MethodBuilder ZlibCreateZstdCompress { get; set; } = null!;
-    public MethodBuilder ZlibCreateZstdDecompress { get; set; } = null!;
-    public MethodBuilder ZlibCreateUnzip { get; set; } = null!;
+    internal void BeginZlibEmission()
+    {
+        if (Zlib is not null)
+            throw new InvalidOperationException("Zlib metadata emission has already started.");
+        Zlib = new EmittedZlibRuntime();
+    }
 
-    // $ZlibTransform type - emitted for standalone zlib streaming support
-    public ConstructorBuilder TSZlibTransformCtor { get; set; } = null!;
+    public EmittedZlibRuntime RequireZlib() => Zlib
+        ?? throw new InvalidOperationException("Zlib runtime was not enabled for this compilation.");
 
     // $EventEmitter type - emitted for standalone event emitter support
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSEventEmitter

--- a/src/SharpTS/Compilation/EmittedZlibRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedZlibRuntime.cs
@@ -1,0 +1,229 @@
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Zlib metadata for one compilation. Declared handles support forward references;
+/// completion validates all handles and freezes the component for consumers.
+/// </summary>
+public sealed class EmittedZlibRuntime
+{
+    internal EmittedZlibRuntime() { }
+
+    public bool IsComplete { get; private set; }
+
+    private ConstructorBuilder? _transformCtor;
+    public ConstructorBuilder TransformCtor
+    {
+        get => Require(_transformCtor);
+        internal set => Set(ref _transformCtor, value);
+    }
+
+    private MethodBuilder? _gzipSync;
+    public MethodBuilder GzipSync
+    {
+        get => Require(_gzipSync);
+        internal set => Set(ref _gzipSync, value);
+    }
+
+    private MethodBuilder? _gunzipSync;
+    public MethodBuilder GunzipSync
+    {
+        get => Require(_gunzipSync);
+        internal set => Set(ref _gunzipSync, value);
+    }
+
+    private MethodBuilder? _deflateSync;
+    public MethodBuilder DeflateSync
+    {
+        get => Require(_deflateSync);
+        internal set => Set(ref _deflateSync, value);
+    }
+
+    private MethodBuilder? _inflateSync;
+    public MethodBuilder InflateSync
+    {
+        get => Require(_inflateSync);
+        internal set => Set(ref _inflateSync, value);
+    }
+
+    private MethodBuilder? _deflateRawSync;
+    public MethodBuilder DeflateRawSync
+    {
+        get => Require(_deflateRawSync);
+        internal set => Set(ref _deflateRawSync, value);
+    }
+
+    private MethodBuilder? _inflateRawSync;
+    public MethodBuilder InflateRawSync
+    {
+        get => Require(_inflateRawSync);
+        internal set => Set(ref _inflateRawSync, value);
+    }
+
+    private MethodBuilder? _brotliCompressSync;
+    public MethodBuilder BrotliCompressSync
+    {
+        get => Require(_brotliCompressSync);
+        internal set => Set(ref _brotliCompressSync, value);
+    }
+
+    private MethodBuilder? _brotliDecompressSync;
+    public MethodBuilder BrotliDecompressSync
+    {
+        get => Require(_brotliDecompressSync);
+        internal set => Set(ref _brotliDecompressSync, value);
+    }
+
+    private MethodBuilder? _zstdCompressSync;
+    public MethodBuilder ZstdCompressSync
+    {
+        get => Require(_zstdCompressSync);
+        internal set => Set(ref _zstdCompressSync, value);
+    }
+
+    private MethodBuilder? _zstdDecompressSync;
+    public MethodBuilder ZstdDecompressSync
+    {
+        get => Require(_zstdDecompressSync);
+        internal set => Set(ref _zstdDecompressSync, value);
+    }
+
+    private MethodBuilder? _unzipSync;
+    public MethodBuilder UnzipSync
+    {
+        get => Require(_unzipSync);
+        internal set => Set(ref _unzipSync, value);
+    }
+
+    private MethodBuilder? _crc32;
+    public MethodBuilder Crc32
+    {
+        get => Require(_crc32);
+        internal set => Set(ref _crc32, value);
+    }
+
+    private MethodBuilder? _createGzip;
+    public MethodBuilder CreateGzip
+    {
+        get => Require(_createGzip);
+        internal set => Set(ref _createGzip, value);
+    }
+
+    private MethodBuilder? _createGunzip;
+    public MethodBuilder CreateGunzip
+    {
+        get => Require(_createGunzip);
+        internal set => Set(ref _createGunzip, value);
+    }
+
+    private MethodBuilder? _createDeflate;
+    public MethodBuilder CreateDeflate
+    {
+        get => Require(_createDeflate);
+        internal set => Set(ref _createDeflate, value);
+    }
+
+    private MethodBuilder? _createInflate;
+    public MethodBuilder CreateInflate
+    {
+        get => Require(_createInflate);
+        internal set => Set(ref _createInflate, value);
+    }
+
+    private MethodBuilder? _createDeflateRaw;
+    public MethodBuilder CreateDeflateRaw
+    {
+        get => Require(_createDeflateRaw);
+        internal set => Set(ref _createDeflateRaw, value);
+    }
+
+    private MethodBuilder? _createInflateRaw;
+    public MethodBuilder CreateInflateRaw
+    {
+        get => Require(_createInflateRaw);
+        internal set => Set(ref _createInflateRaw, value);
+    }
+
+    private MethodBuilder? _createBrotliCompress;
+    public MethodBuilder CreateBrotliCompress
+    {
+        get => Require(_createBrotliCompress);
+        internal set => Set(ref _createBrotliCompress, value);
+    }
+
+    private MethodBuilder? _createBrotliDecompress;
+    public MethodBuilder CreateBrotliDecompress
+    {
+        get => Require(_createBrotliDecompress);
+        internal set => Set(ref _createBrotliDecompress, value);
+    }
+
+    private MethodBuilder? _createZstdCompress;
+    public MethodBuilder CreateZstdCompress
+    {
+        get => Require(_createZstdCompress);
+        internal set => Set(ref _createZstdCompress, value);
+    }
+
+    private MethodBuilder? _createZstdDecompress;
+    public MethodBuilder CreateZstdDecompress
+    {
+        get => Require(_createZstdDecompress);
+        internal set => Set(ref _createZstdDecompress, value);
+    }
+
+    private MethodBuilder? _createUnzip;
+    public MethodBuilder CreateUnzip
+    {
+        get => Require(_createUnzip);
+        internal set => Set(ref _createUnzip, value);
+    }
+
+    private static T Require<T>(T? method, [CallerMemberName] string name = "") where T : class =>
+        method ?? throw new InvalidOperationException($"Zlib metadata '{name}' has not been declared.");
+
+    private void Set<T>(ref T? field, T value) where T : class
+    {
+        EnsureMutable();
+        ArgumentNullException.ThrowIfNull(value);
+        field = value;
+    }
+
+    private void EnsureMutable()
+    {
+        if (IsComplete)
+            throw new InvalidOperationException("Zlib metadata emission is already complete.");
+    }
+
+    internal void CompleteEmission()
+    {
+        EnsureMutable();
+        _ = GzipSync;
+        _ = GunzipSync;
+        _ = DeflateSync;
+        _ = InflateSync;
+        _ = DeflateRawSync;
+        _ = InflateRawSync;
+        _ = BrotliCompressSync;
+        _ = BrotliDecompressSync;
+        _ = ZstdCompressSync;
+        _ = ZstdDecompressSync;
+        _ = UnzipSync;
+        _ = Crc32;
+        _ = CreateGzip;
+        _ = CreateGunzip;
+        _ = CreateDeflate;
+        _ = CreateInflate;
+        _ = CreateDeflateRaw;
+        _ = CreateInflateRaw;
+        _ = CreateBrotliCompress;
+        _ = CreateBrotliDecompress;
+        _ = CreateZstdCompress;
+        _ = CreateZstdDecompress;
+        _ = CreateUnzip;
+        _ = TransformCtor;
+        IsComplete = true;
+    }
+}

--- a/src/SharpTS/Compilation/Emitters/Modules/ZlibModuleEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/Modules/ZlibModuleEmitter.cs
@@ -79,6 +79,7 @@ public sealed class ZlibModuleEmitter : IBuiltInModuleEmitter
     {
         var ctx = emitter.Context;
         var il = ctx.IL;
+        var zlib = ctx.Runtime!.RequireZlib();
 
         // data argument
         if (arguments.Count == 0)
@@ -102,7 +103,7 @@ public sealed class ZlibModuleEmitter : IBuiltInModuleEmitter
             il.Emit(OpCodes.Ldnull);
         }
 
-        il.Emit(OpCodes.Call, ctx.Runtime!.ZlibCrc32);
+        il.Emit(OpCodes.Call, zlib.Crc32);
         return true;
     }
 
@@ -120,6 +121,7 @@ public sealed class ZlibModuleEmitter : IBuiltInModuleEmitter
     {
         var ctx = emitter.Context;
         var il = ctx.IL;
+        var zlib = ctx.Runtime!.RequireZlib();
 
         // Emit options argument (null if not provided)
         if (arguments.Count >= 1)
@@ -135,17 +137,17 @@ public sealed class ZlibModuleEmitter : IBuiltInModuleEmitter
         // Get the runtime method
         var method = runtimeMethodName switch
         {
-            "ZlibCreateGzip" => ctx.Runtime!.ZlibCreateGzip,
-            "ZlibCreateGunzip" => ctx.Runtime!.ZlibCreateGunzip,
-            "ZlibCreateDeflate" => ctx.Runtime!.ZlibCreateDeflate,
-            "ZlibCreateInflate" => ctx.Runtime!.ZlibCreateInflate,
-            "ZlibCreateDeflateRaw" => ctx.Runtime!.ZlibCreateDeflateRaw,
-            "ZlibCreateInflateRaw" => ctx.Runtime!.ZlibCreateInflateRaw,
-            "ZlibCreateBrotliCompress" => ctx.Runtime!.ZlibCreateBrotliCompress,
-            "ZlibCreateBrotliDecompress" => ctx.Runtime!.ZlibCreateBrotliDecompress,
-            "ZlibCreateZstdCompress" => ctx.Runtime!.ZlibCreateZstdCompress,
-            "ZlibCreateZstdDecompress" => ctx.Runtime!.ZlibCreateZstdDecompress,
-            "ZlibCreateUnzip" => ctx.Runtime!.ZlibCreateUnzip,
+            "ZlibCreateGzip" => zlib.CreateGzip,
+            "ZlibCreateGunzip" => zlib.CreateGunzip,
+            "ZlibCreateDeflate" => zlib.CreateDeflate,
+            "ZlibCreateInflate" => zlib.CreateInflate,
+            "ZlibCreateDeflateRaw" => zlib.CreateDeflateRaw,
+            "ZlibCreateInflateRaw" => zlib.CreateInflateRaw,
+            "ZlibCreateBrotliCompress" => zlib.CreateBrotliCompress,
+            "ZlibCreateBrotliDecompress" => zlib.CreateBrotliDecompress,
+            "ZlibCreateZstdCompress" => zlib.CreateZstdCompress,
+            "ZlibCreateZstdDecompress" => zlib.CreateZstdDecompress,
+            "ZlibCreateUnzip" => zlib.CreateUnzip,
             _ => throw new CompileException($"Unknown zlib streaming method: {runtimeMethodName}")
         };
 
@@ -161,6 +163,7 @@ public sealed class ZlibModuleEmitter : IBuiltInModuleEmitter
     {
         var ctx = emitter.Context;
         var il = ctx.IL;
+        var zlib = ctx.Runtime!.RequireZlib();
 
         // Emit input argument
         if (arguments.Count == 0)
@@ -187,17 +190,17 @@ public sealed class ZlibModuleEmitter : IBuiltInModuleEmitter
         // Get the appropriate runtime method
         var method = runtimeMethodName switch
         {
-            "ZlibGzipSync" => ctx.Runtime!.ZlibGzipSync,
-            "ZlibGunzipSync" => ctx.Runtime!.ZlibGunzipSync,
-            "ZlibDeflateSync" => ctx.Runtime!.ZlibDeflateSync,
-            "ZlibInflateSync" => ctx.Runtime!.ZlibInflateSync,
-            "ZlibDeflateRawSync" => ctx.Runtime!.ZlibDeflateRawSync,
-            "ZlibInflateRawSync" => ctx.Runtime!.ZlibInflateRawSync,
-            "ZlibBrotliCompressSync" => ctx.Runtime!.ZlibBrotliCompressSync,
-            "ZlibBrotliDecompressSync" => ctx.Runtime!.ZlibBrotliDecompressSync,
-            "ZlibZstdCompressSync" => ctx.Runtime!.ZlibZstdCompressSync,
-            "ZlibZstdDecompressSync" => ctx.Runtime!.ZlibZstdDecompressSync,
-            "ZlibUnzipSync" => ctx.Runtime!.ZlibUnzipSync,
+            "ZlibGzipSync" => zlib.GzipSync,
+            "ZlibGunzipSync" => zlib.GunzipSync,
+            "ZlibDeflateSync" => zlib.DeflateSync,
+            "ZlibInflateSync" => zlib.InflateSync,
+            "ZlibDeflateRawSync" => zlib.DeflateRawSync,
+            "ZlibInflateRawSync" => zlib.InflateRawSync,
+            "ZlibBrotliCompressSync" => zlib.BrotliCompressSync,
+            "ZlibBrotliDecompressSync" => zlib.BrotliDecompressSync,
+            "ZlibZstdCompressSync" => zlib.ZstdCompressSync,
+            "ZlibZstdDecompressSync" => zlib.ZstdDecompressSync,
+            "ZlibUnzipSync" => zlib.UnzipSync,
             _ => throw new CompileException($"Unknown zlib method: {runtimeMethodName}")
         };
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSZlibTransform.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSZlibTransform.cs
@@ -79,7 +79,7 @@ public partial class RuntimeEmitter
             CallingConventions.Standard,
             [_types.Int32, _types.Int32]  // kind, compressionLevel
         );
-        runtime.TSZlibTransformCtor = ctor;
+        runtime.RequireZlib().TransformCtor = ctor;
 
         var il = ctor.GetILGenerator();
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.ZlibHelpers.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.ZlibHelpers.cs
@@ -474,7 +474,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object]);
-        runtime.ZlibGzipSync = method;
+        runtime.RequireZlib().GzipSync = method;
 
         EmitDeflateFamilyCompress(method.GetILGenerator(), runtime, typeof(GZipStream));
     }
@@ -490,7 +490,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object]);
-        runtime.ZlibGunzipSync = method;
+        runtime.RequireZlib().GunzipSync = method;
 
         EmitDecompressMethod(method.GetILGenerator(), runtime, typeof(GZipStream));
     }
@@ -510,7 +510,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object]);
-        runtime.ZlibDeflateSync = method;
+        runtime.RequireZlib().DeflateSync = method;
 
         EmitDeflateFamilyCompress(method.GetILGenerator(), runtime, typeof(ZLibStream));
     }
@@ -526,7 +526,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object]);
-        runtime.ZlibInflateSync = method;
+        runtime.RequireZlib().InflateSync = method;
 
         EmitDecompressMethod(method.GetILGenerator(), runtime, typeof(ZLibStream));
     }
@@ -546,7 +546,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object]);
-        runtime.ZlibDeflateRawSync = method;
+        runtime.RequireZlib().DeflateRawSync = method;
 
         EmitDeflateFamilyCompress(method.GetILGenerator(), runtime, typeof(DeflateStream));
     }
@@ -562,7 +562,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object]);
-        runtime.ZlibInflateRawSync = method;
+        runtime.RequireZlib().InflateRawSync = method;
 
         EmitDecompressMethod(method.GetILGenerator(), runtime, typeof(DeflateStream));
     }
@@ -582,7 +582,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object]);
-        runtime.ZlibBrotliCompressSync = method;
+        runtime.RequireZlib().BrotliCompressSync = method;
 
         EmitBrotliCompress(method.GetILGenerator(), runtime);
     }
@@ -598,7 +598,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object]);
-        runtime.ZlibBrotliDecompressSync = method;
+        runtime.RequireZlib().BrotliDecompressSync = method;
 
         EmitDecompressMethod(method.GetILGenerator(), runtime, typeof(BrotliStream));
     }
@@ -618,7 +618,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object]);
-        runtime.ZlibZstdCompressSync = method;
+        runtime.RequireZlib().ZstdCompressSync = method;
 
         EmitZstdCompressMethod(method.GetILGenerator(), runtime);
     }
@@ -634,7 +634,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object]);
-        runtime.ZlibZstdDecompressSync = method;
+        runtime.RequireZlib().ZstdDecompressSync = method;
 
         EmitZstdDecompressMethod(method.GetILGenerator(), runtime);
     }
@@ -654,7 +654,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object]);
-        runtime.ZlibUnzipSync = method;
+        runtime.RequireZlib().UnzipSync = method;
 
         var il = method.GetILGenerator();
 
@@ -699,21 +699,21 @@ public partial class RuntimeEmitter
         // It's zlib - call ZlibInflateSync
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.ZlibInflateSync);
+        il.Emit(OpCodes.Call, runtime.RequireZlib().InflateSync);
         il.Emit(OpCodes.Ret);
 
         // It's gzip - call ZlibGunzipSync
         il.MarkLabel(isGzipLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.ZlibGunzipSync);
+        il.Emit(OpCodes.Call, runtime.RequireZlib().GunzipSync);
         il.Emit(OpCodes.Ret);
 
         // Try raw deflate
         il.MarkLabel(tryDeflateLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.ZlibInflateRawSync);
+        il.Emit(OpCodes.Call, runtime.RequireZlib().InflateRawSync);
         il.Emit(OpCodes.Ret);
     }
 
@@ -734,7 +734,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object]);
-        runtime.ZlibCrc32 = method;
+        runtime.RequireZlib().Crc32 = method;
 
         var il = method.GetILGenerator();
 
@@ -843,17 +843,17 @@ public partial class RuntimeEmitter
     private void EmitZlibStreamingMethods(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         // Create methods for each compression/decompression type
-        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateGzip", 0, mb => runtime.ZlibCreateGzip = mb);
-        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateGunzip", 1, mb => runtime.ZlibCreateGunzip = mb);
-        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateDeflate", 2, mb => runtime.ZlibCreateDeflate = mb);
-        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateInflate", 3, mb => runtime.ZlibCreateInflate = mb);
-        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateDeflateRaw", 4, mb => runtime.ZlibCreateDeflateRaw = mb);
-        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateInflateRaw", 5, mb => runtime.ZlibCreateInflateRaw = mb);
-        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateBrotliCompress", 6, mb => runtime.ZlibCreateBrotliCompress = mb);
-        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateBrotliDecompress", 7, mb => runtime.ZlibCreateBrotliDecompress = mb);
-        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateZstdCompress", 9, mb => runtime.ZlibCreateZstdCompress = mb);
-        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateZstdDecompress", 10, mb => runtime.ZlibCreateZstdDecompress = mb);
-        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateUnzip", 8, mb => runtime.ZlibCreateUnzip = mb);
+        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateGzip", 0, mb => runtime.RequireZlib().CreateGzip = mb);
+        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateGunzip", 1, mb => runtime.RequireZlib().CreateGunzip = mb);
+        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateDeflate", 2, mb => runtime.RequireZlib().CreateDeflate = mb);
+        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateInflate", 3, mb => runtime.RequireZlib().CreateInflate = mb);
+        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateDeflateRaw", 4, mb => runtime.RequireZlib().CreateDeflateRaw = mb);
+        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateInflateRaw", 5, mb => runtime.RequireZlib().CreateInflateRaw = mb);
+        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateBrotliCompress", 6, mb => runtime.RequireZlib().CreateBrotliCompress = mb);
+        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateBrotliDecompress", 7, mb => runtime.RequireZlib().CreateBrotliDecompress = mb);
+        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateZstdCompress", 9, mb => runtime.RequireZlib().CreateZstdCompress = mb);
+        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateZstdDecompress", 10, mb => runtime.RequireZlib().CreateZstdDecompress = mb);
+        EmitZlibCreateStreamMethod(typeBuilder, runtime, "ZlibCreateUnzip", 8, mb => runtime.RequireZlib().CreateUnzip = mb);
     }
 
     /// <summary>
@@ -877,7 +877,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4, kindValue);   // kind
         il.Emit(OpCodes.Ldarg_0);              // options
         il.Emit(OpCodes.Call, _getZlibCompressionLevel!);  // -> int (CompressionLevel)
-        il.Emit(OpCodes.Newobj, runtime.TSZlibTransformCtor);  // new $ZlibTransform(kind, level)
+        il.Emit(OpCodes.Newobj, runtime.RequireZlib().TransformCtor);  // new $ZlibTransform(kind, level)
         il.Emit(OpCodes.Ret);
     }
 
@@ -890,20 +890,21 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitZlibMethodWrappers(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
+        var zlib = runtime.RequireZlib();
         var methodNames = new[]
         {
-            ("gzipSync", runtime.ZlibGzipSync),
-            ("gunzipSync", runtime.ZlibGunzipSync),
-            ("deflateSync", runtime.ZlibDeflateSync),
-            ("inflateSync", runtime.ZlibInflateSync),
-            ("deflateRawSync", runtime.ZlibDeflateRawSync),
-            ("inflateRawSync", runtime.ZlibInflateRawSync),
-            ("brotliCompressSync", runtime.ZlibBrotliCompressSync),
-            ("brotliDecompressSync", runtime.ZlibBrotliDecompressSync),
-            ("zstdCompressSync", runtime.ZlibZstdCompressSync),
-            ("zstdDecompressSync", runtime.ZlibZstdDecompressSync),
-            ("unzipSync", runtime.ZlibUnzipSync),
-            ("crc32", runtime.ZlibCrc32)
+            ("gzipSync", zlib.GzipSync),
+            ("gunzipSync", zlib.GunzipSync),
+            ("deflateSync", zlib.DeflateSync),
+            ("inflateSync", zlib.InflateSync),
+            ("deflateRawSync", zlib.DeflateRawSync),
+            ("inflateRawSync", zlib.InflateRawSync),
+            ("brotliCompressSync", zlib.BrotliCompressSync),
+            ("brotliDecompressSync", zlib.BrotliDecompressSync),
+            ("zstdCompressSync", zlib.ZstdCompressSync),
+            ("zstdDecompressSync", zlib.ZstdDecompressSync),
+            ("unzipSync", zlib.UnzipSync),
+            ("crc32", zlib.Crc32)
         };
 
         foreach (var (name, targetMethod) in methodNames)
@@ -926,17 +927,17 @@ public partial class RuntimeEmitter
         // Streaming create* methods (1 arg: options)
         var streamingMethods = new (string name, MethodBuilder target)[]
         {
-            ("createGzip", runtime.ZlibCreateGzip),
-            ("createGunzip", runtime.ZlibCreateGunzip),
-            ("createDeflate", runtime.ZlibCreateDeflate),
-            ("createInflate", runtime.ZlibCreateInflate),
-            ("createDeflateRaw", runtime.ZlibCreateDeflateRaw),
-            ("createInflateRaw", runtime.ZlibCreateInflateRaw),
-            ("createBrotliCompress", runtime.ZlibCreateBrotliCompress),
-            ("createBrotliDecompress", runtime.ZlibCreateBrotliDecompress),
-            ("createZstdCompress", runtime.ZlibCreateZstdCompress),
-            ("createZstdDecompress", runtime.ZlibCreateZstdDecompress),
-            ("createUnzip", runtime.ZlibCreateUnzip)
+            ("createGzip", zlib.CreateGzip),
+            ("createGunzip", zlib.CreateGunzip),
+            ("createDeflate", zlib.CreateDeflate),
+            ("createInflate", zlib.CreateInflate),
+            ("createDeflateRaw", zlib.CreateDeflateRaw),
+            ("createInflateRaw", zlib.CreateInflateRaw),
+            ("createBrotliCompress", zlib.CreateBrotliCompress),
+            ("createBrotliDecompress", zlib.CreateBrotliDecompress),
+            ("createZstdCompress", zlib.CreateZstdCompress),
+            ("createZstdDecompress", zlib.CreateZstdDecompress),
+            ("createUnzip", zlib.CreateUnzip)
         };
 
         foreach (var (name, targetMethod) in streamingMethods)

--- a/src/SharpTS/Compilation/RuntimeEmitter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.cs
@@ -40,6 +40,8 @@ public partial class RuntimeEmitter
         if (_emitHosted)
             _features.UsesPromise = true;
         var runtime = new EmittedRuntime();
+        if (features.UsesZlib)
+            runtime.BeginZlibEmission();
         if (features.UsesDns)
             runtime.BeginDnsEmission();
 
@@ -606,6 +608,7 @@ public partial class RuntimeEmitter
         }
 
         runtime.Dns?.CompleteEmission();
+        runtime.Zlib?.CompleteEmission();
         return runtime;
     }
 }

--- a/tests/SharpTS.Tests/CompilerTests/EmittedZlibRuntimeTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/EmittedZlibRuntimeTests.cs
@@ -1,0 +1,83 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public class EmittedZlibRuntimeTests
+{
+    [Fact]
+    public void CompressionAndStreamingConsumersPassILVerification()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { gzipSync, gunzipSync, createGzip, crc32 } from 'zlib';
+                console.log(gunzipSync(gzipSync('hello')).toString());
+                console.log(crc32('hello'));
+                const stream = createGzip();
+                stream.end('hello');
+                """
+        };
+        Assert.Empty(TestHarness.CompileModulesAndVerifyOnly(files, "main.ts"));
+    }
+
+    [Fact]
+    public void DisabledFeatureHasNoMetadataAndReportsAccidentalUse()
+    {
+        var runtime = EmitRuntime(false);
+        Assert.Null(runtime.Zlib);
+        Assert.Contains("not enabled", Assert.Throws<InvalidOperationException>(runtime.RequireZlib).Message);
+        Assert.DoesNotContain(runtime.RuntimeType.GetMethods(), method => method.Name.StartsWith("Zlib", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DeclaredHandleCanBeUsedBeforeBodyEmission()
+    {
+        var runtime = new EmittedRuntime();
+        runtime.BeginZlibEmission();
+        var zlib = runtime.RequireZlib();
+        Assert.False(zlib.IsComplete);
+        Assert.Contains("GzipSync", Assert.Throws<InvalidOperationException>(() => zlib.GzipSync).Message);
+
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName("zlib_forward"), typeof(object).Assembly);
+        var type = assembly.DefineDynamicModule("main").DefineType("Runtime");
+        var method = type.DefineMethod("GzipSync", MethodAttributes.Public | MethodAttributes.Static, typeof(void), Type.EmptyTypes);
+        zlib.GzipSync = method;
+        Assert.Same(method, zlib.GzipSync);
+        Assert.Throws<InvalidOperationException>(runtime.BeginZlibEmission);
+        Assert.Contains("GunzipSync", Assert.Throws<InvalidOperationException>(zlib.CompleteEmission).Message);
+        Assert.False(zlib.IsComplete);
+        Assert.Throws<ArgumentNullException>(() => zlib.GzipSync = null!);
+        Assert.Same(method, zlib.GzipSync);
+    }
+
+    [Fact]
+    public void EnabledFeatureCompletesAllHandlesAndRejectsFurtherWrites()
+    {
+        var runtime = EmitRuntime(true);
+        var zlib = runtime.RequireZlib();
+        Assert.True(zlib.IsComplete);
+        Assert.Equal("ZlibGzipSync", zlib.GzipSync.Name);
+        Assert.NotNull(zlib.TransformCtor);
+        Assert.All(typeof(EmittedZlibRuntime).GetProperties()
+            .Where(property => property.PropertyType == typeof(MethodBuilder)),
+            property => Assert.NotNull(property.GetValue(zlib)));
+        Assert.Throws<InvalidOperationException>(() => zlib.GzipSync = zlib.GzipSync);
+        Assert.Throws<InvalidOperationException>(() => zlib.TransformCtor = zlib.TransformCtor);
+        Assert.Throws<InvalidOperationException>(zlib.CompleteEmission);
+        Assert.Empty(runtime.RequiredSharpTSRuntimeReasons);
+    }
+
+    private static EmittedRuntime EmitRuntime(bool usesZlib)
+    {
+        var source = usesZlib ? "import * as zlib from 'zlib';" : "console.log(1);";
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var features = new RuntimeFeatureDetector().Detect(statements);
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName($"zlib_metadata_{Guid.NewGuid():N}"), typeof(object).Assembly);
+        return new RuntimeEmitter(TypeProvider.Runtime).EmitAll(assembly.DefineDynamicModule("main"), features);
+    }
+}


### PR DESCRIPTION
Zlib metadata was spread across 24 nullable-by-convention properties on EmittedRuntime. Move the compression methods, streaming factories, and transform constructor into EmittedZlibRuntime, with explicit optional availability and checked initialization.

Create the component before transform emission, allow declared handles to support forward references, and validate/freeze it after runtime type finalization. Remove the migrated flat properties and update emission and module consumers. Document the lifecycle alongside the existing DNS pattern.

This is the next bounded feature migration for #1599, following the merged DNS component. Leave the issue open for subsequent families.

Validation:
- Release core build passed.
- All 244 selected regression tests passed with zero failures or skips: zlib behavior, component lifecycle/tree-shaking, IL verification, and standalone output (including zlib without SharpTS.dll).
- Reversing metadata access substitutions and ignoring whitespace reproduced the original compression, transform, and module emission code.
- git diff --cached --check passed.
- Restore reported NU1900 vulnerability-feed warnings. The full solution, external conformance suites, and benchmarks were not run.

Test command:
```powershell
dotnet test tests/SharpTS.Tests/SharpTS.Tests.csproj -c Release --no-restore -m:1 --filter 'FullyQualifiedName~EmittedZlibRuntimeTests|FullyQualifiedName~ZlibModuleTests|FullyQualifiedName~ILVerificationTests|FullyQualifiedName~StandaloneDllTests'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured runtime metadata for compression and decompression capabilities.
  * Zlib support is now enabled only when required and validates that all supported operations are available before completion.
  * Added safeguards for unavailable, incomplete, or modified zlib runtime capabilities.

* **Documentation**
  * Documented the zlib runtime architecture, including feature gating, dependency ordering, and completion validation.

* **Tests**
  * Added coverage for enabled and disabled zlib scenarios, streaming and synchronous operations, lifecycle validation, and emitted code verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->