### PR TITLE
Extract class property stages and stored descriptor emission

### DIFF
--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.cs
@@ -7,6 +7,154 @@ namespace SharpTS.Compilation;
 
 public partial class RuntimeEmitter
 {
+    // Marks the shared descriptor-found label with an empty stack, then branches to the
+    // shared exit with one result object. Reads the stored descriptor and receiver (arg 0);
+    // internal labels and scratch locals belong to this stage.
+    private void EmitStoredPropertyDescriptorResult(
+        ILGenerator il, EmittedRuntime runtime,
+        LocalBuilder descriptorLocal, LocalBuilder resultDictLocal,
+        Label hasDescriptorLabel, Label endLabel)
+    {
+        // hasDescriptorLabel: Convert $CompiledPropertyDescriptor to JS object
+        il.MarkLabel(hasDescriptorLabel);
+        il.Emit(OpCodes.Newobj, _types.DictionaryStringObjectCtor);
+        il.Emit(OpCodes.Stloc, resultDictLocal);
+
+        // Check if it's an accessor property (has getter or setter)
+        var isAccessorLabel = il.DefineLabel();
+        var isDataLabel = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorGetter.GetGetMethod()!);
+        il.Emit(OpCodes.Brtrue, isAccessorLabel);
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorSetter.GetGetMethod()!);
+        il.Emit(OpCodes.Brtrue, isAccessorLabel);
+        il.Emit(OpCodes.Br, isDataLabel);
+
+        // Accessor property - set get and set. ECMA-262 §6.2.5.4
+        // FromPropertyDescriptor: an accessor descriptor result always has
+        // "get" and "set" keys even when one slot is empty (the missing slot
+        // serializes as JS undefined). Pre-fix the missing key wasn't present
+        // at all, causing `"set" in desc` to be false for getter-only
+        // accessors. Stash $Undefined.Instance when the slot is null.
+        il.MarkLabel(isAccessorLabel);
+
+        // Set get property
+        var noGetLabel = il.DefineLabel();
+        var afterGetLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorGetter.GetGetMethod()!);
+        il.Emit(OpCodes.Brfalse, noGetLabel);
+        il.Emit(OpCodes.Ldloc, resultDictLocal);
+        il.Emit(OpCodes.Ldstr, "get");
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorGetter.GetGetMethod()!);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
+        il.Emit(OpCodes.Br, afterGetLabel);
+        il.MarkLabel(noGetLabel);
+        il.Emit(OpCodes.Ldloc, resultDictLocal);
+        il.Emit(OpCodes.Ldstr, "get");
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
+        il.MarkLabel(afterGetLabel);
+
+        // Set set property
+        var noSetLabel = il.DefineLabel();
+        var afterSetLabel = il.DefineLabel();
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorSetter.GetGetMethod()!);
+        il.Emit(OpCodes.Brfalse, noSetLabel);
+        il.Emit(OpCodes.Ldloc, resultDictLocal);
+        il.Emit(OpCodes.Ldstr, "set");
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorSetter.GetGetMethod()!);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
+        il.Emit(OpCodes.Br, afterSetLabel);
+        il.MarkLabel(noSetLabel);
+        il.Emit(OpCodes.Ldloc, resultDictLocal);
+        il.Emit(OpCodes.Ldstr, "set");
+        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
+        il.MarkLabel(afterSetLabel);
+
+        var afterAccessorLabel = il.DefineLabel();
+        il.Emit(OpCodes.Br, afterAccessorLabel);
+
+        // Data property - set value and writable. Frozen/sealed override the
+        // descriptor's stored writable/configurable: spec says Object.freeze
+        // mutates each descriptor, but we don't mutate storage — reflect at
+        // read time to keep the storage stable across {freeze, defrost} cycles.
+        il.MarkLabel(isDataLabel);
+        var pdsIsFrozenLocal = il.DeclareLocal(_types.Boolean);
+        var pdsIsSealedLocal = il.DeclareLocal(_types.Boolean);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.PDSIsFrozen);
+        il.Emit(OpCodes.Stloc, pdsIsFrozenLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.PDSIsSealed);
+        il.Emit(OpCodes.Stloc, pdsIsSealedLocal);
+
+        // Set value
+        il.Emit(OpCodes.Ldloc, resultDictLocal);
+        il.Emit(OpCodes.Ldstr, "value");
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorValue.GetGetMethod()!);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
+
+        // Set writable: stored value AND !frozen.
+        il.Emit(OpCodes.Ldloc, resultDictLocal);
+        il.Emit(OpCodes.Ldstr, "writable");
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorWritable.GetGetMethod()!);
+        il.Emit(OpCodes.Ldloc, pdsIsFrozenLocal);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ceq);  // !frozen
+        il.Emit(OpCodes.And);
+        il.Emit(OpCodes.Box, _types.Boolean);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
+
+        il.MarkLabel(afterAccessorLabel);
+
+        // Set enumerable (freeze/seal preserve enumerability).
+        il.Emit(OpCodes.Ldloc, resultDictLocal);
+        il.Emit(OpCodes.Ldstr, "enumerable");
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorEnumerable.GetGetMethod()!);
+        il.Emit(OpCodes.Box, _types.Boolean);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
+
+        // Set configurable: stored value AND !(frozen OR sealed).
+        // For accessor (data path not entered), the pdsIs* locals are still
+        // computed in the data branch — when we reach here via accessor,
+        // they're default-zero (Boolean) which means the override AND yields
+        // the stored value. Compute them here for accessor independence.
+        var pdsCfgIsFrozenLocal = il.DeclareLocal(_types.Boolean);
+        var pdsCfgIsSealedLocal = il.DeclareLocal(_types.Boolean);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.PDSIsFrozen);
+        il.Emit(OpCodes.Stloc, pdsCfgIsFrozenLocal);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, runtime.PDSIsSealed);
+        il.Emit(OpCodes.Stloc, pdsCfgIsSealedLocal);
+
+        il.Emit(OpCodes.Ldloc, resultDictLocal);
+        il.Emit(OpCodes.Ldstr, "configurable");
+        il.Emit(OpCodes.Ldloc, descriptorLocal);
+        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorConfigurable.GetGetMethod()!);
+        il.Emit(OpCodes.Ldloc, pdsCfgIsFrozenLocal);
+        il.Emit(OpCodes.Ldloc, pdsCfgIsSealedLocal);
+        il.Emit(OpCodes.Or);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ceq);  // !(frozen || sealed)
+        il.Emit(OpCodes.And);
+        il.Emit(OpCodes.Box, _types.Boolean);
+        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
+
+        il.Emit(OpCodes.Ldloc, resultDictLocal);
+        il.Emit(OpCodes.Br, endLabel);
+    }
+
     /// <summary>
     /// Helper: emits IL to set a boolean descriptor field
     /// (writable/enumerable/configurable) on the result dict to a constant
@@ -3096,144 +3244,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, resultDictLocal);
         il.Emit(OpCodes.Br, endLabel);
 
-        // hasDescriptorLabel: Convert $CompiledPropertyDescriptor to JS object
-        il.MarkLabel(hasDescriptorLabel);
-        il.Emit(OpCodes.Newobj, _types.DictionaryStringObjectCtor);
-        il.Emit(OpCodes.Stloc, resultDictLocal);
-
-        // Check if it's an accessor property (has getter or setter)
-        var isAccessorLabel = il.DefineLabel();
-        var isDataLabel = il.DefineLabel();
-
-        il.Emit(OpCodes.Ldloc, descriptorLocal);
-        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorGetter.GetGetMethod()!);
-        il.Emit(OpCodes.Brtrue, isAccessorLabel);
-        il.Emit(OpCodes.Ldloc, descriptorLocal);
-        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorSetter.GetGetMethod()!);
-        il.Emit(OpCodes.Brtrue, isAccessorLabel);
-        il.Emit(OpCodes.Br, isDataLabel);
-
-        // Accessor property - set get and set. ECMA-262 §6.2.5.4
-        // FromPropertyDescriptor: an accessor descriptor result always has
-        // "get" and "set" keys even when one slot is empty (the missing slot
-        // serializes as JS undefined). Pre-fix the missing key wasn't present
-        // at all, causing `"set" in desc` to be false for getter-only
-        // accessors. Stash $Undefined.Instance when the slot is null.
-        il.MarkLabel(isAccessorLabel);
-
-        // Set get property
-        var noGetLabel = il.DefineLabel();
-        var afterGetLabel = il.DefineLabel();
-        il.Emit(OpCodes.Ldloc, descriptorLocal);
-        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorGetter.GetGetMethod()!);
-        il.Emit(OpCodes.Brfalse, noGetLabel);
-        il.Emit(OpCodes.Ldloc, resultDictLocal);
-        il.Emit(OpCodes.Ldstr, "get");
-        il.Emit(OpCodes.Ldloc, descriptorLocal);
-        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorGetter.GetGetMethod()!);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
-        il.Emit(OpCodes.Br, afterGetLabel);
-        il.MarkLabel(noGetLabel);
-        il.Emit(OpCodes.Ldloc, resultDictLocal);
-        il.Emit(OpCodes.Ldstr, "get");
-        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
-        il.MarkLabel(afterGetLabel);
-
-        // Set set property
-        var noSetLabel = il.DefineLabel();
-        var afterSetLabel = il.DefineLabel();
-        il.Emit(OpCodes.Ldloc, descriptorLocal);
-        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorSetter.GetGetMethod()!);
-        il.Emit(OpCodes.Brfalse, noSetLabel);
-        il.Emit(OpCodes.Ldloc, resultDictLocal);
-        il.Emit(OpCodes.Ldstr, "set");
-        il.Emit(OpCodes.Ldloc, descriptorLocal);
-        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorSetter.GetGetMethod()!);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
-        il.Emit(OpCodes.Br, afterSetLabel);
-        il.MarkLabel(noSetLabel);
-        il.Emit(OpCodes.Ldloc, resultDictLocal);
-        il.Emit(OpCodes.Ldstr, "set");
-        il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
-        il.MarkLabel(afterSetLabel);
-
-        var afterAccessorLabel = il.DefineLabel();
-        il.Emit(OpCodes.Br, afterAccessorLabel);
-
-        // Data property - set value and writable. Frozen/sealed override the
-        // descriptor's stored writable/configurable: spec says Object.freeze
-        // mutates each descriptor, but we don't mutate storage — reflect at
-        // read time to keep the storage stable across {freeze, defrost} cycles.
-        il.MarkLabel(isDataLabel);
-        var pdsIsFrozenLocal = il.DeclareLocal(_types.Boolean);
-        var pdsIsSealedLocal = il.DeclareLocal(_types.Boolean);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.PDSIsFrozen);
-        il.Emit(OpCodes.Stloc, pdsIsFrozenLocal);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.PDSIsSealed);
-        il.Emit(OpCodes.Stloc, pdsIsSealedLocal);
-
-        // Set value
-        il.Emit(OpCodes.Ldloc, resultDictLocal);
-        il.Emit(OpCodes.Ldstr, "value");
-        il.Emit(OpCodes.Ldloc, descriptorLocal);
-        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorValue.GetGetMethod()!);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
-
-        // Set writable: stored value AND !frozen.
-        il.Emit(OpCodes.Ldloc, resultDictLocal);
-        il.Emit(OpCodes.Ldstr, "writable");
-        il.Emit(OpCodes.Ldloc, descriptorLocal);
-        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorWritable.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloc, pdsIsFrozenLocal);
-        il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Ceq);  // !frozen
-        il.Emit(OpCodes.And);
-        il.Emit(OpCodes.Box, _types.Boolean);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
-
-        il.MarkLabel(afterAccessorLabel);
-
-        // Set enumerable (freeze/seal preserve enumerability).
-        il.Emit(OpCodes.Ldloc, resultDictLocal);
-        il.Emit(OpCodes.Ldstr, "enumerable");
-        il.Emit(OpCodes.Ldloc, descriptorLocal);
-        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorEnumerable.GetGetMethod()!);
-        il.Emit(OpCodes.Box, _types.Boolean);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
-
-        // Set configurable: stored value AND !(frozen OR sealed).
-        // For accessor (data path not entered), the pdsIs* locals are still
-        // computed in the data branch — when we reach here via accessor,
-        // they're default-zero (Boolean) which means the override AND yields
-        // the stored value. Compute them here for accessor independence.
-        var pdsCfgIsFrozenLocal = il.DeclareLocal(_types.Boolean);
-        var pdsCfgIsSealedLocal = il.DeclareLocal(_types.Boolean);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.PDSIsFrozen);
-        il.Emit(OpCodes.Stloc, pdsCfgIsFrozenLocal);
-        il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.PDSIsSealed);
-        il.Emit(OpCodes.Stloc, pdsCfgIsSealedLocal);
-
-        il.Emit(OpCodes.Ldloc, resultDictLocal);
-        il.Emit(OpCodes.Ldstr, "configurable");
-        il.Emit(OpCodes.Ldloc, descriptorLocal);
-        il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorConfigurable.GetGetMethod()!);
-        il.Emit(OpCodes.Ldloc, pdsCfgIsFrozenLocal);
-        il.Emit(OpCodes.Ldloc, pdsCfgIsSealedLocal);
-        il.Emit(OpCodes.Or);
-        il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Ceq);  // !(frozen || sealed)
-        il.Emit(OpCodes.And);
-        il.Emit(OpCodes.Box, _types.Boolean);
-        il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
-
-        il.Emit(OpCodes.Ldloc, resultDictLocal);
-        il.Emit(OpCodes.Br, endLabel);
+        EmitStoredPropertyDescriptorResult(il, runtime, descriptorLocal, resultDictLocal, hasDescriptorLabel, endLabel);
 
         // returnNullLabel: return undefined
         il.MarkLabel(returnNullLabel);

--- a/src/SharpTS/TypeSystem/TypeChecker.Statements.Classes.cs
+++ b/src/SharpTS/TypeSystem/TypeChecker.Statements.Classes.cs
@@ -277,6 +277,286 @@ public partial class TypeChecker
         }
     }
 
+    // Runs in the class type-parameter environment and populates the caller-owned mutable signature model.
+    private void CollectClassFieldTypes(Stmt.Class classStmt, TypeInfo.MutableClass mutableClass)
+    {
+        // Collect static property types, field access modifiers, and non-static field types
+        foreach (var field in classStmt.Fields)
+        {
+            // Check field decorators
+            DecoratorTarget fieldTarget = field.IsStatic ? DecoratorTarget.StaticField : DecoratorTarget.Field;
+            CheckDecorators(field.Decorators, fieldTarget);
+
+            string fieldName = GetFieldMemberName(field);
+            if (field.TypeAnnotationNode is { } fieldNode &&
+                ContainsSelfIndexedAccess(fieldNode, classStmt.Name.Lexeme, requireLiteralIndex: true))
+            {
+                RecordTypeError(new TypeCheckException(
+                    $"'{fieldName}' is referenced directly or indirectly in its own type annotation.",
+                    field.Name.Line,
+                    tsCode: "TS2502"));
+            }
+            TypeInfo fieldType = ResolveAnnotation(field.TypeAnnotation, field.TypeAnnotationNode)
+                ?? TypeInfo.Any.Shared;
+
+            // TS1166: a computed DATA-property name (a class field, unlike a method/accessor) must be a
+            // literal type or a 'unique symbol'. A plain, non-unique `symbol` — e.g. `[Symbol()]` —
+            // is not allowed; a well-known symbol (`[Symbol.iterator]`) is a unique symbol, so it's fine.
+            if (field.ComputedKey != null && CheckExpr(field.ComputedKey) is TypeInfo.Symbol)
+            {
+                RecordTypeError(new TypeCheckException(
+                    "A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.",
+                    line: TryGetExprLine(field.ComputedKey) ?? field.Name.Line, tsCode: "TS1166"));
+            }
+
+            // Handle ES2022 private fields (#field)
+            if (field.IsPrivate)
+            {
+                if (field.IsStatic)
+                {
+                    mutableClass.StaticPrivateFields[fieldName] = fieldType;
+                }
+                else
+                {
+                    mutableClass.PrivateFields[fieldName] = fieldType;
+                }
+            }
+            else if (field.IsStatic)
+            {
+                mutableClass.StaticProperties[fieldName] = fieldType;
+            }
+            else
+            {
+                mutableClass.FieldTypes[fieldName] = fieldType;
+            }
+            if (!field.IsPrivate)
+            {
+                (field.IsStatic ? mutableClass.StaticFieldAccess : mutableClass.FieldAccess)[fieldName] = field.Access;
+            }
+            if (field.IsReadonly)
+            {
+                mutableClass.ReadonlyFields.Add(fieldName);
+            }
+        }
+    }
+
+    // Requires method signatures to be registered for duplicate detection; keeps pair validation in the same class environment.
+    private void CollectClassAccessorTypes(Stmt.Class classStmt, TypeInfo.MutableClass mutableClass)
+    {
+        // Collect accessor types
+        if (classStmt.Accessors != null)
+        {
+            // TS2300: two getters (or two setters) with the same name/static-ness are a duplicate
+            // identifier — a class, unlike an object literal, can't have two same-kind accessors for
+            // one member at all (a get+set PAIR is fine; that's tracked separately below). Covers both
+            // plain and well-known-symbol computed names (`get [Symbol.hasInstance]()` declared twice),
+            // neither of which had any duplicate-accessor detection before.
+            var seenGetters = new Dictionary<(bool IsStatic, string Name), int>();
+            var seenSetters = new Dictionary<(bool IsStatic, string Name), int>();
+            foreach (var accessor in classStmt.Accessors)
+            {
+                // Check accessor decorators
+                DecoratorTarget accessorTarget = accessor.Kind.Type == TokenType.GET
+                    ? DecoratorTarget.Getter
+                    : DecoratorTarget.Setter;
+                CheckDecorators(accessor.Decorators, accessorTarget);
+
+                string? canonicalName = accessor.ComputedKey != null
+                    ? TryGetWellKnownSymbolMemberName(accessor.ComputedKey)
+                    : accessor.Name.Lexeme;
+                if (canonicalName != null)
+                {
+                    int line = accessor.ComputedKey != null
+                        ? TryGetExprLine(accessor.ComputedKey) ?? accessor.Name.Line
+                        : accessor.Name.Line;
+                    string displayName = accessor.ComputedKey != null ? $"[Symbol.{canonicalName["@@".Length..]}]" : canonicalName;
+                    // A method already registered under this name (methods are processed above)
+                    // makes ANY accessor of the same name a duplicate too — a class member can't be
+                    // both a method and an accessor. tsc flags the accessor, not the method.
+                    var methodDict = accessor.IsStatic ? mutableClass.StaticMethods : mutableClass.Methods;
+                    var seen = accessor.Kind.Type == TokenType.GET ? seenGetters : seenSetters;
+                    var key = (accessor.IsStatic, canonicalName);
+                    if (methodDict.ContainsKey(canonicalName) || !seen.TryAdd(key, line))
+                    {
+                        RecordTypeError(new TypeCheckException(
+                            $" Duplicate identifier '{displayName}'.", line: line, tsCode: "TS2300"));
+                    }
+                }
+
+                // Arbitrary computed names have no stable member identity. Well-known and augmented
+                // unique symbols do, and use the same @@ key as interfaces/object literals.
+                if (canonicalName == null)
+                {
+                    continue;
+                }
+
+                string propName = canonicalName;
+
+                if (accessor.Kind.Type == TokenType.GET)
+                {
+                    TypeInfo getterRetType = accessor.ReturnType != null
+                        ? ResolveAnnotation(accessor.ReturnType, accessor.ReturnTypeNode)!
+                        : TypeInfo.Inferred.Shared;
+                    mutableClass.Getters[propName] = getterRetType;
+
+                    // Track abstract getters
+                    if (accessor.IsAbstract)
+                    {
+                        mutableClass.AbstractGetters.Add(propName);
+                    }
+                }
+                else // SET
+                {
+                    TypeInfo paramType = accessor.SetterParam?.Type != null
+                        ? ResolveAnnotation(accessor.SetterParam.Type, accessor.SetterParam.TypeAnnotationNode)!
+                        : TypeInfo.Inferred.Shared;
+                    mutableClass.Setters[propName] = paramType;
+
+                    // Track abstract setters
+                    if (accessor.IsAbstract)
+                    {
+                        mutableClass.AbstractSetters.Add(propName);
+                    }
+                }
+            }
+
+            // Validate that getter/setter pairs have matching types
+            foreach (var propName in mutableClass.Getters.Keys.Intersect(mutableClass.Setters.Keys))
+            {
+                TypeInfo getterType = mutableClass.Getters[propName];
+                TypeInfo setterType = mutableClass.Setters[propName];
+                if (getterType is TypeInfo.Inferred && setterType is not TypeInfo.Inferred)
+                {
+                    mutableClass.Getters[propName] = setterType;
+                }
+                else if (setterType is TypeInfo.Inferred && getterType is not TypeInfo.Inferred)
+                {
+                    mutableClass.Setters[propName] = getterType;
+                }
+                else if (!IsCompatible(getterType, setterType))
+                {
+                    throw new TypeCheckException($" Getter and setter for '{propName}' have incompatible types.", tsCode: "TS2380");
+                }
+            }
+        }
+    }
+
+    // Resolves auto-accessors in the active class environment, mutating signatures before the caller freezes them.
+    private void CollectClassAutoAccessorTypes(Stmt.Class classStmt, TypeInfo.MutableClass mutableClass, TypeInfo? superclass)
+    {
+        // Collect auto-accessor types (TypeScript 4.9+)
+        if (classStmt.AutoAccessors != null)
+        {
+            foreach (var autoAccessor in classStmt.AutoAccessors)
+            {
+                // Check auto-accessor decorators (Stage 3: kind = "accessor")
+                DecoratorTarget accessorTarget = DecoratorTarget.Getter; // Use Getter target for auto-accessors
+                CheckDecorators(autoAccessor.Decorators, accessorTarget);
+
+                string propName = autoAccessor.Name.Lexeme;
+
+                // Determine the type from annotation or initializer
+                TypeInfo accessorType;
+                if (autoAccessor.TypeAnnotation != null)
+                {
+                    accessorType = ResolveAnnotation(autoAccessor.TypeAnnotation, autoAccessor.TypeAnnotationNode)!;
+                }
+                else if (autoAccessor.Initializer != null)
+                {
+                    accessorType = CheckExpr(autoAccessor.Initializer);
+                }
+                else
+                {
+                    accessorType = TypeInfo.Any.Shared;
+                }
+
+                // Register as getter (always available)
+                mutableClass.Getters[propName] = accessorType;
+
+                // Register as setter (unless readonly)
+                if (!autoAccessor.IsReadonly)
+                {
+                    mutableClass.Setters[propName] = accessorType;
+                }
+
+                // Track as auto-accessor for decorator context
+                mutableClass.AutoAccessors.Add(propName);
+
+                // Validate override if specified
+                if (autoAccessor.IsOverride)
+                {
+                    if (superclass == null)
+                    {
+                        throw new TypeCheckException($" Cannot use 'override' for auto-accessor '{propName}' in a class that does not extend another class.", tsCode: "TS4112");
+                    }
+
+                    // Check if parent has a matching getter
+                    bool parentHasGetter = false;
+                    TypeInfo? currentSuperclass = superclass;
+                    while (currentSuperclass != null)
+                    {
+                        if (currentSuperclass is TypeInfo.Class sc && sc.Getters.ContainsKey(propName))
+                        {
+                            parentHasGetter = true;
+                            break;
+                        }
+                        currentSuperclass = currentSuperclass switch
+                        {
+                            TypeInfo.Class c => c.Superclass,
+                            TypeInfo.InstantiatedGeneric ig when ig.GenericDefinition is TypeInfo.GenericClass gc => gc.Superclass,
+                            _ => null
+                        };
+                    }
+
+                    if (!parentHasGetter)
+                    {
+                        throw new TypeCheckException($" Auto-accessor '{propName}' uses 'override' but parent class has no accessor with this name.", tsCode: "TS4113");
+                    }
+                }
+            }
+        }
+    }
+
+    // Owns the static-block environment and context flags; restores them even when body checking throws.
+    private void CheckClassStaticBlocks(Stmt.Class classStmt, TypeInfo.Class classTypeForBody)
+    {
+        // Type-check static blocks
+        if (classStmt.StaticInitializers != null)
+        {
+            // Create environment with static class context ('this' refers to the class constructor)
+            var staticBlockEnv = new TypeEnvironment(_environment);
+            staticBlockEnv.Define("this", classTypeForBody);
+
+            foreach (var initializer in classStmt.StaticInitializers)
+            {
+                if (initializer is Stmt.StaticBlock block)
+                {
+                    using var _ = new EnvironmentScope(this, staticBlockEnv);
+                    bool previousInStaticBlock = _inStaticBlock;
+                    bool previousInStaticMethod = _inStaticMethod;
+                    var previousClass = _currentClass;
+                    _inStaticBlock = true;
+                    _inStaticMethod = true;
+                    _currentClass = classTypeForBody;
+
+                    try
+                    {
+                        foreach (var stmt in block.Body)
+                        {
+                            CheckStmt(stmt);
+                        }
+                    }
+                    finally
+                    {
+                        _inStaticBlock = previousInStaticBlock;
+                        _inStaticMethod = previousInStaticMethod;
+                        _currentClass = previousClass;
+                    }
+                }
+            }
+        }
+    }
+
     private void CheckClassDeclaration(Stmt.Class classStmt)
     {
         bool previousRecoveryMode = _recoveryMode;
@@ -381,233 +661,12 @@ public partial class TypeChecker
 
         CollectNamedClassMethodSignatures(classStmt, mutableClass);
 
-        // Collect static property types, field access modifiers, and non-static field types
-        foreach (var field in classStmt.Fields)
-        {
-            // Check field decorators
-            DecoratorTarget fieldTarget = field.IsStatic ? DecoratorTarget.StaticField : DecoratorTarget.Field;
-            CheckDecorators(field.Decorators, fieldTarget);
+        CollectClassFieldTypes(classStmt, mutableClass);
 
-            string fieldName = GetFieldMemberName(field);
-            if (field.TypeAnnotationNode is { } fieldNode &&
-                ContainsSelfIndexedAccess(fieldNode, classStmt.Name.Lexeme, requireLiteralIndex: true))
-            {
-                RecordTypeError(new TypeCheckException(
-                    $"'{fieldName}' is referenced directly or indirectly in its own type annotation.",
-                    field.Name.Line,
-                    tsCode: "TS2502"));
-            }
-            TypeInfo fieldType = ResolveAnnotation(field.TypeAnnotation, field.TypeAnnotationNode)
-                ?? TypeInfo.Any.Shared;
+        CollectClassAccessorTypes(classStmt, mutableClass);
 
-            // TS1166: a computed DATA-property name (a class field, unlike a method/accessor) must be a
-            // literal type or a 'unique symbol'. A plain, non-unique `symbol` — e.g. `[Symbol()]` —
-            // is not allowed; a well-known symbol (`[Symbol.iterator]`) is a unique symbol, so it's fine.
-            if (field.ComputedKey != null && CheckExpr(field.ComputedKey) is TypeInfo.Symbol)
-            {
-                RecordTypeError(new TypeCheckException(
-                    "A computed property name in a class property declaration must have a simple literal type or a 'unique symbol' type.",
-                    line: TryGetExprLine(field.ComputedKey) ?? field.Name.Line, tsCode: "TS1166"));
-            }
+        CollectClassAutoAccessorTypes(classStmt, mutableClass, superclass);
 
-            // Handle ES2022 private fields (#field)
-            if (field.IsPrivate)
-            {
-                if (field.IsStatic)
-                {
-                    mutableClass.StaticPrivateFields[fieldName] = fieldType;
-                }
-                else
-                {
-                    mutableClass.PrivateFields[fieldName] = fieldType;
-                }
-            }
-            else if (field.IsStatic)
-            {
-                mutableClass.StaticProperties[fieldName] = fieldType;
-            }
-            else
-            {
-                mutableClass.FieldTypes[fieldName] = fieldType;
-            }
-            if (!field.IsPrivate)
-            {
-                (field.IsStatic ? mutableClass.StaticFieldAccess : mutableClass.FieldAccess)[fieldName] = field.Access;
-            }
-            if (field.IsReadonly)
-            {
-                mutableClass.ReadonlyFields.Add(fieldName);
-            }
-        }
-
-        // Collect accessor types
-        if (classStmt.Accessors != null)
-        {
-            // TS2300: two getters (or two setters) with the same name/static-ness are a duplicate
-            // identifier — a class, unlike an object literal, can't have two same-kind accessors for
-            // one member at all (a get+set PAIR is fine; that's tracked separately below). Covers both
-            // plain and well-known-symbol computed names (`get [Symbol.hasInstance]()` declared twice),
-            // neither of which had any duplicate-accessor detection before.
-            var seenGetters = new Dictionary<(bool IsStatic, string Name), int>();
-            var seenSetters = new Dictionary<(bool IsStatic, string Name), int>();
-            foreach (var accessor in classStmt.Accessors)
-            {
-                // Check accessor decorators
-                DecoratorTarget accessorTarget = accessor.Kind.Type == TokenType.GET
-                    ? DecoratorTarget.Getter
-                    : DecoratorTarget.Setter;
-                CheckDecorators(accessor.Decorators, accessorTarget);
-
-                string? canonicalName = accessor.ComputedKey != null
-                    ? TryGetWellKnownSymbolMemberName(accessor.ComputedKey)
-                    : accessor.Name.Lexeme;
-                if (canonicalName != null)
-                {
-                    int line = accessor.ComputedKey != null
-                        ? TryGetExprLine(accessor.ComputedKey) ?? accessor.Name.Line
-                        : accessor.Name.Line;
-                    string displayName = accessor.ComputedKey != null ? $"[Symbol.{canonicalName["@@".Length..]}]" : canonicalName;
-                    // A method already registered under this name (methods are processed above)
-                    // makes ANY accessor of the same name a duplicate too — a class member can't be
-                    // both a method and an accessor. tsc flags the accessor, not the method.
-                    var methodDict = accessor.IsStatic ? mutableClass.StaticMethods : mutableClass.Methods;
-                    var seen = accessor.Kind.Type == TokenType.GET ? seenGetters : seenSetters;
-                    var key = (accessor.IsStatic, canonicalName);
-                    if (methodDict.ContainsKey(canonicalName) || !seen.TryAdd(key, line))
-                    {
-                        RecordTypeError(new TypeCheckException(
-                            $" Duplicate identifier '{displayName}'.", line: line, tsCode: "TS2300"));
-                    }
-                }
-
-                // Arbitrary computed names have no stable member identity. Well-known and augmented
-                // unique symbols do, and use the same @@ key as interfaces/object literals.
-                if (canonicalName == null)
-                {
-                    continue;
-                }
-
-                string propName = canonicalName;
-
-                if (accessor.Kind.Type == TokenType.GET)
-                {
-                    TypeInfo getterRetType = accessor.ReturnType != null
-                        ? ResolveAnnotation(accessor.ReturnType, accessor.ReturnTypeNode)!
-                        : TypeInfo.Inferred.Shared;
-                    mutableClass.Getters[propName] = getterRetType;
-
-                    // Track abstract getters
-                    if (accessor.IsAbstract)
-                    {
-                        mutableClass.AbstractGetters.Add(propName);
-                    }
-                }
-                else // SET
-                {
-                    TypeInfo paramType = accessor.SetterParam?.Type != null
-                        ? ResolveAnnotation(accessor.SetterParam.Type, accessor.SetterParam.TypeAnnotationNode)!
-                        : TypeInfo.Inferred.Shared;
-                    mutableClass.Setters[propName] = paramType;
-
-                    // Track abstract setters
-                    if (accessor.IsAbstract)
-                    {
-                        mutableClass.AbstractSetters.Add(propName);
-                    }
-                }
-            }
-
-            // Validate that getter/setter pairs have matching types
-            foreach (var propName in mutableClass.Getters.Keys.Intersect(mutableClass.Setters.Keys))
-            {
-                TypeInfo getterType = mutableClass.Getters[propName];
-                TypeInfo setterType = mutableClass.Setters[propName];
-                if (getterType is TypeInfo.Inferred && setterType is not TypeInfo.Inferred)
-                {
-                    mutableClass.Getters[propName] = setterType;
-                }
-                else if (setterType is TypeInfo.Inferred && getterType is not TypeInfo.Inferred)
-                {
-                    mutableClass.Setters[propName] = getterType;
-                }
-                else if (!IsCompatible(getterType, setterType))
-                {
-                    throw new TypeCheckException($" Getter and setter for '{propName}' have incompatible types.", tsCode: "TS2380");
-                }
-            }
-        }
-
-        // Collect auto-accessor types (TypeScript 4.9+)
-        if (classStmt.AutoAccessors != null)
-        {
-            foreach (var autoAccessor in classStmt.AutoAccessors)
-            {
-                // Check auto-accessor decorators (Stage 3: kind = "accessor")
-                DecoratorTarget accessorTarget = DecoratorTarget.Getter; // Use Getter target for auto-accessors
-                CheckDecorators(autoAccessor.Decorators, accessorTarget);
-
-                string propName = autoAccessor.Name.Lexeme;
-
-                // Determine the type from annotation or initializer
-                TypeInfo accessorType;
-                if (autoAccessor.TypeAnnotation != null)
-                {
-                    accessorType = ResolveAnnotation(autoAccessor.TypeAnnotation, autoAccessor.TypeAnnotationNode)!;
-                }
-                else if (autoAccessor.Initializer != null)
-                {
-                    accessorType = CheckExpr(autoAccessor.Initializer);
-                }
-                else
-                {
-                    accessorType = TypeInfo.Any.Shared;
-                }
-
-                // Register as getter (always available)
-                mutableClass.Getters[propName] = accessorType;
-
-                // Register as setter (unless readonly)
-                if (!autoAccessor.IsReadonly)
-                {
-                    mutableClass.Setters[propName] = accessorType;
-                }
-
-                // Track as auto-accessor for decorator context
-                mutableClass.AutoAccessors.Add(propName);
-
-                // Validate override if specified
-                if (autoAccessor.IsOverride)
-                {
-                    if (superclass == null)
-                    {
-                        throw new TypeCheckException($" Cannot use 'override' for auto-accessor '{propName}' in a class that does not extend another class.", tsCode: "TS4112");
-                    }
-
-                    // Check if parent has a matching getter
-                    bool parentHasGetter = false;
-                    TypeInfo? currentSuperclass = superclass;
-                    while (currentSuperclass != null)
-                    {
-                        if (currentSuperclass is TypeInfo.Class sc && sc.Getters.ContainsKey(propName))
-                        {
-                            parentHasGetter = true;
-                            break;
-                        }
-                        currentSuperclass = currentSuperclass switch
-                        {
-                            TypeInfo.Class c => c.Superclass,
-                            TypeInfo.InstantiatedGeneric ig when ig.GenericDefinition is TypeInfo.GenericClass gc => gc.Superclass,
-                            _ => null
-                        };
-                    }
-
-                    if (!parentHasGetter)
-                    {
-                        throw new TypeCheckException($" Auto-accessor '{propName}' uses 'override' but parent class has no accessor with this name.", tsCode: "TS4113");
-                    }
-                }
-            }
-        }
         }
 
         // Freeze the mutable class and create GenericClass or regular Class based on type parameters.
@@ -824,41 +883,7 @@ public partial class TypeChecker
             }
         }
 
-        // Type-check static blocks
-        if (classStmt.StaticInitializers != null)
-        {
-            // Create environment with static class context ('this' refers to the class constructor)
-            var staticBlockEnv = new TypeEnvironment(_environment);
-            staticBlockEnv.Define("this", classTypeForBody);
-
-            foreach (var initializer in classStmt.StaticInitializers)
-            {
-                if (initializer is Stmt.StaticBlock block)
-                {
-                    using var _ = new EnvironmentScope(this, staticBlockEnv);
-                    bool previousInStaticBlock = _inStaticBlock;
-                    bool previousInStaticMethod = _inStaticMethod;
-                    var previousClass = _currentClass;
-                    _inStaticBlock = true;
-                    _inStaticMethod = true;
-                    _currentClass = classTypeForBody;
-
-                    try
-                    {
-                        foreach (var stmt in block.Body)
-                        {
-                            CheckStmt(stmt);
-                        }
-                    }
-                    finally
-                    {
-                        _inStaticBlock = previousInStaticBlock;
-                        _inStaticMethod = previousInStaticMethod;
-                        _currentClass = previousClass;
-                    }
-                }
-            }
-        }
+        CheckClassStaticBlocks(classStmt, classTypeForBody);
 
         // Third pass: body check
         TypeEnvironment classEnv = new(_environment);

--- a/tests/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/ILVerificationTests.cs
@@ -11,6 +11,34 @@ namespace SharpTS.Tests.CompilerTests;
 public class ILVerificationTests
 {
     [Fact]
+    public void StoredPropertyDescriptors_AfterSealAndFreeze_PassILVerification()
+    {
+        var source = """
+            const target: any = {};
+            Object.defineProperty(target, "data", {
+                value: 7, writable: true, enumerable: true, configurable: true
+            });
+            Object.defineProperty(target, "read", { get: () => 8, configurable: true });
+            Object.defineProperty(target, "write", { set: (value: number) => {}, configurable: true });
+            Object.seal(target);
+            let data: any = Object.getOwnPropertyDescriptor(target, "data");
+            console.log(data.value, data.writable, data.enumerable, data.configurable);
+            Object.freeze(target);
+            data = Object.getOwnPropertyDescriptor(target, "data");
+            console.log(data.value, data.writable, data.enumerable, data.configurable);
+            const read: any = Object.getOwnPropertyDescriptor(target, "read");
+            const write: any = Object.getOwnPropertyDescriptor(target, "write");
+            console.log(typeof read.get, "set" in read, typeof read.set, read.configurable);
+            console.log("get" in write, typeof write.get, typeof write.set, write.configurable);
+            """;
+
+        var (errors, output) = TestHarness.CompileVerifyAndRun(source);
+
+        Assert.Empty(errors);
+        Assert.Equal("7 true true false\n7 false true false\nfunction true undefined false\ntrue undefined function false\n", output);
+    }
+
+    [Fact]
     public void SameModuleExportBindingsInFunctionBody_PassILVerification()
     {
         var files = new Dictionary<string, string>


### PR DESCRIPTION
Class checking still mixed field/accessor signature collection and static-block execution into its declaration orchestration. Extract those four stages with explicit mutable-class inputs and preserve the existing class environment, recovery scope, diagnostic order, and static-context restoration.

Extract stored property descriptor result construction from Object.getOwnPropertyDescriptor. The helper owns its scratch locals and internal labels; its documented shared-label contract preserves the empty entry stack and single-object exit stack. Add IL verification covering data descriptors and missing accessor slots after seal/freeze.

Continues #1598 after merged PR #1606. This is a bounded, behavior-preserving increment; leave the issue open for the remaining descriptor validation/receiver paths and class body decomposition. No PR for #1598 was open when this work was selected.

Validation:
- Release build and 2,478 selected checker, class, accessor, symbol, proxy, decorator, generic, property, and IL-verification regression tests passed with no failures or skips.
- TypeScript conformance baseline check passed against the configured 534-case corpus subset.
- git diff --cached --check passed.
- Expanding all five helper calls reconstructs the original production source apart from whitespace; extracted bodies are unchanged.
- All 319 additional object-property tests and the new descriptor IL-verification test passed with no failures or skips (2,797 regression tests total).
- NuGet reported NU1900 vulnerability-feed warnings. The temporary local corpus junctions also caused a MinVer default-version warning during conformance setup; those junctions were removed before the final test build. Full solution tests and the full Test262 suite were not run.

Commands:
```powershell
dotnet test tests/SharpTS.Tests/SharpTS.Tests.csproj -c Release -m:1 --filter 'FullyQualifiedName~TypeCheckerTests|FullyQualifiedName~ClassTests|FullyQualifiedName~Accessor|FullyQualifiedName~StaticBlockTests|FullyQualifiedName~PropertySemanticsTests|FullyQualifiedName~Symbol|FullyQualifiedName~ProxyTests|FullyQualifiedName~ILVerificationTests|FullyQualifiedName~GenericsTests|FullyQualifiedName~Decorator'
dotnet test tests/conformance/SharpTS.TypeScriptConformance/SharpTS.TypeScriptConformance.csproj -c Release -m:1 --filter 'FullyQualifiedName~TypeScriptConformanceTests.InterpretedBaseline'
dotnet test tests/SharpTS.Tests/SharpTS.Tests.csproj -c Release --no-restore -m:1 --filter 'FullyQualifiedName~ObjectFeatureTests|FullyQualifiedName~Issue1279ParityRuntimeTests|FullyQualifiedName~StoredPropertyDescriptors_AfterSealAndFreeze'
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved property descriptor reporting after objects are sealed or frozen, including accurate accessor fields and writable/configurable status.

- **Tests**
  - Added coverage verifying property descriptors for data properties, getter-only accessors, and setter-only accessors after sealing and freezing.
  - Confirmed the resulting code compiles, verifies, and runs successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->