### PR TITLE
Refactor TLS runtime metadata into a checked feature component

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -181,6 +181,14 @@ wrappers. `EmitAll` completes the component after type finalization. The 24 hand
 separate dependencies, and zlib retains
 its standalone output behavior.
 
+TLS uses `Tls` / `RequireTls()` for its eleven migrated module and socket handles.
+`EmitAll` creates it only for `UsesTls`, before socket/server phase 1. The declared
+`Connect` handle is also the source used to emit its deferred body after closure creation.
+Completion follows socket, runtime, and server finalization; net types remain separate
+dependencies. TLS-only constant and certificate emitters accept `EmittedTlsRuntime` directly.
+The shared built-in module registry still owns named-import dispatch (including
+`checkServerIdentity`); emitter-local closure and field state stays with the emitter.
+
 During emission, each handle becomes readable as soon as its declaration is assigned, so forward
 references do not require a method body to exist yet. An early read names the missing declaration.
 Completion is an orchestration boundary, not an IL verifier: body emission and type finalization

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -2287,24 +2287,18 @@ public class EmittedRuntime
     public ConstructorBuilder? BlockListCtor { get; set; }
     public MethodBuilder? BlockListCheckIp { get; set; }
 
-    // TLS module methods
-    public MethodBuilder TlsCreateServer { get; set; } = null!;
-    public MethodBuilder TlsConnect { get; set; } = null!;
-    public MethodBuilder TlsCreateSecureContext { get; set; } = null!;
-    public MethodBuilder TlsGetDefaultMinVersion { get; set; } = null!;
-    public MethodBuilder TlsGetDefaultMaxVersion { get; set; } = null!;
-    public MethodBuilder TlsGetCiphers { get; set; } = null!;
-    public MethodBuilder TlsRootCertificates { get; set; } = null!;
-    public MethodBuilder TlsCreateSocket { get; set; } = null!;
+    /// <summary>TLS metadata, or null when TLS is tree-shaken from this compilation.</summary>
+    public EmittedTlsRuntime? Tls { get; private set; }
 
-    // $TlsSocket emitted type - pure IL standalone TLS socket
-    // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSTlsSocket
-    public Type TlsSocketType { get; set; } = null!;
-    public ConstructorBuilder TlsSocketCtor { get; set; } = null!;
+    internal void BeginTlsEmission()
+    {
+        if (Tls is not null)
+            throw new InvalidOperationException("TLS metadata emission has already started.");
+        Tls = new EmittedTlsRuntime();
+    }
 
-    // $TlsServer emitted type - pure IL standalone TLS server
-    // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSTlsServer
-    public ConstructorBuilder TlsServerCtor { get; set; } = null!;
+    public EmittedTlsRuntime RequireTls() => Tls
+        ?? throw new InvalidOperationException("TLS runtime was not enabled for this compilation.");
 
     // Dgram module methods
     public MethodBuilder DgramCreateSocket { get; set; } = null!;

--- a/src/SharpTS/Compilation/EmittedTlsRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedTlsRuntime.cs
@@ -1,0 +1,125 @@
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// TLS metadata for one compilation. Declarations support forward references;
+/// completion validates and freezes handles after deferred bodies and types are finalized.
+/// </summary>
+public sealed class EmittedTlsRuntime
+{
+    internal EmittedTlsRuntime() { }
+
+    public bool IsComplete { get; private set; }
+
+    private MethodBuilder? _createServer;
+    public MethodBuilder CreateServer
+    {
+        get => Require(_createServer);
+        internal set => Set(ref _createServer, value);
+    }
+
+    private MethodBuilder? _connect;
+    public MethodBuilder Connect
+    {
+        get => Require(_connect);
+        internal set => Set(ref _connect, value);
+    }
+
+    private MethodBuilder? _createSecureContext;
+    public MethodBuilder CreateSecureContext
+    {
+        get => Require(_createSecureContext);
+        internal set => Set(ref _createSecureContext, value);
+    }
+
+    private MethodBuilder? _getDefaultMinVersion;
+    public MethodBuilder GetDefaultMinVersion
+    {
+        get => Require(_getDefaultMinVersion);
+        internal set => Set(ref _getDefaultMinVersion, value);
+    }
+
+    private MethodBuilder? _getDefaultMaxVersion;
+    public MethodBuilder GetDefaultMaxVersion
+    {
+        get => Require(_getDefaultMaxVersion);
+        internal set => Set(ref _getDefaultMaxVersion, value);
+    }
+
+    private MethodBuilder? _getCiphers;
+    public MethodBuilder GetCiphers
+    {
+        get => Require(_getCiphers);
+        internal set => Set(ref _getCiphers, value);
+    }
+
+    private MethodBuilder? _rootCertificates;
+    public MethodBuilder RootCertificates
+    {
+        get => Require(_rootCertificates);
+        internal set => Set(ref _rootCertificates, value);
+    }
+
+    private MethodBuilder? _createSocket;
+    public MethodBuilder CreateSocket
+    {
+        get => Require(_createSocket);
+        internal set => Set(ref _createSocket, value);
+    }
+
+    private Type? _socketType;
+    public Type SocketType
+    {
+        get => Require(_socketType);
+        internal set => Set(ref _socketType, value);
+    }
+
+    private ConstructorBuilder? _socketCtor;
+    public ConstructorBuilder SocketCtor
+    {
+        get => Require(_socketCtor);
+        internal set => Set(ref _socketCtor, value);
+    }
+
+    private ConstructorBuilder? _serverCtor;
+    public ConstructorBuilder ServerCtor
+    {
+        get => Require(_serverCtor);
+        internal set => Set(ref _serverCtor, value);
+    }
+
+    private static T Require<T>(T? handle, [CallerMemberName] string name = "") where T : class =>
+        handle ?? throw new InvalidOperationException($"TLS metadata '{name}' has not been declared.");
+
+    private void Set<T>(ref T? field, T value) where T : class
+    {
+        EnsureMutable();
+        ArgumentNullException.ThrowIfNull(value);
+        field = value;
+    }
+
+    private void EnsureMutable()
+    {
+        if (IsComplete)
+            throw new InvalidOperationException("TLS metadata emission is already complete.");
+    }
+
+    internal void CompleteEmission()
+    {
+        EnsureMutable();
+        _ = CreateServer;
+        _ = Connect;
+        _ = CreateSecureContext;
+        _ = GetDefaultMinVersion;
+        _ = GetDefaultMaxVersion;
+        _ = GetCiphers;
+        _ = RootCertificates;
+        _ = CreateSocket;
+        _ = SocketType;
+        _ = SocketCtor;
+        _ = ServerCtor;
+        IsComplete = true;
+    }
+}

--- a/src/SharpTS/Compilation/Emitters/Modules/TlsModuleEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/Modules/TlsModuleEmitter.cs
@@ -41,7 +41,7 @@ public sealed class TlsModuleEmitter : IBuiltInModuleEmitter
             "connect" => EmitConnect(emitter, arguments),
             "createSecureContext" => EmitCreateSecureContext(emitter, arguments),
             "checkServerIdentity" => EmitCheckServerIdentity(emitter, arguments),
-            "getCiphers" => EmitNoArgCall(emitter, emitter.Context.Runtime!.TlsGetCiphers),
+            "getCiphers" => EmitNoArgCall(emitter, emitter.Context.Runtime!.RequireTls().GetCiphers),
             "TLSSocket" => EmitCreateSocket(emitter),
             _ => false
         };
@@ -83,9 +83,9 @@ public sealed class TlsModuleEmitter : IBuiltInModuleEmitter
 
         return propertyName switch
         {
-            "DEFAULT_MIN_VERSION" => EmitConstantProperty(il, ctx.Runtime!.TlsGetDefaultMinVersion),
-            "DEFAULT_MAX_VERSION" => EmitConstantProperty(il, ctx.Runtime!.TlsGetDefaultMaxVersion),
-            "rootCertificates" => EmitConstantProperty(il, ctx.Runtime!.TlsRootCertificates),
+            "DEFAULT_MIN_VERSION" => EmitConstantProperty(il, ctx.Runtime!.RequireTls().GetDefaultMinVersion),
+            "DEFAULT_MAX_VERSION" => EmitConstantProperty(il, ctx.Runtime!.RequireTls().GetDefaultMaxVersion),
+            "rootCertificates" => EmitConstantProperty(il, ctx.Runtime!.RequireTls().RootCertificates),
             _ => false
         };
     }
@@ -124,7 +124,7 @@ public sealed class TlsModuleEmitter : IBuiltInModuleEmitter
         }
 
         // Call $Runtime.TlsCreateServer(options, callback)
-        il.Emit(OpCodes.Call, ctx.Runtime!.TlsCreateServer);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireTls().CreateServer);
         emitter.SetStackUnknown();
         return true;
     }
@@ -149,7 +149,7 @@ public sealed class TlsModuleEmitter : IBuiltInModuleEmitter
         }
 
         // Call $Runtime.TlsConnect(portOrOptions, hostOrCallback, optionsOrNull, callbackOrNull)
-        il.Emit(OpCodes.Call, ctx.Runtime!.TlsConnect);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireTls().Connect);
         emitter.SetStackUnknown();
         return true;
     }
@@ -169,7 +169,7 @@ public sealed class TlsModuleEmitter : IBuiltInModuleEmitter
             il.Emit(OpCodes.Ldnull);
         }
 
-        il.Emit(OpCodes.Call, ctx.Runtime!.TlsCreateSecureContext);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireTls().CreateSecureContext);
         emitter.SetStackUnknown();
         return true;
     }
@@ -180,7 +180,7 @@ public sealed class TlsModuleEmitter : IBuiltInModuleEmitter
         var il = ctx.IL;
 
         // Call $Runtime.TlsCreateSocket() - creates a new $TlsSocket
-        il.Emit(OpCodes.Call, ctx.Runtime!.TlsCreateSocket);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireTls().CreateSocket);
         emitter.SetStackUnknown();
         return true;
     }

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSTlsAccept.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSTlsAccept.cs
@@ -610,7 +610,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, typeof(SslStream).GetMethod("AuthenticateAsServer", [typeof(SslServerAuthenticationOptions)])!);
 
         // socket = new $TlsSocket(); populate
-        il.Emit(OpCodes.Newobj, runtime.TlsSocketCtor);
+        il.Emit(OpCodes.Newobj, runtime.RequireTls().SocketCtor);
         il.Emit(OpCodes.Stloc, socketLocal);
         EmitTlsPopulateSocket(il,
             loadSocket: () => il.Emit(OpCodes.Ldloc, socketLocal),

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSTlsSocket.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSTlsSocket.cs
@@ -82,7 +82,7 @@ public partial class RuntimeEmitter
             runtime.NetSocketType  // extends $NetSocket — inherits real socket I/O over the SslStream
         );
         _tlsSocketTypeBuilder = typeBuilder;
-        runtime.TlsSocketType = typeBuilder;
+        runtime.RequireTls().SocketType = typeBuilder;
 
         // Fields (Assembly so the connect/accept workers can populate them)
         _tlsSocketSslStreamField = typeBuilder.DefineField("_sslStream", typeof(SslStream), FieldAttributes.Assembly);
@@ -98,7 +98,7 @@ public partial class RuntimeEmitter
             CallingConventions.Standard,
             Type.EmptyTypes
         );
-        runtime.TlsSocketCtor = ctor;
+        runtime.RequireTls().SocketCtor = ctor;
         var ctorIL = ctor.GetILGenerator();
         ctorIL.Emit(OpCodes.Ldarg_0);
         ctorIL.Emit(OpCodes.Call, runtime.NetSocketCtor);
@@ -780,7 +780,7 @@ public partial class RuntimeEmitter
             CallingConventions.Standard,
             [_types.Object, _types.Object]
         );
-        runtime.TlsServerCtor = ctor;
+        runtime.RequireTls().ServerCtor = ctor;
 
         var ctorIL = ctor.GetILGenerator();
         ctorIL.Emit(OpCodes.Ldarg_0);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Tls.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Tls.cs
@@ -20,9 +20,9 @@ public partial class RuntimeEmitter
         EmitTlsCreateSecureContext(typeBuilder, runtime);
         EmitTlsCheckServerIdentity(typeBuilder, runtime);
         EmitTlsGetCiphers(typeBuilder, runtime);
-        EmitTlsRootCertificates(typeBuilder, runtime);
-        EmitTlsGetDefaultMinVersion(typeBuilder, runtime);
-        EmitTlsGetDefaultMaxVersion(typeBuilder, runtime);
+        EmitTlsRootCertificates(typeBuilder, runtime.RequireTls());
+        EmitTlsGetDefaultMinVersion(typeBuilder, runtime.RequireTls());
+        EmitTlsGetDefaultMaxVersion(typeBuilder, runtime.RequireTls());
     }
 
     /// <summary>
@@ -37,7 +37,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object, _types.Object]
         );
-        runtime.TlsCreateServer = method;
+        runtime.RequireTls().CreateServer = method;
         runtime.RegisterBuiltInModuleMethod("tls", "createServer", method);
         runtime.RegisterBuiltInModuleMethod("tls", "Server", method); // alias
 
@@ -46,7 +46,7 @@ public partial class RuntimeEmitter
         // new $TlsServer(options, callback)
         il.Emit(OpCodes.Ldarg_0); // options
         il.Emit(OpCodes.Ldarg_1); // callback
-        il.Emit(OpCodes.Newobj, runtime.TlsServerCtor);
+        il.Emit(OpCodes.Newobj, runtime.RequireTls().ServerCtor);
         il.Emit(OpCodes.Ret);
     }
 
@@ -58,8 +58,6 @@ public partial class RuntimeEmitter
     /// NOTE: The TlsConnect body is deferred to EmitTlsConnectBody (Phase 2) since it
     /// depends on the $TlsConnectClosure type defined after EmitRuntimeClass.
     /// </summary>
-    private MethodBuilder? _tlsConnectMethod;
-
     private void EmitTlsConnect(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
         var method = typeBuilder.DefineMethod(
@@ -68,9 +66,9 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object, _types.Object, _types.Object, _types.Object]
         );
-        runtime.TlsConnect = method;
+        runtime.RequireTls().Connect = method;
         runtime.RegisterBuiltInModuleMethod("tls", "connect", method);
-        _tlsConnectMethod = method;
+
         // Body emitted in EmitTlsConnectBody after $TlsConnectClosure is defined
     }
 
@@ -79,7 +77,7 @@ public partial class RuntimeEmitter
     /// </summary>
     internal void EmitTlsConnectBody(EmittedRuntime runtime)
     {
-        var il = _tlsConnectMethod!.GetILGenerator();
+        var il = runtime.RequireTls().Connect.GetILGenerator();
 
         // Parse port from arg0 (double → int)
         var portLocal = il.DeclareLocal(_types.Int32);
@@ -223,8 +221,8 @@ public partial class RuntimeEmitter
         il.MarkLabel(alpnDone);
 
         // Create socket
-        var socketLocal = il.DeclareLocal(runtime.TlsSocketType);
-        il.Emit(OpCodes.Newobj, runtime.TlsSocketCtor);
+        var socketLocal = il.DeclareLocal(runtime.RequireTls().SocketType);
+        il.Emit(OpCodes.Newobj, runtime.RequireTls().SocketCtor);
         il.Emit(OpCodes.Stloc, socketLocal);
         il.Emit(OpCodes.Ldloc, socketLocal);
         il.Emit(OpCodes.Ldloc, hostLocal);
@@ -278,13 +276,13 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.TlsCreateSocket = method;
+        runtime.RequireTls().CreateSocket = method;
         runtime.RegisterBuiltInModuleMethod("tls", "TLSSocket", method);
 
         var il = method.GetILGenerator();
 
         // new $TlsSocket()
-        il.Emit(OpCodes.Newobj, runtime.TlsSocketCtor);
+        il.Emit(OpCodes.Newobj, runtime.RequireTls().SocketCtor);
         il.Emit(OpCodes.Ret);
     }
 
@@ -302,7 +300,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object]
         );
-        runtime.TlsCreateSecureContext = method;
+        runtime.RequireTls().CreateSecureContext = method;
         runtime.RegisterBuiltInModuleMethod("tls", "createSecureContext", method);
 
         var il = method.GetILGenerator();
@@ -349,7 +347,7 @@ public partial class RuntimeEmitter
     /// Emits: public static object TlsGetDefaultMinVersion()
     /// Returns "TLSv1.2" - no reflection needed.
     /// </summary>
-    private void EmitTlsGetDefaultMinVersion(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTlsGetDefaultMinVersion(TypeBuilder typeBuilder, EmittedTlsRuntime tls)
     {
         var method = typeBuilder.DefineMethod(
             "TlsGetDefaultMinVersion",
@@ -357,7 +355,7 @@ public partial class RuntimeEmitter
             _types.Object,
             []
         );
-        runtime.TlsGetDefaultMinVersion = method;
+        tls.GetDefaultMinVersion = method;
 
         var il = method.GetILGenerator();
         il.Emit(OpCodes.Ldstr, "TLSv1.2");
@@ -368,7 +366,7 @@ public partial class RuntimeEmitter
     /// Emits: public static object TlsGetDefaultMaxVersion()
     /// Returns "TLSv1.3" - no reflection needed.
     /// </summary>
-    private void EmitTlsGetDefaultMaxVersion(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTlsGetDefaultMaxVersion(TypeBuilder typeBuilder, EmittedTlsRuntime tls)
     {
         var method = typeBuilder.DefineMethod(
             "TlsGetDefaultMaxVersion",
@@ -376,7 +374,7 @@ public partial class RuntimeEmitter
             _types.Object,
             []
         );
-        runtime.TlsGetDefaultMaxVersion = method;
+        tls.GetDefaultMaxVersion = method;
 
         var il = method.GetILGenerator();
         il.Emit(OpCodes.Ldstr, "TLSv1.3");

--- a/src/SharpTS/Compilation/RuntimeEmitter.TlsExtras.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TlsExtras.cs
@@ -23,7 +23,7 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.TlsGetCiphers = method;
+        runtime.RequireTls().GetCiphers = method;
         runtime.RegisterBuiltInModuleMethod("tls", "getCiphers", method);
 
         var il = method.GetILGenerator();
@@ -50,7 +50,7 @@ public partial class RuntimeEmitter
     /// Emits: public static object TlsRootCertificates() — a List&lt;object&gt; of PEM root certs
     /// enumerated from the platform Root store (CurrentUser + LocalMachine).
     /// </summary>
-    private void EmitTlsRootCertificates(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTlsRootCertificates(TypeBuilder typeBuilder, EmittedTlsRuntime tls)
     {
         var method = typeBuilder.DefineMethod(
             "TlsRootCertificates",
@@ -58,7 +58,7 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.TlsRootCertificates = method;
+        tls.RootCertificates = method;
 
         var il = method.GetILGenerator();
         var listType = _types.ListOfObject;

--- a/src/SharpTS/Compilation/RuntimeEmitter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.cs
@@ -40,6 +40,8 @@ public partial class RuntimeEmitter
         if (_emitHosted)
             _features.UsesPromise = true;
         var runtime = new EmittedRuntime();
+        if (features.UsesTls)
+            runtime.BeginTlsEmission();
         if (features.UsesZlib)
             runtime.BeginZlibEmission();
         if (features.UsesDns)
@@ -609,6 +611,7 @@ public partial class RuntimeEmitter
 
         runtime.Dns?.CompleteEmission();
         runtime.Zlib?.CompleteEmission();
+        runtime.Tls?.CompleteEmission();
         return runtime;
     }
 }

--- a/tests/SharpTS.Tests/CompilerTests/EmittedTlsRuntimeTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/EmittedTlsRuntimeTests.cs
@@ -1,0 +1,90 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public class EmittedTlsRuntimeTests
+{
+    [Fact]
+    public void ModuleConsumersAndDeferredBodiesPassILVerification()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as tls from 'tls';
+                import { createServer, connect, createSecureContext, getCiphers } from 'tls';
+                console.log(tls.DEFAULT_MIN_VERSION, tls.DEFAULT_MAX_VERSION);
+                console.log(tls.rootCertificates.length, getCiphers().length);
+                const server = createServer();
+                const socket = connect({ port: 12345, host: '127.0.0.1' });
+                const context = createSecureContext();
+                """
+        };
+        Assert.Empty(TestHarness.CompileModulesAndVerifyOnly(files, "main.ts"));
+    }
+
+    [Fact]
+    public void DisabledFeatureHasNoMetadataAndReportsAccidentalUse()
+    {
+        var runtime = EmitRuntime(false);
+        Assert.Null(runtime.Tls);
+        Assert.Contains("not enabled", Assert.Throws<InvalidOperationException>(runtime.RequireTls).Message);
+        Assert.DoesNotContain(runtime.RuntimeType.GetMethods(), method => method.Name.StartsWith("Tls", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ConnectDeclarationSupportsForwardReferencesAndIncompleteEmissionFails()
+    {
+        var runtime = new EmittedRuntime();
+        runtime.BeginTlsEmission();
+        var tls = runtime.RequireTls();
+        Assert.False(tls.IsComplete);
+        Assert.Contains("Connect", Assert.Throws<InvalidOperationException>(() => tls.Connect).Message);
+
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName("tls_forward"), typeof(object).Assembly);
+        var type = assembly.DefineDynamicModule("main").DefineType("Runtime");
+        var method = type.DefineMethod("Connect", MethodAttributes.Public | MethodAttributes.Static, typeof(void), Type.EmptyTypes);
+        tls.Connect = method;
+        Assert.Same(method, tls.Connect);
+        Assert.Throws<InvalidOperationException>(runtime.BeginTlsEmission);
+        Assert.Contains("CreateServer", Assert.Throws<InvalidOperationException>(tls.CompleteEmission).Message);
+        Assert.False(tls.IsComplete);
+        Assert.Throws<ArgumentNullException>(() => tls.Connect = null!);
+        Assert.Same(method, tls.Connect);
+    }
+
+    [Fact]
+    public void EnabledFeatureCompletesAllHandlesAndRejectsFurtherWrites()
+    {
+        var runtime = EmitRuntime(true);
+        var tls = runtime.RequireTls();
+        Assert.True(tls.IsComplete);
+        Assert.Equal("TlsConnect", tls.Connect.Name);
+        Assert.Equal("$TlsSocket", tls.SocketType.Name);
+        Assert.NotNull(tls.SocketCtor);
+        Assert.NotNull(tls.ServerCtor);
+        Assert.All(typeof(EmittedTlsRuntime).GetProperties()
+            .Where(property => property.PropertyType == typeof(MethodBuilder)),
+            property => Assert.NotNull(property.GetValue(tls)));
+        Assert.Same(tls.Connect, runtime.GetBuiltInModuleMethod("tls", "connect"));
+        Assert.Same(tls.CreateServer, runtime.GetBuiltInModuleMethod("tls", "Server"));
+        Assert.Throws<InvalidOperationException>(() => tls.Connect = tls.Connect);
+        Assert.Throws<InvalidOperationException>(() => tls.SocketCtor = tls.SocketCtor);
+        Assert.Throws<InvalidOperationException>(() => tls.SocketType = tls.SocketType);
+        Assert.Throws<InvalidOperationException>(tls.CompleteEmission);
+        Assert.Empty(runtime.RequiredSharpTSRuntimeReasons);
+    }
+
+    private static EmittedRuntime EmitRuntime(bool usesTls)
+    {
+        var source = usesTls ? "import * as tls from 'tls';" : "console.log(1);";
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var features = new RuntimeFeatureDetector().Detect(statements);
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName($"tls_metadata_{Guid.NewGuid():N}"), typeof(object).Assembly);
+        return new RuntimeEmitter(TypeProvider.Runtime).EmitAll(assembly.DefineDynamicModule("main"), features);
+    }
+}


### PR DESCRIPTION
This continues #1599 by moving TLS's eleven flat module/socket metadata handles into `EmittedTlsRuntime`. Disabled TLS has no component; premature handle reads name the missing declaration, and completion validates and freezes the handles after deferred bodies and type finalization.

The deferred `connect` body now uses the component's declared handle instead of a second emitter field. TLS-only constant/certificate emitters accept the component directly. Existing feature gates, IL instructions, emission order, and named-import registration are preserved. The architecture guide documents the migration boundary and remaining emitter-local state.

Validation:
- Release solution build: zero warnings and errors.
- TLS-focused tests: 91 passed, including four new lifecycle/IL-verification tests, interpreter/compiler parity, and standalone TLS handshake execution without SharpTS.dll.
- Standard core suite (`Category!=LiveNetwork&Category!=LoadSensitive&Category!=npm`): 18,192 passed, 3 skipped, 0 failed (9m 3s).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved TLS runtime metadata handling during compilation.
  - TLS resources are now initialized only when TLS functionality is used and finalized in the correct order.
  - TLS module operations continue to support server creation, secure connections, certificates, ciphers, and socket handling.

- **Documentation**
  - Updated architecture documentation to describe TLS runtime emission and lifecycle behavior.

- **Tests**
  - Added coverage for TLS compilation, feature-disabled scenarios, deferred references, incomplete emission, and runtime metadata completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->