### PR TITLE
Extract datagram runtime metadata into a checked component

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -189,6 +189,15 @@ dependencies. TLS-only constant and certificate emitters accept `EmittedTlsRunti
 The shared built-in module registry still owns named-import dispatch (including
 `checkServerIdentity`); emitter-local closure and field state stays with the emitter.
 
+Dgram uses `Dgram` / `RequireDgram()` only when `UsesDgram` is enabled. Its component owns the
+socket type and constructor, module factory, forward-declared receive worker, and message closure
+constructor/entry point. Phase 1 declares the receive worker before `bind` references it; phase 2
+emits its body after the message closure is available and then finalizes the socket type.
+Completion follows runtime finalization. The factory and socket finalizer take `EmittedDgramRuntime`
+directly; event-loop, Buffer, and EventEmitter dependencies remain on the shared runtime. Socket
+fields and synchronous method helpers stay local to the emitter, and named-import dispatch remains
+in the shared built-in module registry.
+
 During emission, each handle becomes readable as soon as its declaration is assigned, so forward
 references do not require a method body to exist yet. An early read names the missing declaration.
 Completion is an orchestration boundary, not an IL verifier: body emission and type finalization

--- a/src/SharpTS/Compilation/EmittedDgramRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedDgramRuntime.cs
@@ -1,0 +1,85 @@
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Datagram metadata for one compilation. Declarations support forward references;
+/// completion validates and freezes handles after the receive worker and types are finalized.
+/// </summary>
+public sealed class EmittedDgramRuntime
+{
+    internal EmittedDgramRuntime() { }
+
+    public bool IsComplete { get; private set; }
+
+    private MethodBuilder? _createSocket;
+    public MethodBuilder CreateSocket
+    {
+        get => Require(_createSocket);
+        internal set => Set(ref _createSocket, value);
+    }
+
+    private TypeBuilder? _socketType;
+    public TypeBuilder SocketType
+    {
+        get => Require(_socketType);
+        internal set => Set(ref _socketType, value);
+    }
+
+    private ConstructorBuilder? _socketCtor;
+    public ConstructorBuilder SocketCtor
+    {
+        get => Require(_socketCtor);
+        internal set => Set(ref _socketCtor, value);
+    }
+
+    private MethodBuilder? _receiveWorker;
+    public MethodBuilder ReceiveWorker
+    {
+        get => Require(_receiveWorker);
+        internal set => Set(ref _receiveWorker, value);
+    }
+
+    private ConstructorBuilder? _messageClosureCtor;
+    public ConstructorBuilder MessageClosureCtor
+    {
+        get => Require(_messageClosureCtor);
+        internal set => Set(ref _messageClosureCtor, value);
+    }
+
+    private MethodBuilder? _messageClosureRun;
+    public MethodBuilder MessageClosureRun
+    {
+        get => Require(_messageClosureRun);
+        internal set => Set(ref _messageClosureRun, value);
+    }
+
+    private static T Require<T>(T? handle, [CallerMemberName] string name = "") where T : class =>
+        handle ?? throw new InvalidOperationException($"Dgram metadata '{name}' has not been declared.");
+
+    private void Set<T>(ref T? field, T value) where T : class
+    {
+        EnsureMutable();
+        ArgumentNullException.ThrowIfNull(value);
+        field = value;
+    }
+
+    private void EnsureMutable()
+    {
+        if (IsComplete)
+            throw new InvalidOperationException("Dgram metadata emission is already complete.");
+    }
+
+    internal void CompleteEmission()
+    {
+        EnsureMutable();
+        _ = CreateSocket;
+        _ = SocketType;
+        _ = SocketCtor;
+        _ = ReceiveWorker;
+        _ = MessageClosureCtor;
+        _ = MessageClosureRun;
+        IsComplete = true;
+    }
+}

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -2300,11 +2300,18 @@ public class EmittedRuntime
     public EmittedTlsRuntime RequireTls() => Tls
         ?? throw new InvalidOperationException("TLS runtime was not enabled for this compilation.");
 
-    // Dgram module methods
-    public MethodBuilder DgramCreateSocket { get; set; } = null!;
+    /// <summary>Datagram metadata, or null when dgram is tree-shaken from this compilation.</summary>
+    public EmittedDgramRuntime? Dgram { get; private set; }
 
-    // $DatagramSocket emitted type
-    public ConstructorBuilder DatagramSocketCtor { get; set; } = null!;
+    internal void BeginDgramEmission()
+    {
+        if (Dgram is not null)
+            throw new InvalidOperationException("Dgram metadata emission has already started.");
+        Dgram = new EmittedDgramRuntime();
+    }
+
+    public EmittedDgramRuntime RequireDgram() => Dgram
+        ?? throw new InvalidOperationException("Dgram runtime was not enabled for this compilation.");
 
     // $Headers type - emitted for standalone Headers support
     public TypeBuilder TSHeadersType { get; set; } = null!;

--- a/src/SharpTS/Compilation/Emitters/Modules/DgramModuleEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/Modules/DgramModuleEmitter.cs
@@ -43,7 +43,7 @@ public sealed class DgramModuleEmitter : IBuiltInModuleEmitter
                 il.Emit(OpCodes.Ldnull);
             }
 
-            il.Emit(OpCodes.Call, ctx.Runtime!.DgramCreateSocket);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequireDgram().CreateSocket);
             emitter.SetStackUnknown();
             return true;
         }

--- a/src/SharpTS/Compilation/RuntimeEmitter.Dgram.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Dgram.cs
@@ -11,14 +11,16 @@ public partial class RuntimeEmitter
 {
     private void EmitDgramModuleMethods(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        EmitDgramCreateSocket(typeBuilder, runtime);
+        var dgram = runtime.RequireDgram();
+        EmitDgramCreateSocket(typeBuilder, dgram);
+        runtime.RegisterBuiltInModuleMethod("dgram", "createSocket", dgram.CreateSocket);
     }
 
     /// <summary>
     /// Emits: public static object DgramCreateSocket(object? typeOrOptions, object? callback)
     /// Creates a $DatagramSocket instance using the emitted constructor (pure IL).
     /// </summary>
-    private void EmitDgramCreateSocket(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitDgramCreateSocket(TypeBuilder typeBuilder, EmittedDgramRuntime dgram)
     {
         var method = typeBuilder.DefineMethod(
             "DgramCreateSocket",
@@ -26,8 +28,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object, _types.Object]
         );
-        runtime.DgramCreateSocket = method;
-        runtime.RegisterBuiltInModuleMethod("dgram", "createSocket", method);
+        dgram.CreateSocket = method;
 
         var il = method.GetILGenerator();
 
@@ -55,7 +56,7 @@ public partial class RuntimeEmitter
 
         // return new $DatagramSocket(typeString)
         il.Emit(OpCodes.Ldloc, typeStringLocal);
-        il.Emit(OpCodes.Newobj, runtime.DatagramSocketCtor);
+        il.Emit(OpCodes.Newobj, dgram.SocketCtor);
         il.Emit(OpCodes.Ret);
     }
 }

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSDatagramReceive.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSDatagramReceive.cs
@@ -20,14 +20,14 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitDgramMessageClosureClass(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
     {
+        var dgram = runtime.RequireDgram();
         var typeBuilder = EmitTypeDefinitions.DefineType(moduleBuilder,
             "$DgramMessageClosure",
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
             _types.Object
         );
 
-        // Fields — use _dgramSocketTypeBuilder so Callvirt resolves Emit correctly
-        var socketField = typeBuilder.DefineField("_socket", _dgramSocketTypeBuilder, FieldAttributes.Private);
+        var socketField = typeBuilder.DefineField("_socket", dgram.SocketType, FieldAttributes.Private);
         var dataField = typeBuilder.DefineField("_data", typeof(byte[]), FieldAttributes.Private);
         var addressField = typeBuilder.DefineField("_address", _types.String, FieldAttributes.Private);
         var familyField = typeBuilder.DefineField("_family", _types.String, FieldAttributes.Private);
@@ -38,9 +38,9 @@ public partial class RuntimeEmitter
         var ctor = typeBuilder.DefineConstructor(
             MethodAttributes.Public,
             CallingConventions.Standard,
-            [_dgramSocketTypeBuilder, typeof(byte[]), _types.String, _types.String, _types.Double, _types.Double]
+            [dgram.SocketType, typeof(byte[]), _types.String, _types.String, _types.Double, _types.Double]
         );
-        _dgramMessageClosureCtor = ctor;
+        dgram.MessageClosureCtor = ctor;
 
         var ctorIL = ctor.GetILGenerator();
         ctorIL.Emit(OpCodes.Ldarg_0);
@@ -73,7 +73,7 @@ public partial class RuntimeEmitter
             typeof(void),
             Type.EmptyTypes
         );
-        _dgramMessageClosureRun = runMethod;
+        dgram.MessageClosureRun = runMethod;
 
         var il = runMethod.GetILGenerator();
 
@@ -163,7 +163,8 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitDgramReceiveWorkerBody(EmittedRuntime runtime)
     {
-        var il = _dgramReceiveWorkerMethod.GetILGenerator();
+        var dgram = runtime.RequireDgram();
+        var il = dgram.ReceiveWorker.GetILGenerator();
 
         var loopTop = il.DefineLabel();
         var loopExit = il.DefineLabel();
@@ -284,8 +285,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, familyStrLocal);
         il.Emit(OpCodes.Ldloc, portDblLocal);
         il.Emit(OpCodes.Ldloc, sizeDblLocal);
-        il.Emit(OpCodes.Newobj, _dgramMessageClosureCtor);
-        il.Emit(OpCodes.Ldftn, _dgramMessageClosureRun);
+        il.Emit(OpCodes.Newobj, dgram.MessageClosureCtor);
+        il.Emit(OpCodes.Ldftn, dgram.MessageClosureRun);
         il.Emit(OpCodes.Newobj, typeof(Action).GetConstructor([_types.Object, typeof(IntPtr)])!);
         il.Emit(OpCodes.Call, runtime.EventLoopSchedule);
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSDatagramSocket.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSDatagramSocket.cs
@@ -17,7 +17,6 @@ namespace SharpTS.Compilation;
 public partial class RuntimeEmitter
 {
     // Field builders for $DatagramSocket (used across method emitters)
-    private TypeBuilder _dgramSocketTypeBuilder = null!;
     private FieldBuilder _dgramClientField = null!;
     private FieldBuilder _dgramFamilyField = null!;
     private FieldBuilder _dgramBoundField = null!;
@@ -28,14 +27,11 @@ public partial class RuntimeEmitter
     private FieldBuilder _dgramReceiveCtsField = null!;
     private FieldBuilder _dgramPendingCloseCallbackField = null!;
     private FieldBuilder _dgramPendingErrorField = null!;
-    private MethodBuilder _dgramReceiveWorkerMethod = null!;
     private MethodBuilder _dgramEmitListeningMethod = null!;
     private MethodBuilder _dgramEmitCloseMethod = null!;
     private MethodBuilder _dgramEmitConnectMethod = null!;
     private MethodBuilder _dgramFireCloseCallbackMethod = null!;
     private MethodBuilder _dgramFireBindErrorMethod = null!;
-    private ConstructorBuilder _dgramMessageClosureCtor = null!;
-    private MethodBuilder _dgramMessageClosureRun = null!;
 
     /// <summary>
     /// Phase 1: Defines the $DatagramSocket type, fields, constructor, and all sync methods.
@@ -43,13 +39,14 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitDatagramSocketTypeDefinition(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
     {
+        var dgram = runtime.RequireDgram();
         // Define class: public sealed class $DatagramSocket extends $EventEmitter
         var typeBuilder = EmitTypeDefinitions.DefineType(moduleBuilder,
             "$DatagramSocket",
             TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.BeforeFieldInit,
             runtime.TSEventEmitterType
         );
-        _dgramSocketTypeBuilder = typeBuilder;
+        dgram.SocketType = typeBuilder;
 
         // Fields
         _dgramClientField = typeBuilder.DefineField("_client", typeof(UdpClient), FieldAttributes.Private);
@@ -69,7 +66,7 @@ public partial class RuntimeEmitter
             CallingConventions.Standard,
             [_types.Object]
         );
-        runtime.DatagramSocketCtor = ctor;
+        dgram.SocketCtor = ctor;
 
         var ctorIL = ctor.GetILGenerator();
         // Call base constructor ($EventEmitter)
@@ -120,7 +117,7 @@ public partial class RuntimeEmitter
 
         // Define receive worker method stub (body emitted in Phase 2)
         // Must be defined before EmitDgramBind which references it.
-        _dgramReceiveWorkerMethod = typeBuilder.DefineMethod(
+        dgram.ReceiveWorker = typeBuilder.DefineMethod(
             "_DgramReceiveWorker",
             MethodAttributes.Private,
             typeof(void),
@@ -169,9 +166,9 @@ public partial class RuntimeEmitter
     /// <summary>
     /// Phase 2: Finalizes the $DatagramSocket type after EmitRuntimeClass.
     /// </summary>
-    private void EmitDatagramSocketFinalize(EmittedRuntime runtime)
+    private static void EmitDatagramSocketFinalize(EmittedDgramRuntime dgram)
     {
-        _ = _dgramSocketTypeBuilder.CreateType()!;
+        _ = dgram.SocketType.CreateType()!;
     }
 
     /// <summary>
@@ -657,7 +654,7 @@ public partial class RuntimeEmitter
         // Start receive loop on ThreadPool
         // ThreadPool.QueueUserWorkItem(new WaitCallback(this._DgramReceiveWorker))
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldftn, _dgramReceiveWorkerMethod);
+        il.Emit(OpCodes.Ldftn, runtime.RequireDgram().ReceiveWorker);
         il.Emit(OpCodes.Newobj, typeof(WaitCallback).GetConstructor([_types.Object, typeof(IntPtr)])!);
         il.Emit(OpCodes.Call, typeof(ThreadPool).GetMethod("QueueUserWorkItem", [typeof(WaitCallback)])!);
         il.Emit(OpCodes.Pop);

--- a/src/SharpTS/Compilation/RuntimeEmitter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.cs
@@ -46,6 +46,8 @@ public partial class RuntimeEmitter
             runtime.BeginZlibEmission();
         if (features.UsesDns)
             runtime.BeginDnsEmission();
+        if (features.UsesDgram)
+            runtime.BeginDgramEmission();
 
         // Emit $Undefined singleton class first (other methods need this type)
         EmitUndefinedClass(moduleBuilder, runtime);
@@ -569,7 +571,7 @@ public partial class RuntimeEmitter
         {
             EmitDgramMessageClosureClass(moduleBuilder, runtime);
             EmitDgramReceiveWorkerBody(runtime);
-            EmitDatagramSocketFinalize(runtime);
+            EmitDatagramSocketFinalize(runtime.RequireDgram());
         }
 
         if (features.UsesTls)
@@ -612,6 +614,7 @@ public partial class RuntimeEmitter
         runtime.Dns?.CompleteEmission();
         runtime.Zlib?.CompleteEmission();
         runtime.Tls?.CompleteEmission();
+        runtime.Dgram?.CompleteEmission();
         return runtime;
     }
 }

--- a/tests/SharpTS.Tests/CompilerTests/EmittedDgramRuntimeTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/EmittedDgramRuntimeTests.cs
@@ -1,0 +1,130 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public class EmittedDgramRuntimeTests
+{
+    [Fact]
+    public void ModuleConsumersAndDeferredReceiveBodyPassILVerification()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as dgram from 'dgram';
+                import { createSocket } from 'dgram';
+                const receiver = dgram.createSocket('udp4');
+                const sender = createSocket('udp4');
+                const factory = createSocket;
+                const unbound = factory('udp4');
+                receiver.on('message', (msg: any) => {
+                    console.log(msg.toString());
+                    receiver.close();
+                });
+                receiver.bind(0, '127.0.0.1', () => {
+                    sender.send('hello', receiver.address().port, '127.0.0.1', () => sender.close());
+                });
+                """
+        };
+        Assert.Empty(TestHarness.CompileModulesAndVerifyOnly(files, "main.ts"));
+    }
+
+    [Fact]
+    public void DisabledFeatureHasNoMetadataAndReportsAccidentalUse()
+    {
+        var runtime = EmitRuntime(false);
+        Assert.Null(runtime.Dgram);
+        Assert.Contains("not enabled", Assert.Throws<InvalidOperationException>(runtime.RequireDgram).Message);
+        Assert.Null(runtime.GetBuiltInModuleMethod("dgram", "createSocket"));
+        Assert.DoesNotContain(runtime.RuntimeType.GetMethods(), method => method.Name.StartsWith("Dgram", StringComparison.Ordinal));
+        using var stream = new MemoryStream();
+        ((PersistedAssemblyBuilder)runtime.RuntimeType.Assembly).Save(stream);
+        stream.Position = 0;
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+        var typeNames = reader.TypeDefinitions.Select(handle => reader.GetString(reader.GetTypeDefinition(handle).Name)).ToArray();
+        Assert.DoesNotContain("$DatagramSocket", typeNames);
+        Assert.DoesNotContain("$DgramMessageClosure", typeNames);
+    }
+
+    [Fact]
+    public void ReceiveWorkerDeclarationSupportsForwardReferencesAndIncompleteEmissionFails()
+    {
+        var runtime = new EmittedRuntime();
+        runtime.BeginDgramEmission();
+        var dgram = runtime.RequireDgram();
+        Assert.False(dgram.IsComplete);
+        Assert.Contains("ReceiveWorker", Assert.Throws<InvalidOperationException>(() => dgram.ReceiveWorker).Message);
+        Assert.Contains("SocketCtor", Assert.Throws<InvalidOperationException>(() => dgram.SocketCtor).Message);
+
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName("dgram_forward"), typeof(object).Assembly);
+        var type = assembly.DefineDynamicModule("main").DefineType("Socket");
+        var worker = type.DefineMethod("ReceiveWorker", MethodAttributes.Private, typeof(void), [typeof(object)]);
+        dgram.SocketType = type;
+        dgram.ReceiveWorker = worker;
+        var caller = type.DefineMethod("Bind", MethodAttributes.Public, typeof(void), Type.EmptyTypes).GetILGenerator();
+        caller.Emit(OpCodes.Ldarg_0);
+        caller.Emit(OpCodes.Ldnull);
+        caller.Emit(OpCodes.Call, dgram.ReceiveWorker);
+        caller.Emit(OpCodes.Ret);
+        Assert.Same(worker, dgram.ReceiveWorker);
+        Assert.False(dgram.SocketType.IsCreated());
+        worker.GetILGenerator().Emit(OpCodes.Ret);
+        type.CreateType();
+
+        Assert.Throws<InvalidOperationException>(runtime.BeginDgramEmission);
+        Assert.Contains("CreateSocket", Assert.Throws<InvalidOperationException>(dgram.CompleteEmission).Message);
+        Assert.False(dgram.IsComplete);
+        Assert.Throws<ArgumentNullException>(() => dgram.ReceiveWorker = null!);
+        Assert.Same(worker, dgram.ReceiveWorker);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void EnabledFeatureCompletesAllHandlesAndRejectsFurtherWrites(bool emitEverything)
+    {
+        var runtime = EmitRuntime(true, emitEverything);
+        var dgram = runtime.RequireDgram();
+        Assert.True(dgram.IsComplete);
+        Assert.Equal("DgramCreateSocket", dgram.CreateSocket.Name);
+        Assert.Equal("$DatagramSocket", dgram.SocketType.Name);
+        Assert.True(dgram.SocketType.IsCreated());
+        Assert.Same(dgram.SocketType, dgram.SocketCtor.DeclaringType);
+        Assert.Same(dgram.SocketType, dgram.ReceiveWorker.DeclaringType);
+        Assert.Equal("_DgramReceiveWorker", dgram.ReceiveWorker.Name);
+        Assert.Equal("$DgramMessageClosure", dgram.MessageClosureCtor.DeclaringType!.Name);
+        Assert.Same(dgram.MessageClosureCtor.DeclaringType, dgram.MessageClosureRun.DeclaringType);
+        Assert.True(((TypeBuilder)dgram.MessageClosureRun.DeclaringType!).IsCreated());
+        Assert.Same(dgram.CreateSocket, runtime.GetBuiltInModuleMethod("dgram", "createSocket"));
+        Assert.Throws<InvalidOperationException>(() => dgram.CreateSocket = dgram.CreateSocket);
+        Assert.Throws<InvalidOperationException>(() => dgram.SocketType = dgram.SocketType);
+        Assert.Throws<InvalidOperationException>(() => dgram.SocketCtor = dgram.SocketCtor);
+        Assert.Throws<InvalidOperationException>(() => dgram.ReceiveWorker = dgram.ReceiveWorker);
+        Assert.Throws<InvalidOperationException>(() => dgram.MessageClosureCtor = dgram.MessageClosureCtor);
+        Assert.Throws<InvalidOperationException>(() => dgram.MessageClosureRun = dgram.MessageClosureRun);
+        Assert.Throws<InvalidOperationException>(dgram.CompleteEmission);
+        if (!emitEverything)
+        {
+            Assert.Empty(runtime.RequiredSharpTSRuntimeReasons);
+            Assert.Equal(SharpTSRuntimeRequirements.None, runtime.RequiredSharpTSRuntimeRequirements);
+        }
+    }
+
+    private static EmittedRuntime EmitRuntime(bool usesDgram, bool emitEverything = false)
+    {
+        var source = usesDgram ? "import * as dgram from 'dgram';" : "console.log(1);";
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var features = new RuntimeFeatureDetector().Detect(statements);
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName($"dgram_metadata_{Guid.NewGuid():N}"), typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("main");
+        var emitter = new RuntimeEmitter(TypeProvider.Runtime);
+        return emitEverything ? emitter.EmitAll(module) : emitter.EmitAll(module, features);
+    }
+}

--- a/tests/SharpTS.Tests/CompilerTests/StableDestructuringLoadTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StableDestructuringLoadTests.cs
@@ -179,26 +179,56 @@ public sealed partial class StableDestructuringLoadTests
         Assert.DoesNotContain(reductionInstructions, instruction =>
             instruction.Member?.Name == "get_IsMaterialized");
 
-        objectLoop(1_000);
-        runDirect(1_000);
-        long before = GC.GetAllocatedBytesForCurrentThread();
-        objectLoop(1_000);
-        long objectSmallAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
-        before = GC.GetAllocatedBytesForCurrentThread();
-        objectLoop(100_000);
-        long objectLargeAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
-        before = GC.GetAllocatedBytesForCurrentThread();
-        runDirect(1_000);
-        long directSmallAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
-        before = GC.GetAllocatedBytesForCurrentThread();
-        runDirect(100_000);
-        long directLargeAllocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        long objectSmallAllocated = MeasureMinimumLoopAllocations(objectLoop, 1_000, 7_000);
+        long objectLargeAllocated = MeasureMinimumLoopAllocations(objectLoop, 100_000, 700_000);
+        long directSmallAllocated = MeasureMinimumLoopAllocations(runDirect, 1_000, 7_000);
+        long directLargeAllocated = MeasureMinimumLoopAllocations(runDirect, 100_000, 700_000);
 
         Assert.True(objectLargeAllocated <= objectSmallAllocated + 1_024,
             $"Object destructuring allocations scaled: {objectSmallAllocated} vs {objectLargeAllocated}.");
         Assert.True(directLargeAllocated <= directSmallAllocated + 1_024,
             $"Direct record-read allocations scaled: {directSmallAllocated} vs {directLargeAllocated}.");
         Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AllocationSampling_DistinguishesTransientOverheadFromScaling(bool allocationsScaleWithIterations)
+    {
+        int calls = 0;
+        double Loop(double iterations)
+        {
+            if (allocationsScaleWithIterations)
+                GC.KeepAlive(new byte[(int)iterations]);
+            else if (++calls % 2 == 0)
+                GC.KeepAlive(new byte[16_384]);
+            return iterations * 7;
+        }
+
+        long small = MeasureMinimumLoopAllocations(Loop, 1_000, 7_000);
+        long large = MeasureMinimumLoopAllocations(Loop, 100_000, 700_000);
+        Assert.Equal(allocationsScaleWithIterations, large > small + 1_024);
+    }
+
+    private static long MeasureMinimumLoopAllocations(
+        Func<double, double> loop, double iterations, double expectedResult)
+    {
+        Assert.Equal(expectedResult, loop(iterations));
+
+        // Compare steady-state floors so transient runtime bookkeeping cannot be
+        // mistaken for per-iteration allocation growth on busy CI runners.
+        // Persistent per-iteration allocations remain in every sample.
+        long minimum = long.MaxValue;
+        for (int sample = 0; sample < 5; sample++)
+        {
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            double result = loop(iterations);
+            long allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+            Assert.Equal(expectedResult, result);
+            minimum = Math.Min(minimum, allocated);
+        }
+        return minimum;
     }
 
     [Theory, ModeData]

--- a/tests/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
@@ -1189,6 +1189,42 @@ public class StandaloneDllTests
     }
 
     [Fact]
+    public void Isolated_DgramModule_ShouldSendAndReceiveWithoutSharpTsDll()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as dgram from 'dgram';
+                import { createSocket } from 'dgram';
+                const receiver = dgram.createSocket('udp4');
+                receiver.on('message', (msg: any, rinfo: any) => {
+                    console.log(msg.toString());
+                    console.log(rinfo.address === '127.0.0.1');
+                    console.log(rinfo.size === 5);
+                    receiver.close();
+                });
+                receiver.bind(0, '127.0.0.1', () => {
+                    const sender = createSocket('udp4');
+                    sender.send('hello', receiver.address().port, '127.0.0.1', () => sender.close());
+                });
+                """
+        };
+
+        var (tempDir, dllPath) = CompileStandaloneModule(files, "main.ts");
+        try
+        {
+            Assert.DoesNotContain("SharpTS", GetAssemblyReferences(dllPath));
+            Assert.False(File.Exists(Path.Combine(tempDir, "SharpTS.dll")));
+            var output = ExecuteCompiledDllIsolated(dllPath, timeoutMs: 15000);
+            Assert.Equal("hello\ntrue\ntrue\n", output);
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
+    [Fact]
     public void Isolated_DnsModule_ShouldExecuteWithoutSharpTsDll()
     {
         var files = new Dictionary<string, string>


### PR DESCRIPTION
Datagram emission currently keeps its factory and constructor on the flat `EmittedRuntime` holder and its deferred receive handles in unchecked emitter fields. This increment of #1599 puts those six handles in `EmittedDgramRuntime`, with explicit feature availability, errors for undeclared handles, and validation that prevents further handle writes once emission completes.

The migration preserves the existing declaration/body-emission order, removes the old properties and duplicate fields, passes the component directly to datagram-only helpers, and documents the pattern in `ARCHITECTURE.md`. The generated IL and standalone dependency rules are unchanged. Other feature families remain for subsequent increments of #1599.

The stable-record allocation regression compares warmed five-sample minima at each loop size to avoid mistaking transient runtime overhead for allocation growth on Windows CI. It retains the 1,024-byte growth limit and IL assertions, checks every measured result, and includes controls for transient overhead and persistent size-proportional allocation.

Validation:
- 215 selected tests pass, covering datagram behavior in both execution modes, forward declarations and lifecycle checks, tree shaking, standalone UDP send/receive without `SharpTS.dll`, IL verification, and existing component/feature/dependency regressions.
- 78 related Release tests pass after the CI test fix; the previously failing test and both allocation controls also pass in 10 consecutive runs.
- `./scripts/test-code-quality.ps1` passes.
- `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of compiled datagram networking features, including socket creation, message receiving, sending, and binding.
  * Ensured standalone applications using datagram networking run correctly without requiring an additional runtime assembly.

* **Tests**
  * Added coverage for datagram runtime validation, feature-disabled behavior, deferred callbacks, and incomplete compilation states.
  * Added an end-to-end standalone datagram networking test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
