### PR TITLE
Preserve internal failures and structured diagnostics during checker/LSP recovery

### DIFF
--- a/src/SharpTS.LanguageServer/Services/DiagnosticsCoordinator.cs
+++ b/src/SharpTS.LanguageServer/Services/DiagnosticsCoordinator.cs
@@ -20,6 +20,7 @@ public sealed class DiagnosticsCoordinator : IDisposable
     private readonly DocumentDependencyGraph _graph;
     private readonly DiagnosticsSettings _settings;
     private readonly Action<PublishDiagnosticsParams> _publish;
+    private readonly Action<Exception> _reportFailure;
     private readonly TimeSpan _debounce;
     private readonly Dictionary<string, CancellationTokenSource> _documentCancellation =
         new(StringComparer.OrdinalIgnoreCase);
@@ -49,7 +50,8 @@ public sealed class DiagnosticsCoordinator : IDisposable
         DocumentDependencyGraph graph,
         DiagnosticsSettings settings,
         Action<PublishDiagnosticsParams> publish,
-        TimeSpan debounce)
+        TimeSpan debounce,
+        Action<Exception>? reportFailure = null)
     {
         _store = store;
         _diagnostics = diagnostics;
@@ -57,6 +59,9 @@ public sealed class DiagnosticsCoordinator : IDisposable
         _settings = settings;
         _publish = publish;
         _debounce = debounce;
+        // Stdio is the LSP transport. Internal failures belong on the host's stderr channel.
+        _reportFailure = reportFailure ?? (exception =>
+            Console.Error.WriteLine($"SharpTS background diagnostics failed: {exception}"));
     }
 
     public void Queue(string uri)
@@ -147,53 +152,39 @@ public sealed class DiagnosticsCoordinator : IDisposable
         string uri,
         CancellationToken cancellationToken)
     {
-        try
-        {
-            await Task.Delay(_debounce, cancellationToken);
-            if (!_store.TryCapture(uri, out DocumentRequestSnapshot? snapshot))
-                return;
+        await Task.Delay(_debounce, cancellationToken);
+        if (!_store.TryCapture(uri, out DocumentRequestSnapshot? snapshot))
+            return;
 
-            cancellationToken.ThrowIfCancellationRequested();
-            IReadOnlyList<Parsing.Stmt> statements = _diagnostics.GetStatements(
-                snapshot.Document,
-                cancellationToken);
-            IReadOnlySet<string> affected = _graph.Update(
-                snapshot.Document,
-                snapshot.TextOverlay,
-                statements,
-                cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
+        IReadOnlyList<Parsing.Stmt> statements = _diagnostics.GetStatements(
+            snapshot.Document,
+            cancellationToken);
+        IReadOnlySet<string> affected = _graph.Update(
+            snapshot.Document,
+            snapshot.TextOverlay,
+            statements,
+            cancellationToken);
 
-            await AnalyzeAndPublishAsync(snapshot, affected, cancellationToken);
-        }
-        catch (OperationCanceledException)
-        {
-            // A newer document/workspace version owns publication now.
-        }
+        await AnalyzeAndPublishAsync(snapshot, affected, cancellationToken);
     }
 
     private async Task RunAffectedDocumentsAsync(
         IEnumerable<string> affectedPaths,
         CancellationToken cancellationToken)
     {
-        try
+        await Task.Delay(_debounce, cancellationToken);
+        HashSet<string> pending = affectedPaths.ToHashSet(
+            StringComparer.OrdinalIgnoreCase);
+        foreach (DocumentSnapshot open in _store.SnapshotDocuments())
         {
-            await Task.Delay(_debounce, cancellationToken);
-            HashSet<string> pending = affectedPaths.ToHashSet(
-                StringComparer.OrdinalIgnoreCase);
-            foreach (DocumentSnapshot open in _store.SnapshotDocuments())
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                if (open.FilePath is null || !pending.Contains(open.FilePath))
-                    continue;
-                if (!_store.TryCapture(open.Uri, out DocumentRequestSnapshot? snapshot))
-                    continue;
+            cancellationToken.ThrowIfCancellationRequested();
+            if (open.FilePath is null || !pending.Contains(open.FilePath))
+                continue;
+            if (!_store.TryCapture(open.Uri, out DocumentRequestSnapshot? snapshot))
+                continue;
 
-                Publish(snapshot, snapshot.Document, cancellationToken);
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            // A newer document/workspace version owns publication now.
+            Publish(snapshot, snapshot.Document, cancellationToken);
         }
     }
 
@@ -256,30 +247,40 @@ public sealed class DiagnosticsCoordinator : IDisposable
 
     private void Track(Task task)
     {
+        // Drain the observation, including failure reporting, rather than the faulted analysis.
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         lock (_gate)
-            _pending.Add(task);
-        _ = ObserveAsync(task);
+            _pending.Add(completion.Task);
+        _ = ObserveAsync(task, completion);
     }
 
     [SuppressMessage(
         "Usage",
         "VSTHRD003",
         Justification = "Background diagnostic tasks are isolated, caught, and never synchronously blocked.")]
-    private async Task ObserveAsync(Task task)
+    private async Task ObserveAsync(Task task, TaskCompletionSource completion)
     {
         try
         {
             await task.ConfigureAwait(false);
         }
-        catch (Exception)
+        catch (OperationCanceledException)
+        {
+            // A newer document/workspace version owns publication now.
+        }
+        catch (Exception ex)
         {
             // Diagnostics are advisory. A failed analysis must not terminate the LSP process;
             // the next edit creates a fresh version and retries the pipeline.
+            _reportFailure(ex);
         }
         finally
         {
             lock (_gate)
-                _pending.Remove(task);
+            {
+                _pending.Remove(completion.Task);
+                completion.SetResult();
+            }
         }
     }
 

--- a/src/SharpTS.LanguageServer/Services/NavigationModelBuilder.cs
+++ b/src/SharpTS.LanguageServer/Services/NavigationModelBuilder.cs
@@ -4,6 +4,7 @@ using SharpTS.Configuration;
 using SharpTS.Modules;
 using SharpTS.Parsing;
 using SharpTS.TypeSystem;
+using SharpTS.TypeSystem.Exceptions;
 using Range = OmniSharp.Extensions.LanguageServer.Protocol.Models.Range;
 
 namespace SharpTS.LanguageServer.Services;
@@ -48,16 +49,10 @@ internal static class NavigationModelBuilder
         string? configPath = TsConfigLoader.Discover(directory);
         if (configPath is not null)
         {
+            NavigationWorkspace? configuredWorkspace = null;
             try
             {
-                ProjectBuildResult configured = TryBuildProject(
-                    absolutePath,
-                    overlay,
-                    NavigationWorkspace.FromProject(TsConfigLoader.Load(configPath)),
-                    requireMembership: true,
-                    cancellationToken);
-                if (configured.Model is not null)
-                    return configured.Model;
+                configuredWorkspace = NavigationWorkspace.FromProject(TsConfigLoader.Load(configPath));
             }
             catch (OperationCanceledException)
             {
@@ -66,6 +61,17 @@ internal static class NavigationModelBuilder
             catch
             {
                 // Fall through to an explicitly incomplete open-document model.
+            }
+            if (configuredWorkspace is not null)
+            {
+                ProjectBuildResult configured = TryBuildProject(
+                    absolutePath,
+                    overlay,
+                    configuredWorkspace,
+                    requireMembership: true,
+                    cancellationToken);
+                if (configured.Model is not null)
+                    return configured.Model;
             }
         }
 
@@ -122,9 +128,13 @@ internal static class NavigationModelBuilder
         bool requireMembership,
         CancellationToken cancellationToken)
     {
+        ModuleResolver resolver;
+        List<ParsedModule> modulesToCheck;
+        CheckedNavigationModel model;
+        bool isComplete;
         try
         {
-            var resolver = new ModuleResolver(
+            resolver = new ModuleResolver(
                 workspace.BasePath,
                 workspace.ResolutionOptions,
                 overlay,
@@ -226,19 +236,15 @@ internal static class NavigationModelBuilder
                 .WithFilePath(absolutePath)
                 .WithCancellation(cancellationToken);
             checker.SetDecoratorMode(workspace.DecoratorMode);
-            checker.CheckModules(
-                resolver.GetModulesInOrder(connectedRoots),
-                resolver);
-            var model = new CheckedNavigationModel(
+            modulesToCheck = resolver.GetModulesInOrder(connectedRoots);
+            model = new CheckedNavigationModel(
                 checker,
                 document,
                 new NavigationGraphScope(
                     workspace.ConfigPath,
                     workspace.RootFiles,
                     workspace.IsConfigured && isMember && allRootsLoaded));
-            return new ProjectBuildResult(
-                model,
-                workspace.IsConfigured && allRootsLoaded);
+            isComplete = workspace.IsConfigured && allRootsLoaded;
         }
         catch (OperationCanceledException)
         {
@@ -248,6 +254,20 @@ internal static class NavigationModelBuilder
         {
             return new ProjectBuildResult(null, IsComplete: false);
         }
+
+        // The checker already recovers expected source errors. Internal checking failures must
+        // reach the host's observation boundary instead of silently triggering a fallback model.
+        try
+        {
+            model.Checker.CheckModules(modulesToCheck, resolver);
+        }
+        catch (TypeCheckException)
+        {
+            // Source errors from a preparatory pass can still require a standalone check.
+            return new ProjectBuildResult(null, IsComplete: false);
+        }
+        cancellationToken.ThrowIfCancellationRequested();
+        return new ProjectBuildResult(model, isComplete);
     }
 
     private static HashSet<ParsedModule> FindConnectedComponent(

--- a/src/SharpTS/TypeSystem/TypeChecker.Statements.Functions.cs
+++ b/src/SharpTS/TypeSystem/TypeChecker.Statements.Functions.cs
@@ -352,7 +352,7 @@ public partial class TypeChecker
         if (typeAnnotation is not null)
         {
             try { _environment.Define(name.Lexeme, ResolveAnnotation(typeAnnotation, typeAnnotationNode)!); }
-            catch { _environment.Define(name.Lexeme, TypeInfo.Any.Shared); }
+            catch (TypeCheckException) { _environment.Define(name.Lexeme, TypeInfo.Any.Shared); }
             return;
         }
 
@@ -838,9 +838,9 @@ public partial class TypeChecker
                 if (!suppress)
                     MarkUndefinedReachableNumericSlots(body, funcStmt.Parameters);
             }
-            catch (Exception) when (suppress)
+            catch (TypeCheckException) when (suppress)
             {
-                // Speculative inference is best-effort: degrade to the `any` placeholder on any failure.
+                // An expected source error leaves the speculative `any` placeholder in place.
                 bodyFailed = true;
             }
 

--- a/src/SharpTS/TypeSystem/TypeChecker.cs
+++ b/src/SharpTS/TypeSystem/TypeChecker.cs
@@ -918,7 +918,7 @@ public partial class TypeChecker
     private CancellationToken _cancellationToken;
 
     /// <summary>
-    /// When &gt; 0, <see cref="RecordTypeError(TypeCheckException)"/> and its overload are no-ops.
+    /// When &gt; 0, <see cref="RecordTypeError(TypeCheckException)"/> is a no-op.
     /// Set during speculative hoist-time return-type inference (#383), which checks a function body
     /// purely to learn its inferred return type and must not surface (duplicate) diagnostics — the
     /// real declaration pass reports them at their proper locations.
@@ -1416,79 +1416,82 @@ public partial class TypeChecker
         _standaloneSourceDocument = sourceDocument;
 
         _diagnostics.Clear();
+        bool previousRecoveryMode = _recoveryMode;
+        int? previousStatementLine = _currentStatementLine;
         _recoveryMode = true;
-        // Clear caches for fresh check
-        _compatibilityCache = null;
-        _expandedTypeAliasCache = null;
-        _compatibilityInProgress = null;
-        _implicitAnyReported = null;
-        _compatibilityCheckDepth = 0;
-        _narrowingContextStack.Clear();
-
-        // Module/top-level declarations live in their own declared-type frame so that
-        // GetDeclaredType / IsDeclaredTypeTracked treat them like function locals (#743).
-        // Clear first: the checker is reused across REPL lines and may retain frames from a
-        // prior check (function frames are normally popped, but be defensive on early-exit).
-        _declaredVariableTypesStack.Clear();
-        _definiteAssignmentStack.Clear();
-        PushDeclaredVariableScope();
-
-        // Pre-define built-ins
-        _environment.Define("console", TypeInfo.Any.Shared);
-        _environment.Define("Reflect", TypeInfo.Any.Shared);
-        _environment.Define("process", TypeInfo.Any.Shared);
-
-        // Pre-register type declarations
-        PreRegisterTypeDeclarations(statements);
-        ThrowIfCancellationRequested();
-
-        // Hoist class declarations (as Any for forward references in function bodies)
-        HoistClassDeclarations(statements);
-        ThrowIfCancellationRequested();
-
-        // Hoist function declarations
-        HoistFunctionDeclarations(statements);
-        ThrowIfCancellationRequested();
-
-        // Hoist var declarations (pre-define as any for forward reference support)
-        HoistVarDeclarations(statements);
-        ThrowIfCancellationRequested();
-
-        // Hoist let/const declarations (pre-define as any so an earlier function body can
-        // forward-reference a later block-scoped binding — #533)
-        HoistLexicalDeclarations(statements);
-
-        foreach (Stmt statement in statements)
+        _currentStatementLine = null;
+        try
         {
             ThrowIfCancellationRequested();
-            if (_diagnostics.HitErrorLimit)
-            {
-                _recoveryMode = false;
-                return new TypeCheckDiagnosticResult(_typeMap, _diagnostics.Diagnostics, HitErrorLimit: true);
-            }
+            // Clear caches for fresh check
+            _compatibilityCache = null;
+            _expandedTypeAliasCache = null;
+            _compatibilityInProgress = null;
+            _implicitAnyReported = null;
+            _compatibilityCheckDepth = 0;
+            _narrowingContextStack.Clear();
 
-            _currentStatementLine = TryGetStmtLine(statement);
-            try
+            // Module/top-level declarations live in their own declared-type frame so that
+            // GetDeclaredType / IsDeclaredTypeTracked treat them like function locals (#743).
+            // Clear first: the checker is reused across REPL lines and may retain frames from a
+            // prior check (function frames are normally popped, but be defensive on early-exit).
+            _declaredVariableTypesStack.Clear();
+            _definiteAssignmentStack.Clear();
+            PushDeclaredVariableScope();
+
+            // Pre-define built-ins
+            _environment.Define("console", TypeInfo.Any.Shared);
+            _environment.Define("Reflect", TypeInfo.Any.Shared);
+            _environment.Define("process", TypeInfo.Any.Shared);
+
+            // Pre-register type declarations
+            PreRegisterTypeDeclarations(statements);
+            ThrowIfCancellationRequested();
+
+            // Hoist class declarations (as Any for forward references in function bodies)
+            HoistClassDeclarations(statements);
+            ThrowIfCancellationRequested();
+
+            // Hoist function declarations
+            HoistFunctionDeclarations(statements);
+            ThrowIfCancellationRequested();
+
+            // Hoist var declarations (pre-define as any for forward reference support)
+            HoistVarDeclarations(statements);
+            ThrowIfCancellationRequested();
+
+            // Hoist let/const declarations (pre-define as any so an earlier function body can
+            // forward-reference a later block-scoped binding — #533)
+            HoistLexicalDeclarations(statements);
+
+            foreach (Stmt statement in statements)
             {
-                CheckStmt(statement);
+                ThrowIfCancellationRequested();
+                if (_diagnostics.HitErrorLimit)
+                {
+                    return new TypeCheckDiagnosticResult(_typeMap, _diagnostics.Diagnostics, HitErrorLimit: true);
+                }
+
+                _currentStatementLine = TryGetStmtLine(statement);
+                try
+                {
+                    CheckStmt(statement);
+                }
+                catch (TypeCheckException ex)
+                {
+                    RecordTypeError(ex);
+                }
             }
-            catch (TypeMismatchException ex)
-            {
-                RecordTypeError(ex);
-            }
-            catch (TypeCheckException ex)
-            {
-                RecordTypeError(ex);
-            }
-            catch (Exception ex)
-            {
-                RecordTypeError(ex.Message, _currentStatementLine);
-            }
+            // Cancellation during the final statement must not return a successful analysis.
+            ThrowIfCancellationRequested();
+
+            return new TypeCheckDiagnosticResult(_typeMap, _diagnostics.Diagnostics);
         }
-        _currentStatementLine = null;
-        _recoveryMode = false;
-
-        return new TypeCheckDiagnosticResult(_typeMap, _diagnostics.Diagnostics);
+        finally
+        {
+            _currentStatementLine = previousStatementLine;
+            _recoveryMode = previousRecoveryMode;
+        }
     }
 
     /// <summary>
@@ -1497,59 +1500,19 @@ public partial class TypeChecker
     private void RecordTypeError(TypeCheckException ex)
     {
         if (_suppressDiagnostics > 0) return;
-        // Extract the core message by removing the "Type Error: " or "Type Error at line X: " prefix
-        string message = ex.Message;
-        if (message.StartsWith("Type Error at line"))
+        Diagnostic diagnostic = ex.Diagnostic;
+        // Keep an explicit file and span; fill only missing attribution. The statement-line
+        // fallback lets @ts-ignore / @ts-expect-error target throw sites without token locations.
+        SourceLocation? location = diagnostic.Location is { } explicitLocation
+            ? explicitLocation with { FilePath = explicitLocation.FilePath ?? _filePath }
+            : _currentStatementLine is { } line ? new SourceLocation(_filePath, line) : null;
+        _diagnostics.Add(diagnostic with
         {
-            var colonIndex = message.IndexOf(": ", 15); // Skip past "Type Error at line X"
-            if (colonIndex > 0)
-                message = message[(colonIndex + 2)..];
-        }
-        else if (message.StartsWith("Type Error: "))
-        {
-            message = message["Type Error: ".Length..];
-        }
-
-        // Map exception type to diagnostic code
-        DiagnosticCode code = ex switch
-        {
-            TypeMismatchException => DiagnosticCode.TypeMismatch,
-            TypeOperationException => DiagnosticCode.TypeOperation,
-            _ => DiagnosticCode.TypeError
-        };
-
-        // Fall back to the current statement's line when the exception didn't carry one.
-        // Lets `// @ts-ignore` / `@ts-expect-error` line directives target diagnostics
-        // whose throw-sites don't (yet) plumb token-level line info.
-        int? line = ex.Line ?? _currentStatementLine;
-        SourceLocation? location = line.HasValue
-            ? new SourceLocation(_filePath, line.Value, ex.Column ?? 1)
-            : null;
-
-        // Preserve the canonical TSnnnn code from the throw site so the TS conformance
-        // runner (which diffs on (line, tsCode)) can match against *.errors.txt baselines.
-        string? tsCode = ex.Diagnostic.TsCode;
-
-        if (IsLenientModule())
-            _diagnostics.AddWarning(code, message, location, tsCode);
-        else
-            _diagnostics.AddError(code, message, location, tsCode);
-    }
-
-    /// <summary>
-    /// Records a type checking error from a raw message.
-    /// </summary>
-    private void RecordTypeError(string message, int? line = null)
-    {
-        if (_suppressDiagnostics > 0) return;
-
-        SourceLocation? location = line.HasValue
-            ? new SourceLocation(_filePath, line.Value)
-            : null;
-        if (IsLenientModule())
-            _diagnostics.AddWarning(DiagnosticCode.TypeError, message, location);
-        else
-            _diagnostics.AddError(DiagnosticCode.TypeError, message, location);
+            Location = location,
+            Severity = IsLenientModule() && diagnostic.Severity == DiagnosticSeverity.Error
+                ? DiagnosticSeverity.Warning
+                : diagnostic.Severity,
+        });
     }
 
     /// <summary>
@@ -2068,6 +2031,7 @@ public partial class TypeChecker
         _currentModule = null;
         _filePath = null;
         _currentStatementLine = null;
+        ThrowIfCancellationRequested();
         return _typeMap;
     }
 
@@ -2173,16 +2137,21 @@ public partial class TypeChecker
     {
         using (new EnvironmentScope(this, scriptEnv))
         {
-            try { PreRegisterTypeDeclarations(library.Statements); }
-            catch { /* keep binding the remaining declarations below */ }
-            try { HoistClassDeclarations(library.Statements); }
-            catch { }
-            try { HoistFunctionDeclarations(library.Statements); }
-            catch { }
-            try { HoistVarDeclarations(library.Statements); }
-            catch { }
-            try { HoistLexicalDeclarations(library.Statements); }
-            catch { }
+            // Default libraries are trusted declaration inputs. Unsupported type constructs
+            // may be skipped, but cancellation and compiler defects must reach the caller.
+            void BindDeclarations(Action bind)
+            {
+                ThrowIfCancellationRequested();
+                try { bind(); }
+                catch (TypeCheckException) { }
+                ThrowIfCancellationRequested();
+            }
+
+            BindDeclarations(() => PreRegisterTypeDeclarations(library.Statements));
+            BindDeclarations(() => HoistClassDeclarations(library.Statements));
+            BindDeclarations(() => HoistFunctionDeclarations(library.Statements));
+            BindDeclarations(() => HoistVarDeclarations(library.Statements));
+            BindDeclarations(() => HoistLexicalDeclarations(library.Statements));
 
             _suppressDiagnostics++;
             bool previousRecoveryMode = _recoveryMode;
@@ -2191,15 +2160,7 @@ public partial class TypeChecker
             {
                 foreach (var statement in library.Statements)
                 {
-                    try
-                    {
-                        CheckStmt(statement);
-                    }
-                    catch (Exception)
-                    {
-                        // A single declaration must not prevent later globals in
-                        // the same standard library from being available.
-                    }
+                    BindDeclarations(() => CheckStmt(statement));
                 }
             }
             finally

--- a/tests/SharpTS.Tests/LanguageServer/DiagnosticsCoordinatorTests.cs
+++ b/tests/SharpTS.Tests/LanguageServer/DiagnosticsCoordinatorTests.cs
@@ -1,0 +1,124 @@
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using SharpTS.LanguageServer;
+using SharpTS.LanguageServer.Conversions;
+using SharpTS.LanguageServer.Services;
+using SharpTS.Tests.Infrastructure;
+using SharpTS.Tests.IntegrationTests;
+using Xunit;
+
+namespace SharpTS.Tests.LanguageServer;
+
+public sealed class DiagnosticsCoordinatorTests
+{
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(25, false)]
+    [InlineData(0, true)]
+    [InlineData(25, true)]
+    public async Task AnalysisFailureIsReportedWithDetailsAndNextEditCanPublish(
+        int debounceMilliseconds, bool useHostChannel)
+    {
+        AsyncLocalConsoleRedirector.Install();
+        using var stderr = new StringWriter();
+        using var captureError = AsyncLocalConsoleRedirector.WithErr(stderr);
+        using var stdout = AsyncLocalConsoleRedirector.Capture();
+        using var directory = CliTestHelper.CreateTempDirectory();
+        const string source = "@DotNetType('Injected.Type') declare class Injected {}";
+        string path = directory.CreateFile("input.ts", source);
+        string uri = new Uri(path).AbsoluteUri;
+        var store = new DocumentStore();
+        store.Open(uri, source, version: 1);
+        var failure = new InvalidOperationException("analysis defect", new Exception("original cause"));
+        List<Exception> failures = [];
+        List<PublishDiagnosticsParams> published = [];
+        using var coordinator = new DiagnosticsCoordinator(
+            store,
+            new DiagnosticsService(resolve: _ => throw failure),
+            new DocumentDependencyGraph(),
+            new DiagnosticsSettings(DiagnosticPublishMode.All),
+            published.Add,
+            TimeSpan.FromMilliseconds(debounceMilliseconds),
+            useHostChannel ? null : failures.Add);
+
+        coordinator.Queue(uri);
+        await coordinator.DrainAsync();
+
+        if (useHostChannel)
+        {
+            Assert.Empty(failures);
+            Assert.Contains(failure.ToString(), stderr.ToString());
+        }
+        else
+        {
+            Assert.Same(failure, Assert.Single(failures));
+            Assert.Equal("", stderr.ToString());
+        }
+        Assert.Equal("", stdout.GetOutput());
+        Assert.Contains("original cause", failure.ToString());
+        Assert.Contains("InteropAnalyzer", failure.StackTrace);
+        Assert.Empty(published);
+        string report = stderr.ToString();
+
+        store.Open(uri, "const value = 1;", version: 2);
+        coordinator.Queue(uri);
+        await coordinator.DrainAsync();
+
+        Assert.Equal(useHostChannel ? 0 : 1, failures.Count);
+        Assert.Equal(report, stderr.ToString());
+        Assert.Equal(2, Assert.Single(published).Version);
+    }
+
+    [Fact]
+    public async Task AnalysisCancellationIsObservedWithoutFailureOrPublication()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        const string source = "@DotNetType('Injected.Type') declare class Injected {}";
+        string path = directory.CreateFile("input.ts", source);
+        string uri = new Uri(path).AbsoluteUri;
+        var store = new DocumentStore();
+        store.Open(uri, source, version: 1);
+        List<Exception> failures = [];
+        List<PublishDiagnosticsParams> published = [];
+        using var coordinator = new DiagnosticsCoordinator(
+            store,
+            new DiagnosticsService(resolve: _ => throw new OperationCanceledException()),
+            new DocumentDependencyGraph(),
+            new DiagnosticsSettings(),
+            published.Add,
+            TimeSpan.FromMilliseconds(25),
+            failures.Add);
+
+        coordinator.Queue(uri);
+        await coordinator.DrainAsync();
+
+        Assert.Empty(failures);
+        Assert.Empty(published);
+    }
+
+    [Fact]
+    public async Task MalformedSourcePublishesDiagnosticsWithoutReportingInternalFailure()
+    {
+        using var directory = CliTestHelper.CreateTempDirectory();
+        const string source = "let broken = ;\nlet value: number = 'wrong';";
+        string path = directory.CreateFile("input.ts", source);
+        string uri = new Uri(path).AbsoluteUri;
+        var store = new DocumentStore();
+        store.Open(uri, source, version: 1);
+        List<Exception> failures = [];
+        List<PublishDiagnosticsParams> published = [];
+        using var coordinator = new DiagnosticsCoordinator(
+            store,
+            new DiagnosticsService(),
+            new DocumentDependencyGraph(),
+            new DiagnosticsSettings(DiagnosticPublishMode.All),
+            published.Add,
+            TimeSpan.Zero,
+            failures.Add);
+
+        coordinator.Queue(uri);
+        await coordinator.DrainAsync();
+
+        Assert.Empty(failures);
+        Assert.NotEmpty(Assert.Single(published).Diagnostics);
+    }
+}

--- a/tests/SharpTS.Tests/TypeCheckerTests/TypeCheckerRecoveryTests.cs
+++ b/tests/SharpTS.Tests/TypeCheckerTests/TypeCheckerRecoveryTests.cs
@@ -1,4 +1,5 @@
 using SharpTS.Diagnostics;
+using SharpTS.Modules;
 using SharpTS.Parsing;
 using SharpTS.TypeSystem;
 using SharpTS.TypeSystem.Exceptions;
@@ -12,6 +13,180 @@ namespace SharpTS.Tests.TypeCheckerTests;
 /// </summary>
 public class TypeCheckerRecoveryTests
 {
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void UnexpectedFailure_PropagatesWithoutBecomingDiagnostic(bool defaultLibrary)
+    {
+        var failure = new InvalidOperationException("checker defect", new Exception("original cause"));
+        TypeChecker checker = CheckerWithCallback(() => throw failure);
+
+        Exception actual = Assert.Throws<InvalidOperationException>(() =>
+            CheckInjectedStatement(checker, defaultLibrary));
+
+        Assert.Same(failure, actual);
+        Assert.Empty(checker.GetDiagnostics());
+        Assert.Contains(nameof(CallbackType.ToString), actual.StackTrace);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void CancellationDuringLastStatement_Propagates(bool defaultLibrary, bool throwImmediately)
+    {
+        using var cancellation = new CancellationTokenSource();
+        TypeChecker checker = CheckerWithCallback(() =>
+        {
+            cancellation.Cancel();
+            if (throwImmediately)
+                cancellation.Token.ThrowIfCancellationRequested();
+        }).WithCancellation(cancellation.Token);
+
+        var failure = Assert.Throws<OperationCanceledException>(() =>
+            CheckInjectedStatement(checker, defaultLibrary));
+        Assert.Equal(cancellation.Token, failure.CancellationToken);
+        Assert.DoesNotContain(checker.GetDiagnostics(), diagnostic =>
+            diagnostic.Message.Contains("canceled", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void FailedRecovery_RestoresStrictChecking()
+    {
+        TypeChecker checker = CheckerWithCallback(() => throw new InvalidOperationException());
+        Assert.Throws<InvalidOperationException>(() => CheckInjectedStatement(checker, false));
+
+        Assert.Throws<TypeMismatchException>(() => checker.Check(ParseStatements(
+            "{ let value: number = 'wrong'; }")));
+    }
+
+    [Fact]
+    public void SpeculativeFunctionChecking_DoesNotHideInternalFailure()
+    {
+        var failure = new InvalidOperationException("inference defect");
+        TypeChecker checker = CheckerWithCallback(() => throw failure);
+
+        Assert.Same(failure, Assert.Throws<InvalidOperationException>(() =>
+            checker.CheckWithRecovery(ParseStatements("function infer() { let value: number = injected; }"))));
+        Assert.Empty(checker.GetDiagnostics());
+    }
+
+    [Theory]
+    [InlineData(DiagnosticSeverity.Error, false, DiagnosticSeverity.Error)]
+    [InlineData(DiagnosticSeverity.Warning, false, DiagnosticSeverity.Warning)]
+    [InlineData(DiagnosticSeverity.Info, false, DiagnosticSeverity.Info)]
+    [InlineData(DiagnosticSeverity.Error, true, DiagnosticSeverity.Warning)]
+    [InlineData(DiagnosticSeverity.Info, true, DiagnosticSeverity.Info)]
+    public void Recovery_PreservesStructuredDiagnostic(
+        DiagnosticSeverity severity, bool commonJs, DiagnosticSeverity expectedSeverity)
+    {
+        var original = new Diagnostic(
+            severity,
+            DiagnosticCode.TypeOperation,
+            "Type Error: this is the actual message: with punctuation",
+            new SourceLocation("original.ts", 7, 9, 8, 12),
+            new Dictionary<string, object> { ["context"] = "retained" },
+            "TS2349");
+        TypeChecker checker = CheckerWithCallback(() => throw new TypeCheckException(original))
+            .WithFilePath("fallback.ts");
+        if (commonJs)
+            SetCheckerField(checker, "_currentModule", new ParsedModule("dependency.cjs", []) { IsCommonJs = true });
+
+        Diagnostic actual = Assert.Single(CheckInjectedStatement(checker, false));
+
+        Assert.Equal(original with { Severity = expectedSeverity }, actual);
+        Assert.Same(original.Properties, actual.Properties);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Recovery_FillsOnlyMissingLocation(bool hasLocation)
+    {
+        var original = new Diagnostic(
+            DiagnosticSeverity.Error, DiagnosticCode.TypeError, "source error",
+            hasLocation ? new SourceLocation(null, 7, 9, 8, 12) : null,
+            TsCode: "TS2349");
+        TypeChecker checker = CheckerWithCallback(() => throw new TypeCheckException(original))
+            .WithFilePath("fallback.ts");
+
+        Diagnostic actual = Assert.Single(CheckInjectedStatement(checker, false));
+
+        Assert.Equal(hasLocation
+            ? new SourceLocation("fallback.ts", 7, 9, 8, 12)
+            : new SourceLocation("fallback.ts", 3), actual.Location);
+    }
+
+    [Fact]
+    public void DefaultLibrary_SourceErrorsDoNotPreventLaterGlobals()
+    {
+        string directory = Path.GetFullPath("recovery-test");
+        var library = new ParsedModule(Path.Combine(directory, "lib.test.d.ts"), ParseStatements(
+            "missing(); declare var available: string;"))
+        {
+            IsDefaultLibrary = true,
+            IsDeclarationFile = true,
+        };
+        var source = new ParsedModule(Path.Combine(directory, "main.ts"), ParseStatements(
+            "const value: number = available;"));
+        var checker = new TypeChecker();
+
+        checker.CheckModules([library, source], new ModuleResolver(directory));
+
+        Diagnostic error = Assert.Single(checker.GetDiagnostics());
+        Assert.Equal("TS2322", error.TsCode);
+        Assert.Equal(source.Path, error.FilePath);
+    }
+
+    private static IReadOnlyList<Diagnostic> CheckInjectedStatement(TypeChecker checker, bool defaultLibrary)
+    {
+        List<Stmt> statements = ParseStatements("\n\nlet value: number = injected;");
+        if (!defaultLibrary)
+            return checker.CheckWithRecovery(statements).Diagnostics;
+
+        string directory = Path.GetFullPath("recovery-test");
+        var library = new ParsedModule(Path.Combine(directory, "lib.test.d.ts"), statements)
+        {
+            IsDefaultLibrary = true,
+            IsDeclarationFile = true,
+        };
+        checker.CheckModules([library], new ModuleResolver(directory));
+        return checker.GetDiagnostics();
+    }
+
+    private static TypeChecker CheckerWithCallback(Action callback)
+    {
+        var checker = new TypeChecker();
+        var environment = new TypeEnvironment();
+        environment.Define("injected", new CallbackType(callback));
+        SetCheckerField(checker, "_environment", environment);
+        return checker;
+    }
+
+    private static void SetCheckerField(TypeChecker checker, string name, object value) =>
+        typeof(TypeChecker).GetField(name,
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .SetValue(checker, value);
+
+    // Formatting an assignment mismatch happens inside statement checking, after hoisting. This
+    // injects deterministic failures/cancellation without adding a production-only test hook.
+    private sealed record CallbackType(Action Callback) : TypeInfo
+    {
+        public override string ToString()
+        {
+            Callback();
+            return "callback type";
+        }
+    }
+
+    private static List<Stmt> ParseStatements(string source)
+    {
+        var parsed = new Parser(new Lexer(source).ScanTokens()).Parse();
+        Assert.True(parsed.IsSuccess);
+        return parsed.Statements;
+    }
+
     #region Helpers
 
     private static TypeCheckDiagnosticResult CheckWithRecovery(string source)


### PR DESCRIPTION
Checker recovery could turn an internal exception into an ordinary type error, while background LSP failures disappeared without evidence. Recover only expected type-check failures at the affected boundaries, propagate cancellation (including during the final statement), and preserve each exception's structured diagnostic, source span, metadata, and severity policy.

Report unexpected background diagnostics failures to stderr without corrupting the LSP transport. Wait for failure observation when draining pending work, allow subsequent edits to publish normally, and keep internal checker failures out of navigation's fallback recovery.

Closes #1613.

Validation:
- 1,750 checker, LSP, parser-recovery, and diagnostic tests passed, including the new failure, cancellation, structured-diagnostic, and stderr regressions.
- Repository code-quality gates and `git diff --check` passed.
- All 534 TypeScript corpus cases matched the committed baseline. The full conformance suite had 383 passing tests and one unrelated existing failure: `TypesBaselineParserTests.Parse_IsDeterministicAcrossLineEndingsAndBom` converts an already-CRLF fixture to CRCRLF on Windows. Its parser, test, and fixtures are unchanged by this PR.
