### PR TITLE
Unify Function constructor source support across execution modes

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -62,7 +62,7 @@ irrelevant: `strictNullChecks` defaults on, most other strictness flags default 
 | Promises and scheduling | ✅ | Promise combinators, timers, microtasks, abort signals/controllers |
 | Web-shaped APIs | ✅ | URL, URLSearchParams, TextEncoder/Decoder, fetch primitives, streams, Blob, FormData |
 | `eval` | ⚠️ | Direct lexical eval in the interpreter; compiled mode uses indirect runtime eval and cannot see compiled locals. |
-| `Function` constructor | ❌ | Constructing functions from source strings is not supported. |
+| `Function` constructor | ⚠️ | Zero-argument construction and a bounded `return this` global-discovery body work in both modes; all other source construction is rejected. See the [execution contract](docs/execution-modes.md#function-construction). |
 
 ## 4. Node.js built-in modules
 

--- a/docs/execution-modes.md
+++ b/docs/execution-modes.md
@@ -187,6 +187,31 @@ For supported language and library features, interpreted and compiled programs s
 same observable result. Every normal feature test should run in both modes. A backend-specific test
 or behavior needs an explicit reason and documentation.
 
+### Function construction
+
+Both modes support `Function()` and `new Function()` as fresh, empty anonymous functions
+with length zero and an `undefined` return value. General construction from source strings
+is unsupported and throws at construction time, including empty strings, numeric returns,
+invalid source, parameter strings, and non-string arguments. Arguments are evaluated normally
+before this check; unsupported source is neither executed nor silently ignored.
+
+For lodash/core-js global discovery, both modes also support a single string containing
+`return this`, with optional surrounding ECMAScript whitespace, horizontal whitespace between
+the two keywords, and an optional trailing semicolon. This is a bounded compatibility grammar;
+comments, additional statements, parentheses, and line terminators between `return` and `this`
+are unsupported. `Function('return this')()` returns `globalThis`. The returned function uses
+ordinary sloppy function receiver binding: object receivers supplied by a method call, `call`,
+`apply`, or `bind` are preserved, and nullish receivers resolve to the global object. It does
+not capture the caller's scope, receiver, or strictness.
+
+These rules apply to direct calls, `new`, aliases, and access through `globalThis.Function`.
+A local binding named `Function` is invoked normally. Compiled support is emitted into the
+output assembly and adds no SharpTS runtime dependency or dynamic-source capability; the same
+contract works with `--standalone`. This compatibility surface does not imply support for
+general dynamic `Function` bodies or reuse `eval` semantics.
+
+### Backend deviations
+
 Known contractual deviations include:
 
 - Interpreted `eval` is lexical; compiled `eval` is indirect and cannot see compiled locals.

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -85,6 +85,7 @@ public class EmittedRuntime
     /// Use when MethodInfo might not support GetParameters() (e.g., MethodBuilder tokens in persisted assemblies).
     /// </summary>
     public ConstructorBuilder TSFunctionCtorWithCache { get; set; } = null!;
+    public MethodBuilder FunctionConstructor { get; set; } = null!;
     public MethodBuilder TSFunctionInvoke { get; set; } = null!;
     public MethodBuilder TSFunctionInvokeWithThis { get; set; } = null!;
     public MethodBuilder TSFunctionGetTarget { get; set; } = null!;

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -40,17 +40,11 @@ public abstract partial class ExpressionEmitterBase
         if (TryEmitCjsRequireCall(c))
             return;
 
-        if (TryEmitFunctionReturnThisIdiom(c))
-            return;
-
-        // Function(...) constructs a callable function object. Dynamic source
-        // compilation remains outside compiled mode, but the callable carrier
-        // itself must still have Function branding and identity semantics.
+        // Share the runtime contract with aliased and constructed calls.
         if (c.Callee is Expr.Variable { Name.Lexeme: "Function" }
-            && Ctx.Locals.GetLocal("Function") == null
-            && !Ctx.Functions.ContainsKey(Ctx.ResolveFunctionName("Function")))
+            && !Resolver.HasVariable("Function") && !Ctx.HasVisibleValueBinding("Function"))
         {
-            EmitFunctionConstructorShell(c.Arguments);
+            EmitFunctionConstructor(c.Arguments);
             return;
         }
 
@@ -1844,31 +1838,6 @@ public abstract partial class ExpressionEmitterBase
             return true;
         var objType = Ctx.TypeMap?.Get(obj);
         return objType != null && Ctx.TypeEmitterRegistry.GetStrategy(objType) != null;
-    }
-
-    /// <summary>
-    /// lodash/core-js global-detection idiom: <c>Function('return this')()</c>.
-    /// The Function constructor isn't supported in either mode, but this probe
-    /// just means "give me globalThis". Compiled mode represents globalThis in
-    /// value position as the runtime sentinel (#271, see EmitVariable), so emit
-    /// the same value — packages probing via
-    /// <c>freeGlobal || freeSelf || Function('return this')()</c> get a real
-    /// root object whose <c>.Object</c>/<c>.Math</c> resolve to real constructors.
-    /// </summary>
-    protected bool TryEmitFunctionReturnThisIdiom(Expr.Call c)
-    {
-        if (c.Arguments.Count == 0
-            && c.Callee is Expr.Call inner
-            && inner.Callee is Expr.Variable { Name.Lexeme: "Function" }
-            && inner.Arguments.Count == 1
-            && inner.Arguments[0] is Expr.Literal { Value: string body }
-            && body.Trim() == "return this")
-        {
-            IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.GlobalThisSingletonField);
-            SetStackUnknown();
-            return true;
-        }
-        return false;
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.Constructors.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.Constructors.cs
@@ -13,21 +13,10 @@ namespace SharpTS.Compilation;
 /// </summary>
 public abstract partial class ExpressionEmitterBase
 {
-    private void EmitFunctionConstructorShell(List<Expr> arguments)
+    private void EmitFunctionConstructor(List<Expr> arguments)
     {
-        // Preserve left-to-right argument evaluation even though compiled mode
-        // does not yet compile the constructor's source strings into a body.
-        foreach (var argument in arguments)
-        {
-            EmitExpression(argument);
-            IL.Emit(OpCodes.Pop);
-        }
-
-        IL.Emit(OpCodes.Ldnull); // target
-        IL.Emit(OpCodes.Ldnull); // MethodInfo: a valid no-body callable shell
-        IL.Emit(OpCodes.Ldstr, "anonymous");
-        IL.Emit(OpCodes.Ldc_I4, Math.Max(0, arguments.Count - 1));
-        IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSFunctionCtorWithCache);
+        EmitArgsArrayWithSpread(arguments);
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.FunctionConstructor);
         SetStackUnknown();
     }
 
@@ -342,7 +331,8 @@ public abstract partial class ExpressionEmitterBase
                 return true;
 
             case "Function":
-                EmitFunctionConstructorShell(arguments);
+                if (Resolver.HasVariable("Function") || Ctx.HasVisibleValueBinding("Function")) return false;
+                EmitFunctionConstructor(arguments);
                 return true;
 
             // --- String / Number / Boolean primitive wrappers ---

--- a/src/SharpTS/Compilation/ILEmitter.Calls.Constructors.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.Constructors.cs
@@ -508,6 +508,19 @@ public partial class ILEmitter
         var typeLocal = IL.DeclareLocal(_ctx.Types.Type);
         IL.Emit(OpCodes.Stloc, typeLocal);
 
+        // Test before evaluating arguments so Function's spread arguments use
+        // the ordinary call expansion exactly once.
+        var notFunctionType = IL.DefineLabel();
+        var functionDone = IL.DefineLabel();
+        IL.Emit(OpCodes.Ldloc, typeLocal);
+        IL.Emit(OpCodes.Ldtoken, _ctx.Runtime!.TSFunctionType);
+        IL.Emit(OpCodes.Call, _ctx.Types.GetMethod(_ctx.Types.Type, "GetTypeFromHandle", _ctx.Types.RuntimeTypeHandle));
+        IL.Emit(OpCodes.Bne_Un, notFunctionType);
+        EmitArgsArrayWithSpread(n.Arguments);
+        IL.Emit(OpCodes.Call, _ctx.Runtime.FunctionConstructor);
+        IL.Emit(OpCodes.Br, functionDone);
+        IL.MarkLabel(notFunctionType);
+
         List<LocalBuilder> argTemps = [];
         foreach (var arg in n.Arguments)
         {
@@ -685,6 +698,7 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Ldloc, argsArrayLocal);
         IL.Emit(OpCodes.Callvirt, invokeMethod);
         IL.MarkLabel(constructionDone);
+        IL.MarkLabel(functionDone);
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/ILEmitter.Calls.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.cs
@@ -204,9 +204,6 @@ public partial class ILEmitter
         // `'[object Math]' === Object.prototype.toString.call(Math)`.
         if (TryEmitObjectPrototypeToStringCall(c)) return;
 
-        // Function('return this')() — global-detection probe; see helper doc.
-        if (TryEmitFunctionReturnThisIdiom(c)) return;
-
         // `String(x)` / `Number(x)` / `Boolean(x)` — non-`new` coercion calls.
         // Compiled mode would otherwise resolve `String` as `typeof(string)` and
         // try to "call" the Type, which devolves to Stringify → wrong format for

--- a/src/SharpTS/Compilation/RuntimeEmitter.DynamicConstruct.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.DynamicConstruct.cs
@@ -117,6 +117,16 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notStringTypeLabel);
 
+        var notFunctionType = il.DefineLabel();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldtoken, runtime.TSFunctionType);
+        il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
+        il.Emit(OpCodes.Bne_Un, notFunctionType);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, runtime.FunctionConstructor);
+        il.Emit(OpCodes.Ret);
+        il.MarkLabel(notFunctionType);
+
         // System.Type (built-in or user class reference) → Activator.CreateInstance(type, args)
         var notTypeLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);

--- a/src/SharpTS/Compilation/RuntimeEmitter.FunctionConstructor.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.FunctionConstructor.cs
@@ -1,0 +1,88 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text.RegularExpressions;
+using SharpTS.Runtime.Types;
+
+namespace SharpTS.Compilation;
+
+public partial class RuntimeEmitter
+{
+    private void EmitFunctionConstructor(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    {
+        // These are ordinary sloppy functions, with the same receiver binding
+        // as guest functions. Keep them off $Runtime, whose methods are branded
+        // as non-constructible built-ins by IsConstructor/GetFunctionMethod.
+        var emptyBody = typeBuilder.DefineMethod("EmptyFunctionBody",
+            MethodAttributes.Public | MethodAttributes.Static, _types.Object, [_types.Object]);
+        emptyBody.DefineParameter(1, ParameterAttributes.None, "__this");
+        var emptyIL = emptyBody.GetILGenerator();
+        emptyIL.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
+        emptyIL.Emit(OpCodes.Ret);
+
+        var returnThisBody = typeBuilder.DefineMethod("ReturnThisFunctionBody",
+            MethodAttributes.Public | MethodAttributes.Static, _types.Object, [_types.Object]);
+        returnThisBody.DefineParameter(1, ParameterAttributes.None, "__this");
+        var bodyIL = returnThisBody.GetILGenerator();
+        var useGlobal = bodyIL.DefineLabel();
+        bodyIL.Emit(OpCodes.Ldarg_0);
+        bodyIL.Emit(OpCodes.Brfalse, useGlobal);
+        bodyIL.Emit(OpCodes.Ldarg_0);
+        bodyIL.Emit(OpCodes.Isinst, runtime.UndefinedType);
+        bodyIL.Emit(OpCodes.Brtrue, useGlobal);
+        bodyIL.Emit(OpCodes.Ldarg_0);
+        bodyIL.Emit(OpCodes.Ret);
+        bodyIL.MarkLabel(useGlobal);
+        bodyIL.Emit(OpCodes.Ldsfld, runtime.GlobalThisSingletonField);
+        bodyIL.Emit(OpCodes.Ret);
+
+        var method = typeBuilder.DefineMethod("ConstructFunction",
+            MethodAttributes.Public | MethodAttributes.Static, typeBuilder, [_types.ObjectArray]);
+        runtime.FunctionConstructor = method;
+        var il = method.GetILGenerator();
+        var body = il.DeclareLocal(_types.String);
+        var empty = il.DefineLabel();
+        var unsupported = il.DefineLabel();
+        var create = il.DefineLabel();
+
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Brfalse, empty);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldlen);
+        il.Emit(OpCodes.Conv_I4);
+        il.Emit(OpCodes.Ldc_I4_1);
+        il.Emit(OpCodes.Bne_Un, unsupported);
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Ldelem_Ref);
+        il.Emit(OpCodes.Isinst, _types.String);
+        il.Emit(OpCodes.Stloc, body);
+        il.Emit(OpCodes.Ldloc, body);
+        il.Emit(OpCodes.Brfalse, unsupported);
+        il.Emit(OpCodes.Ldloc, body);
+        il.Emit(OpCodes.Ldstr, FunctionConstructorContract.ReturnThisPattern);
+        il.Emit(OpCodes.Ldc_I4, (int)RegexOptions.NonBacktracking);
+        il.Emit(OpCodes.Call, _types.GetMethod(typeof(Regex), "IsMatch", _types.String, _types.String, typeof(RegexOptions)));
+        il.Emit(OpCodes.Brfalse, unsupported);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldtoken, returnThisBody);
+        il.Emit(OpCodes.Br, create);
+
+        il.MarkLabel(unsupported);
+        il.Emit(OpCodes.Ldstr, FunctionConstructorContract.UnsupportedSourceMessage);
+        il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.Exception, _types.String)!);
+        il.Emit(OpCodes.Throw);
+
+        il.MarkLabel(empty);
+        il.Emit(OpCodes.Ldnull);
+        il.Emit(OpCodes.Ldtoken, emptyBody);
+        il.MarkLabel(create);
+        il.Emit(OpCodes.Call, _types.GetMethod(typeof(MethodBase), "GetMethodFromHandle", _types.RuntimeMethodHandle));
+        il.Emit(OpCodes.Castclass, _types.MethodInfo);
+        il.Emit(OpCodes.Ldstr, "anonymous");
+        il.Emit(OpCodes.Ldc_I4_0);
+        il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);
+        il.Emit(OpCodes.Ret);
+    }
+}

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Invocation.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Invocation.cs
@@ -391,7 +391,7 @@ public partial class RuntimeEmitter
         // Function call form. Bare Function is represented by the $TSFunction
         // Type token; calling it (including through the GeneratorFunction
         // constructor identity currently exposed by generator prototypes)
-        // produces the same anonymous callable shell as `new Function(...)`.
+        // uses the same source contract as `new Function(...)`.
         var notFunctionTypeLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Castclass, _types.Type);
@@ -401,25 +401,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "op_Equality",
             [_types.Type, _types.Type])!);
         il.Emit(OpCodes.Brfalse, notFunctionTypeLabel);
-        var dynamicFunctionLengthLocal = il.DeclareLocal(_types.Int32);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Ldlen);
-        il.Emit(OpCodes.Conv_I4);
-        il.Emit(OpCodes.Ldc_I4_1);
-        il.Emit(OpCodes.Sub);
-        il.Emit(OpCodes.Stloc, dynamicFunctionLengthLocal);
-        var functionLengthNonNegative = il.DefineLabel();
-        il.Emit(OpCodes.Ldloc, dynamicFunctionLengthLocal);
-        il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Bge, functionLengthNonNegative);
-        il.Emit(OpCodes.Ldc_I4_0);
-        il.Emit(OpCodes.Stloc, dynamicFunctionLengthLocal);
-        il.MarkLabel(functionLengthNonNegative);
-        il.Emit(OpCodes.Ldnull);
-        il.Emit(OpCodes.Ldnull);
-        il.Emit(OpCodes.Ldstr, "anonymous");
-        il.Emit(OpCodes.Ldloc, dynamicFunctionLengthLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSFunctionCtorWithCache);
+        il.Emit(OpCodes.Call, runtime.FunctionConstructor);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notFunctionTypeLabel);
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSFunction.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSFunction.cs
@@ -456,6 +456,8 @@ public partial class RuntimeEmitter
         ctorCacheIL.MarkLabel(noCachedMethodLabel);
         ctorCacheIL.Emit(OpCodes.Ret);
 
+        EmitFunctionConstructor(typeBuilder, runtime);
+
         // Static factory: public static $TSFunction GetOrCreate(MethodInfo method, string name, int length).
         // Returns a cached $TSFunction for the given method + JS metadata, creating one if
         // not present. Used only for function DECLARATIONS (target=null), where

--- a/src/SharpTS/Runtime/Types/FunctionConstructorContract.cs
+++ b/src/SharpTS/Runtime/Types/FunctionConstructorContract.cs
@@ -1,0 +1,15 @@
+namespace SharpTS.Runtime.Types;
+
+internal static class FunctionConstructorContract
+{
+    // A bounded package-compatibility grammar, not a general source evaluator.
+    // ECMAScript whitespace is explicit: .NET \s also accepts non-JS whitespace.
+    // A line terminator between return and this would change the return via ASI.
+    private const string Space = @"[\t\v\f \u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff]";
+    private const string Trivia = @"[\t\v\f \r\n\u2028\u2029\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff]*";
+    internal const string ReturnThisPattern = @"\A" + Trivia + "return" + Space + "+this" + Trivia + ";?" + Trivia + @"\z";
+
+    internal const string UnsupportedSourceMessage =
+        "Runtime Error: Dynamic Function() construction with source text is not supported. " +
+        "Only zero arguments or a single 'return this' body (whitespace and an optional semicolon) are supported.";
+}

--- a/src/SharpTS/Runtime/Types/SharpTSFunctionGlobal.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSFunctionGlobal.cs
@@ -1,9 +1,12 @@
+using System.Text.RegularExpressions;
+using SharpTS.Parsing;
+
 namespace SharpTS.Runtime.Types;
 
 /// <summary>
 /// Global <c>Function</c> constructor. The zero-argument form produces the
-/// spec-equivalent empty anonymous function; parsing parameter/body strings is
-/// deliberately rejected until the dynamic-source path can validate them.
+/// empty anonymous function. Source construction is limited to the documented
+/// return-this package-compatibility grammar in both execution modes.
 /// </summary>
 public sealed class SharpTSFunctionGlobal : ISharpTSCallable
 {
@@ -15,26 +18,23 @@ public sealed class SharpTSFunctionGlobal : ISharpTSCallable
 
     public object? Call(Execution.Interpreter interpreter, List<object?> arguments)
     {
-        if (arguments.Count == 1
-            && arguments[0] is string body
-            && body.Trim() == "return 42;")
+        string body = "";
+        if (arguments.Count != 0
+            && (arguments.Count != 1 || arguments[0] is not string source
+                || !Regex.IsMatch(source, FunctionConstructorContract.ReturnThisPattern, RegexOptions.NonBacktracking)))
         {
-            return new BuiltIns.BuiltInMethod(
-                "anonymous",
-                0,
-                static (_, _, _) => 42d);
+            throw new Exception(FunctionConstructorContract.UnsupportedSourceMessage);
         }
+        if (arguments.Count == 1)
+            body = (string)arguments[0]!;
 
-        if (arguments.Count != 0)
-        {
-            throw new Exception(
-                "Runtime Error: Dynamic Function() construction with source text is not supported.");
-        }
-
-        return new BuiltIns.BuiltInMethod(
-            "anonymous",
-            0,
-            static (_, _, _) => SharpTSUndefined.Instance);
+        // Use ordinary function execution and receiver binding. The supported
+        // bodies reference no bindings; an isolated sloppy scope prevents the
+        // caller's lexical variables, this, or strictness from leaking in.
+        var tokens = new Lexer("const fn = function anonymous() {\n" + body + "\n};").ScanTokens();
+        var declaration = (Stmt.Const)new Parser(tokens).ParseOrThrow()[0];
+        return new SharpTSArrowFunction((Expr.ArrowFunction)declaration.Initializer,
+            new RuntimeEnvironment(strictMode: false), hasOwnThis: true);
     }
 
     public object? GetMember(string name)

--- a/tests/SharpTS.Tests/CompilerTests/RuntimeDependencySignalTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/RuntimeDependencySignalTests.cs
@@ -41,6 +41,20 @@ public class RuntimeDependencySignalTests
     }
 
     [Fact]
+    public void FunctionConstructorContract_RequiresNoRuntime()
+    {
+        var compiler = CompilerFor("""
+            const ctor: any = Function;
+            console.log(ctor()());
+            console.log(typeof (new ctor("return this;"))());
+            try { Function("return 42;"); } catch { console.log("rejected"); }
+            """);
+
+        Assert.Empty(compiler.RequiredSharpTSRuntimeReasons);
+        Assert.Equal(SharpTSRuntimeRequirements.None, compiler.RequiredSharpTSRuntimeRequirements);
+    }
+
+    [Fact]
     public void DynamicEval_RequiresRuntime()
     {
         var reasons = ReasonsFor("""

--- a/tests/SharpTS.Tests/GlobalThisTests.cs
+++ b/tests/SharpTS.Tests/GlobalThisTests.cs
@@ -201,9 +201,8 @@ public class GlobalThisTests
     }
 
     // #271: the lodash/core-js `Function('return this')()` global probe yields
-    // the same real globalThis value (compiled mode; the interpreter rejects the
-    // dynamic Function constructor, so this is compiled-only).
-    [Theory, CompiledOnlyData]
+    // the same real globalThis value in both execution modes.
+    [Theory, ModeData]
     public void GlobalThis_FunctionReturnThisProbe_IsGlobalThis(ExecutionMode mode)
     {
         var result = TestHarness.Run("""

--- a/tests/SharpTS.Tests/SharedTests/FunctionConstructorTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/FunctionConstructorTests.cs
@@ -1,0 +1,180 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+public class FunctionConstructorTests
+{
+    [Theory, ModeData]
+    public void UnsupportedSource_IsRejectedAcrossCallAndConstructForms(ExecutionMode mode)
+    {
+        const string source = """
+            const ctor: any = globalThis.Function;
+            const bodies = ["return 42;", "return 43;", "return 42", " \treturn 43;\n",
+                "", " ", "return @@@", "return this.x", "returnthis", "return\nthis",
+                "return\rthis", "return\u2028this", "return\u2029this", "return this; extra()"];
+            let rejected = 0;
+            function check(action: any) {
+                try { action(); }
+                catch (error) {
+                    if (error.message.includes("Dynamic Function() construction with source text is not supported"))
+                        rejected++;
+                }
+            }
+            for (const body of bodies) {
+                check(() => Function(body));
+                check(() => new Function(body));
+                check(() => ctor(body));
+                check(() => new ctor(body));
+                check(() => globalThis.Function(body));
+                check(() => new globalThis.Function(body));
+            }
+            check(() => ctor("x", "return this"));
+            check(() => new ctor("", "return this"));
+            check(() => ctor(undefined));
+            check(() => ctor(null));
+            check(() => ctor(42));
+            console.log(rejected);
+            """;
+
+        Assert.Equal("89\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void ReturnThis_UsesOneContractForEquivalentForms(ExecutionMode mode)
+    {
+        const string source = """
+            const ctor: any = globalThis.Function;
+            const bodies = ["return this", "return this;", " \nreturn\tthis ;\r\n", "\ufeffreturn  this\u00a0"];
+            let passed = 0;
+            for (const body of bodies) {
+                if (Function(body)() === globalThis) passed++;
+                if ((new Function(body))() === globalThis) passed++;
+                if (ctor(body)() === globalThis) passed++;
+                if ((new ctor(body))() === globalThis) passed++;
+                if (globalThis.Function(body)() === globalThis) passed++;
+                if ((new globalThis.Function(body))() === globalThis) passed++;
+            }
+            console.log(passed);
+            """;
+
+        Assert.Equal("24\n", TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void ConstructedFunctions_HaveOrdinaryReceiverAndIdentitySemantics(ExecutionMode mode)
+    {
+        const string source = """
+            function make() {
+                "use strict";
+                const globalThis = { local: true };
+                return Function("return this;");
+            }
+            const fn: any = make.call({ caller: true });
+            const receiver: any = { fn };
+            console.log(fn() === globalThis);
+            console.log(receiver.fn() === receiver);
+            console.log(fn.call(receiver) === receiver);
+            console.log(fn.apply(receiver, []) === receiver);
+            console.log(fn.bind(receiver)() === receiver);
+            console.log(fn.call(null) === globalThis);
+            console.log(fn.call(undefined) === globalThis);
+            console.log(fn.name, fn.length, typeof fn);
+            console.log(fn !== Function("return this;"));
+            console.log(typeof new fn());
+            const empty: any = Function();
+            console.log(empty(), empty.name, empty.length);
+            console.log((new Function())());
+            const ctor: any = globalThis.Function;
+            console.log(ctor()(), (new ctor())());
+            """;
+
+        var result = TestHarness.Run(source, mode);
+        Assert.Equal("true\ntrue\ntrue\ntrue\ntrue\ntrue\ntrue\nanonymous 0 function\ntrue\nobject\nundefined anonymous 0\nundefined\nundefined undefined\n", result);
+    }
+
+    [Theory, ModeData]
+    public void ShadowedFunction_IsInvokedNormally(ExecutionMode mode)
+    {
+        const string source = """
+            function withParameter(Function: any) {
+                console.log(Function("return this")());
+                console.log((new Function("return this;"))());
+                return () => Function("return this")();
+            }
+            function replacement(body: string): any {
+                console.log(body);
+                return () => 17;
+            }
+            console.log(withParameter(replacement)());
+            {
+                const Function: any = replacement;
+                console.log(Function("return this")());
+                console.log((new Function("return this"))());
+            }
+            """;
+
+        Assert.Equal("return this\n17\nreturn this;\n17\nreturn this\n17\nreturn this\n17\nreturn this\n17\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void ArgumentEvaluationAndSpreads_ArePreserved(ExecutionMode mode)
+    {
+        const string source = """
+            const ctor: any = globalThis.Function;
+            function arg(label: string): string { console.log(label); return label; }
+            try { ctor(arg("a"), arg("b")); } catch { console.log("rejected"); }
+            try { new Function(arg("c"), arg("d")); } catch { console.log("rejected"); }
+            const args: any = ["return this;"];
+            console.log(Function(...args)() === globalThis);
+            console.log((new Function(...args))() === globalThis);
+            console.log(ctor(...args)() === globalThis);
+            console.log((new ctor(...args))() === globalThis);
+            const none: any = [];
+            console.log(Function(...none)());
+            console.log((new ctor(...none))());
+            """;
+
+        Assert.Equal("a\nb\nrejected\nc\nd\nrejected\ntrue\ntrue\ntrue\ntrue\nundefined\nundefined\n",
+            TestHarness.Run(source, mode));
+    }
+
+    [Fact]
+    public void CompiledContract_WorksWithoutSharpTSRuntime()
+    {
+        Assert.Equal("true\nundefined\nrejected\n", TestHarness.RunCompiledStandalone("""
+            const ctor: any = globalThis.Function;
+            console.log((new ctor(" return this; "))() === globalThis);
+            console.log(ctor()());
+            try { ctor("return 42;"); } catch { console.log("rejected"); }
+            """));
+    }
+
+    [Theory, ModeData]
+    public void AsyncAndGeneratorConstruction_UseTheSameContract(ExecutionMode mode)
+    {
+        const string source = """
+            const ctor: any = globalThis.Function;
+            const root: any = globalThis;
+            async function run() {
+                const body = await Promise.resolve("return this;");
+                console.log((new ctor(body))() === root);
+                console.log(Function(body)() === root);
+                try { new ctor("return 43;"); } catch { console.log("async rejected"); }
+            }
+            function* generate() {
+                const body = yield "ready";
+                yield (new ctor(body))() === root;
+                try { new ctor("return 42;"); } catch { yield "generator rejected"; }
+            }
+            const values = generate();
+            console.log(values.next().value);
+            console.log(values.next("return this").value);
+            console.log(values.next().value);
+            run();
+            """;
+
+        Assert.Equal("ready\ntrue\ngenerator rejected\ntrue\ntrue\nasync rejected\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
The interpreter previously accepted `Function("return 42;")` while rejecting equivalent numeric bodies, and compiled construction could silently create an empty function. Both modes now reject unsupported source at construction time and retain zero-argument construction.

Preserve the lodash/core-js `return this` probe through a documented compatibility grammar supporting whitespace and an optional semicolon. Route direct, aliased, `globalThis`, and `new` forms through the same contract; honor local shadowing, receiver binding, caller-scope isolation, argument evaluation, and spreads. Compiled support runs without SharpTS.dll and introduces no constructor-specific runtime requirement. General dynamic Function source remains unsupported.

Validation:
- Release build and `git diff --check` passed.
- Focused function/globalThis/runtime-dependency/standalone run: 149 passed, 1 failed. All new dual-mode, async/generator, and standalone tests passed.
- The failure, `StandaloneDllTests.Isolated_Tls_ShouldExecuteWithoutSharpTsDll`, reports TLS authentication failure and also reproduces against the untouched main-checkout test binary.
- Seven selected Test262 cases passed in both modes, covering function descriptors, construction spreads, preventExtensions, and constructor metadata, using corpus revision d5e73fc8d2c663554fb72e2380a8c2bc1a318a33.
- The full test suite was not run.

Closes #1614.
