### PR TITLE
Extract net transport metadata into a checked component

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -198,6 +198,16 @@ directly; event-loop, Buffer, and EventEmitter dependencies remain on the shared
 fields and synchronous method helpers stay local to the emitter, and named-import dispatch remains
 in the shared built-in module registry.
 
+Net uses `Net` / `RequireNet()` for its module factories, TCP/IPC socket and server metadata,
+and native BlockList enforcement handles. `EmitAll` starts it for `UsesNet`, including net implied
+by HTTP, TLS, or fetch. Socket methods are declared before factories, TLS subclasses, and accept/read
+closures reference them; phase 2 uses those same component handles to emit bodies and finalize the
+socket and server types. Completion follows runtime and dependent-type finalization. Net factories
+and BlockList emission take `EmittedNetRuntime` directly; EventEmitter, Buffer, event-loop helpers,
+and module registration remain separate dependencies. Migrated type/method handles have no duplicate
+emitter fields. Socket/server fields, other transport methods, and closure construction state remain
+local to the emitter.
+
 During emission, each handle becomes readable as soon as its declaration is assigned, so forward
 references do not require a method body to exist yet. An early read names the missing declaration.
 Completion is an orchestration boundary, not an IL verifier: body emission and type finalization

--- a/src/SharpTS/Compilation/EmittedNetRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedNetRuntime.cs
@@ -1,0 +1,173 @@
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// TCP/IPC transport metadata for one compilation. Declarations support forward references;
+/// completion validates and freezes handles after socket/server bodies and types are finalized.
+/// </summary>
+public sealed class EmittedNetRuntime
+{
+    internal EmittedNetRuntime() { }
+
+    public bool IsComplete { get; private set; }
+
+    private MethodBuilder? _createServer;
+    public MethodBuilder CreateServer
+    {
+        get => Require(_createServer);
+        internal set => Set(ref _createServer, value);
+    }
+
+    private MethodBuilder? _createConnection;
+    public MethodBuilder CreateConnection
+    {
+        get => Require(_createConnection);
+        internal set => Set(ref _createConnection, value);
+    }
+
+    private MethodBuilder? _createSocket;
+    public MethodBuilder CreateSocket
+    {
+        get => Require(_createSocket);
+        internal set => Set(ref _createSocket, value);
+    }
+
+    private MethodBuilder? _createBlockList;
+    public MethodBuilder CreateBlockList
+    {
+        get => Require(_createBlockList);
+        internal set => Set(ref _createBlockList, value);
+    }
+
+    private TypeBuilder? _blockListType;
+    public TypeBuilder BlockListType
+    {
+        get => Require(_blockListType);
+        internal set => Set(ref _blockListType, value);
+    }
+
+    private ConstructorBuilder? _blockListCtor;
+    public ConstructorBuilder BlockListCtor
+    {
+        get => Require(_blockListCtor);
+        internal set => Set(ref _blockListCtor, value);
+    }
+
+    private MethodBuilder? _blockListCheckIp;
+    public MethodBuilder BlockListCheckIp
+    {
+        get => Require(_blockListCheckIp);
+        internal set => Set(ref _blockListCheckIp, value);
+    }
+
+    private TypeBuilder? _serverType;
+    public TypeBuilder ServerType
+    {
+        get => Require(_serverType);
+        internal set => Set(ref _serverType, value);
+    }
+
+    private ConstructorBuilder? _serverCtor;
+    public ConstructorBuilder ServerCtor
+    {
+        get => Require(_serverCtor);
+        internal set => Set(ref _serverCtor, value);
+    }
+
+    private TypeBuilder? _socketType;
+    public TypeBuilder SocketType
+    {
+        get => Require(_socketType);
+        internal set => Set(ref _socketType, value);
+    }
+
+    private ConstructorBuilder? _socketCtor;
+    public ConstructorBuilder SocketCtor
+    {
+        get => Require(_socketCtor);
+        internal set => Set(ref _socketCtor, value);
+    }
+
+    private ConstructorBuilder? _socketCtorTcpClient;
+    public ConstructorBuilder SocketCtorTcpClient
+    {
+        get => Require(_socketCtorTcpClient);
+        internal set => Set(ref _socketCtorTcpClient, value);
+    }
+
+    private ConstructorBuilder? _socketCtorStream;
+    public ConstructorBuilder SocketCtorStream
+    {
+        get => Require(_socketCtorStream);
+        internal set => Set(ref _socketCtorStream, value);
+    }
+
+    private MethodBuilder? _socketConnect;
+    public MethodBuilder SocketConnect
+    {
+        get => Require(_socketConnect);
+        internal set => Set(ref _socketConnect, value);
+    }
+
+    private MethodBuilder? _socketWrite;
+    public MethodBuilder SocketWrite
+    {
+        get => Require(_socketWrite);
+        internal set => Set(ref _socketWrite, value);
+    }
+
+    private MethodBuilder? _socketStartReading;
+    public MethodBuilder SocketStartReading
+    {
+        get => Require(_socketStartReading);
+        internal set => Set(ref _socketStartReading, value);
+    }
+
+    private MethodBuilder? _socketGetMember;
+    public MethodBuilder SocketGetMember
+    {
+        get => Require(_socketGetMember);
+        internal set => Set(ref _socketGetMember, value);
+    }
+
+    private static T Require<T>(T? handle, [CallerMemberName] string name = "") where T : class =>
+        handle ?? throw new InvalidOperationException($"Net metadata '{name}' has not been declared.");
+
+    private void Set<T>(ref T? field, T value) where T : class
+    {
+        EnsureMutable();
+        ArgumentNullException.ThrowIfNull(value);
+        field = value;
+    }
+
+    private void EnsureMutable()
+    {
+        if (IsComplete)
+            throw new InvalidOperationException("Net metadata emission is already complete.");
+    }
+
+    internal void CompleteEmission()
+    {
+        EnsureMutable();
+        _ = CreateServer;
+        _ = CreateConnection;
+        _ = CreateSocket;
+        _ = CreateBlockList;
+        _ = BlockListType;
+        _ = BlockListCtor;
+        _ = BlockListCheckIp;
+        _ = ServerType;
+        _ = ServerCtor;
+        _ = SocketType;
+        _ = SocketCtor;
+        _ = SocketCtorTcpClient;
+        _ = SocketCtorStream;
+        _ = SocketConnect;
+        _ = SocketWrite;
+        _ = SocketStartReading;
+        _ = SocketGetMember;
+        IsComplete = true;
+    }
+}

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -2277,16 +2277,18 @@ public class EmittedRuntime
     public TypeBuilder TSHttpResponseType { get; set; } = null!;
     public ConstructorBuilder TSHttpResponseCtor { get; set; } = null!;
 
-    // Net module methods
-    public MethodBuilder NetCreateServer { get; set; } = null!;
-    public MethodBuilder NetCreateConnection { get; set; } = null!;
-    public MethodBuilder NetCreateSocket { get; set; } = null!;
-    public MethodBuilder NetCreateBlockList { get; set; } = null!;
+    /// <summary>TCP/IPC metadata, or null when net is tree-shaken from this compilation.</summary>
+    public EmittedNetRuntime? Net { get; private set; }
 
-    // Opaque net.BlockList enforcement handle. Null when UsesNet is off.
-    public TypeBuilder? BlockListType { get; set; }
-    public ConstructorBuilder? BlockListCtor { get; set; }
-    public MethodBuilder? BlockListCheckIp { get; set; }
+    internal void BeginNetEmission()
+    {
+        if (Net is not null)
+            throw new InvalidOperationException("Net metadata emission has already started.");
+        Net = new EmittedNetRuntime();
+    }
+
+    public EmittedNetRuntime RequireNet() => Net
+        ?? throw new InvalidOperationException("Net runtime was not enabled for this compilation.");
 
     /// <summary>TLS metadata, or null when TLS is tree-shaken from this compilation.</summary>
     public EmittedTlsRuntime? Tls { get; private set; }
@@ -2931,23 +2933,6 @@ public class EmittedRuntime
     /// escaping to the thread pool.
     /// </summary>
     public ConstructorBuilder EventLoopSyncContextCtor { get; set; } = null!;
-
-    // ============================================================
-    // $NetServer — emitted TCP server (extends $EventEmitter)
-    // ============================================================
-    public ConstructorBuilder NetServerCtor { get; set; } = null!;
-
-    // ============================================================
-    // $NetSocket — emitted TCP socket (extends $EventEmitter)
-    // ============================================================
-    public TypeBuilder NetSocketType { get; set; } = null!;
-    public ConstructorBuilder NetSocketCtor { get; set; } = null!;
-    public ConstructorBuilder NetSocketCtorTcpClient { get; set; } = null!;
-    public ConstructorBuilder NetSocketCtorStream { get; set; } = null!;
-    public MethodBuilder NetSocketConnect { get; set; } = null!;
-    public MethodBuilder NetSocketWrite { get; set; } = null!;
-    public MethodBuilder NetSocketStartReading { get; set; } = null!;
-    public MethodBuilder NetSocketGetMember { get; set; } = null!;
 
     // Vm module methods
     public MethodBuilder VmRunInNewContext { get; set; } = null!;

--- a/src/SharpTS/Compilation/Emitters/Modules/NetModuleEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/Modules/NetModuleEmitter.cs
@@ -33,8 +33,8 @@ public sealed class NetModuleEmitter : IBuiltInModuleEmitter
         {
             "createServer" => EmitCreateServer(emitter, arguments),
             "createConnection" => EmitCreateConnection(emitter, arguments),
-            "createSocket" => EmitOneArgCall(emitter, arguments, emitter.Context.Runtime!.NetCreateSocket),
-            "createBlockList" => EmitZeroArgCall(emitter, emitter.Context.Runtime!.NetCreateBlockList),
+            "createSocket" => EmitOneArgCall(emitter, arguments, emitter.Context.Runtime!.RequireNet().CreateSocket),
+            "createBlockList" => EmitZeroArgCall(emitter, emitter.Context.Runtime!.RequireNet().CreateBlockList),
             _ => false
         };
     }
@@ -88,7 +88,7 @@ public sealed class NetModuleEmitter : IBuiltInModuleEmitter
         }
 
         // Call $Runtime.NetCreateServer(optionsOrCallback, callback)
-        il.Emit(OpCodes.Call, ctx.Runtime!.NetCreateServer);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireNet().CreateServer);
         return true;
     }
 
@@ -113,7 +113,7 @@ public sealed class NetModuleEmitter : IBuiltInModuleEmitter
         }
 
         // Call $Runtime.NetCreateConnection(options, hostOrCallback, callback)
-        il.Emit(OpCodes.Call, ctx.Runtime!.NetCreateConnection);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequireNet().CreateConnection);
         return true;
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Net.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Net.cs
@@ -13,17 +13,22 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitNetModuleMethods(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        EmitNetCreateServer(typeBuilder, runtime);
-        EmitNetCreateConnection(typeBuilder, runtime);
-        EmitNetCreateSocket(typeBuilder, runtime);
-        EmitNetCreateBlockList(typeBuilder, runtime);
+        var net = runtime.RequireNet();
+        EmitNetCreateServer(typeBuilder, net);
+        EmitNetCreateConnection(typeBuilder, net);
+        EmitNetCreateSocket(typeBuilder, net);
+        EmitNetCreateBlockList(typeBuilder, net);
+        runtime.RegisterBuiltInModuleMethod("primitive:net", "createServer", net.CreateServer);
+        runtime.RegisterBuiltInModuleMethod("primitive:net", "createConnection", net.CreateConnection);
+        runtime.RegisterBuiltInModuleMethod("primitive:net", "createSocket", net.CreateSocket);
+        runtime.RegisterBuiltInModuleMethod("primitive:net", "createBlockList", net.CreateBlockList);
     }
 
     /// <summary>
     /// Emits: public static object NetCreateBlockList() — creates the opaque
     /// native handle used by the TypeScript BlockList facade.
     /// </summary>
-    private void EmitNetCreateBlockList(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitNetCreateBlockList(TypeBuilder typeBuilder, EmittedNetRuntime net)
     {
         var method = typeBuilder.DefineMethod(
             "NetCreateBlockList",
@@ -31,11 +36,10 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.NetCreateBlockList = method;
-        runtime.RegisterBuiltInModuleMethod("primitive:net", "createBlockList", method);
+        net.CreateBlockList = method;
 
         var il = method.GetILGenerator();
-        il.Emit(OpCodes.Newobj, runtime.BlockListCtor!);
+        il.Emit(OpCodes.Newobj, net.BlockListCtor);
         il.Emit(OpCodes.Ret);
     }
 
@@ -46,7 +50,7 @@ public partial class RuntimeEmitter
     /// as the first arg carries per-socket settings (highWaterMark) applied to
     /// accepted connections.
     /// </summary>
-    private void EmitNetCreateServer(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitNetCreateServer(TypeBuilder typeBuilder, EmittedNetRuntime net)
     {
         var method = typeBuilder.DefineMethod(
             "NetCreateServer",
@@ -54,11 +58,10 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object, _types.Object]
         );
-        runtime.NetCreateServer = method;
-        runtime.RegisterBuiltInModuleMethod("primitive:net", "createServer", method);
+        net.CreateServer = method;
 
         var il = method.GetILGenerator();
-        var serverLocal = il.DeclareLocal(_netServerTypeBuilder);
+        var serverLocal = il.DeclareLocal(net.ServerType);
         var cbLocal = il.DeclareLocal(_types.Object);
 
         // callback = (arg0 is Dictionary) ? arg1 : arg0
@@ -77,7 +80,7 @@ public partial class RuntimeEmitter
 
         // server = new $NetServer(callback)
         il.Emit(OpCodes.Ldloc, cbLocal);
-        il.Emit(OpCodes.Newobj, runtime.NetServerCtor);
+        il.Emit(OpCodes.Newobj, net.ServerCtor);
         il.Emit(OpCodes.Stloc, serverLocal);
 
         // if (arg0 is Dictionary) parse per-socket options
@@ -115,7 +118,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "TryGetValue", [_types.String, _types.Object.MakeByRefType()])!);
             il.Emit(OpCodes.Brfalse, noBlockList);
             il.Emit(OpCodes.Ldloc, valLocal);
-            il.Emit(OpCodes.Isinst, _blockListTypeBuilder);
+            il.Emit(OpCodes.Isinst, net.BlockListType);
             il.Emit(OpCodes.Brfalse, noBlockList);
             il.Emit(OpCodes.Ldloc, serverLocal);
             il.Emit(OpCodes.Ldloc, valLocal);
@@ -152,7 +155,7 @@ public partial class RuntimeEmitter
     /// Node signature: connect(options|port|path[, host][, connectListener]) —
     /// the socket's Connect does the positional-arg parsing.
     /// </summary>
-    private void EmitNetCreateConnection(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitNetCreateConnection(TypeBuilder typeBuilder, EmittedNetRuntime net)
     {
         var method = typeBuilder.DefineMethod(
             "NetCreateConnection",
@@ -160,14 +163,13 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object, _types.Object, _types.Object]
         );
-        runtime.NetCreateConnection = method;
-        runtime.RegisterBuiltInModuleMethod("primitive:net", "createConnection", method);
+        net.CreateConnection = method;
 
         var il = method.GetILGenerator();
 
         // var socket = new $NetSocket()
-        var socketLocal = il.DeclareLocal(runtime.NetSocketType);
-        il.Emit(OpCodes.Newobj, runtime.NetSocketCtor);
+        var socketLocal = il.DeclareLocal(net.SocketType);
+        il.Emit(OpCodes.Newobj, net.SocketCtor);
         il.Emit(OpCodes.Stloc, socketLocal);
 
         // socket.Connect(options, hostOrCallback, callback)
@@ -179,7 +181,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0); // options/port/path
         il.Emit(OpCodes.Ldarg_1); // host or callback
         il.Emit(OpCodes.Ldarg_2); // callback
-        il.Emit(OpCodes.Callvirt, runtime.NetSocketConnect);
+        il.Emit(OpCodes.Callvirt, net.SocketConnect);
         il.Emit(OpCodes.Pop);
 
         il.MarkLabel(noOptions);
@@ -193,7 +195,7 @@ public partial class RuntimeEmitter
     /// Creates an unconnected native Socket and applies constructor options.
     /// The public callable/newable Socket export lives in stdlib/node/net.ts.
     /// </summary>
-    private void EmitNetCreateSocket(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitNetCreateSocket(TypeBuilder typeBuilder, EmittedNetRuntime net)
     {
         var method = typeBuilder.DefineMethod(
             "NetCreateSocket",
@@ -201,12 +203,11 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object]
         );
-        runtime.NetCreateSocket = method;
-        runtime.RegisterBuiltInModuleMethod("primitive:net", "createSocket", method);
+        net.CreateSocket = method;
 
         var il = method.GetILGenerator();
-        var socketLocal = il.DeclareLocal(runtime.NetSocketType);
-        il.Emit(OpCodes.Newobj, runtime.NetSocketCtor);
+        var socketLocal = il.DeclareLocal(net.SocketType);
+        il.Emit(OpCodes.Newobj, net.SocketCtor);
         il.Emit(OpCodes.Stloc, socketLocal);
 
         var done = il.DefineLabel();

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSNetBlockList.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSNetBlockList.cs
@@ -12,7 +12,6 @@ namespace SharpTS.Compilation;
 /// </summary>
 public partial class RuntimeEmitter
 {
-    private TypeBuilder _blockListTypeBuilder = null!;
     private FieldBuilder _blockListRulesField = null!;
     private MethodBuilder _blockListParseAddrMethod = null!;
     private MethodBuilder _blockListCompareBytesMethod = null!;
@@ -20,14 +19,13 @@ public partial class RuntimeEmitter
     private MethodBuilder _blockListAddRuleMethod = null!;
     private MethodBuilder _blockListMatchBytesMethod = null!;
 
-    private void EmitTSNetBlockListTypes(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    private void EmitTSNetBlockListTypes(ModuleBuilder moduleBuilder, EmittedNetRuntime net)
     {
         var typeBuilder = moduleBuilder.DefineType(
             "$BlockList",
             TypeAttributes.Public | TypeAttributes.BeforeFieldInit,
             typeof(object));
-        _blockListTypeBuilder = typeBuilder;
-        runtime.BlockListType = typeBuilder;
+        net.BlockListType = typeBuilder;
 
         // Each rule is object[3] { boxed bool isV6, byte[] start, byte[] end }.
         _blockListRulesField = typeBuilder.DefineField(
@@ -37,7 +35,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public,
             CallingConventions.Standard,
             Type.EmptyTypes);
-        runtime.BlockListCtor = ctor;
+        net.BlockListCtor = ctor;
         {
             var il = ctor.GetILGenerator();
             il.Emit(OpCodes.Ldarg_0);
@@ -56,7 +54,7 @@ public partial class RuntimeEmitter
         EmitBlockListAddAddress(typeBuilder);
         EmitBlockListAddRange(typeBuilder);
         EmitBlockListAddSubnet(typeBuilder);
-        EmitBlockListCheckIp(typeBuilder, runtime);
+        EmitBlockListCheckIp(typeBuilder, net);
 
         typeBuilder.CreateType();
     }
@@ -487,11 +485,11 @@ public partial class RuntimeEmitter
         EmitInvalidBlockListMutation(il, invalid);
     }
 
-    private void EmitBlockListCheckIp(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitBlockListCheckIp(TypeBuilder typeBuilder, EmittedNetRuntime net)
     {
         var method = typeBuilder.DefineMethod(
             "CheckIp", MethodAttributes.Public, _types.Boolean, [typeof(IPAddress)]);
-        runtime.BlockListCheckIp = method;
+        net.BlockListCheckIp = method;
         var il = method.GetILGenerator();
         var address = il.DeclareLocal(typeof(IPAddress));
         il.Emit(OpCodes.Ldarg_1);

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSNetClosures.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSNetClosures.cs
@@ -47,14 +47,14 @@ public partial class RuntimeEmitter
             typeof(object)
         );
 
-        var serverField = typeBuilder.DefineField("_server", _netServerTypeBuilder, FieldAttributes.Private);
+        var serverField = typeBuilder.DefineField("_server", runtime.RequireNet().ServerType, FieldAttributes.Private);
         var clientField = typeBuilder.DefineField("_client", typeof(TcpClient), FieldAttributes.Private);
 
         // Constructor: (server, client)
         var ctor = typeBuilder.DefineConstructor(
             MethodAttributes.Public,
             CallingConventions.Standard,
-            [_netServerTypeBuilder, typeof(TcpClient)]
+            [runtime.RequireNet().ServerType, typeof(TcpClient)]
         );
         {
             var il = ctor.GetILGenerator();
@@ -80,7 +80,7 @@ public partial class RuntimeEmitter
         );
         {
             var il = run.GetILGenerator();
-            var socketLocal = il.DeclareLocal(_netSocketTypeBuilder); // local 0: $NetSocket
+            var socketLocal = il.DeclareLocal(runtime.RequireNet().SocketType); // local 0: $NetSocket
 
             // BlockList rejection (#1069): a blocked peer is closed silently — no
             // 'connection' event, no socket construction (Node semantics).
@@ -102,10 +102,10 @@ public partial class RuntimeEmitter
                 il.Emit(OpCodes.Ldarg_0);
                 il.Emit(OpCodes.Ldfld, serverField);
                 il.Emit(OpCodes.Ldfld, _netServerBlockListField);
-                il.Emit(OpCodes.Castclass, runtime.BlockListType!);
+                il.Emit(OpCodes.Castclass, runtime.RequireNet().BlockListType);
                 il.Emit(OpCodes.Ldloc, epLocal);
                 il.Emit(OpCodes.Callvirt, typeof(System.Net.IPEndPoint).GetProperty("Address")!.GetGetMethod()!);
-                il.Emit(OpCodes.Callvirt, runtime.BlockListCheckIp!);
+                il.Emit(OpCodes.Callvirt, runtime.RequireNet().BlockListCheckIp);
                 il.Emit(OpCodes.Brfalse, noBlock);
                 // blocked: try { _client.Close() } catch { } ; return
                 il.BeginExceptionBlock();
@@ -139,13 +139,13 @@ public partial class RuntimeEmitter
 
                 il.MarkLabel(loopTop);
                 // if (_connections[i] is $NetSocket s && s._destroyed) RemoveAt(i)
-                var sockLocal = il.DeclareLocal(_netSocketTypeBuilder);
+                var sockLocal = il.DeclareLocal(runtime.RequireNet().SocketType);
                 il.Emit(OpCodes.Ldarg_0);
                 il.Emit(OpCodes.Ldfld, serverField);
                 il.Emit(OpCodes.Ldfld, _netServerConnectionsField);
                 il.Emit(OpCodes.Ldloc, iLocal);
                 il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "get_Item")!);
-                il.Emit(OpCodes.Isinst, _netSocketTypeBuilder);
+                il.Emit(OpCodes.Isinst, runtime.RequireNet().SocketType);
                 il.Emit(OpCodes.Stloc, sockLocal);
                 il.Emit(OpCodes.Ldloc, sockLocal);
                 il.Emit(OpCodes.Brfalse, nextIter);
@@ -214,7 +214,7 @@ public partial class RuntimeEmitter
             // var socket = new $NetSocket(_client)
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, clientField);
-            il.Emit(OpCodes.Newobj, runtime.NetSocketCtorTcpClient);
+            il.Emit(OpCodes.Newobj, runtime.RequireNet().SocketCtorTcpClient);
             il.Emit(OpCodes.Stloc, socketLocal);
 
             EmitApplyServerSocketOptions(il, serverField, socketLocal);
@@ -268,7 +268,7 @@ public partial class RuntimeEmitter
 
             // socket.StartReading()
             il.Emit(OpCodes.Ldloc, socketLocal);
-            il.Emit(OpCodes.Callvirt, runtime.NetSocketStartReading);
+            il.Emit(OpCodes.Callvirt, runtime.RequireNet().SocketStartReading);
 
             il.Emit(OpCodes.Ret);
         }
@@ -290,7 +290,7 @@ public partial class RuntimeEmitter
             typeof(object)
         );
 
-        var serverField = typeBuilder.DefineField("_server", _netServerTypeBuilder, FieldAttributes.Private);
+        var serverField = typeBuilder.DefineField("_server", runtime.RequireNet().ServerType, FieldAttributes.Private);
         var streamField = typeBuilder.DefineField("_stream", typeof(Stream), FieldAttributes.Private);
         var pipePathField = typeBuilder.DefineField("_pipePath", _types.String, FieldAttributes.Private);
 
@@ -298,7 +298,7 @@ public partial class RuntimeEmitter
         var ctor = typeBuilder.DefineConstructor(
             MethodAttributes.Public,
             CallingConventions.Standard,
-            [_netServerTypeBuilder, typeof(Stream), _types.String]
+            [runtime.RequireNet().ServerType, typeof(Stream), _types.String]
         );
         {
             var il = ctor.GetILGenerator();
@@ -325,14 +325,14 @@ public partial class RuntimeEmitter
         );
         {
             var il = run.GetILGenerator();
-            var socketLocal = il.DeclareLocal(_netSocketTypeBuilder);
+            var socketLocal = il.DeclareLocal(runtime.RequireNet().SocketType);
 
             // var socket = new $NetSocket(_stream, _pipePath)
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, streamField);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, pipePathField);
-            il.Emit(OpCodes.Newobj, runtime.NetSocketCtorStream);
+            il.Emit(OpCodes.Newobj, runtime.RequireNet().SocketCtorStream);
             il.Emit(OpCodes.Stloc, socketLocal);
 
             EmitApplyServerSocketOptions(il, serverField, socketLocal);
@@ -346,7 +346,7 @@ public partial class RuntimeEmitter
 
             // socket.StartReading() — must start BEFORE callbacks so reader is pending
             il.Emit(OpCodes.Ldloc, socketLocal);
-            il.Emit(OpCodes.Callvirt, runtime.NetSocketStartReading);
+            il.Emit(OpCodes.Callvirt, runtime.RequireNet().SocketStartReading);
 
             // socket._readReady?.Wait(5000) — wait for read worker to be ready
             var skipWait = il.DefineLabel();
@@ -526,14 +526,14 @@ public partial class RuntimeEmitter
             typeof(object)
         );
 
-        var socketField = typeBuilder.DefineField("_socket", _netSocketTypeBuilder, FieldAttributes.Private);
+        var socketField = typeBuilder.DefineField("_socket", runtime.RequireNet().SocketType, FieldAttributes.Private);
         var chunkField = typeBuilder.DefineField("_chunk", _types.Object, FieldAttributes.Private);
 
         // Constructor: (socket, chunk)
         var ctor = typeBuilder.DefineConstructor(
             MethodAttributes.Public,
             CallingConventions.Standard,
-            [_netSocketTypeBuilder, _types.Object]
+            [runtime.RequireNet().SocketType, _types.Object]
         );
         {
             var il = ctor.GetILGenerator();
@@ -592,13 +592,13 @@ public partial class RuntimeEmitter
             typeof(object)
         );
 
-        var socketField = typeBuilder.DefineField("_socket", _netSocketTypeBuilder, FieldAttributes.Private);
+        var socketField = typeBuilder.DefineField("_socket", runtime.RequireNet().SocketType, FieldAttributes.Private);
 
         // Constructor: (socket)
         var ctor = typeBuilder.DefineConstructor(
             MethodAttributes.Public,
             CallingConventions.Standard,
-            [_netSocketTypeBuilder]
+            [runtime.RequireNet().SocketType]
         );
         {
             var il = ctor.GetILGenerator();
@@ -765,13 +765,13 @@ public partial class RuntimeEmitter
             typeof(object)
         );
 
-        var socketField = typeBuilder.DefineField("_socket", _netSocketTypeBuilder, FieldAttributes.Private);
+        var socketField = typeBuilder.DefineField("_socket", runtime.RequireNet().SocketType, FieldAttributes.Private);
 
         // Constructor: (socket)
         var ctor = typeBuilder.DefineConstructor(
             MethodAttributes.Public,
             CallingConventions.Standard,
-            [_netSocketTypeBuilder]
+            [runtime.RequireNet().SocketType]
         );
         {
             var il = ctor.GetILGenerator();
@@ -813,7 +813,7 @@ public partial class RuntimeEmitter
             // ── IPC path: StartReading → wait → emit connect ──
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, socketField);
-            il.Emit(OpCodes.Callvirt, runtime.NetSocketStartReading);
+            il.Emit(OpCodes.Callvirt, runtime.RequireNet().SocketStartReading);
 
             // _socket._readReady?.Wait(5000)
             var skipIpcWait = il.DefineLabel();
@@ -855,7 +855,7 @@ public partial class RuntimeEmitter
             // _socket.StartReading()
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, socketField);
-            il.Emit(OpCodes.Callvirt, runtime.NetSocketStartReading);
+            il.Emit(OpCodes.Callvirt, runtime.RequireNet().SocketStartReading);
 
             il.MarkLabel(done);
 
@@ -885,7 +885,7 @@ public partial class RuntimeEmitter
             typeof(object)
         );
 
-        var socketField = typeBuilder.DefineField("_socket", _netSocketTypeBuilder, FieldAttributes.Private);
+        var socketField = typeBuilder.DefineField("_socket", runtime.RequireNet().SocketType, FieldAttributes.Private);
         var errorMsgField = typeBuilder.DefineField("_errorMsg", _types.String, FieldAttributes.Private);
         var errorCodeField = typeBuilder.DefineField("_errorCode", _types.String, FieldAttributes.Private);
 
@@ -893,7 +893,7 @@ public partial class RuntimeEmitter
         var ctor = typeBuilder.DefineConstructor(
             MethodAttributes.Public,
             CallingConventions.Standard,
-            [_netSocketTypeBuilder, _types.String, _types.String]
+            [runtime.RequireNet().SocketType, _types.String, _types.String]
         );
         {
             var il = ctor.GetILGenerator();

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSNetServer.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSNetServer.cs
@@ -20,7 +20,6 @@ namespace SharpTS.Compilation;
 public partial class RuntimeEmitter
 {
     // Field builders for $NetServer
-    private TypeBuilder _netServerTypeBuilder = null!;
     private FieldBuilder _netServerListenerField = null!;
     private FieldBuilder _netServerIsListeningField = null!;
     private FieldBuilder _netServerCtsField = null!;
@@ -66,7 +65,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.BeforeFieldInit,
             runtime.TSEventEmitterType
         );
-        _netServerTypeBuilder = typeBuilder;
+        runtime.RequireNet().ServerType = typeBuilder;
         _ = typeBuilder;
 
         // ── Fields ──
@@ -150,7 +149,7 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitTSNetServerPhase2(EmittedRuntime runtime)
     {
-        var typeBuilder = _netServerTypeBuilder;
+        var typeBuilder = runtime.RequireNet().ServerType;
 
         // Emit method bodies
         EmitNetServerListenBody(typeBuilder, runtime);
@@ -174,7 +173,7 @@ public partial class RuntimeEmitter
             CallingConventions.Standard,
             [_types.Object]
         );
-        runtime.NetServerCtor = ctor;
+        runtime.RequireNet().ServerCtor = ctor;
 
         var il = ctor.GetILGenerator();
         // base()
@@ -585,7 +584,7 @@ public partial class RuntimeEmitter
     private void EmitTcpAcceptWorkerStart(ILGenerator callerIl, EmittedRuntime runtime)
     {
         // Emit a private _TcpAcceptWorker(object state) method that creates and runs the closure
-        var acceptWorker = _netServerTypeBuilder.DefineMethod(
+        var acceptWorker = runtime.RequireNet().ServerType.DefineMethod(
             "_TcpAcceptWorker",
             MethodAttributes.Private,
             typeof(void),
@@ -651,7 +650,7 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitIpcAcceptWorkerUnixStart(ILGenerator callerIl, EmittedRuntime runtime)
     {
-        var acceptWorker = _netServerTypeBuilder.DefineMethod(
+        var acceptWorker = runtime.RequireNet().ServerType.DefineMethod(
             "_IpcAcceptWorkerUnix",
             MethodAttributes.Private,
             typeof(void),
@@ -738,7 +737,7 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitIpcAcceptWorkerWindowsStart(ILGenerator callerIl, EmittedRuntime runtime)
     {
-        var acceptWorker = _netServerTypeBuilder.DefineMethod(
+        var acceptWorker = runtime.RequireNet().ServerType.DefineMethod(
             "_IpcAcceptWorkerWindows",
             MethodAttributes.Private,
             typeof(void),

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSNetSocket.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSNetSocket.cs
@@ -21,7 +21,6 @@ namespace SharpTS.Compilation;
 public partial class RuntimeEmitter
 {
     // Field builders for $NetSocket
-    private TypeBuilder _netSocketTypeBuilder = null!;
     private FieldBuilder _netSocketClientField = null!;
     private FieldBuilder _netSocketStreamField = null!;
     private FieldBuilder _netSocketConnectingField = null!;
@@ -57,13 +56,9 @@ public partial class RuntimeEmitter
     internal FieldBuilder _netSocketFinishAfterEndField = null!;
 
     // Method builders for $NetSocket (defined in Phase 1a, bodies emitted in Phase 2)
-    private MethodBuilder _netSocketConnectMethod = null!;
-    private MethodBuilder _netSocketWriteMethod = null!;
     private MethodBuilder _netSocketEndMethod = null!;
     private MethodBuilder _netSocketDestroyMethod = null!;
-    private MethodBuilder _netSocketStartReadingMethod = null!;
     private MethodBuilder _netSocketSetEncodingMethod = null!;
-    private MethodBuilder _netSocketGetMemberMethod = null!;
     private MethodBuilder _netSocketEnqueueWriteMethod = null!;
     private MethodBuilder _netSocketWriteWorkerMethod = null!;
     private MethodBuilder _netSocketFlushTickMethod = null!;
@@ -95,8 +90,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.BeforeFieldInit,
             runtime.TSEventEmitterType
         );
-        _netSocketTypeBuilder = typeBuilder;
-        runtime.NetSocketType = typeBuilder;
+        runtime.RequireNet().SocketType = typeBuilder;
 
         // ── Fields ──
         // Assembly (internal) rather than Private so the $TlsSocket subclass and the
@@ -152,29 +146,26 @@ public partial class RuntimeEmitter
 
         // ── Method stubs (no bodies — emitted in Phase 2) ──
 
-        _netSocketStartReadingMethod = typeBuilder.DefineMethod(
+        runtime.RequireNet().SocketStartReading = typeBuilder.DefineMethod(
             "StartReading",
             MethodAttributes.Public,
             typeof(void),
             Type.EmptyTypes
         );
-        runtime.NetSocketStartReading = _netSocketStartReadingMethod;
 
-        _netSocketConnectMethod = typeBuilder.DefineMethod(
+        runtime.RequireNet().SocketConnect = typeBuilder.DefineMethod(
             "Connect",
             MethodAttributes.Public,
             _types.Object,
             [_types.Object, _types.Object, _types.Object]
         );
-        runtime.NetSocketConnect = _netSocketConnectMethod;
 
-        _netSocketWriteMethod = typeBuilder.DefineMethod(
+        runtime.RequireNet().SocketWrite = typeBuilder.DefineMethod(
             "Write",
             MethodAttributes.Public,
             _types.Object,
             [_types.Object, _types.Object, _types.Object]
         );
-        runtime.NetSocketWrite = _netSocketWriteMethod;
 
         _netSocketEndMethod = typeBuilder.DefineMethod(
             "End",
@@ -200,13 +191,12 @@ public partial class RuntimeEmitter
         );
         _ = _netSocketSetEncodingMethod;
 
-        _netSocketGetMemberMethod = typeBuilder.DefineMethod(
+        runtime.RequireNet().SocketGetMember = typeBuilder.DefineMethod(
             "GetMember",
             MethodAttributes.Public,
             _types.Object,
             [_types.String]
         );
-        runtime.NetSocketGetMember = _netSocketGetMemberMethod;
 
         // Write-queue plumbing (#1068) — private helpers; bodies emitted in Phase 2.
         _netSocketEnqueueWriteMethod = typeBuilder.DefineMethod(
@@ -261,7 +251,7 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitTSNetSocketPhase2(EmittedRuntime runtime)
     {
-        var typeBuilder = _netSocketTypeBuilder;
+        var typeBuilder = runtime.RequireNet().SocketType;
 
         // Emit method bodies
         EmitNetSocketStartReadingBody(typeBuilder, runtime);
@@ -312,7 +302,7 @@ public partial class RuntimeEmitter
             CallingConventions.Standard,
             Type.EmptyTypes
         );
-        runtime.NetSocketCtor = ctor;
+        runtime.RequireNet().SocketCtor = ctor;
 
         var il = ctor.GetILGenerator();
         // base()
@@ -333,7 +323,7 @@ public partial class RuntimeEmitter
             CallingConventions.Standard,
             [typeof(TcpClient)]
         );
-        runtime.NetSocketCtorTcpClient = ctor;
+        runtime.RequireNet().SocketCtorTcpClient = ctor;
 
         var il = ctor.GetILGenerator();
         // base()
@@ -363,7 +353,7 @@ public partial class RuntimeEmitter
             CallingConventions.Standard,
             [typeof(System.IO.Stream), _types.String]
         );
-        runtime.NetSocketCtorStream = ctor;
+        runtime.RequireNet().SocketCtorStream = ctor;
 
         var il = ctor.GetILGenerator();
         // base()
@@ -399,7 +389,7 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitNetSocketConnectBody(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        var il = _netSocketConnectMethod.GetILGenerator();
+        var il = runtime.RequireNet().SocketConnect.GetILGenerator();
 
         // Locals
         var portLocal = il.DeclareLocal(_types.Int32);      // port
@@ -1082,7 +1072,7 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitNetSocketWriteBody(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        var il = _netSocketWriteMethod.GetILGenerator();
+        var il = runtime.RequireNet().SocketWrite.GetILGenerator();
 
         // if (_destroyed || _stream == null) return false
         var okLabel = il.DefineLabel();
@@ -1724,7 +1714,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ldnull);
-        il.Emit(OpCodes.Call, runtime.NetSocketWrite);
+        il.Emit(OpCodes.Call, runtime.RequireNet().SocketWrite);
         il.Emit(OpCodes.Pop);
 
         il.MarkLabel(noFinalWrite);
@@ -1939,7 +1929,7 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitNetSocketStartReadingBody(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        var il = _netSocketStartReadingMethod.GetILGenerator();
+        var il = runtime.RequireNet().SocketStartReading.GetILGenerator();
 
         // if (_destroyed || _stream == null) return
         var okLabel = il.DefineLabel();
@@ -2159,7 +2149,7 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitNetSocketGetMemberBody(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        var il = _netSocketGetMemberMethod.GetILGenerator();
+        var il = runtime.RequireNet().SocketGetMember.GetILGenerator();
 
         // Property dispatch labels
         var remoteAddressLabel = il.DefineLabel();

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSTlsAccept.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSTlsAccept.cs
@@ -122,7 +122,7 @@ public partial class RuntimeEmitter
         // _socket.StartReading()  (inherited $NetSocket method — pumps 'data'/'end'/'close')
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, socketField);
-        il.Emit(OpCodes.Callvirt, runtime.NetSocketStartReading);
+        il.Emit(OpCodes.Callvirt, runtime.RequireNet().SocketStartReading);
 
         il.Emit(OpCodes.Ret);
 
@@ -229,7 +229,7 @@ public partial class RuntimeEmitter
         // _socket.StartReading()
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, socketField);
-        il.Emit(OpCodes.Callvirt, runtime.NetSocketStartReading);
+        il.Emit(OpCodes.Callvirt, runtime.RequireNet().SocketStartReading);
 
         // EventLoop.Unref() — release the in-flight-connect ref taken in TlsConnect
         il.Emit(OpCodes.Call, runtime.EventLoopGetInstance);

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSTlsSocket.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSTlsSocket.cs
@@ -79,7 +79,7 @@ public partial class RuntimeEmitter
         var typeBuilder = EmitTypeDefinitions.DefineType(moduleBuilder,
             "$TlsSocket",
             TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.BeforeFieldInit,
-            runtime.NetSocketType  // extends $NetSocket — inherits real socket I/O over the SslStream
+            runtime.RequireNet().SocketType  // extends $NetSocket — inherits real socket I/O over the SslStream
         );
         _tlsSocketTypeBuilder = typeBuilder;
         runtime.RequireTls().SocketType = typeBuilder;
@@ -101,7 +101,7 @@ public partial class RuntimeEmitter
         runtime.RequireTls().SocketCtor = ctor;
         var ctorIL = ctor.GetILGenerator();
         ctorIL.Emit(OpCodes.Ldarg_0);
-        ctorIL.Emit(OpCodes.Call, runtime.NetSocketCtor);
+        ctorIL.Emit(OpCodes.Call, runtime.RequireNet().SocketCtor);
         ctorIL.Emit(OpCodes.Ret);
 
         // Static helpers
@@ -710,7 +710,7 @@ public partial class RuntimeEmitter
         il.MarkLabel(defaultLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.NetSocketGetMember);
+        il.Emit(OpCodes.Call, runtime.RequireNet().SocketGetMember);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.cs
@@ -40,6 +40,8 @@ public partial class RuntimeEmitter
         if (_emitHosted)
             _features.UsesPromise = true;
         var runtime = new EmittedRuntime();
+        if (features.UsesNet)
+            runtime.BeginNetEmission();
         if (features.UsesTls)
             runtime.BeginTlsEmission();
         if (features.UsesZlib)
@@ -414,7 +416,7 @@ public partial class RuntimeEmitter
         {
             // The opaque $BlockList handle is self-contained (pure BCL) and must
             // exist before $NetServer and the primitive net factory reference it.
-            EmitTSNetBlockListTypes(moduleBuilder, runtime);
+            EmitTSNetBlockListTypes(moduleBuilder, runtime.RequireNet());
             EmitTSNetSocketPhase1(moduleBuilder, runtime);
             EmitTSNetServerPhase1(moduleBuilder, runtime);
         }
@@ -615,6 +617,7 @@ public partial class RuntimeEmitter
         runtime.Zlib?.CompleteEmission();
         runtime.Tls?.CompleteEmission();
         runtime.Dgram?.CompleteEmission();
+        runtime.Net?.CompleteEmission();
         return runtime;
     }
 }

--- a/tests/SharpTS.Tests/CompilerTests/EmittedNetRuntimeTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/EmittedNetRuntimeTests.cs
@@ -1,0 +1,176 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public class EmittedNetRuntimeTests
+{
+    [Theory]
+    [InlineData("const list = new net.BlockList(); list.addAddress('127.0.0.2');")]
+    [InlineData("const server = createServer({ highWaterMark: 4 }, (socket: any) => { socket.on('data', (chunk: any) => socket.write(chunk)); });")]
+    [InlineData("const client = createConnection({ port: 12345, host: '127.0.0.1' });")]
+    [InlineData("const factory = createConnection; const client = factory({ port: 12345, host: '127.0.0.1' });")]
+    [InlineData("const socket = new net.Socket({ highWaterMark: 4 });")]
+    [InlineData("const unconnected = net.Socket();")]
+    public void ModuleConsumersAndDeferredTransportBodiesPassILVerification(string body)
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import * as net from 'net';
+                import { createServer, createConnection } from 'net';
+                """ + Environment.NewLine + body
+        };
+        var errors = TestHarness.CompileModulesAndVerifyOnly(files, "main.ts");
+        Assert.True(errors.Count == 0, string.Join(Environment.NewLine, errors));
+    }
+
+    [Fact]
+    public void DisabledFeatureHasNoMetadataAndReportsAccidentalUse()
+    {
+        var runtime = EmitRuntime("console.log(1);");
+        Assert.Null(runtime.Net);
+        Assert.Contains("not enabled", Assert.Throws<InvalidOperationException>(runtime.RequireNet).Message);
+        foreach (var name in new[] { "createServer", "createConnection", "createSocket", "createBlockList" })
+            Assert.Null(runtime.GetBuiltInModuleMethod("primitive:net", name));
+        Assert.DoesNotContain(runtime.RuntimeType.GetMethods(), method => method.Name.StartsWith("Net", StringComparison.Ordinal));
+
+        using var stream = new MemoryStream();
+        ((PersistedAssemblyBuilder)runtime.RuntimeType.Assembly).Save(stream);
+        stream.Position = 0;
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+        var names = reader.TypeDefinitions.Select(handle => reader.GetString(reader.GetTypeDefinition(handle).Name)).ToArray();
+        Assert.DoesNotContain("$NetSocket", names);
+        Assert.DoesNotContain("$NetServer", names);
+        Assert.DoesNotContain("$BlockList", names);
+        Assert.DoesNotContain("$TcpAcceptClosure", names);
+        Assert.DoesNotContain("$SocketReadDataClosure", names);
+    }
+
+    [Fact]
+    public void SocketDeclarationSupportsCallsBeforeBodyEmission()
+    {
+        var runtime = new EmittedRuntime();
+        runtime.BeginNetEmission();
+        var net = runtime.RequireNet();
+        Assert.False(net.IsComplete);
+        Assert.Contains("SocketConnect", Assert.Throws<InvalidOperationException>(() => net.SocketConnect).Message);
+
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName("net_forward"), typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("main");
+        var socket = module.DefineType("Socket");
+        net.SocketType = socket;
+        net.SocketCtor = socket.DefineDefaultConstructor(MethodAttributes.Public);
+        var connect = socket.DefineMethod("Connect", MethodAttributes.Public, typeof(void), Type.EmptyTypes);
+        net.SocketConnect = connect;
+
+        var factory = module.DefineType("Factory");
+        net.CreateConnection = factory.DefineMethod("CreateConnection", MethodAttributes.Public | MethodAttributes.Static, typeof(void), Type.EmptyTypes);
+        var il = net.CreateConnection.GetILGenerator();
+        il.Emit(OpCodes.Newobj, net.SocketCtor);
+        il.Emit(OpCodes.Callvirt, net.SocketConnect);
+        il.Emit(OpCodes.Ret);
+        Assert.Same(connect, net.SocketConnect);
+        Assert.False(net.SocketType.IsCreated());
+        connect.GetILGenerator().Emit(OpCodes.Ret);
+        socket.CreateType();
+        factory.CreateType();
+        using var stream = new MemoryStream();
+        assembly.Save(stream);
+
+        Assert.Throws<InvalidOperationException>(runtime.BeginNetEmission);
+        Assert.Contains("CreateServer", Assert.Throws<InvalidOperationException>(net.CompleteEmission).Message);
+        Assert.False(net.IsComplete);
+        Assert.Throws<ArgumentNullException>(() => net.SocketConnect = null!);
+        Assert.Same(connect, net.SocketConnect);
+    }
+
+    public static IEnumerable<object[]> HandleNames => typeof(EmittedNetRuntime).GetProperties()
+        .Where(property => property.Name != nameof(EmittedNetRuntime.IsComplete))
+        .Select(property => new object[] { property.Name });
+
+    [Theory]
+    [MemberData(nameof(HandleNames))]
+    public void CompletionRejectsEachMissingDeclaration(string missingHandle)
+    {
+        var net = new EmittedNetRuntime();
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName("net_incomplete"), typeof(object).Assembly);
+        var type = assembly.DefineDynamicModule("main").DefineType("Placeholder");
+        var ctor = type.DefineDefaultConstructor(MethodAttributes.Public);
+        var method = type.DefineMethod("Placeholder", MethodAttributes.Public, typeof(void), Type.EmptyTypes);
+        foreach (var property in typeof(EmittedNetRuntime).GetProperties())
+        {
+            if (property.Name == missingHandle || property.Name == nameof(EmittedNetRuntime.IsComplete))
+                continue;
+            object handle = property.PropertyType == typeof(TypeBuilder) ? type
+                : property.PropertyType == typeof(ConstructorBuilder) ? ctor : method;
+            property.SetValue(net, handle);
+        }
+
+        Assert.Contains($"'{missingHandle}'", Assert.Throws<InvalidOperationException>(net.CompleteEmission).Message);
+        Assert.False(net.IsComplete);
+    }
+
+    [Theory]
+    [InlineData("import * as net from 'net';")]
+    [InlineData("import * as tls from 'tls';")]
+    [InlineData("import * as http from 'http';")]
+    [InlineData("fetch('http://127.0.0.1/');")]
+    [InlineData(null)]
+    public void EnabledAndImpliedFeaturesCompleteHandlesAndRejectFurtherWrites(string? source)
+    {
+        var runtime = EmitRuntime(source);
+        var net = runtime.RequireNet();
+        Assert.True(net.IsComplete);
+        Assert.Equal("$NetSocket", net.SocketType.Name);
+        Assert.Equal("$NetServer", net.ServerType.Name);
+        Assert.Equal("$BlockList", net.BlockListType.Name);
+        Assert.True(net.SocketType.IsCreated());
+        Assert.True(net.ServerType.IsCreated());
+        Assert.True(net.BlockListType.IsCreated());
+        Assert.Same(net.SocketType, net.SocketCtor.DeclaringType);
+        Assert.Same(net.SocketType, net.SocketCtorTcpClient.DeclaringType);
+        Assert.Same(net.SocketType, net.SocketCtorStream.DeclaringType);
+        Assert.Same(net.SocketType, net.SocketConnect.DeclaringType);
+        Assert.Same(net.ServerType, net.ServerCtor.DeclaringType);
+        Assert.Same(net.BlockListType, net.BlockListCtor.DeclaringType);
+        Assert.Same(net.BlockListType, net.BlockListCheckIp.DeclaringType);
+        Assert.Same(net.CreateServer, runtime.GetBuiltInModuleMethod("primitive:net", "createServer"));
+        Assert.Same(net.CreateConnection, runtime.GetBuiltInModuleMethod("primitive:net", "createConnection"));
+        Assert.Same(net.CreateSocket, runtime.GetBuiltInModuleMethod("primitive:net", "createSocket"));
+        Assert.Same(net.CreateBlockList, runtime.GetBuiltInModuleMethod("primitive:net", "createBlockList"));
+        foreach (var property in typeof(EmittedNetRuntime).GetProperties()
+            .Where(property => property.Name != nameof(EmittedNetRuntime.IsComplete)))
+        {
+            var value = property.GetValue(net);
+            Assert.NotNull(value);
+            Assert.False(property.SetMethod!.IsPublic);
+            var exception = Assert.Throws<TargetInvocationException>(() => property.SetValue(net, value));
+            Assert.IsType<InvalidOperationException>(exception.InnerException);
+        }
+        Assert.Throws<InvalidOperationException>(net.CompleteEmission);
+        if (source == "import * as net from 'net';")
+        {
+            Assert.Empty(runtime.RequiredSharpTSRuntimeReasons);
+            Assert.Equal(SharpTSRuntimeRequirements.None, runtime.RequiredSharpTSRuntimeRequirements);
+        }
+    }
+
+    private static EmittedRuntime EmitRuntime(string? source)
+    {
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName($"net_metadata_{Guid.NewGuid():N}"), typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("main");
+        var emitter = new RuntimeEmitter(TypeProvider.Runtime);
+        if (source is null)
+            return emitter.EmitAll(module);
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        return emitter.EmitAll(module, new RuntimeFeatureDetector().Detect(statements));
+    }
+}

--- a/tests/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/StandaloneDllTests.cs
@@ -1334,6 +1334,44 @@ public class StandaloneDllTests
         }
     }
 
+    [Fact]
+    public void Isolated_NetTransport_ShouldSendAndReceiveWithoutSharpTsDll()
+    {
+        var files = new Dictionary<string, string>
+        {
+            ["main.ts"] = """
+                import { createServer, createConnection, BlockList } from 'net';
+                const list = new BlockList();
+                list.addAddress('127.0.0.2');
+                const server = createServer({ blockList: list }, (socket: any) => {
+                    socket.setEncoding('utf8');
+                    let received = '';
+                    socket.on('data', (chunk: string) => { received += chunk; });
+                    socket.on('end', () => {
+                        console.log(received);
+                        socket.end();
+                        server.close();
+                    });
+                });
+                server.listen(0, '127.0.0.1', () => {
+                    const client = createConnection({ port: server.address().port, host: '127.0.0.1' });
+                    client.on('connect', () => client.end('hello from TCP'));
+                });
+                """
+        };
+
+        var (tempDir, dllPath) = CompileStandaloneModule(files, "main.ts");
+        try
+        {
+            Assert.DoesNotContain(GetAssemblyReferences(dllPath), r => r == "SharpTS");
+            Assert.Equal("hello from TCP\n", ExecuteCompiledDllIsolated(dllPath, timeoutMs: 15000));
+        }
+        finally
+        {
+            CleanupTempDir(tempDir);
+        }
+    }
+
     /// <summary>
     /// #1033 guardrail: a --compile'd tls client↔server program must complete a real SslStream
     /// handshake and exchange data with NO SharpTS.dll co-located. The handshake, introspection,


### PR DESCRIPTION
TCP/IPC emission spreads its metadata across unchecked `EmittedRuntime` properties and duplicate emitter fields. This increment of #1599 moves the 16 flat net handles, plus the emitter-owned server type, into `EmittedNetRuntime`. Disabled features are explicit, undeclared reads name the missing handle, and completion validates every declaration and prevents further handle assignments.

Socket factories, TLS subclasses, and transport closures retain their existing forward references. Deferred socket bodies now use the same component handles declared in phase 1. Net factories and BlockList emitters take the component directly; shared dependencies and module registration stay at their existing boundaries. The migration removes the old properties and seven emitter fields and documents the pattern in `ARCHITECTURE.md`. Emission order, generated signatures, feature implications, transport behavior, and standalone dependency rules are preserved.

This completes the net family increment following DNS, zlib, TLS, and dgram. Other families remain for subsequent PRs under #1599.

Validation:
- Release solution build succeeds.
- 824 related Release tests pass; two existing Windows wildcard-listener cases skip because they require a provisioned URL ACL. Coverage includes net/TLS/HTTP/fetch behavior, IPC and backpressure, component lifecycle, tree shaking, standalone execution, dependency signaling, and IL verification.
- The new component coverage exercises all 17 missing declarations, forward calls before body emission, completed-handle immutability, disabled and implied features, and individual module consumer cases. A new isolated TCP exchange runs without `SharpTS.dll`.
- `./scripts/test-code-quality.ps1` and `git diff --check` pass.

Baseline checks: the solution's ancillary `Union_Promise_Void.get_AsType0` IL diagnostics also occur on the starting commit, `2b8d7205`. An exploratory combined net program likewise reports the same module-initializer `BackwardBranch` error on that commit; the final IL tests cover its API cases individually. Neither existing compiler issue is changed by this metadata refactor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of networking features, including servers, sockets, connections, TLS transport, and block lists.
  * Ensured applications using networking can run correctly as standalone compiled programs without requiring the SharpTS runtime assembly.

* **Tests**
  * Added coverage for networking compilation, deferred transport generation, feature handling, and standalone TCP communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->