### PR TITLE
Extract shared interpreter prototype property overlays

### DIFF
--- a/src/SharpTS/Runtime/Types/PrototypePropertyOverlay.cs
+++ b/src/SharpTS/Runtime/Types/PrototypePropertyOverlay.cs
@@ -1,0 +1,91 @@
+namespace SharpTS.Runtime.Types;
+
+// Owned by one interpreter prototype. Built-in lookup, method caches and constructor
+// identity stay on that prototype; this object only shadows or suppresses its members.
+internal sealed class PrototypePropertyOverlay(
+    Func<string, bool> isBuiltIn,
+    bool preserveBuiltInAssignmentAttributes = false)
+{
+    private readonly SharpTSObject _extras = new([]);
+    private readonly HashSet<string> _deletedBuiltIns = [];
+
+    public bool HasExtra(string name) => _extras.HasProperty(name) || _extras.HasSetter(name);
+    public object? GetProperty(string name) => _extras.GetProperty(name);
+
+    // A present null/undefined value (or an accessor) must still shadow a built-in.
+    // Accessors are retrieved below, then invoked by the interpreter with its receiver.
+    public bool TryGetOverride(string name, out object? value)
+    {
+        if (HasExtra(name))
+        {
+            value = GetProperty(name);
+            return true;
+        }
+        value = null;
+        return _deletedBuiltIns.Contains(name);
+    }
+
+    public void SetProperty(string name, object? value)
+    {
+        _deletedBuiltIns.Remove(name);
+        // BigInt/Symbol preserve these attributes even after delete + assignment.
+        // Other prototypes retain their existing ordinary expando assignment policy.
+        if (preserveBuiltInAssignmentAttributes && isBuiltIn(name) && !HasExtra(name))
+        {
+            _extras.DefineProperty(name, new SharpTSPropertyDescriptor
+            {
+                Value = value,
+                HasValue = true,
+                Writable = true,
+                HasWritable = true,
+                Enumerable = false,
+                HasEnumerable = true,
+                Configurable = true,
+                HasConfigurable = true,
+            });
+            return;
+        }
+        _extras.SetProperty(name, value);
+    }
+
+    public bool DefineProperty(string name, SharpTSPropertyDescriptor descriptor)
+    {
+        _deletedBuiltIns.Remove(name);
+        return _extras.DefineProperty(name, descriptor);
+    }
+
+    public bool DeleteProperty(string name)
+    {
+        if (HasExtra(name) && !_extras.DeleteProperty(name)) return false;
+        if (isBuiltIn(name)) _deletedBuiltIns.Add(name);
+        return true;
+    }
+
+    public bool HasOwnProperty(string name)
+        => HasExtra(name) || (!_deletedBuiltIns.Contains(name) && isBuiltIn(name));
+
+    public SharpTSPropertyDescriptor? GetOwnPropertyDescriptor(string name)
+        => _extras.GetOwnPropertyDescriptor(name);
+    public ISharpTSCallable? GetGetter(string name) => _extras.GetGetter(name);
+    public ISharpTSCallable? GetSetter(string name) => _extras.GetSetter(name);
+    public IEnumerable<string> OwnEnumerableKeys() => _extras.OwnEnumerableKeys();
+    public bool HasIndexedOwnProperty(long exclusiveLength) => _extras.HasIndexedOwnProperty(exclusiveLength);
+
+    // Symbol intrinsics are materialized in the descriptor store, so deleting them
+    // needs no string-name tombstone. Keep each prototype's existing symbol surface.
+    public bool HasSymbolProperty(SharpTSSymbol symbol) => _extras.HasSymbolProperty(symbol);
+    public object? GetBySymbol(SharpTSSymbol symbol) => _extras.GetBySymbol(symbol);
+    public void SetBySymbol(SharpTSSymbol symbol, object? value) => _extras.SetBySymbol(symbol, value);
+    public void SetBySymbolStrict(SharpTSSymbol symbol, object? value, bool strictMode)
+        => _extras.SetBySymbolStrict(symbol, value, strictMode);
+    public bool TryGetSymbolAccessor(
+        SharpTSSymbol symbol, out ISharpTSCallable? getter, out ISharpTSCallable? setter)
+        => _extras.TryGetSymbolAccessor(symbol, out getter, out setter);
+    public bool DefineProperty(SharpTSSymbol symbol, SharpTSPropertyDescriptor descriptor)
+        => _extras.DefineProperty(symbol, descriptor);
+    public SharpTSPropertyDescriptor? GetOwnPropertyDescriptor(SharpTSSymbol symbol)
+        => _extras.GetOwnPropertyDescriptor(symbol);
+    public bool DeleteBySymbolStrict(SharpTSSymbol symbol, bool strictMode)
+        => _extras.DeleteBySymbolStrict(symbol, strictMode);
+    public IEnumerable<SharpTSSymbol> GetSymbolPropertyNames() => _extras.GetSymbolPropertyNames();
+}

--- a/src/SharpTS/Runtime/Types/SharpTSArrayGlobal.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSArrayGlobal.cs
@@ -107,43 +107,36 @@ public sealed class SharpTSArrayGlobal : ISharpTSCallable, ISharpTSMutableBuiltI
 public sealed class SharpTSArrayPrototype : ISharpTSMutableBuiltIn, ISharpTSSymbolPropertyBag
 {
     internal SharpTSArrayGlobal? RealmConstructor { get; set; }
-    // Array.prototype is an ordinary mutable object. Reuse SharpTSObject's
-    // descriptor-aware storage so defineProperty can install accessors and
-    // enforce writable/configurable flags instead of maintaining a parallel
-    // value-only expando dictionary.
-    private readonly SharpTSObject _extras = new([]);
-    private readonly HashSet<string> _deletedBuiltIns = [];
+    private readonly PrototypePropertyOverlay _overlay;
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, ArrayPrototypeMethodWrapper>
         _methodCache = new(StringComparer.Ordinal);
 
-    public bool HasExtra(string name) => _extras.HasProperty(name) || _extras.HasSetter(name);
+    public SharpTSArrayPrototype()
+    {
+        _overlay = new(IsBuiltIn);
+    }
+
+    public bool HasExtra(string name) => _overlay.HasExtra(name);
     internal bool HasIndexedExtra(long exclusiveLength)
-        => _extras.HasIndexedOwnProperty(exclusiveLength);
-    public object? TryGetExtra(string name) => _extras.GetProperty(name);
-    public void SetExtra(string name, object? value)
-    {
-        _deletedBuiltIns.Remove(name);
-        _extras.SetProperty(name, value);
-    }
+        => _overlay.HasIndexedOwnProperty(exclusiveLength);
+    public object? TryGetExtra(string name) => _overlay.GetProperty(name);
+    public void SetExtra(string name, object? value) => _overlay.SetProperty(name, value);
     public bool DefineExtraProperty(string name, SharpTSPropertyDescriptor descriptor)
-    {
-        _deletedBuiltIns.Remove(name);
-        return _extras.DefineProperty(name, descriptor);
-    }
+        => _overlay.DefineProperty(name, descriptor);
     public SharpTSPropertyDescriptor? GetOwnPropertyDescriptor(string name)
-        => _extras.GetOwnPropertyDescriptor(name);
-    public ISharpTSCallable? GetExtraGetter(string name) => _extras.GetGetter(name);
-    public ISharpTSCallable? GetExtraSetter(string name) => _extras.GetSetter(name);
+        => _overlay.GetOwnPropertyDescriptor(name);
+    public ISharpTSCallable? GetExtraGetter(string name) => _overlay.GetGetter(name);
+    public ISharpTSCallable? GetExtraSetter(string name) => _overlay.GetSetter(name);
     bool ISharpTSSymbolPropertyBag.HasSymbolProperty(SharpTSSymbol symbol)
-        => _extras.HasSymbolProperty(symbol);
+        => _overlay.HasSymbolProperty(symbol);
     object? ISharpTSSymbolPropertyBag.GetBySymbol(SharpTSSymbol symbol)
-        => _extras.GetBySymbol(symbol);
+        => _overlay.GetBySymbol(symbol);
     bool ISharpTSSymbolPropertyBag.TryGetSymbolAccessor(
         SharpTSSymbol symbol, out ISharpTSCallable? getter, out ISharpTSCallable? setter)
-        => _extras.TryGetSymbolAccessor(symbol, out getter, out setter);
+        => _overlay.TryGetSymbolAccessor(symbol, out getter, out setter);
     void ISharpTSSymbolPropertyBag.SetBySymbolStrict(
         SharpTSSymbol symbol, object? value, bool strictMode)
-        => _extras.SetBySymbolStrict(symbol, value, strictMode);
+        => _overlay.SetBySymbolStrict(symbol, value, strictMode);
 
     private object? GetBuiltInMember(string name)
     {
@@ -158,25 +151,17 @@ public sealed class SharpTSArrayPrototype : ISharpTSMutableBuiltIn, ISharpTSSymb
 
     private bool IsBuiltIn(string name) => GetBuiltInMember(name) != null;
 
-    public bool HasOwnProperty(string name)
-        => HasExtra(name) || (!_deletedBuiltIns.Contains(name) && IsBuiltIn(name));
+    public bool HasOwnProperty(string name) => _overlay.HasOwnProperty(name);
 
-    public bool DeleteProperty(string name)
-    {
-        bool hadExtra = HasExtra(name);
-        if (hadExtra && !_extras.DeleteProperty(name)) return false;
-        if (IsBuiltIn(name)) _deletedBuiltIns.Add(name);
-        return true;
-    }
+    public bool DeleteProperty(string name) => _overlay.DeleteProperty(name);
 
-    public IEnumerable<string> OwnEnumerableKeys() => _extras.OwnEnumerableKeys();
+    public IEnumerable<string> OwnEnumerableKeys() => _overlay.OwnEnumerableKeys();
 
     // All Array.prototype methods now route through ArrayBuiltIns so instance
     // dispatch and generic call/apply share the same receiver semantics.
     public object? GetMember(string name)
     {
-        if (HasExtra(name)) return TryGetExtra(name);
-        if (_deletedBuiltIns.Contains(name)) return null;
+        if (_overlay.TryGetOverride(name, out var value)) return value;
         return GetBuiltInMember(name);
     }
 

--- a/src/SharpTS/Runtime/Types/SharpTSClassPrototype.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSClassPrototype.cs
@@ -10,7 +10,7 @@ namespace SharpTS.Runtime.Types;
 /// <c>X.prototype === X.prototype</c> holds.
 /// </summary>
 /// <remarks>
-/// Guest-added properties live in <see cref="_extras"/>, a descriptor-aware
+/// Guest-added properties live in <see cref="_overlay"/>, backed by a descriptor-aware
 /// <see cref="SharpTSObject"/>, so <c>Object.defineProperty(Error.prototype, …)</c> — including
 /// Symbol-keyed writes like <c>@@toStringTag</c> — works and the attributes round-trip. The
 /// class's own method table stays read-only: an assignment shadows a method for reads without
@@ -19,54 +19,40 @@ namespace SharpTS.Runtime.Types;
 public sealed class SharpTSClassPrototype : ISharpTSMutableBuiltIn
 {
     private readonly SharpTSClass _klass;
-    private readonly SharpTSObject _extras = new([]);
-    private readonly HashSet<string> _deletedBuiltIns = [];
+    private readonly PrototypePropertyOverlay _overlay;
 
     public SharpTSClassPrototype(SharpTSClass klass)
     {
         _klass = klass;
+        _overlay = new(IsBuiltIn);
     }
 
     public SharpTSClass Class => _klass;
 
-    public bool HasExtra(string name) => _extras.HasProperty(name) || _extras.HasSetter(name);
-    public object? TryGetExtra(string name) => _extras.GetProperty(name);
-    public void SetExtra(string name, object? value)
-    {
-        _deletedBuiltIns.Remove(name);
-        _extras.SetProperty(name, value);
-    }
+    public bool HasExtra(string name) => _overlay.HasExtra(name);
+    public object? TryGetExtra(string name) => _overlay.GetProperty(name);
+    public void SetExtra(string name, object? value) => _overlay.SetProperty(name, value);
     public bool DefineExtraProperty(string name, SharpTSPropertyDescriptor descriptor)
-    {
-        _deletedBuiltIns.Remove(name);
-        return _extras.DefineProperty(name, descriptor);
-    }
+        => _overlay.DefineProperty(name, descriptor);
     public SharpTSPropertyDescriptor? GetOwnPropertyDescriptor(string name)
-        => _extras.GetOwnPropertyDescriptor(name);
-    public ISharpTSCallable? GetExtraGetter(string name) => _extras.GetGetter(name);
-    public ISharpTSCallable? GetExtraSetter(string name) => _extras.GetSetter(name);
-    public bool DeleteProperty(string name)
-    {
-        if (HasExtra(name) && !_extras.DeleteProperty(name)) return false;
-        if (name == "constructor" || _klass.FindMethod(name) != null)
-            _deletedBuiltIns.Add(name);
-        return true;
-    }
-    public bool HasOwnProperty(string name)
-        => HasExtra(name)
-            || (!_deletedBuiltIns.Contains(name)
-                && (name == "constructor" || _klass.FindMethod(name) != null));
-    public IEnumerable<string> OwnEnumerableKeys() => _extras.OwnEnumerableKeys();
+        => _overlay.GetOwnPropertyDescriptor(name);
+    public ISharpTSCallable? GetExtraGetter(string name) => _overlay.GetGetter(name);
+    public ISharpTSCallable? GetExtraSetter(string name) => _overlay.GetSetter(name);
+    public bool DeleteProperty(string name) => _overlay.DeleteProperty(name);
+
+    private bool IsBuiltIn(string name) => name == "constructor" || _klass.FindMethod(name) != null;
+
+    public bool HasOwnProperty(string name) => _overlay.HasOwnProperty(name);
+    public IEnumerable<string> OwnEnumerableKeys() => _overlay.OwnEnumerableKeys();
 
     /// <summary>Symbol-keyed own properties (<c>Error.prototype[Symbol.toStringTag]</c>).</summary>
-    public bool HasSymbolProperty(SharpTSSymbol key) => _extras.HasSymbolProperty(key);
-    public object? GetBySymbol(SharpTSSymbol key) => _extras.GetBySymbol(key);
-    public void SetBySymbol(SharpTSSymbol key, object? value) => _extras.SetBySymbol(key, value);
+    public bool HasSymbolProperty(SharpTSSymbol key) => _overlay.HasSymbolProperty(key);
+    public object? GetBySymbol(SharpTSSymbol key) => _overlay.GetBySymbol(key);
+    public void SetBySymbol(SharpTSSymbol key, object? value) => _overlay.SetBySymbol(key, value);
 
     public object? GetMember(string name)
     {
-        if (HasExtra(name)) return TryGetExtra(name);
-        if (_deletedBuiltIns.Contains(name)) return null;
+        if (_overlay.TryGetOverride(name, out var value)) return value;
         if (name == "constructor") return _klass;
         var method = _klass.FindMethod(name);
         if (method != null) return method;

--- a/src/SharpTS/Runtime/Types/SharpTSFunctionGlobal.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSFunctionGlobal.cs
@@ -57,58 +57,42 @@ public sealed class SharpTSFunctionGlobal : ISharpTSCallable
 /// </summary>
 public sealed class SharpTSFunctionPrototype : ISharpTSMutableBuiltIn, ISharpTSSymbolPropertyBag
 {
-    private readonly SharpTSObject _extras = new([]);
-    private readonly HashSet<string> _deletedBuiltIns = [];
+    private readonly PrototypePropertyOverlay _overlay = new(IsBuiltIn);
 
-    public bool HasExtra(string name) => _extras.HasProperty(name) || _extras.HasSetter(name);
-    public object? TryGetExtra(string name) => _extras.GetProperty(name);
-    public void SetExtra(string name, object? value)
-    {
-        _deletedBuiltIns.Remove(name);
-        _extras.SetProperty(name, value);
-    }
+    public bool HasExtra(string name) => _overlay.HasExtra(name);
+    public object? TryGetExtra(string name) => _overlay.GetProperty(name);
+    public void SetExtra(string name, object? value) => _overlay.SetProperty(name, value);
     public bool DefineExtraProperty(string name, SharpTSPropertyDescriptor descriptor)
-    {
-        _deletedBuiltIns.Remove(name);
-        return _extras.DefineProperty(name, descriptor);
-    }
+        => _overlay.DefineProperty(name, descriptor);
     public SharpTSPropertyDescriptor? GetOwnPropertyDescriptor(string name)
-        => _extras.GetOwnPropertyDescriptor(name);
-    public ISharpTSCallable? GetExtraGetter(string name) => _extras.GetGetter(name);
-    public ISharpTSCallable? GetExtraSetter(string name) => _extras.GetSetter(name);
+        => _overlay.GetOwnPropertyDescriptor(name);
+    public ISharpTSCallable? GetExtraGetter(string name) => _overlay.GetGetter(name);
+    public ISharpTSCallable? GetExtraSetter(string name) => _overlay.GetSetter(name);
 
     bool ISharpTSSymbolPropertyBag.HasSymbolProperty(SharpTSSymbol symbol)
-        => _extras.HasSymbolProperty(symbol);
+        => _overlay.HasSymbolProperty(symbol);
     object? ISharpTSSymbolPropertyBag.GetBySymbol(SharpTSSymbol symbol)
-        => _extras.GetBySymbol(symbol);
+        => _overlay.GetBySymbol(symbol);
     bool ISharpTSSymbolPropertyBag.TryGetSymbolAccessor(
         SharpTSSymbol symbol, out ISharpTSCallable? getter, out ISharpTSCallable? setter)
-        => _extras.TryGetSymbolAccessor(symbol, out getter, out setter);
+        => _overlay.TryGetSymbolAccessor(symbol, out getter, out setter);
     void ISharpTSSymbolPropertyBag.SetBySymbolStrict(
         SharpTSSymbol symbol, object? value, bool strictMode)
-        => _extras.SetBySymbolStrict(symbol, value, strictMode);
+        => _overlay.SetBySymbolStrict(symbol, value, strictMode);
 
     private static bool IsBuiltIn(string name)
         => BuiltIns.FunctionBuiltIns.GetPrototypeMethod(name) != null
             || name is "toString" or "constructor";
 
-    public bool HasOwnProperty(string name)
-        => HasExtra(name) || (!_deletedBuiltIns.Contains(name) && IsBuiltIn(name));
+    public bool HasOwnProperty(string name) => _overlay.HasOwnProperty(name);
 
-    public bool DeleteProperty(string name)
-    {
-        bool hadExtra = HasExtra(name);
-        if (hadExtra && !_extras.DeleteProperty(name)) return false;
-        if (IsBuiltIn(name)) _deletedBuiltIns.Add(name);
-        return true;
-    }
+    public bool DeleteProperty(string name) => _overlay.DeleteProperty(name);
 
-    public IEnumerable<string> OwnEnumerableKeys() => _extras.OwnEnumerableKeys();
+    public IEnumerable<string> OwnEnumerableKeys() => _overlay.OwnEnumerableKeys();
 
     public object? GetMember(string name)
     {
-        if (HasExtra(name)) return TryGetExtra(name);
-        if (_deletedBuiltIns.Contains(name)) return null;
+        if (_overlay.TryGetOverride(name, out var value)) return value;
         var method = BuiltIns.FunctionBuiltIns.GetPrototypeMethod(name);
         if (method != null) return method;
         if (name == "toString") return SharpTSFunctionProtoToString.Instance;

--- a/src/SharpTS/Runtime/Types/SharpTSObjectPrototype.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSObjectPrototype.cs
@@ -16,35 +16,20 @@ public sealed class SharpTSObjectPrototype : ISharpTSMutableBuiltIn
     public static readonly SharpTSObjectPrototype Instance = new();
     internal SharpTSObjectPrototype() { }
 
-    // Object.prototype is an ordinary mutable object. Reuse SharpTSObject's
-    // descriptor-aware storage — as Array/String/Number.prototype already do — so
-    // `Object.defineProperty(Object.prototype, …)` can install accessors, `delete`
-    // takes, and for-in / getOwnPropertyDescriptor see the same keys. The previous
-    // value-only Dictionary supported none of that: every one of those operations
-    // either threw or silently no-oped, and Test262 leans on patching
-    // Object.prototype constantly to exercise inherited-property paths.
-    private readonly SharpTSObject _extras = new([]);
-    private readonly HashSet<string> _deletedBuiltIns = [];
+    private readonly PrototypePropertyOverlay _overlay = new(IsBuiltIn);
     internal SharpTSObjectNamespace? RealmConstructor { get; set; }
 
-    public bool HasExtra(string name) => _extras.HasProperty(name) || _extras.HasSetter(name);
+    public bool HasExtra(string name) => _overlay.HasExtra(name);
     internal bool HasIndexedExtra(long exclusiveLength)
-        => _extras.HasIndexedOwnProperty(exclusiveLength);
-    public object? TryGetExtra(string name) => _extras.GetProperty(name);
-    public void SetExtra(string name, object? value)
-    {
-        _deletedBuiltIns.Remove(name);
-        _extras.SetProperty(name, value);
-    }
+        => _overlay.HasIndexedOwnProperty(exclusiveLength);
+    public object? TryGetExtra(string name) => _overlay.GetProperty(name);
+    public void SetExtra(string name, object? value) => _overlay.SetProperty(name, value);
     public bool DefineExtraProperty(string name, SharpTSPropertyDescriptor descriptor)
-    {
-        _deletedBuiltIns.Remove(name);
-        return _extras.DefineProperty(name, descriptor);
-    }
+        => _overlay.DefineProperty(name, descriptor);
     public SharpTSPropertyDescriptor? GetOwnPropertyDescriptor(string name)
-        => _extras.GetOwnPropertyDescriptor(name);
-    public ISharpTSCallable? GetExtraGetter(string name) => _extras.GetGetter(name);
-    public ISharpTSCallable? GetExtraSetter(string name) => _extras.GetSetter(name);
+        => _overlay.GetOwnPropertyDescriptor(name);
+    public ISharpTSCallable? GetExtraGetter(string name) => _overlay.GetGetter(name);
+    public ISharpTSCallable? GetExtraSetter(string name) => _overlay.GetSetter(name);
 
     // Per-realm copies of the unbound methods. The templates below are process-wide statics,
     // but each carries mutable ECMA-262 §17 metadata (a `delete fn.length` is observable), so
@@ -57,24 +42,16 @@ public sealed class SharpTSObjectPrototype : ISharpTSMutableBuiltIn
 
     private static bool IsBuiltIn(string name) => BuiltInMemberTemplate(name) != null;
 
-    public bool HasOwnProperty(string name)
-        => HasExtra(name) || (!_deletedBuiltIns.Contains(name) && IsBuiltIn(name));
+    public bool HasOwnProperty(string name) => _overlay.HasOwnProperty(name);
 
-    public bool DeleteProperty(string name)
-    {
-        bool hadExtra = HasExtra(name);
-        if (hadExtra && !_extras.DeleteProperty(name)) return false;
-        if (IsBuiltIn(name)) _deletedBuiltIns.Add(name);
-        return true;
-    }
+    public bool DeleteProperty(string name) => _overlay.DeleteProperty(name);
 
     /// <summary>Own enumerable string keys — the for-in / Object.keys surface.</summary>
-    public IEnumerable<string> OwnEnumerableKeys() => _extras.OwnEnumerableKeys();
+    public IEnumerable<string> OwnEnumerableKeys() => _overlay.OwnEnumerableKeys();
 
     public object? GetMember(string name)
     {
-        if (HasExtra(name)) return TryGetExtra(name);
-        if (_deletedBuiltIns.Contains(name)) return null;
+        if (_overlay.TryGetOverride(name, out var value)) return value;
         if (name == "constructor")
             return RealmConstructor ?? SharpTSObjectNamespace.Instance;
         var template = BuiltInMemberTemplate(name);

--- a/src/SharpTS/Runtime/Types/SharpTSPrimitiveNamespaces.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSPrimitiveNamespaces.cs
@@ -168,13 +168,13 @@ public sealed class SharpTSStringPrototype : ISharpTSMutableBuiltIn, ISharpTSSym
     /// </summary>
     public static readonly SharpTSStringPrototype Instance = new();
     // internal (not private) so each Interpreter can construct its own realm
-    // instance; only the _extras overlay differs between instances.
+    // instance with its own overlay and method cache.
     internal SharpTSStringPrototype()
     {
         var iterator = new StringPrototypeMethodWrapper(
             "[Symbol.iterator]",
             StringBuiltIns.GetPrototypeMethod("[Symbol.iterator]")!);
-        _extras.DefineProperty(SharpTSSymbol.Iterator, new SharpTSPropertyDescriptor
+        _overlay.DefineProperty(SharpTSSymbol.Iterator, new SharpTSPropertyDescriptor
         {
             Value = iterator,
             HasValue = true,
@@ -187,68 +187,52 @@ public sealed class SharpTSStringPrototype : ISharpTSMutableBuiltIn, ISharpTSSym
         });
     }
 
-    private readonly SharpTSObject _extras = new([]);
-    private readonly HashSet<string> _deletedBuiltIns = [];
+    private readonly PrototypePropertyOverlay _overlay = new(IsBuiltIn);
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, StringPrototypeMethodWrapper>
         _methodCache = new(StringComparer.Ordinal);
-    public bool HasExtra(string name) => _extras.HasProperty(name) || _extras.HasSetter(name);
-    public object? TryGetExtra(string name) => _extras.GetProperty(name);
-    public void SetExtra(string name, object? value)
-    {
-        _deletedBuiltIns.Remove(name);
-        _extras.SetProperty(name, value);
-    }
+    public bool HasExtra(string name) => _overlay.HasExtra(name);
+    public object? TryGetExtra(string name) => _overlay.GetProperty(name);
+    public void SetExtra(string name, object? value) => _overlay.SetProperty(name, value);
     public bool DefineExtraProperty(string name, SharpTSPropertyDescriptor descriptor)
-    {
-        _deletedBuiltIns.Remove(name);
-        return _extras.DefineProperty(name, descriptor);
-    }
+        => _overlay.DefineProperty(name, descriptor);
     public SharpTSPropertyDescriptor? GetOwnPropertyDescriptor(string name)
-        => _extras.GetOwnPropertyDescriptor(name);
-    public ISharpTSCallable? GetExtraGetter(string name) => _extras.GetGetter(name);
-    public ISharpTSCallable? GetExtraSetter(string name) => _extras.GetSetter(name);
+        => _overlay.GetOwnPropertyDescriptor(name);
+    public ISharpTSCallable? GetExtraGetter(string name) => _overlay.GetGetter(name);
+    public ISharpTSCallable? GetExtraSetter(string name) => _overlay.GetSetter(name);
     internal IEnumerable<SharpTSSymbol> GetSymbolPropertyNames()
-        => _extras.GetSymbolPropertyNames();
-    internal object? GetBySymbol(SharpTSSymbol symbol) => _extras.GetBySymbol(symbol);
+        => _overlay.GetSymbolPropertyNames();
+    internal object? GetBySymbol(SharpTSSymbol symbol) => _overlay.GetBySymbol(symbol);
     internal void SetBySymbolStrict(SharpTSSymbol symbol, object? value, bool strictMode)
-        => _extras.SetBySymbolStrict(symbol, value, strictMode);
+        => _overlay.SetBySymbolStrict(symbol, value, strictMode);
     internal bool DeleteBySymbolStrict(SharpTSSymbol symbol, bool strictMode)
-        => _extras.DeleteBySymbolStrict(symbol, strictMode);
+        => _overlay.DeleteBySymbolStrict(symbol, strictMode);
     internal bool DefineProperty(SharpTSSymbol symbol, SharpTSPropertyDescriptor descriptor)
-        => _extras.DefineProperty(symbol, descriptor);
+        => _overlay.DefineProperty(symbol, descriptor);
     internal SharpTSPropertyDescriptor? GetOwnPropertyDescriptor(SharpTSSymbol symbol)
-        => _extras.GetOwnPropertyDescriptor(symbol);
+        => _overlay.GetOwnPropertyDescriptor(symbol);
     bool ISharpTSSymbolPropertyBag.HasSymbolProperty(SharpTSSymbol symbol)
-        => _extras.HasSymbolProperty(symbol);
+        => _overlay.HasSymbolProperty(symbol);
     object? ISharpTSSymbolPropertyBag.GetBySymbol(SharpTSSymbol symbol)
-        => _extras.GetBySymbol(symbol);
+        => _overlay.GetBySymbol(symbol);
     bool ISharpTSSymbolPropertyBag.TryGetSymbolAccessor(
         SharpTSSymbol symbol, out ISharpTSCallable? getter, out ISharpTSCallable? setter)
-        => _extras.TryGetSymbolAccessor(symbol, out getter, out setter);
+        => _overlay.TryGetSymbolAccessor(symbol, out getter, out setter);
     void ISharpTSSymbolPropertyBag.SetBySymbolStrict(
         SharpTSSymbol symbol, object? value, bool strictMode)
-        => _extras.SetBySymbolStrict(symbol, value, strictMode);
+        => _overlay.SetBySymbolStrict(symbol, value, strictMode);
 
-    private bool IsBuiltIn(string name)
+    private static bool IsBuiltIn(string name)
         => name == "constructor" || StringBuiltIns.GetPrototypeMethod(name) != null;
 
-    public bool HasOwnProperty(string name)
-        => HasExtra(name) || (!_deletedBuiltIns.Contains(name) && IsBuiltIn(name));
+    public bool HasOwnProperty(string name) => _overlay.HasOwnProperty(name);
 
-    public bool DeleteProperty(string name)
-    {
-        bool hadExtra = HasExtra(name);
-        if (hadExtra && !_extras.DeleteProperty(name)) return false;
-        if (IsBuiltIn(name)) _deletedBuiltIns.Add(name);
-        return true;
-    }
+    public bool DeleteProperty(string name) => _overlay.DeleteProperty(name);
 
-    public IEnumerable<string> OwnEnumerableKeys() => _extras.OwnEnumerableKeys();
+    public IEnumerable<string> OwnEnumerableKeys() => _overlay.OwnEnumerableKeys();
 
     public object? GetMember(string name)
     {
-        if (HasExtra(name)) return TryGetExtra(name);
-        if (_deletedBuiltIns.Contains(name)) return null;
+        if (_overlay.TryGetOverride(name, out var value)) return value;
         if (name == "constructor") return RealmConstructor ?? (object)SharpTSStringNamespace.Instance;
         var method = StringBuiltIns.GetPrototypeMethod(name);
         if (method is null) return null;
@@ -388,14 +372,12 @@ internal sealed class StringPrototypeMethodWrapper : ISharpTSCallable, IBuiltInF
 public sealed class SharpTSBigIntPrototype : ISharpTSMutableBuiltIn, ISharpTSSymbolPropertyBag
 {
     internal object? RealmConstructor { get; set; }
-    private readonly SharpTSObject _extras = new([]);
-    private bool _constructorDeleted;
+    private readonly PrototypePropertyOverlay _overlay = new(IsBuiltIn, preserveBuiltInAssignmentAttributes: true);
     private readonly Dictionary<string, BigIntPrototypeMethodWrapper> _methodCache = [];
-    private readonly HashSet<string> _deletedMethods = [];
 
     internal SharpTSBigIntPrototype()
     {
-        _extras.DefineProperty(SharpTSSymbol.ToStringTag, new SharpTSPropertyDescriptor
+        _overlay.DefineProperty(SharpTSSymbol.ToStringTag, new SharpTSPropertyDescriptor
         {
             Value = "BigInt",
             HasValue = true,
@@ -408,80 +390,45 @@ public sealed class SharpTSBigIntPrototype : ISharpTSMutableBuiltIn, ISharpTSSym
         });
     }
 
-    public bool HasExtra(string name) => _extras.HasProperty(name) || _extras.HasSetter(name);
-    public object? TryGetExtra(string name) => _extras.GetProperty(name);
-    public void SetExtra(string name, object? value)
-    {
-        _deletedMethods.Remove(name);
-        if (name == "constructor") _constructorDeleted = false;
-        if (name is "constructor" or "valueOf" or "toString" or "toLocaleString" && !HasExtra(name))
-        {
-            _extras.DefineProperty(name, new SharpTSPropertyDescriptor
-            {
-                Value = value,
-                HasValue = true,
-                Writable = true,
-                HasWritable = true,
-                Enumerable = false,
-                HasEnumerable = true,
-                Configurable = true,
-                HasConfigurable = true,
-            });
-            return;
-        }
-        _extras.SetProperty(name, value);
-    }
+    public bool HasExtra(string name) => _overlay.HasExtra(name);
+    public object? TryGetExtra(string name) => _overlay.GetProperty(name);
+    public void SetExtra(string name, object? value) => _overlay.SetProperty(name, value);
     public bool DefineExtraProperty(string name, SharpTSPropertyDescriptor descriptor)
-    {
-        _deletedMethods.Remove(name);
-        if (name == "constructor") _constructorDeleted = false;
-        return _extras.DefineProperty(name, descriptor);
-    }
+        => _overlay.DefineProperty(name, descriptor);
     public SharpTSPropertyDescriptor? GetOwnPropertyDescriptor(string name)
-        => _extras.GetOwnPropertyDescriptor(name);
-    public ISharpTSCallable? GetExtraGetter(string name) => _extras.GetGetter(name);
-    public ISharpTSCallable? GetExtraSetter(string name) => _extras.GetSetter(name);
-    public bool HasOwnProperty(string name)
-        => HasExtra(name)
-            || name == "constructor" && !_constructorDeleted
-            || name is "valueOf" or "toString" or "toLocaleString" && !_deletedMethods.Contains(name);
-    public bool DeleteProperty(string name)
-    {
-        if (HasExtra(name))
-        {
-            bool deleted = _extras.DeleteProperty(name);
-            if (deleted && name == "constructor") _constructorDeleted = true;
-            if (deleted && name is "valueOf" or "toString" or "toLocaleString") _deletedMethods.Add(name);
-            return deleted;
-        }
-        if (name == "constructor") _constructorDeleted = true;
-        if (name is "valueOf" or "toString" or "toLocaleString") _deletedMethods.Add(name);
-        return true;
-    }
-    public IEnumerable<string> OwnEnumerableKeys() => _extras.OwnEnumerableKeys();
+        => _overlay.GetOwnPropertyDescriptor(name);
+    public ISharpTSCallable? GetExtraGetter(string name) => _overlay.GetGetter(name);
+    public ISharpTSCallable? GetExtraSetter(string name) => _overlay.GetSetter(name);
+    private static bool IsBuiltIn(string name) => name is "constructor" or "valueOf" or "toString" or "toLocaleString";
+
+    public bool HasOwnProperty(string name) => _overlay.HasOwnProperty(name);
+    public bool DeleteProperty(string name) => _overlay.DeleteProperty(name);
+    public IEnumerable<string> OwnEnumerableKeys() => _overlay.OwnEnumerableKeys();
     internal bool DefineProperty(SharpTSSymbol symbol, SharpTSPropertyDescriptor descriptor)
-        => _extras.DefineProperty(symbol, descriptor);
+        => _overlay.DefineProperty(symbol, descriptor);
     internal SharpTSPropertyDescriptor? GetOwnPropertyDescriptor(SharpTSSymbol symbol)
-        => _extras.GetOwnPropertyDescriptor(symbol);
+        => _overlay.GetOwnPropertyDescriptor(symbol);
     internal bool DeleteBySymbolStrict(SharpTSSymbol symbol, bool strictMode)
-        => _extras.DeleteBySymbolStrict(symbol, strictMode);
+        => _overlay.DeleteBySymbolStrict(symbol, strictMode);
     bool ISharpTSSymbolPropertyBag.HasSymbolProperty(SharpTSSymbol symbol)
-        => _extras.HasSymbolProperty(symbol);
+        => _overlay.HasSymbolProperty(symbol);
     object? ISharpTSSymbolPropertyBag.GetBySymbol(SharpTSSymbol symbol)
-        => _extras.GetBySymbol(symbol);
+        => _overlay.GetBySymbol(symbol);
     bool ISharpTSSymbolPropertyBag.TryGetSymbolAccessor(
         SharpTSSymbol symbol, out ISharpTSCallable? getter, out ISharpTSCallable? setter)
-        => _extras.TryGetSymbolAccessor(symbol, out getter, out setter);
+        => _overlay.TryGetSymbolAccessor(symbol, out getter, out setter);
     void ISharpTSSymbolPropertyBag.SetBySymbolStrict(
         SharpTSSymbol symbol, object? value, bool strictMode)
-        => _extras.SetBySymbolStrict(symbol, value, strictMode);
+        => _overlay.SetBySymbolStrict(symbol, value, strictMode);
     public object? GetMember(string name)
-        => HasExtra(name) ? TryGetExtra(name)
-            : name == "constructor" && !_constructorDeleted ? RealmConstructor
-            : name is "valueOf" or "toString" or "toLocaleString" && !_deletedMethods.Contains(name)
-                ? _methodCache.GetValueOrDefault(name)
-                    ?? (_methodCache[name] = new BigIntPrototypeMethodWrapper(name))
+    {
+        if (_overlay.TryGetOverride(name, out var value)) return value;
+        if (name == "constructor") return RealmConstructor;
+        return name is "valueOf" or "toString" or "toLocaleString"
+            ? _methodCache.GetValueOrDefault(name)
+                ?? (_methodCache[name] = new BigIntPrototypeMethodWrapper(name))
             : null;
+    }
     public override string ToString() => "[object BigInt]";
 }
 
@@ -540,71 +487,34 @@ internal sealed class BigIntPrototypeMethodWrapper : ISharpTSCallable, IBuiltInF
 public sealed class SharpTSSymbolPrototype : ISharpTSMutableBuiltIn
 {
     internal object? RealmConstructor { get; set; }
-    private readonly SharpTSObject _extras = new([]);
-    private bool _constructorDeleted;
+    private readonly PrototypePropertyOverlay _overlay = new(IsBuiltIn, preserveBuiltInAssignmentAttributes: true);
     private readonly Dictionary<string, SymbolPrototypeMethodWrapper> _methodCache = [];
-    private readonly HashSet<string> _deletedMethods = [];
 
     internal SharpTSSymbolPrototype() { }
 
-    public bool HasExtra(string name) => _extras.HasProperty(name) || _extras.HasSetter(name);
-    public object? TryGetExtra(string name) => _extras.GetProperty(name);
-    public void SetExtra(string name, object? value)
-    {
-        _deletedMethods.Remove(name);
-        if (name == "constructor") _constructorDeleted = false;
-        if (name is "constructor" or "toString" or "valueOf" && !HasExtra(name))
-        {
-            _extras.DefineProperty(name, new SharpTSPropertyDescriptor
-            {
-                Value = value,
-                HasValue = true,
-                Writable = true,
-                HasWritable = true,
-                Enumerable = false,
-                HasEnumerable = true,
-                Configurable = true,
-                HasConfigurable = true,
-            });
-            return;
-        }
-        _extras.SetProperty(name, value);
-    }
+    public bool HasExtra(string name) => _overlay.HasExtra(name);
+    public object? TryGetExtra(string name) => _overlay.GetProperty(name);
+    public void SetExtra(string name, object? value) => _overlay.SetProperty(name, value);
     public bool DefineExtraProperty(string name, SharpTSPropertyDescriptor descriptor)
-    {
-        _deletedMethods.Remove(name);
-        if (name == "constructor") _constructorDeleted = false;
-        return _extras.DefineProperty(name, descriptor);
-    }
+        => _overlay.DefineProperty(name, descriptor);
     public SharpTSPropertyDescriptor? GetOwnPropertyDescriptor(string name)
-        => _extras.GetOwnPropertyDescriptor(name);
-    public ISharpTSCallable? GetExtraGetter(string name) => _extras.GetGetter(name);
-    public ISharpTSCallable? GetExtraSetter(string name) => _extras.GetSetter(name);
-    public bool HasOwnProperty(string name)
-        => HasExtra(name)
-            || name == "constructor" && !_constructorDeleted
-            || name is "toString" or "valueOf" && !_deletedMethods.Contains(name);
-    public bool DeleteProperty(string name)
-    {
-        if (HasExtra(name))
-        {
-            bool deleted = _extras.DeleteProperty(name);
-            if (deleted && name == "constructor") _constructorDeleted = true;
-            if (deleted && name is "toString" or "valueOf") _deletedMethods.Add(name);
-            return deleted;
-        }
-        if (name == "constructor") _constructorDeleted = true;
-        if (name is "toString" or "valueOf") _deletedMethods.Add(name);
-        return true;
-    }
-    public IEnumerable<string> OwnEnumerableKeys() => _extras.OwnEnumerableKeys();
+        => _overlay.GetOwnPropertyDescriptor(name);
+    public ISharpTSCallable? GetExtraGetter(string name) => _overlay.GetGetter(name);
+    public ISharpTSCallable? GetExtraSetter(string name) => _overlay.GetSetter(name);
+    private static bool IsBuiltIn(string name) => name is "constructor" or "toString" or "valueOf";
+
+    public bool HasOwnProperty(string name) => _overlay.HasOwnProperty(name);
+    public bool DeleteProperty(string name) => _overlay.DeleteProperty(name);
+    public IEnumerable<string> OwnEnumerableKeys() => _overlay.OwnEnumerableKeys();
     public object? GetMember(string name)
-        => HasExtra(name) ? TryGetExtra(name)
-            : name == "constructor" && !_constructorDeleted ? RealmConstructor
-            : name is "toString" or "valueOf" && !_deletedMethods.Contains(name)
-                ? _methodCache.GetValueOrDefault(name)
-                    ?? (_methodCache[name] = new SymbolPrototypeMethodWrapper(name))
+    {
+        if (_overlay.TryGetOverride(name, out var value)) return value;
+        if (name == "constructor") return RealmConstructor;
+        return name is "toString" or "valueOf"
+            ? _methodCache.GetValueOrDefault(name)
+                ?? (_methodCache[name] = new SymbolPrototypeMethodWrapper(name))
             : null;
+    }
     public override string ToString() => "[object Symbol]";
 }
 
@@ -813,65 +723,49 @@ public sealed class SharpTSNumberPrototype : ISharpTSMutableBuiltIn, ISharpTSSym
     /// </summary>
     public static readonly SharpTSNumberPrototype Instance = new();
     // internal (not private) so each Interpreter can construct its own realm
-    // instance; only the _extras overlay differs between instances.
+    // instance with its own overlay and method cache.
     internal SharpTSNumberPrototype() { }
 
-    private readonly SharpTSObject _extras = new([]);
-    private readonly HashSet<string> _deletedBuiltIns = [];
+    private readonly PrototypePropertyOverlay _overlay = new(IsBuiltIn);
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, NumberPrototypeMethodWrapper>
         _methodCache = new(StringComparer.Ordinal);
-    public bool HasExtra(string name) => _extras.HasProperty(name) || _extras.HasSetter(name);
-    public object? TryGetExtra(string name) => _extras.GetProperty(name);
-    public void SetExtra(string name, object? value)
-    {
-        _deletedBuiltIns.Remove(name);
-        _extras.SetProperty(name, value);
-    }
+    public bool HasExtra(string name) => _overlay.HasExtra(name);
+    public object? TryGetExtra(string name) => _overlay.GetProperty(name);
+    public void SetExtra(string name, object? value) => _overlay.SetProperty(name, value);
     public bool DefineExtraProperty(string name, SharpTSPropertyDescriptor descriptor)
-    {
-        _deletedBuiltIns.Remove(name);
-        return _extras.DefineProperty(name, descriptor);
-    }
+        => _overlay.DefineProperty(name, descriptor);
     public SharpTSPropertyDescriptor? GetOwnPropertyDescriptor(string name)
-        => _extras.GetOwnPropertyDescriptor(name);
-    public ISharpTSCallable? GetExtraGetter(string name) => _extras.GetGetter(name);
-    public ISharpTSCallable? GetExtraSetter(string name) => _extras.GetSetter(name);
+        => _overlay.GetOwnPropertyDescriptor(name);
+    public ISharpTSCallable? GetExtraGetter(string name) => _overlay.GetGetter(name);
+    public ISharpTSCallable? GetExtraSetter(string name) => _overlay.GetSetter(name);
     bool ISharpTSSymbolPropertyBag.HasSymbolProperty(SharpTSSymbol symbol)
-        => _extras.HasSymbolProperty(symbol);
+        => _overlay.HasSymbolProperty(symbol);
     object? ISharpTSSymbolPropertyBag.GetBySymbol(SharpTSSymbol symbol)
-        => _extras.GetBySymbol(symbol);
+        => _overlay.GetBySymbol(symbol);
     bool ISharpTSSymbolPropertyBag.TryGetSymbolAccessor(
         SharpTSSymbol symbol, out ISharpTSCallable? getter, out ISharpTSCallable? setter)
-        => _extras.TryGetSymbolAccessor(symbol, out getter, out setter);
+        => _overlay.TryGetSymbolAccessor(symbol, out getter, out setter);
     void ISharpTSSymbolPropertyBag.SetBySymbolStrict(
         SharpTSSymbol symbol, object? value, bool strictMode)
-        => _extras.SetBySymbolStrict(symbol, value, strictMode);
+        => _overlay.SetBySymbolStrict(symbol, value, strictMode);
 
-    public IEnumerable<string> OwnEnumerableKeys() => _extras.OwnEnumerableKeys();
+    public IEnumerable<string> OwnEnumerableKeys() => _overlay.OwnEnumerableKeys();
 
-    private bool IsBuiltIn(string name)
+    private static bool IsBuiltIn(string name)
         => name == "constructor" || NumberBuiltIns.GetPrototypeMethod(name) != null;
 
-    public bool HasOwnProperty(string name)
-        => HasExtra(name) || (!_deletedBuiltIns.Contains(name) && IsBuiltIn(name));
+    public bool HasOwnProperty(string name) => _overlay.HasOwnProperty(name);
 
     /// <summary>
     /// Number.prototype is an ordinary object, so its built-in methods are configurable
     /// and `delete Number.prototype.toString` must take — after which the name resolves
     /// up the chain to Object.prototype.
     /// </summary>
-    public bool DeleteProperty(string name)
-    {
-        bool hadExtra = HasExtra(name);
-        if (hadExtra && !_extras.DeleteProperty(name)) return false;
-        if (IsBuiltIn(name)) _deletedBuiltIns.Add(name);
-        return true;
-    }
+    public bool DeleteProperty(string name) => _overlay.DeleteProperty(name);
 
     public object? GetMember(string name)
     {
-        if (HasExtra(name)) return TryGetExtra(name);
-        if (_deletedBuiltIns.Contains(name)) return null;
+        if (_overlay.TryGetOverride(name, out var value)) return value;
         if (name == "constructor") return RealmConstructor ?? (object)SharpTSNumberNamespace.Instance;
         var method = NumberBuiltIns.GetPrototypeMethod(name);
         if (method is null) return null;
@@ -1043,53 +937,38 @@ public sealed class SharpTSBooleanPrototype : ISharpTSMutableBuiltIn, ISharpTSSy
     /// </summary>
     public static readonly SharpTSBooleanPrototype Instance = new();
     // internal (not private) so each Interpreter can construct its own realm
-    // instance; only the _extras overlay differs between instances.
+    // instance with its own overlay.
     internal SharpTSBooleanPrototype() { }
 
-    private readonly SharpTSObject _extras = new([]);
-    private readonly HashSet<string> _deletedBuiltIns = [];
-    public bool HasExtra(string name) => _extras.HasProperty(name) || _extras.HasSetter(name);
-    public object? TryGetExtra(string name) => _extras.GetProperty(name);
-    public void SetExtra(string name, object? value)
-    {
-        _deletedBuiltIns.Remove(name);
-        _extras.SetProperty(name, value);
-    }
+    private readonly PrototypePropertyOverlay _overlay = new(IsBuiltIn);
+    public bool HasExtra(string name) => _overlay.HasExtra(name);
+    public object? TryGetExtra(string name) => _overlay.GetProperty(name);
+    public void SetExtra(string name, object? value) => _overlay.SetProperty(name, value);
     public bool DefineExtraProperty(string name, SharpTSPropertyDescriptor descriptor)
-    {
-        _deletedBuiltIns.Remove(name);
-        return _extras.DefineProperty(name, descriptor);
-    }
+        => _overlay.DefineProperty(name, descriptor);
     public SharpTSPropertyDescriptor? GetOwnPropertyDescriptor(string name)
-        => _extras.GetOwnPropertyDescriptor(name);
-    public ISharpTSCallable? GetExtraGetter(string name) => _extras.GetGetter(name);
-    public ISharpTSCallable? GetExtraSetter(string name) => _extras.GetSetter(name);
+        => _overlay.GetOwnPropertyDescriptor(name);
+    public ISharpTSCallable? GetExtraGetter(string name) => _overlay.GetGetter(name);
+    public ISharpTSCallable? GetExtraSetter(string name) => _overlay.GetSetter(name);
     bool ISharpTSSymbolPropertyBag.HasSymbolProperty(SharpTSSymbol symbol)
-        => _extras.HasSymbolProperty(symbol);
+        => _overlay.HasSymbolProperty(symbol);
     object? ISharpTSSymbolPropertyBag.GetBySymbol(SharpTSSymbol symbol)
-        => _extras.GetBySymbol(symbol);
+        => _overlay.GetBySymbol(symbol);
     bool ISharpTSSymbolPropertyBag.TryGetSymbolAccessor(
         SharpTSSymbol symbol, out ISharpTSCallable? getter, out ISharpTSCallable? setter)
-        => _extras.TryGetSymbolAccessor(symbol, out getter, out setter);
+        => _overlay.TryGetSymbolAccessor(symbol, out getter, out setter);
     void ISharpTSSymbolPropertyBag.SetBySymbolStrict(
         SharpTSSymbol symbol, object? value, bool strictMode)
-        => _extras.SetBySymbolStrict(symbol, value, strictMode);
+        => _overlay.SetBySymbolStrict(symbol, value, strictMode);
     private static bool IsBuiltIn(string name)
         => name is "constructor" or "toString" or "valueOf";
 
-    public bool DeleteProperty(string name)
-    {
-        if (HasExtra(name) && !_extras.DeleteProperty(name)) return false;
-        if (IsBuiltIn(name)) _deletedBuiltIns.Add(name);
-        return true;
-    }
-    public bool HasOwnProperty(string name)
-        => HasExtra(name) || (!_deletedBuiltIns.Contains(name) && IsBuiltIn(name));
-    public IEnumerable<string> OwnEnumerableKeys() => _extras.OwnEnumerableKeys();
+    public bool DeleteProperty(string name) => _overlay.DeleteProperty(name);
+    public bool HasOwnProperty(string name) => _overlay.HasOwnProperty(name);
+    public IEnumerable<string> OwnEnumerableKeys() => _overlay.OwnEnumerableKeys();
     public object? GetMember(string name)
     {
-        if (HasExtra(name)) return TryGetExtra(name);
-        if (_deletedBuiltIns.Contains(name)) return null;
+        if (_overlay.TryGetOverride(name, out var value)) return value;
         return name switch
         {
             "constructor" => RealmConstructor ?? (object)SharpTSBooleanNamespace.Instance,

--- a/src/SharpTS/Runtime/Types/SharpTSPromisePrototype.cs
+++ b/src/SharpTS/Runtime/Types/SharpTSPromisePrototype.cs
@@ -16,54 +16,37 @@ namespace SharpTS.Runtime.Types;
 public sealed class SharpTSPromisePrototype : ISharpTSMutableBuiltIn
 {
     /// <summary>
-    /// Process-wide instance. Promise.prototype carries no per-realm mutable state here
-    /// (guest writes land on <see cref="_extras"/>, which is per-instance), matching how the
-    /// other built-in prototypes start out.
+    /// Process-wide template. Guest reads use the interpreter's per-realm prototype;
+    /// its <see cref="_overlay"/> and method cache belong to that instance.
     /// </summary>
     public static readonly SharpTSPromisePrototype Instance = new();
 
     internal SharpTSPromisePrototype() { }
 
-    private readonly SharpTSObject _extras = new([]);
-    private readonly HashSet<string> _deletedBuiltIns = [];
+    private readonly PrototypePropertyOverlay _overlay = new(IsBuiltIn);
     private readonly Dictionary<string, ISharpTSCallable> _builtIns = [];
 
-    public bool HasExtra(string name) => _extras.HasProperty(name) || _extras.HasSetter(name);
-    public object? TryGetExtra(string name) => _extras.GetProperty(name);
-    public void SetExtra(string name, object? value)
-    {
-        _deletedBuiltIns.Remove(name);
-        _extras.SetProperty(name, value);
-    }
+    public bool HasExtra(string name) => _overlay.HasExtra(name);
+    public object? TryGetExtra(string name) => _overlay.GetProperty(name);
+    public void SetExtra(string name, object? value) => _overlay.SetProperty(name, value);
     public bool DefineExtraProperty(string name, SharpTSPropertyDescriptor descriptor)
-    {
-        _deletedBuiltIns.Remove(name);
-        return _extras.DefineProperty(name, descriptor);
-    }
+        => _overlay.DefineProperty(name, descriptor);
     public SharpTSPropertyDescriptor? GetOwnPropertyDescriptor(string name)
-        => _extras.GetOwnPropertyDescriptor(name);
-    public ISharpTSCallable? GetExtraGetter(string name) => _extras.GetGetter(name);
+        => _overlay.GetOwnPropertyDescriptor(name);
+    public ISharpTSCallable? GetExtraGetter(string name) => _overlay.GetGetter(name);
 
     private static bool IsBuiltIn(string name)
         => name is "then" or "catch" or "finally" or "constructor";
 
-    public bool HasOwnProperty(string name)
-        => HasExtra(name) || (!_deletedBuiltIns.Contains(name) && IsBuiltIn(name));
+    public bool HasOwnProperty(string name) => _overlay.HasOwnProperty(name);
 
-    public bool DeleteProperty(string name)
-    {
-        bool hadExtra = HasExtra(name);
-        if (hadExtra && !_extras.DeleteProperty(name)) return false;
-        if (IsBuiltIn(name)) _deletedBuiltIns.Add(name);
-        return true;
-    }
+    public bool DeleteProperty(string name) => _overlay.DeleteProperty(name);
 
-    public IEnumerable<string> OwnEnumerableKeys() => _extras.OwnEnumerableKeys();
+    public IEnumerable<string> OwnEnumerableKeys() => _overlay.OwnEnumerableKeys();
 
     public object? GetMember(string name)
     {
-        if (HasExtra(name)) return TryGetExtra(name);
-        if (_deletedBuiltIns.Contains(name)) return null;
+        if (_overlay.TryGetOverride(name, out var value)) return value;
         // The unbound form: PromiseBuiltIns.GetMember binds each method to a concrete
         // promise, which is wrong for a read off the prototype itself.
         if (_builtIns.TryGetValue(name, out var cached)) return cached;

--- a/tests/SharpTS.Tests/RuntimeTests/PrototypeOverlayCharacterizationTests.cs
+++ b/tests/SharpTS.Tests/RuntimeTests/PrototypeOverlayCharacterizationTests.cs
@@ -1,0 +1,122 @@
+using SharpTS.Execution;
+using SharpTS.Runtime.Types;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.RuntimeTests;
+
+// These characterize interpreter representations before extraction (#1616).
+// They deliberately preserve existing differences instead of imposing new semantics.
+public class PrototypeOverlayCharacterizationTests
+{
+    [Fact]
+    public void BuiltInAssignment_UsesExistingPrototypeSpecificEnumerability()
+    {
+        const string source = """
+            const prototypes: any[] = [String.prototype, Number.prototype, Boolean.prototype,
+                Array.prototype, Object.prototype, Function.prototype, Error.prototype,
+                Promise.prototype, BigInt.prototype, Symbol.prototype];
+            for (const p of prototypes) {
+                p.constructor = 1;
+                console.log(Object.getOwnPropertyDescriptor(p, "constructor").enumerable);
+                delete p.constructor;
+                p.constructor = 2;
+                console.log(Object.getOwnPropertyDescriptor(p, "constructor").enumerable);
+            }
+            """;
+        Assert.Equal(string.Concat(Enumerable.Repeat("true\ntrue\n", 8)) + "false\nfalse\nfalse\nfalse\n",
+            TestHarness.Run(source, ExecutionMode.Interpreted));
+    }
+
+    [Fact]
+    public void ArrayLength_RemainsAVirtualBuiltInWithAnIndependentOverlay()
+    {
+        var prototype = new SharpTSArrayPrototype();
+        Assert.True(prototype.HasOwnProperty("length"));
+        Assert.Equal(0d, prototype.GetMember("length"));
+        Assert.Null(prototype.GetOwnPropertyDescriptor("length"));
+        prototype.SetExtra("7", 42d);
+        Assert.Equal(0d, prototype.GetMember("length"));
+        Assert.True(prototype.HasIndexedExtra(8));
+        Assert.False(prototype.HasIndexedExtra(7));
+        Assert.True(prototype.DeleteProperty("length"));
+        Assert.False(prototype.HasOwnProperty("length"));
+        Assert.Null(prototype.GetMember("length"));
+        prototype.SetExtra("length", 3d);
+        Assert.Equal(3d, prototype.GetMember("length"));
+        Assert.True(prototype.GetOwnPropertyDescriptor("length")!.Enumerable);
+    }
+
+    [Fact]
+    public void PrototypeState_AndConstructorIdentity_RemainRealmOwned()
+    {
+        using var first = new Interpreter(TextWriter.Null, TextWriter.Null);
+        using var second = new Interpreter(TextWriter.Null, TextWriter.Null);
+        var a = first.GetStringPrototype();
+        var b = second.GetStringPrototype();
+        Assert.Same(a, first.GetStringPrototype());
+        Assert.Same(first.GetStringNamespace(), a.GetMember("constructor"));
+        Assert.Same(second.GetStringNamespace(), b.GetMember("constructor"));
+        Assert.NotSame(a, b);
+        var iterator = b.GetBySymbol(SharpTSSymbol.Iterator);
+        Assert.True(a.DeleteProperty("trim"));
+        Assert.True(a.DeleteBySymbolStrict(SharpTSSymbol.Iterator, false));
+        a.SetExtra("overlayOnly", 42d);
+        Assert.True(b.HasOwnProperty("trim"));
+        Assert.Same(iterator, b.GetBySymbol(SharpTSSymbol.Iterator));
+        Assert.False(b.HasExtra("overlayOnly"));
+        a.DefineExtraProperty("trim", new SharpTSPropertyDescriptor { Value = 5d, HasValue = true });
+        Assert.Equal(5d, a.GetMember("trim"));
+        Assert.IsAssignableFrom<ISharpTSCallable>(b.GetMember("trim"));
+    }
+
+    [Fact]
+    public void ClassOverlay_DoesNotMutateInheritedMethodTables()
+    {
+        var method = SharpTSFunctionProtoToString.Instance;
+        var parent = new SharpTSClass("Parent", null, new() { ["method"] = method }, [], []);
+        var child = new SharpTSClass("Child", parent, [], [], []);
+        var prototype = child.Prototype;
+        Assert.Same(prototype, child.Prototype);
+        Assert.Same(child, prototype.GetMember("constructor"));
+        Assert.Same(method, prototype.GetMember("method"));
+        Assert.True(prototype.HasOwnProperty("method"));
+        prototype.SetExtra("method", null);
+        Assert.Null(prototype.GetMember("method"));
+        Assert.True(prototype.HasOwnProperty("method"));
+        Assert.True(prototype.DeleteProperty("method"));
+        Assert.False(prototype.HasOwnProperty("method"));
+        Assert.Null(prototype.GetMember("method"));
+        Assert.Same(method, child.FindMethod("method"));
+        Assert.Same(method, parent.Prototype.GetMember("method"));
+    }
+
+    [Fact]
+    public void StringSymbolOverlay_PreservesDescriptorsDeletionAndAccessorIdentity()
+    {
+        using var realm = new Interpreter(TextWriter.Null, TextWriter.Null);
+        var prototype = realm.GetStringPrototype();
+        var key = SharpTSSymbol.Iterator;
+        var original = prototype.GetOwnPropertyDescriptor(key)!;
+        Assert.True(original.Writable);
+        Assert.False(original.Enumerable);
+        Assert.True(original.Configurable);
+        Assert.True(prototype.DeleteBySymbolStrict(key, false));
+        Assert.DoesNotContain(key, prototype.GetSymbolPropertyNames());
+        var accessor = SharpTSFunctionProtoToString.Instance;
+        Assert.True(prototype.DefineProperty(key, new SharpTSPropertyDescriptor
+        {
+            Get = accessor, HasGet = true, Set = accessor, HasSet = true,
+            Configurable = false, HasConfigurable = true,
+        }));
+        var bag = (ISharpTSSymbolPropertyBag)prototype;
+        Assert.True(bag.TryGetSymbolAccessor(key, out var getter, out var setter));
+        Assert.Same(accessor, getter);
+        Assert.Same(accessor, setter);
+        Assert.False(prototype.DeleteBySymbolStrict(key, false));
+        Assert.ThrowsAny<Exception>(() => prototype.DeleteBySymbolStrict(key, true));
+        Assert.False(prototype.DefineProperty(key, original));
+        Assert.Contains(key, prototype.GetSymbolPropertyNames());
+        Assert.Empty(prototype.OwnEnumerableKeys());
+    }
+}

--- a/tests/SharpTS.Tests/SharedTests/PrototypeOverlayTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/PrototypeOverlayTests.cs
@@ -1,0 +1,135 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+public class PrototypeOverlayTests
+{
+    [Theory, ModeData]
+    public void BuiltInDeletion_DefinitionAndAssignment_DoNotResurrectOriginal(ExecutionMode mode)
+    {
+        var source = """
+            const prototypes: any[] = [Object.prototype, Array.prototype, String.prototype,
+                Number.prototype, Boolean.prototype, BigInt.prototype, Symbol.prototype,
+                Function.prototype, Error.prototype, Promise.prototype];
+            const names = ["valueOf", "map", "trim", "toFixed", "valueOf", "valueOf",
+                "valueOf", "bind", "toString", "then"];
+            for (let i = 0; i < prototypes.length; i++) {
+                const p: any = prototypes[i];
+                const name = names[i];
+                console.log(delete p[name]);
+                console.log(Object.prototype.hasOwnProperty.call(p, name));
+                Object.defineProperty(p, name, {
+                    value: 17, writable: true, enumerable: false, configurable: true
+                });
+                console.log(p[name]);
+                console.log(delete p[name]);
+                console.log(Object.prototype.hasOwnProperty.call(p, name));
+                p[name] = 23;
+                console.log(p[name]);
+                Object.defineProperty(p, name, { value: 23, writable: false, configurable: false });
+                console.log(delete p[name]);
+                let rejected = false;
+                try { Object.defineProperty(p, name, { value: 99 }); }
+                catch (e) { rejected = true; }
+                console.log(rejected);
+                console.log(p[name]);
+            }
+            """;
+        Assert.Equal(string.Concat(Enumerable.Repeat("true\nfalse\n17\ntrue\nfalse\n23\nfalse\ntrue\n23\n", 10)),
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void ExtraDescriptors_PreserveKeyOrderAttributesAndUndefinedAccessors(ExecutionMode mode)
+    {
+        var source = """
+            function overlayKeys(p: any): string {
+                const keys: string[] = [];
+                for (const key in p) {
+                    if (key === "2" || key === "9" || key.startsWith("overlay")) keys.push(key);
+                }
+                return keys.join(",");
+            }
+            const prototypes: any[] = [Array.prototype, String.prototype, Number.prototype,
+                Boolean.prototype, BigInt.prototype, Symbol.prototype, Function.prototype,
+                Error.prototype, Promise.prototype, Object.prototype];
+            for (const p of prototypes) {
+                p.overlayFirst = null;
+                p[9] = 9;
+                p[2] = 2;
+                Object.defineProperty(p, "overlayHidden", { value: 1, configurable: true });
+                Object.defineProperty(p, "overlayEmpty", {
+                    get: undefined, set: undefined, enumerable: true, configurable: true
+                });
+                console.log(Object.getOwnPropertyDescriptor(p, "overlayFirst").value === null);
+                console.log(p.overlayEmpty === undefined);
+                console.log(Object.getOwnPropertyDescriptor(p, "overlayEmpty") !== undefined);
+                const d = Object.getOwnPropertyDescriptor(p, "overlayHidden");
+                console.log(d.writable, d.enumerable, d.configurable);
+                console.log(overlayKeys(p));
+                delete p.overlayFirst;
+                p.overlayFirst = undefined;
+                console.log(overlayKeys(p));
+                delete p.overlayFirst;
+                delete p[9];
+                delete p[2];
+                delete p.overlayHidden;
+                delete p.overlayEmpty;
+            }
+            """;
+        Assert.Equal(string.Concat(Enumerable.Repeat(
+            "true\ntrue\ntrue\nfalse false true\n2,9,overlayFirst,overlayEmpty\n2,9,overlayEmpty,overlayFirst\n", 10)),
+            TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void AccessorDescriptors_PreserveIdentityWithoutInvokingCallbacks(ExecutionMode mode)
+    {
+        var source = """
+            const prototypes: any[] = [Array.prototype, String.prototype, Number.prototype,
+                Boolean.prototype, BigInt.prototype, Symbol.prototype, Function.prototype,
+                Error.prototype, Object.prototype];
+            for (const p of prototypes) {
+                let reads = 0;
+                let writes = 0;
+                const getter = function(this: any): any { reads++; return this; };
+                const setter = function(this: any, value: any): void { writes++; };
+                Object.defineProperty(p, "overlayAccessor", {
+                    get: getter, set: setter, enumerable: true, configurable: true
+                });
+                const d = Object.getOwnPropertyDescriptor(p, "overlayAccessor");
+                console.log(d.get === getter, d.set === setter, reads, writes);
+                delete p.overlayAccessor;
+            }
+            """;
+        Assert.Equal(string.Concat(Enumerable.Repeat(
+            "true true 0 0\n", 9)), TestHarness.Run(source, mode));
+    }
+
+    [Theory, ModeData]
+    public void InheritedPrimitiveAccessors_PreserveExistingReceiverIdentity(ExecutionMode mode)
+    {
+        const string source = """
+            const values: any = new Number(1);
+            let getReceiver: any;
+            let setReceiver: any;
+            let assigned: any;
+            Object.defineProperty(Number.prototype, "overlayAccessor", {
+                get: function(this: any): any { getReceiver = this; return 42; },
+                set: function(this: any, value: any): void { setReceiver = this; assigned = value; },
+                configurable: true
+            });
+            console.log(values.overlayAccessor);
+            values.overlayAccessor = 17;
+            console.log(getReceiver === values, setReceiver === values, assigned);
+            console.log(Object.prototype.hasOwnProperty.call(values, "overlayAccessor"));
+            delete (Number.prototype as any).overlayAccessor;
+            """;
+        // Baseline difference: compiled Number getters do not retain boxed receiver
+        // identity. The interpreter uses the boxed instance for both accessors.
+        Assert.Equal(mode == ExecutionMode.Interpreted
+            ? "42\ntrue true 17\nfalse\n"
+            : "42\nfalse true 17\nfalse\n", TestHarness.Run(source, mode));
+    }
+}


### PR DESCRIPTION
Ten interpreter prototypes independently maintained descriptor-backed extra properties and deleted-built-in state. Introduce a per-instance `PrototypePropertyOverlay` and compose it into the class, Function, Object, Array, String, Number, Boolean, BigInt, Symbol, and Promise prototypes.

Each prototype retains its built-in lookup, method cache, constructor identity, and existing symbol surface. The helper shares overlay reads/writes, descriptor and accessor storage, enumeration, and deletion/redefinition bookkeeping. Characterization tests preserve BigInt/Symbol assignment attributes, Array's virtual `length`, inherited class methods, symbol descriptors, realm isolation, and the existing boxed Number getter receiver difference between execution modes.

Validation:

- All 13 new characterization cases passed against the original runtime before rebuilding the extraction.
- 1,194 relevant unit/regression tests passed after extraction, including prototype, descriptor, deletion, symbol, accessor, and realm-isolation coverage.
- 91 focused Test262 parity cases passed against the pinned corpus.
- `scripts/test-code-quality.ps1` passed, including analyzer fixtures and the duplicate-method gate; no baseline changes were needed.
- `git diff --cached --check` passed.

Closes #1616.
