### PR TITLE
Share binding bookkeeping across optimization analyzers

### DIFF
--- a/src/SharpTS/Compilation/FunctionScopedBindingVisitor.cs
+++ b/src/SharpTS/Compilation/FunctionScopedBindingVisitor.cs
@@ -1,0 +1,75 @@
+using SharpTS.Parsing;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// A conservative optimization identity, local to one visitor traversal. Scope zero is the
+/// program; every function/arrow (including its parameter defaults) gets a fresh scope.
+/// This is not lexical name resolution: blocks share their function's identity and duplicate
+/// var/let/const declarations disable candidates. References in nested functions are keyed in
+/// that nested scope; consumers must still apply their separate closure/capture proof.
+/// </summary>
+internal readonly record struct FunctionScopedBinding(int Scope, string Name);
+
+/// <summary>
+/// Bookkeeping for optimization passes with the same function-scope model. Counts declarations
+/// during each consumer's existing semantic traversal, without introducing a separate program
+/// walk. Candidate selection, allowed uses, and intrinsic mutation policies remain in consumers.
+/// </summary>
+internal abstract class FunctionScopedBindingVisitor : VariableWriteVisitor
+{
+    private int _scope;
+    private int _nextScope;
+
+    public Dictionary<FunctionScopedBinding, int> DeclarationCounts { get; } = [];
+    public HashSet<FunctionScopedBinding> Disqualified { get; } = [];
+
+    protected FunctionScopedBinding Binding(Token name) => new(_scope, name.Lexeme);
+
+    protected override void VisitFunction(Stmt.Function statement)
+    {
+        int saved = _scope;
+        _scope = ++_nextScope;
+        try
+        {
+            base.VisitFunction(statement);
+        }
+        finally
+        {
+            _scope = saved;
+        }
+    }
+
+    protected override void VisitArrowFunction(Expr.ArrowFunction expression)
+    {
+        int saved = _scope;
+        _scope = ++_nextScope;
+        try
+        {
+            base.VisitArrowFunction(expression);
+        }
+        finally
+        {
+            _scope = saved;
+        }
+    }
+
+    protected sealed override void VisitVar(Stmt.Var statement) =>
+        VisitDeclaration(statement.Name, statement.Initializer);
+
+    protected sealed override void VisitConst(Stmt.Const statement) =>
+        VisitDeclaration(statement.Name, statement.Initializer);
+
+    private void VisitDeclaration(Token name, Expr? initializer)
+    {
+        var binding = Binding(name);
+        DeclarationCounts[binding] = DeclarationCounts.GetValueOrDefault(binding) + 1;
+        OnDeclaration(binding, name, initializer);
+        if (initializer != null)
+            Visit(initializer);
+    }
+
+    protected abstract void OnDeclaration(FunctionScopedBinding binding, Token name, Expr? initializer);
+
+    protected override void OnVariableWrite(Token name) => Disqualified.Add(Binding(name));
+}

--- a/src/SharpTS/Compilation/NumericMapLocalPromotionAnalyzer.cs
+++ b/src/SharpTS/Compilation/NumericMapLocalPromotionAnalyzer.cs
@@ -1,5 +1,4 @@
 using SharpTS.Parsing;
-using SharpTS.Parsing.Visitors;
 using SharpTS.TypeSystem;
 
 namespace SharpTS.Compilation;
@@ -48,44 +47,17 @@ internal static class NumericMapLocalPromotionAnalyzer
         && IsNumber(map.KeyType)
         && IsNumber(map.ValueType);
 
-    private sealed class Visitor(TypeMap typeMap) : AstVisitorBase
+    private sealed class Visitor(TypeMap typeMap) : FunctionScopedBindingVisitor
     {
         private readonly TypeMap _typeMap = typeMap;
         private Expr.Call? _discardedCall;
-        private int _scope;
-        private int _nextScope;
 
-        public Dictionary<(int Scope, string Name), Token> Candidates { get; } = [];
-        public Dictionary<(int Scope, string Name), int> DeclarationCounts { get; } = [];
-        public HashSet<(int Scope, string Name)> Disqualified { get; } = [];
+        public Dictionary<FunctionScopedBinding, Token> Candidates { get; } = [];
         public bool ContainsDirectEval { get; private set; }
         public bool IntrinsicMapIsObservable { get; private set; }
 
-        protected override void VisitFunction(Stmt.Function statement) =>
-            InScope(() => base.VisitFunction(statement));
-
-        protected override void VisitArrowFunction(Expr.ArrowFunction expression) =>
-            InScope(() => base.VisitArrowFunction(expression));
-
-        private void InScope(Action visit)
+        protected override void OnDeclaration(FunctionScopedBinding key, Token name, Expr? initializer)
         {
-            int saved = _scope;
-            _scope = ++_nextScope;
-            visit();
-            _scope = saved;
-        }
-
-        protected override void VisitVar(Stmt.Var statement) =>
-            HandleDeclaration(statement.Name, statement.Initializer);
-
-        protected override void VisitConst(Stmt.Const statement) =>
-            HandleDeclaration(statement.Name, statement.Initializer);
-
-        private void HandleDeclaration(Token name, Expr? initializer)
-        {
-            var key = (_scope, name.Lexeme);
-            DeclarationCounts[key] = DeclarationCounts.GetValueOrDefault(key) + 1;
-
             if (initializer is Expr.New
                 {
                     Callee: Expr.Variable { Name.Lexeme: "Map" },
@@ -95,9 +67,6 @@ internal static class NumericMapLocalPromotionAnalyzer
             {
                 Candidates.TryAdd(key, name);
             }
-
-            if (initializer != null)
-                Visit(initializer);
         }
 
         protected override void VisitNew(Expr.New expression)
@@ -202,45 +171,14 @@ internal static class NumericMapLocalPromotionAnalyzer
         {
             if (expression.Name.Lexeme == "Map")
                 IntrinsicMapIsObservable = true;
-            Disqualified.Add((_scope, expression.Name.Lexeme));
+            Disqualified.Add(Binding(expression.Name));
         }
 
-        protected override void VisitAssign(Expr.Assign expression)
+        protected override void OnVariableWrite(Token name)
         {
-            if (expression.Name.Lexeme == "Map")
+            if (name.Lexeme == "Map")
                 IntrinsicMapIsObservable = true;
-            Disqualified.Add((_scope, expression.Name.Lexeme));
-            base.VisitAssign(expression);
-        }
-
-        protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
-        {
-            if (expression.Name.Lexeme == "Map")
-                IntrinsicMapIsObservable = true;
-            Disqualified.Add((_scope, expression.Name.Lexeme));
-            base.VisitCompoundAssign(expression);
-        }
-
-        protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
-        {
-            if (expression.Name.Lexeme == "Map")
-                IntrinsicMapIsObservable = true;
-            Disqualified.Add((_scope, expression.Name.Lexeme));
-            base.VisitLogicalAssign(expression);
-        }
-
-        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expression)
-        {
-            if (expression.Operand is Expr.Variable variable)
-                Disqualified.Add((_scope, variable.Name.Lexeme));
-            base.VisitPrefixIncrement(expression);
-        }
-
-        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expression)
-        {
-            if (expression.Operand is Expr.Variable variable)
-                Disqualified.Add((_scope, variable.Name.Lexeme));
-            base.VisitPostfixIncrement(expression);
+            base.OnVariableWrite(name);
         }
     }
 }

--- a/src/SharpTS/Compilation/StableMapIterationAnalyzer.cs
+++ b/src/SharpTS/Compilation/StableMapIterationAnalyzer.cs
@@ -1,5 +1,4 @@
 using SharpTS.Parsing;
-using SharpTS.Parsing.Visitors;
 using SharpTS.TypeSystem;
 
 namespace SharpTS.Compilation;
@@ -53,49 +52,18 @@ internal static class StableMapIterationAnalyzer
     private static bool IsNumber(TypeInfo? type) =>
         type is TypeInfo.Primitive { Type: TokenType.TYPE_NUMBER } or TypeInfo.NumberLiteral;
 
-    private sealed class ReceiverVisitor(TypeMap typeMap) : AstVisitorBase
+    private sealed class ReceiverVisitor(TypeMap typeMap) : FunctionScopedBindingVisitor
     {
         private readonly TypeMap _typeMap = typeMap;
-        private readonly Stack<(int Scope, string Name)> _activeMapIterations = new();
+        private readonly Stack<FunctionScopedBinding> _activeMapIterations = new();
         private Expr.Call? _discardedCall;
-        private int _scope;
-        private int _nextScope;
 
-        public HashSet<(int Scope, string Name)> Candidates { get; } = [];
-        public HashSet<(int Scope, string Name)> Disqualified { get; } = [];
-        public Dictionary<(int Scope, string Name), int> DeclarationCounts { get; } = [];
-        public Dictionary<(int Scope, string Name), List<Stmt.ForOf>> Loops { get; } = [];
+        public HashSet<FunctionScopedBinding> Candidates { get; } = [];
+        public Dictionary<FunctionScopedBinding, List<Stmt.ForOf>> Loops { get; } = [];
         public bool ContainsDirectEval { get; private set; }
 
-        protected override void VisitFunction(Stmt.Function statement) =>
-            InScope(() => base.VisitFunction(statement));
-
-        protected override void VisitArrowFunction(Expr.ArrowFunction expression) =>
-            InScope(() => base.VisitArrowFunction(expression));
-
-        private void InScope(Action visit)
+        protected override void OnDeclaration(FunctionScopedBinding key, Token name, Expr? initializer)
         {
-            int saved = _scope;
-            _scope = ++_nextScope;
-            visit();
-            _scope = saved;
-        }
-
-        protected override void VisitVar(Stmt.Var statement)
-        {
-            HandleDeclaration(statement.Name, statement.Initializer);
-        }
-
-        protected override void VisitConst(Stmt.Const statement)
-        {
-            HandleDeclaration(statement.Name, statement.Initializer);
-        }
-
-        private void HandleDeclaration(Token name, Expr? initializer)
-        {
-            var key = (_scope, name.Lexeme);
-            DeclarationCounts[key] = DeclarationCounts.GetValueOrDefault(key) + 1;
-
             if (initializer is Expr.New
                 {
                     Callee: Expr.Variable { Name.Lexeme: "Map" },
@@ -107,16 +75,13 @@ internal static class StableMapIterationAnalyzer
             {
                 Candidates.Add(key);
             }
-
-            if (initializer != null)
-                Visit(initializer);
         }
 
         protected override void VisitForOf(Stmt.ForOf statement)
         {
             if (statement.Iterable is Expr.Variable receiver)
             {
-                var key = (_scope, receiver.Name.Lexeme);
+                var key = Binding(receiver.Name);
                 if (!Loops.TryGetValue(key, out var loops))
                     Loops[key] = loops = [];
                 loops.Add(statement);
@@ -159,7 +124,7 @@ internal static class StableMapIterationAnalyzer
                 && IsNumber(_typeMap.Get(key))
                 && IsNumber(_typeMap.Get(value))
                 && ReferenceEquals(expression, _discardedCall)
-                && !_activeMapIterations.Contains((_scope, receiver.Name.Lexeme)))
+                && !_activeMapIterations.Contains(Binding(receiver.Name)))
             {
                 Visit(key);
                 Visit(value);
@@ -197,42 +162,10 @@ internal static class StableMapIterationAnalyzer
         }
 
         protected override void VisitVariable(Expr.Variable expression) =>
-            Disqualified.Add((_scope, expression.Name.Lexeme));
-
-        protected override void VisitAssign(Expr.Assign expression)
-        {
-            Disqualified.Add((_scope, expression.Name.Lexeme));
-            base.VisitAssign(expression);
-        }
-
-        protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
-        {
-            Disqualified.Add((_scope, expression.Name.Lexeme));
-            base.VisitCompoundAssign(expression);
-        }
-
-        protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
-        {
-            Disqualified.Add((_scope, expression.Name.Lexeme));
-            base.VisitLogicalAssign(expression);
-        }
-
-        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expression)
-        {
-            if (expression.Operand is Expr.Variable variable)
-                Disqualified.Add((_scope, variable.Name.Lexeme));
-            base.VisitPrefixIncrement(expression);
-        }
-
-        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expression)
-        {
-            if (expression.Operand is Expr.Variable variable)
-                Disqualified.Add((_scope, variable.Name.Lexeme));
-            base.VisitPostfixIncrement(expression);
-        }
+            Disqualified.Add(Binding(expression.Name));
     }
 
-    private sealed class EntryUseVisitor(string entryName) : AstVisitorBase
+    private sealed class EntryUseVisitor(string entryName) : VariableWriteVisitor
     {
         private readonly string _entryName = entryName;
         public bool Safe { get; private set; } = true;
@@ -323,25 +256,10 @@ internal static class StableMapIterationAnalyzer
                 Safe = false;
         }
 
-        protected override void VisitAssign(Expr.Assign expression)
+        protected override void OnVariableWrite(Token name)
         {
-            if (expression.Name.Lexeme == _entryName)
+            if (name.Lexeme == _entryName)
                 Safe = false;
-            base.VisitAssign(expression);
-        }
-
-        protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
-        {
-            if (expression.Name.Lexeme == _entryName)
-                Safe = false;
-            base.VisitCompoundAssign(expression);
-        }
-
-        protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
-        {
-            if (expression.Name.Lexeme == _entryName)
-                Safe = false;
-            base.VisitLogicalAssign(expression);
         }
 
         protected override void VisitPrefixIncrement(Expr.PrefixIncrement expression)

--- a/src/SharpTS/Compilation/StablePrimitivePromiseThenAnalyzer.cs
+++ b/src/SharpTS/Compilation/StablePrimitivePromiseThenAnalyzer.cs
@@ -1,5 +1,4 @@
 using SharpTS.Parsing;
-using SharpTS.Parsing.Visitors;
 using SharpTS.TypeSystem;
 
 namespace SharpTS.Compilation;
@@ -131,55 +130,27 @@ internal static class StablePrimitivePromiseThenAnalyzer
         };
     }
 
-    private sealed class BindingVisitor(TypeMap typeMap) : AstVisitorBase
+    private sealed class BindingVisitor(TypeMap typeMap) : FunctionScopedBindingVisitor
     {
         private readonly TypeMap _typeMap = typeMap;
-        private int _scope;
-        private int _nextScope;
         private Expr.Assign? _linearAssignmentStatement;
 
-        public HashSet<(int Scope, string Name)> Candidates { get; } = [];
-        public HashSet<(int Scope, string Name)> Disqualified { get; } = [];
-        public Dictionary<(int Scope, string Name), int> DeclarationCounts { get; } = [];
-        public Dictionary<(int Scope, string Name), int> TerminalCounts { get; } = [];
-        public Dictionary<(int Scope, string Name), List<Expr.Get>> Calls { get; } = [];
+        public HashSet<FunctionScopedBinding> Candidates { get; } = [];
+        public Dictionary<FunctionScopedBinding, int> TerminalCounts { get; } = [];
+        public Dictionary<FunctionScopedBinding, List<Expr.Get>> Calls { get; } = [];
         public HashSet<Expr.Get> DirectSeedCalls { get; } = new(ReferenceEqualityComparer.Instance);
-        private HashSet<(int Scope, string Name)> Terminated { get; } = [];
+        private HashSet<FunctionScopedBinding> Terminated { get; } = [];
 
-        protected override void VisitFunction(Stmt.Function statement) =>
-            InScope(() => base.VisitFunction(statement));
-
-        protected override void VisitArrowFunction(Expr.ArrowFunction expression) =>
-            InScope(() => base.VisitArrowFunction(expression));
-
-        private void InScope(Action visit)
+        protected override void OnDeclaration(FunctionScopedBinding key, Token name, Expr? initializer)
         {
-            int saved = _scope;
-            _scope = ++_nextScope;
-            visit();
-            _scope = saved;
-        }
-
-        protected override void VisitVar(Stmt.Var statement) =>
-            HandleDeclaration(statement.Name, statement.Initializer);
-
-        protected override void VisitConst(Stmt.Const statement) =>
-            HandleDeclaration(statement.Name, statement.Initializer);
-
-        private void HandleDeclaration(Token name, Expr? initializer)
-        {
-            var key = (_scope, name.Lexeme);
-            DeclarationCounts[key] = DeclarationCounts.GetValueOrDefault(key) + 1;
             // Top-level bindings can be observed through ESM exports (including
             // under an imported alias), so this deliberately remains a local-
             // binding optimization. Function-local bindings cannot become live
             // module cells unless another use below proves that they escape.
-            if (_scope != 0
+            if (key.Scope != 0
                 && initializer is not null
                 && IsIntrinsicResolveSeed(initializer))
                 Candidates.Add(key);
-            if (initializer is not null)
-                Visit(initializer);
         }
 
         protected override void VisitExpression(Stmt.Expression statement)
@@ -198,7 +169,7 @@ internal static class StablePrimitivePromiseThenAnalyzer
 
         protected override void VisitAssign(Expr.Assign expression)
         {
-            var key = (_scope, expression.Name.Lexeme);
+            var key = Binding(expression.Name);
             // The assignment's resulting value is itself observable when it is
             // nested in another expression (for example, consume(chain = ...)).
             // Only a discarded expression statement proves that no intermediate
@@ -215,7 +186,6 @@ internal static class StablePrimitivePromiseThenAnalyzer
                 return;
             }
 
-            Disqualified.Add(key);
             base.VisitAssign(expression);
         }
 
@@ -228,7 +198,7 @@ internal static class StablePrimitivePromiseThenAnalyzer
                     // Only `chain = chain.then(handler)` is a linear append.
                     // A bare or sibling call observes a distinct intermediate
                     // Promise and therefore cannot share the fused carrier.
-                    Disqualified.Add((_scope, receiver.Name.Lexeme));
+                    Disqualified.Add(Binding(receiver.Name));
                     VisitEligibleArguments(call);
                     return;
                 }
@@ -245,7 +215,7 @@ internal static class StablePrimitivePromiseThenAnalyzer
             base.VisitCall(expression);
         }
 
-        private void RecordCall((int Scope, string Name) key, Expr.Get method)
+        private void RecordCall(FunctionScopedBinding key, Expr.Get method)
         {
             if (!Calls.TryGetValue(key, out var calls))
                 Calls[key] = calls = [];
@@ -262,7 +232,7 @@ internal static class StablePrimitivePromiseThenAnalyzer
         {
             if (ExpressionUnwrapper.Unwrap(expression.Expression) is Expr.Variable variable)
             {
-                RecordTerminal((_scope, variable.Name.Lexeme));
+                RecordTerminal(Binding(variable.Name));
                 return;
             }
             base.VisitAwait(expression);
@@ -273,45 +243,19 @@ internal static class StablePrimitivePromiseThenAnalyzer
             if (statement.Value is not null
                 && ExpressionUnwrapper.Unwrap(statement.Value) is Expr.Variable variable)
             {
-                RecordTerminal((_scope, variable.Name.Lexeme));
+                RecordTerminal(Binding(variable.Name));
                 return;
             }
             base.VisitReturn(statement);
         }
 
-        private void RecordTerminal((int Scope, string Name) key)
+        private void RecordTerminal(FunctionScopedBinding key)
         {
             TerminalCounts[key] = TerminalCounts.GetValueOrDefault(key) + 1;
             Terminated.Add(key);
         }
 
         protected override void VisitVariable(Expr.Variable expression) =>
-            Disqualified.Add((_scope, expression.Name.Lexeme));
-
-        protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
-        {
-            Disqualified.Add((_scope, expression.Name.Lexeme));
-            base.VisitCompoundAssign(expression);
-        }
-
-        protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
-        {
-            Disqualified.Add((_scope, expression.Name.Lexeme));
-            base.VisitLogicalAssign(expression);
-        }
-
-        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expression)
-        {
-            if (expression.Operand is Expr.Variable variable)
-                Disqualified.Add((_scope, variable.Name.Lexeme));
-            base.VisitPrefixIncrement(expression);
-        }
-
-        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expression)
-        {
-            if (expression.Operand is Expr.Variable variable)
-                Disqualified.Add((_scope, variable.Name.Lexeme));
-            base.VisitPostfixIncrement(expression);
-        }
+            Disqualified.Add(Binding(expression.Name));
     }
 }

--- a/src/SharpTS/Compilation/TypedArrayHoistAnalyzer.cs
+++ b/src/SharpTS/Compilation/TypedArrayHoistAnalyzer.cs
@@ -1,5 +1,4 @@
 using SharpTS.Parsing;
-using SharpTS.Parsing.Visitors;
 using SharpTS.TypeSystem;
 
 namespace SharpTS.Compilation;
@@ -106,15 +105,11 @@ public static class TypedArrayHoistAnalyzer
             new(ReferenceEqualityComparer.Instance);
     }
 
-    private sealed class StableBackingVisitor(TypeMap typeMap) : AstVisitorBase
+    private sealed class StableBackingVisitor(TypeMap typeMap) : FunctionScopedBindingVisitor
     {
         private readonly TypeMap _typeMap = typeMap;
-        private int _scope;
-        private int _nextScope;
 
-        public Dictionary<(int Scope, string Name), StableBackingCandidate> Candidates { get; } = [];
-        public Dictionary<(int Scope, string Name), int> DeclarationCounts { get; } = [];
-        public HashSet<(int Scope, string Name)> Disqualified { get; } = [];
+        public Dictionary<FunctionScopedBinding, StableBackingCandidate> Candidates { get; } = [];
         public bool ContainsDirectEval { get; private set; }
         public bool IntrinsicConstructorIsObservable { get; private set; }
 
@@ -122,31 +117,11 @@ public static class TypedArrayHoistAnalyzer
         {
             if (TypedArrayElementLayout.IsSupportedConstructor(statement.Name.Lexeme))
                 IntrinsicConstructorIsObservable = true;
-            InScope(() => base.VisitFunction(statement));
+            base.VisitFunction(statement);
         }
 
-        protected override void VisitArrowFunction(Expr.ArrowFunction expression) =>
-            InScope(() => base.VisitArrowFunction(expression));
-
-        private void InScope(Action visit)
+        protected override void OnDeclaration(FunctionScopedBinding key, Token name, Expr? initializer)
         {
-            int saved = _scope;
-            _scope = ++_nextScope;
-            visit();
-            _scope = saved;
-        }
-
-        protected override void VisitVar(Stmt.Var statement) =>
-            HandleDeclaration(statement.Name, statement.Initializer);
-
-        protected override void VisitConst(Stmt.Const statement) =>
-            HandleDeclaration(statement.Name, statement.Initializer);
-
-        private void HandleDeclaration(Token name, Expr? initializer)
-        {
-            var key = (_scope, name.Lexeme);
-            DeclarationCounts[key] = DeclarationCounts.GetValueOrDefault(key) + 1;
-
             if (TypedArrayElementLayout.IsSupportedConstructor(name.Lexeme))
                 IntrinsicConstructorIsObservable = true;
 
@@ -162,9 +137,6 @@ public static class TypedArrayHoistAnalyzer
             {
                 Candidates.TryAdd(key, new StableBackingCandidate(typedArray.ElementType));
             }
-
-            if (initializer != null)
-                Visit(initializer);
         }
 
         protected override void VisitNew(Expr.New expression)
@@ -257,7 +229,7 @@ public static class TypedArrayHoistAnalyzer
                 return false;
             }
 
-            var key = (_scope, receiver.Name.Lexeme);
+            var key = Binding(receiver.Name);
             if (Candidates.TryGetValue(key, out var candidate)
                 && candidate.ElementType == typedArray.ElementType)
             {
@@ -270,46 +242,14 @@ public static class TypedArrayHoistAnalyzer
         {
             if (TypedArrayElementLayout.IsSupportedConstructor(expression.Name.Lexeme))
                 IntrinsicConstructorIsObservable = true;
-            Disqualified.Add((_scope, expression.Name.Lexeme));
+            Disqualified.Add(Binding(expression.Name));
         }
 
-        protected override void VisitAssign(Expr.Assign expression)
+        protected override void OnVariableWrite(Token name)
         {
-            NoteAssignment(expression.Name.Lexeme);
-            base.VisitAssign(expression);
-        }
-
-        protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
-        {
-            NoteAssignment(expression.Name.Lexeme);
-            base.VisitCompoundAssign(expression);
-        }
-
-        protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
-        {
-            NoteAssignment(expression.Name.Lexeme);
-            base.VisitLogicalAssign(expression);
-        }
-
-        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expression)
-        {
-            if (expression.Operand is Expr.Variable variable)
-                NoteAssignment(variable.Name.Lexeme);
-            base.VisitPrefixIncrement(expression);
-        }
-
-        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expression)
-        {
-            if (expression.Operand is Expr.Variable variable)
-                NoteAssignment(variable.Name.Lexeme);
-            base.VisitPostfixIncrement(expression);
-        }
-
-        private void NoteAssignment(string name)
-        {
-            if (TypedArrayElementLayout.IsSupportedConstructor(name))
+            if (TypedArrayElementLayout.IsSupportedConstructor(name.Lexeme))
                 IntrinsicConstructorIsObservable = true;
-            Disqualified.Add((_scope, name));
+            base.OnVariableWrite(name);
         }
 
         private static bool IsDirectCompoundOperator(TokenType op) => op is
@@ -319,7 +259,7 @@ public static class TypedArrayHoistAnalyzer
             TokenType.GREATER_GREATER_EQUAL;
     }
 
-    private sealed class TypedArrayAccessVisitor(TypeMap typeMap) : AstVisitorBase
+    private sealed class TypedArrayAccessVisitor(TypeMap typeMap) : VariableWriteVisitor
     {
         private readonly TypeMap _typeMap = typeMap;
 
@@ -347,37 +287,7 @@ public static class TypedArrayHoistAnalyzer
             base.VisitCompoundSetIndex(expr);
         }
 
-        protected override void VisitAssign(Expr.Assign expr)
-        {
-            Reassigned.Add(expr.Name.Lexeme);
-            base.VisitAssign(expr);
-        }
-
-        protected override void VisitCompoundAssign(Expr.CompoundAssign expr)
-        {
-            Reassigned.Add(expr.Name.Lexeme);
-            base.VisitCompoundAssign(expr);
-        }
-
-        protected override void VisitLogicalAssign(Expr.LogicalAssign expr)
-        {
-            Reassigned.Add(expr.Name.Lexeme);
-            base.VisitLogicalAssign(expr);
-        }
-
-        protected override void VisitPrefixIncrement(Expr.PrefixIncrement expr)
-        {
-            if (expr.Operand is Expr.Variable variable)
-                Reassigned.Add(variable.Name.Lexeme);
-            base.VisitPrefixIncrement(expr);
-        }
-
-        protected override void VisitPostfixIncrement(Expr.PostfixIncrement expr)
-        {
-            if (expr.Operand is Expr.Variable variable)
-                Reassigned.Add(variable.Name.Lexeme);
-            base.VisitPostfixIncrement(expr);
-        }
+        protected override void OnVariableWrite(Token name) => Reassigned.Add(name.Lexeme);
 
         protected override void VisitCall(Expr.Call expr)
         {

--- a/src/SharpTS/Compilation/VariableWriteVisitor.cs
+++ b/src/SharpTS/Compilation/VariableWriteVisitor.cs
@@ -1,0 +1,46 @@
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Discovers writes to variable bindings while leaving property/index mutation policies to
+/// consumers. Destructuring writes reach these methods through AstVisitorBase's traversal of
+/// the parser's lowered assignments, including nested patterns, defaults, and rest targets.
+/// </summary>
+internal abstract class VariableWriteVisitor : AstVisitorBase
+{
+    protected abstract void OnVariableWrite(Token name);
+
+    protected override void VisitAssign(Expr.Assign expression)
+    {
+        OnVariableWrite(expression.Name);
+        base.VisitAssign(expression);
+    }
+
+    protected override void VisitCompoundAssign(Expr.CompoundAssign expression)
+    {
+        OnVariableWrite(expression.Name);
+        base.VisitCompoundAssign(expression);
+    }
+
+    protected override void VisitLogicalAssign(Expr.LogicalAssign expression)
+    {
+        OnVariableWrite(expression.Name);
+        base.VisitLogicalAssign(expression);
+    }
+
+    protected override void VisitPrefixIncrement(Expr.PrefixIncrement expression)
+    {
+        if (expression.Operand is Expr.Variable variable)
+            OnVariableWrite(variable.Name);
+        base.VisitPrefixIncrement(expression);
+    }
+
+    protected override void VisitPostfixIncrement(Expr.PostfixIncrement expression)
+    {
+        if (expression.Operand is Expr.Variable variable)
+            OnVariableWrite(variable.Name);
+        base.VisitPostfixIncrement(expression);
+    }
+}

--- a/tests/SharpTS.Tests/Compilation/OptimizationBindingScopeTests.cs
+++ b/tests/SharpTS.Tests/Compilation/OptimizationBindingScopeTests.cs
@@ -1,0 +1,229 @@
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Parsing.Visitors;
+using SharpTS.TypeSystem;
+using Xunit;
+
+namespace SharpTS.Tests.Compilation;
+
+public sealed class OptimizationBindingScopeTests
+{
+    public enum Consumer { NumericMap, MapIteration, PromiseThen, TypedArray }
+
+    public static TheoryData<Consumer, string, bool> ScopeCases
+    {
+        get
+        {
+            var cases = new TheoryData<Consumer, string, bool>();
+            foreach (var consumer in Enum.GetValues<Consumer>())
+            {
+                cases.Add(consumer, "", true);
+                // These passes intentionally merge block declarations by function and name.
+                cases.Add(consumer, "{ let value ANNOTATION = SEED; value = SEED; }", false);
+                cases.Add(consumer, "function nested(): void { let value ANNOTATION = SEED; value = SEED; }", true);
+                cases.Add(consumer, "const nested = (): void => { let value ANNOTATION = SEED; value = SEED; };", true);
+                cases.Add(consumer, "const nested = () => value;", false);
+                cases.Add(consumer, "function nested(): void {} value = SEED;", false);
+                cases.Add(consumer, "const nested = (): void => {}; value = SEED;", false);
+            }
+            return cases;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ScopeCases))]
+    public void FunctionIdentity_BlockShadowingAndCaptures_KeepConservativeProof(
+        Consumer consumer, string body, bool optimized)
+    {
+        AssertProof(consumer, body, optimized);
+    }
+
+    public static TheoryData<Consumer, string> WriteCases
+    {
+        get
+        {
+            var cases = new TheoryData<Consumer, string>();
+            foreach (var consumer in Enum.GetValues<Consumer>())
+            foreach (string write in new[]
+            {
+                "value = SEED;", "value ||= SEED;", "value &&= SEED;", "value ??= SEED;",
+                "[value] = [SEED];", "({ item: value } = { item: SEED });",
+                "({ item: [value] } = { item: [SEED] });"
+            })
+                cases.Add(consumer, write);
+            return cases;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(WriteCases))]
+    public void BindingWrites_DisqualifyEveryConsumer(Consumer consumer, string write) =>
+        AssertProof(consumer, write, optimized: false);
+
+    public static TheoryData<Consumer, string> UncheckedWriteCases
+    {
+        get
+        {
+            var cases = new TheoryData<Consumer, string>();
+            foreach (var consumer in Enum.GetValues<Consumer>())
+            foreach (string write in new[] { "value += 1;", "++value;", "--value;", "value++;", "value--;" })
+                cases.Add(consumer, write);
+            return cases;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(UncheckedWriteCases))]
+    public void NonNumericBindingUpdates_AreConservativeEvenForUncheckedAst(Consumer consumer, string write) =>
+        AssertProof(consumer, "", optimized: false, uncheckedWrite: write);
+
+    [Theory]
+    [InlineData("", true)]
+    [InlineData("data[0]++;", true)]
+    [InlineData("data = new Int32Array(1);", false)]
+    [InlineData("data ||= new Int32Array(1);", false)]
+    [InlineData("[data] = [new Int32Array(1)];", false)]
+    [InlineData("{ const data = new Int32Array(1); }", false)]
+    [InlineData("const nested = () => { data = new Int32Array(1); };", false)]
+    public void LoopReceiverScan_RetainsNameBasedWriteAndDeclarationPolicy(string body, bool hoisted)
+    {
+        string source = $$"""
+            function exercise(data: Int32Array): void {
+                for (let i = 0; i < 1; i++) {
+                    data[0] = 1;
+                    {{body}}
+                }
+            }
+            """;
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var function = Assert.IsType<Stmt.Function>(Assert.Single(statements));
+        var loop = Assert.IsType<Stmt.For>(Assert.Single(function.Body!));
+        var candidates = TypedArrayHoistAnalyzer.AnalyzeFor(loop.Body, loop.Condition, loop.Increment, typeMap);
+        Assert.Equal(hoisted, candidates.ContainsKey("data"));
+    }
+
+    [Theory]
+    [InlineData("", true)]
+    [InlineData("entry = replacement;", false)]
+    [InlineData("entry ||= replacement;", false)]
+    [InlineData("[entry] = [replacement];", false)]
+    [InlineData("entry[0]++;", false)]
+    [InlineData("++entry[1];", false)]
+    [InlineData("{ const entry = [3, 4]; }", false)]
+    public void MapEntryScan_RetainsBindingAndElementMutationPolicy(string body, bool optimized)
+    {
+        string source = $$"""
+            function exercise(): void {
+                const replacement: [number, number] = [3, 4];
+                const map = new Map<number, number>();
+                map.set(1, 2);
+                for (let entry of map) {
+                    {{body}}
+                    console.log(entry[0] + entry[1]);
+                }
+            }
+            """;
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        var closures = new ClosureAnalyzer();
+        closures.Analyze(statements);
+        StableMapIterationAnalyzer.Analyze(statements, typeMap, closures);
+        var proof = new ProofVisitor(typeMap);
+        proof.Visit(Assert.Single(statements));
+        Assert.Equal(optimized, proof.Optimized);
+    }
+
+    private static void AssertProof(Consumer consumer, string body, bool optimized, string? uncheckedWrite = null)
+    {
+        string seed = consumer switch
+        {
+            Consumer.NumericMap or Consumer.MapIteration => "new Map<number, number>()",
+            Consumer.PromiseThen => "Promise.resolve(0)",
+            Consumer.TypedArray => "new Int32Array(4)",
+            _ => throw new ArgumentOutOfRangeException(nameof(consumer))
+        };
+        string use = consumer switch
+        {
+            Consumer.NumericMap => "value.set(1, 2); return value.size;",
+            Consumer.MapIteration => "value.set(1, 2); for (const entry of value) { const sum = entry[0] + entry[1]; } return 0;",
+            Consumer.PromiseThen => "value = value.then((n: number): number => n + 1); return value;",
+            Consumer.TypedArray => "value[0] = 1; return value[0];",
+            _ => throw new ArgumentOutOfRangeException(nameof(consumer))
+        };
+        string returnType = consumer == Consumer.PromiseThen ? "Promise<number>" : "number";
+        string annotation = consumer == Consumer.PromiseThen ? ": Promise<number>" : "";
+        string source = $$"""
+            function exercise(): {{returnType}} {
+                let value{{annotation}} = {{seed}};
+                {{body.Replace("SEED", seed).Replace("ANNOTATION", annotation)}}
+                {{use}}
+            }
+            """;
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        var typeMap = new TypeChecker().Check(statements);
+        if (uncheckedWrite != null)
+        {
+            // Numeric updates on Map/Promise/TypedArray bindings are rejected by the checker.
+            // Exercise the analyzer's write proof directly on an otherwise checked candidate.
+            var function = Assert.IsType<Stmt.Function>(Assert.Single(statements));
+            function.Body!.InsertRange(1, new Parser(new Lexer(uncheckedWrite).ScanTokens()).ParseOrThrow());
+        }
+        var closures = new ClosureAnalyzer();
+        closures.Analyze(statements);
+        switch (consumer)
+        {
+            case Consumer.NumericMap:
+                NumericMapLocalPromotionAnalyzer.Analyze(statements, typeMap, closures);
+                break;
+            case Consumer.MapIteration:
+                StableMapIterationAnalyzer.Analyze(statements, typeMap, closures);
+                break;
+            case Consumer.PromiseThen:
+                StablePrimitivePromiseThenAnalyzer.Analyze(statements, typeMap, closures,
+                    PromiseMutationAnalyzer.HasObservableMutation(statements, typeMap));
+                break;
+            case Consumer.TypedArray:
+                TypedArrayHoistAnalyzer.Analyze(statements, typeMap, closures);
+                break;
+        }
+        var proof = new ProofVisitor(typeMap);
+        foreach (var statement in statements)
+            proof.Visit(statement);
+        Assert.Equal(optimized, proof.Optimized);
+    }
+
+    private sealed class ProofVisitor(TypeMap typeMap) : AstVisitorBase
+    {
+        public bool Optimized { get; private set; }
+
+        protected override void VisitFunction(Stmt.Function statement)
+        {
+            if (statement.Name.Lexeme == "exercise")
+                base.VisitFunction(statement);
+        }
+
+        protected override void VisitArrowFunction(Expr.ArrowFunction expression) { }
+
+        protected override void VisitVar(Stmt.Var statement)
+        {
+            Optimized |= typeMap.IsPromotableNumericMapLocal(statement.Name);
+            base.VisitVar(statement);
+        }
+
+        protected override void VisitVariable(Expr.Variable expression) =>
+            Optimized |= typeMap.IsStableTypedArrayBackingReceiver(expression);
+
+        protected override void VisitGet(Expr.Get expression)
+        {
+            Optimized |= typeMap.IsStablePrimitivePromiseThen(expression);
+            base.VisitGet(expression);
+        }
+
+        protected override void VisitForOf(Stmt.ForOf statement)
+        {
+            Optimized |= typeMap.IsStableNumericMapIteration(statement);
+            base.VisitForOf(statement);
+        }
+    }
+}

--- a/tests/SharpTS.Tests/Compilation/VariableWriteVisitorTests.cs
+++ b/tests/SharpTS.Tests/Compilation/VariableWriteVisitorTests.cs
@@ -1,0 +1,110 @@
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using Xunit;
+
+namespace SharpTS.Tests.Compilation;
+
+public sealed class VariableWriteVisitorTests
+{
+    [Theory]
+    [InlineData("x = 1;", "x")]
+    [InlineData("x += 1;", "x")]
+    [InlineData("x -= 1;", "x")]
+    [InlineData("x *= 1;", "x")]
+    [InlineData("x /= 1;", "x")]
+    [InlineData("x %= 1;", "x")]
+    [InlineData("x &= 1;", "x")]
+    [InlineData("x |= 1;", "x")]
+    [InlineData("x ^= 1;", "x")]
+    [InlineData("x <<= 1;", "x")]
+    [InlineData("x >>= 1;", "x")]
+    [InlineData("x >>>= 1;", "x")]
+    [InlineData("x ||= 1;", "x")]
+    [InlineData("x &&= 1;", "x")]
+    [InlineData("x ??= 1;", "x")]
+    [InlineData("++x;", "x")]
+    [InlineData("--x;", "x")]
+    [InlineData("x++;", "x")]
+    [InlineData("x--;", "x")]
+    [InlineData("x = (y += 1);", "x,y")]
+    [InlineData("[x, , ...y] = source;", "x,y")]
+    [InlineData("({ field: x, ...y } = source);", "x,y")]
+    [InlineData("({ field: [x = (y = 1)] } = source);", "x,y")]
+    [InlineData("({ [y = 'key']: x } = source);", "x,y")]
+    [InlineData("let [x, ...y] = source;", "")]
+    [InlineData("const { field: x } = source;", "")]
+    [InlineData("obj.x = 1; obj.x += 1; obj.x ||= 1; obj.x++; ++obj.x;", "")]
+    [InlineData("obj[x] = 1; obj[x] += 1; obj[x] ??= 1; obj[x]++; ++obj[x];", "")]
+    [InlineData("obj[x = 0] += (y = 1);", "x,y")]
+    [InlineData("[obj.x, obj[y = 0]] = source;", "y")]
+    public void DiscoversBindingWrites_AndTraversesValuesAndLoweredPatterns(string source, string expected)
+    {
+        var visitor = new WriteVisitor();
+        foreach (var statement in Parse(source))
+            visitor.Visit(statement);
+        Assert.Equal(expected, string.Join(",", visitor.Writes));
+    }
+
+    [Fact]
+    public void FunctionAndArrowDefaults_UseTheirOwnScope_AndRestoreTheirParent()
+    {
+        var visitor = new ScopeVisitor();
+        foreach (var statement in Parse("""
+            let value = 0;
+            function outer(parameter = (value = 1)) {
+                let value = 2;
+                { const value = 3; }
+                const arrow = (parameter = (value = 4)) => { value = 5; };
+                value = 6;
+            }
+            value = 7;
+            function sibling() { let value = 8; }
+            """))
+            visitor.Visit(statement);
+
+        Assert.Equal(new[] { 1, 2, 2, 1, 0 }, visitor.Writes.Select(binding => binding.Scope));
+        Assert.All(visitor.Writes, binding => Assert.Equal("value", binding.Name));
+        Assert.Equal(1, visitor.DeclarationCounts[new(0, "value")]);
+        Assert.Equal(2, visitor.DeclarationCounts[new(1, "value")]);
+        Assert.Equal(1, visitor.DeclarationCounts[new(3, "value")]);
+        Assert.DoesNotContain(visitor.DeclarationCounts.Keys, binding => binding.Name == "parameter");
+    }
+
+    [Theory]
+    [InlineData("function outer() { let fail = 1; }")]
+    [InlineData("const arrow = () => { let fail = 1; };")]
+    [InlineData("function outer() { const arrow = () => { let fail = 1; }; }")]
+    public void AbortedNestedTraversal_RestoresProgramScope(string source)
+    {
+        var visitor = new ScopeVisitor();
+        Assert.Throws<InvalidOperationException>(() => visitor.Visit(Assert.Single(Parse(source))));
+        visitor.Visit(Assert.Single(Parse("value = 1;")));
+        Assert.Equal(new FunctionScopedBinding(0, "value"), Assert.Single(visitor.Writes));
+    }
+
+    private static List<Stmt> Parse(string source) =>
+        new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+
+    private sealed class WriteVisitor : VariableWriteVisitor
+    {
+        public List<string> Writes { get; } = [];
+        protected override void OnVariableWrite(Token name) => Writes.Add(name.Lexeme);
+    }
+
+    private sealed class ScopeVisitor : FunctionScopedBindingVisitor
+    {
+        public List<FunctionScopedBinding> Writes { get; } = [];
+
+        protected override void OnVariableWrite(Token name)
+        {
+            Writes.Add(Binding(name));
+            base.OnVariableWrite(name);
+        }
+
+        protected override void OnDeclaration(FunctionScopedBinding binding, Token name, Expr? initializer)
+        {
+            if (name.Lexeme == "fail")
+                throw new InvalidOperationException("Abort the traversal inside the nested scope.");
+        }
+    }
+}

--- a/tests/SharpTS.Tests/SharedTests/OptimizationBindingParityTests.cs
+++ b/tests/SharpTS.Tests/SharedTests/OptimizationBindingParityTests.cs
@@ -1,0 +1,70 @@
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.SharedTests;
+
+public sealed class OptimizationBindingParityTests
+{
+    private const string Source = """
+        function containers(): void {
+            let map = new Map<number, number>();
+            map.set(1, 2);
+            let data = new Int32Array(1);
+            data[0] = 3;
+            {
+                const map = new Map<number, number>();
+                map.set(8, 9);
+                const data = new Int32Array(1);
+                data[0] = 11;
+                console.log(map.size + data[0]);
+            }
+            function nested(): number {
+                const map = new Map<number, number>();
+                map.set(1, 6);
+                const data = new Int32Array(1);
+                data[0] = 7;
+                return map.size + data[0];
+            }
+            console.log(nested());
+            [map] = [new Map<number, number>()];
+            map.set(4, 5);
+            ({ data } = { data: new Int32Array(1) });
+            data[0] = 9;
+            let sum: number = 0;
+            for (const entry of map) sum += entry[0] + entry[1];
+            console.log(sum + data[0]);
+            const capture = (): number => map.size + data[0];
+            console.log(capture());
+        }
+        async function promises(): Promise<void> {
+            let chain: Promise<number> = Promise.resolve(1);
+            {
+                let chain: Promise<number> = Promise.resolve(40);
+                chain = chain.then((n: number): number => n + 2);
+                console.log(await chain);
+            }
+            const nested = (): Promise<number> => {
+                let chain: Promise<number> = Promise.resolve(2);
+                chain = chain.then((n: number): number => n + 3);
+                return chain;
+            };
+            console.log(await nested());
+            [chain] = [Promise.resolve(3)];
+            chain = chain.then((n: number): number => n + 4);
+            const capture = (): Promise<number> => chain;
+            console.log(await capture());
+        }
+        containers();
+        promises();
+        """;
+
+    private const string Expected = "12\n8\n18\n10\n42\n5\n7\n";
+
+    [Theory, ModeData]
+    public void ShadowedNestedCapturedAndDestructuredBindings_PreserveOutput(ExecutionMode mode) =>
+        Assert.Equal(Expected, TestHarness.Run(Source, mode));
+
+    [Fact]
+    public void ShadowedNestedCapturedAndDestructuredBindings_PreserveStandaloneOutput() =>
+        Assert.Equal(Expected, TestHarness.RunCompiledStandalone(Source));
+}


### PR DESCRIPTION
The Map promotion, stable Map iteration, primitive Promise.then, and TypedArray analyses duplicated function scopes, declaration counts, and binding-write handlers. Extract that bookkeeping into `FunctionScopedBindingVisitor` and `VariableWriteVisitor`, and reuse write discovery in the TypedArray loop and Map entry scans.

Keep each optimization's candidate selection, allowed uses, capture checks, terminal-use rules, and intrinsic mutation policies. Function/name identities explicitly retain conservative block-shadowing behavior; scope restoration now uses `finally`. Bookkeeping stays within existing traversals, with no additional whole-program walk or change to the shared `PromiseMutationAnalyzer`.

Validation:
- 90 characterization cases passed against the original analyzers, covering positive cases, nested scopes, shadowing, captures, and disqualifying writes.
- Fresh Release build and 276 focused tests passed on the refactor, including ordinary/compound/logical/prefix/postfix writes, lowered destructuring, compiled optimization checks, interpreter/compiler parity, IL verification, and standalone output.
- `scripts/test-code-quality.ps1` passed (zero errors); `git diff --check` passed.

Closes #1617.
