### PR TITLE
Remove write-only EmittedRuntime metadata holders

### DIFF
--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -140,7 +140,6 @@ public class EmittedRuntime
     // class creates its prototype through a compiler-only constructor and
     // registers it here when the class definition is evaluated.
     public Type ClassPrototypeMarkerType { get; set; } = null!;
-    public FieldBuilder ClassPrototypeCacheField { get; set; } = null!;
     public MethodBuilder GetClassPrototypeMethod { get; set; } = null!;
     public MethodBuilder RegisterClassPrototypeMethod { get; set; } = null!;
 
@@ -338,11 +337,8 @@ public class EmittedRuntime
     public MethodBuilder ArrayEntries { get; set; } = null!;
     public MethodBuilder ArrayKeys { get; set; } = null!;
     public MethodBuilder ArrayValues { get; set; } = null!;
-    public TypeBuilder ArrayIteratorType { get; set; } = null!;
     public ConstructorBuilder ArrayIteratorCtor { get; set; } = null!;
-    public TypeBuilder MapCollectionIteratorType { get; set; } = null!;
     public ConstructorBuilder MapCollectionIteratorCtor { get; set; } = null!;
-    public TypeBuilder SetCollectionIteratorType { get; set; } = null!;
     public ConstructorBuilder SetCollectionIteratorCtor { get; set; } = null!;
     public MethodBuilder ArrayLikeMaterialize { get; set; } = null!;
     // ECMA-262 RequireObjectCoercible(this) — throws TypeError if `this` is
@@ -980,7 +976,6 @@ public class EmittedRuntime
     public Dictionary<string, MethodBuilder> CompactObjectRecordIsMaterializedGetters { get; } = [];
     public Dictionary<string, MethodBuilder> CompactObjectRecordTryGetMaterializedDictionary { get; } = [];
     public MethodBuilder JsonScalarRecordShapeGetter { get; set; } = null!;
-    public MethodBuilder JsonScalarRecordValuesGetter { get; set; } = null!;
     public MethodBuilder JsonScalarRecordGetValue { get; set; } = null!;
     public MethodBuilder JsonScalarRecordIsMaterializedGetter { get; set; } = null!;
     public TypeBuilder TSRawJsonType { get; set; } = null!;
@@ -1119,8 +1114,6 @@ public class EmittedRuntime
     public MethodBuilder PromiseResolveValueMethod { get; set; } = null!;
     public MethodBuilder AdoptPromiseCombinatorResultMethod { get; set; } = null!;
     public MethodBuilder SettlePromiseCombinatorResultMethod { get; set; } = null!;
-    /// <summary>Custom NewPromiseCapability results that must not participate in SharpTS's non-standard top-level expression auto-await.</summary>
-    public FieldBuilder NonAutoAwaitPromisesField { get; set; } = null!;
     public MethodBuilder MarkNonAutoAwaitPromiseMethod { get; set; } = null!;
     public MethodBuilder ShouldAutoAwaitPromiseMethod { get; set; } = null!;
     /// <summary>$Runtime.CoerceAwaitableToTask(object value) -> Task&lt;object?&gt; — the await coercion for a value that is neither a $Promise nor a Task&lt;object?&gt;: an ordinary thenable (a value whose <c>then</c> member is callable) is adopted by invoking <c>then(resolve, reject)</c> into a fresh capability (#349); anything else becomes Task.FromResult(value). Called at every state-machine await's wrap-value site.</summary>
@@ -1454,7 +1447,6 @@ public class EmittedRuntime
     public MethodBuilder TSRegExpProtoToString { get; set; } = null!;
     public MethodBuilder TSRegExpTestMethod { get; set; } = null!;
     public MethodBuilder TSRegExpExecMethod { get; set; } = null!;
-    public MethodBuilder TSRegExpToStringMethod { get; set; } = null!;
     public MethodBuilder TSRegExpReplaceMethod { get; set; } = null!;
     // ECMA-262 (ES2025) RegExp.escape static — emitted standalone on $RegExp.
     public MethodBuilder TSRegExpEscapeMethod { get; set; } = null!;
@@ -2239,7 +2231,6 @@ public class EmittedRuntime
     public MethodBuilder TSKeyObjectImportDer { get; set; } = null!;
     public MethodBuilder TSKeyObjectGetOption { get; set; } = null!;
     public MethodBuilder TSKeyObjectDeriveSecret { get; set; } = null!;
-    public MethodBuilder CryptoDiffieHellman { get; set; } = null!;
 
     // HTTP module methods
     public MethodBuilder Fetch { get; set; } = null!;
@@ -2266,7 +2257,6 @@ public class EmittedRuntime
     // $HttpServer type - emitted for standalone HTTP server support
     public TypeBuilder TSHttpServerType { get; set; } = null!;
     public ConstructorBuilder TSHttpServerCtor { get; set; } = null!;
-    public MethodBuilder TSHttpServerClose { get; set; } = null!;
     public MethodBuilder TSHttpServerAddress { get; set; } = null!;
 
     // $HttpRequest type - emitted for standalone HTTP request support

--- a/src/SharpTS/Compilation/RuntimeEmitter.CryptoHelpers.KeyObject.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.CryptoHelpers.KeyObject.cs
@@ -459,7 +459,6 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object]);
-        runtime.CryptoDiffieHellman = method;
         var il = method.GetILGenerator();
         var privateKeyLocal = il.DeclareLocal(_types.Object);
         var publicKeyLocal = il.DeclareLocal(_types.Object);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Iterator.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Iterator.cs
@@ -22,7 +22,6 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.IEnumeratorOfObject, _types.IEnumerator, _types.IDisposable,
              _types.IEnumerableOfObject, _types.IEnumerable]);
-        runtime.ArrayIteratorType = typeBuilder;
 
         var arrayField = typeBuilder.DefineField(
             "_array", _types.ListOfObject, FieldAttributes.Private | FieldAttributes.InitOnly);
@@ -241,7 +240,6 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.IEnumeratorOfObject, _types.IEnumerator, _types.IDisposable,
              _types.IEnumerableOfObject, _types.IEnumerable]);
-        runtime.MapCollectionIteratorType = typeBuilder;
 
         var mapField = typeBuilder.DefineField("_map", _types.DictionaryObjectObject,
             FieldAttributes.Private | FieldAttributes.InitOnly);
@@ -441,7 +439,6 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.IEnumeratorOfObject, _types.IEnumerator, _types.IDisposable,
              _types.IEnumerableOfObject, _types.IEnumerable]);
-        runtime.SetCollectionIteratorType = typeBuilder;
 
         var setField = typeBuilder.DefineField("_set", _types.HashSetOfObject,
             FieldAttributes.Private | FieldAttributes.InitOnly);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.ScalarRecord.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.ScalarRecord.cs
@@ -58,7 +58,6 @@ public partial class RuntimeEmitter
             MethodAttributes.HideBySig,
             _types.ObjectArray,
             Type.EmptyTypes);
-        runtime.JsonScalarRecordValuesGetter = valuesGetter;
         var baseValuesIl = valuesGetter.GetILGenerator();
         baseValuesIl.Emit(OpCodes.Ldnull);
         baseValuesIl.Emit(OpCodes.Ret);

--- a/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -252,7 +252,6 @@ public partial class RuntimeEmitter
             "_classPrototypeCache",
             classPrototypeCacheType,
             FieldAttributes.Private | FieldAttributes.Static | FieldAttributes.InitOnly);
-        runtime.ClassPrototypeCacheField = classPrototypeCacheField;
         EmitClassPrototypeSupport(typeBuilder, runtime, classPrototypeCacheField);
 
         // CheckCancellation(): if (_cancelRequested) throw new
@@ -413,7 +412,6 @@ public partial class RuntimeEmitter
                 _types.ConditionalWeakTable,
                 FieldAttributes.Public | FieldAttributes.Static | FieldAttributes.InitOnly
             );
-            runtime.NonAutoAwaitPromisesField = nonAutoAwaitPromisesField;
 
             var markNonAutoAwaitPromise = typeBuilder.DefineMethod(
                 "MarkNonAutoAwaitPromise",

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSHttpServer.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSHttpServer.cs
@@ -2084,7 +2084,6 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.Object]
         );
-        runtime.TSHttpServerClose = method;
 
         var il = method.GetILGenerator();
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSRegExp.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSRegExp.cs
@@ -130,7 +130,7 @@ public partial class RuntimeEmitter
         EmitTSRegExpResolveLastIndex(typeBuilder, runtime);
         EmitTSRegExpTest(typeBuilder, runtime);
         EmitTSRegExpExec(typeBuilder, runtime);
-        EmitTSRegExpToStringMethod(typeBuilder, runtime);
+        EmitTSRegExpToStringMethod(typeBuilder);
         EmitTSRegExpEscape(typeBuilder, runtime);
 
         // Internal methods for string operations
@@ -2004,7 +2004,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitTSRegExpToStringMethod(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTSRegExpToStringMethod(TypeBuilder typeBuilder)
     {
         // public override string ToString() => $"/{_source}/{_flags}"
         var method = typeBuilder.DefineMethod(
@@ -2013,7 +2013,6 @@ public partial class RuntimeEmitter
             _types.String,
             Type.EmptyTypes
         );
-        runtime.TSRegExpToStringMethod = method;
 
         var il = method.GetILGenerator();
 


### PR DESCRIPTION
Removes the nine write-only `EmittedRuntime` properties from #1618 and their assignments, reducing shared mutable compiler metadata without changing emitted runtime members. Also removes the now-unused `EmittedRuntime` parameter from the private RegExp `ToString` emitter.

Closes #1618.

The reference audit was repeated on current main (`c0faeae0`), including source, tests, benchmarks, documentation/configuration, literal property names, and reflection over the holder. Each candidate had only its declaration and assignment; no reflective consumer or supported external API obligation was identified. `CONTRIBUTING.md` distinguishes public compiler implementation types from supported consumer APIs, and the documented embedding APIs do not expose these properties. No candidate was retained.

The emitted implementation and its live handles remain intact:

- Class prototype cache definition, helper calls, and static initialization.
- Array/Map/Set iterator types, constructor handles used by iterator factories, and `CreateType()` calls.
- JSON scalar-record values getter body and derived override.
- Promise auto-await weak table, initialization, and mark/query helpers.
- RegExp `ToString` override, crypto `diffieHellman` module registration, and HTTP server `Close` body/finalization.

All existing emitter locals still have consumers and are retained.

Validation:

- Core Release build: passed, zero warnings/errors.
- `scripts/test-code-quality.ps1`: passed, including analyzer fixtures and unused-emitter/duplicate gates.
- Focused Release regression suite: 2,357 passed, 0 failed, 2 existing Windows wildcard-URL-ACL skips. Covers runtime-type synchronization and reflection boundaries, iterators/collections, JSON, Promise, RegExp, crypto, HTTP, standalone output, class prototypes, and IL verification. Excludes the standard LiveNetwork/LoadSensitive/npm categories. Tests ran outside the sandbox so Windows HTTP listeners and cryptographic operations were available.
- `git diff --check`: passed.

