### PR TITLE
Extract Promise runtime metadata into a checked feature component

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -208,6 +208,17 @@ and module registration remain separate dependencies. Migrated type/method handl
 emitter fields. Socket/server fields, other transport methods, and closure construction state remain
 local to the emitter.
 
+Promise uses `Promise` / `RequirePromise()` for its 77 type, capability, resolving-callback,
+combinator, prototype, adoption, and reaction handles. `EmitAll` starts it for `UsesPromise`,
+including implied async/module features and hosted emission. Adoption helpers are declared before
+resolving callbacks, and capability helpers before static wrappers; later body emitters reuse those
+declarations. Completion follows runtime and dependent-type finalization. Promise type emission,
+task wrapping, and capability-only helpers accept `EmittedPromiseRuntime` directly. State-machine
+carriers and the Promise task field stay local to the emitter. The shared FIFO `QueuePromiseJob`,
+timer/stream Promise APIs, and filesystem/module registries remain owned by their respective
+infrastructure or feature families; they are not duplicate Promise handles and remain in the
+residual migration scope of #1599.
+
 During emission, each handle becomes readable as soon as its declaration is assigned, so forward
 references do not require a method body to exist yet. An early read names the missing declaration.
 Completion is an orchestration boundary, not an IL verifier: body emission and type finalization

--- a/src/SharpTS/Compilation/AsyncFunctionMoveNextEmitter.Await.cs
+++ b/src/SharpTS/Compilation/AsyncFunctionMoveNextEmitter.Await.cs
@@ -213,7 +213,7 @@ public abstract partial class AsyncFunctionMoveNextEmitter
         var haveTaskLabel = IL.DefineLabel();
 
         IL.Emit(OpCodes.Dup);
-        IL.Emit(OpCodes.Isinst, Ctx.Runtime!.TSPromiseType);
+        IL.Emit(OpCodes.Isinst, Ctx.Runtime!.RequirePromise().Type);
         IL.Emit(OpCodes.Brtrue, isPromiseLabel);
 
         IL.Emit(OpCodes.Dup);
@@ -223,7 +223,7 @@ public abstract partial class AsyncFunctionMoveNextEmitter
         IL.MarkLabel(wrapValueLabel);
         // Adopt an ordinary thenable (e.g. a general non-Promise then/catch/finally
         // species result, #349); non-thenables become Task.FromResult(value).
-        IL.Emit(OpCodes.Call, Ctx.Runtime!.CoerceAwaitableToTaskMethod);
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.RequirePromise().CoerceAwaitableToTaskMethod);
         IL.Emit(OpCodes.Stloc, taskLocal);
         IL.Emit(OpCodes.Br, haveTaskLabel);
 
@@ -233,8 +233,8 @@ public abstract partial class AsyncFunctionMoveNextEmitter
         IL.Emit(OpCodes.Br, haveTaskLabel);
 
         IL.MarkLabel(isPromiseLabel);
-        IL.Emit(OpCodes.Castclass, Ctx.Runtime.TSPromiseType);
-        IL.Emit(OpCodes.Callvirt, Ctx.Runtime.TSPromiseTaskGetter);
+        IL.Emit(OpCodes.Castclass, Ctx.Runtime.RequirePromise().Type);
+        IL.Emit(OpCodes.Callvirt, Ctx.Runtime.RequirePromise().TaskGetter);
         IL.Emit(OpCodes.Stloc, taskLocal);
 
         IL.MarkLabel(haveTaskLabel);

--- a/src/SharpTS/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
+++ b/src/SharpTS/Compilation/AsyncGeneratorMoveNextEmitter.Expressions.cs
@@ -416,7 +416,7 @@ public partial class AsyncGeneratorMoveNextEmitter
         var haveTaskLabel = _il.DefineLabel();
 
         _il.Emit(OpCodes.Dup);
-        _il.Emit(OpCodes.Isinst, _ctx!.Runtime!.TSPromiseType);
+        _il.Emit(OpCodes.Isinst, _ctx!.Runtime!.RequirePromise().Type);
         _il.Emit(OpCodes.Brtrue, isPromiseLabel);
 
         // Not a $Promise - check if it's a Task<object>
@@ -428,7 +428,7 @@ public partial class AsyncGeneratorMoveNextEmitter
         // non-Promise then/catch/finally species result, #349); non-thenables
         // become Task.FromResult(value).
         _il.MarkLabel(wrapValueLabel);
-        _il.Emit(OpCodes.Call, _ctx!.Runtime!.CoerceAwaitableToTaskMethod);
+        _il.Emit(OpCodes.Call, _ctx!.Runtime!.RequirePromise().CoerceAwaitableToTaskMethod);
         _il.Emit(OpCodes.Stloc, taskLocal);
         _il.Emit(OpCodes.Br, haveTaskLabel);
 
@@ -440,8 +440,8 @@ public partial class AsyncGeneratorMoveNextEmitter
 
         // Is a $Promise - extract its Task property
         _il.MarkLabel(isPromiseLabel);
-        _il.Emit(OpCodes.Castclass, _ctx.Runtime.TSPromiseType);
-        _il.Emit(OpCodes.Callvirt, _ctx.Runtime.TSPromiseTaskGetter);
+        _il.Emit(OpCodes.Castclass, _ctx.Runtime.RequirePromise().Type);
+        _il.Emit(OpCodes.Callvirt, _ctx.Runtime.RequirePromise().TaskGetter);
         _il.Emit(OpCodes.Stloc, taskLocal);
 
         _il.MarkLabel(haveTaskLabel);

--- a/src/SharpTS/Compilation/CallHandlers/SuperConstructorHandler.cs
+++ b/src/SharpTS/Compilation/CallHandlers/SuperConstructorHandler.cs
@@ -53,7 +53,7 @@ public class SuperConstructorHandler : ICallHandler
         // Built-in Promise (#242): run the executor through
         // PromiseFromExecutor and chain the resulting Task<object?> to
         // $Promise's constructor.
-        if (ctx.CurrentSuperclassName == "Promise" && ctx.Runtime?.TSPromiseCtor != null)
+        if (ctx.CurrentSuperclassName == "Promise" && ctx.Runtime?.Promise is not null)
         {
             EmitSuperPromiseCtorCall(emitter, call.Arguments);
             return true;
@@ -246,8 +246,8 @@ public class SuperConstructorHandler : ICallHandler
         {
             il.Emit(OpCodes.Ldnull);
         }
-        il.Emit(OpCodes.Call, ctx.Runtime!.PromiseFromExecutor);
-        il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseCtor);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().FromExecutor);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().Ctor);
 
         il.Emit(OpCodes.Ldnull); // super() returns undefined
         emitter.SetStackUnknown();

--- a/src/SharpTS/Compilation/EmittedPromiseRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedPromiseRuntime.cs
@@ -1,0 +1,690 @@
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Promise metadata for one compilation. Declarations support forward references;
+/// completion validates every handle and freezes the component for consumers.
+/// </summary>
+public sealed class EmittedPromiseRuntime
+{
+    internal EmittedPromiseRuntime() { }
+
+    public bool IsComplete { get; private set; }
+
+    private FieldBuilder? _prototypeField;
+    /// <summary>Promise.prototype singleton dict (ECMA-262 §27.2.5): then/catch/finally/constructor + @@toStringTag.</summary>
+    public FieldBuilder PrototypeField
+    {
+        get => Require(_prototypeField);
+        internal set => Set(ref _prototypeField, value);
+    }
+
+    private MethodBuilder? _prototypePopulateMethod;
+    /// <summary>Idempotent populate for <see cref="PrototypeField"/>.</summary>
+    public MethodBuilder PrototypePopulateMethod
+    {
+        get => Require(_prototypePopulateMethod);
+        internal set => Set(ref _prototypePopulateMethod, value);
+    }
+
+    private MethodBuilder? _thenHelperMethod;
+    /// <summary>$Runtime.PromiseThenHelper(__this, args) — wraps PromiseThen for Promise.prototype.then.call patterns.</summary>
+    public MethodBuilder ThenHelperMethod
+    {
+        get => Require(_thenHelperMethod);
+        internal set => Set(ref _thenHelperMethod, value);
+    }
+
+    private MethodBuilder? _catchHelperMethod;
+    /// <summary>$Runtime.PromiseCatchHelper(__this, args) — wraps PromiseCatch for Promise.prototype.catch.call patterns.</summary>
+    public MethodBuilder CatchHelperMethod
+    {
+        get => Require(_catchHelperMethod);
+        internal set => Set(ref _catchHelperMethod, value);
+    }
+
+    private MethodBuilder? _finallyHelperMethod;
+    /// <summary>$Runtime.PromiseFinallyHelper(__this, args) — wraps PromiseFinally for Promise.prototype.finally.call patterns.</summary>
+    public MethodBuilder FinallyHelperMethod
+    {
+        get => Require(_finallyHelperMethod);
+        internal set => Set(ref _finallyHelperMethod, value);
+    }
+
+    // Promise support
+    private MethodBuilder? _resolve;
+    public MethodBuilder Resolve
+    {
+        get => Require(_resolve);
+        internal set => Set(ref _resolve, value);
+    }
+
+    private MethodBuilder? _reject;
+    public MethodBuilder Reject
+    {
+        get => Require(_reject);
+        internal set => Set(ref _reject, value);
+    }
+
+    // Value-form `Promise.resolve` / `Promise.reject` wrappers that validate
+    // `this` is Object per ECMA-262 §27.2.5.1 step 2. Used by the $TSFunction
+    // value-form path so `let r = Promise.resolve; r.call(undefined, x)` throws.
+    private MethodBuilder? _resolveStatic;
+    public MethodBuilder ResolveStatic
+    {
+        get => Require(_resolveStatic);
+        internal set => Set(ref _resolveStatic, value);
+    }
+
+    private MethodBuilder? _rejectStatic;
+    public MethodBuilder RejectStatic
+    {
+        get => Require(_rejectStatic);
+        internal set => Set(ref _rejectStatic, value);
+    }
+
+    // Same pattern for all/race/allSettled/any — value-form invocation must
+    // validate `this` is Object before delegating to the iteration helper.
+    private MethodBuilder? _allStatic;
+    public MethodBuilder AllStatic
+    {
+        get => Require(_allStatic);
+        internal set => Set(ref _allStatic, value);
+    }
+
+    private MethodBuilder? _allKeyedStatic;
+    public MethodBuilder AllKeyedStatic
+    {
+        get => Require(_allKeyedStatic);
+        internal set => Set(ref _allKeyedStatic, value);
+    }
+
+    private MethodBuilder? _raceStatic;
+    public MethodBuilder RaceStatic
+    {
+        get => Require(_raceStatic);
+        internal set => Set(ref _raceStatic, value);
+    }
+
+    private MethodBuilder? _allSettledStatic;
+    public MethodBuilder AllSettledStatic
+    {
+        get => Require(_allSettledStatic);
+        internal set => Set(ref _allSettledStatic, value);
+    }
+
+    private MethodBuilder? _allSettledKeyedStatic;
+    public MethodBuilder AllSettledKeyedStatic
+    {
+        get => Require(_allSettledKeyedStatic);
+        internal set => Set(ref _allSettledKeyedStatic, value);
+    }
+
+    private MethodBuilder? _anyStatic;
+    public MethodBuilder AnyStatic
+    {
+        get => Require(_anyStatic);
+        internal set => Set(ref _anyStatic, value);
+    }
+
+    private MethodBuilder? _all;
+    public MethodBuilder All
+    {
+        get => Require(_all);
+        internal set => Set(ref _all, value);
+    }
+
+    private MethodBuilder? _allPrimitive;
+    public MethodBuilder AllPrimitive
+    {
+        get => Require(_allPrimitive);
+        internal set => Set(ref _allPrimitive, value);
+    }
+
+    private MethodBuilder? _allKeyed;
+    public MethodBuilder AllKeyed
+    {
+        get => Require(_allKeyed);
+        internal set => Set(ref _allKeyed, value);
+    }
+
+    private MethodBuilder? _race;
+    public MethodBuilder Race
+    {
+        get => Require(_race);
+        internal set => Set(ref _race, value);
+    }
+
+    private MethodBuilder? _then;
+    public MethodBuilder Then
+    {
+        get => Require(_then);
+        internal set => Set(ref _then, value);
+    }
+
+    private MethodBuilder? _thenObjectPrimitive;
+    /// <summary>$Runtime.PromiseThenObjectPrimitive(Task&lt;object?&gt;, Func&lt;object,object&gt;) -> Task&lt;object?&gt; — fulfillment-only direct Promise.all reaction whose boxed callback result is statically primitive.</summary>
+    public MethodBuilder ThenObjectPrimitive
+    {
+        get => Require(_thenObjectPrimitive);
+        internal set => Set(ref _thenObjectPrimitive, value);
+    }
+
+    private MethodBuilder? _thenPrimitive;
+    /// <summary>$Runtime.PromiseThenPrimitive(Task&lt;object?&gt;, Func&lt;double,double&gt;) -> Task&lt;object?&gt; — stable intrinsic fulfillment-only numeric continuation whose primitive callback result cannot require thenable adoption.</summary>
+    public MethodBuilder ThenPrimitive
+    {
+        get => Require(_thenPrimitive);
+        internal set => Set(ref _thenPrimitive, value);
+    }
+
+    private MethodBuilder? _thenPrimitiveWithRejection;
+    /// <summary>$Runtime.PromiseThenPrimitiveWithRejection(Task&lt;object?&gt;, Func&lt;double,double&gt;, Func&lt;object,double&gt;) -> Task&lt;object?&gt; — stable intrinsic numeric continuation with a typed rejection handler and no thenable-result adoption.</summary>
+    public MethodBuilder ThenPrimitiveWithRejection
+    {
+        get => Require(_thenPrimitiveWithRejection);
+        internal set => Set(ref _thenPrimitiveWithRejection, value);
+    }
+
+    private MethodBuilder? _catch;
+    public MethodBuilder Catch
+    {
+        get => Require(_catch);
+        internal set => Set(ref _catch, value);
+    }
+
+    private MethodBuilder? _finally;
+    public MethodBuilder Finally
+    {
+        get => Require(_finally);
+        internal set => Set(ref _finally, value);
+    }
+
+    private MethodBuilder? _trackTopLevelPromiseReaction;
+    /// <summary>Keeps standalone event-loop execution alive until a discarded top-level Promise reaction settles, without pumping it before the current script job completes.</summary>
+    public MethodBuilder TrackTopLevelPromiseReaction
+    {
+        get => Require(_trackTopLevelPromiseReaction);
+        internal set => Set(ref _trackTopLevelPromiseReaction, value);
+    }
+
+    private MethodBuilder? _allSettled;
+    public MethodBuilder AllSettled
+    {
+        get => Require(_allSettled);
+        internal set => Set(ref _allSettled, value);
+    }
+
+    private MethodBuilder? _allSettledKeyed;
+    public MethodBuilder AllSettledKeyed
+    {
+        get => Require(_allSettledKeyed);
+        internal set => Set(ref _allSettledKeyed, value);
+    }
+
+    private MethodBuilder? _keyedMapResult;
+    public MethodBuilder KeyedMapResult
+    {
+        get => Require(_keyedMapResult);
+        internal set => Set(ref _keyedMapResult, value);
+    }
+
+    private MethodBuilder? _any;
+    public MethodBuilder Any
+    {
+        get => Require(_any);
+        internal set => Set(ref _any, value);
+    }
+
+    private MethodBuilder? _fromExecutor;
+    public MethodBuilder FromExecutor
+    {
+        get => Require(_fromExecutor);
+        internal set => Set(ref _fromExecutor, value);
+    }
+
+    private MethodBuilder? _fromDirectExecutor;
+    /// <summary>$Runtime.PromiseFromDirectExecutor(Func&lt;object,object,object&gt;) -> Task&lt;object?&gt; — compiler-only fast path for an inline, two-argument Promise executor arrow whose CLR signature is known. Avoids materializing a $TSFunction and redispatching the executor through InvokeMethodValue.</summary>
+    public MethodBuilder FromDirectExecutor
+    {
+        get => Require(_fromDirectExecutor);
+        internal set => Set(ref _fromDirectExecutor, value);
+    }
+
+    private MethodBuilder? _withResolvers;
+    public MethodBuilder WithResolvers
+    {
+        get => Require(_withResolvers);
+        internal set => Set(ref _withResolvers, value);
+    }
+
+    private MethodBuilder? _unwrapPromiseReceiverMethod;
+    /// <summary>$Runtime.UnwrapPromiseReceiver(object) -> Task&lt;object?&gt; — $Promise (incl. #242 subclasses) → .Task; anything else is cast to Task&lt;object?&gt;. Used by then/catch/finally emission so promise-typed receivers work regardless of representation.</summary>
+    public MethodBuilder UnwrapPromiseReceiverMethod
+    {
+        get => Require(_unwrapPromiseReceiverMethod);
+        internal set => Set(ref _unwrapPromiseReceiverMethod, value);
+    }
+
+    private MethodBuilder? _normalizePromiseListMethod;
+    /// <summary>$Runtime.NormalizePromiseList(object, object, object, int, bool) -> object — incrementally resolves and wires Promise combinator elements while preserving observable iterator order. Kind 3 is Promise.all; the final flag selects a compiler-proven stable primitive input.</summary>
+    public MethodBuilder NormalizePromiseListMethod
+    {
+        get => Require(_normalizePromiseListMethod);
+        internal set => Set(ref _normalizePromiseListMethod, value);
+    }
+
+    private MethodBuilder? _wrapDerivedPromiseResultMethod;
+    /// <summary>$Runtime.WrapDerivedPromiseResult(Task&lt;object?&gt; result, object receiver) -> object — completes species-based result construction for subclass then/catch/finally results after ObservePromiseConstructor has performed the synchronous own-constructor access (#242). For a $Promise SUBCLASS species, constructs a receiver-typed promise around the result task via the subclass's (object executor) constructor (PromiseFromExecutor adopts the task); for a general non-Promise species, routes to NewPromiseCapabilityResult (#349); for %Promise% (or no subclass receiver) returns the task unchanged.</summary>
+    public MethodBuilder WrapDerivedPromiseResultMethod
+    {
+        get => Require(_wrapDerivedPromiseResultMethod);
+        internal set => Set(ref _wrapDerivedPromiseResultMethod, value);
+    }
+
+    private MethodBuilder? _observePromiseConstructorMethod;
+    /// <summary>$Runtime.ObservePromiseConstructor(object receiver) -> void — synchronously performs the observable own <c>constructor</c> getter step before a then/catch/finally reaction is scheduled. WrapDerivedPromiseResult handles the remaining species/result construction after the reaction task exists.</summary>
+    public MethodBuilder ObservePromiseConstructorMethod
+    {
+        get => Require(_observePromiseConstructorMethod);
+        internal set => Set(ref _observePromiseConstructorMethod, value);
+    }
+
+    private MethodBuilder? _newPromiseCapabilityResultMethod;
+    /// <summary>$Runtime.NewPromiseCapabilityResult(object species, Task&lt;object?&gt; result) -> object — the general NewPromiseCapability (#349/#390): constructs <c>new species(executor)</c> through ConstructDynamicValue (a Type class species → Activator, a function-valued species → the JS new protocol, a non-constructor → TypeError per §7.3.22 step 5), capturing the resolve/reject the executor is handed via a <see cref="CapabilityType"/> holder, then adopts <c>result</c> into that capability (settlement scheduled on the event-loop SynchronizationContext) and returns the constructed (non-Promise) object. Body emitted late (after ConstructDynamicValue); the stub is pre-declared so WrapDerivedPromiseResult can call it.</summary>
+    public MethodBuilder NewPromiseCapabilityResultMethod
+    {
+        get => Require(_newPromiseCapabilityResultMethod);
+        internal set => Set(ref _newPromiseCapabilityResultMethod, value);
+    }
+
+    private MethodBuilder? _preparePromiseCapabilityMethod;
+    /// <summary>$Runtime.PreparePromiseCapability(object constructor) -> object — synchronously performs NewPromiseCapability through construction and callable resolve/reject validation, returning the opaque capability holder. Promise static wrappers call this before starting their operation so constructor side effects and validation have spec order.</summary>
+    public MethodBuilder PreparePromiseCapabilityMethod
+    {
+        get => Require(_preparePromiseCapabilityMethod);
+        internal set => Set(ref _preparePromiseCapabilityMethod, value);
+    }
+
+    private MethodBuilder? _adoptPromiseCapabilityMethod;
+    /// <summary>$Runtime.AdoptPromiseCapability(object capability, Task&lt;object?&gt; result) -> object — schedules settlement of a prepared capability from <c>result</c> and returns its constructed promise object.</summary>
+    public MethodBuilder AdoptPromiseCapabilityMethod
+    {
+        get => Require(_adoptPromiseCapabilityMethod);
+        internal set => Set(ref _adoptPromiseCapabilityMethod, value);
+    }
+
+    private MethodBuilder? _adoptCompletedPromiseCapabilityMethod;
+    public MethodBuilder AdoptCompletedPromiseCapabilityMethod
+    {
+        get => Require(_adoptCompletedPromiseCapabilityMethod);
+        internal set => Set(ref _adoptCompletedPromiseCapabilityMethod, value);
+    }
+
+    private MethodBuilder? _resolvePreparedPromiseCapabilityMethod;
+    public MethodBuilder ResolvePreparedPromiseCapabilityMethod
+    {
+        get => Require(_resolvePreparedPromiseCapabilityMethod);
+        internal set => Set(ref _resolvePreparedPromiseCapabilityMethod, value);
+    }
+
+    private MethodBuilder? _getPromiseCapabilityResolveMethod;
+    public MethodBuilder GetPromiseCapabilityResolveMethod
+    {
+        get => Require(_getPromiseCapabilityResolveMethod);
+        internal set => Set(ref _getPromiseCapabilityResolveMethod, value);
+    }
+
+    private MethodBuilder? _getPromiseCapabilityRejectMethod;
+    public MethodBuilder GetPromiseCapabilityRejectMethod
+    {
+        get => Require(_getPromiseCapabilityRejectMethod);
+        internal set => Set(ref _getPromiseCapabilityRejectMethod, value);
+    }
+
+    private MethodBuilder? _resolveValueMethod;
+    public MethodBuilder ResolveValueMethod
+    {
+        get => Require(_resolveValueMethod);
+        internal set => Set(ref _resolveValueMethod, value);
+    }
+
+    private MethodBuilder? _adoptPromiseCombinatorResultMethod;
+    public MethodBuilder AdoptPromiseCombinatorResultMethod
+    {
+        get => Require(_adoptPromiseCombinatorResultMethod);
+        internal set => Set(ref _adoptPromiseCombinatorResultMethod, value);
+    }
+
+    private MethodBuilder? _settlePromiseCombinatorResultMethod;
+    public MethodBuilder SettlePromiseCombinatorResultMethod
+    {
+        get => Require(_settlePromiseCombinatorResultMethod);
+        internal set => Set(ref _settlePromiseCombinatorResultMethod, value);
+    }
+
+    private MethodBuilder? _markNonAutoAwaitPromiseMethod;
+    public MethodBuilder MarkNonAutoAwaitPromiseMethod
+    {
+        get => Require(_markNonAutoAwaitPromiseMethod);
+        internal set => Set(ref _markNonAutoAwaitPromiseMethod, value);
+    }
+
+    private MethodBuilder? _shouldAutoAwaitPromiseMethod;
+    public MethodBuilder ShouldAutoAwaitPromiseMethod
+    {
+        get => Require(_shouldAutoAwaitPromiseMethod);
+        internal set => Set(ref _shouldAutoAwaitPromiseMethod, value);
+    }
+
+    private MethodBuilder? _coerceAwaitableToTaskMethod;
+    /// <summary>$Runtime.CoerceAwaitableToTask(object value) -> Task&lt;object?&gt; — the await coercion for a value that is neither a $Promise nor a Task&lt;object?&gt;: an ordinary thenable (a value whose <c>then</c> member is callable) is adopted by invoking <c>then(resolve, reject)</c> into a fresh capability (#349); anything else becomes Task.FromResult(value). Called at every state-machine await's wrap-value site.</summary>
+    public MethodBuilder CoerceAwaitableToTaskMethod
+    {
+        get => Require(_coerceAwaitableToTaskMethod);
+        internal set => Set(ref _coerceAwaitableToTaskMethod, value);
+    }
+
+    private TypeBuilder? _capabilityType;
+    /// <summary>$PromiseCapability — the host executor handed to a general (non-Promise) species constructor by NewPromiseCapabilityResult (#349): captures the resolve/reject functions (Capture, exposed as a Func&lt;object[],object&gt;) and drives them when the source task settles (Settle, an Action&lt;Task&lt;object&gt;&gt; continuation).</summary>
+    public TypeBuilder CapabilityType
+    {
+        get => Require(_capabilityType);
+        internal set => Set(ref _capabilityType, value);
+    }
+
+    private ConstructorBuilder? _capabilityCtor;
+    public ConstructorBuilder CapabilityCtor
+    {
+        get => Require(_capabilityCtor);
+        internal set => Set(ref _capabilityCtor, value);
+    }
+
+    private FieldBuilder? _capabilityResolveField;
+    public FieldBuilder CapabilityResolveField
+    {
+        get => Require(_capabilityResolveField);
+        internal set => Set(ref _capabilityResolveField, value);
+    }
+
+    private FieldBuilder? _capabilityRejectField;
+    public FieldBuilder CapabilityRejectField
+    {
+        get => Require(_capabilityRejectField);
+        internal set => Set(ref _capabilityRejectField, value);
+    }
+
+    private FieldBuilder? _capabilityInstanceField;
+    public FieldBuilder CapabilityInstanceField
+    {
+        get => Require(_capabilityInstanceField);
+        internal set => Set(ref _capabilityInstanceField, value);
+    }
+
+    private MethodBuilder? _capabilityCaptureMethod;
+    public MethodBuilder CapabilityCaptureMethod
+    {
+        get => Require(_capabilityCaptureMethod);
+        internal set => Set(ref _capabilityCaptureMethod, value);
+    }
+
+    private MethodBuilder? _capabilitySettleMethod;
+    public MethodBuilder CapabilitySettleMethod
+    {
+        get => Require(_capabilitySettleMethod);
+        internal set => Set(ref _capabilitySettleMethod, value);
+    }
+
+    private TypeBuilder? _resolveCallbackType;
+    public TypeBuilder ResolveCallbackType
+    {
+        get => Require(_resolveCallbackType);
+        internal set => Set(ref _resolveCallbackType, value);
+    }
+
+    private ConstructorBuilder? _resolveCallbackCtor;
+    public ConstructorBuilder ResolveCallbackCtor
+    {
+        get => Require(_resolveCallbackCtor);
+        internal set => Set(ref _resolveCallbackCtor, value);
+    }
+
+    private MethodBuilder? _resolveCallbackInvoke;
+    public MethodBuilder ResolveCallbackInvoke
+    {
+        get => Require(_resolveCallbackInvoke);
+        internal set => Set(ref _resolveCallbackInvoke, value);
+    }
+
+    private TypeBuilder? _rejectCallbackType;
+    public TypeBuilder RejectCallbackType
+    {
+        get => Require(_rejectCallbackType);
+        internal set => Set(ref _rejectCallbackType, value);
+    }
+
+    private ConstructorBuilder? _rejectCallbackCtor;
+    public ConstructorBuilder RejectCallbackCtor
+    {
+        get => Require(_rejectCallbackCtor);
+        internal set => Set(ref _rejectCallbackCtor, value);
+    }
+
+    private MethodBuilder? _rejectCallbackInvoke;
+    public MethodBuilder RejectCallbackInvoke
+    {
+        get => Require(_rejectCallbackInvoke);
+        internal set => Set(ref _rejectCallbackInvoke, value);
+    }
+
+    // Promise callback helpers (direct $TSFunction.Invoke without reflection)
+    private MethodBuilder? _invokeCallback;
+    public MethodBuilder InvokeCallback
+    {
+        get => Require(_invokeCallback);
+        internal set => Set(ref _invokeCallback, value);
+    }
+
+    private MethodBuilder? _invokeCallbackNoArgs;
+    public MethodBuilder InvokeCallbackNoArgs
+    {
+        get => Require(_invokeCallbackNoArgs);
+        internal set => Set(ref _invokeCallbackNoArgs, value);
+    }
+
+    // Promise type - emitted for standalone assemblies
+    // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSPromise
+    private Type? _type;
+    public Type Type
+    {
+        get => Require(_type);
+        internal set => Set(ref _type, value);
+    }
+
+    private ConstructorBuilder? _ctor;
+    public ConstructorBuilder Ctor
+    {
+        get => Require(_ctor);
+        internal set => Set(ref _ctor, value);
+    }
+
+    private MethodBuilder? _taskGetter;
+    public MethodBuilder TaskGetter
+    {
+        get => Require(_taskGetter);
+        internal set => Set(ref _taskGetter, value);
+    }
+
+    private MethodBuilder? _typeResolve;
+    public MethodBuilder TypeResolve
+    {
+        get => Require(_typeResolve);
+        internal set => Set(ref _typeResolve, value);
+    }
+
+    private MethodBuilder? _typeReject;
+    public MethodBuilder TypeReject
+    {
+        get => Require(_typeReject);
+        internal set => Set(ref _typeReject, value);
+    }
+
+    private MethodBuilder? _getValueAsync;
+    public MethodBuilder GetValueAsync
+    {
+        get => Require(_getValueAsync);
+        internal set => Set(ref _getValueAsync, value);
+    }
+
+    private MethodBuilder? _observeDiscardedPromiseResult;
+    /// <summary>
+    /// Observes a Task/$Promise returned from a callback whose result is otherwise
+    /// discarded, enabling process unhandled-rejection lifecycle events.
+    /// </summary>
+    public MethodBuilder ObserveDiscardedPromiseResult
+    {
+        get => Require(_observeDiscardedPromiseResult);
+        internal set => Set(ref _observeDiscardedPromiseResult, value);
+    }
+
+    private MethodBuilder? _notifyPromiseRejectionHandler;
+    /// <summary>
+    /// Marks a source promise handled when a callable rejection reaction is
+    /// attached through then/catch.
+    /// </summary>
+    public MethodBuilder NotifyPromiseRejectionHandler
+    {
+        get => Require(_notifyPromiseRejectionHandler);
+        internal set => Set(ref _notifyPromiseRejectionHandler, value);
+    }
+
+    // Promise rejected exception
+    private Type? _rejectedExceptionType;
+    public Type RejectedExceptionType
+    {
+        get => Require(_rejectedExceptionType);
+        internal set => Set(ref _rejectedExceptionType, value);
+    }
+
+    private ConstructorBuilder? _rejectedExceptionCtor;
+    public ConstructorBuilder RejectedExceptionCtor
+    {
+        get => Require(_rejectedExceptionCtor);
+        internal set => Set(ref _rejectedExceptionCtor, value);
+    }
+
+    private MethodBuilder? _rejectedExceptionReasonGetter;
+    public MethodBuilder RejectedExceptionReasonGetter
+    {
+        get => Require(_rejectedExceptionReasonGetter);
+        internal set => Set(ref _rejectedExceptionReasonGetter, value);
+    }
+
+    private MethodBuilder? _wrapTaskAsPromise;
+    public MethodBuilder WrapTaskAsPromise
+    {
+        get => Require(_wrapTaskAsPromise);
+        internal set => Set(ref _wrapTaskAsPromise, value);
+    }
+
+    private static T Require<T>(T? handle, [CallerMemberName] string name = "") where T : class =>
+        handle ?? throw new InvalidOperationException($"Promise metadata '{name}' has not been declared.");
+
+    private void Set<T>(ref T? field, T value) where T : class
+    {
+        EnsureMutable();
+        ArgumentNullException.ThrowIfNull(value);
+        field = value;
+    }
+
+    private void EnsureMutable()
+    {
+        if (IsComplete)
+            throw new InvalidOperationException("Promise metadata emission is already complete.");
+    }
+
+    internal void CompleteEmission()
+    {
+        EnsureMutable();
+        _ = PrototypeField;
+        _ = PrototypePopulateMethod;
+        _ = ThenHelperMethod;
+        _ = CatchHelperMethod;
+        _ = FinallyHelperMethod;
+        _ = Resolve;
+        _ = Reject;
+        _ = ResolveStatic;
+        _ = RejectStatic;
+        _ = AllStatic;
+        _ = AllKeyedStatic;
+        _ = RaceStatic;
+        _ = AllSettledStatic;
+        _ = AllSettledKeyedStatic;
+        _ = AnyStatic;
+        _ = All;
+        _ = AllPrimitive;
+        _ = AllKeyed;
+        _ = Race;
+        _ = Then;
+        _ = ThenObjectPrimitive;
+        _ = ThenPrimitive;
+        _ = ThenPrimitiveWithRejection;
+        _ = Catch;
+        _ = Finally;
+        _ = TrackTopLevelPromiseReaction;
+        _ = AllSettled;
+        _ = AllSettledKeyed;
+        _ = KeyedMapResult;
+        _ = Any;
+        _ = FromExecutor;
+        _ = FromDirectExecutor;
+        _ = WithResolvers;
+        _ = UnwrapPromiseReceiverMethod;
+        _ = NormalizePromiseListMethod;
+        _ = WrapDerivedPromiseResultMethod;
+        _ = ObservePromiseConstructorMethod;
+        _ = NewPromiseCapabilityResultMethod;
+        _ = PreparePromiseCapabilityMethod;
+        _ = AdoptPromiseCapabilityMethod;
+        _ = AdoptCompletedPromiseCapabilityMethod;
+        _ = ResolvePreparedPromiseCapabilityMethod;
+        _ = GetPromiseCapabilityResolveMethod;
+        _ = GetPromiseCapabilityRejectMethod;
+        _ = ResolveValueMethod;
+        _ = AdoptPromiseCombinatorResultMethod;
+        _ = SettlePromiseCombinatorResultMethod;
+        _ = MarkNonAutoAwaitPromiseMethod;
+        _ = ShouldAutoAwaitPromiseMethod;
+        _ = CoerceAwaitableToTaskMethod;
+        _ = CapabilityType;
+        _ = CapabilityCtor;
+        _ = CapabilityResolveField;
+        _ = CapabilityRejectField;
+        _ = CapabilityInstanceField;
+        _ = CapabilityCaptureMethod;
+        _ = CapabilitySettleMethod;
+        _ = ResolveCallbackType;
+        _ = ResolveCallbackCtor;
+        _ = ResolveCallbackInvoke;
+        _ = RejectCallbackType;
+        _ = RejectCallbackCtor;
+        _ = RejectCallbackInvoke;
+        _ = InvokeCallback;
+        _ = InvokeCallbackNoArgs;
+        _ = Type;
+        _ = Ctor;
+        _ = TaskGetter;
+        _ = TypeResolve;
+        _ = TypeReject;
+        _ = GetValueAsync;
+        _ = ObserveDiscardedPromiseResult;
+        _ = NotifyPromiseRejectionHandler;
+        _ = RejectedExceptionType;
+        _ = RejectedExceptionCtor;
+        _ = RejectedExceptionReasonGetter;
+        _ = WrapTaskAsPromise;
+        IsComplete = true;
+    }
+}

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -711,16 +711,6 @@ public class EmittedRuntime
     public FieldBuilder RegExpPrototypeField { get; set; } = null!;
     /// <summary>Idempotent populate for <see cref="RegExpPrototypeField"/>.</summary>
     public MethodBuilder RegExpPrototypePopulateMethod { get; set; } = null!;
-    /// <summary>Promise.prototype singleton dict (ECMA-262 §27.2.5): then/catch/finally/constructor + @@toStringTag.</summary>
-    public FieldBuilder PromisePrototypeField { get; set; } = null!;
-    /// <summary>Idempotent populate for <see cref="PromisePrototypeField"/>.</summary>
-    public MethodBuilder PromisePrototypePopulateMethod { get; set; } = null!;
-    /// <summary>$Runtime.PromiseThenHelper(__this, args) — wraps PromiseThen for Promise.prototype.then.call patterns.</summary>
-    public MethodBuilder PromiseThenHelperMethod { get; set; } = null!;
-    /// <summary>$Runtime.PromiseCatchHelper(__this, args) — wraps PromiseCatch for Promise.prototype.catch.call patterns.</summary>
-    public MethodBuilder PromiseCatchHelperMethod { get; set; } = null!;
-    /// <summary>$Runtime.PromiseFinallyHelper(__this, args) — wraps PromiseFinally for Promise.prototype.finally.call patterns.</summary>
-    public MethodBuilder PromiseFinallyHelperMethod { get; set; } = null!;
     /// <summary>$Runtime.FunctionProtoCall(__this, args) — ECMA-262 §20.2.3.3 Function.prototype.call. Dispatches __this with args[0] as thisArg, args[1..] as call args.</summary>
     /// <summary>$Runtime.FunctionProtoApply(__this, args) — ECMA-262 §20.2.3.1 Function.prototype.apply. Dispatches __this with args[0] as thisArg, args[1] (array-like) as call args.</summary>
     /// <summary>$Runtime.FunctionProtoBind(__this, args) — ECMA-262 §20.2.3.2 Function.prototype.bind. Returns a $BoundTSFunction (or shim) capturing __this + thisArg + boundArgs.</summary>
@@ -1054,89 +1044,18 @@ public class EmittedRuntime
     public MethodBuilder BigIntGreaterThanOrEqual { get; set; } = null!;
     public MethodBuilder UpdateNumeric { get; set; } = null!;
 
-    // Promise support
-    public MethodBuilder PromiseResolve { get; set; } = null!;
-    public MethodBuilder PromiseReject { get; set; } = null!;
-    // Value-form `Promise.resolve` / `Promise.reject` wrappers that validate
-    // `this` is Object per ECMA-262 §27.2.5.1 step 2. Used by the $TSFunction
-    // value-form path so `let r = Promise.resolve; r.call(undefined, x)` throws.
-    public MethodBuilder PromiseResolveStatic { get; set; } = null!;
-    public MethodBuilder PromiseRejectStatic { get; set; } = null!;
-    // Same pattern for all/race/allSettled/any — value-form invocation must
-    // validate `this` is Object before delegating to the iteration helper.
-    public MethodBuilder PromiseAllStatic { get; set; } = null!;
-    public MethodBuilder PromiseAllKeyedStatic { get; set; } = null!;
-    public MethodBuilder PromiseRaceStatic { get; set; } = null!;
-    public MethodBuilder PromiseAllSettledStatic { get; set; } = null!;
-    public MethodBuilder PromiseAllSettledKeyedStatic { get; set; } = null!;
-    public MethodBuilder PromiseAnyStatic { get; set; } = null!;
-    public MethodBuilder PromiseAll { get; set; } = null!;
-    public MethodBuilder PromiseAllPrimitive { get; set; } = null!;
-    public MethodBuilder PromiseAllKeyed { get; set; } = null!;
-    public MethodBuilder PromiseRace { get; set; } = null!;
-    public MethodBuilder PromiseThen { get; set; } = null!;
-    /// <summary>$Runtime.PromiseThenObjectPrimitive(Task&lt;object?&gt;, Func&lt;object,object&gt;) -> Task&lt;object?&gt; — fulfillment-only direct Promise.all reaction whose boxed callback result is statically primitive.</summary>
-    public MethodBuilder PromiseThenObjectPrimitive { get; set; } = null!;
-    /// <summary>$Runtime.PromiseThenPrimitive(Task&lt;object?&gt;, Func&lt;double,double&gt;) -> Task&lt;object?&gt; — stable intrinsic fulfillment-only numeric continuation whose primitive callback result cannot require thenable adoption.</summary>
-    public MethodBuilder PromiseThenPrimitive { get; set; } = null!;
-    /// <summary>$Runtime.PromiseThenPrimitiveWithRejection(Task&lt;object?&gt;, Func&lt;double,double&gt;, Func&lt;object,double&gt;) -> Task&lt;object?&gt; — stable intrinsic numeric continuation with a typed rejection handler and no thenable-result adoption.</summary>
-    public MethodBuilder PromiseThenPrimitiveWithRejection { get; set; } = null!;
-    public MethodBuilder PromiseCatch { get; set; } = null!;
-    public MethodBuilder PromiseFinally { get; set; } = null!;
-    /// <summary>Keeps standalone event-loop execution alive until a discarded top-level Promise reaction settles, without pumping it before the current script job completes.</summary>
-    public MethodBuilder TrackTopLevelPromiseReaction { get; set; } = null!;
-    public MethodBuilder PromiseAllSettled { get; set; } = null!;
-    public MethodBuilder PromiseAllSettledKeyed { get; set; } = null!;
-    public MethodBuilder PromiseKeyedMapResult { get; set; } = null!;
-    public MethodBuilder PromiseAny { get; set; } = null!;
-    public MethodBuilder PromiseFromExecutor { get; set; } = null!;
-    /// <summary>$Runtime.PromiseFromDirectExecutor(Func&lt;object,object,object&gt;) -> Task&lt;object?&gt; — compiler-only fast path for an inline, two-argument Promise executor arrow whose CLR signature is known. Avoids materializing a $TSFunction and redispatching the executor through InvokeMethodValue.</summary>
-    public MethodBuilder PromiseFromDirectExecutor { get; set; } = null!;
-    public MethodBuilder PromiseWithResolvers { get; set; } = null!;
-    /// <summary>$Runtime.UnwrapPromiseReceiver(object) -> Task&lt;object?&gt; — $Promise (incl. #242 subclasses) → .Task; anything else is cast to Task&lt;object?&gt;. Used by then/catch/finally emission so promise-typed receivers work regardless of representation.</summary>
-    public MethodBuilder UnwrapPromiseReceiverMethod { get; set; } = null!;
-    /// <summary>$Runtime.NormalizePromiseList(object, object, object, int, bool) -> object — incrementally resolves and wires Promise combinator elements while preserving observable iterator order. Kind 3 is Promise.all; the final flag selects a compiler-proven stable primitive input.</summary>
-    public MethodBuilder NormalizePromiseListMethod { get; set; } = null!;
-    /// <summary>$Runtime.WrapDerivedPromiseResult(Task&lt;object?&gt; result, object receiver) -> object — completes species-based result construction for subclass then/catch/finally results after ObservePromiseConstructor has performed the synchronous own-constructor access (#242). For a $Promise SUBCLASS species, constructs a receiver-typed promise around the result task via the subclass's (object executor) constructor (PromiseFromExecutor adopts the task); for a general non-Promise species, routes to NewPromiseCapabilityResult (#349); for %Promise% (or no subclass receiver) returns the task unchanged.</summary>
-    public MethodBuilder WrapDerivedPromiseResultMethod { get; set; } = null!;
-    /// <summary>$Runtime.ObservePromiseConstructor(object receiver) -> void — synchronously performs the observable own <c>constructor</c> getter step before a then/catch/finally reaction is scheduled. WrapDerivedPromiseResult handles the remaining species/result construction after the reaction task exists.</summary>
-    public MethodBuilder ObservePromiseConstructorMethod { get; set; } = null!;
-    /// <summary>$Runtime.NewPromiseCapabilityResult(object species, Task&lt;object?&gt; result) -> object — the general NewPromiseCapability (#349/#390): constructs <c>new species(executor)</c> through ConstructDynamicValue (a Type class species → Activator, a function-valued species → the JS new protocol, a non-constructor → TypeError per §7.3.22 step 5), capturing the resolve/reject the executor is handed via a <see cref="PromiseCapabilityType"/> holder, then adopts <c>result</c> into that capability (settlement scheduled on the event-loop SynchronizationContext) and returns the constructed (non-Promise) object. Body emitted late (after ConstructDynamicValue); the stub is pre-declared so WrapDerivedPromiseResult can call it.</summary>
-    public MethodBuilder NewPromiseCapabilityResultMethod { get; set; } = null!;
-    /// <summary>$Runtime.PreparePromiseCapability(object constructor) -> object — synchronously performs NewPromiseCapability through construction and callable resolve/reject validation, returning the opaque capability holder. Promise static wrappers call this before starting their operation so constructor side effects and validation have spec order.</summary>
-    public MethodBuilder PreparePromiseCapabilityMethod { get; set; } = null!;
-    /// <summary>$Runtime.AdoptPromiseCapability(object capability, Task&lt;object?&gt; result) -> object — schedules settlement of a prepared capability from <c>result</c> and returns its constructed promise object.</summary>
-    public MethodBuilder AdoptPromiseCapabilityMethod { get; set; } = null!;
-    public MethodBuilder AdoptCompletedPromiseCapabilityMethod { get; set; } = null!;
-    public MethodBuilder ResolvePreparedPromiseCapabilityMethod { get; set; } = null!;
-    public MethodBuilder GetPromiseCapabilityResolveMethod { get; set; } = null!;
-    public MethodBuilder GetPromiseCapabilityRejectMethod { get; set; } = null!;
-    public MethodBuilder PromiseResolveValueMethod { get; set; } = null!;
-    public MethodBuilder AdoptPromiseCombinatorResultMethod { get; set; } = null!;
-    public MethodBuilder SettlePromiseCombinatorResultMethod { get; set; } = null!;
-    public MethodBuilder MarkNonAutoAwaitPromiseMethod { get; set; } = null!;
-    public MethodBuilder ShouldAutoAwaitPromiseMethod { get; set; } = null!;
-    /// <summary>$Runtime.CoerceAwaitableToTask(object value) -> Task&lt;object?&gt; — the await coercion for a value that is neither a $Promise nor a Task&lt;object?&gt;: an ordinary thenable (a value whose <c>then</c> member is callable) is adopted by invoking <c>then(resolve, reject)</c> into a fresh capability (#349); anything else becomes Task.FromResult(value). Called at every state-machine await's wrap-value site.</summary>
-    public MethodBuilder CoerceAwaitableToTaskMethod { get; set; } = null!;
-    /// <summary>$PromiseCapability — the host executor handed to a general (non-Promise) species constructor by NewPromiseCapabilityResult (#349): captures the resolve/reject functions (Capture, exposed as a Func&lt;object[],object&gt;) and drives them when the source task settles (Settle, an Action&lt;Task&lt;object&gt;&gt; continuation).</summary>
-    public TypeBuilder PromiseCapabilityType { get; set; } = null!;
-    public ConstructorBuilder PromiseCapabilityCtor { get; set; } = null!;
-    public FieldBuilder PromiseCapabilityResolveField { get; set; } = null!;
-    public FieldBuilder PromiseCapabilityRejectField { get; set; } = null!;
-    public FieldBuilder PromiseCapabilityInstanceField { get; set; } = null!;
-    public MethodBuilder PromiseCapabilityCaptureMethod { get; set; } = null!;
-    public MethodBuilder PromiseCapabilitySettleMethod { get; set; } = null!;
-    public TypeBuilder PromiseResolveCallbackType { get; set; } = null!;
-    public ConstructorBuilder PromiseResolveCallbackCtor { get; set; } = null!;
-    public MethodBuilder PromiseResolveCallbackInvoke { get; set; } = null!;
-    public TypeBuilder PromiseRejectCallbackType { get; set; } = null!;
-    public ConstructorBuilder PromiseRejectCallbackCtor { get; set; } = null!;
-    public MethodBuilder PromiseRejectCallbackInvoke { get; set; } = null!;
+    /// <summary>Promise metadata, or null when Promise support is tree-shaken.</summary>
+    public EmittedPromiseRuntime? Promise { get; private set; }
 
-    // Promise callback helpers (direct $TSFunction.Invoke without reflection)
-    public MethodBuilder InvokeCallback { get; set; } = null!;
-    public MethodBuilder InvokeCallbackNoArgs { get; set; } = null!;
+    internal void BeginPromiseEmission()
+    {
+        if (Promise is not null)
+            throw new InvalidOperationException("Promise metadata emission has already started.");
+        Promise = new EmittedPromiseRuntime();
+    }
 
+    public EmittedPromiseRuntime RequirePromise() => Promise
+        ?? throw new InvalidOperationException("Promise runtime was not enabled for this compilation.");
 
     // Timer support ($TSTimeout type and global functions)
     public TypeBuilder TSTimeoutType { get; set; } = null!;
@@ -1538,33 +1457,8 @@ public class EmittedRuntime
     public ConstructorBuilder ThrownValueExceptionCtor { get; set; } = null!;
     public MethodBuilder ThrownValueExceptionValueGetter { get; set; } = null!;
 
-    // Promise type - emitted for standalone assemblies
-    // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSPromise
-    public Type TSPromiseType { get; set; } = null!;
-    public ConstructorBuilder TSPromiseCtor { get; set; } = null!;
-    public MethodBuilder TSPromiseTaskGetter { get; set; } = null!;
-    public MethodBuilder TSPromiseResolve { get; set; } = null!;
-    public MethodBuilder TSPromiseReject { get; set; } = null!;
-    public MethodBuilder TSPromiseGetValueAsync { get; set; } = null!;
-    /// <summary>
-    /// Observes a Task/$Promise returned from a callback whose result is otherwise
-    /// discarded, enabling process unhandled-rejection lifecycle events.
-    /// </summary>
-    public MethodBuilder ObserveDiscardedPromiseResult { get; set; } = null!;
-    /// <summary>
-    /// Marks a source promise handled when a callable rejection reaction is
-    /// attached through then/catch.
-    /// </summary>
-    public MethodBuilder NotifyPromiseRejectionHandler { get; set; } = null!;
-
-    // Promise rejected exception
-    public Type TSPromiseRejectedExceptionType { get; set; } = null!;
-    public ConstructorBuilder TSPromiseRejectedExceptionCtor { get; set; } = null!;
-    public MethodBuilder TSPromiseRejectedExceptionReasonGetter { get; set; } = null!;
-
     // Dynamic import support
     public MethodBuilder DynamicImportModule { get; set; } = null!;
-    public MethodBuilder WrapTaskAsPromise { get; set; } = null!;
 
     // $ArrayHole singleton — sentinel for ECMA-262 array holes (index in range but never written).
     // NOTE: Must stay in sync with SharpTS.Runtime.Types.ArrayHole

--- a/src/SharpTS/Compilation/Emitters/Modules/FsPromisesModuleEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/Modules/FsPromisesModuleEmitter.cs
@@ -98,7 +98,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         il.Emit(OpCodes.Call, ctx.Runtime!.FsReadFileAsync);
 
         // Wrap Task in Promise
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -112,7 +112,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         {
             // Return rejected promise for invalid args
             il.Emit(OpCodes.Ldstr, "path and data are required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -137,7 +137,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
 
         // Call runtime helper
         il.Emit(OpCodes.Call, ctx.Runtime!.FsWriteFileAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -150,7 +150,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count < 2)
         {
             il.Emit(OpCodes.Ldstr, "path and data are required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -171,7 +171,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         }
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsAppendFileAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -184,7 +184,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count == 0)
         {
             il.Emit(OpCodes.Ldstr, "path is required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -192,7 +192,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         emitter.EmitBoxIfNeeded(arguments[0]);
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsStatAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -205,7 +205,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count == 0)
         {
             il.Emit(OpCodes.Ldstr, "path is required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -213,7 +213,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         emitter.EmitBoxIfNeeded(arguments[0]);
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsLstatAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -226,7 +226,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count == 0)
         {
             il.Emit(OpCodes.Ldstr, "path is required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -234,7 +234,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         emitter.EmitBoxIfNeeded(arguments[0]);
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsUnlinkAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -247,7 +247,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count == 0)
         {
             il.Emit(OpCodes.Ldstr, "path is required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -265,7 +265,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         }
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsMkdirAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -278,7 +278,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count == 0)
         {
             il.Emit(OpCodes.Ldstr, "path is required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -296,7 +296,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         }
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsRmdirAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -309,7 +309,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count == 0)
         {
             il.Emit(OpCodes.Ldstr, "path is required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -327,7 +327,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         }
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsRmAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -340,7 +340,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count == 0)
         {
             il.Emit(OpCodes.Ldstr, "path is required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -358,7 +358,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         }
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsReaddirAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -371,7 +371,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count < 2)
         {
             il.Emit(OpCodes.Ldstr, "oldPath and newPath are required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -382,7 +382,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         emitter.EmitBoxIfNeeded(arguments[1]);
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsRenameAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -395,7 +395,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count < 2)
         {
             il.Emit(OpCodes.Ldstr, "src and dest are required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -416,7 +416,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         }
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsCopyFileAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -429,7 +429,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count == 0)
         {
             il.Emit(OpCodes.Ldstr, "path is required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -447,7 +447,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         }
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsAccessAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -460,7 +460,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count < 2)
         {
             il.Emit(OpCodes.Ldstr, "path and mode are required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -471,7 +471,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         emitter.EmitBoxIfNeeded(arguments[1]);
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsChmodAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -484,7 +484,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count == 0)
         {
             il.Emit(OpCodes.Ldstr, "path is required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -502,7 +502,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         }
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsTruncateAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -515,7 +515,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count < 3)
         {
             il.Emit(OpCodes.Ldstr, "path, atime, and mtime are required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -529,7 +529,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         emitter.EmitBoxIfNeeded(arguments[2]);
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsUtimesAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -542,7 +542,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count == 0)
         {
             il.Emit(OpCodes.Ldstr, "path is required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -550,7 +550,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         emitter.EmitBoxIfNeeded(arguments[0]);
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsReadlinkAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -563,7 +563,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count == 0)
         {
             il.Emit(OpCodes.Ldstr, "path is required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -571,7 +571,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         emitter.EmitBoxIfNeeded(arguments[0]);
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsRealpathAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -584,7 +584,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count < 2)
         {
             il.Emit(OpCodes.Ldstr, "target and path are required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -605,7 +605,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         }
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsSymlinkAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -618,7 +618,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count < 2)
         {
             il.Emit(OpCodes.Ldstr, "existingPath and newPath are required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -629,7 +629,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         emitter.EmitBoxIfNeeded(arguments[1]);
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsLinkAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }
@@ -642,7 +642,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         if (arguments.Count == 0)
         {
             il.Emit(OpCodes.Ldstr, "prefix is required");
-            il.Emit(OpCodes.Call, ctx.Runtime!.TSPromiseReject);
+            il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().TypeReject);
             return true;
         }
 
@@ -650,7 +650,7 @@ public sealed class FsPromisesModuleEmitter : IBuiltInModuleEmitter
         emitter.EmitBoxIfNeeded(arguments[0]);
 
         il.Emit(OpCodes.Call, ctx.Runtime!.FsMkdtempAsync);
-        il.Emit(OpCodes.Call, ctx.Runtime!.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         return true;
     }

--- a/src/SharpTS/Compilation/Emitters/PromiseStaticEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/PromiseStaticEmitter.cs
@@ -55,7 +55,7 @@ public sealed class PromiseStaticEmitter : IStaticTypeEmitterStrategy
                 {
                     il.Emit(OpCodes.Ldnull);
                 }
-                il.Emit(OpCodes.Call, ctx.Runtime!.PromiseResolve);
+                il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().Resolve);
                 return true;
 
             case "reject":
@@ -69,7 +69,7 @@ public sealed class PromiseStaticEmitter : IStaticTypeEmitterStrategy
                 {
                     il.Emit(OpCodes.Ldnull);
                 }
-                il.Emit(OpCodes.Call, ctx.Runtime!.PromiseReject);
+                il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().Reject);
                 return true;
 
             case "all":
@@ -88,13 +88,13 @@ public sealed class PromiseStaticEmitter : IStaticTypeEmitterStrategy
                 il.Emit(OpCodes.Call,
                     arguments.Count > 0
                     && ctx.TypeMap?.IsStablePrimitivePromiseAllIterable(arguments[0]) == true
-                        ? ctx.Runtime!.PromiseAllPrimitive
-                        : ctx.Runtime!.PromiseAll);
+                        ? ctx.Runtime!.RequirePromise().AllPrimitive
+                        : ctx.Runtime!.RequirePromise().All);
                 return true;
 
             case "allKeyed":
                 EmitSingleArgument(emitter, arguments);
-                il.Emit(OpCodes.Call, ctx.Runtime!.PromiseAllKeyed);
+                il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().AllKeyed);
                 return true;
 
             case "race":
@@ -112,7 +112,7 @@ public sealed class PromiseStaticEmitter : IStaticTypeEmitterStrategy
                 {
                     il.Emit(OpCodes.Ldnull);
                 }
-                il.Emit(OpCodes.Call, ctx.Runtime!.PromiseRaceStatic);
+                il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().RaceStatic);
                 return true;
 
             case "allSettled":
@@ -127,12 +127,12 @@ public sealed class PromiseStaticEmitter : IStaticTypeEmitterStrategy
                     il.Emit(OpCodes.Ldnull);
                 }
                 EmitBasePromiseConstructor(ctx);
-                il.Emit(OpCodes.Call, ctx.Runtime!.PromiseAllSettled);
+                il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().AllSettled);
                 return true;
 
             case "allSettledKeyed":
                 EmitSingleArgument(emitter, arguments);
-                il.Emit(OpCodes.Call, ctx.Runtime!.PromiseAllSettledKeyed);
+                il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().AllSettledKeyed);
                 return true;
 
             case "any":
@@ -148,12 +148,12 @@ public sealed class PromiseStaticEmitter : IStaticTypeEmitterStrategy
                 }
                 EmitBasePromiseConstructor(ctx);
                 il.Emit(OpCodes.Ldnull); // no custom capability on intrinsic Promise.any
-                il.Emit(OpCodes.Call, ctx.Runtime!.PromiseAny);
+                il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().Any);
                 return true;
 
             case "withResolvers":
                 // Promise.withResolvers() - returns Task<object?> wrapping {promise, resolve, reject}
-                il.Emit(OpCodes.Call, ctx.Runtime!.PromiseWithResolvers);
+                il.Emit(OpCodes.Call, ctx.Runtime!.RequirePromise().WithResolvers);
                 return true;
 
             default:
@@ -176,15 +176,15 @@ public sealed class PromiseStaticEmitter : IStaticTypeEmitterStrategy
         // `Promise` is always an Object).
         MethodInfo? method = propertyName switch
         {
-            "resolve"        => runtime.PromiseResolveStatic,
-            "reject"         => runtime.PromiseRejectStatic,
-            "all"            => runtime.PromiseAllStatic,
-            "allKeyed"       => runtime.PromiseAllKeyedStatic,
-            "race"           => runtime.PromiseRaceStatic,
-            "allSettled"     => runtime.PromiseAllSettledStatic,
-            "allSettledKeyed" => runtime.PromiseAllSettledKeyedStatic,
-            "any"            => runtime.PromiseAnyStatic,
-            "withResolvers"  => runtime.PromiseWithResolvers,
+            "resolve"        => runtime.RequirePromise().ResolveStatic,
+            "reject"         => runtime.RequirePromise().RejectStatic,
+            "all"            => runtime.RequirePromise().AllStatic,
+            "allKeyed"       => runtime.RequirePromise().AllKeyedStatic,
+            "race"           => runtime.RequirePromise().RaceStatic,
+            "allSettled"     => runtime.RequirePromise().AllSettledStatic,
+            "allSettledKeyed" => runtime.RequirePromise().AllSettledKeyedStatic,
+            "any"            => runtime.RequirePromise().AnyStatic,
+            "withResolvers"  => runtime.RequirePromise().WithResolvers,
             _ => null
         };
         if (method == null) return false;

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -2469,14 +2469,14 @@ public abstract partial class ExpressionEmitterBase
 
             if (TryEmitArrowAsDelegate(objectHandler, typeof(Func<object, object>)))
             {
-                IL.Emit(OpCodes.Call, Ctx.Runtime!.PromiseThenObjectPrimitive);
+                IL.Emit(OpCodes.Call, Ctx.Runtime!.RequirePromise().ThenObjectPrimitive);
             }
             else
             {
                 EmitExpression(objectHandler);
                 EnsureBoxed();
                 IL.Emit(OpCodes.Ldnull);
-                IL.Emit(OpCodes.Call, Ctx.Runtime!.PromiseThen);
+                IL.Emit(OpCodes.Call, Ctx.Runtime!.RequirePromise().Then);
             }
             SetStackUnknown();
             return;
@@ -2531,13 +2531,13 @@ public abstract partial class ExpressionEmitterBase
                 {
                     IL.Emit(OpCodes.Ldloc, fulfilledLocal);
                     IL.Emit(OpCodes.Ldloc, rejectedLocal);
-                    IL.Emit(OpCodes.Call, Ctx.Runtime!.PromiseThenPrimitiveWithRejection);
+                    IL.Emit(OpCodes.Call, Ctx.Runtime!.RequirePromise().ThenPrimitiveWithRejection);
                 }
                 else
                 {
                     EmitBoxedArgOrNull(arguments, 0);
                     EmitBoxedArgOrNull(arguments, 1);
-                    IL.Emit(OpCodes.Call, Ctx.Runtime!.PromiseThen);
+                    IL.Emit(OpCodes.Call, Ctx.Runtime!.RequirePromise().Then);
                 }
             }
             else if (arguments is [Expr.ArrowFunction handler])
@@ -2545,13 +2545,13 @@ public abstract partial class ExpressionEmitterBase
                 IL.Emit(OpCodes.Ldloc, promiseLocal);
                 if (TryEmitArrowAsDelegate(handler, typeof(Func<double, double>)))
                 {
-                    IL.Emit(OpCodes.Call, Ctx.Runtime!.PromiseThenPrimitive);
+                    IL.Emit(OpCodes.Call, Ctx.Runtime!.RequirePromise().ThenPrimitive);
                 }
                 else
                 {
                     EmitBoxedArgOrNull(arguments, 0);
                     IL.Emit(OpCodes.Ldnull);
-                    IL.Emit(OpCodes.Call, Ctx.Runtime!.PromiseThen);
+                    IL.Emit(OpCodes.Call, Ctx.Runtime!.RequirePromise().Then);
                 }
             }
             else
@@ -2562,7 +2562,7 @@ public abstract partial class ExpressionEmitterBase
                 IL.Emit(OpCodes.Ldloc, promiseLocal);
                 EmitBoxedArgOrNull(arguments, 0);
                 EmitBoxedArgOrNull(arguments, 1);
-                IL.Emit(OpCodes.Call, Ctx.Runtime!.PromiseThen);
+                IL.Emit(OpCodes.Call, Ctx.Runtime!.RequirePromise().Then);
             }
             SetStackUnknown();
             return;
@@ -2585,8 +2585,8 @@ public abstract partial class ExpressionEmitterBase
             IL.Emit(OpCodes.Ldloc, promiseReceiverLocal);
             EmitBoxedArgOrNull(arguments, 0);
             IL.Emit(OpCodes.Call, methodName == "catch"
-                ? Ctx.Runtime!.PromiseCatchHelperMethod
-                : Ctx.Runtime!.PromiseFinallyHelperMethod);
+                ? Ctx.Runtime!.RequirePromise().CatchHelperMethod
+                : Ctx.Runtime!.RequirePromise().FinallyHelperMethod);
             SetStackUnknown();
             return;
         }
@@ -2601,18 +2601,18 @@ public abstract partial class ExpressionEmitterBase
                 EmitBoxedArgOrNull(arguments, 1);
                 IL.Emit(OpCodes.Stloc, onRejectedLocal);
                 IL.Emit(OpCodes.Ldloc, promiseReceiverLocal);
-                IL.Emit(OpCodes.Call, Ctx.Runtime!.ObservePromiseConstructorMethod);
+                IL.Emit(OpCodes.Call, Ctx.Runtime!.RequirePromise().ObservePromiseConstructorMethod);
                 IL.Emit(OpCodes.Ldloc, promiseReceiverLocal);
-                IL.Emit(OpCodes.Call, Ctx.Runtime!.UnwrapPromiseReceiverMethod);
+                IL.Emit(OpCodes.Call, Ctx.Runtime!.RequirePromise().UnwrapPromiseReceiverMethod);
                 IL.Emit(OpCodes.Ldloc, onFulfilledLocal);
                 IL.Emit(OpCodes.Ldloc, onRejectedLocal);
-                IL.Emit(OpCodes.Call, Ctx.Runtime!.PromiseThen);
+                IL.Emit(OpCodes.Call, Ctx.Runtime!.RequirePromise().Then);
                 break;
         }
 
         // Subclass receivers get subclass-typed results (species-lite, #242).
         IL.Emit(OpCodes.Ldloc, promiseReceiverLocal);
-        IL.Emit(OpCodes.Call, Ctx.Runtime!.WrapDerivedPromiseResultMethod);
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.RequirePromise().WrapDerivedPromiseResultMethod);
         SetStackUnknown();
     }
 

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.Constructors.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.Constructors.cs
@@ -459,7 +459,7 @@ public abstract partial class ExpressionEmitterBase
                     && TryEmitArrowAsDelegate(
                         executorArrow, typeof(Func<object, object, object>)))
                 {
-                    IL.Emit(OpCodes.Call, Ctx.Runtime!.PromiseFromDirectExecutor);
+                    IL.Emit(OpCodes.Call, Ctx.Runtime!.RequirePromise().FromDirectExecutor);
                     SetStackUnknown();
                     return true;
                 }
@@ -489,7 +489,7 @@ public abstract partial class ExpressionEmitterBase
                         IL.Emit(OpCodes.Ldloc, executor);
                     }
                 }
-                IL.Emit(OpCodes.Call, Ctx.Runtime!.PromiseFromExecutor);
+                IL.Emit(OpCodes.Call, Ctx.Runtime!.RequirePromise().FromExecutor);
                 SetStackUnknown();
                 return true;
 

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.Operators.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.Operators.cs
@@ -734,9 +734,9 @@ public abstract partial class ExpressionEmitterBase
         IL.Emit(OpCodes.Call, Types.ConvertToStringFromObject);
         IL.Emit(OpCodes.Ldstr, Ctx.CurrentModulePath ?? "");
         IL.Emit(OpCodes.Call, Ctx.Runtime!.DynamicImportModule);
-        IL.Emit(OpCodes.Call, Ctx.Runtime!.WrapTaskAsPromise);
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
         IL.Emit(OpCodes.Dup);
-        IL.Emit(OpCodes.Call, Ctx.Runtime!.MarkNonAutoAwaitPromiseMethod);
+        IL.Emit(OpCodes.Call, Ctx.Runtime!.RequirePromise().MarkNonAutoAwaitPromiseMethod);
         SetStackUnknown();
     }
 

--- a/src/SharpTS/Compilation/ILCompiler.Classes.ClassExpressions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.ClassExpressions.cs
@@ -147,7 +147,7 @@ public partial class ILCompiler
             }
             else if (superclassName == "Promise")
             {
-                baseType = _runtime.TSPromiseType;
+                baseType = _runtime.RequirePromise().Type;
             }
         }
 
@@ -717,8 +717,8 @@ public partial class ILCompiler
             else if (superclassName == "Promise")
             {
                 il.Emit(OpCodes.Ldarg_1);
-                il.Emit(OpCodes.Call, _runtime.PromiseFromExecutor);
-                il.Emit(OpCodes.Call, _runtime.TSPromiseCtor);
+                il.Emit(OpCodes.Call, _runtime.RequirePromise().FromExecutor);
+                il.Emit(OpCodes.Call, _runtime.RequirePromise().Ctor);
             }
             else if (Runtime.BuiltIns.BuiltInNames.IsErrorTypeName(superclassName ?? ""))
             {

--- a/src/SharpTS/Compilation/ILCompiler.Classes.Constructors.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.Constructors.cs
@@ -168,8 +168,8 @@ public partial class ILCompiler
             // `constructor(executor) { super(executor) }`.
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1); // executor (object?)
-            il.Emit(OpCodes.Call, _runtime.PromiseFromExecutor);
-            il.Emit(OpCodes.Call, _runtime.TSPromiseCtor);
+            il.Emit(OpCodes.Call, _runtime.RequirePromise().FromExecutor);
+            il.Emit(OpCodes.Call, _runtime.RequirePromise().Ctor);
         }
         else if (constructor == null && qualifiedSuperclass != null && isErrorSubclass)
         {

--- a/src/SharpTS/Compilation/ILCompiler.Classes.Prototypes.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.Prototypes.cs
@@ -54,7 +54,7 @@ public partial class ILCompiler
 
             case "$Promise":
                 il.Emit(OpCodes.Ldnull);
-                il.Emit(OpCodes.Call, _runtime.TSPromiseCtor);
+                il.Emit(OpCodes.Call, _runtime.RequirePromise().Ctor);
                 return;
 
             case "$AggregateError":

--- a/src/SharpTS/Compilation/ILCompiler.Classes.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.cs
@@ -189,7 +189,7 @@ public partial class ILCompiler
             // promise object representation (wraps Task<object?>) — await,
             // then/catch/finally, and instanceof Promise apply to instances
             // unchanged.
-            baseType = _runtime.TSPromiseType;
+            baseType = _runtime.RequirePromise().Type;
         }
         else if (qualifiedSuperclassName != null && classStmt.SuperclassExpr != null
             && Expr.GetSuperclassLeafName(classStmt.SuperclassExpr) is

--- a/src/SharpTS/Compilation/ILCompiler.Modules.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Modules.cs
@@ -456,7 +456,7 @@ public partial class ILCompiler
             var done = il.DefineLabel();
             var task = il.DeclareLocal(_types.TaskOfObject);
             il.Emit(OpCodes.Ldloc, reactionResult);
-            il.Emit(OpCodes.Call, _runtime.ShouldAutoAwaitPromiseMethod);
+            il.Emit(OpCodes.Call, _runtime.RequirePromise().ShouldAutoAwaitPromiseMethod);
             il.Emit(OpCodes.Brfalse, done);
 
             il.Emit(OpCodes.Ldloc, reactionResult);
@@ -467,16 +467,16 @@ public partial class ILCompiler
             il.Emit(OpCodes.Brtrue, haveTask);
 
             il.Emit(OpCodes.Ldloc, reactionResult);
-            il.Emit(OpCodes.Isinst, _runtime.TSPromiseType);
+            il.Emit(OpCodes.Isinst, _runtime.RequirePromise().Type);
             il.Emit(OpCodes.Brfalse, done);
             il.Emit(OpCodes.Ldloc, reactionResult);
-            il.Emit(OpCodes.Castclass, _runtime.TSPromiseType);
-            il.Emit(OpCodes.Callvirt, _runtime.TSPromiseTaskGetter);
+            il.Emit(OpCodes.Castclass, _runtime.RequirePromise().Type);
+            il.Emit(OpCodes.Callvirt, _runtime.RequirePromise().TaskGetter);
             il.Emit(OpCodes.Stloc, task);
 
             il.MarkLabel(haveTask);
             il.Emit(OpCodes.Ldloc, task);
-            il.Emit(OpCodes.Call, _runtime.TrackTopLevelPromiseReaction);
+            il.Emit(OpCodes.Call, _runtime.RequirePromise().TrackTopLevelPromiseReaction);
             il.Emit(OpCodes.Pop);
             il.MarkLabel(done);
             return;
@@ -501,7 +501,7 @@ public partial class ILCompiler
         {
             // Custom capabilities opt out of SharpTS's standalone auto-await.
             il.Emit(OpCodes.Ldloc, exprResult);
-            il.Emit(OpCodes.Call, _runtime.ShouldAutoAwaitPromiseMethod);
+            il.Emit(OpCodes.Call, _runtime.RequirePromise().ShouldAutoAwaitPromiseMethod);
             il.Emit(OpCodes.Brfalse, notTaskLabel);
         }
 
@@ -514,13 +514,13 @@ public partial class ILCompiler
         {
             // Check for $Promise (async function return type)
             il.Emit(OpCodes.Ldloc, exprResult);
-            il.Emit(OpCodes.Isinst, _runtime.TSPromiseType);
+            il.Emit(OpCodes.Isinst, _runtime.RequirePromise().Type);
             il.Emit(OpCodes.Brfalse, notTaskLabel);
 
             // It's a $Promise - extract its underlying Task
             il.Emit(OpCodes.Ldloc, exprResult);
-            il.Emit(OpCodes.Castclass, _runtime.TSPromiseType);
-            il.Emit(OpCodes.Callvirt, _runtime.TSPromiseTaskGetter);
+            il.Emit(OpCodes.Castclass, _runtime.RequirePromise().Type);
+            il.Emit(OpCodes.Callvirt, _runtime.RequirePromise().TaskGetter);
             il.Emit(OpCodes.Br, waitForTaskLabel);
         }
         else

--- a/src/SharpTS/Compilation/ILEmitter.Modules.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Modules.cs
@@ -740,13 +740,13 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Call, _ctx.Runtime!.DynamicImportModule);
 
         // Wrap Task<object?> in SharpTSPromise
-        EmitCallUnknown(_ctx.Runtime!.WrapTaskAsPromise);
+        EmitCallUnknown(_ctx.Runtime!.RequirePromise().WrapTaskAsPromise);
 
         // A bare import() expression returns an ordinary Promise. Do not let
         // the standalone entry point's top-level auto-await convenience turn
         // an intentionally ignored rejection into an uncaught program error.
         IL.Emit(OpCodes.Dup);
-        IL.Emit(OpCodes.Call, _ctx.Runtime!.MarkNonAutoAwaitPromiseMethod);
+        IL.Emit(OpCodes.Call, _ctx.Runtime!.RequirePromise().MarkNonAutoAwaitPromiseMethod);
     }
 
     /// <summary>

--- a/src/SharpTS/Compilation/RuntimeEmitter.Arrays.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Arrays.cs
@@ -1238,13 +1238,13 @@ public partial class RuntimeEmitter
             var notResolveCallbackForNamesLabel = il.DefineLabel();
             var promiseCallbackNamesLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.PromiseResolveCallbackType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().ResolveCallbackType);
             il.Emit(OpCodes.Brfalse, notResolveCallbackForNamesLabel);
             il.Emit(OpCodes.Br, promiseCallbackNamesLabel);
             il.MarkLabel(notResolveCallbackForNamesLabel);
             var notPromiseCallbackForNamesLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.PromiseRejectCallbackType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().RejectCallbackType);
             il.Emit(OpCodes.Brfalse, notPromiseCallbackForNamesLabel);
             il.MarkLabel(promiseCallbackNamesLabel);
             AddName("length");

--- a/src/SharpTS/Compilation/RuntimeEmitter.AsyncFromSyncIterator.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.AsyncFromSyncIterator.cs
@@ -118,11 +118,11 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, valueLocal);
 
         il.Emit(OpCodes.Ldloc, valueLocal);
-        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Brfalse, notPromise);
         il.Emit(OpCodes.Ldloc, valueLocal);
-        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
-        il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);
+        il.Emit(OpCodes.Castclass, runtime.RequirePromise().Type);
+        il.Emit(OpCodes.Callvirt, runtime.RequirePromise().TaskGetter);
         il.Emit(OpCodes.Stloc, taskLocal);
         il.Emit(OpCodes.Br, haveTask);
 
@@ -139,7 +139,7 @@ public partial class RuntimeEmitter
         // adoption path used by compiled await expressions.
         il.MarkLabel(notTask);
         il.Emit(OpCodes.Ldloc, valueLocal);
-        il.Emit(OpCodes.Call, runtime.CoerceAwaitableToTaskMethod);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().CoerceAwaitableToTaskMethod);
         il.Emit(OpCodes.Stloc, taskLocal);
 
         il.MarkLabel(haveTask);

--- a/src/SharpTS/Compilation/RuntimeEmitter.BuiltInStaticDispatch.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.BuiltInStaticDispatch.cs
@@ -188,23 +188,23 @@ public partial class RuntimeEmitter
         // their compile-time static emitters.
         if (_features.UsesPromise)
         {
-            EmitLookup(_types.TaskOfObject, "resolve", runtime.PromiseResolveStatic, 1);
-            EmitLookup(_types.TaskOfObject, "reject", runtime.PromiseRejectStatic, 1);
-            EmitLookup(_types.TaskOfObject, "all", runtime.PromiseAllStatic, 1);
-            EmitLookup(_types.TaskOfObject, "allKeyed", runtime.PromiseAllKeyedStatic, 1);
-            EmitLookup(_types.TaskOfObject, "race", runtime.PromiseRaceStatic, 1);
-            EmitLookup(_types.TaskOfObject, "allSettled", runtime.PromiseAllSettledStatic, 1);
-            EmitLookup(_types.TaskOfObject, "allSettledKeyed", runtime.PromiseAllSettledKeyedStatic, 1);
-            EmitLookup(_types.TaskOfObject, "any", runtime.PromiseAnyStatic, 1);
+            EmitLookup(_types.TaskOfObject, "resolve", runtime.RequirePromise().ResolveStatic, 1);
+            EmitLookup(_types.TaskOfObject, "reject", runtime.RequirePromise().RejectStatic, 1);
+            EmitLookup(_types.TaskOfObject, "all", runtime.RequirePromise().AllStatic, 1);
+            EmitLookup(_types.TaskOfObject, "allKeyed", runtime.RequirePromise().AllKeyedStatic, 1);
+            EmitLookup(_types.TaskOfObject, "race", runtime.RequirePromise().RaceStatic, 1);
+            EmitLookup(_types.TaskOfObject, "allSettled", runtime.RequirePromise().AllSettledStatic, 1);
+            EmitLookup(_types.TaskOfObject, "allSettledKeyed", runtime.RequirePromise().AllSettledKeyedStatic, 1);
+            EmitLookup(_types.TaskOfObject, "any", runtime.RequirePromise().AnyStatic, 1);
             // Guest classes that `extend Promise` derive from the emitted wrapper.
-            EmitLookup(runtime.TSPromiseType, "resolve", runtime.PromiseResolveStatic, 1);
-            EmitLookup(runtime.TSPromiseType, "reject", runtime.PromiseRejectStatic, 1);
-            EmitLookup(runtime.TSPromiseType, "all", runtime.PromiseAllStatic, 1);
-            EmitLookup(runtime.TSPromiseType, "allKeyed", runtime.PromiseAllKeyedStatic, 1);
-            EmitLookup(runtime.TSPromiseType, "race", runtime.PromiseRaceStatic, 1);
-            EmitLookup(runtime.TSPromiseType, "allSettled", runtime.PromiseAllSettledStatic, 1);
-            EmitLookup(runtime.TSPromiseType, "allSettledKeyed", runtime.PromiseAllSettledKeyedStatic, 1);
-            EmitLookup(runtime.TSPromiseType, "any", runtime.PromiseAnyStatic, 1);
+            EmitLookup(runtime.RequirePromise().Type, "resolve", runtime.RequirePromise().ResolveStatic, 1);
+            EmitLookup(runtime.RequirePromise().Type, "reject", runtime.RequirePromise().RejectStatic, 1);
+            EmitLookup(runtime.RequirePromise().Type, "all", runtime.RequirePromise().AllStatic, 1);
+            EmitLookup(runtime.RequirePromise().Type, "allKeyed", runtime.RequirePromise().AllKeyedStatic, 1);
+            EmitLookup(runtime.RequirePromise().Type, "race", runtime.RequirePromise().RaceStatic, 1);
+            EmitLookup(runtime.RequirePromise().Type, "allSettled", runtime.RequirePromise().AllSettledStatic, 1);
+            EmitLookup(runtime.RequirePromise().Type, "allSettledKeyed", runtime.RequirePromise().AllSettledKeyedStatic, 1);
+            EmitLookup(runtime.RequirePromise().Type, "any", runtime.RequirePromise().AnyStatic, 1);
         }
         EmitLookup(runtime.TSErrorType, "isError", runtime.ErrorIsError, 1);
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.DnsPromises.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.DnsPromises.cs
@@ -500,7 +500,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, _dnsRunAsync);
 
         // WrapTaskAsPromise
-        il.Emit(OpCodes.Call, runtime.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().WrapTaskAsPromise);
         il.Emit(OpCodes.Ret);
 
         runtime.RequireDns().RegisterPromiseWrapper(methodName, wrapper);
@@ -559,7 +559,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, _dnsRunAsync);
 
         // WrapTaskAsPromise
-        il.Emit(OpCodes.Call, runtime.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().WrapTaskAsPromise);
         il.Emit(OpCodes.Ret);
 
         runtime.RequireDns().RegisterPromiseWrapper(methodName, wrapper);

--- a/src/SharpTS/Compilation/RuntimeEmitter.DynamicImport.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.DynamicImport.cs
@@ -21,7 +21,7 @@ public partial class RuntimeEmitter
         // even without `import()`.
         EmitModuleRegistry(typeBuilder, runtime);
         if (_features.UsesPromise)
-            EmitWrapTaskAsPromise(typeBuilder, runtime);
+            EmitWrapTaskAsPromise(typeBuilder, runtime.RequirePromise());
         // The two `import(specifier)`-specific helpers are gated separately:
         // only emit when UsesDynamicImport is set.
         if (_features.UsesDynamicImport)
@@ -118,21 +118,21 @@ public partial class RuntimeEmitter
     /// Emits WrapTaskAsPromise: wraps Task&lt;object?&gt; in $Promise.
     /// Signature: $Promise WrapTaskAsPromise(Task&lt;object?&gt; task)
     /// </summary>
-    private void EmitWrapTaskAsPromise(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitWrapTaskAsPromise(TypeBuilder typeBuilder, EmittedPromiseRuntime promise)
     {
         var method = typeBuilder.DefineMethod(
             "WrapTaskAsPromise",
             MethodAttributes.Public | MethodAttributes.Static,
-            runtime.TSPromiseType,
+            promise.Type,
             [_types.TaskOfObject]
         );
-        runtime.WrapTaskAsPromise = method;
+        promise.WrapTaskAsPromise = method;
 
         var il = method.GetILGenerator();
 
         // return new $Promise(task);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Newobj, runtime.TSPromiseCtor);
+        il.Emit(OpCodes.Newobj, promise.Ctor);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.FsAsync.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.FsAsync.cs
@@ -674,7 +674,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, asyncMethod);
 
         // Wrap the Task in a Promise
-        il.Emit(OpCodes.Call, runtime.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().WrapTaskAsPromise);
 
         il.Emit(OpCodes.Ret);
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.HasOwnProperty.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.HasOwnProperty.cs
@@ -154,7 +154,7 @@ public partial class RuntimeEmitter
         if (_features.UsesPromise)
         {
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.PromiseResolveCallbackType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().ResolveCallbackType);
             il.Emit(OpCodes.Brtrue, functionOwnPropertyCheck);
         }
         il.Emit(OpCodes.Ldarg_0);
@@ -163,7 +163,7 @@ public partial class RuntimeEmitter
         if (_features.UsesPromise)
         {
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.PromiseRejectCallbackType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().RejectCallbackType);
             il.Emit(OpCodes.Brfalse, notTSFunction);
         }
         else

--- a/src/SharpTS/Compilation/RuntimeEmitter.Http.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Http.cs
@@ -1035,7 +1035,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.JsonParse);
 
         // Wrap in a resolved Promise
-        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().TypeResolve);
 
         il.Emit(OpCodes.Ret);
     }
@@ -1065,7 +1065,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stfld, _fetchResponseBodyConsumedField);
 
         // Wrap in a resolved Promise
-        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().TypeResolve);
 
         il.Emit(OpCodes.Ret);
     }
@@ -1095,7 +1095,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stfld, _fetchResponseBodyConsumedField);
 
         // Wrap in a resolved Promise
-        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().TypeResolve);
 
         il.Emit(OpCodes.Ret);
     }
@@ -1391,7 +1391,7 @@ public partial class RuntimeEmitter
 
             var il = method.GetILGenerator();
             il.Emit(OpCodes.Ldstr, "HttpClient not available");
-            il.Emit(OpCodes.Call, runtime.TSPromiseReject);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().TypeReject);
             il.Emit(OpCodes.Ret);
             return;
         }
@@ -1460,7 +1460,7 @@ public partial class RuntimeEmitter
         fetchIL.Emit(OpCodes.Call, EmitGenerics.MakeGenericMethod(typeof(Task).GetMethod("Run", 1, [_types.MakeGenericType(typeof(Func<>), Type.MakeGenericMethodParameter(0))])!, typeof(object)));
 
         // WrapTaskAsPromise(task) — returns pending $Promise
-        fetchIL.Emit(OpCodes.Call, runtime.WrapTaskAsPromise);
+        fetchIL.Emit(OpCodes.Call, runtime.RequirePromise().WrapTaskAsPromise);
         fetchIL.Emit(OpCodes.Ret);
     }
 
@@ -3501,7 +3501,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Stfld, _requestBodyConsumedField);
         // Wrap in Promise
-        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().TypeResolve);
         il.Emit(OpCodes.Ret);
     }
 
@@ -3535,7 +3535,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Stfld, _requestBodyConsumedField);
-        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().TypeResolve);
         il.Emit(OpCodes.Ret);
     }
 
@@ -3573,7 +3573,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Stfld, _requestBodyConsumedField);
-        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().TypeResolve);
         il.Emit(OpCodes.Ret);
     }
 
@@ -3846,7 +3846,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Stfld, _responseBodyConsumedField);
 
-        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().TypeResolve);
         il.Emit(OpCodes.Ret);
     }
 
@@ -3865,7 +3865,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Stfld, _responseBodyConsumedField);
 
-        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().TypeResolve);
         il.Emit(OpCodes.Ret);
     }
 
@@ -3882,7 +3882,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Stfld, _responseBodyConsumedField);
 
-        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().TypeResolve);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.Lookup.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.Lookup.cs
@@ -250,7 +250,7 @@ public partial class RuntimeEmitter
         if (_features.UsesPromise)
         {
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.PromiseResolveCallbackType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().ResolveCallbackType);
             il.Emit(OpCodes.Brtrue, functionDescriptorCheckLabel);
         }
         il.Emit(OpCodes.Ldarg_0);
@@ -259,7 +259,7 @@ public partial class RuntimeEmitter
         if (_features.UsesPromise)
         {
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.PromiseRejectCallbackType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().RejectCallbackType);
             il.Emit(OpCodes.Brfalse, notTSFunctionForDescLabel);
         }
         else

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Exceptions.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Exceptions.cs
@@ -96,13 +96,13 @@ public partial class RuntimeEmitter
         if (_features.UsesPromise)
         {
             il.Emit(OpCodes.Ldloc, exLocal);
-            il.Emit(OpCodes.Isinst, runtime.TSPromiseRejectedExceptionType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().RejectedExceptionType);
             il.Emit(OpCodes.Brfalse, checkDataCloneErrorLabel);
 
             // It's a $PromiseRejectedException - return its Reason property
             il.Emit(OpCodes.Ldloc, exLocal);
-            il.Emit(OpCodes.Castclass, runtime.TSPromiseRejectedExceptionType);
-            il.Emit(OpCodes.Call, runtime.TSPromiseRejectedExceptionReasonGetter);
+            il.Emit(OpCodes.Castclass, runtime.RequirePromise().RejectedExceptionType);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().RejectedExceptionReasonGetter);
             il.Emit(OpCodes.Ret);
         }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Index.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Index.cs
@@ -1858,10 +1858,10 @@ public partial class RuntimeEmitter
         if (_features.UsesPromise)
         {
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.PromiseResolveCallbackType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().ResolveCallbackType);
             il.Emit(OpCodes.Brtrue, tsFunctionDeleteIdxLabel);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.PromiseRejectCallbackType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().RejectCallbackType);
             il.Emit(OpCodes.Brtrue, tsFunctionDeleteIdxLabel);
         }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Invocation.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Invocation.cs
@@ -188,12 +188,12 @@ public partial class RuntimeEmitter
         {
             resolveCallbackLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.PromiseResolveCallbackType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().ResolveCallbackType);
             il.Emit(OpCodes.Brtrue, resolveCallbackLabel);
 
             rejectCallbackLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.PromiseRejectCallbackType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().RejectCallbackType);
             il.Emit(OpCodes.Brtrue, rejectCallbackLabel);
         }
 
@@ -506,16 +506,16 @@ public partial class RuntimeEmitter
         {
             il.MarkLabel(resolveCallbackLabel);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Castclass, runtime.PromiseResolveCallbackType);
+            il.Emit(OpCodes.Castclass, runtime.RequirePromise().ResolveCallbackType);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Callvirt, runtime.PromiseResolveCallbackInvoke);
+            il.Emit(OpCodes.Callvirt, runtime.RequirePromise().ResolveCallbackInvoke);
             il.Emit(OpCodes.Ret);
 
             il.MarkLabel(rejectCallbackLabel);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Castclass, runtime.PromiseRejectCallbackType);
+            il.Emit(OpCodes.Castclass, runtime.RequirePromise().RejectCallbackType);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Callvirt, runtime.PromiseRejectCallbackInvoke);
+            il.Emit(OpCodes.Callvirt, runtime.RequirePromise().RejectCallbackInvoke);
             il.Emit(OpCodes.Ret);
         }
 
@@ -726,8 +726,8 @@ public partial class RuntimeEmitter
         }
         if (_features.UsesPromise)
         {
-            EmitWrapperCheck(runtime.PromiseResolveCallbackType, runtime.PromiseResolveCallbackInvoke);
-            EmitWrapperCheck(runtime.PromiseRejectCallbackType, runtime.PromiseRejectCallbackInvoke);
+            EmitWrapperCheck(runtime.RequirePromise().ResolveCallbackType, runtime.RequirePromise().ResolveCallbackInvoke);
+            EmitWrapperCheck(runtime.RequirePromise().RejectCallbackType, runtime.RequirePromise().RejectCallbackInvoke);
         }
 
         // After the chain, mark the final reject label so the fall-through code

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -1496,7 +1496,7 @@ public partial class RuntimeEmitter
             var notPromiseSubclassLabel = il.DefineLabel();
             var promiseSubclassMissLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
             il.Emit(OpCodes.Brfalse, notPromiseSubclassLabel);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Isinst, runtime.IHasFieldsInterface);
@@ -1514,7 +1514,7 @@ public partial class RuntimeEmitter
             il.MarkLabel(notPromiseSubclassLabel);
 
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
             il.Emit(OpCodes.Brtrue, promiseLabel);
         }
 
@@ -1686,13 +1686,13 @@ public partial class RuntimeEmitter
             var notPromiseResolveCallbackLabel = il.DefineLabel();
             var promiseCallbackMetadataLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.PromiseResolveCallbackType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().ResolveCallbackType);
             il.Emit(OpCodes.Brfalse, notPromiseResolveCallbackLabel);
             il.Emit(OpCodes.Br, promiseCallbackMetadataLabel);
             il.MarkLabel(notPromiseResolveCallbackLabel);
             var notPromiseCallbackLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.PromiseRejectCallbackType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().RejectCallbackType);
             il.Emit(OpCodes.Brfalse, notPromiseCallbackLabel);
             il.MarkLabel(promiseCallbackMetadataLabel);
             var promiseCallbackNotLengthLabel = il.DefineLabel();
@@ -1900,8 +1900,8 @@ public partial class RuntimeEmitter
                 il.Emit(OpCodes.Ldtoken, _types.TaskOfObject);
                 il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
                 il.Emit(OpCodes.Bne_Un, notPromiseProtoLabel);
-                il.Emit(OpCodes.Call, runtime.PromisePrototypePopulateMethod);
-                il.Emit(OpCodes.Ldsfld, runtime.PromisePrototypeField);
+                il.Emit(OpCodes.Call, runtime.RequirePromise().PrototypePopulateMethod);
+                il.Emit(OpCodes.Ldsfld, runtime.RequirePromise().PrototypeField);
                 il.Emit(OpCodes.Ret);
                 il.MarkLabel(notPromiseProtoLabel);
             }
@@ -2242,7 +2242,7 @@ public partial class RuntimeEmitter
             {
                 var noBaseBuiltInLabel = il.DefineLabel();
                 il.Emit(OpCodes.Ldloc, walkTypeLocal);
-                il.Emit(OpCodes.Ldtoken, runtime.TSPromiseType);
+                il.Emit(OpCodes.Ldtoken, runtime.RequirePromise().Type);
                 il.Emit(OpCodes.Call, _types.GetMethod(
                     _types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
                 il.Emit(OpCodes.Bne_Un, noBaseBuiltInLabel);
@@ -2575,7 +2575,7 @@ public partial class RuntimeEmitter
 
         // Check if obj is $Promise
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Brtrue, isTSPromiseLabel);
 
         // It's a raw Task<object?>, use directly
@@ -2587,8 +2587,8 @@ public partial class RuntimeEmitter
         // It's a $Promise, extract the Task property
         il.MarkLabel(isTSPromiseLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
-        il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);
+        il.Emit(OpCodes.Castclass, runtime.RequirePromise().Type);
+        il.Emit(OpCodes.Callvirt, runtime.RequirePromise().TaskGetter);
         il.Emit(OpCodes.Stloc, taskLocal);
 
         il.MarkLabel(haveTaskLabel);
@@ -2611,9 +2611,9 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldstr, jsName);
             il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
             il.Emit(OpCodes.Brfalse, notThisLabel);
-            il.Emit(OpCodes.Call, runtime.PromisePrototypePopulateMethod);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().PrototypePopulateMethod);
             var protoValLocal = il.DeclareLocal(_types.Object);
-            il.Emit(OpCodes.Ldsfld, runtime.PromisePrototypeField);
+            il.Emit(OpCodes.Ldsfld, runtime.RequirePromise().PrototypeField);
             il.Emit(OpCodes.Ldstr, jsName);
             il.Emit(OpCodes.Ldloca, protoValLocal);
             il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "TryGetValue",
@@ -2645,14 +2645,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, _types.GetMethod(_types.String, "op_Equality", _types.String, _types.String));
         il.Emit(OpCodes.Brfalse, notPromiseCtorLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Brfalse, defaultPromiseCtorLabel);
         var ctorTypeLocal = il.DeclareLocal(_types.Type);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
         il.Emit(OpCodes.Stloc, ctorTypeLocal);
         il.Emit(OpCodes.Ldloc, ctorTypeLocal);
-        il.Emit(OpCodes.Ldtoken, runtime.TSPromiseType);
+        il.Emit(OpCodes.Ldtoken, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
         il.Emit(OpCodes.Beq, defaultPromiseCtorLabel);
         il.Emit(OpCodes.Ldloc, ctorTypeLocal);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Prototype.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Prototype.cs
@@ -725,14 +725,14 @@ public partial class RuntimeEmitter
         // Promise instances ($TSPromise + raw Task<object>) → Promise.prototype
         // per ECMA-262 §27.2.5. Without this, Object.getPrototypeOf(promise)
         // returns null and `Promise.prototype.isPrototypeOf(p)` fails.
-        if (runtime.TSPromiseType != null)
+        if (runtime.Promise is not null)
         {
             var notTSPromiseForProtoLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
             il.Emit(OpCodes.Brfalse, notTSPromiseForProtoLabel);
-            il.Emit(OpCodes.Call, runtime.PromisePrototypePopulateMethod);
-            il.Emit(OpCodes.Ldsfld, runtime.PromisePrototypeField);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().PrototypePopulateMethod);
+            il.Emit(OpCodes.Ldsfld, runtime.RequirePromise().PrototypeField);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(notTSPromiseForProtoLabel);
         }
@@ -742,8 +742,8 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Isinst, _types.TaskOfObject);
             il.Emit(OpCodes.Brfalse, notTaskForProtoLabel);
-            il.Emit(OpCodes.Call, runtime.PromisePrototypePopulateMethod);
-            il.Emit(OpCodes.Ldsfld, runtime.PromisePrototypeField);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().PrototypePopulateMethod);
+            il.Emit(OpCodes.Ldsfld, runtime.RequirePromise().PrototypeField);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(notTaskForProtoLabel);
         }
@@ -781,14 +781,14 @@ public partial class RuntimeEmitter
         {
             var notResolveCallbackForProtoLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.PromiseResolveCallbackType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().ResolveCallbackType);
             il.Emit(OpCodes.Brfalse, notResolveCallbackForProtoLabel);
             il.Emit(OpCodes.Ldsfld, runtime.FunctionPrototypeField);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(notResolveCallbackForProtoLabel);
             var notRejectCallbackForProtoLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.PromiseRejectCallbackType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().RejectCallbackType);
             il.Emit(OpCodes.Brfalse, notRejectCallbackForProtoLabel);
             il.Emit(OpCodes.Ldsfld, runtime.FunctionPrototypeField);
             il.Emit(OpCodes.Ret);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.SetProperty.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.SetProperty.cs
@@ -279,7 +279,7 @@ public partial class RuntimeEmitter
         if (_features.UsesPromise)
         {
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
             il.Emit(OpCodes.Brtrue, pdsStoreLabel);
             // The intrinsic Promise representation is Task<object?>.
             il.Emit(OpCodes.Ldarg_0);
@@ -591,7 +591,7 @@ public partial class RuntimeEmitter
         if (_features.UsesPromise)
         {
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
             il.Emit(OpCodes.Brtrue, fieldsPdsStoreLabel);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Isinst, _types.TaskOfObject);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Operators.cs
@@ -438,10 +438,10 @@ public partial class RuntimeEmitter
             // Promise resolving functions are callable built-ins even though
             // their optimized CLR representation is not a $TSFunction/delegate.
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.PromiseResolveCallbackType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().ResolveCallbackType);
             il.Emit(OpCodes.Brtrue, functionLabel);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.PromiseRejectCallbackType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().RejectCallbackType);
             il.Emit(OpCodes.Brtrue, functionLabel);
         }
 
@@ -762,7 +762,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
             il.Emit(OpCodes.Bne_Un, notTaskTargetLabel);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
             il.Emit(OpCodes.Brtrue, trueLabel);
             il.MarkLabel(notTaskTargetLabel);
         }

--- a/src/SharpTS/Compilation/RuntimeEmitter.PromisePrototypePopulate.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.PromisePrototypePopulate.cs
@@ -7,7 +7,7 @@ public partial class RuntimeEmitter
 {
     private void DefinePromisePrototypePopulateShell(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        runtime.PromisePrototypePopulateMethod = typeBuilder.DefineMethod(
+        runtime.RequirePromise().PrototypePopulateMethod = typeBuilder.DefineMethod(
             "_PromisePrototypePopulate",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Void,
@@ -20,7 +20,7 @@ public partial class RuntimeEmitter
     /// receiver to <c>Task&lt;object&gt;</c> (handles raw Task and $Promise wrapper),
     /// then dispatches to the corresponding state-machine helper. Used as
     /// MethodInfo backing for the <c>$TSFunction</c> wrappers installed on
-    /// <see cref="EmittedRuntime.PromisePrototypeField"/>.
+    /// <see cref="EmittedPromiseRuntime.PrototypeField"/>.
     /// </summary>
     private void EmitPromisePrototypeHelpers(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
@@ -37,7 +37,7 @@ public partial class RuntimeEmitter
             m.DefineParameter(1, ParameterAttributes.None, "__this");
             m.DefineParameter(2, ParameterAttributes.None, "onFulfilled");
             m.DefineParameter(3, ParameterAttributes.None, "onRejected");
-            runtime.PromiseThenHelperMethod = m;
+            runtime.RequirePromise().ThenHelperMethod = m;
 
             var il = m.GetILGenerator();
             // ECMA-262 §27.2.5.4 step 2: If IsPromise(promise) is false, throw
@@ -46,7 +46,7 @@ public partial class RuntimeEmitter
             EmitThrowIfNullOrUndefined(il, runtime, "Promise.prototype.then called on null or undefined");
             var isPromiseOkLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
             il.Emit(OpCodes.Brtrue, isPromiseOkLabel);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Isinst, _types.TaskOfObject);
@@ -54,16 +54,16 @@ public partial class RuntimeEmitter
             GuestErrorEmitter.ThrowTypeError(il, runtime, "Promise.prototype.then called on non-Promise");
             il.MarkLabel(isPromiseOkLabel);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Call, runtime.ObservePromiseConstructorMethod);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().ObservePromiseConstructorMethod);
             var taskLocal = il.DeclareLocal(_types.TaskOfObject);
             EmitUnwrapToTask(il, runtime, taskLocal);
             il.Emit(OpCodes.Ldloc, taskLocal);
             il.Emit(OpCodes.Ldarg_1);
             il.Emit(OpCodes.Ldarg_2);
-            il.Emit(OpCodes.Call, runtime.PromiseThen);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().Then);
             // Promise-subclass receivers get subclass-typed results (#242).
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Call, runtime.WrapDerivedPromiseResultMethod);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().WrapDerivedPromiseResultMethod);
             il.Emit(OpCodes.Ret);
         }
 
@@ -76,7 +76,7 @@ public partial class RuntimeEmitter
                 [_types.Object, _types.Object]);
             m.DefineParameter(1, ParameterAttributes.None, "__this");
             m.DefineParameter(2, ParameterAttributes.None, "onRejected");
-            runtime.PromiseCatchHelperMethod = m;
+            runtime.RequirePromise().CatchHelperMethod = m;
 
             var il = m.GetILGenerator();
             // ECMA-262 §27.2.5.1: catch(onRejected) is `this.then(undefined, onRejected)`.
@@ -98,7 +98,7 @@ public partial class RuntimeEmitter
                 [_types.Object, _types.Object]);
             m.DefineParameter(1, ParameterAttributes.None, "__this");
             m.DefineParameter(2, ParameterAttributes.None, "onFinally");
-            runtime.PromiseFinallyHelperMethod = m;
+            runtime.RequirePromise().FinallyHelperMethod = m;
 
             var il = m.GetILGenerator();
             EmitThrowIfNullOrUndefined(il, runtime, "Promise.prototype.finally called on null or undefined");
@@ -208,7 +208,7 @@ public partial class RuntimeEmitter
 
             // promise = PromiseResolve(%Promise%, result)
             il.Emit(OpCodes.Ldloc, resultLocal);
-            il.Emit(OpCodes.Call, runtime.CoerceAwaitableToTaskMethod);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().CoerceAwaitableToTaskMethod);
             il.Emit(OpCodes.Stloc, promiseLocal);
 
             // thunk = new ValueThunk(valueOrReason, throws)
@@ -375,7 +375,7 @@ public partial class RuntimeEmitter
         // the user installed an own `then` descriptor on the instance, in
         // which case spec requires invoking that user-installed function.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Brfalse, notTSPromiseLabel);
         // Check PDS for own "then" — if present, user has installed it →
         // user-then path (preserves spec-compliant `Invoke(this, "then", ...)`).
@@ -385,8 +385,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, userThenPathLabel);
         // No user override → extract Task and use fast path.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
-        il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);
+        il.Emit(OpCodes.Castclass, runtime.RequirePromise().Type);
+        il.Emit(OpCodes.Callvirt, runtime.RequirePromise().TaskGetter);
         il.Emit(OpCodes.Stloc, taskLocal);
         il.Emit(OpCodes.Br, fastPathLabel);
 
@@ -407,13 +407,13 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(fastPathLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.ObservePromiseConstructorMethod);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().ObservePromiseConstructorMethod);
         il.Emit(OpCodes.Ldloc, taskLocal);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, isCatch ? runtime.PromiseCatch : runtime.PromiseFinally);
+        il.Emit(OpCodes.Call, isCatch ? runtime.RequirePromise().Catch : runtime.RequirePromise().Finally);
         // Promise-subclass receivers get subclass-typed results (#242).
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.WrapDerivedPromiseResultMethod);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().WrapDerivedPromiseResultMethod);
         il.Emit(OpCodes.Br, endLabel);
 
         // Branch C: user object — look up `then`, validate callable, invoke.
@@ -498,11 +498,11 @@ public partial class RuntimeEmitter
         var doneLabel = il.DefineLabel();
 
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Brfalse, notTSPromiseLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
-        il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);
+        il.Emit(OpCodes.Castclass, runtime.RequirePromise().Type);
+        il.Emit(OpCodes.Callvirt, runtime.RequirePromise().TaskGetter);
         il.Emit(OpCodes.Stloc, taskLocal);
         il.Emit(OpCodes.Br, doneLabel);
 
@@ -519,24 +519,24 @@ public partial class RuntimeEmitter
     }
 
     /// <summary>
-    /// Populates <see cref="EmittedRuntime.PromisePrototypeField"/> with
+    /// Populates <see cref="EmittedPromiseRuntime.PrototypeField"/> with
     /// <c>$TSFunction</c> wrappers for then/catch/finally + a constructor
     /// pointer to <c>typeof(Task&lt;object&gt;)</c> + non-enumerable PDS
     /// descriptors (ECMA-262 §17 spec attrs for built-in methods).
     /// </summary>
     private void EmitPromisePrototypePopulate(TypeBuilder typeBuilder, EmittedRuntime runtime)
     {
-        var method = runtime.PromisePrototypePopulateMethod;
+        var method = runtime.RequirePromise().PrototypePopulateMethod;
         var il = method.GetILGenerator();
         var setItem = _types.GetMethod(_types.DictionaryStringObject, "set_Item",
             _types.String, _types.Object);
 
-        EmitPrototypePopulateGuard(il, runtime.PromisePrototypeField);
+        EmitPrototypePopulateGuard(il, runtime.RequirePromise().PrototypeField);
 
         var descLocal = il.DeclareLocal(runtime.CompiledPropertyDescriptorType);
 
         // Promise.prototype.constructor === Promise (= typeof(Task<object>)).
-        EmitInstallConstructor(il, runtime, runtime.PromisePrototypeField, descLocal, setItem, () =>
+        EmitInstallConstructor(il, runtime, runtime.RequirePromise().PrototypeField, descLocal, setItem, () =>
         {
             il.Emit(OpCodes.Ldtoken, _types.TaskOfObject);
             il.Emit(OpCodes.Call, _types.GetMethod(_types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
@@ -546,19 +546,19 @@ public partial class RuntimeEmitter
         // take the receiver as __this (named at their emit site — nameThisParam:
         // false skips the rename).
         void Wire(string jsName, MethodBuilder helper, int jsLength)
-            => EmitWirePrototypeMethod(il, runtime, runtime.PromisePrototypeField, descLocal,
+            => EmitWirePrototypeMethod(il, runtime, runtime.RequirePromise().PrototypeField, descLocal,
                 setItem, jsName, helper, jsLength, nameThisParam: false);
 
         // ECMA-262 §27.2.5: then/catch take 2 and 1 args respectively;
         // finally takes 1 (onFinally). Spec lengths matter for length.js tests.
-        Wire("then",    runtime.PromiseThenHelperMethod,    2);
-        Wire("catch",   runtime.PromiseCatchHelperMethod,   1);
-        Wire("finally", runtime.PromiseFinallyHelperMethod, 1);
+        Wire("then",    runtime.RequirePromise().ThenHelperMethod,    2);
+        Wire("catch",   runtime.RequirePromise().CatchHelperMethod,   1);
+        Wire("finally", runtime.RequirePromise().FinallyHelperMethod, 1);
 
         // ECMA-262 §27.2.5.5: Promise.prototype[@@toStringTag] = "Promise".
         // Attributes per spec: writable:false, enumerable:false, configurable:true.
         // GetSymbolDict(PromisePrototype)[SymbolToStringTag] = "Promise".
-        il.Emit(OpCodes.Ldsfld, runtime.PromisePrototypeField);
+        il.Emit(OpCodes.Ldsfld, runtime.RequirePromise().PrototypeField);
         il.Emit(OpCodes.Call, runtime.GetSymbolDictMethod);
         il.Emit(OpCodes.Ldsfld, runtime.SymbolToStringTag);
         il.Emit(OpCodes.Ldstr, "Promise");

--- a/src/SharpTS/Compilation/RuntimeEmitter.PromiseRejections.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.PromiseRejections.cs
@@ -219,11 +219,11 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Void,
             [_types.Object]);
-        runtime.ObserveDiscardedPromiseResult = method;
+        runtime.RequirePromise().ObserveDiscardedPromiseResult = method;
 
         var il = method.GetILGenerator();
         var task = il.DeclareLocal(_types.TaskOfObject);
-        var wrapper = il.DeclareLocal(runtime.TSPromiseType);
+        var wrapper = il.DeclareLocal(runtime.RequirePromise().Type);
         var tracker = il.DeclareLocal(trackerType);
         var haveTask = il.DefineLabel();
         var haveTable = il.DefineLabel();
@@ -238,12 +238,12 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, task);
         il.Emit(OpCodes.Brtrue, haveTask);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Stloc, wrapper);
         il.Emit(OpCodes.Ldloc, wrapper);
         il.Emit(OpCodes.Brfalse, ret);
         il.Emit(OpCodes.Ldloc, wrapper);
-        il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);
+        il.Emit(OpCodes.Callvirt, runtime.RequirePromise().TaskGetter);
         il.Emit(OpCodes.Stloc, task);
         il.MarkLabel(haveTask);
 
@@ -331,7 +331,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Void,
             [_types.TaskOfObject]);
-        runtime.NotifyPromiseRejectionHandler = method;
+        runtime.RequirePromise().NotifyPromiseRejectionHandler = method;
 
         var il = method.GetILGenerator();
         var tracker = il.DeclareLocal(trackerType);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.All.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.All.cs
@@ -107,7 +107,7 @@ public partial class RuntimeEmitter
             _features.UsesArrayPrototypeMutation
             || _features.UsesDynamicPropertyDescriptors
             || _features.UsesClassPrototypeMutation
-                ? runtime.AdoptPromiseCombinatorResultMethod
+                ? runtime.RequirePromise().AdoptPromiseCombinatorResultMethod
                 : null;
 
         EmitCombinatorWrapper(il, sm.Type, sm.StateField, sm.IterableField, sm.BuilderField, sm.BuilderType,
@@ -118,7 +118,7 @@ public partial class RuntimeEmitter
                 il.Emit(OpCodes.Ldarg_0);
             }, sm.ConstructorField, () => il.Emit(OpCodes.Ldarg_1),
             sm.CapabilityField, () => il.Emit(OpCodes.Ldarg_2),
-            markNonAutoAwaitMethod: runtime.MarkNonAutoAwaitPromiseMethod,
+            markNonAutoAwaitMethod: runtime.RequirePromise().MarkNonAutoAwaitPromiseMethod,
             adoptResultMethod: adoptResultMethod,
             stablePrimitiveField: sm.StablePrimitiveField,
             emitStablePrimitiveValue: () => il.Emit(

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.AllSettled.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.AllSettled.cs
@@ -214,8 +214,8 @@ public partial class RuntimeEmitter
                 // Normalize inside MoveNext's try block; see PromiseAll.
                 il.Emit(OpCodes.Ldarg_0);
             }, sm.ConstructorField, () => il.Emit(OpCodes.Ldarg_1),
-            markNonAutoAwaitMethod: runtime.MarkNonAutoAwaitPromiseMethod,
-            adoptResultMethod: runtime.AdoptPromiseCombinatorResultMethod);
+            markNonAutoAwaitMethod: runtime.RequirePromise().MarkNonAutoAwaitPromiseMethod,
+            adoptResultMethod: runtime.RequirePromise().AdoptPromiseCombinatorResultMethod);
 
     /// <summary>
     /// Emits the MoveNext body for PromiseAllSettled state machine.

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.Any.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.Any.cs
@@ -332,8 +332,8 @@ public partial class RuntimeEmitter
                 il.Emit(OpCodes.Ldarg_0);
             }, sm.ConstructorField, () => il.Emit(OpCodes.Ldarg_1),
             sm.CapabilityField, () => il.Emit(OpCodes.Ldarg_2),
-            runtime.MarkNonAutoAwaitPromiseMethod,
-            runtime.AdoptPromiseCombinatorResultMethod);
+            runtime.RequirePromise().MarkNonAutoAwaitPromiseMethod,
+            runtime.RequirePromise().AdoptPromiseCombinatorResultMethod);
 
     /// <summary>
     /// Emits the MoveNext body for PromiseAny state machine.

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.Capability.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.Capability.cs
@@ -16,7 +16,7 @@ public partial class RuntimeEmitter
 {
     /// <summary>
     /// Emits the <c>$PromiseCapability</c> holder type and fills the
-    /// pre-declared <see cref="EmittedRuntime.NewPromiseCapabilityResultMethod"/>
+    /// pre-declared <see cref="EmittedPromiseRuntime.NewPromiseCapabilityResultMethod"/>
     /// body. Must be called AFTER <c>EmitConstructDynamicValue</c> and after the
     /// $Runtime helpers it depends on (<c>InvokeValue</c>, <c>WrapException</c>,
     /// <c>ConstructDynamicValue</c>) are emitted, but while <c>$Runtime</c> is
@@ -29,8 +29,8 @@ public partial class RuntimeEmitter
         EmitAdoptPromiseCapabilityBody(runtime);
         EmitAdoptCompletedPromiseCapabilityBody(runtime);
         EmitResolvePreparedPromiseCapabilityBody(runtime);
-        EmitPromiseCapabilitySlotGetterBodies(runtime);
-        EmitNewPromiseCapabilityResultBody(runtime);
+        EmitPromiseCapabilitySlotGetterBodies(runtime.RequirePromise());
+        EmitNewPromiseCapabilityResultBody(runtime.RequirePromise());
         EmitCoerceAwaitableToTask(runtime);
     }
 
@@ -45,7 +45,7 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitCoerceAwaitableToTask(EmittedRuntime runtime)
     {
-        var method = runtime.CoerceAwaitableToTaskMethod;
+        var method = runtime.RequirePromise().CoerceAwaitableToTaskMethod;
 
         var il = method.GetILGenerator();
         var wrapLabel = il.DefineLabel();
@@ -69,11 +69,11 @@ public partial class RuntimeEmitter
 
         var notPromiseLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Brfalse, notPromiseLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
-        il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);
+        il.Emit(OpCodes.Castclass, runtime.RequirePromise().Type);
+        il.Emit(OpCodes.Callvirt, runtime.RequirePromise().TaskGetter);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notPromiseLabel);
 
@@ -116,13 +116,13 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Ldloc, tcsLocal);
         il.Emit(OpCodes.Ldloc, lockLocal);
-        il.Emit(OpCodes.Newobj, runtime.PromiseResolveCallbackCtor);
+        il.Emit(OpCodes.Newobj, runtime.RequirePromise().ResolveCallbackCtor);
         il.Emit(OpCodes.Stelem_Ref);
         il.Emit(OpCodes.Dup);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Ldloc, tcsLocal);
         il.Emit(OpCodes.Ldloc, lockLocal);
-        il.Emit(OpCodes.Newobj, runtime.PromiseRejectCallbackCtor);
+        il.Emit(OpCodes.Newobj, runtime.RequirePromise().RejectCallbackCtor);
         il.Emit(OpCodes.Stelem_Ref);
         il.Emit(OpCodes.Call, runtime.InvokeMethodValue);
         il.Emit(OpCodes.Pop);
@@ -133,7 +133,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, tcsLocal);
         il.Emit(OpCodes.Ldloc, exLocal);
         il.Emit(OpCodes.Call, runtime.WrapException);
-        il.Emit(OpCodes.Newobj, runtime.TSPromiseRejectedExceptionCtor);
+        il.Emit(OpCodes.Newobj, runtime.RequirePromise().RejectedExceptionCtor);
         il.Emit(OpCodes.Callvirt, tcsType.GetMethod("TrySetException", [_types.Exception])!);
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Leave, endTryLabel);
@@ -308,13 +308,13 @@ public partial class RuntimeEmitter
         }
 
         typeBuilder.CreateType();
-        runtime.PromiseCapabilityType = typeBuilder;
-        runtime.PromiseCapabilityCtor = ctor;
-        runtime.PromiseCapabilityResolveField = resolveField;
-        runtime.PromiseCapabilityRejectField = rejectField;
-        runtime.PromiseCapabilityInstanceField = instanceField;
-        runtime.PromiseCapabilityCaptureMethod = capture;
-        runtime.PromiseCapabilitySettleMethod = settle;
+        runtime.RequirePromise().CapabilityType = typeBuilder;
+        runtime.RequirePromise().CapabilityCtor = ctor;
+        runtime.RequirePromise().CapabilityResolveField = resolveField;
+        runtime.RequirePromise().CapabilityRejectField = rejectField;
+        runtime.RequirePromise().CapabilityInstanceField = instanceField;
+        runtime.RequirePromise().CapabilityCaptureMethod = capture;
+        runtime.RequirePromise().CapabilitySettleMethod = settle;
     }
 
     /// <summary>
@@ -326,18 +326,18 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitPreparePromiseCapabilityBody(EmittedRuntime runtime)
     {
-        var il = runtime.PreparePromiseCapabilityMethod.GetILGenerator();
-        var capabilityType = runtime.PromiseCapabilityType;
+        var il = runtime.RequirePromise().PreparePromiseCapabilityMethod.GetILGenerator();
+        var capabilityType = runtime.RequirePromise().CapabilityType;
         var funcType = _types.FuncObjectArrayToObject;
         var capabilityLocal = il.DeclareLocal(capabilityType);
         var instanceLocal = il.DeclareLocal(_types.Object);
         var executorLocal = il.DeclareLocal(funcType);
 
-        il.Emit(OpCodes.Newobj, runtime.PromiseCapabilityCtor);
+        il.Emit(OpCodes.Newobj, runtime.RequirePromise().CapabilityCtor);
         il.Emit(OpCodes.Stloc, capabilityLocal);
 
         il.Emit(OpCodes.Ldloc, capabilityLocal);
-        il.Emit(OpCodes.Ldftn, runtime.PromiseCapabilityCaptureMethod);
+        il.Emit(OpCodes.Ldftn, runtime.RequirePromise().CapabilityCaptureMethod);
         il.Emit(OpCodes.Newobj, _types.GetConstructor(funcType, [_types.Object, typeof(IntPtr)])!);
         il.Emit(OpCodes.Stloc, executorLocal);
 
@@ -353,7 +353,7 @@ public partial class RuntimeEmitter
             _types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
         il.Emit(OpCodes.Bne_Un, constructGeneralLabel);
         il.Emit(OpCodes.Ldloc, executorLocal);
-        il.Emit(OpCodes.Call, runtime.PromiseFromExecutor);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().FromExecutor);
         il.Emit(OpCodes.Stloc, instanceLocal);
         il.Emit(OpCodes.Br, haveInstanceLabel);
 
@@ -370,15 +370,15 @@ public partial class RuntimeEmitter
         il.MarkLabel(haveInstanceLabel);
 
         EmitRequireCallableCapabilitySlot(il, runtime, capabilityLocal,
-            runtime.PromiseCapabilityResolveField);
+            runtime.RequirePromise().CapabilityResolveField);
         EmitRequireCallableCapabilitySlot(il, runtime, capabilityLocal,
-            runtime.PromiseCapabilityRejectField);
+            runtime.RequirePromise().CapabilityRejectField);
 
         il.Emit(OpCodes.Ldloc, capabilityLocal);
         il.Emit(OpCodes.Ldloc, instanceLocal);
-        il.Emit(OpCodes.Stfld, runtime.PromiseCapabilityInstanceField);
+        il.Emit(OpCodes.Stfld, runtime.RequirePromise().CapabilityInstanceField);
         il.Emit(OpCodes.Ldloc, instanceLocal);
-        il.Emit(OpCodes.Call, runtime.MarkNonAutoAwaitPromiseMethod);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().MarkNonAutoAwaitPromiseMethod);
         il.Emit(OpCodes.Ldloc, capabilityLocal);
         il.Emit(OpCodes.Ret);
     }
@@ -405,8 +405,8 @@ public partial class RuntimeEmitter
     /// <summary>Adopts a task into a previously prepared capability.</summary>
     private void EmitAdoptPromiseCapabilityBody(EmittedRuntime runtime)
     {
-        var il = runtime.AdoptPromiseCapabilityMethod.GetILGenerator();
-        var capabilityType = runtime.PromiseCapabilityType;
+        var il = runtime.RequirePromise().AdoptPromiseCapabilityMethod.GetILGenerator();
+        var capabilityType = runtime.RequirePromise().CapabilityType;
         var actionType = typeof(Action<Task<object?>>);
         var schedulerType = typeof(TaskScheduler);
         var syncContextType = typeof(SynchronizationContext);
@@ -430,7 +430,7 @@ public partial class RuntimeEmitter
 
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldloc, capabilityLocal);
-        il.Emit(OpCodes.Ldftn, runtime.PromiseCapabilitySettleMethod);
+        il.Emit(OpCodes.Ldftn, runtime.RequirePromise().CapabilitySettleMethod);
         il.Emit(OpCodes.Newobj, actionType.GetConstructor([_types.Object, typeof(IntPtr)])!);
         il.Emit(OpCodes.Call, typeof(CancellationToken).GetProperty("None")!.GetGetMethod()!);
         il.Emit(OpCodes.Ldc_I4, (int)TaskContinuationOptions.ExecuteSynchronously);
@@ -441,7 +441,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Pop);
 
         il.Emit(OpCodes.Ldloc, capabilityLocal);
-        il.Emit(OpCodes.Ldfld, runtime.PromiseCapabilityInstanceField);
+        il.Emit(OpCodes.Ldfld, runtime.RequirePromise().CapabilityInstanceField);
         il.Emit(OpCodes.Ret);
     }
 
@@ -453,11 +453,11 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitAdoptCompletedPromiseCapabilityBody(EmittedRuntime runtime)
     {
-        var il = runtime.AdoptCompletedPromiseCapabilityMethod.GetILGenerator();
+        var il = runtime.RequirePromise().AdoptCompletedPromiseCapabilityMethod.GetILGenerator();
         var schedulePendingLabel = il.DefineLabel();
         var settleFaultedLabel = il.DefineLabel();
         var returnPromiseLabel = il.DefineLabel();
-        var capabilityType = runtime.PromiseCapabilityType;
+        var capabilityType = runtime.RequirePromise().CapabilityType;
         var capabilityLocal = il.DeclareLocal(capabilityType);
         var exceptionLocal = il.DeclareLocal(_types.Exception);
 
@@ -483,13 +483,13 @@ public partial class RuntimeEmitter
         il.BeginExceptionBlock();
         il.Emit(OpCodes.Ldloc, capabilityLocal);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.PromiseCapabilitySettleMethod);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().CapabilitySettleMethod);
         il.Emit(OpCodes.Leave, returnPromiseLabel);
 
         il.BeginCatchBlock(_types.Exception);
         il.Emit(OpCodes.Stloc, exceptionLocal);
         il.Emit(OpCodes.Ldloc, capabilityLocal);
-        il.Emit(OpCodes.Ldfld, runtime.PromiseCapabilityRejectField);
+        il.Emit(OpCodes.Ldfld, runtime.RequirePromise().CapabilityRejectField);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Newarr, _types.Object);
         il.Emit(OpCodes.Dup);
@@ -505,31 +505,31 @@ public partial class RuntimeEmitter
         il.MarkLabel(settleFaultedLabel);
         il.Emit(OpCodes.Ldloc, capabilityLocal);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.PromiseCapabilitySettleMethod);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().CapabilitySettleMethod);
 
         il.MarkLabel(returnPromiseLabel);
         il.Emit(OpCodes.Ldloc, capabilityLocal);
-        il.Emit(OpCodes.Ldfld, runtime.PromiseCapabilityInstanceField);
+        il.Emit(OpCodes.Ldfld, runtime.RequirePromise().CapabilityInstanceField);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(schedulePendingLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.AdoptPromiseCapabilityMethod);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().AdoptPromiseCapabilityMethod);
         il.Emit(OpCodes.Ret);
     }
 
     private void EmitResolvePreparedPromiseCapabilityBody(EmittedRuntime runtime)
     {
-        var il = runtime.ResolvePreparedPromiseCapabilityMethod.GetILGenerator();
-        var capabilityType = runtime.PromiseCapabilityType;
+        var il = runtime.RequirePromise().ResolvePreparedPromiseCapabilityMethod.GetILGenerator();
+        var capabilityType = runtime.RequirePromise().CapabilityType;
         var capabilityLocal = il.DeclareLocal(capabilityType);
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Castclass, capabilityType);
         il.Emit(OpCodes.Stloc, capabilityLocal);
         il.Emit(OpCodes.Ldloc, capabilityLocal);
-        il.Emit(OpCodes.Ldfld, runtime.PromiseCapabilityResolveField);
+        il.Emit(OpCodes.Ldfld, runtime.RequirePromise().CapabilityResolveField);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Newarr, _types.Object);
         il.Emit(OpCodes.Dup);
@@ -539,22 +539,22 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.InvokeValue);
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ldloc, capabilityLocal);
-        il.Emit(OpCodes.Ldfld, runtime.PromiseCapabilityInstanceField);
+        il.Emit(OpCodes.Ldfld, runtime.RequirePromise().CapabilityInstanceField);
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitPromiseCapabilitySlotGetterBodies(EmittedRuntime runtime)
+    private void EmitPromiseCapabilitySlotGetterBodies(EmittedPromiseRuntime promise)
     {
-        EmitGetter(runtime.GetPromiseCapabilityResolveMethod,
-            runtime.PromiseCapabilityResolveField);
-        EmitGetter(runtime.GetPromiseCapabilityRejectMethod,
-            runtime.PromiseCapabilityRejectField);
+        EmitGetter(promise.GetPromiseCapabilityResolveMethod,
+            promise.CapabilityResolveField);
+        EmitGetter(promise.GetPromiseCapabilityRejectMethod,
+            promise.CapabilityRejectField);
 
         void EmitGetter(MethodBuilder method, FieldInfo field)
         {
             var il = method.GetILGenerator();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Castclass, runtime.PromiseCapabilityType);
+            il.Emit(OpCodes.Castclass, promise.CapabilityType);
             il.Emit(OpCodes.Ldfld, field);
             il.Emit(OpCodes.Ret);
         }
@@ -585,14 +585,14 @@ public partial class RuntimeEmitter
     /// <paramref name="result"/> onto the current SynchronizationContext, and
     /// returns the constructed object.
     /// </summary>
-    private void EmitNewPromiseCapabilityResultBody(EmittedRuntime runtime)
+    private void EmitNewPromiseCapabilityResultBody(EmittedPromiseRuntime promise)
     {
-        var method = runtime.NewPromiseCapabilityResultMethod;
+        var method = promise.NewPromiseCapabilityResultMethod;
         var il = method.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.PreparePromiseCapabilityMethod);
+        il.Emit(OpCodes.Call, promise.PreparePromiseCapabilityMethod);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.AdoptPromiseCapabilityMethod);
+        il.Emit(OpCodes.Call, promise.AdoptPromiseCapabilityMethod);
         il.Emit(OpCodes.Ret);
     }
 }

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.CombinatorShared.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.CombinatorShared.cs
@@ -225,7 +225,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, stablePrimitiveField);
         }
-        il.Emit(OpCodes.Call, runtime.NormalizePromiseListMethod);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().NormalizePromiseListMethod);
         il.Emit(OpCodes.Stfld, iterableField);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.Executor.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.Executor.cs
@@ -25,26 +25,15 @@ public partial class RuntimeEmitter
     private void EmitPromiseExecutorSupport(TypeBuilder runtimeType, EmittedRuntime runtime, ModuleBuilder moduleBuilder)
     {
         // Emit the PromiseFromExecutor method
-        EmitPromiseFromExecutorMethod(runtimeType, runtime, runtime.PromiseResolveCallbackType, runtime.PromiseRejectCallbackType);
+        EmitPromiseFromExecutorMethod(runtimeType, runtime, runtime.RequirePromise().ResolveCallbackType, runtime.RequirePromise().RejectCallbackType);
         EmitPromiseFromDirectExecutorMethod(runtimeType, runtime,
-            runtime.PromiseResolveCallbackType, runtime.PromiseRejectCallbackType);
+            runtime.RequirePromise().ResolveCallbackType, runtime.RequirePromise().RejectCallbackType);
 
         // Promise-subclass support (#242): receiver unwrapping + derived-result wrapping
         EmitUnwrapPromiseReceiverMethod(runtimeType, runtime);
 
-        // Pre-declare the general NewPromiseCapability helper (#349) so
-        // WrapDerivedPromiseResult can call it; the body and the $PromiseCapability
-        // type are emitted later (EmitPromiseCapabilitySupport, after
-        // ConstructDynamicValue) when all of its dependencies are available. The
-        // species is typed `object` (not `Type`): a class species arrives as a Type
-        // token, but a function-valued species or a non-constructor arrives as its
-        // raw value, and ConstructDynamicValue dispatches all three (Type →
-        // Activator, function → NewOnFunction, non-constructor → TypeError, #390).
-        runtime.NewPromiseCapabilityResultMethod ??= runtimeType.DefineMethod(
-            "NewPromiseCapabilityResult",
-            MethodAttributes.Public | MethodAttributes.Static,
-            _types.Object,
-            [_types.Object, _types.TaskOfObject]);
+        // NewPromiseCapabilityResult was declared by EmitPromiseMethods. Its body
+        // is filled by EmitPromiseCapabilitySupport after ConstructDynamicValue.
 
         EmitObservePromiseConstructorMethod(runtimeType, runtime);
         EmitWrapDerivedPromiseResultMethod(runtimeType, runtime);
@@ -64,7 +53,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Void,
             [_types.Object]);
-        runtime.ObservePromiseConstructorMethod = method;
+        runtime.RequirePromise().ObservePromiseConstructorMethod = method;
 
         var il = method.GetILGenerator();
         var getterLocal = il.DeclareLocal(_types.Object);
@@ -119,8 +108,8 @@ public partial class RuntimeEmitter
             var thenIl = invokeThenMethod.GetILGenerator();
             var tcsLocal = thenIl.DeclareLocal(_types.TaskCompletionSourceOfObject);
             var settledLocal = thenIl.DeclareLocal(_types.Object);
-            var resolveLocal = thenIl.DeclareLocal(runtime.PromiseResolveCallbackType);
-            var rejectLocal = thenIl.DeclareLocal(runtime.PromiseRejectCallbackType);
+            var resolveLocal = thenIl.DeclareLocal(runtime.RequirePromise().ResolveCallbackType);
+            var rejectLocal = thenIl.DeclareLocal(runtime.RequirePromise().RejectCallbackType);
 
             thenIl.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(
                 _types.TaskCompletionSourceOfObject));
@@ -133,12 +122,12 @@ public partial class RuntimeEmitter
 
             thenIl.Emit(OpCodes.Ldloc, tcsLocal);
             thenIl.Emit(OpCodes.Ldloc, settledLocal);
-            thenIl.Emit(OpCodes.Newobj, runtime.PromiseResolveCallbackCtor);
+            thenIl.Emit(OpCodes.Newobj, runtime.RequirePromise().ResolveCallbackCtor);
             thenIl.Emit(OpCodes.Stloc, resolveLocal);
 
             thenIl.Emit(OpCodes.Ldloc, tcsLocal);
             thenIl.Emit(OpCodes.Ldloc, settledLocal);
-            thenIl.Emit(OpCodes.Newobj, runtime.PromiseRejectCallbackCtor);
+            thenIl.Emit(OpCodes.Newobj, runtime.RequirePromise().RejectCallbackCtor);
             thenIl.Emit(OpCodes.Stloc, rejectLocal);
 
             thenIl.Emit(OpCodes.Ldarg_0);
@@ -240,7 +229,7 @@ public partial class RuntimeEmitter
             closeIl.Emit(OpCodes.Throw);
         }
 
-        var method = runtime.NormalizePromiseListMethod;
+        var method = runtime.RequirePromise().NormalizePromiseListMethod;
 
         var il = method.GetILGenerator();
         var listType = _types.ListOfObject;
@@ -286,7 +275,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, _types.GetMethod(
             _types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
         il.Emit(OpCodes.Beq, resolveCaptureDoneLabel);
-        il.Emit(OpCodes.Ldtoken, runtime.TSPromiseType);
+        il.Emit(OpCodes.Ldtoken, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Call, _types.GetMethod(
             _types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
         il.Emit(OpCodes.Ldloc, constructorTypeLocal);
@@ -397,7 +386,7 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(fastTaskScanTSPromiseLabel);
         il.Emit(OpCodes.Ldloc, elementLocal);
-        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Stloc, resolvedElementLocal);
         il.Emit(OpCodes.Ldloc, resolvedElementLocal);
         il.Emit(OpCodes.Brfalse, ordinaryListNormalizationLabel);
@@ -410,8 +399,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, ordinaryListNormalizationLabel);
         il.MarkLabel(stableTSPromiseTaskLabel);
         il.Emit(OpCodes.Ldloc, resolvedElementLocal);
-        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
-        il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);
+        il.Emit(OpCodes.Castclass, runtime.RequirePromise().Type);
+        il.Emit(OpCodes.Callvirt, runtime.RequirePromise().TaskGetter);
         il.Emit(OpCodes.Stloc, resolvedElementLocal);
 
         il.MarkLabel(fastTaskScanStoreLabel);
@@ -630,10 +619,10 @@ public partial class RuntimeEmitter
             targetIl.Emit(OpCodes.Isinst, _types.TaskOfObject);
             targetIl.Emit(OpCodes.Brtrue, capabilityResolutionReadyLabel);
             targetIl.Emit(OpCodes.Ldloc, resolvedElementLocal);
-            targetIl.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+            targetIl.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
             targetIl.Emit(OpCodes.Brtrue, capabilityResolutionReadyLabel);
             targetIl.Emit(OpCodes.Ldloc, resolvedElementLocal);
-            targetIl.Emit(OpCodes.Call, runtime.PromiseResolveValueMethod);
+            targetIl.Emit(OpCodes.Call, runtime.RequirePromise().ResolveValueMethod);
             targetIl.Emit(OpCodes.Stloc, resolvedElementLocal);
             targetIl.MarkLabel(capabilityResolutionReadyLabel);
 
@@ -669,7 +658,7 @@ public partial class RuntimeEmitter
             targetIl.Emit(OpCodes.Ldloc, resolvedElementLocal);
             targetIl.Emit(OpCodes.Ldloc, thenFunctionLocal);
             targetIl.Emit(OpCodes.Ldarg_2);
-            targetIl.Emit(OpCodes.Call, runtime.GetPromiseCapabilityResolveMethod);
+            targetIl.Emit(OpCodes.Call, runtime.RequirePromise().GetPromiseCapabilityResolveMethod);
             targetIl.Emit(OpCodes.Ldnull);
             targetIl.Emit(OpCodes.Call, invokeThenMethod);
             targetIl.Emit(OpCodes.Br, normalizedLabel);
@@ -701,7 +690,7 @@ public partial class RuntimeEmitter
             targetIl.Emit(OpCodes.Ldloc, thenFunctionLocal);
             targetIl.Emit(OpCodes.Ldnull);
             targetIl.Emit(OpCodes.Ldarg_2);
-            targetIl.Emit(OpCodes.Call, runtime.GetPromiseCapabilityRejectMethod);
+            targetIl.Emit(OpCodes.Call, runtime.RequirePromise().GetPromiseCapabilityRejectMethod);
             targetIl.Emit(OpCodes.Call, invokeThenMethod);
             targetIl.Emit(OpCodes.Br, normalizedLabel);
 
@@ -728,12 +717,12 @@ public partial class RuntimeEmitter
             targetIl.Emit(OpCodes.Dup);
             targetIl.Emit(OpCodes.Ldc_I4_0);
             targetIl.Emit(OpCodes.Ldarg_2);
-            targetIl.Emit(OpCodes.Call, runtime.GetPromiseCapabilityResolveMethod);
+            targetIl.Emit(OpCodes.Call, runtime.RequirePromise().GetPromiseCapabilityResolveMethod);
             targetIl.Emit(OpCodes.Stelem_Ref);
             targetIl.Emit(OpCodes.Dup);
             targetIl.Emit(OpCodes.Ldc_I4_1);
             targetIl.Emit(OpCodes.Ldarg_2);
-            targetIl.Emit(OpCodes.Call, runtime.GetPromiseCapabilityRejectMethod);
+            targetIl.Emit(OpCodes.Call, runtime.RequirePromise().GetPromiseCapabilityRejectMethod);
             targetIl.Emit(OpCodes.Stelem_Ref);
             targetIl.Emit(OpCodes.Call, runtime.InvokeMethodValue);
             targetIl.Emit(OpCodes.Pop);
@@ -774,7 +763,7 @@ public partial class RuntimeEmitter
 
             targetIl.MarkLabel(checkNativePromiseObjectLabel);
             targetIl.Emit(OpCodes.Ldloc, resolvedElementLocal);
-            targetIl.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+            targetIl.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
             targetIl.Emit(OpCodes.Brfalse, ordinaryResolutionLabel);
             targetIl.Emit(OpCodes.Ldloc, resolvedElementLocal);
             targetIl.Emit(OpCodes.Ldstr, "then");
@@ -788,11 +777,11 @@ public partial class RuntimeEmitter
             targetIl.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
             targetIl.Emit(OpCodes.Brfalse, useOrdinaryCoercionLabel);
             targetIl.Emit(OpCodes.Ldloc, resolvedElementLocal);
-            targetIl.Emit(OpCodes.Call, runtime.PromiseResolveValueMethod);
+            targetIl.Emit(OpCodes.Call, runtime.RequirePromise().ResolveValueMethod);
             targetIl.Emit(OpCodes.Br, normalizedLabel);
             targetIl.MarkLabel(useOrdinaryCoercionLabel);
             targetIl.Emit(OpCodes.Ldloc, resolvedElementLocal);
-            targetIl.Emit(OpCodes.Call, runtime.CoerceAwaitableToTaskMethod);
+            targetIl.Emit(OpCodes.Call, runtime.RequirePromise().CoerceAwaitableToTaskMethod);
             targetIl.Emit(OpCodes.Br, normalizedLabel);
 
             targetIl.MarkLabel(invokeObservableThenLabel);
@@ -828,7 +817,7 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitPromiseCombinatorResultAdoption(EmittedRuntime runtime)
     {
-        var settle = runtime.SettlePromiseCombinatorResultMethod;
+        var settle = runtime.RequirePromise().SettlePromiseCombinatorResultMethod;
         {
             var il = settle.GetILGenerator();
             var callbacksLocal = il.DeclareLocal(_types.ObjectArray);
@@ -877,14 +866,14 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldloc, callbacksLocal);
             il.Emit(OpCodes.Ldc_I4_1);
             il.Emit(OpCodes.Ldelem_Ref);
-            il.Emit(OpCodes.Castclass, runtime.PromiseRejectCallbackType);
+            il.Emit(OpCodes.Castclass, runtime.RequirePromise().RejectCallbackType);
             il.Emit(OpCodes.Ldc_I4_1);
             il.Emit(OpCodes.Newarr, _types.Object);
             il.Emit(OpCodes.Dup);
             il.Emit(OpCodes.Ldc_I4_0);
             il.Emit(OpCodes.Ldloc, reasonLocal);
             il.Emit(OpCodes.Stelem_Ref);
-            il.Emit(OpCodes.Callvirt, runtime.PromiseRejectCallbackInvoke);
+            il.Emit(OpCodes.Callvirt, runtime.RequirePromise().RejectCallbackInvoke);
             il.Emit(OpCodes.Pop);
             il.Emit(OpCodes.Br, doneLabel);
 
@@ -892,7 +881,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldloc, callbacksLocal);
             il.Emit(OpCodes.Ldc_I4_0);
             il.Emit(OpCodes.Ldelem_Ref);
-            il.Emit(OpCodes.Castclass, runtime.PromiseResolveCallbackType);
+            il.Emit(OpCodes.Castclass, runtime.RequirePromise().ResolveCallbackType);
             il.Emit(OpCodes.Ldc_I4_1);
             il.Emit(OpCodes.Newarr, _types.Object);
             il.Emit(OpCodes.Dup);
@@ -901,20 +890,20 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Callvirt, _types.GetProperty(
                 _types.TaskOfObject, "Result").GetGetMethod()!);
             il.Emit(OpCodes.Stelem_Ref);
-            il.Emit(OpCodes.Callvirt, runtime.PromiseResolveCallbackInvoke);
+            il.Emit(OpCodes.Callvirt, runtime.RequirePromise().ResolveCallbackInvoke);
             il.Emit(OpCodes.Pop);
 
             il.MarkLabel(doneLabel);
             il.Emit(OpCodes.Ret);
         }
 
-        var adopt = runtime.AdoptPromiseCombinatorResultMethod;
+        var adopt = runtime.RequirePromise().AdoptPromiseCombinatorResultMethod;
         {
             var il = adopt.GetILGenerator();
             var tcsLocal = il.DeclareLocal(_types.TaskCompletionSourceOfObject);
             var settledLocal = il.DeclareLocal(_types.Object);
-            var resolveLocal = il.DeclareLocal(runtime.PromiseResolveCallbackType);
-            var rejectLocal = il.DeclareLocal(runtime.PromiseRejectCallbackType);
+            var resolveLocal = il.DeclareLocal(runtime.RequirePromise().ResolveCallbackType);
+            var rejectLocal = il.DeclareLocal(runtime.RequirePromise().RejectCallbackType);
             var callbacksLocal = il.DeclareLocal(_types.ObjectArray);
             var scheduleLabel = il.DefineLabel();
             var doneLabel = il.DefineLabel();
@@ -936,11 +925,11 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Stloc, settledLocal);
             il.Emit(OpCodes.Ldloc, tcsLocal);
             il.Emit(OpCodes.Ldloc, settledLocal);
-            il.Emit(OpCodes.Newobj, runtime.PromiseResolveCallbackCtor);
+            il.Emit(OpCodes.Newobj, runtime.RequirePromise().ResolveCallbackCtor);
             il.Emit(OpCodes.Stloc, resolveLocal);
             il.Emit(OpCodes.Ldloc, tcsLocal);
             il.Emit(OpCodes.Ldloc, settledLocal);
-            il.Emit(OpCodes.Newobj, runtime.PromiseRejectCallbackCtor);
+            il.Emit(OpCodes.Newobj, runtime.RequirePromise().RejectCallbackCtor);
             il.Emit(OpCodes.Stloc, rejectLocal);
 
             il.Emit(OpCodes.Ldc_I4_2);
@@ -1008,17 +997,17 @@ public partial class RuntimeEmitter
             _types.TaskOfObject,
             [_types.Object]
         );
-        runtime.UnwrapPromiseReceiverMethod = method;
+        runtime.RequirePromise().UnwrapPromiseReceiverMethod = method;
 
         var il = method.GetILGenerator();
         var notPromiseObjLabel = il.DefineLabel();
 
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Brfalse, notPromiseObjLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
-        il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);
+        il.Emit(OpCodes.Castclass, runtime.RequirePromise().Type);
+        il.Emit(OpCodes.Callvirt, runtime.RequirePromise().TaskGetter);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(notPromiseObjLabel);
@@ -1052,7 +1041,7 @@ public partial class RuntimeEmitter
     /// the two (SymbolRegistryKey/CloseSymbolAccessor) and a species naming a
     /// generic subclass is closed via SymbolClosedOwner before construction.
     /// A species that is NOT a $Promise subclass (a general guest constructor)
-    /// is routed to <see cref="EmittedRuntime.NewPromiseCapabilityResultMethod"/>
+    /// is routed to <see cref="EmittedPromiseRuntime.NewPromiseCapabilityResultMethod"/>
     /// (#349): the (object)→PromiseFromExecutor task-adoption path below only
     /// works for $Promise subclasses, so a general class is constructed with a
     /// real capturing executor and the result task adopted into its capability.
@@ -1065,7 +1054,7 @@ public partial class RuntimeEmitter
             _types.Object,
             [_types.TaskOfObject, _types.Object]
         );
-        runtime.WrapDerivedPromiseResultMethod = method;
+        runtime.RequirePromise().WrapDerivedPromiseResultMethod = method;
 
         var il = method.GetILGenerator();
         var returnResultLabel = il.DefineLabel();
@@ -1084,7 +1073,7 @@ public partial class RuntimeEmitter
 
         // if (receiver is not $Promise) return result;
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Brfalse, returnResultLabel);
 
         // var recvType = receiver.GetType();
@@ -1093,7 +1082,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, typeLocal);
         // if (recvType == typeof($Promise)) return result;
         il.Emit(OpCodes.Ldloc, typeLocal);
-        il.Emit(OpCodes.Ldtoken, runtime.TSPromiseType);
+        il.Emit(OpCodes.Ldtoken, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Call, getTypeFromHandle);
         il.Emit(OpCodes.Beq, returnResultLabel);
 
@@ -1228,14 +1217,14 @@ public partial class RuntimeEmitter
         // if (!typeof($Promise).IsAssignableFrom(speciesType))
         //     return NewPromiseCapabilityResult(speciesType, result);
         var promiseSubclassLabel = il.DefineLabel();
-        il.Emit(OpCodes.Ldtoken, runtime.TSPromiseType);
+        il.Emit(OpCodes.Ldtoken, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Call, getTypeFromHandle);
         il.Emit(OpCodes.Ldloc, speciesTypeLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.Type, "IsAssignableFrom", _types.Type));
         il.Emit(OpCodes.Brtrue, promiseSubclassLabel);
         il.Emit(OpCodes.Ldloc, speciesTypeLocal);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.NewPromiseCapabilityResultMethod);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().NewPromiseCapabilityResultMethod);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(promiseSubclassLabel);
 
@@ -1273,7 +1262,7 @@ public partial class RuntimeEmitter
         il.MarkLabel(generalFromValueLabel);
         il.Emit(OpCodes.Ldloc, speciesValLocal);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.NewPromiseCapabilityResultMethod);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().NewPromiseCapabilityResultMethod);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(returnResultLabel);
@@ -1520,11 +1509,11 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Isinst, _types.TaskOfObject);
             il.Emit(OpCodes.Brfalse, resolveOrdinaryValueLabel);
             il.Emit(OpCodes.Ldloc, valueLocal);
-            il.Emit(OpCodes.Call, runtime.CoerceAwaitableToTaskMethod);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().CoerceAwaitableToTaskMethod);
             il.Emit(OpCodes.Br, haveAdoptedTaskLabel);
             il.MarkLabel(resolveOrdinaryValueLabel);
             il.Emit(OpCodes.Ldloc, valueLocal);
-            il.Emit(OpCodes.Call, runtime.PromiseResolveValueMethod);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().ResolveValueMethod);
             il.MarkLabel(haveAdoptedTaskLabel);
             il.Emit(OpCodes.Stloc, adoptedTaskLocal);
             // Resolving a promise with itself rejects with TypeError rather than
@@ -1581,9 +1570,9 @@ public partial class RuntimeEmitter
         }
 
         typeBuilder.CreateType();
-        runtime.PromiseResolveCallbackType = typeBuilder;
-        runtime.PromiseResolveCallbackCtor = ctor;
-        runtime.PromiseResolveCallbackInvoke = invokeMethod;
+        runtime.RequirePromise().ResolveCallbackType = typeBuilder;
+        runtime.RequirePromise().ResolveCallbackCtor = ctor;
+        runtime.RequirePromise().ResolveCallbackInvoke = invokeMethod;
         return typeBuilder;
     }
 
@@ -1701,7 +1690,7 @@ public partial class RuntimeEmitter
             // SharpTSPromiseRejectedException; #232 reason-preservation).
             il.Emit(OpCodes.Ldloc, tcsLocal);
             il.Emit(OpCodes.Ldloc, reasonLocal);
-            il.Emit(OpCodes.Newobj, runtime.TSPromiseRejectedExceptionCtor);
+            il.Emit(OpCodes.Newobj, runtime.RequirePromise().RejectedExceptionCtor);
             var trySetException = typeof(TaskCompletionSource<object?>).GetMethod("TrySetException", [typeof(Exception)])!;
             il.Emit(OpCodes.Callvirt, trySetException);
             il.Emit(OpCodes.Pop);
@@ -1712,9 +1701,9 @@ public partial class RuntimeEmitter
         }
 
         typeBuilder.CreateType();
-        runtime.PromiseRejectCallbackType = typeBuilder;
-        runtime.PromiseRejectCallbackCtor = ctor;
-        runtime.PromiseRejectCallbackInvoke = invokeMethod;
+        runtime.RequirePromise().RejectCallbackType = typeBuilder;
+        runtime.RequirePromise().RejectCallbackCtor = ctor;
+        runtime.RequirePromise().RejectCallbackInvoke = invokeMethod;
         return typeBuilder;
     }
 
@@ -1733,7 +1722,7 @@ public partial class RuntimeEmitter
             _types.TaskOfObject,
             [_types.Object]
         );
-        runtime.PromiseFromExecutor = method;
+        runtime.RequirePromise().FromExecutor = method;
 
         var il = method.GetILGenerator();
 
@@ -1771,13 +1760,13 @@ public partial class RuntimeEmitter
         // var resolveCallback = new $PromiseResolveCallback(tcs, lockObj);
         il.Emit(OpCodes.Ldloc, tcsLocal);
         il.Emit(OpCodes.Ldloc, lockLocal);
-        il.Emit(OpCodes.Newobj, runtime.PromiseResolveCallbackCtor);
+        il.Emit(OpCodes.Newobj, runtime.RequirePromise().ResolveCallbackCtor);
         il.Emit(OpCodes.Stloc, resolveLocal);
 
         // var rejectCallback = new $PromiseRejectCallback(tcs, lockObj);
         il.Emit(OpCodes.Ldloc, tcsLocal);
         il.Emit(OpCodes.Ldloc, lockLocal);
-        il.Emit(OpCodes.Newobj, runtime.PromiseRejectCallbackCtor);
+        il.Emit(OpCodes.Newobj, runtime.RequirePromise().RejectCallbackCtor);
         il.Emit(OpCodes.Stloc, rejectLocal);
 
         // Create args array [resolveCallback, rejectCallback]
@@ -1827,7 +1816,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, exLocal);
         il.Emit(OpCodes.Call, runtime.WrapException);
         il.Emit(OpCodes.Stelem_Ref);
-        il.Emit(OpCodes.Callvirt, runtime.PromiseRejectCallbackInvoke);
+        il.Emit(OpCodes.Callvirt, runtime.RequirePromise().RejectCallbackInvoke);
         il.Emit(OpCodes.Pop);
 
         il.Emit(OpCodes.Leave, endTryLabel);
@@ -1870,7 +1859,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.TaskOfObject,
             [executorType]);
-        runtime.PromiseFromDirectExecutor = method;
+        runtime.RequirePromise().FromDirectExecutor = method;
 
         var il = method.GetILGenerator();
         var tcsLocal = il.DeclareLocal(typeof(TaskCompletionSource<object?>));
@@ -1890,12 +1879,12 @@ public partial class RuntimeEmitter
 
         il.Emit(OpCodes.Ldloc, tcsLocal);
         il.Emit(OpCodes.Ldloc, settledLocal);
-        il.Emit(OpCodes.Newobj, runtime.PromiseResolveCallbackCtor);
+        il.Emit(OpCodes.Newobj, runtime.RequirePromise().ResolveCallbackCtor);
         il.Emit(OpCodes.Stloc, resolveLocal);
 
         il.Emit(OpCodes.Ldloc, tcsLocal);
         il.Emit(OpCodes.Ldloc, settledLocal);
-        il.Emit(OpCodes.Newobj, runtime.PromiseRejectCallbackCtor);
+        il.Emit(OpCodes.Newobj, runtime.RequirePromise().RejectCallbackCtor);
         il.Emit(OpCodes.Stloc, rejectLocal);
 
         var completedLabel = il.DefineLabel();
@@ -1917,7 +1906,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, exLocal);
         il.Emit(OpCodes.Call, runtime.WrapException);
         il.Emit(OpCodes.Stelem_Ref);
-        il.Emit(OpCodes.Callvirt, runtime.PromiseRejectCallbackInvoke);
+        il.Emit(OpCodes.Callvirt, runtime.RequirePromise().RejectCallbackInvoke);
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Leave, completedLabel);
         il.EndExceptionBlock();

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.Finally.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.Finally.cs
@@ -247,13 +247,13 @@ public partial class RuntimeEmitter
         // Invoke callback with no args: result = InvokeCallbackNoArgs(onFinally)
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, sm.OnFinallyField);
-        il.Emit(OpCodes.Call, runtime.InvokeCallbackNoArgs);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().InvokeCallbackNoArgs);
         il.Emit(OpCodes.Stloc, callbackResultLocal);
 
         // Await PromiseResolve(result), including the observable `then` lookup
         // required for native promises whose method was overridden.
         il.Emit(OpCodes.Ldloc, callbackResultLocal);
-        il.Emit(OpCodes.Call, runtime.PromiseResolveValueMethod);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().ResolveValueMethod);
         il.Emit(OpCodes.Callvirt, _types.TaskOfObjectGetAwaiter);
         var callbackAwaiterLocal = il.DeclareLocal(awaiterType);
         il.Emit(OpCodes.Stloc, callbackAwaiterLocal);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.Keyed.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.Keyed.cs
@@ -12,9 +12,9 @@ public partial class RuntimeEmitter
     /// </summary>
     private void EmitPromiseKeyedMethodBodies(EmittedRuntime runtime)
     {
-        EmitPromiseKeyedBody(runtime.PromiseAllKeyed, runtime.PromiseAll, runtime);
+        EmitPromiseKeyedBody(runtime.RequirePromise().AllKeyed, runtime.RequirePromise().All, runtime);
         EmitPromiseKeyedBody(
-            runtime.PromiseAllSettledKeyed, runtime.PromiseAllSettled, runtime);
+            runtime.RequirePromise().AllSettledKeyed, runtime.RequirePromise().AllSettled, runtime);
         EmitPromiseKeyedMapResultBody(runtime);
     }
 
@@ -41,7 +41,7 @@ public partial class RuntimeEmitter
         il.MarkLabel(rejectInput);
         il.Emit(OpCodes.Ldstr, "Promise keyed combinator requires an object argument");
         il.Emit(OpCodes.Newobj, runtime.TSTypeErrorCtor);
-        il.Emit(OpCodes.Call, runtime.PromiseReject);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().Reject);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(validInput);
@@ -148,11 +148,11 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldtoken, _types.TaskOfObject);
         il.Emit(OpCodes.Call, _types.GetMethod(
             _types.Type, "GetTypeFromHandle", _types.RuntimeTypeHandle));
-        if (settlementMethod == runtime.PromiseAll)
+        if (settlementMethod == runtime.RequirePromise().All)
             il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Call, settlementMethod);
         il.Emit(OpCodes.Ldnull);
-        il.Emit(OpCodes.Ldftn, runtime.PromiseKeyedMapResult);
+        il.Emit(OpCodes.Ldftn, runtime.RequirePromise().KeyedMapResult);
         il.Emit(OpCodes.Newobj, _types.GetConstructor(
             callbackType, _types.Object, _types.IntPtr));
         il.Emit(OpCodes.Ldloc, keys);
@@ -163,7 +163,7 @@ public partial class RuntimeEmitter
 
     private void EmitPromiseKeyedMapResultBody(EmittedRuntime runtime)
     {
-        var il = runtime.PromiseKeyedMapResult.GetILGenerator();
+        var il = runtime.RequirePromise().KeyedMapResult.GetILGenerator();
         var listType = _types.ListOfObject;
         var keys = il.DeclareLocal(listType);
         var values = il.DeclareLocal(listType);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.Race.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.Race.cs
@@ -51,7 +51,7 @@ public partial class RuntimeEmitter
                 il.Emit(OpCodes.Ldarg_0);
             }, sm.ConstructorField, () => il.Emit(OpCodes.Ldarg_1),
             sm.CapabilityField, () => il.Emit(OpCodes.Ldarg_2),
-            runtime.MarkNonAutoAwaitPromiseMethod);
+            runtime.RequirePromise().MarkNonAutoAwaitPromiseMethod);
 
     /// <summary>
     /// Emits the MoveNext body for PromiseRace state machine.

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.ResolveValue.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.ResolveValue.cs
@@ -14,7 +14,7 @@ public partial class RuntimeEmitter
         ModuleBuilder moduleBuilder, EmittedRuntime runtime)
     {
         var jobType = EmitPromiseResolveThenableJob(moduleBuilder, runtime);
-        var method = runtime.PromiseResolveValueMethod;
+        var method = runtime.RequirePromise().ResolveValueMethod;
         var il = method.GetILGenerator();
         var tcsType = _types.TaskCompletionSourceOfObject;
         var resultLocal = il.DeclareLocal(_types.TaskOfObject);
@@ -122,9 +122,9 @@ public partial class RuntimeEmitter
         var valueField = typeBuilder.DefineField("Value", _types.Object, FieldAttributes.Private);
         var thenField = typeBuilder.DefineField("Then", _types.Object, FieldAttributes.Private);
         var resolveField = typeBuilder.DefineField(
-            "Resolve", runtime.PromiseResolveCallbackType, FieldAttributes.Private);
+            "Resolve", runtime.RequirePromise().ResolveCallbackType, FieldAttributes.Private);
         var rejectField = typeBuilder.DefineField(
-            "Reject", runtime.PromiseRejectCallbackType, FieldAttributes.Private);
+            "Reject", runtime.RequirePromise().RejectCallbackType, FieldAttributes.Private);
 
         var ctor = typeBuilder.DefineConstructor(
             MethodAttributes.Public,
@@ -147,12 +147,12 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_3);
             il.Emit(OpCodes.Ldloc, boxLocal);
-            il.Emit(OpCodes.Newobj, runtime.PromiseResolveCallbackCtor);
+            il.Emit(OpCodes.Newobj, runtime.RequirePromise().ResolveCallbackCtor);
             il.Emit(OpCodes.Stfld, resolveField);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_3);
             il.Emit(OpCodes.Ldloc, boxLocal);
-            il.Emit(OpCodes.Newobj, runtime.PromiseRejectCallbackCtor);
+            il.Emit(OpCodes.Newobj, runtime.RequirePromise().RejectCallbackCtor);
             il.Emit(OpCodes.Stfld, rejectField);
             il.Emit(OpCodes.Ret);
         }
@@ -195,7 +195,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldloc, exceptionLocal);
             il.Emit(OpCodes.Call, runtime.WrapException);
             il.Emit(OpCodes.Stelem_Ref);
-            il.Emit(OpCodes.Callvirt, runtime.PromiseRejectCallbackInvoke);
+            il.Emit(OpCodes.Callvirt, runtime.RequirePromise().RejectCallbackInvoke);
             il.Emit(OpCodes.Pop);
             il.Emit(OpCodes.Leave, doneLabel);
             il.EndExceptionBlock();

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.Then.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.Then.cs
@@ -163,14 +163,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.BoundArrayMethodType);
         il.Emit(OpCodes.Brtrue, attachHandler);
         il.Emit(OpCodes.Ldarg_2);
-        il.Emit(OpCodes.Isinst, runtime.PromiseResolveCallbackType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().ResolveCallbackType);
         il.Emit(OpCodes.Brtrue, attachHandler);
         il.Emit(OpCodes.Ldarg_2);
-        il.Emit(OpCodes.Isinst, runtime.PromiseRejectCallbackType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().RejectCallbackType);
         il.Emit(OpCodes.Brfalse, attachDone);
         il.MarkLabel(attachHandler);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.NotifyPromiseRejectionHandler);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().NotifyPromiseRejectionHandler);
         il.MarkLabel(attachDone);
 
         // Initialize state machine: var sm = default($PromiseThen_SM);
@@ -375,11 +375,11 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, onFulfilledCallableLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, sm.OnFulfilledField);
-        il.Emit(OpCodes.Isinst, runtime.PromiseResolveCallbackType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().ResolveCallbackType);
         il.Emit(OpCodes.Brtrue, onFulfilledCallableLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, sm.OnFulfilledField);
-        il.Emit(OpCodes.Isinst, runtime.PromiseRejectCallbackType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().RejectCallbackType);
         il.Emit(OpCodes.Brtrue, onFulfilledCallableLabel);
         il.Emit(OpCodes.Br, noCallbackLabel);
         il.MarkLabel(onFulfilledCallableLabel);
@@ -406,7 +406,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldfld, sm.OnFulfilledField);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, sm.ValueField);
-        il.Emit(OpCodes.Call, runtime.InvokeCallback);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().InvokeCallback);
         il.Emit(OpCodes.Stloc, callbackResultLocal);
 
         // Primitive values cannot be thenables. Complete the reaction directly
@@ -448,7 +448,7 @@ public partial class RuntimeEmitter
         // Task-backed native Promise (an own `then` override must win), and
         // turns an abrupt getter into a rejected task.
         il.Emit(OpCodes.Ldloc, callbackResultLocal);
-        il.Emit(OpCodes.Call, runtime.PromiseResolveValueMethod);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().ResolveValueMethod);
         il.Emit(OpCodes.Callvirt, _types.TaskOfObjectGetAwaiter);
         var flattenAwaiterLocal = il.DeclareLocal(awaiterType);
         il.Emit(OpCodes.Stloc, flattenAwaiterLocal);
@@ -553,11 +553,11 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, onRejectedCallableLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, sm.OnRejectedField);
-        il.Emit(OpCodes.Isinst, runtime.PromiseResolveCallbackType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().ResolveCallbackType);
         il.Emit(OpCodes.Brtrue, onRejectedCallableLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, sm.OnRejectedField);
-        il.Emit(OpCodes.Isinst, runtime.PromiseRejectCallbackType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().RejectCallbackType);
         il.Emit(OpCodes.Brtrue, onRejectedCallableLabel);
         il.Emit(OpCodes.Br, noRejectCallbackLabel);
         il.MarkLabel(onRejectedCallableLabel);
@@ -585,7 +585,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldfld, sm.OnRejectedField);
         il.Emit(OpCodes.Ldloc, exceptionLocal);
         il.Emit(OpCodes.Call, runtime.WrapException);
-        il.Emit(OpCodes.Call, runtime.InvokeCallback);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().InvokeCallback);
         il.Emit(OpCodes.Stloc, resultLocal);
         il.Emit(OpCodes.Leave, handlerInvokeDoneLabel);
         il.BeginCatchBlock(typeof(Exception));
@@ -605,7 +605,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, handlerExceptionLocal);
         il.Emit(OpCodes.Brtrue, rejectionHandlerNonTaskLabel);
         il.Emit(OpCodes.Ldloc, resultLocal);
-        il.Emit(OpCodes.Call, runtime.PromiseResolveValueMethod);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().ResolveValueMethod);
         il.Emit(OpCodes.Stloc, rejectionTaskLocal);
         il.Emit(OpCodes.Ldloc, rejectionTaskLocal);
         il.Emit(OpCodes.Callvirt, _types.TaskOfObjectGetAwaiter);
@@ -788,7 +788,7 @@ public partial class RuntimeEmitter
             // PerformPromiseThen marks a rejected source handled when the
             // callable rejection reaction is attached, before the job runs.
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Call, runtime!.NotifyPromiseRejectionHandler);
+            il.Emit(OpCodes.Call, runtime!.RequirePromise().NotifyPromiseRejectionHandler);
         }
 
         il.Emit(OpCodes.Ldloca, smLocal);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Promises.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Promises.cs
@@ -204,32 +204,32 @@ public partial class RuntimeEmitter
         // Static value-form methods need NewPromiseCapability before the
         // executor-support bodies are filled at the end of this emitter.
         // Predeclare the shared helper so those wrappers can reference it.
-        runtime.NewPromiseCapabilityResultMethod ??= typeBuilder.DefineMethod(
+        runtime.RequirePromise().NewPromiseCapabilityResultMethod = typeBuilder.DefineMethod(
             "NewPromiseCapabilityResult",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.TaskOfObject]);
-        runtime.PreparePromiseCapabilityMethod ??= typeBuilder.DefineMethod(
+        runtime.RequirePromise().PreparePromiseCapabilityMethod = typeBuilder.DefineMethod(
             "PreparePromiseCapability",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object]);
-        runtime.AdoptPromiseCapabilityMethod ??= typeBuilder.DefineMethod(
+        runtime.RequirePromise().AdoptPromiseCapabilityMethod = typeBuilder.DefineMethod(
             "AdoptPromiseCapability",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.TaskOfObject]);
-        runtime.AdoptCompletedPromiseCapabilityMethod ??= typeBuilder.DefineMethod(
+        runtime.RequirePromise().AdoptCompletedPromiseCapabilityMethod = typeBuilder.DefineMethod(
             "AdoptCompletedPromiseCapability",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.TaskOfObject]);
-        runtime.GetPromiseCapabilityResolveMethod ??= typeBuilder.DefineMethod(
+        runtime.RequirePromise().GetPromiseCapabilityResolveMethod = typeBuilder.DefineMethod(
             "GetPromiseCapabilityResolve",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object]);
-        runtime.GetPromiseCapabilityRejectMethod ??= typeBuilder.DefineMethod(
+        runtime.RequirePromise().GetPromiseCapabilityRejectMethod = typeBuilder.DefineMethod(
             "GetPromiseCapabilityReject",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
@@ -244,7 +244,7 @@ public partial class RuntimeEmitter
             taskType,
             [_types.Object]
         );
-        runtime.PromiseResolve = resolve;
+        runtime.RequirePromise().Resolve = resolve;
         {
             var il = resolve.GetILGenerator();
             var notTaskLabel = il.DefineLabel();
@@ -252,7 +252,7 @@ public partial class RuntimeEmitter
             var taskLocal = il.DeclareLocal(taskType);
             var tcsType = typeof(TaskCompletionSource<object?>);
             var tcsLocal = il.DeclareLocal(tcsType);
-            var callbackLocal = il.DeclareLocal(runtime.PromiseResolveCallbackType);
+            var callbackLocal = il.DeclareLocal(runtime.RequirePromise().ResolveCallbackType);
 
             // Check if value is already a Task<object?>
             il.Emit(OpCodes.Ldarg_0);
@@ -284,7 +284,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldloc, tcsLocal);
             il.Emit(OpCodes.Newobj, typeof(System.Runtime.CompilerServices.StrongBox<bool>)
                 .GetConstructor(Type.EmptyTypes)!);
-            il.Emit(OpCodes.Newobj, runtime.PromiseResolveCallbackCtor);
+            il.Emit(OpCodes.Newobj, runtime.RequirePromise().ResolveCallbackCtor);
             il.Emit(OpCodes.Stloc, callbackLocal);
             il.Emit(OpCodes.Ldloc, callbackLocal);
             il.Emit(OpCodes.Ldc_I4_1);
@@ -293,7 +293,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldc_I4_0);
             il.Emit(OpCodes.Ldloc, taskLocal);
             il.Emit(OpCodes.Stelem_Ref);
-            il.Emit(OpCodes.Callvirt, runtime.PromiseResolveCallbackInvoke);
+            il.Emit(OpCodes.Callvirt, runtime.RequirePromise().ResolveCallbackInvoke);
             il.Emit(OpCodes.Pop);
             il.Emit(OpCodes.Ldloc, tcsLocal);
             il.Emit(OpCodes.Callvirt, tcsType.GetProperty("Task")!.GetGetMethod()!);
@@ -304,7 +304,7 @@ public partial class RuntimeEmitter
             // it is callable.
             il.MarkLabel(notTaskLabel);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Call, runtime.PromiseResolveValueMethod);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().ResolveValueMethod);
             il.Emit(OpCodes.Ret);
         }
 
@@ -316,12 +316,12 @@ public partial class RuntimeEmitter
             taskType,
             [_types.Object]
         );
-        runtime.PromiseReject = reject;
+        runtime.RequirePromise().Reject = reject;
         {
             var il = reject.GetILGenerator();
             // Create $PromiseRejectedException from reason (preserves original value in Reason property)
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Newobj, runtime.TSPromiseRejectedExceptionCtor);
+            il.Emit(OpCodes.Newobj, runtime.RequirePromise().RejectedExceptionCtor);
             // Call Task.FromException<object?>(exception) - keep typeof() for arity-based generic lookup
             var fromException = EmitGenerics.MakeGenericMethod(typeof(Task).GetMethod("FromException", 1, [typeof(Exception)])!, _types.Object);
             il.Emit(OpCodes.Call, fromException);
@@ -341,7 +341,7 @@ public partial class RuntimeEmitter
             [_types.Object, _types.Object]);
         resolveStatic.DefineParameter(1, ParameterAttributes.None, "__this");
         resolveStatic.DefineParameter(2, ParameterAttributes.None, "value");
-        runtime.PromiseResolveStatic = resolveStatic;
+        runtime.RequirePromise().ResolveStatic = resolveStatic;
         {
             var il = resolveStatic.GetILGenerator();
             EmitPromiseStaticThisObjectCheck(il, runtime,
@@ -355,9 +355,9 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Beq, intrinsicLabel);
 
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Call, runtime.PreparePromiseCapabilityMethod);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().PreparePromiseCapabilityMethod);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, runtime.ResolvePreparedPromiseCapabilityMethod);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().ResolvePreparedPromiseCapabilityMethod);
             il.Emit(OpCodes.Ret);
 
             il.MarkLabel(intrinsicLabel);
@@ -373,7 +373,7 @@ public partial class RuntimeEmitter
             [_types.Object, _types.Object]);
         rejectStatic.DefineParameter(1, ParameterAttributes.None, "__this");
         rejectStatic.DefineParameter(2, ParameterAttributes.None, "reason");
-        runtime.PromiseRejectStatic = rejectStatic;
+        runtime.RequirePromise().RejectStatic = rejectStatic;
         {
             var il = rejectStatic.GetILGenerator();
             EmitPromiseStaticThisObjectCheck(il, runtime,
@@ -389,7 +389,7 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.PromiseWithResolvers = withResolvers;
+        runtime.RequirePromise().WithResolvers = withResolvers;
         {
             var il = withResolvers.GetILGenerator();
 
@@ -547,29 +547,20 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ret);
         }
 
-        // Predeclare the promise/thenable adoption helper. Its body is emitted
-        // later with the capability support, but combinator normalization must
-        // be able to reference it now.
-        runtime.CoerceAwaitableToTaskMethod ??= typeBuilder.DefineMethod(
-            "CoerceAwaitableToTask",
-            MethodAttributes.Public | MethodAttributes.Static,
-            _types.TaskOfObject,
-            [_types.Object]);
-
         // Reserve NormalizePromiseList before the combinators so their state
         // machines can reference it. Its body is emitted after the iterator
         // protocol helpers and $IteratorWrapper exist.
-        runtime.NormalizePromiseListMethod = typeBuilder.DefineMethod(
+        runtime.RequirePromise().NormalizePromiseListMethod = typeBuilder.DefineMethod(
             "NormalizePromiseList",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.Object,
             [_types.Object, _types.Object, _types.Object, _types.Int32, _types.Boolean]);
-        runtime.AdoptPromiseCombinatorResultMethod = typeBuilder.DefineMethod(
+        runtime.RequirePromise().AdoptPromiseCombinatorResultMethod = typeBuilder.DefineMethod(
             "AdoptPromiseCombinatorResult",
             MethodAttributes.Public | MethodAttributes.Static,
             _types.TaskOfObject,
             [_types.TaskOfObject]);
-        runtime.SettlePromiseCombinatorResultMethod = typeBuilder.DefineMethod(
+        runtime.RequirePromise().SettlePromiseCombinatorResultMethod = typeBuilder.DefineMethod(
             "SettlePromiseCombinatorResult",
             MethodAttributes.Private | MethodAttributes.Static,
             _types.Void,
@@ -583,7 +574,7 @@ public partial class RuntimeEmitter
             taskType,
             [_types.Object, _types.Object, _types.Object]
         );
-        runtime.PromiseAll = all;
+        runtime.RequirePromise().All = all;
         EmitPromiseAllWrapper(all.GetILGenerator(), promiseAllSM, runtime, stablePrimitive: false);
 
         var allPrimitive = typeBuilder.DefineMethod(
@@ -592,7 +583,7 @@ public partial class RuntimeEmitter
             taskType,
             [_types.Object, _types.Object, _types.Object]
         );
-        runtime.PromiseAllPrimitive = allPrimitive;
+        runtime.RequirePromise().AllPrimitive = allPrimitive;
         var primitiveAllSettlement = DefineCompletedPrimitivePromiseAllSettlement(
             moduleBuilder);
         EmitCompletedPrimitivePromiseAll(
@@ -609,7 +600,7 @@ public partial class RuntimeEmitter
             taskType,
             [_types.Object, _types.Object, _types.Object]
         );
-        runtime.PromiseRace = race;
+        runtime.RequirePromise().Race = race;
         EmitPromiseRaceWrapper(race.GetILGenerator(), promiseRaceSM, runtime);
         EmitPromiseRaceMoveNext(promiseRaceSM, runtime);
         promiseRaceSM.Type.CreateType();
@@ -634,7 +625,7 @@ public partial class RuntimeEmitter
             taskType,
             [_types.Object, _types.Object]
         );
-        runtime.PromiseAllSettled = allSettled;
+        runtime.RequirePromise().AllSettled = allSettled;
         EmitPromiseAllSettledWrapper(allSettled.GetILGenerator(), promiseAllSettledSM, processElementSettled, runtime);
         EmitPromiseAllSettledMoveNext(promiseAllSettledSM, processElementSettled, runtime);
         promiseAllSettledSM.Type.CreateType();
@@ -642,13 +633,13 @@ public partial class RuntimeEmitter
         // Await Dictionary proposal combinators. Their shells are declared
         // here with the other Promise statics; bodies are emitted later, once
         // own-key, descriptor, symbol, and prototype helpers are available.
-        runtime.PromiseAllKeyed = typeBuilder.DefineMethod(
+        runtime.RequirePromise().AllKeyed = typeBuilder.DefineMethod(
             "PromiseAllKeyed", MethodAttributes.Public | MethodAttributes.Static,
             taskType, [_types.Object]);
-        runtime.PromiseAllSettledKeyed = typeBuilder.DefineMethod(
+        runtime.RequirePromise().AllSettledKeyed = typeBuilder.DefineMethod(
             "PromiseAllSettledKeyed", MethodAttributes.Public | MethodAttributes.Static,
             taskType, [_types.Object]);
-        runtime.PromiseKeyedMapResult = typeBuilder.DefineMethod(
+        runtime.RequirePromise().KeyedMapResult = typeBuilder.DefineMethod(
             "PromiseKeyedMapResult", MethodAttributes.Private | MethodAttributes.Static,
             _types.Object, [taskType, _types.Object]);
 
@@ -691,7 +682,7 @@ public partial class RuntimeEmitter
             taskType,
             [_types.Object, _types.Object, _types.Object]
         );
-        runtime.PromiseAny = any;
+        runtime.RequirePromise().Any = any;
         EmitPromiseAnyWrapper(any.GetILGenerator(), promiseAnySM, runtime);
         EmitPromiseAnyMoveNext(promiseAnySM, anyState, anyElementState,
             handleAnyCompletionShim, runtime);
@@ -718,12 +709,12 @@ public partial class RuntimeEmitter
                 passCapabilityToIntrinsic: jsName is "all" or "race" or "any",
                 prepareIntrinsicCapability: jsName == "race");
         }
-        EmitAllRaceVariantStaticWrapper("PromiseAllStatic", "all", all, m => runtime.PromiseAllStatic = m);
-        EmitAllRaceVariantStaticWrapper("PromiseAllKeyedStatic", "allKeyed", runtime.PromiseAllKeyed, m => runtime.PromiseAllKeyedStatic = m);
-        EmitAllRaceVariantStaticWrapper("PromiseRaceStatic", "race", race, m => runtime.PromiseRaceStatic = m);
-        EmitAllRaceVariantStaticWrapper("PromiseAllSettledStatic", "allSettled", allSettled, m => runtime.PromiseAllSettledStatic = m);
-        EmitAllRaceVariantStaticWrapper("PromiseAllSettledKeyedStatic", "allSettledKeyed", runtime.PromiseAllSettledKeyed, m => runtime.PromiseAllSettledKeyedStatic = m);
-        EmitAllRaceVariantStaticWrapper("PromiseAnyStatic", "any", any, m => runtime.PromiseAnyStatic = m);
+        EmitAllRaceVariantStaticWrapper("PromiseAllStatic", "all", all, m => runtime.RequirePromise().AllStatic = m);
+        EmitAllRaceVariantStaticWrapper("PromiseAllKeyedStatic", "allKeyed", runtime.RequirePromise().AllKeyed, m => runtime.RequirePromise().AllKeyedStatic = m);
+        EmitAllRaceVariantStaticWrapper("PromiseRaceStatic", "race", race, m => runtime.RequirePromise().RaceStatic = m);
+        EmitAllRaceVariantStaticWrapper("PromiseAllSettledStatic", "allSettled", allSettled, m => runtime.RequirePromise().AllSettledStatic = m);
+        EmitAllRaceVariantStaticWrapper("PromiseAllSettledKeyedStatic", "allSettledKeyed", runtime.RequirePromise().AllSettledKeyed, m => runtime.RequirePromise().AllSettledKeyedStatic = m);
+        EmitAllRaceVariantStaticWrapper("PromiseAnyStatic", "any", any, m => runtime.RequirePromise().AnyStatic = m);
 
         // Callback invocation helpers must be emitted first (used by then/finally)
         EmitCallbackHelpers(typeBuilder, runtime);
@@ -737,7 +728,7 @@ public partial class RuntimeEmitter
             taskType,
             [taskType, _types.Object, _types.Object]
         );
-        runtime.PromiseThen = then;
+        runtime.RequirePromise().Then = then;
         EmitPromiseThenWrapper(then.GetILGenerator(), promiseThenSM, runtime);
         EmitPromiseThenMoveNext(promiseThenSM, runtime, promiseJobAwaiterType);
         promiseThenSM.Type.CreateType();
@@ -757,7 +748,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             taskType,
             [taskType, objectPrimitiveHandlerType]);
-        runtime.PromiseThenObjectPrimitive = objectPrimitiveThen;
+        runtime.RequirePromise().ThenObjectPrimitive = objectPrimitiveThen;
         EmitPrimitivePromiseThenWrapper(
             objectPrimitiveThen.GetILGenerator(), objectPrimitivePromiseThenSM);
         EmitPrimitivePromiseThenMoveNext(
@@ -784,7 +775,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             taskType,
             [taskType, primitiveHandlerType, primitiveRejectHandlerType]);
-        runtime.PromiseThenPrimitiveWithRejection = primitiveWithRejection;
+        runtime.RequirePromise().ThenPrimitiveWithRejection = primitiveWithRejection;
         EmitPrimitivePromiseThenWrapper(
             primitiveWithRejection.GetILGenerator(), primitiveWithRejectionSM, runtime);
         EmitPrimitivePromiseThenWithRejectionMoveNext(
@@ -823,7 +814,7 @@ public partial class RuntimeEmitter
             taskType,
             [taskType, typeof(Func<double, double>)]
         );
-        runtime.PromiseThenPrimitive = primitiveThen;
+        runtime.RequirePromise().ThenPrimitive = primitiveThen;
         EmitPrimitivePromiseChainAppend(
             primitiveThen.GetILGenerator(),
             primitiveChain,
@@ -840,7 +831,7 @@ public partial class RuntimeEmitter
             taskType,
             [taskType, _types.Object]
         );
-        runtime.PromiseCatch = catchMethod;
+        runtime.RequirePromise().Catch = catchMethod;
         {
             var il = catchMethod.GetILGenerator();
             il.Emit(OpCodes.Ldarg_0);  // task
@@ -859,7 +850,7 @@ public partial class RuntimeEmitter
             taskType,
             [taskType, _types.Object]
         );
-        runtime.PromiseFinally = finallyMethod;
+        runtime.RequirePromise().Finally = finallyMethod;
         EmitPromiseFinallyWrapper(finallyMethod.GetILGenerator(), promiseFinallySM);
         EmitPromiseFinallyMoveNext(
             promiseFinallySM, runtime, promiseJobAwaiterType);
@@ -885,7 +876,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public | MethodAttributes.Static,
             _types.TaskOfObject,
             [_types.TaskOfObject]);
-        runtime.TrackTopLevelPromiseReaction = method;
+        runtime.RequirePromise().TrackTopLevelPromiseReaction = method;
 
         var il = method.GetILGenerator();
         var done = il.DefineLabel();
@@ -1002,7 +993,7 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(customConstructorLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.PreparePromiseCapabilityMethod);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().PreparePromiseCapabilityMethod);
         il.Emit(OpCodes.Stloc, capabilityLocal);
 
         il.MarkLabel(invokeIntrinsicLabel);
@@ -1019,7 +1010,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, returnIntrinsicLabel);
         il.Emit(OpCodes.Ldloc, capabilityLocal);
         il.Emit(OpCodes.Ldloc, taskLocal);
-        il.Emit(OpCodes.Call, runtime.AdoptCompletedPromiseCapabilityMethod);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().AdoptCompletedPromiseCapabilityMethod);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(returnIntrinsicLabel);
@@ -1041,7 +1032,7 @@ public partial class RuntimeEmitter
             typeof(object),
             [typeof(object), typeof(object)]
         );
-        runtime.InvokeCallback = invokeCallback;
+        runtime.RequirePromise().InvokeCallback = invokeCallback;
         {
             var il = invokeCallback.GetILGenerator();
             var nullLabel = il.DefineLabel();
@@ -1120,7 +1111,7 @@ public partial class RuntimeEmitter
             typeof(object),
             [typeof(object)]
         );
-        runtime.InvokeCallbackNoArgs = invokeCallbackNoArgs;
+        runtime.RequirePromise().InvokeCallbackNoArgs = invokeCallbackNoArgs;
         {
             var il = invokeCallbackNoArgs.GetILGenerator();
             var nullLabel = il.DefineLabel();

--- a/src/SharpTS/Compilation/RuntimeEmitter.ReadableStream.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.ReadableStream.cs
@@ -762,11 +762,11 @@ public partial class RuntimeEmitter
         il.MarkLabel(pullNotTaskLabel);
         // if (pullResult is $Promise p) p.GetValueAsync().GetAwaiter().GetResult()
         il.Emit(OpCodes.Ldloc, pullResultLocal);
-        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Brfalse, pullNotPromiseLabel);
         il.Emit(OpCodes.Ldloc, pullResultLocal);
-        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
-        il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);
+        il.Emit(OpCodes.Castclass, runtime.RequirePromise().Type);
+        il.Emit(OpCodes.Callvirt, runtime.RequirePromise().TaskGetter);
         EmitSyncAwaitTaskOfObject(il, pullAwaiterLocal);
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Br, pullAwaitDoneLabel);
@@ -1311,11 +1311,11 @@ public partial class RuntimeEmitter
         // else if (result is $Promise p) sync-await(p.GetValueAsync())
         il.MarkLabel(notTaskLabel);
         il.Emit(OpCodes.Ldloc, resultLocal);
-        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Brfalse, notPromiseLabel);
         il.Emit(OpCodes.Ldloc, resultLocal);
-        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
-        il.Emit(OpCodes.Callvirt, runtime.TSPromiseGetValueAsync);
+        il.Emit(OpCodes.Castclass, runtime.RequirePromise().Type);
+        il.Emit(OpCodes.Callvirt, runtime.RequirePromise().GetValueAsync);
         EmitSyncAwaitTaskOfObject(il, awaiterLocal);
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Br, doneLabel);
@@ -1363,11 +1363,11 @@ public partial class RuntimeEmitter
         // else if (result is $Promise p) { coopTask = p.GetValueAsync(); goto haveTask }
         il.MarkLabel(notTaskLabel);
         il.Emit(OpCodes.Ldloc, resultLocal);
-        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Brfalse, notPromiseLabel);
         il.Emit(OpCodes.Ldloc, resultLocal);
-        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
-        il.Emit(OpCodes.Callvirt, runtime.TSPromiseGetValueAsync);
+        il.Emit(OpCodes.Castclass, runtime.RequirePromise().Type);
+        il.Emit(OpCodes.Callvirt, runtime.RequirePromise().GetValueAsync);
         il.Emit(OpCodes.Stloc, coopTaskLocal);
         il.Emit(OpCodes.Br, haveTaskLabel);
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Reflect.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Reflect.cs
@@ -1259,7 +1259,7 @@ public partial class RuntimeEmitter
         // executor must throw before GetPrototypeFromConstructor(newTarget), so
         // a bound newTarget with an abrupt prototype getter cannot mask the
         // required TypeError (ECMA-262 Promise constructor steps 2-3).
-        if (runtime.PromiseFromExecutor is not null)
+        if (runtime.Promise is not null)
         {
             var notPromiseTypeLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
@@ -1284,7 +1284,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldloc, argsLocal);
             il.Emit(OpCodes.Ldc_I4_0);
             il.Emit(OpCodes.Ldelem_Ref);
-            il.Emit(OpCodes.Call, runtime.PromiseFromExecutor);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().FromExecutor);
             il.Emit(OpCodes.Ret);
 
             il.MarkLabel(notPromiseTypeLabel);

--- a/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RuntimeClass.cs
@@ -240,7 +240,7 @@ public partial class RuntimeEmitter
         // Promise.prototype is entirely absent from Promise-free assemblies.
         if (_features.UsesPromise)
         {
-            runtime.PromisePrototypeField = typeBuilder.DefineField(
+            runtime.RequirePromise().PrototypeField = typeBuilder.DefineField(
                 "_promisePrototype",
                 _types.DictionaryStringObject,
                 FieldAttributes.Public | FieldAttributes.Static);
@@ -418,7 +418,7 @@ public partial class RuntimeEmitter
                 MethodAttributes.Public | MethodAttributes.Static,
                 _types.Void,
                 [_types.Object]);
-            runtime.MarkNonAutoAwaitPromiseMethod = markNonAutoAwaitPromise;
+            runtime.RequirePromise().MarkNonAutoAwaitPromiseMethod = markNonAutoAwaitPromise;
             {
                 var il = markNonAutoAwaitPromise.GetILGenerator();
                 var doneLabel = il.DefineLabel();
@@ -438,7 +438,7 @@ public partial class RuntimeEmitter
                 MethodAttributes.Public | MethodAttributes.Static,
                 _types.Boolean,
                 [_types.Object]);
-            runtime.ShouldAutoAwaitPromiseMethod = shouldAutoAwaitPromise;
+            runtime.RequirePromise().ShouldAutoAwaitPromiseMethod = shouldAutoAwaitPromise;
             {
                 var il = shouldAutoAwaitPromise.GetILGenerator();
                 var valueLocal = il.DeclareLocal(_types.Object);
@@ -648,7 +648,7 @@ public partial class RuntimeEmitter
         {
             // Promise.prototype starts empty; populated lazily on first read.
             cctorIL.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.DictionaryStringObject));
-            cctorIL.Emit(OpCodes.Stsfld, runtime.PromisePrototypeField);
+            cctorIL.Emit(OpCodes.Stsfld, runtime.RequirePromise().PrototypeField);
         }
 
         cctorIL.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(classPrototypeCacheType));
@@ -814,21 +814,21 @@ public partial class RuntimeEmitter
         EmitJsLessOrEqual(typeBuilder, runtime);
         EmitUpdateNumeric(typeBuilder, runtime);
         EmitIsTruthy(typeBuilder, runtime);
-        // Promise resolving callbacks need the adoption helper token before
-        // EmitPromiseMethods fills in its body later in this method.
+        // Promise resolving callbacks need these adoption tokens before their
+        // bodies are filled by the resolve-value and capability emitters.
         if (_features.UsesPromise)
         {
-            runtime.CoerceAwaitableToTaskMethod ??= typeBuilder.DefineMethod(
+            runtime.RequirePromise().CoerceAwaitableToTaskMethod = typeBuilder.DefineMethod(
                 "CoerceAwaitableToTask",
                 MethodAttributes.Public | MethodAttributes.Static,
                 _types.TaskOfObject,
                 [_types.Object]);
-            runtime.PromiseResolveValueMethod ??= typeBuilder.DefineMethod(
+            runtime.RequirePromise().ResolveValueMethod = typeBuilder.DefineMethod(
                 "PromiseResolveValue",
                 MethodAttributes.Public | MethodAttributes.Static,
                 _types.TaskOfObject,
                 [_types.Object]);
-            runtime.ResolvePreparedPromiseCapabilityMethod ??= typeBuilder.DefineMethod(
+            runtime.RequirePromise().ResolvePreparedPromiseCapabilityMethod = typeBuilder.DefineMethod(
                 "ResolvePreparedPromiseCapability",
                 MethodAttributes.Public | MethodAttributes.Static,
                 _types.Object,
@@ -1434,7 +1434,7 @@ public partial class RuntimeEmitter
         // were never created.
         if (_features.UsesRegExp)
             EmitRegExpPrototypePopulate(typeBuilder, runtime);
-        // Promise.prototype helpers + populate. Helpers wrap runtime.PromiseThen
+        // Promise.prototype helpers + populate. Helpers wrap runtime.RequirePromise().Then
         // /PromiseCatch/PromiseFinally with an `__this`-aware signature so
         // `Promise.prototype.then.call(p, fn)` routes correctly. Must come
         // after EmitPromiseMethods so the helper bodies can reference the

--- a/src/SharpTS/Compilation/RuntimeEmitter.StringPrototypeStubs.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.StringPrototypeStubs.cs
@@ -638,11 +638,11 @@ public partial class RuntimeEmitter
         // populate with "Promise". Emit a direct brand check here so
         // `Object.prototype.toString.call(promise) === "[object Promise]"`
         // without depending on prototype-chain walks at runtime.
-        if (runtime.TSPromiseType != null)
+        if (runtime.Promise is not null)
         {
             var notTSPromiseLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
             il.Emit(OpCodes.Brfalse, notTSPromiseLabel);
             EmitTag("[object Promise]");
             il.MarkLabel(notTSPromiseLabel);

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSEventEmitter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSEventEmitter.cs
@@ -421,11 +421,11 @@ public partial class RuntimeEmitter
         {
             var notPromise = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
             il.Emit(OpCodes.Brfalse, notPromise);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
-            il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);
+            il.Emit(OpCodes.Castclass, runtime.RequirePromise().Type);
+            il.Emit(OpCodes.Callvirt, runtime.RequirePromise().TaskGetter);
             il.Emit(OpCodes.Stloc, taskLocal);
             il.Emit(OpCodes.Br, haveTask);
             il.MarkLabel(notPromise);
@@ -462,11 +462,11 @@ public partial class RuntimeEmitter
         {
             var notRejected = il.DefineLabel();
             il.Emit(OpCodes.Ldloc, innerLocal);
-            il.Emit(OpCodes.Isinst, runtime.TSPromiseRejectedExceptionType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().RejectedExceptionType);
             il.Emit(OpCodes.Brfalse, notRejected);
             il.Emit(OpCodes.Ldloc, innerLocal);
-            il.Emit(OpCodes.Castclass, runtime.TSPromiseRejectedExceptionType);
-            il.Emit(OpCodes.Callvirt, runtime.TSPromiseRejectedExceptionReasonGetter);
+            il.Emit(OpCodes.Castclass, runtime.RequirePromise().RejectedExceptionType);
+            il.Emit(OpCodes.Callvirt, runtime.RequirePromise().RejectedExceptionReasonGetter);
             il.Emit(OpCodes.Stloc, reasonLocal);
             il.Emit(OpCodes.Br, haveReason);
             il.MarkLabel(notRejected);

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSPromise.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSPromise.cs
@@ -12,10 +12,10 @@ public partial class RuntimeEmitter
     // Promise class fields
     private FieldBuilder _tsPromiseTaskField = null!;
 
-    private void EmitTSPromiseClass(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    private void EmitTSPromiseClass(ModuleBuilder moduleBuilder, EmittedPromiseRuntime promise)
     {
         // First emit the PromiseRejectedException class (needed by Reject method)
-        EmitTSPromiseRejectedException(moduleBuilder, runtime);
+        EmitTSPromiseRejectedException(moduleBuilder, promise);
 
         // Define class: public class $Promise
         var typeBuilder = EmitTypeDefinitions.DefineType(moduleBuilder,
@@ -23,7 +23,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.BeforeFieldInit,
             _types.Object
         );
-        runtime.TSPromiseType = typeBuilder;
+        promise.Type = typeBuilder;
 
         // Field: private readonly Task<object?> _task
         _tsPromiseTaskField = typeBuilder.DefineField(
@@ -33,37 +33,37 @@ public partial class RuntimeEmitter
         );
 
         // Constructor: public $Promise(Task<object?> task)
-        EmitTSPromiseConstructor(typeBuilder, runtime);
+        EmitTSPromiseConstructor(typeBuilder, promise);
 
         // Property: Task (getter)
-        EmitTSPromiseTaskProperty(typeBuilder, runtime);
+        EmitTSPromiseTaskProperty(typeBuilder, promise);
 
         // Static method: Resolve(object? value)
-        EmitTSPromiseResolve(typeBuilder, runtime);
+        EmitTSPromiseResolve(typeBuilder, promise);
 
         // Static method: Reject(object? reason)
-        EmitTSPromiseReject(typeBuilder, runtime);
+        EmitTSPromiseReject(typeBuilder, promise);
 
         // Method: GetValueAsync()
-        EmitTSPromiseGetValueAsync(typeBuilder, runtime);
+        EmitTSPromiseGetValueAsync(typeBuilder, promise);
 
         // Property: IsCompleted
-        EmitTSPromiseIsCompletedProperty(typeBuilder, runtime);
+        EmitTSPromiseIsCompletedProperty(typeBuilder, promise);
 
         // Override: ToString()
-        EmitTSPromiseToString(typeBuilder, runtime);
+        EmitTSPromiseToString(typeBuilder, promise);
 
         typeBuilder.CreateType();
     }
 
-    private void EmitTSPromiseConstructor(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTSPromiseConstructor(TypeBuilder typeBuilder, EmittedPromiseRuntime promise)
     {
         var ctor = typeBuilder.DefineConstructor(
             MethodAttributes.Public,
             CallingConventions.Standard,
             [_types.TaskOfObject]
         );
-        runtime.TSPromiseCtor = ctor;
+        promise.Ctor = ctor;
 
         var il = ctor.GetILGenerator();
 
@@ -79,7 +79,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitTSPromiseTaskProperty(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTSPromiseTaskProperty(TypeBuilder typeBuilder, EmittedPromiseRuntime promise)
     {
         var prop = typeBuilder.DefineProperty(
             "Task",
@@ -94,7 +94,7 @@ public partial class RuntimeEmitter
             _types.TaskOfObject,
             Type.EmptyTypes
         );
-        runtime.TSPromiseTaskGetter = getter;
+        promise.TaskGetter = getter;
 
         var il = getter.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);
@@ -104,45 +104,45 @@ public partial class RuntimeEmitter
         prop.SetGetMethod(getter);
     }
 
-    private void EmitTSPromiseResolve(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTSPromiseResolve(TypeBuilder typeBuilder, EmittedPromiseRuntime promise)
     {
         var method = typeBuilder.DefineMethod(
             "Resolve",
             MethodAttributes.Public | MethodAttributes.Static,
-            runtime.TSPromiseType,
+            promise.Type,
             [_types.Object]
         );
-        runtime.TSPromiseResolve = method;
+        promise.TypeResolve = method;
 
         var il = method.GetILGenerator();
         var notPromiseLabel = il.DefineLabel();
 
         // If value is already a $Promise, return it
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Isinst, promise.Type);
         il.Emit(OpCodes.Brfalse, notPromiseLabel);
 
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
+        il.Emit(OpCodes.Castclass, promise.Type);
         il.Emit(OpCodes.Ret);
 
         // Otherwise, create new Promise from Task.FromResult(value)
         il.MarkLabel(notPromiseLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, EmitGenerics.MakeGenericMethod(_types.GetMethod(_types.Task, "FromResult")!, _types.Object));
-        il.Emit(OpCodes.Newobj, runtime.TSPromiseCtor);
+        il.Emit(OpCodes.Newobj, promise.Ctor);
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitTSPromiseReject(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTSPromiseReject(TypeBuilder typeBuilder, EmittedPromiseRuntime promise)
     {
         var method = typeBuilder.DefineMethod(
             "Reject",
             MethodAttributes.Public | MethodAttributes.Static,
-            runtime.TSPromiseType,
+            promise.Type,
             [_types.Object]
         );
-        runtime.TSPromiseReject = method;
+        promise.TypeReject = method;
 
         var il = method.GetILGenerator();
         var tcsLocal = il.DeclareLocal(_types.TaskCompletionSourceOfObject);
@@ -154,17 +154,17 @@ public partial class RuntimeEmitter
         // tcs.SetException(new $PromiseRejectedException(reason));
         il.Emit(OpCodes.Ldloc, tcsLocal);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Newobj, runtime.TSPromiseRejectedExceptionCtor);
+        il.Emit(OpCodes.Newobj, promise.RejectedExceptionCtor);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.TaskCompletionSourceOfObject, "SetException", _types.Exception));
 
         // return new $Promise(tcs.Task);
         il.Emit(OpCodes.Ldloc, tcsLocal);
         il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.TaskCompletionSourceOfObject, "Task").GetGetMethod()!);
-        il.Emit(OpCodes.Newobj, runtime.TSPromiseCtor);
+        il.Emit(OpCodes.Newobj, promise.Ctor);
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitTSPromiseGetValueAsync(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTSPromiseGetValueAsync(TypeBuilder typeBuilder, EmittedPromiseRuntime promise)
     {
         // This is an async method, but for simplicity, we'll emit it as a regular method
         // that returns Task<object?> and handles promise flattening.
@@ -179,7 +179,7 @@ public partial class RuntimeEmitter
             _types.TaskOfObject,
             Type.EmptyTypes
         );
-        runtime.TSPromiseGetValueAsync = method;
+        promise.GetValueAsync = method;
 
         var il = method.GetILGenerator();
 
@@ -190,7 +190,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitTSPromiseIsCompletedProperty(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTSPromiseIsCompletedProperty(TypeBuilder typeBuilder, EmittedPromiseRuntime promise)
     {
         var prop = typeBuilder.DefineProperty(
             "IsCompleted",
@@ -215,7 +215,7 @@ public partial class RuntimeEmitter
         prop.SetGetMethod(getter);
     }
 
-    private void EmitTSPromiseToString(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTSPromiseToString(TypeBuilder typeBuilder, EmittedPromiseRuntime promise)
     {
         var method = typeBuilder.DefineMethod(
             "ToString",
@@ -255,7 +255,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitTSPromiseRejectedException(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    private void EmitTSPromiseRejectedException(ModuleBuilder moduleBuilder, EmittedPromiseRuntime promise)
     {
         // Define class: public class $PromiseRejectedException : Exception
         var typeBuilder = EmitTypeDefinitions.DefineType(moduleBuilder,
@@ -263,7 +263,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.BeforeFieldInit,
             _types.Exception
         );
-        runtime.TSPromiseRejectedExceptionType = typeBuilder;
+        promise.RejectedExceptionType = typeBuilder;
 
         // Field: private readonly object? _reason
         var reasonField = typeBuilder.DefineField(
@@ -278,7 +278,7 @@ public partial class RuntimeEmitter
             CallingConventions.Standard,
             [_types.Object]
         );
-        runtime.TSPromiseRejectedExceptionCtor = ctor;
+        promise.RejectedExceptionCtor = ctor;
 
         var il = ctor.GetILGenerator();
         var hasReasonLabel = il.DefineLabel();
@@ -318,7 +318,7 @@ public partial class RuntimeEmitter
             _types.Object,
             Type.EmptyTypes
         );
-        runtime.TSPromiseRejectedExceptionReasonGetter = getter;
+        promise.RejectedExceptionReasonGetter = getter;
 
         var getIL = getter.GetILGenerator();
         getIL.Emit(OpCodes.Ldarg_0);

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSReadableAsyncIter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSReadableAsyncIter.cs
@@ -130,7 +130,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, tcsErrLocal);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, _tsReadableErrorField);
-        il.Emit(OpCodes.Newobj, runtime.TSPromiseRejectedExceptionCtor);
+        il.Emit(OpCodes.Newobj, runtime.RequirePromise().RejectedExceptionCtor);
         il.Emit(OpCodes.Callvirt, trySetException);
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ldloc, tcsErrLocal);
@@ -320,7 +320,7 @@ public partial class RuntimeEmitter
 
         il.Emit(OpCodes.Ldloc, wLocal);
         il.Emit(OpCodes.Ldarg_1); // error
-        il.Emit(OpCodes.Newobj, runtime.TSPromiseRejectedExceptionCtor);
+        il.Emit(OpCodes.Newobj, runtime.RequirePromise().RejectedExceptionCtor);
         il.Emit(OpCodes.Callvirt, trySetException);
         il.Emit(OpCodes.Pop);
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSReadableHelpers.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSReadableHelpers.cs
@@ -120,7 +120,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, countLocal);
         il.Emit(OpCodes.Brtrue, haveItems);
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
-        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().TypeResolve);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(haveItems);
         // acc = items[0]; i = 1;
@@ -165,7 +165,7 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(endLoop);
         il.Emit(OpCodes.Ldloc, accLocal);
-        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().TypeResolve);
         il.Emit(OpCodes.Ret);
     }
 
@@ -248,7 +248,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldloc, iLocal);
             il.Emit(OpCodes.Callvirt, ListItemGetter);
         }
-        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().TypeResolve);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(endLoop);
@@ -267,7 +267,7 @@ public partial class RuntimeEmitter
         {
             il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         }
-        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().TypeResolve);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.TimerPromises.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TimerPromises.cs
@@ -228,7 +228,7 @@ public partial class RuntimeEmitter
                 [_types.MakeGenericType(typeof(Func<,>), typeof(Task), Type.MakeGenericMethodParameter(0))])!, typeof(object)));
 
         // WrapTaskAsPromise(task)
-        il.Emit(OpCodes.Call, runtime.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().WrapTaskAsPromise);
         il.Emit(OpCodes.Ret);
     }
 
@@ -264,7 +264,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldstr, "AbortError: The operation was aborted");
             il.Emit(OpCodes.Newobj, _types.ExceptionCtorString);
             il.Emit(OpCodes.Call, EmitGenerics.MakeGenericMethod(typeof(Task).GetMethod("FromException", 1, [typeof(Exception)])!, typeof(object)));
-            il.Emit(OpCodes.Call, runtime.WrapTaskAsPromise);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().WrapTaskAsPromise);
             il.Emit(OpCodes.Ret);
         }
         il.MarkLabel(notAbortedLabel);
@@ -310,7 +310,7 @@ public partial class RuntimeEmitter
                 [_types.MakeGenericType(typeof(Func<,>), typeof(Task), Type.MakeGenericMethodParameter(0))])!, typeof(object)));
 
         // WrapTaskAsPromise
-        il.Emit(OpCodes.Call, runtime.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().WrapTaskAsPromise);
         il.Emit(OpCodes.Ret);
     }
 
@@ -456,7 +456,7 @@ public partial class RuntimeEmitter
             // Task.FromResult<object>(dict)
             il.Emit(OpCodes.Call, EmitGenerics.MakeGenericMethod(typeof(Task).GetMethod("FromResult")!, typeof(object)));
             // WrapTaskAsPromise → $TSPromise
-            il.Emit(OpCodes.Call, runtime.WrapTaskAsPromise);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().WrapTaskAsPromise);
             il.Emit(OpCodes.Ret);
         }
 
@@ -482,7 +482,7 @@ public partial class RuntimeEmitter
                 [_types.MakeGenericType(typeof(Func<,>), typeof(Task), Type.MakeGenericMethodParameter(0))])!, typeof(object)));
 
         // WrapTaskAsPromise → $TSPromise
-        il.Emit(OpCodes.Call, runtime.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().WrapTaskAsPromise);
         il.Emit(OpCodes.Ret);
     }
 
@@ -605,7 +605,7 @@ public partial class RuntimeEmitter
 
         // Task.FromResult<object>(dict) → WrapTaskAsPromise → $TSPromise
         il.Emit(OpCodes.Call, EmitGenerics.MakeGenericMethod(typeof(Task).GetMethod("FromResult")!, typeof(object)));
-        il.Emit(OpCodes.Call, runtime.WrapTaskAsPromise);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().WrapTaskAsPromise);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.VirtualTimers.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.VirtualTimers.cs
@@ -297,7 +297,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldfld, runtime.VirtualTimerArgs);
         il.Emit(OpCodes.Call, runtime.InvokeValue);
         if (_features.UsesPromise)
-            il.Emit(OpCodes.Call, runtime.ObserveDiscardedPromiseResult);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().ObserveDiscardedPromiseResult);
         else
             il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ldc_I4_1);
@@ -559,7 +559,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldfld, runtime.VirtualTimerArgs);
         il.Emit(OpCodes.Call, runtime.InvokeValue);
         if (_features.UsesPromise)
-            il.Emit(OpCodes.Call, runtime.ObserveDiscardedPromiseResult);
+            il.Emit(OpCodes.Call, runtime.RequirePromise().ObserveDiscardedPromiseResult);
         else
             il.Emit(OpCodes.Pop);
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.VmHelpers.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.VmHelpers.cs
@@ -67,7 +67,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.MethodInfo, "Invoke", _types.Object, _types.ObjectArray));
 
         // return $Runtime.Resolve(dict)  →  native $Promise
-        il.Emit(OpCodes.Call, runtime.TSPromiseResolve);
+        il.Emit(OpCodes.Call, runtime.RequirePromise().TypeResolve);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.WebCrypto.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.WebCrypto.cs
@@ -476,7 +476,7 @@ public partial class RuntimeEmitter
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, fromResult);
-        il.Emit(OpCodes.Newobj, runtime.TSPromiseCtor);
+        il.Emit(OpCodes.Newobj, runtime.RequirePromise().Ctor);
         il.Emit(OpCodes.Ret);
 
         // object WcRejected(Exception ex) — new $Promise(Task.FromException(ex)).
@@ -488,7 +488,7 @@ public partial class RuntimeEmitter
             .GetMethod("FromException", 1, [typeof(Exception)])!, _types.Object);
         ril.Emit(OpCodes.Ldarg_0);
         ril.Emit(OpCodes.Call, fromException);
-        ril.Emit(OpCodes.Newobj, runtime.TSPromiseCtor);
+        ril.Emit(OpCodes.Newobj, runtime.RequirePromise().Ctor);
         ril.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.WritableStream.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.WritableStream.cs
@@ -254,11 +254,11 @@ public partial class RuntimeEmitter
         // $Promise check
         il.MarkLabel(notTaskLabel);
         il.Emit(OpCodes.Ldloc, resultLocal);
-        il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+        il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
         il.Emit(OpCodes.Brfalse, notPromiseLabel);
         il.Emit(OpCodes.Ldloc, resultLocal);
-        il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
-        il.Emit(OpCodes.Callvirt, runtime.TSPromiseGetValueAsync);
+        il.Emit(OpCodes.Castclass, runtime.RequirePromise().Type);
+        il.Emit(OpCodes.Callvirt, runtime.RequirePromise().GetValueAsync);
         il.Emit(OpCodes.Br, doneLabel);
 
         // Default: Task.FromResult(result ?? undefined)

--- a/src/SharpTS/Compilation/RuntimeEmitter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.cs
@@ -40,6 +40,8 @@ public partial class RuntimeEmitter
         if (_emitHosted)
             _features.UsesPromise = true;
         var runtime = new EmittedRuntime();
+        if (features.UsesPromise)
+            runtime.BeginPromiseEmission();
         if (features.UsesNet)
             runtime.BeginNetEmission();
         if (features.UsesTls)
@@ -151,7 +153,7 @@ public partial class RuntimeEmitter
         // Emit $Promise class for standalone Promise support.
         // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSPromise
         if (features.UsesPromise)
-            EmitTSPromiseClass(moduleBuilder, runtime);
+            EmitTSPromiseClass(moduleBuilder, runtime.RequirePromise());
 
         // Emit $ArrayHole singleton first — $Array methods reference
         // $ArrayHole.Instance for padding intermediate positions on sparse writes
@@ -618,6 +620,7 @@ public partial class RuntimeEmitter
         runtime.Tls?.CompleteEmission();
         runtime.Dgram?.CompleteEmission();
         runtime.Net?.CompleteEmission();
+        runtime.Promise?.CompleteEmission();
         return runtime;
     }
 }

--- a/src/SharpTS/Compilation/StatementEmitterBase.cs
+++ b/src/SharpTS/Compilation/StatementEmitterBase.cs
@@ -1207,12 +1207,12 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
             // (custom async iterators may return $TSPromise via WrapTaskAsPromise)
             var notTSPromiseLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldloc, nextResultLocal);
-            il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+            il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
             il.Emit(OpCodes.Brfalse, notTSPromiseLabel);
             // Replace nextResultLocal with the inner Task
             il.Emit(OpCodes.Ldloc, nextResultLocal);
-            il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
-            il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);
+            il.Emit(OpCodes.Castclass, runtime.RequirePromise().Type);
+            il.Emit(OpCodes.Callvirt, runtime.RequirePromise().TaskGetter);
             il.Emit(OpCodes.Stloc, nextResultLocal);
             il.MarkLabel(notTSPromiseLabel);
 
@@ -1302,11 +1302,11 @@ public abstract class StatementEmitterBase : ExpressionEmitterBase
                 // If $TSPromise, replace with inner Task<object?>
                 var returnNotTSPromiseLabel = il.DefineLabel();
                 il.Emit(OpCodes.Ldloc, returnResultLocal);
-                il.Emit(OpCodes.Isinst, runtime.TSPromiseType);
+                il.Emit(OpCodes.Isinst, runtime.RequirePromise().Type);
                 il.Emit(OpCodes.Brfalse, returnNotTSPromiseLabel);
                 il.Emit(OpCodes.Ldloc, returnResultLocal);
-                il.Emit(OpCodes.Castclass, runtime.TSPromiseType);
-                il.Emit(OpCodes.Callvirt, runtime.TSPromiseTaskGetter);
+                il.Emit(OpCodes.Castclass, runtime.RequirePromise().Type);
+                il.Emit(OpCodes.Callvirt, runtime.RequirePromise().TaskGetter);
                 il.Emit(OpCodes.Stloc, returnResultLocal);
                 il.MarkLabel(returnNotTSPromiseLabel);
 

--- a/tests/SharpTS.Tests/CompilerTests/EmittedPromiseRuntimeTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/EmittedPromiseRuntimeTests.cs
@@ -1,0 +1,199 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public class EmittedPromiseRuntimeTests
+{
+    [Theory]
+    [InlineData("console.log(1);")]
+    [InlineData("setTimeout(() => console.log(1), 0);")]
+    public void DisabledFeatureHasNoMetadataAndReportsAccidentalUse(string source)
+    {
+        var runtime = EmitRuntime(source);
+        Assert.Null(runtime.Promise);
+        Assert.Contains("not enabled", Assert.Throws<InvalidOperationException>(runtime.RequirePromise).Message);
+        // The shared FIFO job queue also serves non-Promise microtasks.
+        Assert.NotNull(runtime.QueuePromiseJob);
+    }
+
+    [Fact]
+    public void CapabilityDeclarationSupportsCallsBeforeBodyEmission()
+    {
+        var runtime = new EmittedRuntime();
+        runtime.BeginPromiseEmission();
+        var promise = runtime.RequirePromise();
+        Assert.False(promise.IsComplete);
+        Assert.Contains("NewPromiseCapabilityResultMethod",
+            Assert.Throws<InvalidOperationException>(() => promise.NewPromiseCapabilityResultMethod).Message);
+
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName("promise_forward"), typeof(object).Assembly);
+        var type = assembly.DefineDynamicModule("main").DefineType("Runtime");
+        var capability = type.DefineMethod("Capability", MethodAttributes.Public | MethodAttributes.Static,
+            typeof(object), [typeof(object), typeof(Task<object>)]);
+        promise.NewPromiseCapabilityResultMethod = capability;
+        var caller = type.DefineMethod("Caller", MethodAttributes.Public | MethodAttributes.Static,
+            typeof(object), [typeof(object), typeof(Task<object>)]);
+        var il = caller.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Ldarg_1);
+        il.Emit(OpCodes.Call, promise.NewPromiseCapabilityResultMethod);
+        il.Emit(OpCodes.Ret);
+        Assert.Same(capability, promise.NewPromiseCapabilityResultMethod);
+        Assert.False(type.IsCreated());
+        capability.GetILGenerator().Emit(OpCodes.Ldarg_0);
+        capability.GetILGenerator().Emit(OpCodes.Ret);
+        type.CreateType();
+        using var stream = new MemoryStream();
+        assembly.Save(stream);
+
+        Assert.Throws<InvalidOperationException>(runtime.BeginPromiseEmission);
+        Assert.Throws<InvalidOperationException>(promise.CompleteEmission);
+        Assert.False(promise.IsComplete);
+        Assert.Throws<ArgumentNullException>(() => promise.NewPromiseCapabilityResultMethod = null!);
+        Assert.Same(capability, promise.NewPromiseCapabilityResultMethod);
+    }
+
+    public static IEnumerable<object[]> HandleNames => Handles.Select(property => new object[] { property.Name });
+
+    private static IEnumerable<PropertyInfo> Handles => typeof(EmittedPromiseRuntime).GetProperties()
+        .Where(property => property.Name != nameof(EmittedPromiseRuntime.IsComplete));
+
+    [Theory]
+    [MemberData(nameof(HandleNames))]
+    public void CompletionRejectsEachMissingDeclaration(string missingHandle)
+    {
+        var promise = new EmittedPromiseRuntime();
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName("promise_incomplete"), typeof(object).Assembly);
+        var type = assembly.DefineDynamicModule("main").DefineType("Placeholder");
+        var ctor = type.DefineDefaultConstructor(MethodAttributes.Public);
+        var method = type.DefineMethod("Placeholder", MethodAttributes.Public, typeof(void), Type.EmptyTypes);
+        var field = type.DefineField("Placeholder", typeof(object), FieldAttributes.Public);
+        foreach (var property in Handles.Where(property => property.Name != missingHandle))
+        {
+            object handle = property.PropertyType.IsAssignableFrom(typeof(TypeBuilder)) ? type
+                : property.PropertyType == typeof(ConstructorBuilder) ? ctor
+                : property.PropertyType == typeof(FieldBuilder) ? field : method;
+            property.SetValue(promise, handle);
+        }
+
+        Assert.Contains($"'{missingHandle}'", Assert.Throws<InvalidOperationException>(promise.CompleteEmission).Message);
+        Assert.False(promise.IsComplete);
+    }
+
+    [Theory]
+    [InlineData("Promise.resolve(1);")]
+    [InlineData("async function f() { return 1; }")]
+    [InlineData("async function* f() { yield 1; }")]
+    [InlineData("import('value');")]
+    [InlineData("import { readFile } from 'fs/promises';")]
+    [InlineData("import * as dns from 'dns/promises';")]
+    [InlineData("import * as timers from 'timers/promises';")]
+    [InlineData("import * as stream from 'stream/promises';")]
+    [InlineData("import * as crypto from 'crypto';")]
+    [InlineData("fetch('http://127.0.0.1/');")]
+    [InlineData(null)]
+    public void EnabledAndImpliedFeaturesCompleteHandlesAndRejectFurtherWrites(string? source)
+        => AssertComplete(EmitRuntime(source));
+
+    [Fact]
+    public void HostedEmissionEnablesAndCompletesPromiseForSynchronousSource()
+        => AssertComplete(EmitRuntime("console.log(1);", hosted: true));
+
+    [Fact]
+    public void PromiseMetadataDoesNotIntroduceGuestRuntimeDependencies()
+    {
+        var runtime = EmitRuntime("Promise.resolve(1);");
+        Assert.Empty(runtime.RequiredSharpTSRuntimeReasons);
+        Assert.Equal(SharpTSRuntimeRequirements.None, runtime.RequiredSharpTSRuntimeRequirements);
+        using var stream = new MemoryStream();
+        ((PersistedAssemblyBuilder)runtime.RuntimeType.Assembly).Save(stream);
+        stream.Position = 0;
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+        Assert.DoesNotContain(reader.AssemblyReferences,
+            handle => reader.GetString(reader.GetAssemblyReference(handle).Name) == "SharpTS");
+    }
+
+    private static void AssertComplete(EmittedRuntime runtime)
+    {
+        var promise = runtime.RequirePromise();
+        Assert.True(promise.IsComplete);
+        Assert.Equal("$Promise", promise.Type.Name);
+        Assert.Equal("$PromiseRejectedException", promise.RejectedExceptionType.Name);
+        Assert.True(Assert.IsAssignableFrom<TypeBuilder>(promise.Type).IsCreated());
+        Assert.True(Assert.IsAssignableFrom<TypeBuilder>(promise.RejectedExceptionType).IsCreated());
+        Assert.True(promise.CapabilityType.IsCreated());
+        Assert.True(promise.ResolveCallbackType.IsCreated());
+        Assert.True(promise.RejectCallbackType.IsCreated());
+        Assert.Same(promise.Type, promise.Ctor.DeclaringType);
+        Assert.Same(promise.CapabilityType, promise.CapabilityCtor.DeclaringType);
+        Assert.Same(promise.ResolveCallbackType, promise.ResolveCallbackCtor.DeclaringType);
+        Assert.Same(promise.RejectCallbackType, promise.RejectCallbackCtor.DeclaringType);
+        foreach (var property in Handles)
+        {
+            var value = property.GetValue(promise);
+            Assert.NotNull(value);
+            Assert.False(property.SetMethod!.IsPublic);
+            var exception = Assert.Throws<TargetInvocationException>(() => property.SetValue(promise, value));
+            Assert.IsType<InvalidOperationException>(exception.InnerException);
+        }
+        Assert.Throws<InvalidOperationException>(promise.CompleteEmission);
+        Assert.Throws<InvalidOperationException>(runtime.BeginPromiseEmission);
+    }
+
+    [Fact]
+    public void CombinatorsAndCapabilitiesVerifyAndRunStandalone()
+    {
+        const string source = """
+            async function main(): Promise<void> {
+                const capability = Promise.withResolvers();
+                capability.resolve(3);
+                console.log(await capability.promise);
+                console.log((await Promise.all([Promise.resolve(1), 2])).join(','));
+                console.log(await Promise.race([Promise.resolve(4)]));
+                console.log(await Promise.any([Promise.reject('skip'), Promise.resolve(5)]));
+                const settled = await Promise.allSettled([Promise.resolve(6), Promise.reject('bad')]);
+                console.log(settled[0].status, settled[1].status);
+                console.log(await new Promise<number>((resolve) => resolve(9)));
+                console.log(await Promise.reject('caught').catch(reason => reason).finally(() => console.log('finally')));
+            }
+            main().catch(error => console.log('unexpected', error));
+            """;
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+        Assert.Equal("3\n1,2\n4\n5\nfulfilled rejected\n9\nfinally\ncaught\n",
+            TestHarness.RunCompiledStandalone(source));
+    }
+
+    [Fact]
+    public void PrototypeHelpersVerifyAndRunStandalone()
+    {
+        const string source = """
+            const then = Promise.prototype.then;
+            then.call(Promise.resolve(7), (value: number) => console.log(value + 1));
+            const catchMethod = Promise.prototype.catch;
+            catchMethod.call(Promise.reject('caught'), (reason: any) => console.log(reason));
+            const finallyMethod = Promise.prototype.finally;
+            finallyMethod.call(Promise.resolve(9), () => console.log('finally'));
+            """;
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+        Assert.Equal("8\ncaught\nfinally\n", TestHarness.RunCompiledStandalone(source));
+    }
+
+    private static EmittedRuntime EmitRuntime(string? source, bool hosted = false)
+    {
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName($"promise_metadata_{Guid.NewGuid():N}"), typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("main");
+        var emitter = new RuntimeEmitter(TypeProvider.Runtime, emitHosted: hosted);
+        if (source is null)
+            return emitter.EmitAll(module);
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        return emitter.EmitAll(module, new RuntimeFeatureDetector().Detect(statements));
+    }
+}


### PR DESCRIPTION
Promise metadata still lived in mutable, implicitly initialized `EmittedRuntime` properties. This migrates 77 handles into `EmittedPromiseRuntime`, so disabled-feature access and reads before declaration report the missing phase, and successful completion freezes the metadata for consumers.

- Start the component for `UsesPromise`, including implied features and hosted emission, and complete it after runtime/type finalization.
- Preserve declaration order and reuse the declared adoption/capability methods when emitting deferred bodies. Remove the migrated flat properties and route consumers through the component; Promise type emission, task wrapping, and capability-only helpers take it directly.
- Cover every missing declaration, forward calls before body emission, completion and write rejection, feature gating, hosted/implied features, standalone output, guest assembly dependencies, and IL verification.
- Document the boundary: shared FIFO jobs, timer/stream Promise APIs, and filesystem/module registries remain with their respective infrastructure or families.

Continues #1599. Keep the umbrella issue open for the remaining families and residual-state audit.

### Validation

- Release solution build passed with zero errors; restore reports the existing `Microsoft.Build.Tasks.Git` NU1902 warning.
- Full core CI selection: **18,556 passed, 3 skipped, 0 failed**, including all 95 Promise component cases. The skips are two interface-binding cases and the Unix shebang case on Windows.
- Repository code-quality gates passed (analyzer fixtures, unused-emitter checks, duplicate checks).
- Both standalone probes passed IL verification and ran without SharpTS.dll. Their emitted type metadata, method signatures, and IL bodies matched main at `425b8345` (105 types / 1,163 methods and 104 types / 1,159 methods).
- `git diff --check` passed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded architecture documentation for the Promise runtime and its emission lifecycle.

- **Refactor**
  - Consolidated Promise compilation metadata and helpers into a dedicated runtime component.
  - Improved validation and lifecycle handling for Promise-related compilation support.
  - Existing Promise behavior, async handling, dynamic imports, timers, streams, and module integrations remain consistent.

- **Tests**
  - Added comprehensive coverage for Promise runtime initialization, completion validation, capabilities, combinators, prototype helpers, and feature-disabled scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->