### PR TITLE
Extract array storage metadata into a checked runtime component

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,6 +219,18 @@ timer/stream Promise APIs, and filesystem/module registries remain owned by thei
 infrastructure or feature families; they are not duplicate Promise handles and remain in the
 residual migration scope of #1599.
 
+Array storage uses the required `ArrayStorage` component for its 47 declarations: the `$Array`
+and `$ArrayHole` types, constructors, sparse and packed-double accessors, rest builders, and four
+immutable numeric/boolean queue records. These types are always emitted, including for minimal
+tree-shaken programs, so the component is created with `EmittedRuntime` rather than gated on an
+optional feature. `EnsureBoxed` is declared before the base-list methods that call it; its later
+body emission uses the same component handle without an emitter-local alias. Array-only helpers
+accept `EmittedArrayStorageRuntime` directly, while descriptor, error, and undefined dependencies
+still require the shared runtime. `EmitAll` completes storage after runtime finalization, validating
+queue declarations as well as array handles. Boolean queues intentionally omit unboxed numeric
+reads. Array operations, prototype and bound-method helpers, iterators, ArrayBuffer/TypedArray
+metadata, and the shared call-argument pool remain separate residual work under #1599.
+
 During emission, each handle becomes readable as soon as its declaration is assigned, so forward
 references do not require a method body to exist yet. An early read names the missing declaration.
 Completion is an orchestration boundary, not an IL verifier: body emission and type finalization

--- a/src/SharpTS/Compilation/CallHandlers/ArrayDestructureHandler.cs
+++ b/src/SharpTS/Compilation/CallHandlers/ArrayDestructureHandler.cs
@@ -54,7 +54,7 @@ public class ArrayDestructureHandler : ICallHandler
             il.Emit(OpCodes.Ldtoken, ctx.Runtime.RuntimeType);
             il.Emit(OpCodes.Call, ctx.Types.GetMethod(ctx.Types.Type, "GetTypeFromHandle"));
             il.Emit(OpCodes.Call, ctx.Runtime.IterateToList);
-            il.Emit(OpCodes.Newobj, ctx.Runtime.TSArrayCtor);
+            il.Emit(OpCodes.Newobj, ctx.Runtime.ArrayStorage.Ctor);
             return true;
         }
 

--- a/src/SharpTS/Compilation/CallHandlers/SuperConstructorHandler.cs
+++ b/src/SharpTS/Compilation/CallHandlers/SuperConstructorHandler.cs
@@ -44,7 +44,7 @@ public class SuperConstructorHandler : ICallHandler
         // which applies ECMA-262 Array(...) semantics (single numeric arg
         // sets the length; otherwise args become elements). Only reached when
         // no user class claimed the name via ClassRegistry above.
-        if (ctx.CurrentSuperclassName == "Array" && ctx.Runtime?.TSArrayCtorFromCtorArgs != null)
+        if (ctx.CurrentSuperclassName == "Array" && ctx.Runtime?.ArrayStorage.CtorFromCtorArgs != null)
         {
             EmitSuperArrayCtorCall(emitter, call.Arguments);
             return true;
@@ -218,7 +218,7 @@ public class SuperConstructorHandler : ICallHandler
             emitter.EmitBoxIfNeeded(arguments[i]);
             il.Emit(OpCodes.Stelem_Ref);
         }
-        il.Emit(OpCodes.Call, ctx.Runtime!.TSArrayCtorFromCtorArgs);
+        il.Emit(OpCodes.Call, ctx.Runtime!.ArrayStorage.CtorFromCtorArgs);
 
         il.Emit(OpCodes.Ldnull); // super() returns undefined
         emitter.SetStackUnknown();

--- a/src/SharpTS/Compilation/CompilationContext.cs
+++ b/src/SharpTS/Compilation/CompilationContext.cs
@@ -506,10 +506,10 @@ public partial class CompilationContext
     {
         if (Runtime == null || !Locals.TryGetLocal(name, out var local)) return null;
         var type = Locals.GetLocalType(name);
-        if (type == Runtime.NumberQueue.Type) return (local, Runtime.NumberQueue);
-        if (type == Runtime.BooleanQueue.Type) return (local, Runtime.BooleanQueue);
-        if (type == Runtime.NumberQueueWithHoles.Type) return (local, Runtime.NumberQueueWithHoles);
-        if (type == Runtime.BooleanQueueWithHoles.Type) return (local, Runtime.BooleanQueueWithHoles);
+        if (type == Runtime.ArrayStorage.NumberQueue.Type) return (local, Runtime.ArrayStorage.NumberQueue);
+        if (type == Runtime.ArrayStorage.BooleanQueue.Type) return (local, Runtime.ArrayStorage.BooleanQueue);
+        if (type == Runtime.ArrayStorage.NumberQueueWithHoles.Type) return (local, Runtime.ArrayStorage.NumberQueueWithHoles);
+        if (type == Runtime.ArrayStorage.BooleanQueueWithHoles.Type) return (local, Runtime.ArrayStorage.BooleanQueueWithHoles);
         return null;
     }
 

--- a/src/SharpTS/Compilation/EmittedArrayStorageRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedArrayStorageRuntime.cs
@@ -1,0 +1,455 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+
+namespace SharpTS.Compilation;
+
+/// <summary>
+/// Required array storage metadata for one compilation. Declarations support forward
+/// references; completion validates the handles and freezes the component.
+/// </summary>
+public sealed class EmittedArrayStorageRuntime
+{
+    internal EmittedArrayStorageRuntime() { }
+
+    public bool IsComplete { get; private set; }
+
+    private ArrayQueueTypeInfo? _numberQueue;
+    public ArrayQueueTypeInfo NumberQueue
+    {
+        get => Require(_numberQueue);
+        internal set => SetHandle(ref _numberQueue, value);
+    }
+
+    private ArrayQueueTypeInfo? _booleanQueue;
+    public ArrayQueueTypeInfo BooleanQueue
+    {
+        get => Require(_booleanQueue);
+        internal set => SetHandle(ref _booleanQueue, value);
+    }
+
+    private ArrayQueueTypeInfo? _numberQueueWithHoles;
+    public ArrayQueueTypeInfo NumberQueueWithHoles
+    {
+        get => Require(_numberQueueWithHoles);
+        internal set => SetHandle(ref _numberQueueWithHoles, value);
+    }
+
+    private ArrayQueueTypeInfo? _booleanQueueWithHoles;
+    public ArrayQueueTypeInfo BooleanQueueWithHoles
+    {
+        get => Require(_booleanQueueWithHoles);
+        internal set => SetHandle(ref _booleanQueueWithHoles, value);
+    }
+
+    // $ArrayHole singleton — sentinel for ECMA-262 array holes (index in range but never written).
+    // NOTE: Must stay in sync with SharpTS.Runtime.Types.ArrayHole
+    private Type? _holeType;
+    public Type HoleType
+    {
+        get => Require(_holeType);
+        internal set => SetHandle(ref _holeType, value);
+    }
+
+    private FieldInfo? _holeInstance;
+    public FieldInfo HoleInstance
+    {
+        get => Require(_holeInstance);
+        internal set => SetHandle(ref _holeInstance, value);
+    }
+
+    // $Array type - emitted for standalone assemblies
+    // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSArray
+    private Type? _type;
+    public Type Type
+    {
+        get => Require(_type);
+        internal set => SetHandle(ref _type, value);
+    }
+
+    private ConstructorBuilder? _ctor;
+    public ConstructorBuilder Ctor
+    {
+        get => Require(_ctor);
+        internal set => SetHandle(ref _ctor, value);
+    }
+
+    private ConstructorBuilder? _literalCtor;
+    public ConstructorBuilder LiteralCtor
+    {
+        get => Require(_literalCtor);
+        internal set => SetHandle(ref _literalCtor, value);
+    }
+
+    private ConstructorBuilder? _numericLiteralCtor;
+    public ConstructorBuilder NumericLiteralCtor
+    {
+        get => Require(_numericLiteralCtor);
+        internal set => SetHandle(ref _numericLiteralCtor, value);
+    }
+
+    private ConstructorBuilder? _restCtor;
+    public ConstructorBuilder RestCtor
+    {
+        get => Require(_restCtor);
+        internal set => SetHandle(ref _restCtor, value);
+    }
+
+    private MethodBuilder? _createNumericRest;
+    public MethodBuilder CreateNumericRest
+    {
+        get => Require(_createNumericRest);
+        internal set => SetHandle(ref _createNumericRest, value);
+    }
+
+    private MethodBuilder? _appendRest;
+    public MethodBuilder AppendRest
+    {
+        get => Require(_appendRest);
+        internal set => SetHandle(ref _appendRest, value);
+    }
+
+    private MethodBuilder? _appendRestDouble;
+    public MethodBuilder AppendRestDouble
+    {
+        get => Require(_appendRestDouble);
+        internal set => SetHandle(ref _appendRestDouble, value);
+    }
+
+    private MethodBuilder? _appendRestValue;
+    public MethodBuilder AppendRestValue
+    {
+        get => Require(_appendRestValue);
+        internal set => SetHandle(ref _appendRestValue, value);
+    }
+
+    private MethodBuilder? _reserveRest;
+    public MethodBuilder ReserveRest
+    {
+        get => Require(_reserveRest);
+        internal set => SetHandle(ref _reserveRest, value);
+    }
+
+    private MethodBuilder? _appendNumericRestSource;
+    public MethodBuilder AppendNumericRestSource
+    {
+        get => Require(_appendNumericRestSource);
+        internal set => SetHandle(ref _appendNumericRestSource, value);
+    }
+
+    private MethodBuilder? _finishRest;
+    public MethodBuilder FinishRest
+    {
+        get => Require(_finishRest);
+        internal set => SetHandle(ref _finishRest, value);
+    }
+
+    private ConstructorBuilder? _ctorFromCtorArgs;
+    /// <summary>$Array(object?[] ctorArgs) — ECMA-262 Array-constructor semantics for guest classes extending Array (#233): implicit ctors and super(...) chain through this.</summary>
+    public ConstructorBuilder CtorFromCtorArgs
+    {
+        get => Require(_ctorFromCtorArgs);
+        internal set => SetHandle(ref _ctorFromCtorArgs, value);
+    }
+
+    private MethodBuilder? _elementsGetter;
+    public MethodBuilder ElementsGetter
+    {
+        get => Require(_elementsGetter);
+        internal set => SetHandle(ref _elementsGetter, value);
+    }
+
+    private MethodBuilder? _freeze;
+    public MethodBuilder Freeze
+    {
+        get => Require(_freeze);
+        internal set => SetHandle(ref _freeze, value);
+    }
+
+    private MethodBuilder? _get;
+    public MethodBuilder Get
+    {
+        get => Require(_get);
+        internal set => SetHandle(ref _get, value);
+    }
+
+    private MethodBuilder? _set;
+    public MethodBuilder Set
+    {
+        get => Require(_set);
+        internal set => SetHandle(ref _set, value);
+    }
+
+    // Stage E.2 additions (long-indexed sparse/hole-aware API).
+    // Mirrors SharpTSArray public surface. Legacy int-indexed Get/Set above
+    // continue to work (they widen to the long path internally).
+    // Count is inherited from List<object?> — no custom getter.
+    private MethodBuilder? _longLengthGetter;
+    public MethodBuilder LongLengthGetter
+    {
+        get => Require(_longLengthGetter);
+        internal set => SetHandle(ref _longLengthGetter, value);
+    }
+
+    private MethodBuilder? _lengthGetter;
+    public MethodBuilder LengthGetter
+    {
+        get => Require(_lengthGetter);
+        internal set => SetHandle(ref _lengthGetter, value);
+    }
+
+    private MethodBuilder? _hasIndex;
+    public MethodBuilder HasIndex
+    {
+        get => Require(_hasIndex);
+        internal set => SetHandle(ref _hasIndex, value);
+    }
+
+    private MethodBuilder? _getLong;
+    public MethodBuilder GetLong
+    {
+        get => Require(_getLong);
+        internal set => SetHandle(ref _getLong, value);
+    }
+
+    private MethodBuilder? _setLong;
+    public MethodBuilder SetLong
+    {
+        get => Require(_setLong);
+        internal set => SetHandle(ref _setLong, value);
+    }
+
+    private MethodBuilder? _setStrictLong;
+    public MethodBuilder SetStrictLong
+    {
+        get => Require(_setStrictLong);
+        internal set => SetHandle(ref _setStrictLong, value);
+    }
+
+    private MethodBuilder? _setLength;
+    public MethodBuilder SetLength
+    {
+        get => Require(_setLength);
+        internal set => SetHandle(ref _setLength, value);
+    }
+
+    private MethodBuilder? _deleteAt;
+    public MethodBuilder DeleteAt
+    {
+        get => Require(_deleteAt);
+        internal set => SetHandle(ref _deleteAt, value);
+    }
+
+    // Unboxed packed-double elements-kind accessors (number[] unboxing project).
+    // GetDouble/SetDouble/PushDouble are the fast paths the compiler emits at
+    // statically-number[] sites; EnsureBoxed is the deopt (numeric -> boxed).
+    private MethodBuilder? _canGetDouble;
+    public MethodBuilder CanGetDouble
+    {
+        get => Require(_canGetDouble);
+        internal set => SetHandle(ref _canGetDouble, value);
+    }
+
+    private MethodBuilder? _tryGetBoxedDouble;
+    public MethodBuilder TryGetBoxedDouble
+    {
+        get => Require(_tryGetBoxedDouble);
+        internal set => SetHandle(ref _tryGetBoxedDouble, value);
+    }
+
+    private MethodBuilder? _getDouble;
+    public MethodBuilder GetDouble
+    {
+        get => Require(_getDouble);
+        internal set => SetHandle(ref _getDouble, value);
+    }
+
+    private MethodBuilder? _setDouble;
+    public MethodBuilder SetDouble
+    {
+        get => Require(_setDouble);
+        internal set => SetHandle(ref _setDouble, value);
+    }
+
+    private MethodBuilder? _pushDouble;
+    public MethodBuilder PushDouble
+    {
+        get => Require(_pushDouble);
+        internal set => SetHandle(ref _pushDouble, value);
+    }
+
+    private MethodBuilder? _ensureDoubleCapacity;
+    public MethodBuilder EnsureDoubleCapacity
+    {
+        get => Require(_ensureDoubleCapacity);
+        internal set => SetHandle(ref _ensureDoubleCapacity, value);
+    }
+
+    private MethodBuilder? _ensureBoxed;
+    public MethodBuilder EnsureBoxed
+    {
+        get => Require(_ensureBoxed);
+        internal set => SetHandle(ref _ensureBoxed, value);
+    }
+
+    private MethodBuilder? _isNumericGetter;
+    public MethodBuilder IsNumericGetter
+    {
+        get => Require(_isNumericGetter);
+        internal set => SetHandle(ref _isNumericGetter, value);
+    }
+
+    private MethodBuilder? _numericCountGetter;
+    public MethodBuilder NumericCountGetter
+    {
+        get => Require(_numericCountGetter);
+        internal set => SetHandle(ref _numericCountGetter, value);
+    }
+
+    private MethodBuilder? _canMutateNumericGetter;
+    public MethodBuilder CanMutateNumericGetter
+    {
+        get => Require(_canMutateNumericGetter);
+        internal set => SetHandle(ref _canMutateNumericGetter, value);
+    }
+
+    private MethodBuilder? _shiftNumeric;
+    public MethodBuilder ShiftNumeric
+    {
+        get => Require(_shiftNumeric);
+        internal set => SetHandle(ref _shiftNumeric, value);
+    }
+
+    private MethodBuilder? _unshiftNumeric;
+    public MethodBuilder UnshiftNumeric
+    {
+        get => Require(_unshiftNumeric);
+        internal set => SetHandle(ref _unshiftNumeric, value);
+    }
+
+    private MethodBuilder? _cloneNumeric;
+    public MethodBuilder CloneNumeric
+    {
+        get => Require(_cloneNumeric);
+        internal set => SetHandle(ref _cloneNumeric, value);
+    }
+
+    private MethodBuilder? _sortNumeric;
+    public MethodBuilder SortNumeric
+    {
+        get => Require(_sortNumeric);
+        internal set => SetHandle(ref _sortNumeric, value);
+    }
+
+    // Flips an empty $Array into numeric (unboxed double[]) mode — emitted at
+    // statically-number[] array-creation sites so escaping number[] arrays start
+    // unboxed. No-op on a non-empty / sparse array (stays boxed).
+    private MethodBuilder? _markNumeric;
+    public MethodBuilder MarkNumeric
+    {
+        get => Require(_markNumeric);
+        internal set => SetHandle(ref _markNumeric, value);
+    }
+
+    // Sets $Array._isNonExtensible so the unboxed PushDouble fast path refuses to append; called by
+    // Object.seal / Object.preventExtensions (which otherwise only register the array externally).
+    private MethodBuilder? _markNonExtensible;
+    public MethodBuilder MarkNonExtensible
+    {
+        get => Require(_markNonExtensible);
+        internal set => SetHandle(ref _markNonExtensible, value);
+    }
+
+    private static T Require<T>(T? handle, [CallerMemberName] string name = "") where T : class =>
+        handle ?? throw new InvalidOperationException($"Array storage metadata '{name}' has not been declared.");
+
+    private void SetHandle<T>(ref T? field, T value) where T : class
+    {
+        EnsureMutable();
+        ArgumentNullException.ThrowIfNull(value);
+        field = value;
+    }
+
+    private void EnsureMutable()
+    {
+        if (IsComplete)
+            throw new InvalidOperationException("Array storage metadata emission is already complete.");
+    }
+
+    internal void CompleteEmission()
+    {
+        EnsureMutable();
+        _ = NumberQueue;
+        _ = BooleanQueue;
+        _ = NumberQueueWithHoles;
+        _ = BooleanQueueWithHoles;
+        _ = HoleType;
+        _ = HoleInstance;
+        _ = Type;
+        _ = Ctor;
+        _ = LiteralCtor;
+        _ = NumericLiteralCtor;
+        _ = RestCtor;
+        _ = CreateNumericRest;
+        _ = AppendRest;
+        _ = AppendRestDouble;
+        _ = AppendRestValue;
+        _ = ReserveRest;
+        _ = AppendNumericRestSource;
+        _ = FinishRest;
+        _ = CtorFromCtorArgs;
+        _ = ElementsGetter;
+        _ = Freeze;
+        _ = Get;
+        _ = Set;
+        _ = LongLengthGetter;
+        _ = LengthGetter;
+        _ = HasIndex;
+        _ = GetLong;
+        _ = SetLong;
+        _ = SetStrictLong;
+        _ = SetLength;
+        _ = DeleteAt;
+        _ = CanGetDouble;
+        _ = TryGetBoxedDouble;
+        _ = GetDouble;
+        _ = SetDouble;
+        _ = PushDouble;
+        _ = EnsureDoubleCapacity;
+        _ = EnsureBoxed;
+        _ = IsNumericGetter;
+        _ = NumericCountGetter;
+        _ = CanMutateNumericGetter;
+        _ = ShiftNumeric;
+        _ = UnshiftNumeric;
+        _ = CloneNumeric;
+        _ = SortNumeric;
+        _ = MarkNumeric;
+        _ = MarkNonExtensible;
+        ValidateQueue(NumberQueue, nameof(NumberQueue));
+        ValidateQueue(BooleanQueue, nameof(BooleanQueue));
+        ValidateQueue(NumberQueueWithHoles, nameof(NumberQueueWithHoles));
+        ValidateQueue(BooleanQueueWithHoles, nameof(BooleanQueueWithHoles));
+        IsComplete = true;
+    }
+
+    private static void ValidateQueue(ArrayQueueTypeInfo queue, string name)
+    {
+        _ = Require(queue.Type, $"{name}.{nameof(queue.Type)}");
+        _ = Require(queue.Constructor, $"{name}.{nameof(queue.Constructor)}");
+        _ = Require(queue.Elements, $"{name}.{nameof(queue.Elements)}");
+        _ = Require(queue.Count, $"{name}.{nameof(queue.Count)}");
+        _ = Require(queue.Push, $"{name}.{nameof(queue.Push)}");
+        _ = Require(queue.Unshift, $"{name}.{nameof(queue.Unshift)}");
+        _ = Require(queue.Shift, $"{name}.{nameof(queue.Shift)}");
+        _ = Require(queue.Get, $"{name}.{nameof(queue.Get)}");
+        _ = Require(queue.Set, $"{name}.{nameof(queue.Set)}");
+        _ = Require(queue.Reserve, $"{name}.{nameof(queue.Reserve)}");
+        // Only number queues declare unboxed numeric reads; boolean queues omit them.
+        if (queue.Elements.Kind == ArrayElementsKind.Double)
+        {
+            _ = Require(queue.ShiftNumber, $"{name}.{nameof(queue.ShiftNumber)}");
+            _ = Require(queue.GetNumber, $"{name}.{nameof(queue.GetNumber)}");
+        }
+    }
+}

--- a/src/SharpTS/Compilation/EmittedRuntime.cs
+++ b/src/SharpTS/Compilation/EmittedRuntime.cs
@@ -17,10 +17,9 @@ namespace SharpTS.Compilation;
 /// <seealso cref="ILEmitter"/>
 public class EmittedRuntime
 {
-    public ArrayQueueTypeInfo NumberQueue { get; set; } = null!;
-    public ArrayQueueTypeInfo BooleanQueue { get; set; } = null!;
-    public ArrayQueueTypeInfo NumberQueueWithHoles { get; set; } = null!;
-    public ArrayQueueTypeInfo BooleanQueueWithHoles { get; set; } = null!;
+    /// <summary>Required array storage metadata, emitted for every compilation.</summary>
+    public EmittedArrayStorageRuntime ArrayStorage { get; } = new();
+
     /// <summary>
     /// Human-readable reasons this compilation emitted late binding into the SharpTS runtime
     /// assembly (e.g. "eval()", "Proxy", "Intl"). Populated during emission by
@@ -1460,76 +1459,12 @@ public class EmittedRuntime
     // Dynamic import support
     public MethodBuilder DynamicImportModule { get; set; } = null!;
 
-    // $ArrayHole singleton — sentinel for ECMA-262 array holes (index in range but never written).
-    // NOTE: Must stay in sync with SharpTS.Runtime.Types.ArrayHole
-    public Type ArrayHoleType { get; set; } = null!;
-    public FieldInfo ArrayHoleInstance { get; set; } = null!;
-
-    // $Array type - emitted for standalone assemblies
-    // NOTE: Must stay in sync with SharpTS.Runtime.Types.SharpTSArray
-    public Type TSArrayType { get; set; } = null!;
-
     /// <summary>
     /// $CallArgsPool.Get(int arity) — returns a thread-static object[]
     /// of the given arity (cached for arities 1..4, fresh allocation
     /// for ≥5). Used at method-call sites to avoid per-call newarr.
     /// </summary>
     public MethodBuilder CallArgsPoolGet { get; set; } = null!;
-    public ConstructorBuilder TSArrayCtor { get; set; } = null!;
-    public ConstructorBuilder TSArrayLiteralCtor { get; set; } = null!;
-    public ConstructorBuilder TSArrayNumericLiteralCtor { get; set; } = null!;
-    public ConstructorBuilder TSArrayRestCtor { get; set; } = null!;
-    public MethodBuilder TSArrayCreateNumericRest { get; set; } = null!;
-    public MethodBuilder TSArrayAppendRest { get; set; } = null!;
-    public MethodBuilder TSArrayAppendRestDouble { get; set; } = null!;
-    public MethodBuilder TSArrayAppendRestValue { get; set; } = null!;
-    public MethodBuilder TSArrayReserveRest { get; set; } = null!;
-    public MethodBuilder TSArrayAppendNumericRestSource { get; set; } = null!;
-    public MethodBuilder TSArrayFinishRest { get; set; } = null!;
-    /// <summary>$Array(object?[] ctorArgs) — ECMA-262 Array-constructor semantics for guest classes extending Array (#233): implicit ctors and super(...) chain through this.</summary>
-    public ConstructorBuilder TSArrayCtorFromCtorArgs { get; set; } = null!;
-    public MethodBuilder TSArrayElementsGetter { get; set; } = null!;
-    public MethodBuilder TSArrayFreeze { get; set; } = null!;
-    public MethodBuilder TSArrayGet { get; set; } = null!;
-    public MethodBuilder TSArraySet { get; set; } = null!;
-
-    // Stage E.2 additions (long-indexed sparse/hole-aware API).
-    // Mirrors SharpTSArray public surface. Legacy int-indexed Get/Set above
-    // continue to work (they widen to the long path internally).
-    // Count is inherited from List<object?> — no custom getter.
-    public MethodBuilder TSArrayLongLengthGetter { get; set; } = null!;
-    public MethodBuilder TSArrayLengthGetter { get; set; } = null!;
-    public MethodBuilder TSArrayHasIndex { get; set; } = null!;
-    public MethodBuilder TSArrayGetLong { get; set; } = null!;
-    public MethodBuilder TSArraySetLong { get; set; } = null!;
-    public MethodBuilder TSArraySetStrictLong { get; set; } = null!;
-    public MethodBuilder TSArraySetLength { get; set; } = null!;
-    public MethodBuilder TSArrayDeleteAt { get; set; } = null!;
-
-    // Unboxed packed-double elements-kind accessors (number[] unboxing project).
-    // GetDouble/SetDouble/PushDouble are the fast paths the compiler emits at
-    // statically-number[] sites; EnsureBoxed is the deopt (numeric -> boxed).
-    public MethodBuilder TSArrayCanGetDouble { get; set; } = null!;
-    public MethodBuilder TSArrayTryGetBoxedDouble { get; set; } = null!;
-    public MethodBuilder TSArrayGetDouble { get; set; } = null!;
-    public MethodBuilder TSArraySetDouble { get; set; } = null!;
-    public MethodBuilder TSArrayPushDouble { get; set; } = null!;
-    public MethodBuilder TSArrayEnsureDoubleCapacity { get; set; } = null!;
-    public MethodBuilder TSArrayEnsureBoxed { get; set; } = null!;
-    public MethodBuilder TSArrayIsNumericGetter { get; set; } = null!;
-    public MethodBuilder TSArrayNumericCountGetter { get; set; } = null!;
-    public MethodBuilder TSArrayCanMutateNumericGetter { get; set; } = null!;
-    public MethodBuilder TSArrayShiftNumeric { get; set; } = null!;
-    public MethodBuilder TSArrayUnshiftNumeric { get; set; } = null!;
-    public MethodBuilder TSArrayCloneNumeric { get; set; } = null!;
-    public MethodBuilder TSArraySortNumeric { get; set; } = null!;
-    // Flips an empty $Array into numeric (unboxed double[]) mode — emitted at
-    // statically-number[] array-creation sites so escaping number[] arrays start
-    // unboxed. No-op on a non-empty / sparse array (stays boxed).
-    public MethodBuilder TSArrayMarkNumeric { get; set; } = null!;
-    // Sets $Array._isNonExtensible so the unboxed PushDouble fast path refuses to append; called by
-    // Object.seal / Object.preventExtensions (which otherwise only register the array externally).
-    public MethodBuilder TSArrayMarkNonExtensible { get; set; } = null!;
 
     // $IHasFields interface - for unified property access on user classes and $Object
     // Note: These use MethodInfo instead of MethodBuilder because we need the actual

--- a/src/SharpTS/Compilation/Emitters/ArrayEmitter.cs
+++ b/src/SharpTS/Compilation/Emitters/ArrayEmitter.cs
@@ -353,7 +353,7 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
                 }
                 else
                 {
-                    il.Emit(OpCodes.Ldsfld, ctx.Runtime!.ArrayHoleInstance);
+                    il.Emit(OpCodes.Ldsfld, ctx.Runtime!.ArrayStorage.HoleInstance);
                 }
                 il.Emit(OpCodes.Call, methodName == "indexOf" ? ctx.Runtime!.ArrayIndexOf : ctx.Runtime!.ArrayLastIndexOf);
                 il.Emit(OpCodes.Box, ctx.Types.Double);
@@ -533,7 +533,7 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         if (returnsNewArray)
         {
             // Stack: [list]  → want: [new $Array(list)]
-            il.Emit(OpCodes.Newobj, ctx.Runtime!.TSArrayCtor);
+            il.Emit(OpCodes.Newobj, ctx.Runtime!.ArrayStorage.Ctor);
         }
     }
 
@@ -584,7 +584,7 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
                     // and report 0, so a loop-condition `i < arr.length` never runs. A $Array is never the
                     // arguments object, so no $Arguments check is needed on this arm.
                     il.Emit(OpCodes.Ldloc, h.TypedLocal);
-                    il.Emit(OpCodes.Callvirt, ctx.Runtime!.TSArrayLongLengthGetter);
+                    il.Emit(OpCodes.Callvirt, ctx.Runtime!.ArrayStorage.LongLengthGetter);
                     il.Emit(OpCodes.Conv_R8);
                     il.Emit(OpCodes.Br, endLabel);
                 }
@@ -645,11 +645,11 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         // int.MaxValue; M3 acceptance demands `a.length === 2147483649` works).
         var tsArrayCheckLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, objLocal);
-        il.Emit(OpCodes.Isinst, ctx.Runtime!.TSArrayType);
+        il.Emit(OpCodes.Isinst, ctx.Runtime!.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, tsArrayCheckLabel);
         il.Emit(OpCodes.Ldloc, objLocal);
-        il.Emit(OpCodes.Castclass, ctx.Runtime!.TSArrayType);
-        il.Emit(OpCodes.Callvirt, ctx.Runtime!.TSArrayLongLengthGetter);
+        il.Emit(OpCodes.Castclass, ctx.Runtime!.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, ctx.Runtime!.ArrayStorage.LongLengthGetter);
         il.Emit(OpCodes.Conv_R8);
         il.Emit(OpCodes.Br, endLabelNH);
 
@@ -719,14 +719,14 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         // and would otherwise read the empty base list. EnsureBoxed is a no-op
         // for boxed-mode arrays.
         var deoptDone = il.DefineLabel();
-        var arrLocal = il.DeclareLocal(ctx.Runtime!.TSArrayType);
+        var arrLocal = il.DeclareLocal(ctx.Runtime!.ArrayStorage.Type);
         il.Emit(OpCodes.Ldloc, objLocal);
-        il.Emit(OpCodes.Isinst, ctx.Runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, ctx.Runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Stloc, arrLocal);
         il.Emit(OpCodes.Ldloc, arrLocal);
         il.Emit(OpCodes.Brfalse, deoptDone);
         il.Emit(OpCodes.Ldloc, arrLocal);
-        il.Emit(OpCodes.Callvirt, ctx.Runtime.TSArrayEnsureBoxed);
+        il.Emit(OpCodes.Callvirt, ctx.Runtime.ArrayStorage.EnsureBoxed);
         il.MarkLabel(deoptDone);
 
         var isListLabel = il.DefineLabel();
@@ -740,7 +740,7 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         // Check if it's $Array - get Elements
         var tsArrayLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, objLocal);
-        il.Emit(OpCodes.Isinst, ctx.Runtime!.TSArrayType);
+        il.Emit(OpCodes.Isinst, ctx.Runtime!.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, tsArrayLabel);
 
         // Check if it's a typed array (List<double>, List<bool>) via IList interface.
@@ -759,8 +759,8 @@ public sealed class ArrayEmitter : ITypeEmitterStrategy
         // $Array path
         il.MarkLabel(tsArrayLabel);
         il.Emit(OpCodes.Ldloc, objLocal);
-        il.Emit(OpCodes.Castclass, ctx.Runtime!.TSArrayType);
-        il.Emit(OpCodes.Callvirt, ctx.Runtime.TSArrayElementsGetter);
+        il.Emit(OpCodes.Castclass, ctx.Runtime!.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, ctx.Runtime.ArrayStorage.ElementsGetter);
         il.Emit(OpCodes.Br, endLabel);
 
         // Typed list path: convert IList to List<object?> via boxing loop.

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.CallHelpers.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.CallHelpers.cs
@@ -918,15 +918,15 @@ public abstract partial class ExpressionEmitterBase
                 var missing = IL.DefineLabel();
                 var ready = IL.DefineLabel();
                 IL.Emit(OpCodes.Ldloc, expanded);
-                IL.Emit(OpCodes.Castclass, Ctx.Runtime!.TSArrayType);
-                IL.Emit(OpCodes.Call, Ctx.Runtime.TSArrayLengthGetter);
+                IL.Emit(OpCodes.Castclass, Ctx.Runtime!.ArrayStorage.Type);
+                IL.Emit(OpCodes.Call, Ctx.Runtime.ArrayStorage.LengthGetter);
                 IL.Emit(OpCodes.Ldc_I4, i);
                 IL.Emit(OpCodes.Ble, missing);
                 IL.Emit(OpCodes.Ldloc, expanded);
-                IL.Emit(OpCodes.Castclass, Ctx.Runtime!.TSArrayType);
+                IL.Emit(OpCodes.Castclass, Ctx.Runtime!.ArrayStorage.Type);
                 IL.Emit(OpCodes.Ldc_I4, i);
                 IL.Emit(OpCodes.Conv_I8);
-                IL.Emit(OpCodes.Call, Ctx.Runtime.TSArrayGetLong);
+                IL.Emit(OpCodes.Call, Ctx.Runtime.ArrayStorage.GetLong);
                 EmitCoerceBoxedToType(targetParams[i].ParameterType);
                 IL.Emit(OpCodes.Br, ready);
                 IL.MarkLabel(missing);
@@ -934,10 +934,10 @@ public abstract partial class ExpressionEmitterBase
                 IL.MarkLabel(ready);
             }
             IL.Emit(OpCodes.Ldloc, expanded);
-            IL.Emit(OpCodes.Castclass, Ctx.Runtime!.TSArrayType);
+            IL.Emit(OpCodes.Castclass, Ctx.Runtime!.ArrayStorage.Type);
             IL.Emit(OpCodes.Dup);
             IL.Emit(OpCodes.Ldc_I4, regularCount);
-            IL.Emit(OpCodes.Call, Ctx.Runtime.TSArrayFinishRest);
+            IL.Emit(OpCodes.Call, Ctx.Runtime.ArrayStorage.FinishRest);
             return;
         }
 
@@ -995,15 +995,15 @@ public abstract partial class ExpressionEmitterBase
         bool numericRest = allowNumericStorage && !hasSuspension && restArgsCount > 0
             && argLocals.Skip(regularCount).All(local => local.LocalType == Types.Double);
         IL.Emit(OpCodes.Ldc_I4, restArgsCount);
-        if (numericRest) IL.Emit(OpCodes.Call, Ctx.Runtime!.TSArrayCreateNumericRest);
-        else IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSArrayRestCtor);
+        if (numericRest) IL.Emit(OpCodes.Call, Ctx.Runtime!.ArrayStorage.CreateNumericRest);
+        else IL.Emit(OpCodes.Newobj, Ctx.Runtime!.ArrayStorage.RestCtor);
         for (int i = 0; i < restArgsCount; i++)
         {
             IL.Emit(OpCodes.Dup);
             IL.Emit(OpCodes.Ldloc, argLocals[regularCount + i]);
             if (!numericRest && argLocals[regularCount + i].LocalType == Types.Double)
                 IL.Emit(OpCodes.Box, Types.Double);
-            IL.Emit(OpCodes.Call, numericRest ? Ctx.Runtime.TSArrayPushDouble : Ctx.Runtime.TSArrayAppendRest);
+            IL.Emit(OpCodes.Call, numericRest ? Ctx.Runtime.ArrayStorage.PushDouble : Ctx.Runtime.ArrayStorage.AppendRest);
         }
     }
 
@@ -1017,8 +1017,8 @@ public abstract partial class ExpressionEmitterBase
         // Numeric builders reserve at the first known spread length. A scalar
         // prefix uses the normal small numeric capacity, not expression count.
         IL.Emit(OpCodes.Ldc_I4, numeric ? 0 : arguments.Count);
-        if (numeric) IL.Emit(OpCodes.Call, Ctx.Runtime!.TSArrayCreateNumericRest);
-        else IL.Emit(OpCodes.Newobj, Ctx.Runtime!.TSArrayRestCtor);
+        if (numeric) IL.Emit(OpCodes.Call, Ctx.Runtime!.ArrayStorage.CreateNumericRest);
+        else IL.Emit(OpCodes.Newobj, Ctx.Runtime!.ArrayStorage.RestCtor);
         var target = _helpers.SpillStoreObject();
         foreach (var argument in arguments)
         {
@@ -1030,9 +1030,9 @@ public abstract partial class ExpressionEmitterBase
                 var scalar = IL.DeclareLocal(native ? Types.Double : Types.Object);
                 IL.Emit(OpCodes.Stloc, scalar);
                 IL.Emit(OpCodes.Ldloc, target);
-                IL.Emit(OpCodes.Castclass, Ctx.Runtime.TSArrayType);
+                IL.Emit(OpCodes.Castclass, Ctx.Runtime.ArrayStorage.Type);
                 IL.Emit(OpCodes.Ldloc, scalar);
-                IL.Emit(OpCodes.Call, native ? Ctx.Runtime.TSArrayAppendRestDouble : Ctx.Runtime.TSArrayAppendRest);
+                IL.Emit(OpCodes.Call, native ? Ctx.Runtime.ArrayStorage.AppendRestDouble : Ctx.Runtime.ArrayStorage.AppendRest);
                 continue;
             }
             var value = SpillBoxed(argument is Expr.Spread spread ? spread.Expression : argument);
@@ -1050,9 +1050,9 @@ public abstract partial class ExpressionEmitterBase
             else
             {
                 IL.Emit(OpCodes.Ldloc, target);
-                IL.Emit(OpCodes.Castclass, Ctx.Runtime.TSArrayType);
+                IL.Emit(OpCodes.Castclass, Ctx.Runtime.ArrayStorage.Type);
                 IL.Emit(OpCodes.Ldloc, value);
-                IL.Emit(OpCodes.Call, Ctx.Runtime.TSArrayAppendRest);
+                IL.Emit(OpCodes.Call, Ctx.Runtime.ArrayStorage.AppendRest);
             }
         }
         return target;
@@ -2716,7 +2716,7 @@ public abstract partial class ExpressionEmitterBase
                 if (arguments.Count > 1)
                     EmitBoxedArgOrNull(arguments, 1);
                 else
-                    IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.ArrayHoleInstance);
+                    IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.ArrayStorage.HoleInstance);
                 IL.Emit(OpCodes.Call, methodName == "indexOf" ? Ctx.Runtime!.ArrayIndexOf : Ctx.Runtime!.ArrayLastIndexOf);
                 IL.Emit(OpCodes.Box, typeof(double));
                 break;

--- a/src/SharpTS/Compilation/ExpressionEmitterBase.cs
+++ b/src/SharpTS/Compilation/ExpressionEmitterBase.cs
@@ -1391,7 +1391,7 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
                 if (elementLocals[i] == null)
                 {
                     // Elided position → true ECMA-262 hole, not an undefined element.
-                    IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.ArrayHoleInstance);
+                    IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.ArrayStorage.HoleInstance);
                 }
                 else
                 {
@@ -1424,7 +1424,7 @@ public abstract partial class ExpressionEmitterBase : IEmitterContext
                     IL.Emit(OpCodes.Ldc_I4_0);
                     if (elementLocals[i] == null)
                     {
-                        IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.ArrayHoleInstance);
+                        IL.Emit(OpCodes.Ldsfld, Ctx.Runtime!.ArrayStorage.HoleInstance);
                     }
                     else
                     {

--- a/src/SharpTS/Compilation/ILCompiler.Classes.ClassExpressions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.ClassExpressions.cs
@@ -143,7 +143,7 @@ public partial class ILCompiler
             }
             else if (superclassName == "Array")
             {
-                baseType = _runtime.TSArrayType;
+                baseType = _runtime.ArrayStorage.Type;
             }
             else if (superclassName == "Promise")
             {
@@ -712,7 +712,7 @@ public partial class ILCompiler
             if (superclassName == "Array")
             {
                 il.Emit(OpCodes.Ldarg_1);
-                il.Emit(OpCodes.Call, _runtime.TSArrayCtorFromCtorArgs);
+                il.Emit(OpCodes.Call, _runtime.ArrayStorage.CtorFromCtorArgs);
             }
             else if (superclassName == "Promise")
             {

--- a/src/SharpTS/Compilation/ILCompiler.Classes.Constructors.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.Constructors.cs
@@ -160,7 +160,7 @@ public partial class ILCompiler
             // implicit `constructor(...args) { super(...args) }` argument list.
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Call, _runtime.TSArrayCtorFromCtorArgs);
+            il.Emit(OpCodes.Call, _runtime.ArrayStorage.CtorFromCtorArgs);
         }
         else if (constructor == null && isDirectPromiseSubclass)
         {

--- a/src/SharpTS/Compilation/ILCompiler.Classes.Prototypes.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.Prototypes.cs
@@ -49,7 +49,7 @@ public partial class ILCompiler
             case "$Array":
                 il.Emit(OpCodes.Ldc_I4_0);
                 il.Emit(OpCodes.Newarr, _types.Object);
-                il.Emit(OpCodes.Call, _runtime.TSArrayCtorFromCtorArgs);
+                il.Emit(OpCodes.Call, _runtime.ArrayStorage.CtorFromCtorArgs);
                 return;
 
             case "$Promise":

--- a/src/SharpTS/Compilation/ILCompiler.Classes.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Classes.cs
@@ -180,7 +180,7 @@ public partial class ILCompiler
             // itself inherits List<object?> — every IList-based array dispatch
             // (push/length/iteration/Array.isArray/instanceof Array) applies
             // to instances unchanged.
-            baseType = _runtime.TSArrayType;
+            baseType = _runtime.ArrayStorage.Type;
         }
         else if (qualifiedSuperclassName != null && classStmt.SuperclassExpr != null
             && Expr.GetSuperclassLeafName(classStmt.SuperclassExpr) == "Promise")

--- a/src/SharpTS/Compilation/ILCompiler.Functions.cs
+++ b/src/SharpTS/Compilation/ILCompiler.Functions.cs
@@ -1090,11 +1090,11 @@ public partial class ILCompiler
             // A rest argument can be a numeric $Array with an empty base list.
             var plainList = il.DefineLabel();
             il.Emit(OpCodes.Ldarg, argIndex);
-            il.Emit(OpCodes.Isinst, ctx.Runtime!.TSArrayType);
+            il.Emit(OpCodes.Isinst, ctx.Runtime!.ArrayStorage.Type);
             il.Emit(OpCodes.Brfalse, plainList);
             il.Emit(OpCodes.Ldarg, argIndex);
-            il.Emit(OpCodes.Castclass, ctx.Runtime.TSArrayType);
-            il.Emit(OpCodes.Call, ctx.Runtime.TSArrayEnsureBoxed);
+            il.Emit(OpCodes.Castclass, ctx.Runtime.ArrayStorage.Type);
+            il.Emit(OpCodes.Call, ctx.Runtime.ArrayStorage.EnsureBoxed);
             il.MarkLabel(plainList);
             var addRange = ctx.Types.GetMethod(
                 targetListType,

--- a/src/SharpTS/Compilation/ILEmitter.Calls.AmbiguousDispatch.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.AmbiguousDispatch.cs
@@ -280,7 +280,7 @@ public partial class ILEmitter
                 }
                 else
                 {
-                    IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.ArrayHoleInstance);
+                    IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.ArrayStorage.HoleInstance);
                 }
                 // ArrayIncludes already returns a boxed bool (object). The
                 // earlier `Box Boolean` here double-boxed it — reinterpreting

--- a/src/SharpTS/Compilation/ILEmitter.Calls.ExternalInterop.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.ExternalInterop.cs
@@ -840,11 +840,11 @@ public partial class ILEmitter
         var ordinaryList = IL.DefineLabel();
         var listReady = IL.DefineLabel();
         IL.Emit(OpCodes.Ldloc, source);
-        IL.Emit(OpCodes.Isinst, _ctx.Runtime!.TSArrayType);
+        IL.Emit(OpCodes.Isinst, _ctx.Runtime!.ArrayStorage.Type);
         IL.Emit(OpCodes.Brfalse, ordinaryList);
         IL.Emit(OpCodes.Ldloc, source);
-        IL.Emit(OpCodes.Castclass, _ctx.Runtime.TSArrayType);
-        IL.Emit(OpCodes.Callvirt, _ctx.Runtime.TSArrayElementsGetter);
+        IL.Emit(OpCodes.Castclass, _ctx.Runtime.ArrayStorage.Type);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime.ArrayStorage.ElementsGetter);
         IL.Emit(OpCodes.Castclass, typeof(System.Collections.IList));
         IL.Emit(OpCodes.Stloc, list);
         IL.Emit(OpCodes.Br, listReady);

--- a/src/SharpTS/Compilation/ILEmitter.Calls.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Calls.cs
@@ -826,7 +826,7 @@ public partial class ILEmitter
                 else
                 {
                     if (methodName is "indexOf" or "lastIndexOf")
-                        IL.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+                        IL.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
                     else if (methodName == "join")
                         IL.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
                     else
@@ -855,7 +855,7 @@ public partial class ILEmitter
                 else
                 {
                     if (methodName is "indexOf" or "lastIndexOf")
-                        IL.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+                        IL.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
                     else
                         IL.Emit(OpCodes.Ldnull);
                 }

--- a/src/SharpTS/Compilation/ILEmitter.Destructuring.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Destructuring.cs
@@ -68,9 +68,9 @@ public partial class ILEmitter
             _ctx.TypeMap?.Get(call.Arguments[0]) is not (TypeInfo.Array or TypeInfo.Tuple))
             return;
 
-        var arrayLocal = IL.DeclareLocal(_ctx.Runtime!.TSArrayType);
+        var arrayLocal = IL.DeclareLocal(_ctx.Runtime!.ArrayStorage.Type);
         IL.Emit(OpCodes.Ldloc, objectLocal);
-        IL.Emit(OpCodes.Isinst, _ctx.Runtime.TSArrayType);
+        IL.Emit(OpCodes.Isinst, _ctx.Runtime.ArrayStorage.Type);
         IL.Emit(OpCodes.Stloc, arrayLocal);
         _stableArrayDestructureBindings[declaration.Name.Lexeme] =
             new StableArrayDestructureBinding(objectLocal, arrayLocal);
@@ -137,7 +137,7 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Brfalse, fallback);
         IL.Emit(OpCodes.Ldloc, binding.ArrayLocal);
         IL.Emit(OpCodes.Ldc_I8, checked((long)index));
-        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArrayGetLong);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.ArrayStorage.GetLong);
         IL.Emit(OpCodes.Br, end);
 
         IL.MarkLabel(fallback);
@@ -170,11 +170,11 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Brfalse, genericReceiver);
         IL.Emit(OpCodes.Ldloc, binding.ArrayLocal);
         IL.Emit(OpCodes.Ldc_I4, intIndex);
-        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArrayCanGetDouble);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.ArrayStorage.CanGetDouble);
         IL.Emit(OpCodes.Brfalse, boxedArrayValue);
         IL.Emit(OpCodes.Ldloc, binding.ArrayLocal);
         IL.Emit(OpCodes.Ldc_I4, intIndex);
-        IL.Emit(OpCodes.Callvirt, _ctx.Runtime.TSArrayGetDouble);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime.ArrayStorage.GetDouble);
         IL.Emit(OpCodes.Stloc, result);
         IL.Emit(OpCodes.Br, end);
 
@@ -182,7 +182,7 @@ public partial class ILEmitter
         IL.MarkLabel(boxedArrayValue);
         IL.Emit(OpCodes.Ldloc, binding.ArrayLocal);
         IL.Emit(OpCodes.Ldc_I8, (long)intIndex);
-        IL.Emit(OpCodes.Callvirt, _ctx.Runtime.TSArrayGetLong);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime.ArrayStorage.GetLong);
         IL.Emit(OpCodes.Call, _ctx.Runtime.ConvertToNumber);
         IL.Emit(OpCodes.Stloc, result);
         IL.Emit(OpCodes.Br, end);

--- a/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.Literals.cs
@@ -23,7 +23,7 @@ public partial class ILEmitter
                 EmitExpressionAsDouble(a.Elements[i]);
                 IL.Emit(OpCodes.Stelem_R8);
             }
-            IL.Emit(OpCodes.Newobj, _ctx.Runtime!.TSArrayNumericLiteralCtor);
+            IL.Emit(OpCodes.Newobj, _ctx.Runtime!.ArrayStorage.NumericLiteralCtor);
             SetStackUnknown();
             return;
         }
@@ -55,13 +55,13 @@ public partial class ILEmitter
             // Literal initialization is private: append into the final backing store,
             // without calling observable Array.prototype methods or copying a list.
             IL.Emit(OpCodes.Ldc_I4, a.Elements.Count);
-            IL.Emit(OpCodes.Newobj, _ctx.Runtime!.TSArrayRestCtor);
+            IL.Emit(OpCodes.Newobj, _ctx.Runtime!.ArrayStorage.RestCtor);
             foreach (var element in a.Elements)
             {
                 IL.Emit(OpCodes.Dup);
                 EmitExpression(element);
                 EmitBoxIfNeeded(element);
-                IL.Emit(OpCodes.Call, _ctx.Runtime.TSArrayAppendRest);
+                IL.Emit(OpCodes.Call, _ctx.Runtime.ArrayStorage.AppendRest);
             }
             SetStackUnknown();
             return;
@@ -80,7 +80,7 @@ public partial class ILEmitter
                 if (a.IsHole(i))
                 {
                     // Elided position → true ECMA-262 hole, not an undefined element.
-                    IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.ArrayHoleInstance);
+                    IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.ArrayStorage.HoleInstance);
                 }
                 else
                 {
@@ -119,7 +119,7 @@ public partial class ILEmitter
                     IL.Emit(OpCodes.Ldc_I4, 0);
                     if (a.IsHole(i))
                     {
-                        IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.ArrayHoleInstance);
+                        IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.ArrayStorage.HoleInstance);
                     }
                     else
                     {
@@ -197,7 +197,7 @@ public partial class ILEmitter
                 IL.Emit(OpCodes.Box, _ctx.Types.Double);
             IL.Emit(numeric ? OpCodes.Stelem_R8 : OpCodes.Stelem_Ref);
         }
-        if (numeric) IL.Emit(OpCodes.Newobj, _ctx.Runtime!.TSArrayNumericLiteralCtor);
+        if (numeric) IL.Emit(OpCodes.Newobj, _ctx.Runtime!.ArrayStorage.NumericLiteralCtor);
         else IL.Emit(OpCodes.Call, _ctx.Runtime!.CreateArray);
         SetStackUnknown();
     }

--- a/src/SharpTS/Compilation/ILEmitter.Properties.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Properties.cs
@@ -1401,7 +1401,7 @@ public partial class ILEmitter
                         IL.Emit(OpCodes.Ldloc, h.TypedLocal);
                         EmitExpressionAsDouble(gi.Index);
                         IL.Emit(OpCodes.Conv_I8);
-                        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArrayGetLong);
+                        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.ArrayStorage.GetLong);
                         SetStackUnknown();
                         IL.Emit(OpCodes.Br, endLabel);
                     }
@@ -1478,14 +1478,14 @@ public partial class ILEmitter
             // $Array first (inherits List<object?>; checking List first
             // truncates large indices via Conv_I4 and would throw or misread
             // for uint32-range writes). TSArrayGetLong handles OOB and holes.
-            IL.Emit(OpCodes.Isinst, _ctx.Runtime!.TSArrayType);
+            IL.Emit(OpCodes.Isinst, _ctx.Runtime!.ArrayStorage.Type);
             var notTSArrayGet = IL.DefineLabel();
             IL.Emit(OpCodes.Brfalse, notTSArrayGet);
             IL.Emit(OpCodes.Ldloc, objLocal);
-            IL.Emit(OpCodes.Castclass, _ctx.Runtime!.TSArrayType);
+            IL.Emit(OpCodes.Castclass, _ctx.Runtime!.ArrayStorage.Type);
             EmitExpressionAsDouble(gi.Index);
             IL.Emit(OpCodes.Conv_I8);
-            IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArrayGetLong);
+            IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.ArrayStorage.GetLong);
             SetStackUnknown();
             IL.Emit(OpCodes.Br, endLabelNH);
 
@@ -1601,9 +1601,9 @@ public partial class ILEmitter
             EmitBoxIfNeeded(gi.Object);
             IL.Emit(OpCodes.Stloc, receiverLocal);
 
-            arrayLocal = IL.DeclareLocal(_ctx.Runtime!.TSArrayType);
+            arrayLocal = IL.DeclareLocal(_ctx.Runtime!.ArrayStorage.Type);
             IL.Emit(OpCodes.Ldloc, receiverLocal);
-            IL.Emit(OpCodes.Isinst, _ctx.Runtime.TSArrayType);
+            IL.Emit(OpCodes.Isinst, _ctx.Runtime.ArrayStorage.Type);
             IL.Emit(OpCodes.Stloc, arrayLocal);
         }
         else
@@ -1647,14 +1647,14 @@ public partial class ILEmitter
         {
             IL.Emit(OpCodes.Ldloc, guardedArray);
             IL.Emit(OpCodes.Ldloc, indexInt);
-            IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArrayCanGetDouble);
+            IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.ArrayStorage.CanGetDouble);
             IL.Emit(OpCodes.Brfalse, boxedLabel);
         }
 
         IL.Emit(OpCodes.Ldloc, guardedArray);
         IL.Emit(OpCodes.Ldloc, indexInt);
         if (boxResult) IL.Emit(OpCodes.Conv_I8);
-        IL.Emit(OpCodes.Callvirt, boxResult ? _ctx.Runtime!.TSArrayGetLong : _ctx.Runtime!.TSArrayGetDouble);
+        IL.Emit(OpCodes.Callvirt, boxResult ? _ctx.Runtime!.ArrayStorage.GetLong : _ctx.Runtime!.ArrayStorage.GetDouble);
         IL.Emit(OpCodes.Br, endLabel);
 
         if (!boxResult)
@@ -1664,7 +1664,7 @@ public partial class ILEmitter
             IL.Emit(OpCodes.Ldloc, receiverLocal);
             IL.Emit(OpCodes.Ldloc, indexInt);
             IL.Emit(OpCodes.Ldloca, boxedValue);
-            IL.Emit(OpCodes.Call, _ctx.Runtime.TSArrayTryGetBoxedDouble);
+            IL.Emit(OpCodes.Call, _ctx.Runtime.ArrayStorage.TryGetBoxedDouble);
             IL.Emit(OpCodes.Brfalse, fallbackLabel);
             IL.Emit(OpCodes.Ldloc, boxedValue);
             IL.Emit(OpCodes.Br, endLabel);
@@ -1753,15 +1753,15 @@ public partial class ILEmitter
         else
         {
             IL.Emit(OpCodes.Ldloc, receiverLocal!);
-            IL.Emit(OpCodes.Isinst, _ctx.Runtime!.TSArrayType);
+            IL.Emit(OpCodes.Isinst, _ctx.Runtime!.ArrayStorage.Type);
             IL.Emit(OpCodes.Brfalse, fallbackLabel);
             IL.Emit(OpCodes.Ldloc, receiverLocal!);
-            IL.Emit(OpCodes.Castclass, _ctx.Runtime!.TSArrayType);
+            IL.Emit(OpCodes.Castclass, _ctx.Runtime!.ArrayStorage.Type);
         }
         IL.Emit(OpCodes.Ldloc, indexLocal);
         IL.Emit(OpCodes.Conv_I4);
         IL.Emit(OpCodes.Ldloc, valueLocal);
-        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArraySetDouble);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.ArrayStorage.SetDouble);
         IL.Emit(OpCodes.Br, endLabel);
 
         // A value asserted to number[] can still be an arbitrary array-like at
@@ -2015,7 +2015,7 @@ public partial class ILEmitter
                     // Hoisted numeric $Array (#927 step 1): SetDouble stores the unboxed double straight
                     // into the double[] store (mode-checked — a boxed $Array delegates to the boxed setter,
                     // so this is behaviour-identical for both modes). h.TypedLocal is the hoisted $Array.
-                    IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArraySetDouble);
+                    IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.ArrayStorage.SetDouble);
                 else
                     IL.Emit(OpCodes.Call, h.Descriptor.GetSetArrayElementMethod(_ctx.Runtime!));
                 IL.Emit(OpCodes.Ldloc, typedValueLocal);
@@ -2110,15 +2110,15 @@ public partial class ILEmitter
                 if (desc.Kind == ArrayElementsKind.Double)
                 {
                     IL.Emit(OpCodes.Ldloc, objLocal);
-                    IL.Emit(OpCodes.Isinst, _ctx.Runtime!.TSArrayType);
+                    IL.Emit(OpCodes.Isinst, _ctx.Runtime!.ArrayStorage.Type);
                     var notTSArraySet = IL.DefineLabel();
                     IL.Emit(OpCodes.Brfalse, notTSArraySet);
                     IL.Emit(OpCodes.Ldloc, objLocal);
-                    IL.Emit(OpCodes.Castclass, _ctx.Runtime!.TSArrayType);
+                    IL.Emit(OpCodes.Castclass, _ctx.Runtime!.ArrayStorage.Type);
                     EmitExpressionAsDouble(si.Index);
                     IL.Emit(OpCodes.Conv_I4);
                     IL.Emit(OpCodes.Ldloc, typedValueLocalNH);
-                    IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArraySetDouble);
+                    IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.ArrayStorage.SetDouble);
                     IL.Emit(OpCodes.Ldloc, typedValueLocalNH);
                     desc.EmitBoxElement(IL, _ctx.Types);
                     SetStackUnknown();
@@ -2282,21 +2282,21 @@ public partial class ILEmitter
     {
         EmitExpression(receiver);
         EmitBoxIfNeeded(receiver);
-        IL.Emit(OpCodes.Castclass, _ctx.Runtime!.TSArrayType);
-        var arrLocal = IL.DeclareLocal(_ctx.Runtime!.TSArrayType);
+        IL.Emit(OpCodes.Castclass, _ctx.Runtime!.ArrayStorage.Type);
+        var arrLocal = IL.DeclareLocal(_ctx.Runtime!.ArrayStorage.Type);
         IL.Emit(OpCodes.Stloc, arrLocal);
 
         for (int i = 0; i < arguments.Count; i++)
         {
             IL.Emit(OpCodes.Ldloc, arrLocal);
             EmitExpressionAsDouble(arguments[i]);
-            IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArrayPushDouble);
+            IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.ArrayStorage.PushDouble);
         }
 
         // push() returns the new length. _length is authoritative in both modes
         // (PushDouble maintains it numeric; SyncLength reconciles it boxed).
         IL.Emit(OpCodes.Ldloc, arrLocal);
-        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArrayLongLengthGetter);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.ArrayStorage.LongLengthGetter);
         IL.Emit(OpCodes.Conv_R8);
         SetStackType(StackType.Double);
     }
@@ -2368,16 +2368,16 @@ public partial class ILEmitter
         // large indices through Conv_I4 (2147483648 → int.MinValue), then
         // SetArrayElement's pad-loop OOMs. The long-indexed TSArraySetLong
         // handles uint32 range and sparse transitions natively.
-        IL.Emit(OpCodes.Isinst, _ctx.Runtime!.TSArrayType);
+        IL.Emit(OpCodes.Isinst, _ctx.Runtime!.ArrayStorage.Type);
         var notTSArrayLabel = IL.DefineLabel();
         IL.Emit(OpCodes.Brfalse, notTSArrayLabel);
 
         IL.Emit(OpCodes.Ldloc, objLocal);
-        IL.Emit(OpCodes.Castclass, _ctx.Runtime!.TSArrayType);
+        IL.Emit(OpCodes.Castclass, _ctx.Runtime!.ArrayStorage.Type);
         EmitExpressionAsDouble(si.Index);
         IL.Emit(OpCodes.Conv_I8);
         IL.Emit(OpCodes.Ldloc, valueLocal);
-        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArraySetLong);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.ArrayStorage.SetLong);
         IL.Emit(OpCodes.Ldloc, valueLocal);
         IL.Emit(OpCodes.Br, endLabel);
 

--- a/src/SharpTS/Compilation/ILEmitter.Statements.cs
+++ b/src/SharpTS/Compilation/ILEmitter.Statements.cs
@@ -500,10 +500,10 @@ public partial class ILEmitter
             if (_ctx.TypeMap.IsPromotableQueueLocal(v.Name))
             {
                 var queue = promoElemTok == TokenType.TYPE_NUMBER
-                    ? _ctx.Runtime!.NumberQueue : _ctx.Runtime!.BooleanQueue;
+                    ? _ctx.Runtime!.ArrayStorage.NumberQueue : _ctx.Runtime!.ArrayStorage.BooleanQueue;
                 if (_ctx.TypeMap.QueueLocalHasWrites(v.Name))
                     queue = promoElemTok == TokenType.TYPE_NUMBER
-                        ? _ctx.Runtime!.NumberQueueWithHoles : _ctx.Runtime!.BooleanQueueWithHoles;
+                        ? _ctx.Runtime!.ArrayStorage.NumberQueueWithHoles : _ctx.Runtime!.ArrayStorage.BooleanQueueWithHoles;
                 var queueLocal = _ctx.Locals.DeclareLocal(v.Name.Lexeme, queue.Type);
                 IL.Emit(OpCodes.Newobj, queue.Constructor);
                 IL.Emit(OpCodes.Stloc, queueLocal);
@@ -920,7 +920,7 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Newarr, _ctx.Types.Object);
         IL.Emit(OpCodes.Call, _ctx.Runtime!.CreateArray);            // [$Array] (empty)
         IL.Emit(OpCodes.Dup);                                        // [$Array, $Array]
-        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArrayMarkNumeric); // [$Array]
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.ArrayStorage.MarkNumeric); // [$Array]
         SetStackUnknown();
     }
 
@@ -1859,7 +1859,7 @@ public partial class ILEmitter
         IL.Emit(OpCodes.Call, typeof(Math).GetMethod(
             nameof(Math.Ceiling), [_ctx.Types.Double])!);
         IL.Emit(OpCodes.Conv_I4);
-        IL.Emit(OpCodes.Callvirt, _ctx.Runtime.TSArrayEnsureDoubleCapacity);
+        IL.Emit(OpCodes.Callvirt, _ctx.Runtime.ArrayStorage.EnsureDoubleCapacity);
 
         _ctx.ILBuilder.MarkLabel(skip);
         SetStackUnknown();
@@ -1970,7 +1970,7 @@ public partial class ILEmitter
             // to boxed and reintroduces the per-element boxing this project removed (#927 step 1). Bool/
             // Object kinds keep their List<T> hoist ($Array : List<object?> covers Object directly).
             var hoistType = desc.Kind == ArrayElementsKind.Double
-                ? _ctx.Runtime!.TSArrayType
+                ? _ctx.Runtime!.ArrayStorage.Type
                 : desc.GetListType(_ctx.Types);
             var typedLocal = IL.DeclareLocal(hoistType);
 
@@ -1990,10 +1990,10 @@ public partial class ILEmitter
                 // cached List<object> reads require its boxed representation.
                 var notNumericArray = IL.DefineLabel();
                 IL.Emit(OpCodes.Dup);
-                IL.Emit(OpCodes.Isinst, _ctx.Runtime!.TSArrayType);
+                IL.Emit(OpCodes.Isinst, _ctx.Runtime!.ArrayStorage.Type);
                 IL.Emit(OpCodes.Dup);
                 IL.Emit(OpCodes.Brfalse, notNumericArray);
-                IL.Emit(OpCodes.Callvirt, _ctx.Runtime.TSArrayEnsureBoxed);
+                IL.Emit(OpCodes.Callvirt, _ctx.Runtime.ArrayStorage.EnsureBoxed);
                 var ready = IL.DefineLabel();
                 IL.Emit(OpCodes.Br, ready);
                 IL.MarkLabel(notNumericArray);
@@ -2749,11 +2749,11 @@ public partial class ILEmitter
             // $Array wrapper → .Elements
             var notTSArrayLabel = builder.DefineLabel("forof_arr_not_tsarr");
             IL.Emit(OpCodes.Ldloc, iterableLocal);
-            IL.Emit(OpCodes.Isinst, _ctx.Runtime!.TSArrayType);
+            IL.Emit(OpCodes.Isinst, _ctx.Runtime!.ArrayStorage.Type);
             IL.Emit(OpCodes.Brfalse, notTSArrayLabel);
             IL.Emit(OpCodes.Ldloc, iterableLocal);
-            IL.Emit(OpCodes.Castclass, _ctx.Runtime!.TSArrayType);
-            IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.TSArrayElementsGetter);
+            IL.Emit(OpCodes.Castclass, _ctx.Runtime!.ArrayStorage.Type);
+            IL.Emit(OpCodes.Callvirt, _ctx.Runtime!.ArrayStorage.ElementsGetter);
             IL.Emit(OpCodes.Stloc, listLocal);
             IL.Emit(OpCodes.Br, loopHeadLabel);
 
@@ -2826,7 +2826,7 @@ public partial class ILEmitter
             var notHoleLabel = builder.DefineLabel("forof_arr_not_hole");
             var unholedLabel = builder.DefineLabel("forof_arr_unholed");
             IL.Emit(OpCodes.Dup);
-            IL.Emit(OpCodes.Isinst, _ctx.Runtime!.ArrayHoleType);
+            IL.Emit(OpCodes.Isinst, _ctx.Runtime!.ArrayStorage.HoleType);
             IL.Emit(OpCodes.Brfalse, notHoleLabel);
             IL.Emit(OpCodes.Pop);
             IL.Emit(OpCodes.Ldsfld, _ctx.Runtime!.UndefinedInstance);

--- a/src/SharpTS/Compilation/RuntimeEmitter.ArrayFrom.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.ArrayFrom.cs
@@ -18,7 +18,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "ArrayFrom",
             MethodAttributes.Public | MethodAttributes.Static,
-            runtime.TSArrayType,
+            runtime.ArrayStorage.Type,
             [_types.Object, _types.Object, runtime.TSSymbolType, _types.Type, _types.Object]
         );
         runtime.ArrayFrom = method;
@@ -223,7 +223,7 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(streamingDoneLabel);
         il.Emit(OpCodes.Ldloc, resultLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(eagerIterablePathLabel);
@@ -254,7 +254,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ldloc, normalizeIndexLocal);
         il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.ListOfObject, "Item").GetGetMethod()!);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, normalizeNextLabel);
         il.Emit(OpCodes.Ldloc, resultLocal);
         il.Emit(OpCodes.Ldloc, normalizeIndexLocal);
@@ -348,7 +348,7 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(returnLabel);
         // Wrap the List<object?> in $Array on the way out.
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
     }
 
@@ -362,7 +362,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "ArrayOf",
             MethodAttributes.Public | MethodAttributes.Static,
-            runtime.TSArrayType,
+            runtime.ArrayStorage.Type,
             [_types.ObjectArray]
         );
         runtime.ArrayOf = method;
@@ -372,7 +372,7 @@ public partial class RuntimeEmitter
         // return new $Array(new List<object?>(args));
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, typeof(IEnumerable<object>)));
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
     }
 
@@ -492,7 +492,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "ArrayConstructor",
             MethodAttributes.Public | MethodAttributes.Static,
-            runtime.TSArrayType,
+            runtime.ArrayStorage.Type,
             [_types.ObjectArray]
         );
         runtime.ArrayConstructor = method;
@@ -502,7 +502,7 @@ public partial class RuntimeEmitter
         var argLocal = il.DeclareLocal(_types.Object);
         var dLocal = il.DeclareLocal(_types.Double);
         var nLocal = il.DeclareLocal(_types.Int64);
-        var arrLocal = il.DeclareLocal(runtime.TSArrayType);
+        var arrLocal = il.DeclareLocal(runtime.ArrayStorage.Type);
 
         var emptyCaseLabel = il.DefineLabel();
         var singleArgLabel = il.DefineLabel();
@@ -534,7 +534,7 @@ public partial class RuntimeEmitter
         // --- empty: return new $Array(new List<object?>()) ---
         il.MarkLabel(emptyCaseLabel);
         il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.ListOfObject));
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
 
         // --- single-arg: check numeric-vs-other ---
@@ -604,11 +604,11 @@ public partial class RuntimeEmitter
         // arr.SetLength(n);
         // return arr;
         il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.ListOfObject));
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Stloc, arrLocal);
         il.Emit(OpCodes.Ldloc, arrLocal);
         il.Emit(OpCodes.Ldloc, nLocal);
-        il.Emit(OpCodes.Callvirt, runtime.TSArraySetLength);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.SetLength);
         il.Emit(OpCodes.Ldloc, arrLocal);
         il.Emit(OpCodes.Ret);
 
@@ -618,14 +618,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Dup);
         il.Emit(OpCodes.Ldloc, argLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add")!);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
 
         // --- multi-arg: $Array wrapping new List<object>(args) ---
         il.MarkLabel(multiArgLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, typeof(IEnumerable<object>)));
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
     }
 }

--- a/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Iterators.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Iterators.cs
@@ -59,7 +59,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Isinst, runtime.CompactObjectRecordInterface);
         il.Emit(OpCodes.Brtrue, isLazyTrue);
         il.Emit(OpCodes.Ldloc, rcvrLocal);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, isLazyTrue);
         il.Emit(OpCodes.Ldloc, rcvrLocal);
         il.Emit(OpCodes.Isinst, _types.ListOfObject);
@@ -188,7 +188,7 @@ public partial class RuntimeEmitter
     private void EmitSkipIfHole(ILGenerator il, LocalBuilder indexLocal, Label skipLabel, EmittedRuntime runtime, LocalBuilder isLazyLocal)
     {
         EmitElementLoad(il, indexLocal, runtime, isLazyLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, skipLabel);
     }
 
@@ -205,7 +205,7 @@ public partial class RuntimeEmitter
         var doneLabel = il.DefineLabel();
         EmitElementLoad(il, indexLocal, runtime, isLazyLocal);
         il.Emit(OpCodes.Dup);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, notHoleLabel);
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
@@ -483,7 +483,7 @@ public partial class RuntimeEmitter
         il.MarkLabel(holeLabel);
         // Hole-preserving output: push $ArrayHole.Instance to the result list.
         il.Emit(OpCodes.Ldloc, resultLocal);
-        il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+        il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", _types.Object));
 
         il.MarkLabel(addedLabel);
@@ -563,7 +563,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, listIndexerGetter);
         il.Emit(OpCodes.Stloc, elementLocal);
         il.Emit(OpCodes.Ldloc, elementLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, holeLabel);
 
         // result.Add(cb(element))
@@ -577,7 +577,7 @@ public partial class RuntimeEmitter
         // result.Add($ArrayHole.Instance)
         il.MarkLabel(holeLabel);
         il.Emit(OpCodes.Ldloc, resultLocal);
-        il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+        il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
         il.Emit(OpCodes.Callvirt, listAdd);
 
         il.MarkLabel(addedLabel);
@@ -642,7 +642,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, listIndexerGetter);
         il.Emit(OpCodes.Stloc, elementLocal);
         il.Emit(OpCodes.Ldloc, elementLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, skipAdd);
 
         // if (!IsTruthy(cb(element))) goto skipAdd
@@ -719,7 +719,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, listIndexerGetter);
         il.Emit(OpCodes.Stloc, elementLocal);
         il.Emit(OpCodes.Ldloc, elementLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, skipAdd);
 
         il.Emit(OpCodes.Ldarg_1);
@@ -786,7 +786,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, listIndexerGetter);
         il.Emit(OpCodes.Stloc, elementLocal);
         il.Emit(OpCodes.Ldloc, elementLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, skipCall);
 
         // cb(element); discard return.
@@ -848,7 +848,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, listIndexerGetter);
         il.Emit(OpCodes.Stloc, elementLocal);
         il.Emit(OpCodes.Ldloc, elementLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         var notHole = il.DefineLabel();
         il.Emit(OpCodes.Brfalse, notHole);
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
@@ -916,7 +916,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, listIndexerGetter);
         il.Emit(OpCodes.Stloc, elementLocal);
         il.Emit(OpCodes.Ldloc, elementLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         var notHole = il.DefineLabel();
         il.Emit(OpCodes.Brfalse, notHole);
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
@@ -982,7 +982,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, listIndexerGetter);
         il.Emit(OpCodes.Stloc, elementLocal);
         il.Emit(OpCodes.Ldloc, elementLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         var notHole = il.DefineLabel();
         il.Emit(OpCodes.Brfalse, notHole);
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
@@ -1049,7 +1049,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, listIndexerGetter);
         il.Emit(OpCodes.Stloc, elementLocal);
         il.Emit(OpCodes.Ldloc, elementLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         var notHole = il.DefineLabel();
         il.Emit(OpCodes.Brfalse, notHole);
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
@@ -1156,7 +1156,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, listIndexerGetter);
         il.Emit(OpCodes.Stloc, elementLocal);
         il.Emit(OpCodes.Ldloc, elementLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, advance);
 
         il.Emit(OpCodes.Ldarg_1);
@@ -1225,7 +1225,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, listIndexerGetter);
         il.Emit(OpCodes.Stloc, elementLocal);
         il.Emit(OpCodes.Ldloc, elementLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, advance);
 
         il.Emit(OpCodes.Ldarg_1);
@@ -1795,7 +1795,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, listIndexerGetter);
         il.Emit(OpCodes.Stloc, elementLocal);
         il.Emit(OpCodes.Ldloc, elementLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, advance);
 
         // acc = cb(acc, element)
@@ -2123,7 +2123,7 @@ public partial class RuntimeEmitter
         EmitElementLoad(il, scanLocal, runtime, isLazyLocal);
         il.Emit(OpCodes.Stloc, scanValueLocal);
         il.Emit(OpCodes.Ldloc, scanValueLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, scanFound);
         il.Emit(OpCodes.Ldloc, scanLocal);
         il.Emit(OpCodes.Ldc_I4_1);
@@ -2168,7 +2168,7 @@ public partial class RuntimeEmitter
         EmitElementLoad(il, indexLocal, runtime, isLazyLocal);
         il.Emit(OpCodes.Stloc, elementLocal);
         il.Emit(OpCodes.Ldloc, elementLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, reduceAdvance);
 
         // Per-iter: write into the pre-allocated args[4]. args[3] is constant
@@ -2320,7 +2320,7 @@ public partial class RuntimeEmitter
         EmitElementLoad(il, scanLocal, runtime, isLazyLocal);
         il.Emit(OpCodes.Stloc, scanValueLocal);
         il.Emit(OpCodes.Ldloc, scanValueLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, scanFound);
         il.Emit(OpCodes.Ldloc, scanLocal);
         il.Emit(OpCodes.Ldc_I4_1);
@@ -2367,7 +2367,7 @@ public partial class RuntimeEmitter
         EmitElementLoad(il, indexLocal, runtime, isLazyLocal);
         il.Emit(OpCodes.Stloc, elementLocal);
         il.Emit(OpCodes.Ldloc, elementLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, reduceRightAdvance);
 
         // Per-iter: write into the pre-allocated args[4]. args[3] is constant

--- a/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Mutators.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Mutators.cs
@@ -322,13 +322,13 @@ public partial class RuntimeEmitter
         var plainList = il.DefineLabel();
         var shortened = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, plainList);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Ldloc, lastIndexLocal);
         il.Emit(OpCodes.Conv_I8);
-        il.Emit(OpCodes.Callvirt, runtime.TSArraySetLength);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.SetLength);
         il.Emit(OpCodes.Br, shortened);
         il.MarkLabel(plainList);
         il.Emit(OpCodes.Ldarg_0);
@@ -521,7 +521,7 @@ public partial class RuntimeEmitter
         var generic = il.DefineLabel();
         var fastList = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, fastList);
         il.Emit(OpCodes.Br, generic);
         il.MarkLabel(fastList);
@@ -646,24 +646,24 @@ public partial class RuntimeEmitter
         runtime.ArrayShiftNumber = method;
         var il = method.GetILGenerator();
         var fallback = il.DefineLabel();
-        var array = il.DeclareLocal(runtime.TSArrayType);
+        var array = il.DeclareLocal(runtime.ArrayStorage.Type);
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brfalse, fallback);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
-        il.Emit(OpCodes.Ldtoken, runtime.TSArrayType);
+        il.Emit(OpCodes.Ldtoken, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Call, _types.TypeGetTypeFromHandle);
         il.Emit(OpCodes.Ceq);
         il.Emit(OpCodes.Brfalse, fallback);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Stloc, array);
         il.Emit(OpCodes.Ldloc, array);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayCanMutateNumericGetter);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.CanMutateNumericGetter);
         il.Emit(OpCodes.Brfalse, fallback);
         il.Emit(OpCodes.Ldloc, array);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayShiftNumeric);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.ShiftNumeric);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(fallback);
@@ -743,25 +743,25 @@ public partial class RuntimeEmitter
         runtime.ArrayUnshiftNumber = method;
         var il = method.GetILGenerator();
         var fallback = il.DefineLabel();
-        var array = il.DeclareLocal(runtime.TSArrayType);
+        var array = il.DeclareLocal(runtime.ArrayStorage.Type);
 
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Brfalse, fallback);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
-        il.Emit(OpCodes.Ldtoken, runtime.TSArrayType);
+        il.Emit(OpCodes.Ldtoken, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Call, _types.TypeGetTypeFromHandle);
         il.Emit(OpCodes.Ceq);
         il.Emit(OpCodes.Brfalse, fallback);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Stloc, array);
         il.Emit(OpCodes.Ldloc, array);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayCanMutateNumericGetter);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.CanMutateNumericGetter);
         il.Emit(OpCodes.Brfalse, fallback);
         il.Emit(OpCodes.Ldloc, array);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayUnshiftNumeric);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.UnshiftNumeric);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(fallback);
@@ -884,7 +884,7 @@ public partial class RuntimeEmitter
         var generic = il.DefineLabel();
         var fastList = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, fastList);
         il.Emit(OpCodes.Br, generic);
         il.MarkLabel(fastList);
@@ -1018,7 +1018,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, fallback);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Callvirt, _types.GetMethodNoParams(_types.Object, "GetType"));
-        il.Emit(OpCodes.Ldtoken, runtime.TSArrayType);
+        il.Emit(OpCodes.Ldtoken, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Call, _types.TypeGetTypeFromHandle);
         il.Emit(OpCodes.Ceq);
         il.Emit(OpCodes.Brfalse, fallback);
@@ -1026,13 +1026,13 @@ public partial class RuntimeEmitter
         // A numeric-mode array has no boxed base-list elements yet. Deopt before
         // looking at Count or calling the boxed append helper.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayEnsureBoxed);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.EnsureBoxed);
 
         // Sparse arrays need ArrayPushProto's full long-length/index machinery.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayLongLengthGetter);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.LongLengthGetter);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Castclass, _types.ListOfObject);
         il.Emit(OpCodes.Callvirt,
@@ -1081,7 +1081,7 @@ public partial class RuntimeEmitter
         var generic = il.DefineLabel();
         var fastList = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, fastList);
         il.Emit(OpCodes.Br, generic);
         il.MarkLabel(fastList);
@@ -1365,7 +1365,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, next);
         il.MarkLabel(hole);
         il.Emit(OpCodes.Ldloc, result);
-        il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+        il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", _types.Object));
         il.MarkLabel(next);
         il.Emit(OpCodes.Ldloc, k);
@@ -1654,7 +1654,7 @@ public partial class RuntimeEmitter
         // Add()'d directly into the result list.
         var flatContinueLoop = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, itemLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, flatContinueLoop);
 
         // if (depth > 0 && item is List<object> nestedList)
@@ -1763,7 +1763,7 @@ public partial class RuntimeEmitter
         // and structurally-absent slots return $ArrayHole.
         var flatMapContinue = il.DefineLabel();
         EmitElementLoad(il, iLocal, runtime, isLazyLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, flatMapContinue);
 
         // args[0] = LoadArrayLikeElement(list, i) — lazy-aware
@@ -1821,7 +1821,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "get_Item", _types.Int32));
             il.Emit(OpCodes.Stloc, innerElement);
             il.Emit(OpCodes.Ldloc, innerElement);
-            il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+            il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
             il.Emit(OpCodes.Brtrue, innerSkip);
             il.Emit(OpCodes.Ldloc, resultLocal);
             il.Emit(OpCodes.Ldloc, innerElement);
@@ -1966,27 +1966,27 @@ public partial class RuntimeEmitter
         runtime.ArraySliceNumber = method;
 
         var il = method.GetILGenerator();
-        var array = il.DeclareLocal(runtime.TSArrayType);
+        var array = il.DeclareLocal(runtime.ArrayStorage.Type);
         var count = il.DeclareLocal(_types.Int32);
         var fallback = il.DefineLabel();
 
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Stloc, array);
         il.Emit(OpCodes.Ldloc, array);
         il.Emit(OpCodes.Brfalse, fallback);
         il.Emit(OpCodes.Ldloc, array);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayIsNumericGetter);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.IsNumericGetter);
         il.Emit(OpCodes.Brfalse, fallback);
         il.Emit(OpCodes.Ldloc, array);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayNumericCountGetter);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.NumericCountGetter);
         il.Emit(OpCodes.Stloc, count);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldloc, count);
         il.Emit(OpCodes.Call, runtime.ArraySortCanUseDenseFastPath);
         il.Emit(OpCodes.Brfalse, fallback);
         il.Emit(OpCodes.Ldloc, array);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayCloneNumeric);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.CloneNumeric);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(fallback);
@@ -1994,7 +1994,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Newarr, _types.Object);
         il.Emit(OpCodes.Call, runtime.ArraySlice);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
     }
 
@@ -2016,7 +2016,7 @@ public partial class RuntimeEmitter
         runtime.ArraySortNumeric = method;
 
         var il = method.GetILGenerator();
-        var array = il.DeclareLocal(runtime.TSArrayType);
+        var array = il.DeclareLocal(runtime.ArrayStorage.Type);
         var count = il.DeclareLocal(_types.Int32);
         var frozenMarker = il.DeclareLocal(_types.Object);
         var fallback = il.DefineLabel();
@@ -2024,12 +2024,12 @@ public partial class RuntimeEmitter
         var returnReceiver = il.DefineLabel();
 
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Stloc, array);
         il.Emit(OpCodes.Ldloc, array);
         il.Emit(OpCodes.Brfalse, fallbackReady);
         il.Emit(OpCodes.Ldloc, array);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayIsNumericGetter);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.IsNumericGetter);
         il.Emit(OpCodes.Brfalse, fallback);
 
         // Preserve the existing frozen-array behavior without materializing a
@@ -2045,7 +2045,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, returnReceiver);
 
         il.Emit(OpCodes.Ldloc, array);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayNumericCountGetter);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.NumericCountGetter);
         il.Emit(OpCodes.Stloc, count);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldloc, count);
@@ -2053,12 +2053,12 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, fallback);
         il.Emit(OpCodes.Ldloc, array);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Callvirt, runtime.TSArraySortNumeric);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.SortNumeric);
         il.Emit(OpCodes.Br, returnReceiver);
 
         il.MarkLabel(fallback);
         il.Emit(OpCodes.Ldloc, array);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayEnsureBoxed);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.EnsureBoxed);
         il.MarkLabel(fallbackReady);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Castclass, _types.ListOfObject);
@@ -2118,32 +2118,32 @@ public partial class RuntimeEmitter
         // packed-double $Array deliberately has an empty inherited List, so a
         // Count mismatch gets one representation-aware retry before bailing.
         var backingLengthReady = il.DefineLabel();
-        var numericArray = il.DeclareLocal(runtime.TSArrayType);
+        var numericArray = il.DeclareLocal(runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Ldloc, receiverList);
         il.Emit(OpCodes.Callvirt,
             _types.GetProperty(_types.ListOfObject, "Count").GetGetMethod()!);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Beq, backingLengthReady);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Stloc, numericArray);
         il.Emit(OpCodes.Ldloc, numericArray);
         il.Emit(OpCodes.Brfalse, returnFalse);
         il.Emit(OpCodes.Ldloc, numericArray);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayIsNumericGetter);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.IsNumericGetter);
         il.Emit(OpCodes.Brfalse, returnFalse);
         il.Emit(OpCodes.Ldloc, numericArray);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayNumericCountGetter);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.NumericCountGetter);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Bne_Un, returnFalse);
         il.MarkLabel(backingLengthReady);
 
         var notTSArray = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Dup);
         il.Emit(OpCodes.Brfalse, notTSArray);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayLongLengthGetter);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.LongLengthGetter);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Conv_I8);
         il.Emit(OpCodes.Bne_Un, returnFalse);
@@ -2475,7 +2475,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, isUndefinedLabel);
 
         il.Emit(OpCodes.Ldloc, elementLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, observeProperties ? densePathFoundHole : isUndefinedLabel);
 
         // Not undefined or hole: defined.Add(element)
@@ -2939,7 +2939,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Brfalse, observableWriteBack);
             il.Emit(OpCodes.Ldloc, observableReceiverLocal!);
             il.Emit(OpCodes.Castclass, _types.ListOfObject);
-            il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+            il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
             il.Emit(OpCodes.Callvirt,
                 _types.GetMethod(_types.ListOfObject, "Contains", _types.Object));
             il.Emit(OpCodes.Brtrue, observableWriteBack);
@@ -3720,7 +3720,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, deletedNext);
         il.MarkLabel(deletedHole);
         il.Emit(OpCodes.Ldloc, deleted);
-        il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+        il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", _types.Object));
         il.MarkLabel(deletedNext);
         il.Emit(OpCodes.Ldloc, k);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Search.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Arrays.Search.cs
@@ -397,11 +397,11 @@ public partial class RuntimeEmitter
         // $Array → .Elements
         var notTSArray = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, notTSArray);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayElementsGetter);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.ElementsGetter);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(notTSArray);
 
@@ -664,7 +664,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, addValueLabel);
         il.MarkLabel(addHoleLabel);
         il.Emit(OpCodes.Ldloc, listLocal);
-        il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+        il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
         il.MarkLabel(addValueLabel);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", _types.Object));
 
@@ -837,7 +837,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, afterEntry);
         il.MarkLabel(noEntry);
         il.Emit(OpCodes.Ldloc, listLocal);
-        il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+        il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", _types.Object));
         il.MarkLabel(afterEntry);
 
@@ -1019,7 +1019,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, wasPresent);
         il.MarkLabel(pushHole_dict);
         il.Emit(OpCodes.Ldloc, listLocal);
-        il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+        il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", _types.Object));
         il.Emit(OpCodes.Br, afterPush);
         il.MarkLabel(wasPresent);
@@ -1291,7 +1291,7 @@ public partial class RuntimeEmitter
         var suppliedFromIndex = il.DefineLabel();
         var startReady = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_2);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, suppliedFromIndex);
         if (findLast)
         {
@@ -1557,7 +1557,7 @@ public partial class RuntimeEmitter
 
         // hole?
         il.Emit(OpCodes.Ldloc, elemLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, skipAppend);
         // null?
         il.Emit(OpCodes.Ldloc, elemLocal);
@@ -1826,7 +1826,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Br, copyAddedLabel);
         il.MarkLabel(copyHoleLabel);
         il.Emit(OpCodes.Ldloc, resultLocal);
-        il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+        il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", _types.Object));
         il.MarkLabel(copyAddedLabel);
         il.Emit(OpCodes.Ldloc, copyIndexLocal);
@@ -2141,7 +2141,7 @@ public partial class RuntimeEmitter
 
             // Absent: list.Add($ArrayHole.Instance)
             il.Emit(OpCodes.Ldloc, listLocal);
-            il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+            il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
             il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", _types.Object));
             il.Emit(OpCodes.Br, afterAdd);
 
@@ -2236,7 +2236,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.ListOfObject, "Count").GetGetMethod()!);
         il.Emit(OpCodes.Blt, loadListValue);
-        il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+        il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
         il.Emit(OpCodes.Stloc, listValLocal);
         il.Emit(OpCodes.Br, listValueReady);
         il.MarkLabel(loadListValue);
@@ -2263,7 +2263,7 @@ public partial class RuntimeEmitter
         // deciding whether iteration skips the index.
         var notTSArrayReceiver = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, rcvrLocal);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, notTSArrayReceiver);
         il.Emit(OpCodes.Ldarga_S, (byte)1);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Int32, "ToString", Type.EmptyTypes)!);
@@ -2273,7 +2273,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
         il.Emit(OpCodes.Brtrue, loadArrayPropertyLabel);
         il.Emit(OpCodes.Ldloc, listValLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, returnListValLabel);
         il.Emit(OpCodes.Ldloc, rcvrLocal);
         il.Emit(OpCodes.Ldloc, keyStrLocal);
@@ -2300,7 +2300,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, runtime.PDSGetPropertyDescriptor);
         il.Emit(OpCodes.Brtrue, loadArrayPropertyLabel);
         il.Emit(OpCodes.Ldloc, listValLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, returnListValLabel);
         il.Emit(OpCodes.Ldloc, rcvrLocal);
         il.Emit(OpCodes.Ldloc, keyStrLocal);
@@ -2424,7 +2424,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(returnHoleLabel);
-        il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+        il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(returnListValLabel);
@@ -2565,7 +2565,7 @@ public partial class RuntimeEmitter
         // its intrinsic/custom prototype when absent.
         var notTSArrayLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, currentLocal);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, notTSArrayLabel);
         il.Emit(OpCodes.Ldloc, currentLocal);
         il.Emit(OpCodes.Ldarg_1);
@@ -2578,9 +2578,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Int64, "TryParse", [_types.String, _types.Int64.MakeByRefType()])!);
         il.Emit(OpCodes.Brfalse, tsArrayWalkPrototype);
         il.Emit(OpCodes.Ldloc, currentLocal);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Ldloc, tsArrayIdxLocal);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayHasIndex);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.HasIndex);
         il.Emit(OpCodes.Brtrue, trueLabel);
         il.MarkLabel(tsArrayWalkPrototype);
         il.Emit(OpCodes.Ldloc, currentLocal);
@@ -2632,7 +2632,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, listForCheckLocal);
         il.Emit(OpCodes.Ldloc, listIdxLocal);
         il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.ListOfObject, "Item").GetGetMethod()!);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, walkListPrototypeLabel);
         il.Emit(OpCodes.Br, trueLabel);
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Arrays.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Arrays.cs
@@ -86,7 +86,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "CreateArray",
             MethodAttributes.Public | MethodAttributes.Static,
-            runtime.TSArrayType,
+            runtime.ArrayStorage.Type,
             [_types.ObjectArray]
         );
         runtime.CreateArray = method;
@@ -94,7 +94,7 @@ public partial class RuntimeEmitter
         var il = method.GetILGenerator();
         // Copy the literal elements directly into the final array's storage.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayLiteralCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.LiteralCtor);
         il.Emit(OpCodes.Ret);
     }
 
@@ -127,7 +127,7 @@ public partial class RuntimeEmitter
 
         // $Array (wrapper around List<object?>) - check before typed lists
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, tsArrayLabel);
 
         // Descriptor-driven: emit isinst check for each backing type
@@ -157,8 +157,8 @@ public partial class RuntimeEmitter
         // report 0 instead of 10_000_000.
         il.MarkLabel(tsArrayLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayLengthGetter);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.LengthGetter);
         il.Emit(OpCodes.Ret);
 
         // Descriptor-driven: emit Count handler for each backing type
@@ -196,7 +196,7 @@ public partial class RuntimeEmitter
 
         // $Array (wrapper around List<object?>) - check before List
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, tsArrayElLabel);
 
         // List
@@ -222,13 +222,13 @@ public partial class RuntimeEmitter
         var tsArrayGetItemResult = il.DeclareLocal(_types.Object);
         var tsArrayGetItemNotHole = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayElementsGetter);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.ElementsGetter);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "get_Item", _types.Int32));
         il.Emit(OpCodes.Stloc, tsArrayGetItemResult);
         il.Emit(OpCodes.Ldloc, tsArrayGetItemResult);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, tsArrayGetItemNotHole);
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il.Emit(OpCodes.Ret);
@@ -473,7 +473,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, listLocal);
         il.Emit(OpCodes.Ldloc, indexLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(listType, "get_Item", [_types.Int32])!);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, listLoopSkip);
 
         // Indexed array/list properties can carry descriptor metadata in PDS.
@@ -1134,7 +1134,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Castclass, _types.ListOfObject);
         il.Emit(OpCodes.Ldloc, iLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "get_Item", [_types.Int32])!);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, listLoopSkip);
 
         // names.Add(i.ToString())
@@ -1524,7 +1524,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "ConcatArrays",
             MethodAttributes.Public | MethodAttributes.Static,
-            runtime.TSArrayType,
+            runtime.ArrayStorage.Type,
             [_types.ObjectArray, runtime.TSSymbolType, _types.Type]  // Added iteratorSymbol and runtimeType
         );
         runtime.ConcatArrays = method;
@@ -1575,7 +1575,7 @@ public partial class RuntimeEmitter
         il.MarkLabel(loopEnd);
         // Wrap the List<object?> in $Array on the way out.
         il.Emit(OpCodes.Ldloc, resultLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
     }
 
@@ -1738,12 +1738,12 @@ public partial class RuntimeEmitter
             var notNumeric = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, listField);
-            il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+            il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
             il.Emit(OpCodes.Brfalse, notNumeric);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldfld, listField);
-            il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-            il.Emit(OpCodes.Callvirt, runtime.TSArrayEnsureBoxed);
+            il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+            il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.EnsureBoxed);
             il.MarkLabel(notNumeric);
         }
 
@@ -2014,7 +2014,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Br, afterSecond);
             il.MarkLabel(noSecond);
             if (methodName is "indexOf" or "lastIndexOf")
-                il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+                il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
             else
                 il.Emit(OpCodes.Ldnull);
             il.MarkLabel(afterSecond);

--- a/src/SharpTS/Compilation/RuntimeEmitter.CryptoHelpers.Hashing.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.CryptoHelpers.Hashing.cs
@@ -339,7 +339,7 @@ public partial class RuntimeEmitter
 
         // return new $Array(list)
         il.Emit(OpCodes.Ldloc, listLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
     }
 
@@ -376,7 +376,7 @@ public partial class RuntimeEmitter
 
         // return new $Array(list)
         il.Emit(OpCodes.Ldloc, listLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
     }
 }

--- a/src/SharpTS/Compilation/RuntimeEmitter.CryptoHelpers.Info.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.CryptoHelpers.Info.cs
@@ -222,7 +222,7 @@ public partial class RuntimeEmitter
         }
 
         il.Emit(OpCodes.Ldloc, listLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
     }
 }

--- a/src/SharpTS/Compilation/RuntimeEmitter.Dns.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Dns.cs
@@ -897,7 +897,7 @@ public partial class RuntimeEmitter
         }
         else
         {
-            il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+            il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         }
         il.Emit(OpCodes.Stloc, resultLocal);
     }
@@ -3789,7 +3789,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, outListLocal);
         il.Emit(OpCodes.Ldloc, itemLocal);
         il.Emit(OpCodes.Castclass, _types.ListOfObject);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add")!);
         il.Emit(OpCodes.Br, continueLabel);
 
@@ -3816,7 +3816,7 @@ public partial class RuntimeEmitter
 
         // return new $Array(outList)
         il.Emit(OpCodes.Ldloc, outListLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
     }
 
@@ -4144,7 +4144,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add")!);
 
         il.Emit(OpCodes.Ldloc, listLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Stloc, resultLocal);
 
         // callback(null, result)

--- a/src/SharpTS/Compilation/RuntimeEmitter.Functions.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Functions.cs
@@ -1736,7 +1736,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, isArrayLabel);
 
         il.Emit(OpCodes.Ldloc, argsArrayLocal);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, isTSArrayLabel);
 
         // Unknown type - empty array
@@ -1759,8 +1759,8 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(isTSArrayLabel);
         il.Emit(OpCodes.Ldloc, argsArrayLocal);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayElementsGetter);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.ElementsGetter);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObjectNullable, "ToArray")!);
         il.Emit(OpCodes.Stloc, callArgsLocal);
         il.Emit(OpCodes.Br, afterConvertLabel);

--- a/src/SharpTS/Compilation/RuntimeEmitter.GroupBy.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.GroupBy.cs
@@ -57,7 +57,7 @@ public partial class RuntimeEmitter
         // produces the guest TypeError mandated by GetIterator.
         var groupByMaterializeLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, groupByMaterializeLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, _types.ListOfObject);
@@ -147,7 +147,7 @@ public partial class RuntimeEmitter
         // Create new list, wrap in $Array, store in dict
         // existing = new $Array(new List<object?>())
         il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, _types.EmptyTypes));
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Stloc, existingLocal);
         // dict[keyStr] = existing
         il.Emit(OpCodes.Ldloc, dictLocal);
@@ -160,8 +160,8 @@ public partial class RuntimeEmitter
         // Get elements from existing $Array and add current element
         // ((existing as $Array).Elements).Add(list[i])
         il.Emit(OpCodes.Ldloc, existingLocal);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayElementsGetter);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.ElementsGetter);
         il.Emit(OpCodes.Ldloc, listLocal);
         il.Emit(OpCodes.Ldloc, indexLocal);
         il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.ListOfObject, "Item").GetGetMethod()!);
@@ -235,7 +235,7 @@ public partial class RuntimeEmitter
         // host-IEnumerable compatibility fallback can accept the value.
         var materialize = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, materialize);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, _types.ListOfObject);
@@ -307,7 +307,7 @@ public partial class RuntimeEmitter
 
         // Key doesn't exist: create new $Array, store in map
         il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, _types.EmptyTypes));
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Stloc, existingLocal);
         // MapSet(map, key, existing)
         il.Emit(OpCodes.Ldloc, mapLocal);
@@ -327,8 +327,8 @@ public partial class RuntimeEmitter
         // Add current element to existing $Array
         il.MarkLabel(addElementLabel);
         il.Emit(OpCodes.Ldloc, existingLocal);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayElementsGetter);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.ElementsGetter);
         il.Emit(OpCodes.Ldloc, listLocal);
         il.Emit(OpCodes.Ldloc, indexLocal);
         il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.ListOfObject, "Item").GetGetMethod()!);

--- a/src/SharpTS/Compilation/RuntimeEmitter.HasOwnProperty.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.HasOwnProperty.cs
@@ -404,13 +404,13 @@ public partial class RuntimeEmitter
         // it as own.
         var listReceiverIsPlain = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, listReceiverIsPlain);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Ldloc, listIdxLocal);
         il.Emit(OpCodes.Conv_I8);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayHasIndex);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.HasIndex);
         il.Emit(OpCodes.Brtrue, trueLabel);
         il.Emit(OpCodes.Br, listNotIndexLabel);
         il.MarkLabel(listReceiverIsPlain);
@@ -423,7 +423,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Castclass, _types.ListOfObject);
         il.Emit(OpCodes.Ldloc, listIdxLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "get_Item", _types.Int32));
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, listNotIndexLabel);
         il.Emit(OpCodes.Br, trueLabel);
         il.MarkLabel(listNotIndexLabel);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Iterator.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Iterator.cs
@@ -1175,7 +1175,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, count);
         il.Emit(OpCodes.Ldloc, destination);
         il.Emit(OpCodes.Ldloc, count);
-        il.Emit(OpCodes.Call, runtime.TSArrayReserveRest);
+        il.Emit(OpCodes.Call, runtime.ArrayStorage.ReserveRest);
         il.Emit(OpCodes.Ldc_I4_0);
         il.Emit(OpCodes.Stloc, index);
         var loop = il.DefineLabel();
@@ -1192,14 +1192,14 @@ public partial class RuntimeEmitter
         // Spread fills holes with actual undefined values, never the internal
         // hole sentinel. The no-prototype-mutation proof permits this conversion.
         il.Emit(OpCodes.Ldloc, value);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, present);
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il.Emit(OpCodes.Stloc, value);
         il.MarkLabel(present);
         il.Emit(OpCodes.Ldloc, destination);
         il.Emit(OpCodes.Ldloc, value);
-        il.Emit(OpCodes.Call, runtime.TSArrayAppendRestValue);
+        il.Emit(OpCodes.Call, runtime.ArrayStorage.AppendRestValue);
         il.Emit(OpCodes.Ldloc, index);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Add);
@@ -1216,7 +1216,7 @@ public partial class RuntimeEmitter
 
         void AppendValue()
         {
-            if (appendToExisting) il.Emit(OpCodes.Call, runtime.TSArrayAppendRestValue);
+            if (appendToExisting) il.Emit(OpCodes.Call, runtime.ArrayStorage.AppendRestValue);
             else il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "Add", _types.Object));
         }
 
@@ -1268,26 +1268,26 @@ public partial class RuntimeEmitter
         // use the long-indexed GetLong / HasIndex accessors directly.
         var notTSArrayLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, notTSArrayLabel);
         if (appendToExisting && !_features.UsesArrayPrototypeMutation)
         {
             var boxedSource = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-            il.Emit(OpCodes.Call, runtime.TSArrayIsNumericGetter);
+            il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+            il.Emit(OpCodes.Call, runtime.ArrayStorage.IsNumericGetter);
             il.Emit(OpCodes.Brfalse, boxedSource);
             il.Emit(OpCodes.Ldloc, resultLocal);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-            il.Emit(OpCodes.Call, runtime.TSArrayAppendNumericRestSource);
+            il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+            il.Emit(OpCodes.Call, runtime.ArrayStorage.AppendNumericRestSource);
             il.Emit(OpCodes.Ldloc, resultLocal);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(boxedSource);
         }
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayElementsGetter);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.ElementsGetter);
         if (appendToExisting)
         {
             var elements = il.DeclareLocal(_types.ListOfObject);
@@ -1303,8 +1303,8 @@ public partial class RuntimeEmitter
                 il.Emit(OpCodes.Callvirt, _types.GetPropertyGetter(_types.ListOfObject, "Count"));
                 il.Emit(OpCodes.Conv_I8);
                 il.Emit(OpCodes.Ldarg_0);
-                il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-                il.Emit(OpCodes.Callvirt, runtime.TSArrayLongLengthGetter);
+                il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+                il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.LongLengthGetter);
                 il.Emit(OpCodes.Bne_Un, indexed);
                 EmitAppendDenseIteratorSource(il, runtime, resultLocal, elements);
                 il.Emit(OpCodes.Ldloc, resultLocal);
@@ -1320,8 +1320,8 @@ public partial class RuntimeEmitter
             il.MarkLabel(check);
             il.Emit(OpCodes.Ldloc, index);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-            il.Emit(OpCodes.Callvirt, runtime.TSArrayLongLengthGetter);
+            il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+            il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.LongLengthGetter);
             il.Emit(OpCodes.Bge, done);
             il.Emit(OpCodes.Ldloc, resultLocal);
             il.Emit(OpCodes.Ldarg_0);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.RawJson.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.RawJson.cs
@@ -88,7 +88,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, parsed);
         var primitive = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, parsed);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, invalidBoundary);
         il.Emit(OpCodes.Ldloc, parsed);
         il.Emit(OpCodes.Isinst, _types.ListOfObject);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.Append.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.Append.cs
@@ -413,7 +413,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, indexLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(
             _types.ListOfObject, "get_Item", [_types.Int32]));
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, notHole);
         EmitAppendNullLiteral(il);
         il.Emit(OpCodes.Br, appended);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.Shape.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.Shape.cs
@@ -332,7 +332,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "get_Item", [_types.Int32])!);
         il.Emit(OpCodes.Stloc, valueLocal);
         il.Emit(OpCodes.Ldloc, valueLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, falseLabel);
         il.Emit(OpCodes.Ldloc, valueLocal);
         il.Emit(OpCodes.Ldloc, shapeLocal);
@@ -661,7 +661,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, arrayGuarded);
         var arrayTypeAccepted = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, arrayTypeAccepted);
         EmitExactRuntimeTypeCheck(il, 1, _types.ListOfObject, invalidShape);
         il.MarkLabel(arrayTypeAccepted);
@@ -675,10 +675,10 @@ public partial class RuntimeEmitter
         var arrayNotTsArray = il.DefineLabel();
         var arrayBoxed = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Dup);
         il.Emit(OpCodes.Brfalse, arrayNotTsArray);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayEnsureBoxed);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.EnsureBoxed);
         il.Emit(OpCodes.Br, arrayBoxed);
         il.MarkLabel(arrayNotTsArray);
         il.Emit(OpCodes.Pop);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.Stringify.cs
@@ -1370,7 +1370,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, arrLocal);
         il.Emit(OpCodes.Ldloc, iLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "get_Item", [_types.Int32]));
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, notHoleLabel);
         // Hole: append "null" and skip.
         il.Emit(OpCodes.Ldloc, sbLocal);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Json.StringifyFull.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Json.StringifyFull.cs
@@ -700,7 +700,7 @@ public partial class RuntimeEmitter
         var holeAppendedLabel = il.DefineLabel();
         var notHoleLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, elemLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, notHoleLabel);
         il.Emit(OpCodes.Ldloc, sbLocal);
         il.Emit(OpCodes.Ldstr, "null");

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.DeleteProperty.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.DeleteProperty.cs
@@ -270,7 +270,7 @@ public partial class RuntimeEmitter
         // and converts a false result into the required TypeError.
         var tsArrayDelLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, tsArrayDelLabel);
 
         if (runtime.JsonScalarRecordType is not null)
@@ -657,10 +657,10 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldloc, tsArrIndexDescLocal);
             il.Emit(OpCodes.Brtrue, tsArrIndexSealedPropertyLabel);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+            il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
             il.Emit(OpCodes.Ldloc, tsArrDelIndexLocal);
             il.Emit(OpCodes.Conv_U8);
-            il.Emit(OpCodes.Callvirt, runtime.TSArrayHasIndex);
+            il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.HasIndex);
             il.Emit(OpCodes.Brfalse, tsArrIndexNotSealedLabel);
             il.MarkLabel(tsArrIndexSealedPropertyLabel);
             il.Emit(OpCodes.Ldc_I4_0);
@@ -682,10 +682,10 @@ public partial class RuntimeEmitter
 
             // arr.DeleteAt(idx); return true;
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+            il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
             il.Emit(OpCodes.Ldloc, tsArrDelIndexLocal);
             il.Emit(OpCodes.Conv_U8);
-            il.Emit(OpCodes.Callvirt, runtime.TSArrayDeleteAt);
+            il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.DeleteAt);
             il.Emit(OpCodes.Ldc_I4_1);
             il.Emit(OpCodes.Ret);
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.DefineProperty.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.DefineProperty.cs
@@ -105,7 +105,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, receiverIsSynthableLabel);
         var checkSynthListLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, checkSynthListLabel);
         var synthArrayIndexLocal = il.DeclareLocal(_types.UInt32);
         il.Emit(OpCodes.Ldloc, propNameLocal);
@@ -123,10 +123,10 @@ public partial class RuntimeEmitter
             _types.String, "op_Equality", _types.String, _types.String));
         il.Emit(OpCodes.Brfalse, skipSynthExistingLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Ldloc, synthArrayIndexLocal);
         il.Emit(OpCodes.Conv_U8);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayHasIndex);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.HasIndex);
         il.Emit(OpCodes.Brfalse, skipSynthExistingLabel);
         il.Emit(OpCodes.Br, receiverIsSynthableLabel);
 
@@ -191,7 +191,7 @@ public partial class RuntimeEmitter
         // make length configurable/enumerable/accessor-shaped are rejected.
         var notIntrinsicArrayLengthLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, notIntrinsicArrayLengthLabel);
         il.Emit(OpCodes.Ldloc, propNameLocal);
         il.Emit(OpCodes.Ldstr, "length");
@@ -200,8 +200,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Newobj, runtime.CompiledPropertyDescriptorCtor);
         il.Emit(OpCodes.Dup);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayLongLengthGetter);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.LongLengthGetter);
         il.Emit(OpCodes.Conv_R8);
         il.Emit(OpCodes.Box, _types.Double);
         il.Emit(OpCodes.Callvirt, runtime.CompiledPropertyDescriptorValue.GetSetMethod()!);
@@ -446,7 +446,7 @@ public partial class RuntimeEmitter
         // the accessor path skips the data-value write below.
         var skipArrayIndexLengthGrowth = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, skipArrayIndexLengthGrowth);
         var definedArrayIndexLocal = il.DeclareLocal(_types.UInt32);
         il.Emit(OpCodes.Ldloc, propNameLocal);
@@ -465,20 +465,20 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, skipArrayIndexLengthGrowth);
         var arrayLengthAlreadyCoversIndex = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayLongLengthGetter);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.LongLengthGetter);
         il.Emit(OpCodes.Ldloc, definedArrayIndexLocal);
         il.Emit(OpCodes.Conv_U8);
         il.Emit(OpCodes.Bgt_Un, arrayLengthAlreadyCoversIndex);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Ldloc, definedArrayIndexLocal);
         il.Emit(OpCodes.Conv_U8);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Conv_U8);
         il.Emit(OpCodes.Add);
         il.Emit(OpCodes.Conv_I8);
-        il.Emit(OpCodes.Callvirt, runtime.TSArraySetLength);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.SetLength);
         il.MarkLabel(arrayLengthAlreadyCoversIndex);
         il.MarkLabel(skipArrayIndexLengthGrowth);
     }
@@ -578,7 +578,7 @@ public partial class RuntimeEmitter
         var accessorCleanupNotArrayIndex = il.DefineLabel();
         var accessorArrayIndexLocal = il.DeclareLocal(_types.UInt32);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, accessorCleanupNotArrayIndex);
         il.Emit(OpCodes.Ldloc, propNameLocal);
         il.Emit(OpCodes.Ldloca, accessorArrayIndexLocal);
@@ -595,11 +595,11 @@ public partial class RuntimeEmitter
             _types.String, "op_Equality", _types.String, _types.String));
         il.Emit(OpCodes.Brfalse, accessorCleanupNotArrayIndex);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Ldloc, accessorArrayIndexLocal);
         il.Emit(OpCodes.Conv_U8);
         il.Emit(OpCodes.Conv_I8);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayDeleteAt);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.DeleteAt);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(accessorCleanupNotArrayIndex);
@@ -631,7 +631,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Bge, accessorCleanupReturn);
         il.Emit(OpCodes.Ldloc, accessorListLocal);
         il.Emit(OpCodes.Ldloc, accessorListIndexLocal);
-        il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+        il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "set_Item", _types.Int32, _types.Object));
         il.MarkLabel(accessorCleanupReturn);
         il.Emit(OpCodes.Ldarg_0);
@@ -783,7 +783,7 @@ public partial class RuntimeEmitter
         // already range-validated at the top of this method.
         var notListForLengthLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, notListForLengthLabel);
         il.Emit(OpCodes.Ldloc, propNameLocal);
         il.Emit(OpCodes.Ldstr, "length");
@@ -804,11 +804,11 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, notListForLengthLabel);
         // Convert value to uint32. Already validated.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Ldloc, valueToWriteLocal);
         il.Emit(OpCodes.Call, runtime.ToNumber);
         il.Emit(OpCodes.Conv_I8);
-        il.Emit(OpCodes.Callvirt, runtime.TSArraySetLength);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.SetLength);
         il.Emit(OpCodes.Br, endLabel);
         il.MarkLabel(notListForLengthLabel);
     }
@@ -832,7 +832,7 @@ public partial class RuntimeEmitter
         // inherited index does not count as an own element for that decision.
         var notArrayIdxLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, notArrayIdxLabel);
         var arrIdxLocal = il.DeclareLocal(_types.UInt32);
         il.Emit(OpCodes.Ldloc, propNameLocal);
@@ -854,19 +854,19 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, wasGenericLocal);
         il.Emit(OpCodes.Brfalse, writeArrayIdxLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Ldloc, arrIdxLocal);
         il.Emit(OpCodes.Conv_U8);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayHasIndex);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.HasIndex);
         il.Emit(OpCodes.Brtrue, endLabel);
         il.MarkLabel(writeArrayIdxLabel);
 
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Ldloc, arrIdxLocal);
         il.Emit(OpCodes.Conv_U8);
         il.Emit(OpCodes.Ldloc, valueToWriteLocal);
-        il.Emit(OpCodes.Callvirt, runtime.TSArraySetLong);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.SetLong);
         il.Emit(OpCodes.Br, endLabel);
         il.MarkLabel(notArrayIdxLabel);
     }
@@ -915,7 +915,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, listIdxReceiverLocal);
         il.Emit(OpCodes.Ldloc, listIdxWriteLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "get_Item", _types.Int32));
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, endLabel);
         il.MarkLabel(writeListIdxLabel);
         il.Emit(OpCodes.Ldloc, listIdxReceiverLocal);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.Lookup.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.Lookup.cs
@@ -162,7 +162,7 @@ public partial class RuntimeEmitter
         // successful `arr.length = n` assignment.
         var notArrayLengthDescriptorLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, notArrayLengthDescriptorLabel);
         il.Emit(OpCodes.Ldloc, propNameLocal);
         il.Emit(OpCodes.Ldstr, "length");
@@ -173,8 +173,8 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, resultDictLocal);
         il.Emit(OpCodes.Ldstr, "value");
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayLongLengthGetter);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.LongLengthGetter);
         il.Emit(OpCodes.Conv_R8);
         il.Emit(OpCodes.Box, _types.Double);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.DictionaryStringObject, "set_Item"));
@@ -869,13 +869,13 @@ public partial class RuntimeEmitter
 
         // Check for $Array (SharpTSArray)
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, notTSArrayLabel);
 
         // It's $Array - get Elements list
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayElementsGetter);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.ElementsGetter);
         il.Emit(OpCodes.Stloc, listLocal);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Stloc, descriptorReceiverIsTSArray);
@@ -960,10 +960,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, descriptorReceiverIsTSArray);
         il.Emit(OpCodes.Brfalse, descriptorArrayIndexPresent);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Ldloc, indexLocal);
         il.Emit(OpCodes.Conv_I8);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayHasIndex);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.HasIndex);
         il.Emit(OpCodes.Brfalse, returnNullLabel);
         il.MarkLabel(descriptorArrayIndexPresent);
 
@@ -977,7 +977,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, listLocal);
         il.Emit(OpCodes.Ldloc, indexLocal);
         il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "get_Item", _types.Int32));
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brtrue, returnNullLabel);
 
         // Return element descriptor: { value: element, writable: true, enumerable: true, configurable: true }

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Descriptors.cs
@@ -1130,8 +1130,8 @@ public partial class RuntimeEmitter
         // Array \`length\` special case: read list.Count for compare.
         var afterArrayLenOverride = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
-        var arrayLenLocal = il.DeclareLocal(runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
+        var arrayLenLocal = il.DeclareLocal(runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Stloc, arrayLenLocal);
         il.Emit(OpCodes.Ldloc, arrayLenLocal);
         il.Emit(OpCodes.Brfalse, afterArrayLenOverride);
@@ -1141,7 +1141,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, afterArrayLenOverride);
         // existingValueForCompare = (double)array.[[ArrayLength]]
         il.Emit(OpCodes.Ldloc, arrayLenLocal);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayLongLengthGetter);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.LongLengthGetter);
         il.Emit(OpCodes.Conv_R8);
         il.Emit(OpCodes.Box, _types.Double);
         il.Emit(OpCodes.Stloc, existingValueForCompare);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Extensibility.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Extensibility.cs
@@ -34,11 +34,11 @@ public partial class RuntimeEmitter
         // that predate the $Array encapsulation.
         var notTSArrayLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, notTSArrayLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayFreeze);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.Freeze);
         il.MarkLabel(notTSArrayLabel);
 
         // Mirror for $Object: set its internal _isFrozen/_isSealed/_isNonExtensible
@@ -153,11 +153,11 @@ public partial class RuntimeEmitter
         // ArrayPush consults, which PushDouble can't reach).
         var notTSArraySealLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, notTSArraySealLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayMarkNonExtensible);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.MarkNonExtensible);
         il.MarkLabel(notTSArraySealLabel);
 
         // Call $PropertyDescriptorStore.Seal(obj) - fully standalone, no reflection

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.GetPropertyBranches.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.GetPropertyBranches.cs
@@ -189,7 +189,7 @@ public partial class RuntimeEmitter
     private void EmitSharpTSArrayGetBranch(ILGenerator il, EmittedRuntime runtime, Label notMatch)
     {
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, notMatch);
 
         // Object.defineProperty stores array index accessors in the shared
@@ -280,8 +280,8 @@ public partial class RuntimeEmitter
         // Use the LongLength getter — not the int-clamped Length — so `.length`
         // reads up to 2^32 - 1 survive (M3 acceptance: `a.length === 2147483649`).
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayLongLengthGetter);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.LongLengthGetter);
         il.Emit(OpCodes.Conv_R8);
         il.Emit(OpCodes.Box, _types.Double);
         il.Emit(OpCodes.Ret);
@@ -321,7 +321,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.ListOfObject, "Item").GetGetMethod()!);
         var tsArrayIndexPresent = il.DefineLabel();
         il.Emit(OpCodes.Dup);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, tsArrayIndexPresent);
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Br, tsArrayPrototypeFallback);
@@ -491,7 +491,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Callvirt, _types.GetProperty(_types.ListOfObject, "Item").GetGetMethod()!);
         var listIndexPresentLabel = il.DefineLabel();
         il.Emit(OpCodes.Dup);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, listIndexPresentLabel);
         il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Br, listPrototypeFallback);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Index.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Index.cs
@@ -79,7 +79,7 @@ public partial class RuntimeEmitter
         // $Array (wrapper around List<object?>) - check before List
         var tsArrayLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, tsArrayLabel);
 
         // Descriptor-driven: check each array backing type
@@ -293,7 +293,7 @@ public partial class RuntimeEmitter
         // TSArrayType is non-null here by contract: the dispatch above (Isinst TSArrayType)
         // already passed it to il.Emit, which throws on null. A redundant != null guard here
         // would only poison nullable flow analysis for the unconditional casts further down.
-        EmitProtoSymbolFallback(runtime.TSArrayType, runtime.ArrayPrototypeField, runtime.ArrayPrototypePopulateMethod);
+        EmitProtoSymbolFallback(runtime.ArrayStorage.Type, runtime.ArrayPrototypeField, runtime.ArrayPrototypePopulateMethod);
         // Functions inherit symbol-keyed properties from Function.prototype,
         // including Symbol.isConcatSpreadable. The own symbol dictionary was
         // already checked above; only a miss reaches this fallback.
@@ -681,9 +681,9 @@ public partial class RuntimeEmitter
 
         var tsArrayOwnIndex = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Ldloc, tsArrayGetIdx);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayHasIndex);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.HasIndex);
         il.Emit(OpCodes.Brtrue, tsArrayOwnIndex);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
@@ -692,9 +692,9 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
         il.MarkLabel(tsArrayOwnIndex);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Ldloc, tsArrayGetIdx);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayGetLong);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.GetLong);
         il.Emit(OpCodes.Ret);
 
         // Descriptor-driven: emit get handler for each backing type.
@@ -829,7 +829,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Stloc, listElementLocal);
             var notHoleLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldloc, listElementLocal);
-            il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+            il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
             il.Emit(OpCodes.Brfalse, notHoleLabel);
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Ldarg_1);
@@ -1157,7 +1157,7 @@ public partial class RuntimeEmitter
         // $Array (wrapper around List<object?>) - check before List
         var tsArraySetLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, tsArraySetLabel);
 
         // Descriptor-driven: check each array backing type
@@ -1598,10 +1598,10 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, nullLabel);
         il.MarkLabel(tsArraySetRawStorage);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Ldloc, idxLong);
         il.Emit(OpCodes.Ldarg_2);
-        il.Emit(OpCodes.Callvirt, runtime.TSArraySetLong);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.SetLong);
         il.Emit(OpCodes.Ret);
 
         // Descriptor-driven: emit set handler for each backing type
@@ -1870,7 +1870,7 @@ public partial class RuntimeEmitter
         // the pre-M3 code just returned true without mutating.
         var tsArrayDeleteIdxLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, tsArrayDeleteIdxLabel);
 
         // $Arguments / legacy List<object> array carriers use ArrayHole for
@@ -2066,7 +2066,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Ldarg_0);
             il.Emit(OpCodes.Castclass, _types.ListOfObject);
             il.Emit(OpCodes.Ldloc, listDeleteIndexLocal);
-            il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+            il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
             il.Emit(OpCodes.Callvirt, _types.GetMethod(_types.ListOfObject, "set_Item", [_types.Int32, _types.Object]));
             il.MarkLabel(listDeleteDone);
             il.Emit(OpCodes.Ldc_I4_1);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Iteration.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Iteration.cs
@@ -56,7 +56,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Ldarg_2);
         il.Emit(OpCodes.Call, runtime.IterateToList);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(passThroughLabel);
@@ -509,7 +509,7 @@ public partial class RuntimeEmitter
 
             // Skip holes.
             il.Emit(OpCodes.Ldloc, elemLocal);
-            il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+            il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
             il.Emit(OpCodes.Brtrue, advance);
 
             // result.Add(elem);
@@ -1090,7 +1090,7 @@ public partial class RuntimeEmitter
 
             // Skip holes.
             il.Emit(OpCodes.Ldloc, elemLocal);
-            il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+            il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
             il.Emit(OpCodes.Brtrue, advance);
 
             // entry = new List<object> { i.ToString(), elem }; result.Add(entry);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Properties.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Properties.cs
@@ -1276,7 +1276,7 @@ public partial class RuntimeEmitter
         var notArraySubclassLabel = il.DefineLabel();
         var arraySubclassMissLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, notArraySubclassLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, runtime.IHasFieldsInterface);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.Prototype.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.Prototype.cs
@@ -230,11 +230,11 @@ public partial class RuntimeEmitter
         // can't reach).
         var notTSArrayPxLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, notTSArrayPxLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayMarkNonExtensible);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.MarkNonExtensible);
         il.MarkLabel(notTSArrayPxLabel);
 
         // Call $PropertyDescriptorStore.PreventExtensions(obj) - fully standalone, no reflection

--- a/src/SharpTS/Compilation/RuntimeEmitter.Objects.SetProperty.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Objects.SetProperty.cs
@@ -782,7 +782,7 @@ public partial class RuntimeEmitter
         // neither), and BEFORE SetFieldsProperty fallthrough.
         var tsArraySetPropLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, tsArraySetPropLabel);
 
         // Dictionary
@@ -1194,9 +1194,9 @@ public partial class RuntimeEmitter
 
             il.MarkLabel(validLengthLabel);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+            il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
             il.Emit(OpCodes.Ldloc, u32Local);
-            il.Emit(OpCodes.Callvirt, runtime.TSArraySetLength);
+            il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.SetLength);
             il.Emit(OpCodes.Ret);
 
             il.MarkLabel(notLengthLabel);
@@ -1780,7 +1780,7 @@ public partial class RuntimeEmitter
         // non-writable throws then reuses the non-strict store logic.
         var arraySetStrictLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, arraySetStrictLabel);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Isinst, _types.ListOfObject);
@@ -1814,7 +1814,7 @@ public partial class RuntimeEmitter
             var arrayNamedPropertyLabel = il.DefineLabel();
             var arrayPropertyIndexLocal = il.DeclareLocal(_types.UInt32);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+            il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
             il.Emit(OpCodes.Brfalse, arrayNamedPropertyLabel);
             il.Emit(OpCodes.Ldarg_1);
             il.Emit(OpCodes.Ldloca, arrayPropertyIndexLocal);
@@ -1836,10 +1836,10 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Brtrue, arrayNamedPropertyLabel);
             var arrayIndexedRawStoreLabel = il.DefineLabel();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+            il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
             il.Emit(OpCodes.Ldloc, arrayPropertyIndexLocal);
             il.Emit(OpCodes.Conv_U8);
-            il.Emit(OpCodes.Callvirt, runtime.TSArrayHasIndex);
+            il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.HasIndex);
             il.Emit(OpCodes.Brtrue, arrayIndexedRawStoreLabel);
             var arrayInheritedSetterLocal = il.DeclareLocal(_types.Object);
             il.Emit(OpCodes.Ldsfld, runtime.ArrayPrototypeField);
@@ -1861,12 +1861,12 @@ public partial class RuntimeEmitter
 
             il.MarkLabel(arrayIndexedRawStoreLabel);
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+            il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
             il.Emit(OpCodes.Ldloc, arrayPropertyIndexLocal);
             il.Emit(OpCodes.Conv_I8);
             il.Emit(OpCodes.Ldarg_2);
             il.Emit(OpCodes.Ldarg_3);
-            il.Emit(OpCodes.Callvirt, runtime.TSArraySetStrictLong);
+            il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.SetStrictLong);
             il.Emit(OpCodes.Ret);
             il.MarkLabel(arrayNamedPropertyLabel);
 
@@ -2309,7 +2309,7 @@ public partial class RuntimeEmitter
 
         // Check if $Array (for strict mode support)
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, sharpTSArrayLabel);
 
         // List<object?>
@@ -2416,10 +2416,10 @@ public partial class RuntimeEmitter
         // hole, however, OrdinarySet must walk every inherited object looking
         // for an indexed accessor before creating a new own element.
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Convert, "ToInt64", _types.Object));
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayHasIndex);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.HasIndex);
         il.Emit(OpCodes.Brtrue, strictArrayNoInheritedSetterLabel);
         il.Emit(OpCodes.Ldsfld, runtime.ArrayPrototypeField);
         il.Emit(OpCodes.Stloc, strictArrayPrototypeLocal);
@@ -2452,12 +2452,12 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(strictArrayNoInheritedSetterLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Call, _types.GetMethod(_types.Convert, "ToInt64", _types.Object));
         il.Emit(OpCodes.Ldarg_2); // value
         il.Emit(OpCodes.Ldarg_3); // strictMode
-        il.Emit(OpCodes.Callvirt, runtime.TSArraySetStrictLong);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.SetStrictLong);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(nullLabel);

--- a/src/SharpTS/Compilation/RuntimeEmitter.Operators.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Operators.cs
@@ -944,7 +944,7 @@ public partial class RuntimeEmitter
         // return false).
         var tsArrayHasLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brtrue, tsArrayHasLabel);
 
         // Check if obj is List<object> (array)
@@ -1094,9 +1094,9 @@ public partial class RuntimeEmitter
 
             // arr.HasIndex(idx) — handles sparse + hole semantics.
             il.Emit(OpCodes.Ldarg_1);
-            il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+            il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
             il.Emit(OpCodes.Ldloc, tsArrIndexLocal);
-            il.Emit(OpCodes.Callvirt, runtime.TSArrayHasIndex);
+            il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.HasIndex);
             il.Emit(OpCodes.Ret);
         }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.ReflectMetadata.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.ReflectMetadata.cs
@@ -231,7 +231,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, storeExistsLabel);
         // Return empty array
         il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, Type.EmptyTypes)!);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(storeExistsLabel);
 
@@ -282,7 +282,7 @@ public partial class RuntimeEmitter
 
         // Wrap in TSArray
         il.Emit(OpCodes.Ldloc, listLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.RegExp.SplitProtocol.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RegExp.SplitProtocol.cs
@@ -463,7 +463,7 @@ public partial class RuntimeEmitter
     private static void EmitReturnArray(ILGenerator il, EmittedRuntime runtime, LocalBuilder result)
     {
         il.Emit(OpCodes.Ldloc, result);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
     }
 }

--- a/src/SharpTS/Compilation/RuntimeEmitter.RegExp.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.RegExp.cs
@@ -943,7 +943,7 @@ public partial class RuntimeEmitter
         // MatchAll already returns List<object?>, so hand it straight to the
         // $Array ctor with no intermediate copy. return new $Array(matches)
         il.Emit(OpCodes.Ldloc, matchesLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
 
         // RegExpCreate(pattern, undefined), then Invoke(rx, @@match, « str »).
@@ -1435,7 +1435,7 @@ public partial class RuntimeEmitter
         var matchCollLocal = il.DeclareLocal(typeof(MatchCollection));
         var matchLocal = il.DeclareLocal(typeof(Match));
         var matchElementsLocal = il.DeclareLocal(_types.ListOfObject);
-        var matchArrayLocal = il.DeclareLocal(runtime.TSArrayType);
+        var matchArrayLocal = il.DeclareLocal(runtime.ArrayStorage.Type);
         var iLocal = il.DeclareLocal(_types.Int32);
         var countLocal = il.DeclareLocal(_types.Int32);
         var groupIndexLocal = il.DeclareLocal(_types.Int32);
@@ -1547,7 +1547,7 @@ public partial class RuntimeEmitter
         il.MarkLabel(groupLoopEndLabel);
 
         il.Emit(OpCodes.Ldloc, matchElementsLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Stloc, matchArrayLocal);
 
         il.Emit(OpCodes.Ldloc, matchArrayLocal);

--- a/src/SharpTS/Compilation/RuntimeEmitter.StringPrototypeStubs.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.StringPrototypeStubs.cs
@@ -179,7 +179,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brtrue, nextLabel);
         var elementReadyLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, elementLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, elementReadyLabel);
         // A hole can still be present through Array.prototype. Re-read the
         // original receiver with ordinary property lookup so inherited indexed
@@ -502,7 +502,7 @@ public partial class RuntimeEmitter
         // $Array
         var notTSArrayLabel = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, notTSArrayLabel);
         EmitTag("[object Array]");
         il.MarkLabel(notTSArrayLabel);

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSArray.Rest.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSArray.Rest.cs
@@ -11,7 +11,7 @@ public partial class RuntimeEmitter
     {
         var appendDouble = typeBuilder.DefineMethod("AppendRestDouble", MethodAttributes.Assembly,
             _types.Void, [_types.Double]);
-        runtime.TSArrayAppendRestDouble = appendDouble;
+        runtime.ArrayStorage.AppendRestDouble = appendDouble;
         appendDouble.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
         var il = appendDouble.GetILGenerator();
         var boxed = il.DefineLabel();
@@ -20,19 +20,19 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, boxed);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.TSArrayPushDouble);
+        il.Emit(OpCodes.Call, runtime.ArrayStorage.PushDouble);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(boxed);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Box, _types.Double);
-        il.Emit(OpCodes.Call, runtime.TSArrayAppendRest);
+        il.Emit(OpCodes.Call, runtime.ArrayStorage.AppendRest);
         il.Emit(OpCodes.Ret);
 
         var appendValue = typeBuilder.DefineMethod("AppendRestValue",
             MethodAttributes.Assembly | MethodAttributes.Static, _types.Void,
             [_types.ListOfObject, _types.Object]);
-        runtime.TSArrayAppendRestValue = appendValue;
+        runtime.ArrayStorage.AppendRestValue = appendValue;
         appendValue.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
         il = appendValue.GetILGenerator();
         var plain = il.DefineLabel();
@@ -44,7 +44,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Brfalse, plain);
         il.Emit(OpCodes.Ldloc, destination);
         il.Emit(OpCodes.Ldarg_1);
-        il.Emit(OpCodes.Call, runtime.TSArrayAppendRest);
+        il.Emit(OpCodes.Call, runtime.ArrayStorage.AppendRest);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(plain);
         il.Emit(OpCodes.Ldarg_0);
@@ -57,7 +57,7 @@ public partial class RuntimeEmitter
         var reserve = typeBuilder.DefineMethod("ReserveRest",
             MethodAttributes.Assembly | MethodAttributes.Static, _types.Void,
             [_types.ListOfObject, _types.Int32]);
-        runtime.TSArrayReserveRest = reserve;
+        runtime.ArrayStorage.ReserveRest = reserve;
         il = reserve.GetILGenerator();
         destination = il.DeclareLocal(typeBuilder);
         var capacity = il.DeclareLocal(_types.Int32);
@@ -110,7 +110,7 @@ public partial class RuntimeEmitter
         var appendSource = typeBuilder.DefineMethod("AppendNumericRestSource",
             MethodAttributes.Assembly | MethodAttributes.Static, _types.Void,
             [_types.ListOfObject, typeBuilder]);
-        runtime.TSArrayAppendNumericRestSource = appendSource;
+        runtime.ArrayStorage.AppendNumericRestSource = appendSource;
         il = appendSource.GetILGenerator();
         destination = il.DeclareLocal(typeBuilder);
         var index = il.DeclareLocal(_types.Int32);

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSArray.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSArray.cs
@@ -10,8 +10,8 @@ namespace SharpTS.Compilation;
 /// <remarks>
 /// Stage E.2 M1 (infrastructure, no behavior change): the class now carries the
 /// sparse/hole-aware fields and long-indexed methods needed by later milestones.
-/// Existing callers (IL emitters that invoke <see cref="EmittedRuntime.TSArrayGet"/>,
-/// <see cref="EmittedRuntime.TSArraySet"/>, <see cref="EmittedRuntime.TSArrayElementsGetter"/>)
+/// Existing callers (IL emitters that invoke <see cref="EmittedArrayStorageRuntime.Get"/>,
+/// <see cref="EmittedArrayStorageRuntime.Set"/>, <see cref="EmittedArrayStorageRuntime.ElementsGetter"/>)
 /// continue to observe pre-Stage-E semantics: constructor populates <c>_dense</c>
 /// from the input list, <c>_length == _dense.Count</c>, <c>_sparse == null</c>,
 /// and legacy int-indexed Get/Set bounds-check against <c>_dense.Count</c>. The
@@ -69,11 +69,6 @@ public partial class RuntimeEmitter
     private MethodInfo? _tsArrayListGetItem;
     private MethodInfo? _tsArrayListSetItem;
 
-    // The deopt method (numeric -> boxed). Defined early in EmitTSArrayClass so
-    // the base-list methods emitted below can call it via EmitTSArrayDeoptGuard;
-    // its body is emitted later in EmitTSArrayNumericAccessors.
-    private MethodBuilder _tsArrayEnsureBoxedMethod = null!;
-
     private void InitTSArrayMethodCache()
     {
         _tsArraySparseTryGetValue = _types.GetMethod(_tsArraySparseType, "TryGetValue", [_types.UInt32, _types.Object.MakeByRefType()])!;
@@ -119,7 +114,7 @@ public partial class RuntimeEmitter
             TypeAttributes.Public | TypeAttributes.Class | TypeAttributes.BeforeFieldInit,
             _types.ListOfObject
         );
-        runtime.TSArrayType = typeBuilder;
+        runtime.ArrayStorage.Type = typeBuilder;
 
         // Sparse-aware fields. The dense backing is the base-List's own storage;
         // `_dense` is kept as an alias field for code clarity but points at `this`.
@@ -143,12 +138,11 @@ public partial class RuntimeEmitter
         // EmitTSArrayNumericAccessors) so the base-list methods below can guard
         // themselves with EmitTSArrayDeoptGuard — any boxed-representation access
         // on a numeric-mode array first materializes the unboxed store.
-        _tsArrayEnsureBoxedMethod = typeBuilder.DefineMethod("EnsureBoxed",
+        runtime.ArrayStorage.EnsureBoxed = typeBuilder.DefineMethod("EnsureBoxed",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, System.Type.EmptyTypes);
-        runtime.TSArrayEnsureBoxed = _tsArrayEnsureBoxedMethod;
 
-        EmitTSArrayConstructor(typeBuilder, runtime);
-        EmitTSArrayNumericLiteralConstructor(typeBuilder, runtime);
+        EmitTSArrayConstructor(typeBuilder, runtime.ArrayStorage);
+        EmitTSArrayNumericLiteralConstructor(typeBuilder, runtime.ArrayStorage);
 
         // Elements returns `this` (the inherited List<object?>). In practice
         // callers that cared about the sparse tail have migrated to the
@@ -158,7 +152,7 @@ public partial class RuntimeEmitter
         // interop paths), and (b) as a semantic marker in emitted IL vs.
         // an opaque Castclass. Kept post-Stage E as a shallow forward-
         // compatible helper; safe because the dense prefix IS the instance.
-        EmitTSArrayElementsProperty(typeBuilder, runtime);
+        EmitTSArrayElementsProperty(typeBuilder, runtime.ArrayStorage);
 
         // Private helpers emitted first — all public getters/methods below
         // call SyncLength to absorb mutations that went through inherited
@@ -168,14 +162,14 @@ public partial class RuntimeEmitter
         // undefined.
         var syncLength = EmitTSArraySyncLength(typeBuilder, runtime);
         var materializeDense = EmitTSArrayMaterializeDense(typeBuilder, runtime);
-        var tryCollapseSparse = EmitTSArrayTryCollapseSparse(typeBuilder, runtime);
-        var getCore = EmitTSArrayGetCore(typeBuilder, runtime);
+        var tryCollapseSparse = EmitTSArrayTryCollapseSparse(typeBuilder, runtime.ArrayStorage);
+        var getCore = EmitTSArrayGetCore(typeBuilder, runtime.ArrayStorage);
         var setCore = EmitTSArraySetCore(typeBuilder, runtime);
         var setCoreWithExtend = EmitTSArraySetCoreWithExtend(typeBuilder, runtime, setCore);
         _ = materializeDense;  // reserved for M5 mutator emitters
 
-        EmitTSArrayLongLengthProperty(typeBuilder, runtime, syncLength);
-        EmitTSArrayLengthProperty(typeBuilder, runtime, syncLength);
+        EmitTSArrayLongLengthProperty(typeBuilder, runtime.ArrayStorage, syncLength);
+        EmitTSArrayLengthProperty(typeBuilder, runtime.ArrayStorage, syncLength);
         // No custom Count property — inherited from List<object?>. The public
         // Count + interface ICollection<T>.Count / IReadOnlyCollection<T>.Count
         // all come from the base class. `arr.Count == arr._dense.Count`, which
@@ -185,14 +179,14 @@ public partial class RuntimeEmitter
         EmitTSArrayIsFrozenProperty(typeBuilder, runtime);
         EmitTSArrayIsSealedProperty(typeBuilder, runtime);
 
-        EmitTSArrayFreeze(typeBuilder, runtime);
-        EmitTSArraySeal(typeBuilder, runtime);
+        EmitTSArrayFreeze(typeBuilder, runtime.ArrayStorage);
+        EmitTSArraySeal(typeBuilder, runtime.ArrayStorage);
 
         // Legacy int-indexed methods (pre-Stage-E surface; unchanged semantics).
-        EmitTSArrayGet(typeBuilder, runtime);
-        EmitTSArraySet(typeBuilder, runtime);
+        EmitTSArrayGet(typeBuilder, runtime.ArrayStorage);
+        EmitTSArraySet(typeBuilder, runtime.ArrayStorage);
 
-        EmitTSArrayHasIndex(typeBuilder, runtime, syncLength);
+        EmitTSArrayHasIndex(typeBuilder, runtime.ArrayStorage, syncLength);
         EmitTSArrayGetRaw(typeBuilder, runtime, getCore, syncLength);
         EmitTSArrayGetLong(typeBuilder, runtime, getCore, syncLength);
         EmitTSArraySetLong(typeBuilder, runtime, setCoreWithExtend, syncLength);
@@ -204,7 +198,7 @@ public partial class RuntimeEmitter
         // must be emitted after SetLength, whose MethodBuilder it calls.
         EmitTSArraySubclassConstructor(typeBuilder, runtime);
 
-        EmitTSArrayToString(typeBuilder, runtime);
+        EmitTSArrayToString(typeBuilder, runtime.ArrayStorage);
         // IList<object?> impl is inherited from List<object?> — no explicit
         // bridges needed (was the old composition-based approach).
 
@@ -229,14 +223,14 @@ public partial class RuntimeEmitter
     /// materialization. Idempotent (EnsureBoxed self-guards), so redundant
     /// guards across delegating methods are harmless.
     /// </summary>
-    private void EmitTSArrayDeoptGuard(ILGenerator il)
+    private void EmitTSArrayDeoptGuard(ILGenerator il, EmittedArrayStorageRuntime arrays)
     {
         var skip = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldfld, _tsArrayIsNumericField);
         il.Emit(OpCodes.Brfalse, skip);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, _tsArrayEnsureBoxedMethod);
+        il.Emit(OpCodes.Call, arrays.EnsureBoxed);
         il.MarkLabel(skip);
     }
 
@@ -256,11 +250,11 @@ public partial class RuntimeEmitter
     {
         var skip = il.DefineLabel();
         loadValue();
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, skip);
         loadValue();
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayEnsureBoxed);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.EnsureBoxed);
         il.MarkLabel(skip);
     }
 
@@ -285,23 +279,23 @@ public partial class RuntimeEmitter
 
         // EnsureBoxed's builder was defined early (so base-list methods can guard
         // on it); we only emit its body here. The other accessors are defined now.
-        var ensureBoxed = _tsArrayEnsureBoxedMethod;
+        var ensureBoxed = runtime.ArrayStorage.EnsureBoxed;
         var canGetDouble = typeBuilder.DefineMethod("CanGetDouble",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Boolean, [_types.Int32]);
-        runtime.TSArrayCanGetDouble = canGetDouble;
+        runtime.ArrayStorage.CanGetDouble = canGetDouble;
         var getDouble = typeBuilder.DefineMethod("GetDouble",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Double, [_types.Int32]);
-        runtime.TSArrayGetDouble = getDouble;
+        runtime.ArrayStorage.GetDouble = getDouble;
         EmitTryGetBoxedDouble(typeBuilder, runtime);
         var setDouble = typeBuilder.DefineMethod("SetDouble",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, [_types.Int32, _types.Double]);
-        runtime.TSArraySetDouble = setDouble;
+        runtime.ArrayStorage.SetDouble = setDouble;
         var pushDouble = typeBuilder.DefineMethod("PushDouble",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, [_types.Double]);
-        runtime.TSArrayPushDouble = pushDouble;
+        runtime.ArrayStorage.PushDouble = pushDouble;
         var ensureDoubleCapacity = typeBuilder.DefineMethod("EnsureDoubleCapacity",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, [_types.Int32]);
-        runtime.TSArrayEnsureDoubleCapacity = ensureDoubleCapacity;
+        runtime.ArrayStorage.EnsureDoubleCapacity = ensureDoubleCapacity;
         // #927 step 2: these are the per-element hot paths the compiler emits at statically-number[]
         // sites. They are non-virtual (HideBySig), so a `callvirt` on a $Array-typed receiver
         // devirtualizes; AggressiveInlining lets the JIT fold the field loads + bounds check into the
@@ -343,40 +337,40 @@ public partial class RuntimeEmitter
         }
         var markNumeric = typeBuilder.DefineMethod("MarkNumeric",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, System.Type.EmptyTypes);
-        runtime.TSArrayMarkNumeric = markNumeric;
+        runtime.ArrayStorage.MarkNumeric = markNumeric;
         var markNonExtensible = typeBuilder.DefineMethod("MarkNonExtensible",
             MethodAttributes.Public | MethodAttributes.HideBySig, _types.Void, System.Type.EmptyTypes);
-        runtime.TSArrayMarkNonExtensible = markNonExtensible;
+        runtime.ArrayStorage.MarkNonExtensible = markNonExtensible;
         var isNumericGetter = typeBuilder.DefineMethod("get_IsNumeric",
             MethodAttributes.Assembly | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
             _types.Boolean, Type.EmptyTypes);
-        runtime.TSArrayIsNumericGetter = isNumericGetter;
+        runtime.ArrayStorage.IsNumericGetter = isNumericGetter;
         var numericCountGetter = typeBuilder.DefineMethod("get_NumericCount",
             MethodAttributes.Assembly | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
             _types.Int32, Type.EmptyTypes);
-        runtime.TSArrayNumericCountGetter = numericCountGetter;
+        runtime.ArrayStorage.NumericCountGetter = numericCountGetter;
         var canMutateNumericGetter = typeBuilder.DefineMethod("get_CanMutateNumeric",
             MethodAttributes.Assembly | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
             _types.Boolean, Type.EmptyTypes);
-        runtime.TSArrayCanMutateNumericGetter = canMutateNumericGetter;
+        runtime.ArrayStorage.CanMutateNumericGetter = canMutateNumericGetter;
         var shiftNumeric = typeBuilder.DefineMethod("ShiftNumeric",
             MethodAttributes.Assembly | MethodAttributes.HideBySig,
             _types.Object, Type.EmptyTypes);
-        runtime.TSArrayShiftNumeric = shiftNumeric;
+        runtime.ArrayStorage.ShiftNumeric = shiftNumeric;
         var unshiftNumeric = typeBuilder.DefineMethod("UnshiftNumeric",
             MethodAttributes.Assembly | MethodAttributes.HideBySig,
             _types.Double, [_types.DoubleArray]);
-        runtime.TSArrayUnshiftNumeric = unshiftNumeric;
+        runtime.ArrayStorage.UnshiftNumeric = unshiftNumeric;
         var cloneNumeric = typeBuilder.DefineMethod("CloneNumeric",
             MethodAttributes.Assembly | MethodAttributes.HideBySig,
             typeBuilder, Type.EmptyTypes);
-        runtime.TSArrayCloneNumeric = cloneNumeric;
+        runtime.ArrayStorage.CloneNumeric = cloneNumeric;
         var numericComparatorType = typeof(Func<double, double, double>);
         var sortNumeric = typeBuilder.DefineMethod("SortNumeric",
             MethodAttributes.Assembly | MethodAttributes.HideBySig,
             _types.Void, [numericComparatorType]);
         sortNumeric.SetImplementationFlags(MethodImplAttributes.AggressiveOptimization);
-        runtime.TSArraySortNumeric = sortNumeric;
+        runtime.ArrayStorage.SortNumeric = sortNumeric;
 
         // These representation probes are consumed only by guarded emitted-runtime
         // helpers. They expose no backing storage and do not force materialization.
@@ -574,7 +568,7 @@ public partial class RuntimeEmitter
             var done = il.DefineLabel();
 
             il.Emit(OpCodes.Newobj, _types.GetDefaultConstructor(_types.ListOfObject));
-            il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+            il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
             il.Emit(OpCodes.Stloc, result);
             il.Emit(OpCodes.Ldloc, result);
             il.Emit(OpCodes.Ldc_I4_1);
@@ -1023,7 +1017,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Conv_I8);
             il.Emit(OpCodes.Ldarg_2);
             il.Emit(OpCodes.Box, _types.Double);
-            il.Emit(OpCodes.Call, runtime.TSArraySetLong);
+            il.Emit(OpCodes.Call, runtime.ArrayStorage.SetLong);
             il.Emit(OpCodes.Ret);
 
             il.MarkLabel(notNumeric);
@@ -1032,7 +1026,7 @@ public partial class RuntimeEmitter
             il.Emit(OpCodes.Conv_I8);
             il.Emit(OpCodes.Ldarg_2);
             il.Emit(OpCodes.Box, _types.Double);
-            il.Emit(OpCodes.Call, runtime.TSArraySetLong);
+            il.Emit(OpCodes.Call, runtime.ArrayStorage.SetLong);
             il.Emit(OpCodes.Ret);
         }
 
@@ -1169,7 +1163,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod("TryGetBoxedDouble",
             MethodAttributes.Public | MethodAttributes.Static, _types.Boolean,
             [_types.Object, _types.Int32, _types.Double.MakeByRefType()]);
-        runtime.TSArrayTryGetBoxedDouble = method;
+        runtime.ArrayStorage.TryGetBoxedDouble = method;
         method.SetImplementationFlags(MethodImplAttributes.AggressiveInlining);
         var il = method.GetILGenerator();
         var array = il.DeclareLocal(typeBuilder);
@@ -1239,7 +1233,7 @@ public partial class RuntimeEmitter
     {
         var ctor = typeBuilder.DefineConstructor(MethodAttributes.Assembly,
             CallingConventions.Standard, [_types.Int32]);
-        runtime.TSArrayRestCtor = ctor;
+        runtime.ArrayStorage.RestCtor = ctor;
         var il = ctor.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
@@ -1248,7 +1242,7 @@ public partial class RuntimeEmitter
 
         var numeric = typeBuilder.DefineMethod("CreateNumericRest",
             MethodAttributes.Assembly | MethodAttributes.Static, typeBuilder, [_types.Int32]);
-        runtime.TSArrayCreateNumericRest = numeric;
+        runtime.ArrayStorage.CreateNumericRest = numeric;
         il = numeric.GetILGenerator();
         var result = il.DeclareLocal(typeBuilder);
         var ready = il.DefineLabel();
@@ -1270,7 +1264,7 @@ public partial class RuntimeEmitter
 
         var append = typeBuilder.DefineMethod("AppendRest", MethodAttributes.Assembly,
             _types.Void, [_types.Object]);
-        runtime.TSArrayAppendRest = append;
+        runtime.ArrayStorage.AppendRest = append;
         il = append.GetILGenerator();
         var boxedAppend = il.DefineLabel();
         il.Emit(OpCodes.Ldarg_0);
@@ -1283,11 +1277,11 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Unbox_Any, _types.Double);
-        il.Emit(OpCodes.Call, runtime.TSArrayPushDouble);
+        il.Emit(OpCodes.Call, runtime.ArrayStorage.PushDouble);
         il.Emit(OpCodes.Ret);
         il.MarkLabel(deopt);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Call, runtime.TSArrayEnsureBoxed);
+        il.Emit(OpCodes.Call, runtime.ArrayStorage.EnsureBoxed);
         il.MarkLabel(boxedAppend);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
@@ -1305,7 +1299,7 @@ public partial class RuntimeEmitter
         // whichever private store survived expansion and synchronize length.
         var finish = typeBuilder.DefineMethod("FinishRest", MethodAttributes.Assembly,
             _types.Void, [_types.Int32]);
-        runtime.TSArrayFinishRest = finish;
+        runtime.ArrayStorage.FinishRest = finish;
         il = finish.GetILGenerator();
         var boxedFinish = il.DefineLabel();
         var removed = il.DeclareLocal(_types.Int32);
@@ -1361,13 +1355,13 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitTSArrayNumericLiteralConstructor(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTSArrayNumericLiteralConstructor(TypeBuilder typeBuilder, EmittedArrayStorageRuntime arrays)
     {
         // The emitter hands over a fresh, dense double[]; no other value can
         // observe its storage. Holes continue to use the ordinary literal path.
         var ctor = typeBuilder.DefineConstructor(MethodAttributes.Assembly,
             CallingConventions.Standard, [_types.DoubleArray]);
-        runtime.TSArrayNumericLiteralCtor = ctor;
+        arrays.NumericLiteralCtor = ctor;
         var il = ctor.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Call, _types.GetDefaultConstructor(_types.ListOfObject));
@@ -1390,14 +1384,14 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitTSArrayConstructor(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTSArrayConstructor(TypeBuilder typeBuilder, EmittedArrayStorageRuntime arrays)
     {
         var ctor = typeBuilder.DefineConstructor(
             MethodAttributes.Public,
             CallingConventions.Standard,
             [_types.ListOfObject]
         );
-        runtime.TSArrayCtor = ctor;
+        arrays.Ctor = ctor;
 
         // Internal element construction is distinct from the object[] overload
         // implementing Array(...args), where one number denotes a length.
@@ -1405,7 +1399,7 @@ public partial class RuntimeEmitter
             MethodAttributes.Public,
             CallingConventions.Standard,
             [_types.IEnumerableOfObject]);
-        runtime.TSArrayLiteralCtor = literalCtor;
+        arrays.LiteralCtor = literalCtor;
         var forwardingIl = ctor.GetILGenerator();
         forwardingIl.Emit(OpCodes.Ldarg_0);
         forwardingIl.Emit(OpCodes.Ldarg_1);
@@ -1444,7 +1438,7 @@ public partial class RuntimeEmitter
             CallingConventions.Standard,
             [_types.ObjectArray]
         );
-        runtime.TSArrayCtorFromCtorArgs = ctor;
+        runtime.ArrayStorage.CtorFromCtorArgs = ctor;
 
         var il = ctor.GetILGenerator();
         var elementsLabel = il.DefineLabel();
@@ -1475,7 +1469,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldelem_Ref);
         il.Emit(OpCodes.Unbox_Any, _types.Double);
         il.Emit(OpCodes.Conv_I8);
-        il.Emit(OpCodes.Call, runtime.TSArraySetLength);
+        il.Emit(OpCodes.Call, runtime.ArrayStorage.SetLength);
         il.Emit(OpCodes.Br, doneLabel);
 
         // else: append each ctor arg as an element, then sync _length.
@@ -1510,33 +1504,33 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitTSArrayElementsProperty(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTSArrayElementsProperty(TypeBuilder typeBuilder, EmittedArrayStorageRuntime arrays)
     {
         var prop = typeBuilder.DefineProperty("Elements", PropertyAttributes.None, _types.ListOfObject, null);
         var getter = typeBuilder.DefineMethod(
             "get_Elements",
             MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
             _types.ListOfObject, Type.EmptyTypes);
-        runtime.TSArrayElementsGetter = getter;
+        arrays.ElementsGetter = getter;
 
         var il = getter.GetILGenerator();
         // Elements hands out the inherited List<object?> directly; a numeric-mode
         // array's base list is empty, so materialize first.
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, arrays);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ret);
 
         prop.SetGetMethod(getter);
     }
 
-    private void EmitTSArrayLongLengthProperty(TypeBuilder typeBuilder, EmittedRuntime runtime, MethodBuilder syncLength)
+    private void EmitTSArrayLongLengthProperty(TypeBuilder typeBuilder, EmittedArrayStorageRuntime arrays, MethodBuilder syncLength)
     {
         var prop = typeBuilder.DefineProperty("LongLength", PropertyAttributes.None, _types.Int64, null);
         var getter = typeBuilder.DefineMethod(
             "get_LongLength",
             MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
             _types.Int64, Type.EmptyTypes);
-        runtime.TSArrayLongLengthGetter = getter;
+        arrays.LongLengthGetter = getter;
 
         var il = getter.GetILGenerator();
         il.Emit(OpCodes.Ldarg_0);
@@ -1548,14 +1542,14 @@ public partial class RuntimeEmitter
         prop.SetGetMethod(getter);
     }
 
-    private void EmitTSArrayLengthProperty(TypeBuilder typeBuilder, EmittedRuntime runtime, MethodBuilder syncLength)
+    private void EmitTSArrayLengthProperty(TypeBuilder typeBuilder, EmittedArrayStorageRuntime arrays, MethodBuilder syncLength)
     {
         var prop = typeBuilder.DefineProperty("Length", PropertyAttributes.None, _types.Int32, null);
         var getter = typeBuilder.DefineMethod(
             "get_Length",
             MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
             _types.Int32, Type.EmptyTypes);
-        runtime.TSArrayLengthGetter = getter;
+        arrays.LengthGetter = getter;
 
         var il = getter.GetILGenerator();
         var clampLabel = il.DefineLabel();
@@ -1613,13 +1607,13 @@ public partial class RuntimeEmitter
         prop.SetGetMethod(getter);
     }
 
-    private void EmitTSArrayFreeze(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTSArrayFreeze(TypeBuilder typeBuilder, EmittedArrayStorageRuntime arrays)
     {
         var method = typeBuilder.DefineMethod("Freeze", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
-        runtime.TSArrayFreeze = method;
+        arrays.Freeze = method;
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, arrays);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Stfld, _tsArrayIsFrozenField);
@@ -1631,26 +1625,26 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitTSArraySeal(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTSArraySeal(TypeBuilder typeBuilder, EmittedArrayStorageRuntime arrays)
     {
         var method = typeBuilder.DefineMethod("Seal", MethodAttributes.Public, _types.Void, Type.EmptyTypes);
         _ = method;
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, arrays);
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldc_I4_1);
         il.Emit(OpCodes.Stfld, _tsArrayIsSealedField);
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitTSArrayGet(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTSArrayGet(TypeBuilder typeBuilder, EmittedArrayStorageRuntime arrays)
     {
         var method = typeBuilder.DefineMethod("Get", MethodAttributes.Public, _types.Object, [_types.Int32]);
-        runtime.TSArrayGet = method;
+        arrays.Get = method;
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, arrays);
         var throwLabel = il.DefineLabel();
 
         il.Emit(OpCodes.Ldarg_1);
@@ -1673,13 +1667,13 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Throw);
     }
 
-    private void EmitTSArraySet(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTSArraySet(TypeBuilder typeBuilder, EmittedArrayStorageRuntime arrays)
     {
         var method = typeBuilder.DefineMethod("Set", MethodAttributes.Public, _types.Void, [_types.Int32, _types.Object]);
-        runtime.TSArraySet = method;
+        arrays.Set = method;
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, arrays);
         var frozenLabel = il.DefineLabel();
         var throwLabel = il.DefineLabel();
 
@@ -1768,7 +1762,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod("MaterializeDense", MethodAttributes.Private, _types.Void, Type.EmptyTypes);
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, runtime.ArrayStorage);
         var sparseBranch = il.DefineLabel();
         var throwRangeLabel = il.DefineLabel();
         var loopHead = il.DefineLabel();
@@ -1822,7 +1816,7 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(padHoleLabel);
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+        il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
         il.Emit(OpCodes.Callvirt, _tsArrayListAdd!);
 
         il.MarkLabel(afterAddLabel);
@@ -1845,12 +1839,12 @@ public partial class RuntimeEmitter
     /// <c>private void TryCollapseSparse()</c> — drops the sparse dict when
     /// empty OR fully covered by the dense prefix.
     /// </summary>
-    private MethodBuilder EmitTSArrayTryCollapseSparse(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private MethodBuilder EmitTSArrayTryCollapseSparse(TypeBuilder typeBuilder, EmittedArrayStorageRuntime arrays)
     {
         var method = typeBuilder.DefineMethod("TryCollapseSparse", MethodAttributes.Private, _types.Void, Type.EmptyTypes);
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, arrays);
         var collapseLabel = il.DefineLabel();
         var doneLabel = il.DefineLabel();
 
@@ -1889,12 +1883,12 @@ public partial class RuntimeEmitter
     /// <c>$ArrayHole.Instance</c> for holes. Callers ensure index is in range
     /// (<c>0 &lt;= index &lt; _length</c>).
     /// </summary>
-    private MethodBuilder EmitTSArrayGetCore(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private MethodBuilder EmitTSArrayGetCore(TypeBuilder typeBuilder, EmittedArrayStorageRuntime arrays)
     {
         var method = typeBuilder.DefineMethod("GetCore", MethodAttributes.Private, _types.Object, [_types.Int64]);
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, arrays);
         var sparsePathLabel = il.DefineLabel();
         var returnHoleLabel = il.DefineLabel();
         var lookupLabel = il.DefineLabel();
@@ -1935,7 +1929,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(returnHoleLabel);
-        il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+        il.Emit(OpCodes.Ldsfld, arrays.HoleInstance);
         il.Emit(OpCodes.Ret);
 
         return method;
@@ -1951,7 +1945,7 @@ public partial class RuntimeEmitter
             [_types.Int64, _types.Object]);
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, runtime.ArrayStorage);
         var sparseLabel = il.DefineLabel();
         var denseLabel = il.DefineLabel();
 
@@ -1997,7 +1991,7 @@ public partial class RuntimeEmitter
             [_types.Int64, _types.Object]);
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, runtime.ArrayStorage);
         var denseEntryLabel = il.DefineLabel();
         var sparseWriteReturn = il.DefineLabel();
         var skipLenUpdate = il.DefineLabel();
@@ -2086,7 +2080,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Bgt, padLoopExit);
 
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+        il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
         il.Emit(OpCodes.Callvirt, _tsArrayListAdd!);
         il.Emit(OpCodes.Br, padLoopHead);
 
@@ -2137,13 +2131,13 @@ public partial class RuntimeEmitter
     /// <c>public bool HasIndex(long index)</c> — ECMA-262 HasProperty for
     /// numeric indices. False for holes and out-of-range indices.
     /// </summary>
-    private void EmitTSArrayHasIndex(TypeBuilder typeBuilder, EmittedRuntime runtime, MethodBuilder syncLength)
+    private void EmitTSArrayHasIndex(TypeBuilder typeBuilder, EmittedArrayStorageRuntime arrays, MethodBuilder syncLength)
     {
         var method = typeBuilder.DefineMethod("HasIndex", MethodAttributes.Public, _types.Boolean, [_types.Int64]);
-        runtime.TSArrayHasIndex = method;
+        arrays.HasIndex = method;
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, arrays);
         var returnFalseLabel = il.DefineLabel();
         var sparseBranchLabel = il.DefineLabel();
         var checkDenseHoleLabel = il.DefineLabel();
@@ -2179,7 +2173,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Conv_I4);
         il.Emit(OpCodes.Callvirt, _tsArrayListGetItem!);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, arrays.HoleType);
         il.Emit(OpCodes.Ldnull);
         il.Emit(OpCodes.Ceq);   // 1 if result was null → not a hole → true
         il.Emit(OpCodes.Ret);
@@ -2214,7 +2208,7 @@ public partial class RuntimeEmitter
         _ = method;
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, runtime.ArrayStorage);
         var oobLabel = il.DefineLabel();
 
         il.Emit(OpCodes.Ldarg_0);
@@ -2249,7 +2243,7 @@ public partial class RuntimeEmitter
     private void EmitTSArrayGetLong(TypeBuilder typeBuilder, EmittedRuntime runtime, MethodBuilder getCore, MethodBuilder syncLength)
     {
         var method = typeBuilder.DefineMethod("Get", MethodAttributes.Public, _types.Object, [_types.Int64]);
-        runtime.TSArrayGetLong = method;
+        runtime.ArrayStorage.GetLong = method;
 
         var il = method.GetILGenerator();
         var oobLabel = il.DefineLabel();
@@ -2300,7 +2294,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Stloc, vLocal);
 
         il.Emit(OpCodes.Ldloc, vLocal);
-        il.Emit(OpCodes.Isinst, runtime.ArrayHoleType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.HoleType);
         il.Emit(OpCodes.Brfalse, notHoleLabel);
         il.Emit(OpCodes.Ldsfld, runtime.UndefinedInstance);
         il.Emit(OpCodes.Ret);
@@ -2324,10 +2318,10 @@ public partial class RuntimeEmitter
     {
         var method = typeBuilder.DefineMethod("Set", MethodAttributes.Public, _types.Void,
             [_types.Int64, _types.Object]);
-        runtime.TSArraySetLong = method;
+        runtime.ArrayStorage.SetLong = method;
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, runtime.ArrayStorage);
         var frozenReturnLabel = il.DefineLabel();
         var negThrowLabel = il.DefineLabel();
         var maxThrowLabel = il.DefineLabel();
@@ -2377,10 +2371,10 @@ public partial class RuntimeEmitter
     {
         var method = typeBuilder.DefineMethod("SetStrict", MethodAttributes.Public, _types.Void,
             [_types.Int64, _types.Object, _types.Boolean]);
-        runtime.TSArraySetStrictLong = method;
+        runtime.ArrayStorage.SetStrictLong = method;
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, runtime.ArrayStorage);
         var notFrozenLabel = il.DefineLabel();
         var frozenReturnLabel = il.DefineLabel();
         var negThrowLabel = il.DefineLabel();
@@ -2433,10 +2427,10 @@ public partial class RuntimeEmitter
     private void EmitTSArraySetLength(TypeBuilder typeBuilder, EmittedRuntime runtime, MethodBuilder tryCollapseSparse, MethodBuilder syncLength)
     {
         var method = typeBuilder.DefineMethod("SetLength", MethodAttributes.Public, _types.Void, [_types.Int64]);
-        runtime.TSArraySetLength = method;
+        runtime.ArrayStorage.SetLength = method;
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, runtime.ArrayStorage);
         var negThrowLabel = il.DefineLabel();
         var tooBigThrowLabel = il.DefineLabel();
         var notFrozenLabel = il.DefineLabel();
@@ -2748,7 +2742,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Bge, padLoopExit);
 
         il.Emit(OpCodes.Ldarg_0);
-        il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+        il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
         il.Emit(OpCodes.Callvirt, _tsArrayListAdd!);
         il.Emit(OpCodes.Br, padLoopHead);
 
@@ -2828,10 +2822,10 @@ public partial class RuntimeEmitter
     private void EmitTSArrayDeleteAt(TypeBuilder typeBuilder, EmittedRuntime runtime, MethodBuilder syncLength)
     {
         var method = typeBuilder.DefineMethod("DeleteAt", MethodAttributes.Public, _types.Void, [_types.Int64]);
-        runtime.TSArrayDeleteAt = method;
+        runtime.ArrayStorage.DeleteAt = method;
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, runtime.ArrayStorage);
         var retLabel = il.DefineLabel();
         var denseDeleteLabel = il.DefineLabel();
         var sparseDeleteCheckLabel = il.DefineLabel();
@@ -2871,7 +2865,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldarg_0);
         il.Emit(OpCodes.Ldarg_1);
         il.Emit(OpCodes.Conv_I4);
-        il.Emit(OpCodes.Ldsfld, runtime.ArrayHoleInstance);
+        il.Emit(OpCodes.Ldsfld, runtime.ArrayStorage.HoleInstance);
         il.Emit(OpCodes.Callvirt, _tsArrayListSetItem!);
         il.Emit(OpCodes.Ret);
 
@@ -2891,7 +2885,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
     }
 
-    private void EmitTSArrayToString(TypeBuilder typeBuilder, EmittedRuntime runtime)
+    private void EmitTSArrayToString(TypeBuilder typeBuilder, EmittedArrayStorageRuntime arrays)
     {
         var method = typeBuilder.DefineMethod(
             "ToString",
@@ -2902,7 +2896,7 @@ public partial class RuntimeEmitter
         _ = method;
 
         var il = method.GetILGenerator();
-        EmitTSArrayDeoptGuard(il);
+        EmitTSArrayDeoptGuard(il, arrays);
 
         // ToString renders _dense elements joined by comma — matches pre-refactor
         // behavior exactly. Hole-aware join lives in the array built-ins (M5).

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSArrayHole.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSArrayHole.cs
@@ -10,7 +10,7 @@ public partial class RuntimeEmitter
     /// (index in [0, length) that was never written).
     /// Mirror of <c>SharpTS.Runtime.Types.ArrayHole</c> for standalone assemblies.
     /// </summary>
-    private void EmitArrayHoleClass(ModuleBuilder moduleBuilder, EmittedRuntime runtime)
+    private void EmitArrayHoleClass(ModuleBuilder moduleBuilder, EmittedArrayStorageRuntime arrays)
     {
         // public sealed class $ArrayHole
         var typeBuilder = EmitTypeDefinitions.DefineType(moduleBuilder,
@@ -58,7 +58,7 @@ public partial class RuntimeEmitter
         toStringIL.Emit(OpCodes.Ret);
 
         var createdType = typeBuilder.CreateType()!;
-        runtime.ArrayHoleType = createdType;
-        runtime.ArrayHoleInstance = createdType.GetField("Instance")!;
+        arrays.HoleType = createdType;
+        arrays.HoleInstance = createdType.GetField("Instance")!;
     }
 }

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSBoundTypedArrayMethod.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSBoundTypedArrayMethod.cs
@@ -176,9 +176,9 @@ public partial class RuntimeEmitter
         // else if (source is $Array) -> element-wise via GetElement (coerced by the element setter)
         il.MarkLabel(notTyped);
         var notArray = il.DefineLabel();
-        il.Emit(OpCodes.Ldloc, sourceLoc); il.Emit(OpCodes.Isinst, runtime.TSArrayType); il.Emit(OpCodes.Brfalse, notArray);
-        il.Emit(OpCodes.Ldloc, sourceLoc); il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayLengthGetter); il.Emit(OpCodes.Stloc, lenLoc);
+        il.Emit(OpCodes.Ldloc, sourceLoc); il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type); il.Emit(OpCodes.Brfalse, notArray);
+        il.Emit(OpCodes.Ldloc, sourceLoc); il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.LengthGetter); il.Emit(OpCodes.Stloc, lenLoc);
         // if (offset + len > _array.Length) throw RangeError
         var okRange = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, offsetLoc); il.Emit(OpCodes.Ldloc, lenLoc); il.Emit(OpCodes.Add);

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSEventEmitter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSEventEmitter.cs
@@ -808,7 +808,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "Listeners",
             MethodAttributes.Public,
-            runtime.TSArrayType,
+            runtime.ArrayStorage.Type,
             [_types.String]
         );
         runtime.TSEventEmitterListeners = method;
@@ -867,13 +867,13 @@ public partial class RuntimeEmitter
         il.MarkLabel(loopEnd);
         // return new $Array(resultList)
         il.Emit(OpCodes.Ldloc, resultListLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(emptyLabel);
         // return new $Array(new List<object?>())
         il.Emit(OpCodes.Newobj, _types.GetConstructor(_types.ListOfObject, Type.EmptyTypes)!);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
     }
 
@@ -915,7 +915,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "EventNames",
             MethodAttributes.Public,
-            runtime.TSArrayType,
+            runtime.ArrayStorage.Type,
             Type.EmptyTypes
         );
         runtime.TSEventEmitterEventNames = method;
@@ -967,7 +967,7 @@ public partial class RuntimeEmitter
         il.MarkLabel(loopEnd);
         // return new $Array(resultList)
         il.Emit(OpCodes.Ldloc, resultListLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
     }
 
@@ -1206,7 +1206,7 @@ public partial class RuntimeEmitter
         var method = typeBuilder.DefineMethod(
             "RawListeners",
             MethodAttributes.Public,
-            runtime.TSArrayType,
+            runtime.ArrayStorage.Type,
             [_types.String]
         );
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSProcess.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSProcess.cs
@@ -377,7 +377,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ldloc, count);
         il.Emit(OpCodes.Blt, loop);
         il.Emit(OpCodes.Ldloc, groups);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSReadableHelpers.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSReadableHelpers.cs
@@ -394,7 +394,7 @@ public partial class RuntimeEmitter
         var notArray = il.DefineLabel();
         var afterPush = il.DefineLabel();
         il.Emit(OpCodes.Ldloc, mappedLocal);
-        il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+        il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
         il.Emit(OpCodes.Brfalse, notArray);
 
         // var elems = ((TSArray)mapped).Elements; for j: r.Push(elems[j]);
@@ -402,8 +402,8 @@ public partial class RuntimeEmitter
         var jLocal = il.DeclareLocal(_types.Int32);
         var elemCountLocal = il.DeclareLocal(_types.Int32);
         il.Emit(OpCodes.Ldloc, mappedLocal);
-        il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-        il.Emit(OpCodes.Callvirt, runtime.TSArrayElementsGetter);
+        il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+        il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.ElementsGetter);
         il.Emit(OpCodes.Stloc, elemsLocal);
         il.Emit(OpCodes.Ldloc, elemsLocal);
         il.Emit(OpCodes.Callvirt, ListCountGetter);
@@ -495,7 +495,7 @@ public partial class RuntimeEmitter
         // r.Push(new $Array(pair));
         il.Emit(OpCodes.Ldloc, rLocal);
         il.Emit(OpCodes.Ldloc, pairLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Callvirt, runtime.TSReadablePush);
         il.Emit(OpCodes.Pop);
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSRegExp.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSRegExp.cs
@@ -3349,7 +3349,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Ret);
         il.MarkLabel(nativeHasMatchesLabel);
         il.Emit(OpCodes.Ldloc, arrLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
 
         il.MarkLabel(slowMatchLabel);
@@ -3463,7 +3463,7 @@ public partial class RuntimeEmitter
 
         il.MarkLabel(returnArrLabel);
         il.Emit(OpCodes.Ldloc, arrLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
     }
 

--- a/src/SharpTS/Compilation/RuntimeEmitter.TSX509.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.TSX509.cs
@@ -1316,7 +1316,7 @@ public partial class RuntimeEmitter
         EmitFlagCheck(X509KeyUsageFlags.DecipherOnly, "Decipher Only");
 
         il.Emit(OpCodes.Ldloc, listLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
         prop.SetGetMethod(getter);
     }
@@ -1401,7 +1401,7 @@ public partial class RuntimeEmitter
         il.Emit(OpCodes.Blt, jBody);
 
         il.Emit(OpCodes.Ldloc, listLocal);
-        il.Emit(OpCodes.Newobj, runtime.TSArrayCtor);
+        il.Emit(OpCodes.Newobj, runtime.ArrayStorage.Ctor);
         il.Emit(OpCodes.Ret);
         prop.SetGetMethod(getter);
     }

--- a/src/SharpTS/Compilation/RuntimeEmitter.Worker.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.Worker.cs
@@ -1016,15 +1016,15 @@ public partial class RuntimeEmitter
             var arrILocal = il.DeclareLocal(_types.Int32);
 
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Isinst, runtime.TSArrayType);
+            il.Emit(OpCodes.Isinst, runtime.ArrayStorage.Type);
             il.Emit(OpCodes.Brfalse, isTypedArrayLabel);
 
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Castclass, runtime.TSArrayType);
+            il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
             il.Emit(OpCodes.Stloc, tsArrLocal);
             il.Emit(OpCodes.Ldloc, tsArrLocal);
-            il.Emit(OpCodes.Castclass, runtime.TSArrayType);
-            il.Emit(OpCodes.Callvirt, runtime.TSArrayLengthGetter);
+            il.Emit(OpCodes.Castclass, runtime.ArrayStorage.Type);
+            il.Emit(OpCodes.Callvirt, runtime.ArrayStorage.LengthGetter);
             il.Emit(OpCodes.Stloc, arrLengthLocal);
             il.Emit(OpCodes.Ldloc, arrLengthLocal);
             il.Emit(OpCodes.Newobj, lengthCtor);

--- a/src/SharpTS/Compilation/RuntimeEmitter.cs
+++ b/src/SharpTS/Compilation/RuntimeEmitter.cs
@@ -55,10 +55,10 @@ public partial class RuntimeEmitter
 
         // Emit $Undefined singleton class first (other methods need this type)
         EmitUndefinedClass(moduleBuilder, runtime);
-        runtime.NumberQueue = EmitArrayQueue(moduleBuilder, runtime, ArrayElements.Double);
-        runtime.BooleanQueue = EmitArrayQueue(moduleBuilder, runtime, ArrayElements.Bool);
-        runtime.NumberQueueWithHoles = EmitArrayQueue(moduleBuilder, runtime, ArrayElements.Double, true);
-        runtime.BooleanQueueWithHoles = EmitArrayQueue(moduleBuilder, runtime, ArrayElements.Bool, true);
+        runtime.ArrayStorage.NumberQueue = EmitArrayQueue(moduleBuilder, runtime, ArrayElements.Double);
+        runtime.ArrayStorage.BooleanQueue = EmitArrayQueue(moduleBuilder, runtime, ArrayElements.Bool);
+        runtime.ArrayStorage.NumberQueueWithHoles = EmitArrayQueue(moduleBuilder, runtime, ArrayElements.Double, true);
+        runtime.ArrayStorage.BooleanQueueWithHoles = EmitArrayQueue(moduleBuilder, runtime, ArrayElements.Bool, true);
         EmitLexicalUninitializedClass(moduleBuilder, runtime);
 
         // Marker used only to give compiler-generated prototype constructors a
@@ -159,7 +159,7 @@ public partial class RuntimeEmitter
         // $ArrayHole.Instance for padding intermediate positions on sparse writes
         // and `a.length = N` extensions.
         // NOTE: Must stay in sync with SharpTS.Runtime.Types.ArrayHole
-        EmitArrayHoleClass(moduleBuilder, runtime);
+        EmitArrayHoleClass(moduleBuilder, runtime.ArrayStorage);
 
         // Per-thread args[] pool used by method-call dispatch to skip
         // newarr per `obj.method(a, b)` invocation. Lives on a separate
@@ -615,6 +615,7 @@ public partial class RuntimeEmitter
             EmitBoundDHMethodFinalize(runtime);
         }
 
+        runtime.ArrayStorage.CompleteEmission();
         runtime.Dns?.CompleteEmission();
         runtime.Zlib?.CompleteEmission();
         runtime.Tls?.CompleteEmission();

--- a/tests/SharpTS.Tests/CompilerTests/EmittedArrayStorageRuntimeTests.cs
+++ b/tests/SharpTS.Tests/CompilerTests/EmittedArrayStorageRuntimeTests.cs
@@ -1,0 +1,247 @@
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using SharpTS.Compilation;
+using SharpTS.Parsing;
+using SharpTS.Tests.Infrastructure;
+using Xunit;
+
+namespace SharpTS.Tests.CompilerTests;
+
+public class EmittedArrayStorageRuntimeTests
+{
+    [Fact]
+    public void RequiredStorageSupportsForwardDeclarationsBeforeBodyEmission()
+    {
+        var runtime = new EmittedRuntime();
+        var arrays = runtime.ArrayStorage;
+        Assert.False(arrays.IsComplete);
+        Assert.Contains("'EnsureBoxed'",
+            Assert.Throws<InvalidOperationException>(() => arrays.EnsureBoxed).Message);
+
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName("array_storage_forward"), typeof(object).Assembly);
+        var type = assembly.DefineDynamicModule("main").DefineType("Array");
+        var ensureBoxed = type.DefineMethod("EnsureBoxed", MethodAttributes.Public, typeof(void), Type.EmptyTypes);
+        arrays.EnsureBoxed = ensureBoxed;
+        var caller = type.DefineMethod("Caller", MethodAttributes.Public, typeof(void), Type.EmptyTypes);
+        var il = caller.GetILGenerator();
+        il.Emit(OpCodes.Ldarg_0);
+        il.Emit(OpCodes.Call, arrays.EnsureBoxed);
+        il.Emit(OpCodes.Ret);
+        Assert.Same(ensureBoxed, arrays.EnsureBoxed);
+        Assert.False(type.IsCreated());
+        ensureBoxed.GetILGenerator().Emit(OpCodes.Ret);
+        type.CreateType();
+        using var stream = new MemoryStream();
+        assembly.Save(stream);
+
+        Assert.Throws<InvalidOperationException>(arrays.CompleteEmission);
+        Assert.False(arrays.IsComplete);
+        Assert.Throws<ArgumentNullException>(() => arrays.EnsureBoxed = null!);
+        Assert.Same(ensureBoxed, arrays.EnsureBoxed);
+        Assert.Null(typeof(EmittedRuntime).GetProperty(nameof(EmittedRuntime.ArrayStorage))!.SetMethod);
+    }
+
+    private static IEnumerable<PropertyInfo> Handles => typeof(EmittedArrayStorageRuntime).GetProperties()
+        .Where(property => property.Name != nameof(EmittedArrayStorageRuntime.IsComplete));
+
+    public static IEnumerable<object[]> HandleNames => Handles.Select(property => new object[] { property.Name });
+
+    [Theory]
+    [MemberData(nameof(HandleNames))]
+    public void CompletionRejectsEachMissingDeclaration(string missingHandle)
+    {
+        var arrays = CreateDeclarations(missingHandle);
+        var property = typeof(EmittedArrayStorageRuntime).GetProperty(missingHandle)!;
+        var readError = Assert.Throws<TargetInvocationException>(() => property.GetValue(arrays));
+        Assert.Contains($"'{missingHandle}'", Assert.IsType<InvalidOperationException>(readError.InnerException).Message);
+        Assert.Contains($"'{missingHandle}'", Assert.Throws<InvalidOperationException>(arrays.CompleteEmission).Message);
+        Assert.False(arrays.IsComplete);
+    }
+
+    public static IEnumerable<object[]> QueueHandleNames =>
+        from queue in Handles.Where(property => property.PropertyType == typeof(ArrayQueueTypeInfo))
+        from handle in typeof(ArrayQueueTypeInfo).GetProperties()
+        where queue.Name.StartsWith("Number", StringComparison.Ordinal)
+            || handle.Name is not (nameof(ArrayQueueTypeInfo.ShiftNumber) or nameof(ArrayQueueTypeInfo.GetNumber))
+        select new object[] { queue.Name, handle.Name };
+
+    [Theory]
+    [MemberData(nameof(QueueHandleNames))]
+    public void CompletionRejectsMissingQueueDeclarations(string queueName, string missingHandle)
+    {
+        var arrays = CreateDeclarations();
+        var queue = typeof(EmittedArrayStorageRuntime).GetProperty(queueName)!.GetValue(arrays)!;
+        typeof(ArrayQueueTypeInfo).GetProperty(missingHandle)!.SetValue(queue, null);
+        Assert.Contains($"'{queueName}.{missingHandle}'",
+            Assert.Throws<InvalidOperationException>(arrays.CompleteEmission).Message);
+        Assert.False(arrays.IsComplete);
+    }
+
+    [Theory]
+    [InlineData("console.log(1);")]
+    [InlineData("const values = [1, 2];")]
+    [InlineData("import * as dns from 'dns';")]
+    [InlineData("import * as crypto from 'crypto';")]
+    [InlineData("new Uint8Array(2);")]
+    [InlineData(null)]
+    public void MinimalAndFeatureRichEmissionCompleteStorage(string? source)
+    {
+        var runtime = EmitRuntime(source);
+        AssertComplete(runtime.ArrayStorage);
+        if (source == "console.log(1);")
+        {
+            // Array storage is shared infrastructure even when optional families are absent.
+            Assert.Null(runtime.Promise);
+            Assert.Null(runtime.Dns);
+            Assert.Null(runtime.Net);
+        }
+    }
+
+    [Fact]
+    public void HostedEmissionCompletesStorage() => AssertComplete(EmitRuntime("console.log(1);", hosted: true).ArrayStorage);
+
+    [Fact]
+    public void ArrayStorageDoesNotIntroduceGuestRuntimeDependencies()
+    {
+        var runtime = EmitRuntime("const values = [1, 2];");
+        Assert.Empty(runtime.RequiredSharpTSRuntimeReasons);
+        Assert.Equal(SharpTSRuntimeRequirements.None, runtime.RequiredSharpTSRuntimeRequirements);
+        using var stream = new MemoryStream();
+        ((PersistedAssemblyBuilder)runtime.RuntimeType.Assembly).Save(stream);
+        stream.Position = 0;
+        using var pe = new PEReader(stream);
+        var reader = pe.GetMetadataReader();
+        Assert.DoesNotContain(reader.AssemblyReferences,
+            handle => reader.GetString(reader.GetAssemblyReference(handle).Name) == "SharpTS");
+    }
+
+    [Fact]
+    public void PackedSparseSubclassAndRestStorageVerifyAndRunStandalone()
+    {
+        const string source = """
+            function numbers(): number[] { return [1, 2, 3]; }
+            const packed = numbers();
+            packed[1] = 4;
+            packed.push(5);
+            console.log(packed.join(','));
+            const dynamic: any = packed;
+            dynamic[1] = 'boxed';
+            delete dynamic[2];
+            dynamic[100000] = 9;
+            console.log(dynamic.length, 2 in dynamic, dynamic[1], dynamic[100000]);
+            dynamic.length = 2;
+            console.log(dynamic.join(','), 100000 in dynamic);
+            class Values extends Array<number> {}
+            const derived = new Values(3);
+            derived[1] = 7;
+            console.log(derived.length, 0 in derived, derived[1]);
+            function collect(...values: number[]): number[] { return values; }
+            console.log(collect(...numbers(), 6).join(','));
+            Object.freeze(packed);
+            console.log(Object.isFrozen(packed), packed[0]);
+            """;
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+        Assert.Equal("1,4,3,5\n100001 false boxed 9\n1,boxed false\n3 false 7\n1,2,3,6\ntrue 1\n",
+            TestHarness.RunCompiledStandalone(source));
+    }
+
+    [Fact]
+    public void NumberAndBooleanQueuesVerifyAndRunStandalone()
+    {
+        const string source = """
+            function numbers(n: number): number {
+                const values: number[] = [];
+                for (let i = 0; i < n; i++) values.push(i);
+                values.unshift(10);
+                let total = 0;
+                while (values.length > 0) total += values.shift();
+                return total;
+            }
+            function booleans(): boolean {
+                const values: boolean[] = [];
+                values.push(true);
+                values.unshift(false);
+                values.shift();
+                return values.shift();
+            }
+            function numberHoles(): number {
+                const values: number[] = [];
+                values[3] = 7;
+                values.unshift(1);
+                values.shift();
+                return values.length;
+            }
+            function booleanHoles(): number {
+                const values: boolean[] = [];
+                values[3] = true;
+                values.unshift(false);
+                values.shift();
+                return values.length;
+            }
+            console.log(numbers(5), booleans(), numberHoles(), booleanHoles());
+            """;
+        Assert.Empty(TestHarness.CompileAndVerifyOnly(source));
+        Assert.Equal("20 true 4 4\n", TestHarness.RunCompiledStandalone(source));
+    }
+
+    private static EmittedArrayStorageRuntime CreateDeclarations(string? missingHandle = null)
+    {
+        var arrays = new EmittedArrayStorageRuntime();
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName("array_storage_incomplete"), typeof(object).Assembly);
+        var type = assembly.DefineDynamicModule("main").DefineType("Placeholder");
+        var ctor = type.DefineDefaultConstructor(MethodAttributes.Public);
+        var method = type.DefineMethod("Placeholder", MethodAttributes.Public, typeof(void), Type.EmptyTypes);
+        var field = type.DefineField("Placeholder", typeof(object), FieldAttributes.Public);
+        foreach (var property in Handles.Where(property => property.Name != missingHandle))
+        {
+            var numeric = property.Name.StartsWith("Number", StringComparison.Ordinal);
+            object handle = property.PropertyType == typeof(ArrayQueueTypeInfo)
+                ? new ArrayQueueTypeInfo(type, ctor, numeric ? ArrayElements.Double : ArrayElements.Bool,
+                    method, method, method, method, method, method, numeric ? method : null, numeric ? method : null, method)
+                : property.PropertyType == typeof(Type) ? type
+                : property.PropertyType == typeof(ConstructorBuilder) ? ctor
+                : property.PropertyType == typeof(FieldInfo) ? field : method;
+            property.SetValue(arrays, handle);
+        }
+        return arrays;
+    }
+
+    private static void AssertComplete(EmittedArrayStorageRuntime arrays)
+    {
+        Assert.True(arrays.IsComplete);
+        Assert.Equal("$Array", arrays.Type.Name);
+        Assert.Equal("$ArrayHole", arrays.HoleType.Name);
+        Assert.True(Assert.IsAssignableFrom<TypeBuilder>(arrays.Type).IsCreated());
+        Assert.Same(arrays.Type, arrays.Ctor.DeclaringType);
+        Assert.Same(arrays.Type, arrays.EnsureBoxed.DeclaringType);
+        foreach (var property in Handles)
+        {
+            var value = property.GetValue(arrays);
+            Assert.NotNull(value);
+            Assert.False(property.SetMethod!.IsPublic);
+            var exception = Assert.Throws<TargetInvocationException>(() => property.SetValue(arrays, value));
+            Assert.IsType<InvalidOperationException>(exception.InnerException);
+            if (value is ArrayQueueTypeInfo queue)
+            {
+                Assert.True(queue.Type.IsCreated());
+                Assert.Same(queue.Type, queue.Constructor.DeclaringType);
+                Assert.Equal(queue.Elements.Kind == ArrayElementsKind.Double, queue.ShiftNumber is not null);
+                Assert.Equal(queue.Elements.Kind == ArrayElementsKind.Double, queue.GetNumber is not null);
+            }
+        }
+        Assert.Throws<InvalidOperationException>(arrays.CompleteEmission);
+    }
+
+    private static EmittedRuntime EmitRuntime(string? source, bool hosted = false)
+    {
+        var assembly = new PersistedAssemblyBuilder(new AssemblyName($"array_storage_{Guid.NewGuid():N}"), typeof(object).Assembly);
+        var module = assembly.DefineDynamicModule("main");
+        var emitter = new RuntimeEmitter(TypeProvider.Runtime, emitHosted: hosted);
+        if (source is null)
+            return emitter.EmitAll(module);
+        var statements = new Parser(new Lexer(source).ScanTokens()).ParseOrThrow();
+        return emitter.EmitAll(module, new RuntimeFeatureDetector().Detect(statements));
+    }
+}


### PR DESCRIPTION
Array storage handles on `EmittedRuntime` could be read before declaration or replaced after emission. Move 47 declarations into `EmittedArrayStorageRuntime`, with checked reads, internal writes, and completion validation that freezes the component. This covers `$Array`, `$ArrayHole`, constructors, sparse/packed-double accessors, rest builders, and the four numeric/boolean queue records.

`ArrayStorage` is required because these types are emitted even for minimal tree-shaken programs. Preserve declaration/body order, remove the duplicate `EnsureBoxed` emitter field, and pass the component directly to storage-only helpers. The other consumers only change their handle access paths; emitted operations and optimization decisions are unchanged.

Refs #1599. This is the array-storage slice; the umbrella stays open. `ARCHITECTURE.md` records the remaining array operations, prototype/bound-method helpers, iterators, buffer/typed-array metadata, and shared call-argument pool.

Validation:

- Release solution build: `dotnet build SharpTS.sln -c Release --no-restore -m:1 -nr:false`.
- 102 new tests pass: declaration/queue completeness, forward calls before body emission, completion immutability, minimal/full/hosted emission, dependency metadata, standalone execution, and IL verification.
- Compiler and array regression selection: 2,340 passed initially; the sole TLS handshake failure passed on an isolated unsandboxed rerun (2,341 selected tests total). The selection includes all compiler tests and the shared array, packed-number, numeric-rest, spread-into-rest, and destructuring tests.
- `./scripts/test-code-quality.ps1` passes, including analyzer fixtures, emitter dead-code checks, and the duplicate-method gate.
- `git diff --check` passes. Audited removal of all 47 flat properties and confirmed 59 consumer files contain only handle-routing changes.

The solution build required unsandboxed access for Avalonia's local build log. Package-audit lookups emitted NU1900 warnings because the NuGet service index was unavailable; these did not prevent compilation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated array runtime handling across array creation, access, iteration, destructuring, subclassing, JSON processing, and built-in operations.
  * Preserved existing array behavior, including sparse arrays, numeric arrays, rest parameters, queues, and array-derived results.
  * Improved consistency when arrays are created through standard library and runtime APIs.

* **Tests**
  * Added coverage for packed, sparse, subclassed, numeric, boolean, and rest-parameter array scenarios.
  * Verified standalone and hosted compilation scenarios continue to run successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->